### PR TITLE
Fix/preview button

### DIFF
--- a/src/admin/components/elements/Button/index.tsx
+++ b/src/admin/components/elements/Button/index.tsx
@@ -52,6 +52,7 @@ const Button: React.FC<Props> = (props) => {
     round,
     size = 'medium',
     iconPosition = 'right',
+    newTab,
   } = props;
 
   const classes = [
@@ -76,6 +77,8 @@ const Button: React.FC<Props> = (props) => {
     type,
     className: classes,
     onClick: handleClick,
+    rel: newTab ? 'noopener noreferrer' : undefined,
+    target: newTab ? '_blank' : undefined
   };
 
   switch (el) {

--- a/src/admin/components/elements/Button/types.ts
+++ b/src/admin/components/elements/Button/types.ts
@@ -14,5 +14,6 @@ export type Props = {
     buttonStyle?: 'primary' | 'secondary' | 'transparent' | 'error' | 'none' | 'icon-label',
     round?: boolean,
     size?: 'small' | 'medium',
-    iconPosition?: 'left' | 'right'
+    iconPosition?: 'left' | 'right',
+    newTab?: boolean
 }

--- a/src/admin/components/elements/PreviewButton/index.tsx
+++ b/src/admin/components/elements/PreviewButton/index.tsx
@@ -9,14 +9,18 @@ const PreviewButton: React.FC<Props> = ({ generatePreviewURL, data }) => {
   const { token } = useAuth();
 
   if (generatePreviewURL && typeof generatePreviewURL === 'function') {
-    const previewURL = generatePreviewURL(data, token);
+    const {
+      url,
+      newTab
+    } = generatePreviewURL(data, token);
 
     return (
       <Button
         el="anchor"
         className={baseClass}
         buttonStyle="secondary"
-        url={previewURL}
+        url={url}
+        newTab={newTab}
       >
         Preview
       </Button>

--- a/src/admin/components/elements/PreviewButton/index.tsx
+++ b/src/admin/components/elements/PreviewButton/index.tsx
@@ -1,18 +1,15 @@
 import React from 'react';
 import { useAuth } from '@payloadcms/config-provider';
-import { useForm } from '../../forms/Form/context';
 import Button from '../Button';
 import { Props } from './types';
 
 const baseClass = 'preview-btn';
 
-const PreviewButton: React.FC<Props> = ({ generatePreviewURL }) => {
+const PreviewButton: React.FC<Props> = ({ generatePreviewURL, data }) => {
   const { token } = useAuth();
-  const { getFields } = useForm();
-  const fields = getFields();
 
   if (generatePreviewURL && typeof generatePreviewURL === 'function') {
-    const previewURL = generatePreviewURL(fields, token);
+    const previewURL = generatePreviewURL(data, token);
 
     return (
       <Button

--- a/src/admin/components/elements/PreviewButton/types.ts
+++ b/src/admin/components/elements/PreviewButton/types.ts
@@ -1,3 +1,6 @@
+import { Data } from "../../forms/Form/types";
+
 export type Props = {
-  generatePreviewURL?: (fields: unknown, token: string) => string
+  generatePreviewURL?: (fields: unknown, token: string) => string,
+  data?: Data
 }

--- a/src/admin/components/elements/PreviewButton/types.ts
+++ b/src/admin/components/elements/PreviewButton/types.ts
@@ -1,6 +1,11 @@
 import { Data } from "../../forms/Form/types";
 
+export type GeneratedPreviewURL = {
+  url: string,
+  newTab: boolean
+}
+
 export type Props = {
-  generatePreviewURL?: (fields: unknown, token: string) => string,
+  generatePreviewURL?: (data: unknown, token: string) => GeneratedPreviewURL,
   data?: Data
 }

--- a/src/admin/components/views/Account/Default.tsx
+++ b/src/admin/components/views/Account/Default.tsx
@@ -104,7 +104,10 @@ const DefaultAccount: React.FC<Props> = (props) => {
             )}
           </ul>
           <div className={`${baseClass}__document-actions${preview ? ` ${baseClass}__document-actions--with-preview` : ''}`}>
-            <PreviewButton generatePreviewURL={preview} />
+            <PreviewButton
+              generatePreviewURL={preview}
+              data={data}
+            />
             {hasSavePermission && (
               <FormSubmit>Save</FormSubmit>
             )}

--- a/src/admin/components/views/Global/Default.tsx
+++ b/src/admin/components/views/Global/Default.tsx
@@ -68,9 +68,12 @@ const DefaultGlobalView: React.FC<Props> = (props) => {
           <div className={`${baseClass}__sidebar-sticky`}>
             <div className={`${baseClass}__sidebar-sticky-wrap`}>
               <div className={`${baseClass}__document-actions${preview ? ` ${baseClass}__document-actions--with-preview` : ''}`}>
-                <PreviewButton generatePreviewURL={preview} />
+                <PreviewButton
+                  generatePreviewURL={preview}
+                  data={data}
+                />
                 {hasSavePermission && (
-                <FormSubmit>Save</FormSubmit>
+                  <FormSubmit>Save</FormSubmit>
                 )}
               </div>
               {data && (

--- a/src/admin/components/views/collections/Edit/Default.tsx
+++ b/src/admin/components/views/collections/Edit/Default.tsx
@@ -142,7 +142,10 @@ const DefaultEditView: React.FC<Props> = (props) => {
               ) : undefined}
               <div className={`${baseClass}__document-actions${(preview && isEditing) ? ` ${baseClass}__document-actions--with-preview` : ''}`}>
                 {isEditing && (
-                <PreviewButton generatePreviewURL={preview} />
+                  <PreviewButton
+                    generatePreviewURL={preview}
+                    data={data}
+                  />
                 )}
                 {hasSavePermission && (
                 <FormSubmit>Save</FormSubmit>

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -7,6 +7,7 @@ import { Document, PayloadMongooseDocument } from '../../types';
 import { PayloadRequest } from '../../express/types';
 import { IncomingAuthType, Auth } from '../../auth/types';
 import { IncomingUploadType, Upload } from '../../uploads/types';
+import { GeneratedPreviewURL } from '../../admin/components/elements/PreviewButton/types'
 
 export interface CollectionModel extends PaginateModel<PayloadMongooseDocument>, PassportLocalModel<PayloadMongooseDocument> {
   buildQuery: (query: unknown, locale?: string) => Record<string, unknown>
@@ -108,7 +109,7 @@ export type PayloadCollectionConfig = {
       }
     };
     enableRichTextRelationship?: boolean
-    preview?: (doc: Document, token: string) => string
+    preview?: (doc: Document, token: string) => GeneratedPreviewURL
   };
   hooks?: {
     beforeOperation?: BeforeOperationHook[];

--- a/src/globals/config/types.ts
+++ b/src/globals/config/types.ts
@@ -3,13 +3,14 @@ import { Model, Document } from 'mongoose';
 import { DeepRequired } from 'ts-essentials';
 import { Access } from '../../config/types';
 import { Field } from '../../fields/config/types';
+import { GeneratedPreviewURL } from 'src/admin/components/elements/PreviewButton/types';
 
 export type GlobalModel = Model<Document>
 
 export type PayloadGlobalConfig = {
   slug: string
   label?: string
-  preview?: (doc: Document, token: string) => string
+  preview?: (doc: Document, token: string) => GeneratedPreviewURL
   access?: {
     create?: Access;
     read?: Access;


### PR DESCRIPTION
## Description

Currently, the `collection.admin.preview` callback returns only the document's fields, not the entire document. This change swaps the fields for the entire document as described (9b9d0f2).

This PR also adds a `newTab` prop to the `Button` component, and updates the `generatePreviewURL` api to forward through `PreviewButton` (6b6297f).

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Existing test suite passes locally with my changes
