### PR TITLE
feat: exposes auto-sized uploads on payload req

### DIFF
--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -113,6 +113,12 @@ The Payload Admin panel will also automatically display all available files, inc
 
 Behind the scenes, Payload relies on [`sharp`](https://sharp.pixelplumbing.com/api-resize#resize) to perform its image resizing. You can specify additional options for `sharp` to use while resizing your images.
 
+##### Accessing the resized images in hooks
+
+All auto-resized images are exposed to be re-used in hooks and similar via an object that is bound to `req.payloadUploadSizes`.
+
+The object will have keys for each size generated, and each key will be set equal to a buffer containing the file data.
+
 ### Admin thumbnails
 
 You can specify how Payload retrieves admin thumbnails for your upload-enabled Collections. This property accepts two different configurations:

--- a/src/collections/operations/create.ts
+++ b/src/collections/operations/create.ts
@@ -104,7 +104,8 @@ async function create(this: Payload, incomingArgs: Arguments): Promise<Document>
         fileData.height = dimensions.height;
 
         if (Array.isArray(imageSizes) && file.mimetype !== 'image/svg+xml') {
-          fileData.sizes = await resizeAndSave(staticPath, collectionConfig, fsSafeName, fileData.mimeType);
+          req.payloadUploadSizes = {};
+          fileData.sizes = await resizeAndSave(req, staticPath, collectionConfig, fsSafeName, fileData.mimeType);
         }
       }
     } catch (err) {

--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -150,7 +150,7 @@ async function update(incomingArgs: Arguments): Promise<Document> {
           fileData.height = dimensions.height;
 
           if (Array.isArray(imageSizes) && file.mimetype !== 'image/svg+xml') {
-            fileData.sizes = await resizeAndSave(staticPath, collectionConfig, fsSafeName, fileData.mimeType);
+            fileData.sizes = await resizeAndSave(req, staticPath, collectionConfig, fsSafeName, fileData.mimeType);
           }
         }
       } catch (err) {

--- a/src/express/types.ts
+++ b/src/express/types.ts
@@ -13,6 +13,7 @@ export type PayloadRequest = Request & {
   payloadAPI: 'REST' | 'local' | 'graphQL'
   file?: UploadedFile
   user: User | null
+  payloadUploadSizes?: Record<string, Buffer>
   findByID?: {
     [slug: string]: (q: unknown) => Document
   }


### PR DESCRIPTION
## Description

Exposes all auto-sized uploads on the Payload `req` under a new key `payloadUploadSizes`. 

This makes it possible for hooks to access the resized file buffers in a performant manner.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
