### PR TITLE
Feature/config validation collection field naming

### DIFF
--- a/src/collections/config/schema.ts
+++ b/src/collections/config/schema.ts
@@ -1,5 +1,4 @@
 import joi from 'joi';
-import fieldSchema from '../../fields/config/schema';
 
 const component = joi.alternatives().try(
   joi.object().unknown(),
@@ -34,8 +33,7 @@ const collectionSchema = joi.object().keys({
     preview: joi.func(),
     disableDuplicate: joi.bool(),
   }),
-  fields: joi.array()
-    .items(fieldSchema),
+  fields: joi.array(),
   hooks: joi.object({
     beforeOperation: joi.array().items(joi.func()),
     beforeValidate: joi.array().items(joi.func()),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,4 @@
 import joi from 'joi';
-import globalSchema from '../globals/config/schema';
 
 const component = joi.alternatives().try(
   joi.object().unknown(),
@@ -31,8 +30,7 @@ export default joi.object({
     graphQLPlayground: joi.string(),
   }),
   collections: joi.array(),
-  globals: joi.array()
-    .items(globalSchema),
+  globals: joi.array(),
   admin: joi.object({
     user: joi.string(),
     meta: joi.object()

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,4 @@
 import joi from 'joi';
-import collectionSchema from '../collections/config/schema';
 import globalSchema from '../globals/config/schema';
 
 const component = joi.alternatives().try(
@@ -31,8 +30,7 @@ export default joi.object({
     graphQL: joi.string(),
     graphQLPlayground: joi.string(),
   }),
-  collections: joi.array()
-    .items(collectionSchema),
+  collections: joi.array(),
   globals: joi.array()
     .items(globalSchema),
   admin: joi.object({

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -1,23 +1,53 @@
 import schema from './schema';
+import collectionSchema from '../collections/config/schema';
 import Logger from '../utilities/logger';
 import { PayloadConfig, Config } from './types';
+import { PayloadCollectionConfig } from '../collections/config/types';
 
 const logger = Logger();
+
+const validateCollection = (collections: PayloadCollectionConfig[]): string[] => {
+  const collectionResults = {};
+  collections.forEach((collection) => {
+    collectionResults[collection.slug] = collectionSchema.validate(collection, { abortEarly: false });
+  });
+
+  const collectionErrors: string[] = [];
+  Object.keys(collectionResults).forEach((slug) => {
+    if (collectionResults[slug].error) {
+      collectionResults[slug].error.details.forEach(({ message }) => {
+        collectionErrors.push(`Collection "${slug}" > ${message}`);
+      });
+    }
+  });
+  return collectionErrors;
+};
 
 const validateSchema = (config: PayloadConfig): Config => {
   const result = schema.validate(config, {
     abortEarly: false,
   });
 
-  if (result.error) {
-    logger.error(`There were ${result.error.details.length} errors validating your Payload config`);
+  const collectionErrors = validateCollection(config.collections);
 
-    result.error.details.forEach(({ message }, i) => {
-      logger.error(`${i + 1}: ${message}`);
+  if (result.error || collectionErrors.length > 0) {
+    logger.error(`There were ${(result.error?.details?.length || 0) + collectionErrors.length} errors validating your Payload config`);
+
+    let i = 0;
+    if (result.error) {
+      result.error.details.forEach(({ message }) => {
+        i += 1;
+        logger.error(`${i}: ${message}`);
+      });
+    }
+    collectionErrors.forEach((message) => {
+      i += 1;
+      logger.error(`${i}: ${message}`);
     });
 
     process.exit(1);
   }
+
 
   return result.value as Config;
 };

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -3,24 +3,53 @@ import collectionSchema from '../collections/config/schema';
 import Logger from '../utilities/logger';
 import { PayloadConfig, Config } from './types';
 import { PayloadCollectionConfig } from '../collections/config/types';
+import fieldSchema from '../fields/config/schema';
+import { PayloadGlobalConfig } from '../globals/config/types';
+import globalSchema from '../globals/config/schema';
 
 const logger = Logger();
 
-const validateCollection = (collections: PayloadCollectionConfig[]): string[] => {
-  const collectionResults = {};
-  collections.forEach((collection) => {
-    collectionResults[collection.slug] = collectionSchema.validate(collection, { abortEarly: false });
-  });
-
-  const collectionErrors: string[] = [];
-  Object.keys(collectionResults).forEach((slug) => {
-    if (collectionResults[slug].error) {
-      collectionResults[slug].error.details.forEach(({ message }) => {
-        collectionErrors.push(`Collection "${slug}" > ${message}`);
+const validateFields = (context: string, collection: PayloadCollectionConfig): string[] => {
+  const errors: string[] = [];
+  collection.fields.forEach((field) => {
+    const result = fieldSchema.validate(field, { abortEarly: false });
+    if (result.error) {
+      result.error.details.forEach(({ message }) => {
+        errors.push(`${context} "${collection.slug}" > Field "${field.name}" > ${message}`);
       });
     }
   });
-  return collectionErrors;
+  return errors;
+};
+
+const validateCollections = (collections: PayloadCollectionConfig[]): string[] => {
+  const errors: string[] = [];
+  collections.forEach((collection) => {
+    const result = collectionSchema.validate(collection, { abortEarly: false });
+    if (result.error) {
+      result.error.details.forEach(({ message }) => {
+        errors.push(`Collection "${collection.slug}" > ${message}`);
+      });
+    }
+    errors.push(...validateFields('Collection', collection));
+  });
+
+  return errors;
+};
+
+const validateGlobals = (globals: PayloadGlobalConfig[]): string[] => {
+  const errors: string[] = [];
+  globals.forEach((global) => {
+    const result = globalSchema.validate(global, { abortEarly: false });
+    if (result.error) {
+      result.error.details.forEach(({ message }) => {
+        errors.push(`Globals "${global.slug}" > ${message}`);
+      });
+    }
+    errors.push(...validateFields('Global', global));
+  });
+
+  return errors;
 };
 
 const validateSchema = (config: PayloadConfig): Config => {
@@ -28,10 +57,13 @@ const validateSchema = (config: PayloadConfig): Config => {
     abortEarly: false,
   });
 
-  const collectionErrors = validateCollection(config.collections);
+  const nestedErrors = [
+    ...validateCollections(config.collections),
+    ...validateGlobals(config.globals),
+  ];
 
-  if (result.error || collectionErrors.length > 0) {
-    logger.error(`There were ${(result.error?.details?.length || 0) + collectionErrors.length} errors validating your Payload config`);
+  if (result.error || nestedErrors.length > 0) {
+    logger.error(`There were ${(result.error?.details?.length || 0) + nestedErrors.length} errors validating your Payload config`);
 
     let i = 0;
     if (result.error) {
@@ -40,7 +72,7 @@ const validateSchema = (config: PayloadConfig): Config => {
         logger.error(`${i}: ${message}`);
       });
     }
-    collectionErrors.forEach((message) => {
+    nestedErrors.forEach((message) => {
       i += 1;
       logger.error(`${i}: ${message}`);
     });

--- a/src/globals/config/schema.ts
+++ b/src/globals/config/schema.ts
@@ -1,7 +1,6 @@
 import joi from 'joi';
-import fieldSchema from '../../fields/config/schema';
 
-const schema = joi.object().keys({
+const globalSchema = joi.object().keys({
   slug: joi.string().required(),
   label: joi.string(),
   hooks: joi.object({
@@ -15,7 +14,7 @@ const schema = joi.object().keys({
     read: joi.func(),
     update: joi.func(),
   }),
-  fields: joi.array().items(fieldSchema),
+  fields: joi.array(),
 }).unknown();
 
-export default schema;
+export default globalSchema;


### PR DESCRIPTION
## Description

The config schema validation errors were not user friendly "collections[1].fields[1] does not match any of the allowed types". This PR breaks up the schema checking to provide Collection and global slug and field name in the error message.

![image](https://user-images.githubusercontent.com/6434612/126554003-91cc27e2-b076-4be1-8fd3-94b0eadfdafa.png)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes

