### PR TITLE
fix: updates field description type to include react nodes

### DIFF
--- a/src/admin/components/forms/FieldDescription/types.ts
+++ b/src/admin/components/forms/FieldDescription/types.ts
@@ -2,9 +2,9 @@ import React from 'react';
 
 export type DescriptionFunction = (value: unknown) => string
 
-export type DescriptionComponent = React.ComponentType<{value: unknown}>
+export type DescriptionComponent = React.ComponentType<{ value: unknown }>
 
-type Description = string | DescriptionFunction | DescriptionComponent
+export type Description = string | DescriptionFunction | DescriptionComponent
 
 export type Props = {
   description?: Description

--- a/src/admin/components/forms/field-types/Array/types.ts
+++ b/src/admin/components/forms/field-types/Array/types.ts
@@ -1,7 +1,8 @@
 import { Data } from '../../Form/types';
-import { ArrayField, Labels, Field, Description } from '../../../../../fields/config/types';
+import { ArrayField, Labels, Field } from '../../../../../fields/config/types';
 import { FieldTypes } from '..';
 import { FieldPermissions } from '../../../../../auth/types';
+import { Description } from '../../FieldDescription/types';
 
 export type Props = Omit<ArrayField, 'type'> & {
   path?: string

--- a/src/admin/components/forms/field-types/Blocks/types.ts
+++ b/src/admin/components/forms/field-types/Blocks/types.ts
@@ -1,7 +1,8 @@
 import { Data } from '../../Form/types';
-import { BlockField, Labels, Block, Description } from '../../../../../fields/config/types';
+import { BlockField, Labels, Block } from '../../../../../fields/config/types';
 import { FieldTypes } from '..';
 import { FieldPermissions } from '../../../../../auth/types';
+import { Description } from '../../FieldDescription/types';
 
 export type Props = Omit<BlockField, 'type'> & {
   path?: string

--- a/src/admin/components/forms/field-types/Password/types.ts
+++ b/src/admin/components/forms/field-types/Password/types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Description, Validate } from '../../../../../fields/config/types';
+import { Validate } from '../../../../../fields/config/types';
+import { Description } from '../../FieldDescription/types';
 
 export type Props = {
   autoComplete?: string

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -4,6 +4,7 @@ import { Editor } from 'slate';
 import { PayloadRequest } from '../../express/types';
 import { Document } from '../../types';
 import { ConditionalDateProps } from '../../admin/components/elements/DatePicker/types';
+import { Description } from '../../admin/components/forms/FieldDescription/types';
 
 export type FieldHook = (args: {
   value?: unknown,
@@ -39,8 +40,6 @@ type Admin = {
   }
   hidden?: boolean
 }
-
-export type Description = string | ((value: Record<string, unknown>) => string);
 
 export type Labels = {
   singular: string;
@@ -302,22 +301,22 @@ export type FieldAffectingData =
   | PointField
 
 export type NonPresentationalField = TextField
-| NumberField
-| EmailField
-| TextareaField
-| CheckboxField
-| DateField
-| BlockField
-| GroupField
-| RadioField
-| RelationshipField
-| ArrayField
-| RichTextField
-| SelectField
-| UploadField
-| CodeField
-| PointField
-| RowField;
+  | NumberField
+  | EmailField
+  | TextareaField
+  | CheckboxField
+  | DateField
+  | BlockField
+  | GroupField
+  | RadioField
+  | RelationshipField
+  | ArrayField
+  | RichTextField
+  | SelectField
+  | UploadField
+  | CodeField
+  | PointField
+  | RowField;
 
 export type FieldWithPath = Field & {
   path?: string


### PR DESCRIPTION
## Description

`src/fields/config/types.ts` was declaring its own `Description` type which lacked support for react nodes. A correct version was already declared in `src/admin/components/forms/FieldDescription/types.ts`, so I've updated all description fields to reference this type instead.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
