### PR TITLE
fix: infinite loop caused within block component

### DIFF
--- a/src/admin/components/forms/field-types/Blocks/Blocks.tsx
+++ b/src/admin/components/forms/field-types/Blocks/Blocks.tsx
@@ -22,16 +22,18 @@ import './index.scss';
 
 const baseClass = 'field-type blocks';
 
+const labelDefaults = {
+  singular: 'Block',
+  plural: 'Blocks',
+};
+
 const Blocks: React.FC<Props> = (props) => {
   const {
     label,
     name,
     path: pathFromProps,
     blocks,
-    labels = {
-      singular: 'Block',
-      plural: 'Blocks',
-    },
+    labels = labelDefaults,
     fieldTypes,
     maxRows,
     minRows,


### PR DESCRIPTION
## Description

Fixes #77 - _**wow**_. We were setting default values for the `labels` prop within the `Blocks` component itself, which would cause the `memoizedValidate` callback to be recreated every render. Voila, infinite loop.  

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
