### PR TITLE
feat: applies readOnly consistently within create and update ops

### DIFF
--- a/src/admin/components/forms/RenderFields/index.tsx
+++ b/src/admin/components/forms/RenderFields/index.tsx
@@ -75,8 +75,6 @@ const RenderFields: React.FC<Props> = (props) => {
 
                   if (readOnlyOverride) readOnly = true;
 
-                  if (operation === 'create') readOnly = false;
-
                   if (permissions?.[field?.name]?.read?.permission !== false) {
                     if (permissions?.[field?.name]?.[operation]?.permission === false) {
                       readOnly = true;


### PR DESCRIPTION
## Description

Closes #105. Before, `readOnly` only affected the `update` operations as it was assumed that fields should retain a way for data to be "set" in the admin panel—just not updated. But, it makes more sense to apply this property through both `create` and `update`. That is what this PR does.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Existing test suite passes locally with my changes
