### PR TITLE
feat: allows admins to autoverify via admin

### DIFF
--- a/docs/graphql/overview.mdx
+++ b/docs/graphql/overview.mdx
@@ -17,7 +17,7 @@ The labels you provide for your Collections and Globals are used to name the Gra
 Everything that can be done to a Collection via the REST or Local API can be done with GraphQL (outside of uploading files, which is REST-only). If you have a collection as follows:
 
 ```js
-const Post = {
+const PublicUser = {
   slug: 'public-users',
   auth: true, // Auth is enabled
   labels: {

--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -44,7 +44,7 @@ Example field configuration:
 
 ## Arguments and return values
 
-All field-level hooks are formatted to accept the same arguments, although some may be `undefined` based on which field hook you are utilizing.
+All field-level hooks are formatted to accept the same arguments, although some arguments may be `undefined` based on which field hook you are utilizing.
 
 <Banner type="success">
   <strong>Tip:</strong><br />
@@ -65,7 +65,7 @@ Field Hooks receive one `args` argument that contains the following properties:
 
 #### Return value
 
-All field hooks can optionally modify the return value of the field before the operation continues. Field Hooks may optionally return the value that should be used within the field.
+Field hooks **must** return the intended value for the field to be used in the operation. You can modify the return value of the field before the operation continues, or simply send the `value` that you receive through the hook's argument. If you return `undefined` within a `beforeChange` or `beforeValidate` hook, the property will be unset from its document.
 
 <Banner type="warning">
   <strong>Important</strong><br/>

--- a/src/admin/components/views/collections/Edit/Auth/index.tsx
+++ b/src/admin/components/views/collections/Edit/Auth/index.tsx
@@ -114,9 +114,6 @@ const Auth: React.FC<Props> = (props) => {
         <Checkbox
           label="Verified"
           name="_verified"
-          admin={{
-            readOnly: true,
-          }}
         />
       )}
     </div>

--- a/src/fields/baseFields/baseVerificationFields.ts
+++ b/src/fields/baseFields/baseVerificationFields.ts
@@ -1,4 +1,16 @@
-import { Field } from '../config/types';
+import { Field, FieldHook } from '../config/types';
+
+const autoRemoveVerificationToken: FieldHook = ({ originalDoc, data, value }) => {
+  // If a user manually sets `_verified` to true,
+  // and it was `false`, set _verificationToken to `undefined`.
+  // This is useful because the admin panel
+  // allows users to set `_verified` to true manually
+  if (data?._verified === true && originalDoc?._verified === false) {
+    return undefined;
+  }
+
+  return value;
+};
 
 export default [
   {
@@ -17,5 +29,10 @@ export default [
     name: '_verificationToken',
     type: 'text',
     hidden: true,
+    hooks: {
+      beforeChange: [
+        autoRemoveVerificationToken,
+      ],
+    },
   },
 ] as Field[];

--- a/src/fields/hookPromise.ts
+++ b/src/fields/hookPromise.ts
@@ -33,11 +33,9 @@ const hookPromise = async ({
         data: fullData,
         operation,
         req,
-      }) || data[field.name];
+      });
 
-      if (hookedValue !== undefined) {
-        resultingData[field.name] = hookedValue;
-      }
+      resultingData[field.name] = hookedValue;
     }, Promise.resolve());
   }
 };


### PR DESCRIPTION
Removes `readonly` from `verified` field to allow admins to verify users' accounts manually through the admin UI.

Note: before merging, we should also determine a way to remove the `verificationToken` from users' documents if accounts are verified via admin UI. This will keep the records clean. Could be done with field hooks.

Update: added field hook to auto-remove `_verificationToken` when `_verified` is manually set to `true`. This is a breaking change, as now field hooks are **required** to return a value, which in turn allows us to unset a property if a field hook returns `undefined`.