### PR TITLE
fix: handle add/remove labels for all usage of Array field type

### DIFF
--- a/src/admin/components/forms/field-types/Array/Array.tsx
+++ b/src/admin/components/forms/field-types/Array/Array.tsx
@@ -19,7 +19,6 @@ const baseClass = 'field-type array';
 
 const ArrayFieldType: React.FC<Props> = (props) => {
   const {
-    label,
     name,
     path: pathFromProps,
     fields,
@@ -28,15 +27,22 @@ const ArrayFieldType: React.FC<Props> = (props) => {
     required,
     maxRows,
     minRows,
-    labels = {
-      singular: 'Row',
-      plural: 'Rows',
-    },
     permissions,
     admin: {
       readOnly,
     },
   } = props;
+
+  // Handle labeling for Arrays, Global Arrays, and Blocks
+  const getLabels = (p: Props) => {
+    if (p?.labels) return p.labels;
+    if (p?.label) return { singular: p.label, plural: undefined };
+    return { singular: 'Row', plural: 'Rows' };
+  };
+
+  const labels = getLabels(props);
+  // eslint-disable-next-line react/destructuring-assignment
+  const label = props?.label ?? props?.labels?.singular;
 
   const [rows, dispatchRows] = useReducer(reducer, []);
   const formContext = useForm();


### PR DESCRIPTION
## Description

Handles all usages of the Array field type. There were issues with these labels defaulting to 'Row' or 'Rows depending on the usage.

Partially demonstrated here: https://youtu.be/bxWsZTtqs80?t=5702

![image](https://user-images.githubusercontent.com/65888/114196867-c6022f80-991f-11eb-87ec-f64ad635fabb.png)

Scenarios Checked:

- [x] Collection Array
- [x] Collection Block
- [x] Global Array
- [x] Global Block