### PR TITLE
docs: removes incorrect hasMany from upload field type

### DIFF
--- a/docs/fields/upload.mdx
+++ b/docs/fields/upload.mdx
@@ -27,7 +27,6 @@ keywords: upload, images media, fields, config, configuration, documentation, Co
 | ---------------- | ----------- |
 | **`name`** *         | To be used as the property name when stored and retrieved from the database.  |
 | **`*relationTo`** *  | Provide a single collection `slug` to allow this field to accept a relation to. <strong>Note: the related collection must be configured to support Uploads.</strong> |
-| **`hasMany`**        | Boolean when, if set to `true`, allows this field to have many relations instead of only one. |
 | **`label`**          | Used as a field label in the Admin panel and to name the generated GraphQL type. |
 | **`unique`**         | Enforce that each entry in the Collection has a unique value for this field. |
 | **`validate`**       | Provide a custom validation function that will be executed on both the Admin panel and the backend. [More](/docs/fields/overview#validation) |


### PR DESCRIPTION
## Description

Removes incorrect `hasMany` option from upload field docs

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
