### PR TITLE
fix: update operation can save password changes

### DIFF
--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -238,6 +238,7 @@ async function update(incomingArgs: Arguments): Promise<Document> {
 
   if (password) {
     await doc.setPassword(password as string);
+    await doc.save();
     delete data.password;
     delete result.password;
   }


### PR DESCRIPTION
## Description

It was not possible to save a password change through the update operation.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
