### PR TITLE
Feat/provide field access data

### DIFF
--- a/demo/collections/LocalizedArray.ts
+++ b/demo/collections/LocalizedArray.ts
@@ -1,4 +1,16 @@
 import { PayloadCollectionConfig } from '../../src/collections/config/types';
+import { FieldAccess } from '../../src/fields/config/types';
+import checkRole from '../access/checkRole';
+
+const PublicReadabilityAccess: FieldAccess = ({ req: { user }, siblingData }) => {
+  if (checkRole(['admin'], user)) {
+    return true;
+  }
+
+  if (siblingData.allowPublicReadability) return true;
+
+  return false;
+};
 
 const LocalizedArrays: PayloadCollectionConfig = {
   slug: 'localized-arrays',
@@ -23,16 +35,30 @@ const LocalizedArrays: PayloadCollectionConfig = {
           type: 'row',
           fields: [
             {
+              name: 'allowPublicReadability',
+              label: 'Allow Public Readability',
+              type: 'checkbox',
+            },
+            {
               name: 'arrayText1',
               label: 'Array Text 1',
               type: 'text',
               required: true,
+              admin: {
+                width: '50%',
+              },
+              access: {
+                read: PublicReadabilityAccess,
+              },
             },
             {
               name: 'arrayText2',
               label: 'Array Text 2',
               type: 'text',
               required: true,
+              admin: {
+                width: '50%',
+              },
             },
           ],
         },

--- a/docs/access-control/fields.mdx
+++ b/docs/access-control/fields.mdx
@@ -43,9 +43,11 @@ Returns a boolean which allows or denies the ability to set a field's value when
 
 **Available argument properties:**
 
-| Option    | Description |
-| --------- | ----------- |
-| **`req`** | The Express `request` object containing the currently authenticated `user` |
+| Option            | Description |
+| ----------------- | ----------- |
+| **`req`**         | The Express `request` object containing the currently authenticated `user` |
+| **`data`**        | The full data passed to create the document. |
+| **`siblingData`** | Immediately adjacent field data passed to create the document. |
 
 ### Read
 
@@ -53,10 +55,12 @@ Returns a boolean which allows or denies the ability to read a field's value. If
 
 **Available argument properties:**
 
-| Option    | Description |
-| --------- | ----------- |
-| **`req`** | The Express `request` object containing the currently authenticated `user` |
-| **`id`**  | `id` of the document being read |
+| Option            | Description |
+| ----------------- | ----------- |
+| **`req`**         | The Express `request` object containing the currently authenticated `user` |
+| **`id`**          | `id` of the document being read |
+| **`data`**        | The full data of the document being read. |
+| **`siblingData`** | Immediately adjacent field data of the document being read. |
 
 ### Update
 
@@ -64,7 +68,9 @@ Returns a boolean which allows or denies the ability to update a field's value. 
 
 **Available argument properties:**
 
-| Option    | Description |
-| --------- | ----------- |
-| **`req`** | The Express `request` object containing the currently authenticated `user` |
-| **`id`**  | `id` of the document being updated |
+| Option            | Description |
+| ----------------- | ----------- |
+| **`req`**         | The Express `request` object containing the currently authenticated `user` |
+| **`id`**          | `id` of the document being updated |
+| **`data`**        | The full data passed to update the document. |
+| **`siblingData`** | Immediately adjacent field data passed to update the document with. |

--- a/src/fields/accessPromise.ts
+++ b/src/fields/accessPromise.ts
@@ -6,6 +6,7 @@ import { PayloadRequest } from '../express/types';
 
 type Arguments = {
   data: Record<string, unknown>
+  fullData: Record<string, unknown>
   originalDoc: Record<string, unknown>
   field: Field
   operation: Operation
@@ -21,6 +22,7 @@ type Arguments = {
 
 const accessPromise = async ({
   data,
+  fullData,
   originalDoc,
   field,
   operation,
@@ -45,7 +47,7 @@ const accessPromise = async ({
   }
 
   if (field.access && field.access[accessOperation]) {
-    const result = overrideAccess ? true : await field.access[accessOperation]({ req, id });
+    const result = overrideAccess ? true : await field.access[accessOperation]({ req, id, siblingData: data, data: fullData });
 
     if (!result && accessOperation === 'update' && originalDoc[field.name] !== undefined) {
       resultingData[field.name] = originalDoc[field.name];

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -2,7 +2,6 @@
 import { CSSProperties } from 'react';
 import { Editor } from 'slate';
 import { PayloadRequest } from '../../express/types';
-import { Access } from '../../config/types';
 import { Document } from '../../types';
 import { ConditionalDateProps } from '../../admin/components/elements/DatePicker/types';
 
@@ -15,6 +14,13 @@ export type FieldHook = (args: {
   operation?: 'create' | 'read' | 'update' | 'delete',
   req: PayloadRequest
 }) => Promise<unknown> | unknown;
+
+export type FieldAccess = (args: {
+  req: PayloadRequest
+  id?: string
+  data: Record<string, unknown>
+  siblingData: Record<string, unknown>
+}) => Promise<boolean> | boolean;
 
 type Admin = {
   position?: string;
@@ -60,9 +66,9 @@ export interface FieldBase {
   }
   admin?: Admin;
   access?: {
-    create?: Access;
-    read?: Access;
-    update?: Access;
+    create?: FieldAccess;
+    read?: FieldAccess;
+    update?: FieldAccess;
   };
 }
 

--- a/src/fields/traverseFields.ts
+++ b/src/fields/traverseFields.ts
@@ -138,6 +138,7 @@ const traverseFields = (args: Arguments): void => {
 
     accessPromises.push(accessPromise({
       data,
+      fullData,
       originalDoc,
       field,
       operation,

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,18 @@
 export * from './dist/types';
 
-export { PayloadCollectionConfig as CollectionConfig } from './dist/collections/config/types';
+export {
+  PayloadCollectionConfig as CollectionConfig,
+  BeforeOperationHook as CollectionBeforeOperationHook,
+  BeforeValidateHook as CollectionBeforeValidateHook,
+  BeforeChangeHook as CollectionBeforeChangeHook,
+  AfterChangeHook as CollectionAfterChangeHook,
+  BeforeReadHook as CollectionBeforeReadHook,
+  BeforeDeleteHook as CollectionBeforeDeleteHook,
+  AfterDeleteHook as CollectionAfterDeleteHook,
+  BeforeLoginHook as CollectionBeforeLoginHook,
+  AfterLoginHook as CollectionAfterLoginHook,
+  AfterForgotPasswordHook as CollectionAfterForgotPasswordHook,
+} from './dist/collections/config/types';
+
 export { PayloadGlobalConfig as GlobalConfig } from './dist/globals/config/types';
-export { Field, FieldHook, RichTextCustomElement, RichTextCustomLeaf, Block } from './dist/fields/config/types';
+export { Field, FieldHook, FieldAccess, RichTextCustomElement, RichTextCustomLeaf, Block } from './dist/fields/config/types';


### PR DESCRIPTION
## Description

Passes field-level access control functions with `siblingData` and `data` to effectively unlock more control from field-level access control. 

For example, with this addition, you can have a checkbox field that allows admins to set public visibility on fields within collections. So, a deeply nested field may be able to read an adjacent field's value to allow or disallow public readability. Many more options are available here.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
