### PR TITLE
docs: fix broken links graphql playground and collections preview

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -65,7 +65,7 @@ You can customize the way that the Admin panel behaves on a collection-by-collec
 | `defaultColumns`             | Array of field names that correspond to which columns to show by default in this collection's List view. |
 | `disableDuplicate `          | Disables the "Duplicate" button while editing documents within this collection. |
 | `enableRichTextRelationship` | The [Rich Text](/docs/fields/rich-text) field features a `Relationship` element which allows for users to automatically reference related documents within their rich text. Set this field to `true` to enable the collection to be selected within it. |
-| `preview`                    | Function to generate preview URLS within the Admin panel that can point to your app. [More](/docs/configuration/collections#preview). |
+| `preview`                    | Function to generate preview URLS within the Admin panel that can point to your app. [More](#preview). |
 | `components`                 | Swap in your own React components to be used within this collection. [More](/docs/admin/components#collections) |
 
 ### Preview

--- a/docs/configuration/localization.mdx
+++ b/docs/configuration/localization.mdx
@@ -98,7 +98,7 @@ fetch('https://localhost:3000/api/pages?locale=es&fallback-locale=none');
 
 In the GraphQL API, you can specify `locale` and `fallbackLocale` args to all relevant queries and mutations.
 
-The `locale` arg will only accept valid locales, but locales will be formatted automatically as valid GraphQL enum values (dashes or special characters will be converted to underscores, spaces will be removed, etc.). If you are curious to see how locales are auto-formatted, you can use the [GraphQL playground](/docs/graphql/playground).
+The `locale` arg will only accept valid locales, but locales will be formatted automatically as valid GraphQL enum values (dashes or special characters will be converted to underscores, spaces will be removed, etc.). If you are curious to see how locales are auto-formatted, you can use the [GraphQL playground](/docs/graphql/overview#graphql-playground).
 
 The `fallbackLocale` arg will accept valid locales as well as `none` to disable falling back.
 


### PR DESCRIPTION
## Description

The last of the broken links found in the docs