### PR TITLE
fix: further sanitize serverURL to prevent undefined in admin routes

### DIFF
--- a/src/config/sanitize.ts
+++ b/src/config/sanitize.ts
@@ -25,6 +25,10 @@ const sanitizeConfig = (config: Config): SanitizedConfig => {
     sanitizedConfig.globals = sanitizeGlobals(sanitizedConfig.collections, sanitizedConfig.globals);
   }
 
+  if (typeof sanitizedConfig.serverURL === 'undefined') {
+    sanitizedConfig.serverURL = '';
+  }
+
   if (sanitizedConfig.serverURL !== '') {
     sanitizedConfig.csrf.push(sanitizedConfig.serverURL);
   }


### PR DESCRIPTION
## Description

Small change to further sanitize the serverURL in the config preventing `undefined` from being added to admin api paths.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
