### PR TITLE
fix: config validation correctly prevents empty strings for option vals

### DIFF
--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -111,7 +111,7 @@ export const select = baseField.keys({
   options: joi.array().items(joi.alternatives().try(
     joi.string(),
     joi.object({
-      value: joi.string().allow('').required(),
+      value: joi.string().required(),
       label: joi.string().required(),
     }),
   )).required(),
@@ -128,7 +128,7 @@ export const radio = baseField.keys({
   options: joi.array().items(joi.alternatives().try(
     joi.string(),
     joi.object({
-      value: joi.string().allow('').required(),
+      value: joi.string().required(),
       label: joi.string().required(),
     }),
   )).required(),


### PR DESCRIPTION
## Description

Using an empty string for an option value caused errors in the UI and is not assignable in GraphQL. Config validation no longer allows empty strings in option values.
https://github.com/payloadcms/payload/discussions/310

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
