### PR TITLE
feat: export error types

### DIFF
--- a/errors.d.ts
+++ b/errors.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/errors/types';

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -1,0 +1,1 @@
+export * from '.';


### PR DESCRIPTION
## Description

Exposes error types ie. `import { APIError } from 'payload/errors'`. This previously would not compile in strict mode.

Addresses #251 