### PR TITLE
fix: moving nested arrays now properly persists row count

### DIFF
--- a/demo/collections/NestedArrays.ts
+++ b/demo/collections/NestedArrays.ts
@@ -57,7 +57,6 @@ const NestedArray: PayloadCollectionConfig = {
                   name: 'grandchildIdentifier',
                   label: 'Grandchild Identifier',
                   type: 'text',
-                  required: true,
                 },
               ],
             },

--- a/src/admin/components/forms/Form/buildStateFromSchema.ts
+++ b/src/admin/components/forms/Form/buildStateFromSchema.ts
@@ -25,6 +25,7 @@ const buildStateFromSchema = async (fieldSchema: FieldSchema[], fullData: Data =
         value,
         initialValue: value,
         valid: true,
+        validate: field.validate,
       };
 
       validationPromises.push(buildValidationPromise(fieldState, field));

--- a/src/admin/components/forms/Form/reduceFieldsToValues.ts
+++ b/src/admin/components/forms/Form/reduceFieldsToValues.ts
@@ -5,7 +5,7 @@ const reduceFieldsToValues = (fields: Fields, flatten?: boolean): Data => {
   const data = {};
 
   Object.keys(fields).forEach((key) => {
-    if (!fields[key].disableFormData && fields[key].value !== undefined) {
+    if (!fields[key].disableFormData) {
       if (fields[key].stringify) {
         data[key] = JSON.stringify(fields[key].value);
       } else {

--- a/src/admin/components/forms/field-types/Array/Array.tsx
+++ b/src/admin/components/forms/field-types/Array/Array.tsx
@@ -10,7 +10,6 @@ import buildStateFromSchema from '../../Form/buildStateFromSchema';
 import useFieldType from '../../useFieldType';
 import Error from '../../Error';
 import { array } from '../../../../../fields/validations';
-import getDataByPath from '../../Form/getDataByPath';
 import Banner from '../../../elements/Banner';
 import { Props, RenderArrayProps } from './types';
 
@@ -40,7 +39,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
   } = props;
 
   const [rows, dispatchRows] = useReducer(reducer, []);
-  const { initialState, dispatchFields } = useForm();
+  const { getDataByPath, dispatchFields } = useForm();
 
   const path = pathFromProps || name;
 
@@ -88,9 +87,9 @@ const ArrayFieldType: React.FC<Props> = (props) => {
   }, [moveRow]);
 
   useEffect(() => {
-    const data = getDataByPath(initialState, path);
+    const data = getDataByPath(path);
     dispatchRows({ type: 'SET_ALL', data: data || [] });
-  }, [initialState, path]);
+  }, [getDataByPath, path]);
 
   useEffect(() => {
     setValue(rows?.length || 0);

--- a/src/admin/components/forms/field-types/Blocks/Blocks.tsx
+++ b/src/admin/components/forms/field-types/Blocks/Blocks.tsx
@@ -14,7 +14,6 @@ import useFieldType from '../../useFieldType';
 import Popup from '../../../elements/Popup';
 import BlockSelector from './BlockSelector';
 import { blocks as blocksValidator } from '../../../../../fields/validations';
-import getDataByPath from '../../Form/getDataByPath';
 import Banner from '../../../elements/Banner';
 import { Props, RenderBlockProps } from './types';
 
@@ -48,7 +47,7 @@ const Blocks: React.FC<Props> = (props) => {
   const path = pathFromProps || name;
 
   const [rows, dispatchRows] = useReducer(reducer, []);
-  const { initialState, dispatchFields } = useForm();
+  const { getDataByPath, dispatchFields } = useForm();
 
   const memoizedValidate = useCallback((value) => {
     const validationResult = validate(
@@ -107,9 +106,9 @@ const Blocks: React.FC<Props> = (props) => {
   }, [moveRow]);
 
   useEffect(() => {
-    const data = getDataByPath(initialState, path);
+    const data = getDataByPath(path);
     dispatchRows({ type: 'SET_ALL', data: data || [] });
-  }, [initialState, path]);
+  }, [getDataByPath, path]);
 
   useEffect(() => {
     setValue(rows?.length || 0);

--- a/src/admin/components/forms/field-types/Text/index.tsx
+++ b/src/admin/components/forms/field-types/Text/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import useFieldType from '../../useFieldType';
 import withCondition from '../../withCondition';
 import Label from '../../Label';
@@ -21,20 +21,13 @@ const Text: React.FC<Props> = (props) => {
       style,
       width,
     } = {},
-    minLength,
-    maxLength,
   } = props;
 
   const path = pathFromProps || name;
 
-  const memoizedValidate = useCallback((value) => {
-    const validationResult = validate(value, { minLength, maxLength, required });
-    return validationResult;
-  }, [validate, maxLength, minLength, required]);
-
   const fieldType = useFieldType<string>({
     path,
-    validate: memoizedValidate,
+    validate,
     enableDebouncedValue: true,
   });
 

--- a/src/admin/components/forms/field-types/rowReducer.tsx
+++ b/src/admin/components/forms/field-types/rowReducer.tsx
@@ -54,6 +54,7 @@ const reducer = (currentState, action) => {
       const movingRowState = { ...stateCopy[moveFromIndex] };
       stateCopy.splice(moveFromIndex, 1);
       stateCopy.splice(moveToIndex, 0, movingRowState);
+
       return stateCopy;
     }
 

--- a/src/fields/config/sanitize.ts
+++ b/src/fields/config/sanitize.ts
@@ -20,8 +20,7 @@ const sanitizeFields = (fields, validRelationships) => {
 
     if (typeof field.validate === 'undefined') {
       const defaultValidate = validations[field.type];
-      const noValidate = () => true;
-      field.validate = defaultValidate || noValidate;
+      field.validate = (val) => defaultValidate(val, field);
     }
 
     if (!field.hooks) field.hooks = {};

--- a/src/fields/config/sanitize.ts
+++ b/src/fields/config/sanitize.ts
@@ -20,7 +20,11 @@ const sanitizeFields = (fields, validRelationships) => {
 
     if (typeof field.validate === 'undefined') {
       const defaultValidate = validations[field.type];
-      field.validate = (val) => defaultValidate(val, field);
+      if (defaultValidate) {
+        field.validate = (val) => defaultValidate(val, field);
+      } else {
+        field.validate = () => true;
+      }
     }
 
     if (!field.hooks) field.hooks = {};

--- a/src/fields/traverseFields.ts
+++ b/src/fields/traverseFields.ts
@@ -170,16 +170,20 @@ const traverseFields = (args: Arguments): void => {
         });
       } else if (fieldIsArrayType(field)) {
         if (Array.isArray(data[field.name])) {
-          (data[field.name] as Record<string, unknown>[]).forEach((rowData, i) => {
+          for (let i = 0; i < data[field.name].length; i += 1) {
+            if (typeof (data[field.name][i]) === 'undefined') {
+              data[field.name][i] = {};
+            }
+
             traverseFields({
               ...args,
               fields: field.fields,
-              data: rowData,
+              data: data[field.name][i] || {},
               originalDoc: originalDoc?.[field.name]?.[i],
               docWithLocales: docWithLocales?.[field.name]?.[i],
               path: `${path}${field.name}.${i}.`,
             });
-          });
+          }
         }
       } else {
         traverseFields({
@@ -202,7 +206,7 @@ const traverseFields = (args: Arguments): void => {
             traverseFields({
               ...args,
               fields: block.fields,
-              data: rowData,
+              data: rowData || {},
               originalDoc: originalDoc?.[field.name]?.[i],
               docWithLocales: docWithLocales?.[field.name]?.[i],
               path: `${path}${field.name}.${i}.`,


### PR DESCRIPTION
## Description

Closes #111 where moving nested arrays / blocks does not properly update row count within the nested arrays themselves.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
