### PR TITLE
Adding editableProps

### DIFF
--- a/demo/collections/RichText.ts
+++ b/demo/collections/RichText.ts
@@ -32,6 +32,20 @@ const RichText: PayloadCollectionConfig = {
         ],
       },
     },
+    {
+      name: 'editablePropsRichText',
+      type: 'richText',
+      label: 'Rich Text with Editable props',
+      required: true,
+      admin: {
+        editableProps: {
+          onClick: (e) => console.log('Clicked RichText', e),
+          style: {
+            color: 'rebeccapurple',
+          },
+        },
+      }
+    },
   ],
 };
 

--- a/docs/fields/rich-text.mdx
+++ b/docs/fields/rich-text.mdx
@@ -42,6 +42,10 @@ In addition to the default [field admin config](/docs/fields/overview#admin-conf
 
 Set this property to define a placeholder string in the text input.
 
+**`editableProps`**
+
+Set this property to define props to be passed down to the `Editable` instance.
+
 **`elements`**
 
 The `elements` property is used to specify which built-in or custom [SlateJS elements](https://docs.slatejs.org/concepts/02-nodes#element) should be made available to the field within the admin panel.

--- a/src/admin/components/forms/field-types/RichText/RichText.tsx
+++ b/src/admin/components/forms/field-types/RichText/RichText.tsx
@@ -44,8 +44,10 @@ const RichText: React.FC<Props> = (props) => {
     } = {},
   } = props;
 
+
   const elements: RichTextElement[] = admin?.elements || defaultElements;
   const leaves: RichTextLeaf[] = admin?.leaves || defaultLeaves;
+  const editableProps: object = admin?.editableProps || {};
 
   const path = pathFromProps || name;
 
@@ -236,6 +238,7 @@ const RichText: React.FC<Props> = (props) => {
                   }
                 });
               }}
+              {...editableProps}
             />
           </div>
         </Slate>

--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -221,6 +221,7 @@ export const richText = baseField.keys({
         }),
       ),
     ),
+    editableProps: joi.object(),
   }),
 });
 

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -186,6 +186,7 @@ export type RichTextField = FieldBase & {
     placeholder?: string
     elements?: RichTextElement[];
     leaves?: RichTextLeaf[];
+    editableProps?: object;
   }
 }
 


### PR DESCRIPTION
## Description

Allowing the ability to send down props to SlateJS' `Editable` component through editableProps

- [*] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [*] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [*] I have made corresponding changes to the documentation
