### PR TITLE
Suggestion: Payloads Local api should use 'slug' instead of 'global' for Global operations

### DIFF
--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -275,7 +275,7 @@ The following Global operations are available through the Local API:
 ```js
 // Result will be the Header Global.
 const result = await payload.findGlobal({
-  global: 'header', // required
+  slug: 'header', // required
   depth: 2,
   locale: 'en',
   fallbackLocale: false,
@@ -290,7 +290,7 @@ const result = await payload.findGlobal({
 ```js
 // Result will be the updated Header Global.
 const result = await payload.updateGlobal({
-  global: 'header', // required
+  slug: 'header', // required
   data: { // required
     nav: [
       {

--- a/src/globals/operations/local/findOne.ts
+++ b/src/globals/operations/local/findOne.ts
@@ -1,6 +1,6 @@
 async function findOne(options) {
   const {
-    global: globalSlug,
+    slug: globalSlug,
     depth,
     locale = this?.config?.localization?.defaultLocale,
     fallbackLocale = null,

--- a/src/globals/operations/local/update.ts
+++ b/src/globals/operations/local/update.ts
@@ -1,6 +1,6 @@
 async function update(options) {
   const {
-    global: globalSlug,
+    slug: globalSlug,
     depth,
     locale = this?.config?.localization?.defaultLocale,
     fallbackLocale = null,


### PR DESCRIPTION
## Description

It is a little strange to use `payload.findGlobal({ global: 'header' })` it would make more sense to use `payload.findGlobal({ slug: 'header' })` especially since you are using the `slug` key when creating a global config and not a `global` key.

- Updates find and update functions
- Updates documentation as well

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
