### PR TITLE
feat: exposes further types

### DIFF
--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -157,14 +157,14 @@ export type RelationshipField = FieldBase & {
 
 type RichTextPlugin = (editor: Editor) => Editor;
 
-type RichTextCustomElement = {
+export type RichTextCustomElement = {
   name: string
   Button: React.ComponentType
   Element: React.ComponentType
   plugins?: RichTextPlugin[]
 }
 
-type RichTextCustomLeaf = {
+export type RichTextCustomLeaf = {
   name: string
   Button: React.ComponentType
   Leaf: React.ComponentType

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,4 +2,4 @@ export * from './dist/types';
 
 export { PayloadCollectionConfig as CollectionConfig } from './dist/collections/config/types';
 export { PayloadGlobalConfig as GlobalConfig } from './dist/globals/config/types';
-export { Field, FieldHook } from './dist/fields/config/types';
+export { Field, FieldHook, RichTextCustomElement, RichTextCustomLeaf, Block } from './dist/fields/config/types';


### PR DESCRIPTION
## Description

Exposes more internal TypeScript types for end-users to be able to import from `payload/types`. Specifically,

- `Block`
- `RichTextCustomElement`
- `RichTextCustomLeaf`

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
