### PR TITLE
fix: target es2019, optional chaining not supported for Node < 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@babel/core": "^7.11.6",
     "@babel/node": "^7.12.6",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.8.3",
     "@babel/preset-react": "^7.8.3",

--- a/src/babel.config.js
+++ b/src/babel.config.js
@@ -16,6 +16,5 @@ module.exports = {
   plugins: [
     require.resolve('@babel/plugin-transform-runtime'),
     require.resolve('@babel/plugin-proposal-class-properties'),
-    require.resolve('@babel/plugin-proposal-optional-chaining'),
   ],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2019",
     "module": "commonjs",
     "allowJs": true, /* Allow javascript files to be compiled. */
     "checkJs": false, /* Report errors in .js files. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,7 +363,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.12.7", "@babel/plugin-proposal-optional-chaining@^7.8.3":
+"@babel/plugin-proposal-optional-chaining@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz#e02f0ea1b5dc59d401ec16fb824679f683d3303c"
   integrity sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==


### PR DESCRIPTION
## Description

Fix optional chaining compilation for Node < 14

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
