### PR TITLE
fix: removes overwrite from update operation

### DIFF
--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -107,7 +107,7 @@ async function update(incomingArgs: Arguments): Promise<Document> {
   docWithLocales = JSON.parse(docWithLocales);
 
   const originalDoc = await performFieldOperations(collectionConfig, {
-    depth,
+    depth: 0,
     req,
     data: docWithLocales,
     hook: 'afterRead',

--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -257,7 +257,7 @@ async function update(incomingArgs: Arguments): Promise<Document> {
   result = await Model.findByIdAndUpdate(
     { _id: id },
     result,
-    { overwrite: true, new: true },
+    { new: true },
   );
 
   result = result.toJSON({ virtuals: true });


### PR DESCRIPTION
## Description

Removes `overwrite` from our `update` operation. This caused fields that are not returned from the database, like `salt` and `hash`, from being preserved through updates. 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
