### PR TITLE
fix: make admin field properties in joi schema match TS types

### DIFF
--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -53,6 +53,10 @@ export const text = baseField.keys({
   defaultValue: joi.string(),
   minLength: joi.number(),
   maxLength: joi.number(),
+  admin: baseAdminFields.keys({
+    placeholder: joi.string(),
+    autoComplete: joi.string(),
+  }),
 });
 
 export const number = baseField.keys({
@@ -62,6 +66,8 @@ export const number = baseField.keys({
   min: joi.number(),
   max: joi.number(),
   admin: baseAdminFields.keys({
+    placeholder: joi.string(),
+    autoComplete: joi.string(),
     step: joi.number(),
   }),
 });
@@ -72,6 +78,10 @@ export const textarea = baseField.keys({
   defaultValue: joi.string(),
   minLength: joi.number(),
   maxLength: joi.number(),
+  admin: baseAdminFields.keys({
+    placeholder: joi.string(),
+    rows: joi.number(),
+  }),
 });
 
 export const email = baseField.keys({
@@ -80,6 +90,10 @@ export const email = baseField.keys({
   defaultValue: joi.string(),
   minLength: joi.number(),
   maxLength: joi.number(),
+  admin: baseAdminFields.keys({
+    placeholder: joi.string(),
+    autoComplete: joi.string(),
+  }),
 });
 
 export const code = baseField.keys({
@@ -201,6 +215,7 @@ export const richText = baseField.keys({
   name: joi.string().required(),
   defaultValue: joi.array().items(joi.object()),
   admin: baseAdminFields.keys({
+    placeholder: joi.string(),
     elements: joi.array().items(
       joi.alternatives().try(
         joi.string(),
@@ -231,6 +246,7 @@ export const date = baseField.keys({
   name: joi.string().required(),
   defaultValue: joi.string(),
   admin: baseAdminFields.keys({
+    placeholder: joi.string(),
     date: joi.object({
       displayFormat: joi.string(),
       pickerAppearance: joi.string(),


### PR DESCRIPTION
A few fields in the TS types were missing from the joi schema
