### PR TITLE
Feat/restrict serverurl path

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -29,7 +29,7 @@ Payload is a *config-based*, code-first CMS and application framework. The Paylo
 | `csrf`               | A whitelist array of URLs to allow Payload cookies to be accepted from as a form of CSRF protection. [More](/docs/authentication/overview#csrf-protection) |
 | `defaultDepth`       | If a user does not specify `depth` while requesting a resource, this depth will be used. [More](/docs/getting-started/concepts#depth) |
 | `maxDepth`           | The maximum allowed depth to be permitted application-wide. This setting helps prevent against malicious queries. Defaults to `10`. |
-| `upload`             | Base Payload upload configuration. [More](/docs/admin/upload#global). |
+| `upload`             | Base Payload upload configuration. [More](/docs/upload/overview#payload-wide-upload-options). |
 | `routes`             | Control the routing structure that Payload binds itself to. Specify `admin`, `api`, `graphQL`, and `graphQLPlayground`. |
 | `email`              | Base email settings to allow Payload to generate email such as Forgot Password requests and other requirements. [More](/docs/email/overview#config) |
 | `express`            | Express-specific middleware options such as compression and JSON parsing. [More](/docs/configuration/express). |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payload",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Node, React and MongoDB Headless CMS and Application Framework",
   "license": "SEE LICENSE IN license.md",
   "author": "Payload CMS LLC",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -9,7 +9,21 @@ const component = joi.alternatives().try(
 
 export default joi.object({
   serverURL: joi.string()
-    .required(),
+    .uri()
+    .required()
+    .custom((value, helper) => {
+      const urlWithoutProtocol = value.split('//')[1];
+
+      if (!urlWithoutProtocol) {
+        return helper.message({ custom: 'You need to include either "https://" or "http://" in your serverURL.' });
+      }
+
+      if (urlWithoutProtocol.indexOf('/') > -1) {
+        return helper.message({ custom: 'Your serverURL cannot have a path. It can only contain a protocol, a domain, and an optional port.' });
+      }
+
+      return value;
+    }),
   cookiePrefix: joi.string(),
   routes: joi.object({
     admin: joi.string(),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -72,7 +72,6 @@ export default joi.object({
     joi.array()
       .items(joi.string()),
   ],
-  publicENV: joi.object(),
   express: joi.object()
     .keys({
       json: joi.object(),
@@ -87,8 +86,6 @@ export default joi.object({
           fileSize: joi.number(),
         }),
     }),
-  serverModules: joi.array()
-    .items(joi.string()),
   rateLimit: joi.object()
     .keys({
       window: joi.number(),
@@ -112,20 +109,6 @@ export default joi.object({
         fallback: joi.boolean(),
       }),
       joi.boolean(),
-    ),
-  email: joi.alternatives()
-    .try(
-      joi.object({
-        transport: 'mock',
-        fromName: joi.string(),
-        fromAddress: joi.string(),
-      }),
-      joi.object({
-        transport: joi.object(),
-        transportOptions: joi.object(),
-        fromName: joi.string(),
-        fromAddress: joi.string(),
-      }),
     ),
   hooks: joi.object().keys({
     afterError: joi.func(),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -135,7 +135,6 @@ export type PayloadConfig = {
     disable?: boolean;
   };
   components?: { [key: string]: JSX.Element | (() => JSX.Element) };
-  paths?: { [key: string]: string };
   hooks?: {
     afterError?: AfterErrorHook;
   };
@@ -144,4 +143,5 @@ export type PayloadConfig = {
 export type Config = Omit<DeepRequired<PayloadConfig>, 'collections'> & {
   collections: CollectionConfig[]
   globals: GlobalConfig[]
+  paths: { [key: string]: string };
 }


### PR DESCRIPTION
## Description

1. Ensures that `serverURL` does not contain a path, and validates accordingly using existing Joi schema validation.
2. Updates docs to be more explicit regarding serverURL.
3. Moves `paths` from exposed Payload config type to internal Payload config type. 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
