### PR TITLE
Add ability to hide gutter for RichText fields

### DIFF
--- a/docs/fields/rich-text.mdx
+++ b/docs/fields/rich-text.mdx
@@ -63,6 +63,10 @@ The default `elements` available in Payload are:
 
 The `leaves` property specifies built-in or custom [SlateJS leaves](https://docs.slatejs.org/concepts/08-rendering#leaves) to be enabled within the Admin panel.
 
+**`hideGutter`**
+
+Set this property to hide the gutter.
+
 The default `leaves` available in Payload are:
 
 - `bold`

--- a/src/admin/components/forms/field-types/RichText/RichText.tsx
+++ b/src/admin/components/forms/field-types/RichText/RichText.tsx
@@ -42,6 +42,7 @@ const RichText: React.FC<Props> = (props) => {
       width,
       placeholder,
       condition,
+      hideGutter,
     } = {},
   } = props;
 
@@ -164,7 +165,6 @@ const RichText: React.FC<Props> = (props) => {
     }
   }
   if (!valueToRender) valueToRender = defaultValue;
-
   return (
     <div
       className={classes}
@@ -173,7 +173,7 @@ const RichText: React.FC<Props> = (props) => {
         width,
       }}
     >
-      <FieldTypeGutter />
+      { !hideGutter && (<FieldTypeGutter />) }
       <div className={`${baseClass}__wrap`}>
         <Error
           showError={showError}

--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -238,6 +238,7 @@ export const richText = baseField.keys({
         }),
       ),
     ),
+    hideGutter: joi.boolean().default(false),
   }),
 });
 

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -188,6 +188,7 @@ export type RichTextField = FieldBase & {
     placeholder?: string
     elements?: RichTextElement[];
     leaves?: RichTextLeaf[];
+    hideGutter?: boolean;
   }
 }
 


### PR DESCRIPTION
## Description

Add ability to hide gutter on RichText fields. Especially useful when it's used inside a Blocks field.

- [*] I have read and understand the CONTRIBUTING.md document in this repository

- [*] New feature (non-breaking change which adds functionality)
- [*] This change requires a documentation update

## Checklist:

- [*] Existing test suite passes locally with my changes
- [*] I have made corresponding changes to the documentation
