### PR TITLE
fix: Include 'WebP' as image type for admin dashboard thumbnail component

### DIFF
--- a/src/uploads/isImage.ts
+++ b/src/uploads/isImage.ts
@@ -1,3 +1,3 @@
 export default function isImage(mimeType: string): boolean {
-  return ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'].indexOf(mimeType) > -1;
+  return ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml', 'image/webp'].indexOf(mimeType) > -1;
 }


### PR DESCRIPTION
Adding webp support for thumbnails in the admin Thumbnail component.

## Description

WebP is now at 95.77% according to [caniuse.com](https://caniuse.com/webp), so its reasonable to have webp support for thumbnails in the admin dashboard. This PR includes 'image/webp' in the isImage utility which is called by useThumbnail to check whether the admin panel should use the image thumbnail or a file icon for the media item.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
