### PR TITLE
fix: ensures modal heights are 100% of viewport

### DIFF
--- a/src/admin/scss/app.scss
+++ b/src/admin/scss/app.scss
@@ -116,6 +116,10 @@ dialog {
   padding: 0;
 }
 
+.payload__modal-item {
+  min-height: 100vh;
+}
+
 .payload__modal-container--enterDone {
   overflow: scroll;
 }


### PR DESCRIPTION
## Description

Ensures modals are rendered at 100% of view height at all times.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
