### PR TITLE
fix: changes scss imports to allow vars imports to payload projects

### DIFF
--- a/scss/vars.scss
+++ b/scss/vars.scss
@@ -1,1 +1,13 @@
 @import '../dist/admin/scss/vars';
+@import '../dist/admin/scss/z-index';
+
+//////////////////////////////
+// IMPORT OVERRIDES
+//////////////////////////////
+
+@import '~payload-scss-overrides';
+
+@import '../dist/admin/scss/type';
+@import '../dist/admin/scss/queries';
+@import '../dist/admin/scss/resets';
+@import '../dist/admin/scss/svg';


### PR DESCRIPTION
## Description

There was an error when trying to import vars from Payload in to a Payload project.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
