### PR TITLE
fix: hide force unlock in admin ui when creating auth collection item

### DIFF
--- a/src/admin/components/views/Account/Default.tsx
+++ b/src/admin/components/views/Account/Default.tsx
@@ -81,6 +81,7 @@ const DefaultAccount: React.FC<Props> = (props) => {
                   useAPIKey={auth.useAPIKey}
                   collection={collection}
                   email={data?.email}
+                  operation="update"
                 />
                 <RenderFields
                   operation="update"

--- a/src/admin/components/views/collections/Edit/Auth/index.tsx
+++ b/src/admin/components/views/collections/Edit/Auth/index.tsx
@@ -16,7 +16,7 @@ import './index.scss';
 const baseClass = 'auth-fields';
 
 const Auth: React.FC<Props> = (props) => {
-  const { useAPIKey, requirePassword, verify, collection: { slug }, email } = props;
+  const { useAPIKey, requirePassword, verify, collection: { slug }, email, operation } = props;
   const [changingPassword, setChangingPassword] = useState(requirePassword);
   const { getField } = useWatchForm();
   const modified = useFormModified();
@@ -92,13 +92,15 @@ const Auth: React.FC<Props> = (props) => {
           Change Password
         </Button>
       )}
-      <Button
-        size="small"
-        buttonStyle="secondary"
-        onClick={() => unlock()}
-      >
-        Force Unlock
-      </Button>
+      {operation === 'update' && (
+        <Button
+          size="small"
+          buttonStyle="secondary"
+          onClick={() => unlock()}
+        >
+          Force Unlock
+        </Button>
+      )}
       {useAPIKey && (
         <div className={`${baseClass}__api-key`}>
           <Checkbox

--- a/src/admin/components/views/collections/Edit/Auth/types.ts
+++ b/src/admin/components/views/collections/Edit/Auth/types.ts
@@ -7,4 +7,5 @@ export type Props = {
   verify?: VerifyConfig | boolean
   collection: CollectionConfig
   email: string
+  operation: 'update' | 'create'
 }

--- a/src/admin/components/views/collections/Edit/Default.tsx
+++ b/src/admin/components/views/collections/Edit/Default.tsx
@@ -58,6 +58,8 @@ const DefaultEditView: React.FC<Props> = (props) => {
     isEditing && `${baseClass}--is-editing`,
   ].filter(Boolean).join(' ');
 
+  const operation = isEditing ? 'update' : 'create';
+
   return (
     <div className={classes}>
       <Form
@@ -94,6 +96,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                     verify={auth.verify}
                     collection={collection}
                     email={data?.email}
+                    operation={operation}
                   />
                 )}
                 {upload && (
@@ -103,7 +106,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                   />
                 )}
                 <RenderFields
-                  operation={isEditing ? 'update' : 'create'}
+                  operation={operation}
                   readOnly={!hasSavePermission}
                   permissions={permissions.fields}
                   filter={(field) => (!field?.admin?.position || (field?.admin?.position !== 'sidebar'))}


### PR DESCRIPTION
## Description

https://github.com/payloadcms/payload/issues/48

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes

