### PR TITLE
Feat/default server url

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -42,7 +42,6 @@ import { buildConfig } from 'payload/config';
 import { MyCustomNav, MyCustomLogo, MyCustomIcon, MyCustomAccount, MyCustomDashboard } from './customComponents.js';
 
 export default buildConfig({
-  serverURL: 'http://localhost:3000',
   admin: {
     components: {
       Nav: MyCustomNav,

--- a/docs/admin/customizing-css.mdx
+++ b/docs/admin/customizing-css.mdx
@@ -18,7 +18,6 @@ import { buildConfig } from 'payload/config';
 import path from 'path';
 
 const config = buildConfig({
-	serverURL: 'http://localhost:3000',
 	admin: {
 		css: path.resolve(__dirname, 'relative/path/to/stylesheet.scss'),
 	},
@@ -42,7 +41,6 @@ import { buildConfig } from 'payload/config';
 import path from 'path';
 
 const config = buildConfig({
-	serverURL: 'http://localhost:3000',
 	admin: {
 		scss: path.resolve(__dirname, 'relative/path/to/vars.scss'),
 	},

--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -49,7 +49,6 @@ To specify which Collection to use to log in to the Admin panel, pass the `admin
 import { buildConfig } from 'payload/config';
 
 const config = buildConfig({
-  serverURL: 'http://localhost:3000',
   admin: {
     user: 'admins', // highlight-line
   },

--- a/docs/admin/webpack.mdx
+++ b/docs/admin/webpack.mdx
@@ -15,7 +15,6 @@ To extend the Webpack config, add the `webpack` key to your base Payload config,
 import { buildConfig } from 'payload/config';
 
 export default buildConfig({
-	serverURL: 'http://localhost:3000',
 	admin: {
 		// highlight-start
 		webpack: (config) => {
@@ -128,7 +127,6 @@ const createStripeSubscriptionPath = path.resolve(__dirname, 'collections/Subscr
 const mockModulePath = path.resolve(__dirname, 'mocks/emptyObject.js');
 
 export default buildConfig({
-	serverURL: 'http://localhost:3000',
 	collections: [
 		Subscription
 	],

--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -129,7 +129,6 @@ To define domains that should allow users to identify themselves via the Payload
 import { buildConfig } from 'payload/config';
 
 const config = buildConfig({
-  serverURL: 'http://localhost:3000',
   collections: [
     // collections here
   ],

--- a/docs/configuration/express.mdx
+++ b/docs/configuration/express.mdx
@@ -16,7 +16,6 @@ Payload utilizes a few Express-specific middleware packages within its own route
 
 ```js
 {
-	serverURL: 'http://localhost:3000',
 	express: {
 		json: {
 			limit: '4mb',
@@ -37,7 +36,6 @@ To customize compression options, pass an object to the Payload config's `expres
 
 ```js
 {
-	serverURL: 'http://localhost:3000',
 	express: {
 		compression: {
 			// settings go here

--- a/docs/configuration/localization.mdx
+++ b/docs/configuration/localization.mdx
@@ -16,7 +16,6 @@ Add the `localization` property to your Payload config to enable localization pr
 
 ```js
 {
-	serverURL: 'http://localhost:3000',
 	collections: [
 		... // collections go here
 	],

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -18,7 +18,7 @@ Payload is a *config-based*, code-first CMS and application framework. The Paylo
 
 | Option               | Description  |
 | -------------------- | -------------|
-| `serverURL`          | A _required_ string used to define the absolute URL of your app including the protocol, for example `https://'example.com`. No paths allowed, only protocol, domain and (optionally) port |
+| `serverURL`          | A string used to define the absolute URL of your app including the protocol, for example `https://'example.com`. No paths allowed, only protocol, domain and (optionally) port |
 | `collections`        | An array of all Collections that Payload will manage. To read more about how to define your collection configs, [click here](/docs/configuration/collections). |
 | `globals`            | An array of all Globals that Payload will manage. For more on Globals and their configs, [click here](/docs/configuration/globals). |
 | `admin`              | Base Payload admin configuration. Specify custom components, control metadata, set the Admin user collection, and [more](/docs/admin/overview#admin-options). |
@@ -45,7 +45,6 @@ Payload is a *config-based*, code-first CMS and application framework. The Paylo
 import { buildConfig } from 'payload/config';
 
 const config = buildConfig({
-	serverURL: 'http://localhost:3000',
 	collections: [
 		{
 			slug: 'pages',

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -38,9 +38,6 @@ From there, the first step is writing a baseline config. Create a new `payload.c
 import { buildConfig } from 'payload/config';
 
 export default buildConfig({
-  serverURL: 'http://localhost:3000',
-  // Only serverURL is required
-
   // By default, Payload will boot up normally
   // and you will be provided with a base `User` collection.
   // But, here is where you define how you'd like Payload to work!

--- a/docs/graphql/extending.mdx
+++ b/docs/graphql/extending.mdx
@@ -38,7 +38,6 @@ import { buildConfig } from 'payload/config';
 import myCustomQueryResolver from './graphQL/resolvers/myCustomQueryResolver';
 
 export default buildConfig({
-  serverURL: 'http://localhost:3000',
   graphQL: {
     // highlight-start
     queries: (GraphQL, payload) => {

--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -37,7 +37,6 @@ import addLastModified from 'payload-add-last-modified';
 import passwordProtect from 'payload-password-protect';
 
 const config = buildConfig({
-	serverURL: 'http://localhost:3000',
 	collections: [
 		{
 			slug: 'pages',

--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -96,7 +96,6 @@ A common example of what you might want to customize within Payload-wide Upload 
 import { buildConfig } from 'payload/config';
 
 export default buildConfig({
-  serverURL: 'http://localhost:3000',
   collections: [
     {
       slug: 'media',

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 export const defaults = {
+  serverURL: '',
   defaultDepth: 2,
   maxDepth: 10,
   collections: [],

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -8,7 +8,6 @@ const component = joi.alternatives().try(
 export default joi.object({
   serverURL: joi.string()
     .uri()
-    .required()
     .custom((value, helper) => {
       const urlWithoutProtocol = value.split('//')[1];
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -126,7 +126,7 @@ export type Config = {
   };
   collections?: CollectionConfig[];
   globals?: GlobalConfig[];
-  serverURL: string;
+  serverURL?: string;
   cookiePrefix?: string;
   csrf?: string[];
   cors?: string[] | '*';


### PR DESCRIPTION
## Description

It has been pointed out that in more dynamic deployment configurations, the serverURL can be difficult to provide. We have made it no longer required and the default serverURL is an `''` which effectively makes everything run from a relative path to the node instance.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
