### PR TITLE
Feat/reorder uploads

### DIFF
--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -108,7 +108,7 @@ But, if you do, and you still want to use an ephemeral filesystem provider, you 
 **To automatically send uploaded files to S3 or similar, you could:**
 
 - Write an asynchronous `beforeChange` hook for all Collections that support Uploads, which takes any uploaded `file` from the Express `req` and sends it to an S3 bucket
-- Write an `afterRead` hook for the `filename` field that automatically adjusts the `filename` stored to add its full S3 URL
+- Write an `afterRead` hook to save a `s3URL` field that automatically takes the `filename` stored and formats a full S3 URL
 - Write an `afterDelete` hook that automatically deletes files from the S3 bucket
 
 With the above configuration, deploying to Heroku or similar becomes no problem.

--- a/src/collections/operations/create.ts
+++ b/src/collections/operations/create.ts
@@ -71,59 +71,6 @@ async function create(this: Payload, incomingArgs: Arguments): Promise<Document>
   }
 
   // /////////////////////////////////////
-  // beforeValidate - Fields
-  // /////////////////////////////////////
-
-  data = await this.performFieldOperations(collectionConfig, {
-    data,
-    req,
-    hook: 'beforeValidate',
-    operation: 'create',
-    overrideAccess,
-  });
-
-  // /////////////////////////////////////
-  // beforeValidate - Collections
-  // /////////////////////////////////////
-
-  await collectionConfig.hooks.beforeValidate.reduce(async (priorHook: BeforeValidateHook | Promise<void>, hook: BeforeValidateHook) => {
-    await priorHook;
-
-    data = (await hook({
-      data,
-      req,
-      operation: 'create',
-    })) || data;
-  }, Promise.resolve());
-
-  // /////////////////////////////////////
-  // beforeChange - Collection
-  // /////////////////////////////////////
-
-  await collectionConfig.hooks.beforeChange.reduce(async (priorHook, hook) => {
-    await priorHook;
-
-    data = (await hook({
-      data,
-      req,
-      operation: 'create',
-    })) || data;
-  }, Promise.resolve());
-
-  // /////////////////////////////////////
-  // beforeChange - Fields
-  // /////////////////////////////////////
-
-  let resultWithLocales = await this.performFieldOperations(collectionConfig, {
-    data,
-    hook: 'beforeChange',
-    operation: 'create',
-    req,
-    overrideAccess,
-    unflattenLocales: true,
-  });
-
-  // /////////////////////////////////////
   // Upload and resize potential files
   // /////////////////////////////////////
 
@@ -170,11 +117,64 @@ async function create(this: Payload, incomingArgs: Arguments): Promise<Document>
     fileData.filesize = file.size;
     fileData.mimeType = file.mimetype;
 
-    resultWithLocales = {
-      ...resultWithLocales,
+    data = {
+      ...data,
       ...fileData,
     };
   }
+
+  // /////////////////////////////////////
+  // beforeValidate - Fields
+  // /////////////////////////////////////
+
+  data = await this.performFieldOperations(collectionConfig, {
+    data,
+    req,
+    hook: 'beforeValidate',
+    operation: 'create',
+    overrideAccess,
+  });
+
+  // /////////////////////////////////////
+  // beforeValidate - Collections
+  // /////////////////////////////////////
+
+  await collectionConfig.hooks.beforeValidate.reduce(async (priorHook: BeforeValidateHook | Promise<void>, hook: BeforeValidateHook) => {
+    await priorHook;
+
+    data = (await hook({
+      data,
+      req,
+      operation: 'create',
+    })) || data;
+  }, Promise.resolve());
+
+  // /////////////////////////////////////
+  // beforeChange - Collection
+  // /////////////////////////////////////
+
+  await collectionConfig.hooks.beforeChange.reduce(async (priorHook, hook) => {
+    await priorHook;
+
+    data = (await hook({
+      data,
+      req,
+      operation: 'create',
+    })) || data;
+  }, Promise.resolve());
+
+  // /////////////////////////////////////
+  // beforeChange - Fields
+  // /////////////////////////////////////
+
+  const resultWithLocales = await this.performFieldOperations(collectionConfig, {
+    data,
+    hook: 'beforeChange',
+    operation: 'create',
+    req,
+    overrideAccess,
+    unflattenLocales: true,
+  });
 
   // /////////////////////////////////////
   // Create

--- a/src/fields/baseFields/baseUploadFields.ts
+++ b/src/fields/baseFields/baseUploadFields.ts
@@ -4,18 +4,6 @@ export default [
   {
     name: 'filename',
     label: 'Filename',
-    hooks: {
-      beforeChange: [
-        ({ req, operation, value }) => {
-          if (operation === 'create') {
-            const file = (req.files && req.files.file) ? req.files.file as { name: string } : req.file;
-            return file.name;
-          }
-
-          return value;
-        },
-      ],
-    },
     type: 'text',
     required: true,
     unique: true,

--- a/src/fields/baseFields/baseVerificationFields.ts
+++ b/src/fields/baseFields/baseVerificationFields.ts
@@ -2,7 +2,7 @@ import { Field, FieldHook } from '../config/types';
 
 const autoRemoveVerificationToken: FieldHook = ({ originalDoc, data, value }) => {
   // If a user manually sets `_verified` to true,
-  // and it was `false`, set _verificationToken to `undefined`.
+  // and it was `false`, set _verificationToken to `null`.
   // This is useful because the admin panel
   // allows users to set `_verified` to true manually
   if (data?._verified === true && originalDoc?._verified === false) {


### PR DESCRIPTION
## Description

Reorders upload functionality within `create` and `update` operations to ensure that upload-specific properties like `filename` are available within `beforeValidate` and `beforeChange` hooks.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
