### PR TITLE
docs: fix typo in field types overview

### DIFF
--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -38,7 +38,7 @@ const Pages = {
 - [Array](/docs/fields/array) - for repeating content, supports nested fields
 - [Blocks](/docs/fields/blocks) - block-based fields, allowing powerful layout creation
 - [Checkbox](/docs/fields/checkbox) - boolean true / false checkbox
-- [Code](/docs/fields/code) - xode editor that saves a string to the database
+- [Code](/docs/fields/code) - code editor that saves a string to the database
 - [Date](/docs/fields/date) - date / time field that saves a timestamp
 - [Email](/docs/fields/email) - validates the entry is a properly formatted email
 - [Group](/docs/fields/group) - nest fields within an object


### PR DESCRIPTION
Fix typo in field types overview page.
