### PR TITLE
fix: reverts preview to only returning string

### DIFF
--- a/demo/collections/AllFields.ts
+++ b/demo/collections/AllFields.ts
@@ -15,7 +15,7 @@ const AllFields: PayloadCollectionConfig = {
     useAsTitle: 'text',
     preview: (doc, token) => {
       if (doc && doc.text) {
-        return `http://localhost:3000/previewable-posts/${doc.text.value}?preview=true&token=${token}`;
+        return `http://localhost:3000/previewable-posts/${doc.text}?preview=true&token=${token}`;
       }
 
       return null;

--- a/demo/collections/Preview.ts
+++ b/demo/collections/Preview.ts
@@ -10,7 +10,7 @@ const Preview: PayloadCollectionConfig = {
     useAsTitle: 'title',
     preview: (doc, token) => {
       if (doc.title) {
-        return `http://localhost:3000/previewable-posts/${doc.title.value}?preview=true&token=${token}`;
+        return `http://localhost:3000/previewable-posts/${doc.title}?preview=true&token=${token}`;
       }
 
       return null;

--- a/src/admin/components/elements/PreviewButton/index.tsx
+++ b/src/admin/components/elements/PreviewButton/index.tsx
@@ -9,10 +9,7 @@ const PreviewButton: React.FC<Props> = ({ generatePreviewURL, data }) => {
   const { token } = useAuth();
 
   if (generatePreviewURL && typeof generatePreviewURL === 'function') {
-    const {
-      url,
-      newTab
-    } = generatePreviewURL(data, token);
+    const url = generatePreviewURL(data, token);
 
     return (
       <Button
@@ -20,7 +17,7 @@ const PreviewButton: React.FC<Props> = ({ generatePreviewURL, data }) => {
         className={baseClass}
         buttonStyle="secondary"
         url={url}
-        newTab={newTab}
+        newTab
       >
         Preview
       </Button>

--- a/src/admin/components/elements/PreviewButton/types.ts
+++ b/src/admin/components/elements/PreviewButton/types.ts
@@ -1,11 +1,6 @@
-import { Data } from "../../forms/Form/types";
-
-export type GeneratedPreviewURL = {
-  url: string,
-  newTab: boolean
-}
+import { Data } from '../../forms/Form/types';
 
 export type Props = {
-  generatePreviewURL?: (data: unknown, token: string) => GeneratedPreviewURL,
+  generatePreviewURL?: (data: unknown, token: string) => string,
   data?: Data
 }

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -7,7 +7,6 @@ import { Document } from '../../types';
 import { PayloadRequest } from '../../express/types';
 import { IncomingAuthType, Auth } from '../../auth/types';
 import { IncomingUploadType, Upload } from '../../uploads/types';
-import { GeneratedPreviewURL } from '../../admin/components/elements/PreviewButton/types'
 
 export interface CollectionModel extends PaginateModel<any>, PassportLocalModel<any> {
   buildQuery: (query: unknown, locale?: string) => Record<string, unknown>
@@ -109,7 +108,7 @@ export type PayloadCollectionConfig = {
       }
     };
     enableRichTextRelationship?: boolean
-    preview?: (doc: Document, token: string) => GeneratedPreviewURL
+    preview?: (doc: Document, token: string) => string
   };
   hooks?: {
     beforeOperation?: BeforeOperationHook[];

--- a/src/globals/config/types.ts
+++ b/src/globals/config/types.ts
@@ -3,14 +3,13 @@ import { Model, Document } from 'mongoose';
 import { DeepRequired } from 'ts-essentials';
 import { Access } from '../../config/types';
 import { Field } from '../../fields/config/types';
-import { GeneratedPreviewURL } from 'src/admin/components/elements/PreviewButton/types';
 
 export type GlobalModel = Model<Document>
 
 export type PayloadGlobalConfig = {
   slug: string
   label?: string
-  preview?: (doc: Document, token: string) => GeneratedPreviewURL
+  preview?: (doc: Document, token: string) => string
   access?: {
     create?: Access;
     read?: Access;


### PR DESCRIPTION
## Description

Reverts the return value type of the `preview` function to only a URL string.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
