### PR TITLE
fix: properly exposes scss for reuse

### DIFF
--- a/scss/vars.scss
+++ b/scss/vars.scss
@@ -1,1 +1,1 @@
-@import '../src/admin/scss/vars';
+@import '../dist/admin/scss/vars';

--- a/src/admin/index.tsx
+++ b/src/admin/index.tsx
@@ -12,7 +12,6 @@ import { ConfigProvider, AuthProvider } from '@payloadcms/config-provider';
 import { SearchParamsProvider } from './components/utilities/SearchParams';
 import { LocaleProvider } from './components/utilities/Locale';
 import Routes from './components/Routes';
-import getCSSVariable from '../utilities/getCSSVariable';
 
 import './scss/app.scss';
 
@@ -20,17 +19,17 @@ const Index = () => (
   <React.Fragment>
     <ConfigProvider config={config}>
       <WindowInfoProvider breakpoints={{
-        xs: parseInt(getCSSVariable('breakpoint-xs-width').replace('px', ''), 10),
-        s: parseInt(getCSSVariable('breakpoint-s-width').replace('px', ''), 10),
-        m: parseInt(getCSSVariable('breakpoint-m-width').replace('px', ''), 10),
-        l: parseInt(getCSSVariable('breakpoint-l-width').replace('px', ''), 10),
+        xs: 400,
+        s: 768,
+        m: 1024,
+        l: 1440,
       }}
       >
         <ScrollInfoProvider>
           <Router>
             <ModalProvider
               classPrefix="payload"
-              zIndex={parseInt(getCSSVariable('z-modal'), 10)}
+              zIndex={50}
             >
               <AuthProvider>
                 <SearchParamsProvider>


### PR DESCRIPTION
## Description

Fixes the way that SCSS variables are exposed and also removes reliance on CSS variables in the admin panel's entry point  file. The entry component does not re-render, which means that if the CSS variables are not set _before_ first render, their values will not be able to be used.  

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
