### PR TITLE
feat: allows upload resizing to maintain aspect ratio

### DIFF
--- a/demo/collections/Media.ts
+++ b/demo/collections/Media.ts
@@ -19,6 +19,12 @@ const Media: PayloadCollectionConfig = {
     adminThumbnail: ({ doc }) => `/media/${doc.filename}`,
     imageSizes: [
       {
+        name: 'maintainedAspectRatio',
+        width: 1024,
+        height: null,
+        crop: 'center',
+      },
+      {
         name: 'tablet',
         width: 640,
         height: 480,

--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -66,6 +66,16 @@ const Media = {
         width: 768,
         height: 1024,
         crop: 'centre',
+      },
+      {
+        name: 'tablet',
+        width: 1024,
+        // By specifying `null` or leaving a height undefined,
+        // the image will be sized to a certain width,
+        // but it will retain its original aspect ratio
+        // and calculate a height automatically.
+        height: null,
+        crop: 'centre',
       }
     ],
     adminThumbnail: 'thumbnail',

--- a/src/collections/config/schema.ts
+++ b/src/collections/config/schema.ts
@@ -84,8 +84,8 @@ const collectionSchema = joi.object().keys({
       imageSizes: joi.array().items(
         joi.object().keys({
           name: joi.string(),
-          width: joi.number(),
-          height: joi.number(),
+          width: joi.number().allow(null),
+          height: joi.number().allow(null),
           crop: joi.string(), // TODO: add further specificity with joi.xor
         }),
       ),


### PR DESCRIPTION
## Description

Allows upload size definitions to accept `null` or `undefined` for a `width` or `height`, which effectively allows resizing to maintain original aspect ratios by only specifying either a `width` or a `height`, but not both.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
