### PR TITLE
feat: saves cursor position when relationship element is added to richText field

### DIFF
--- a/demo/client/components/richText/elements/Button/Button/index.tsx
+++ b/demo/client/components/richText/elements/Button/Button/index.tsx
@@ -1,8 +1,7 @@
 import React, { Fragment, useCallback } from 'react';
-import PropTypes from 'prop-types';
 import { Modal, useModal } from '@faceless-ui/modal';
 import { Transforms } from 'slate';
-import { useSlate } from 'slate-react';
+import { useSlate, ReactEditor } from 'slate-react';
 import MinimalTemplate from '../../../../../../../src/admin/components/templates/Minimal';
 import { ElementButton } from '../../../../../../../components/rich-text';
 import X from '../../../../../../../src/admin/components/icons/X';
@@ -17,7 +16,7 @@ const initialFormData = {
   style: 'primary',
 };
 
-const insertButton = (editor, { href, label, style, newTab = false }) => {
+const insertButton = (editor, { href, label, style, newTab = false }: any) => {
   const text = { text: ' ' };
   const button = {
     type: 'button',
@@ -32,10 +31,20 @@ const insertButton = (editor, { href, label, style, newTab = false }) => {
 
   const nodes = [button, { children: [{ text: '' }] }];
 
+  if (editor.blurSelection) {
+    Transforms.select(editor, editor.blurSelection);
+  }
+
   Transforms.insertNodes(editor, nodes);
+
+  const currentPath = editor.selection.anchor.path[0];
+  const newSelection = { anchor: { path: [currentPath + 1, 0], offset: 0 }, focus: { path: [currentPath + 1, 0], offset: 0 } };
+
+  Transforms.select(editor, newSelection);
+  ReactEditor.focus(editor);
 };
 
-const ToolbarButton: React.FC = ({ path }) => {
+const ToolbarButton: React.FC<{path: string}> = ({ path }) => {
   const { open, closeAll } = useModal();
   const editor = useSlate();
 
@@ -110,10 +119,6 @@ const ToolbarButton: React.FC = ({ path }) => {
       </Modal>
     </Fragment>
   );
-};
-
-ToolbarButton.propTypes = {
-  path: PropTypes.string.isRequired,
 };
 
 export default ToolbarButton;

--- a/src/admin/components/forms/field-types/RichText/RichText.tsx
+++ b/src/admin/components/forms/field-types/RichText/RichText.tsx
@@ -126,6 +126,10 @@ const RichText: React.FC<Props> = (props) => {
     return CreatedEditor;
   }, [elements, leaves]);
 
+  const onBlur = useCallback(() => {
+    editor.blurSelection = editor.selection;
+  }, [editor]);
+
   useEffect(() => {
     if (!loaded) {
       const mergedElements = mergeCustomFunctions(elements, elementTypes);
@@ -222,6 +226,7 @@ const RichText: React.FC<Props> = (props) => {
               placeholder={placeholder}
               spellCheck
               readOnly={readOnly}
+              onBlur={onBlur}
               onKeyDown={(event) => {
                 Object.keys(hotkeys).forEach((hotkey) => {
                   if (isHotkey(hotkey, event as any)) {

--- a/src/admin/components/forms/field-types/RichText/elements/relationship/Button/index.tsx
+++ b/src/admin/components/forms/field-types/RichText/elements/relationship/Button/index.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useCallback, useState } from 'react';
 import { Modal, useModal } from '@faceless-ui/modal';
 import { Transforms } from 'slate';
-import { useSlate } from 'slate-react';
+import { ReactEditor, useSlate } from 'slate-react';
 import { useConfig } from '@payloadcms/config-provider';
 import ElementButton from '../../Button';
 import RelationshipIcon from '../../../../../../icons/Relationship';
@@ -36,7 +36,17 @@ const insertRelationship = (editor, { value, relationTo, depth }) => {
 
   const nodes = [relationship, { children: [{ text: '' }] }];
 
+  if (editor.blurSelection) {
+    Transforms.select(editor, editor.blurSelection);
+  }
+
   Transforms.insertNodes(editor, nodes);
+
+  const currentPath = editor.selection.anchor.path[0];
+  const newSelection = { anchor: { path: [currentPath + 1, 0], offset: 0 }, focus: { path: [currentPath + 1, 0], offset: 0 } };
+
+  Transforms.select(editor, newSelection);
+  ReactEditor.focus(editor);
 };
 
 const RelationshipButton = ({ path }) => {


### PR DESCRIPTION
## Description

Right now, due to [a known issue with SlateJS](https://github.com/ianstormtaylor/slate/issues/3412), adding a `relationship` element to a `richText` field adds it to the end of the field data, because selection state is lost.

This PR extends the Slate editor in order to add a `blurSelection` property to the editor when the editor is blurred, so that the position may be restored easily after a new node is added to the field. 

Relevant discussion: #86 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
