### PR TITLE
Feat/custom provider wrapper

### DIFF
--- a/demo/client/components/CustomProvider/index.tsx
+++ b/demo/client/components/CustomProvider/index.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useState, useContext } from 'react';
+
+type CustomContext = {
+  getCustom
+  setCustom
+}
+
+const Context = createContext({} as CustomContext);
+
+const CustomProvider: React.FC = ({ children }) => {
+  const [getCustom, setCustom] = useState({});
+
+  const value = {
+    getCustom,
+    setCustom,
+  };
+
+  console.log('custom provider called');
+
+  return (
+    <Context.Provider value={value}>
+      {children}
+    </Context.Provider>
+  );
+};
+
+export default CustomProvider;
+
+export const useCustom = () => useContext(Context);

--- a/demo/payload.config.ts
+++ b/demo/payload.config.ts
@@ -40,6 +40,7 @@ import CustomRouteWithDefaultTemplate from './client/components/views/CustomDefa
 import AfterDashboard from './client/components/AfterDashboard';
 import AfterNavLinks from './client/components/AfterNavLinks';
 import BeforeLogin from './client/components/BeforeLogin';
+// import CustomProvider from './client/components/CustomProvider';
 
 export default buildConfig({
   cookiePrefix: 'payload',
@@ -58,6 +59,7 @@ export default buildConfig({
     // disable: true,
     scss: path.resolve(__dirname, './client/scss/overrides.scss'),
     components: {
+      // providers: [CustomProvider, CustomProvider],
       routes: [
         {
           path: '/custom-minimal-route',

--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -33,7 +33,7 @@ You can override a set of admin panel-wide components by providing a component t
 | **`graphics.Icon`**   | Used as a graphic within the `Nav` component. Often represents a condensed version of a full logo. |
 | **`graphics.Logo`**   | The full logo to be used in contexts like the `Login` view. |
 | **`routes`**          | Define your own routes to add to the Payload Admin UI. [More](#custom-routes) |
-| **`providers`**       | Define your Providers that will wrap the Payload Admin UI. [More](#custom-providers) |
+| **`providers`**       | Define your own provider components that will wrap the Payload Admin UI. [More](#custom-providers) |
 
 #### Full example:
 
@@ -156,33 +156,9 @@ To see how to pass in your custom views to create custom routes of your own, tak
 
 ## Custom providers
 
-As your admin customizations gets more complex you may want to share state between fields or other components. You can add custom providers to do add your own context to any Payload app for use in other custom components within the admin panel. Within your config add `admin.components.providers`, these can be used to share context or provide other custom functionality.
+As your admin customizations gets more complex you may want to share state between fields or other components. You can add custom providers to do add your own context to any Payload app for use in other custom components within the admin panel. Within your config add `admin.components.providers`, these can be used to share context or provide other custom functionality. Read the [React context](https://reactjs.org/docs/context.html) docs to learn more.
 
-#### Example
-
-```js
-import React, { createContext, useState, useContext } from 'react';
-
-const Context = createContext({});
-
-const CustomProvider = ({ children }) => {
-  const [getCustom, setCustom] = useState({});
-  const value = { getCustom, setCustom };
-
-  return (
-    <Context.Provider value={value}>
-      {children}
-    </Context.Provider>
-  );
-};
-
-export default CustomProvider;
-
-export const useCustom = () => useContext(Context);
-```
 <Banner>Remember to pass the `children` prop in to your provider component and return it within to render the admin UI</Banner>
-
-From your own custom components you can import `useCustom` and use it with `const { getCustom, setCustom } = useCustom()`. This is a generic example that can be modified in to anything you like. Read the [React context](https://reactjs.org/docs/context.html) docs to learn more.
 
 ### Styling Custom Components
 

--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -33,13 +33,14 @@ You can override a set of admin panel-wide components by providing a component t
 | **`graphics.Icon`**   | Used as a graphic within the `Nav` component. Often represents a condensed version of a full logo. |
 | **`graphics.Logo`**   | The full logo to be used in contexts like the `Login` view. |
 | **`routes`**          | Define your own routes to add to the Payload Admin UI. [More](#custom-routes) |
+| **`providers`**       | Define your Providers that will wrap the Payload Admin UI. [More](#custom-providers) |
 
 #### Full example:
 
 `payload.config.js`
 ```js
 import { buildConfig } from 'payload/config';
-import { MyCustomNav, MyCustomLogo, MyCustomIcon, MyCustomAccount, MyCustomDashboard } from './customComponents.js';
+import { MyCustomNav, MyCustomLogo, MyCustomIcon, MyCustomAccount, MyCustomDashboard, MyProvider } from './customComponents.js';
 
 export default buildConfig({
   admin: {
@@ -52,7 +53,8 @@ export default buildConfig({
       views: {
         Account: MyCustomAccount,
         Dashboard: MyCustomDashboard,
-      }
+      },
+      providers: [MyProvider],
     }
   }
 })
@@ -151,6 +153,36 @@ You can find examples of custom route views in the [Payload source code `/demo/c
 1. A custom view that uses the `MinimalTemplate` - which is just a centered template used for things like logging in or out
 
 To see how to pass in your custom views to create custom routes of your own, take a look at the `admin.components.routes` property of the [Payload demo config](https://github.com/payloadcms/payload/blob/master/demo/payload.config.ts).
+
+## Custom providers
+
+As your admin customizations gets more complex you may want to share state between fields or other components. You can add custom providers to do add your own context to any Payload app for use in other custom components within the admin panel. Within your config add `admin.components.providers`, these can be used to share context or provide other custom functionality.
+
+#### Example
+
+```js
+import React, { createContext, useState, useContext } from 'react';
+
+const Context = createContext({});
+
+const CustomProvider = ({ children }) => {
+  const [getCustom, setCustom] = useState({});
+  const value = { getCustom, setCustom };
+
+  return (
+    <Context.Provider value={value}>
+      {children}
+    </Context.Provider>
+  );
+};
+
+export default CustomProvider;
+
+export const useCustom = () => useContext(Context);
+```
+<Banner>Remember to pass the `children` prop in to your provider component and return it within to render the admin UI</Banner>
+
+From your own custom components you can import `useCustom` and use it with `const { getCustom, setCustom } = useCustom()`. This is a generic example that can be modified in to anything you like. Read the [React context](https://reactjs.org/docs/context.html) docs to learn more.
 
 ### Styling Custom Components
 

--- a/src/admin/components/forms/field-types/RichText/RichText.tsx
+++ b/src/admin/components/forms/field-types/RichText/RichText.tsx
@@ -272,6 +272,7 @@ const RichText: React.FC<Props> = (props) => {
               ref={editorRef}
             >
               <Editable
+                className={`${baseClass}__input`}
                 renderElement={renderElement}
                 renderLeaf={renderLeaf}
                 placeholder={placeholder}

--- a/src/admin/components/forms/field-types/RichText/index.scss
+++ b/src/admin/components/forms/field-types/RichText/index.scss
@@ -17,7 +17,6 @@
   }
 
   &__editor {
-    min-height: base(10);
 
     [data-slate-node=element] {
       margin-bottom: base(0.25);
@@ -29,6 +28,10 @@
     h4 {
       margin-bottom: base(.5);
     }
+  }
+
+  &__input {
+    min-height: base(10);
   }
 
   &__wrap {

--- a/src/admin/components/utilities/CustomProvider/index.tsx
+++ b/src/admin/components/utilities/CustomProvider/index.tsx
@@ -21,7 +21,7 @@ const NestProviders = ({ providers, children }) => {
   );
 };
 
-export const Provider: React.FC<{ children }> = ({ children }) => {
+export const CustomProvider: React.FC<{ children }> = ({ children }) => {
   const config = useConfig();
 
   const {

--- a/src/admin/components/utilities/Provider/index.tsx
+++ b/src/admin/components/utilities/Provider/index.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useConfig } from '@payloadcms/config-provider';
+
+const NestProviders = ({ providers, children }) => {
+  const Component = providers[0];
+  if (providers.length > 1) {
+    return (
+      <Component>
+        <NestProviders
+          providers={providers.slice(1)}
+        >
+          {children}
+        </NestProviders>
+      </Component>
+    );
+  }
+  return (
+    <Component>
+      {children}
+    </Component>
+  );
+};
+
+export const Provider: React.FC<{ children }> = ({ children }) => {
+  const config = useConfig();
+
+  const {
+    admin: {
+      components: {
+        providers,
+      },
+    },
+  } = config;
+
+  if (Array.isArray(providers) && providers.length > 0) {
+    return (
+      <NestProviders providers={providers}>
+        {children}
+      </NestProviders>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      {children}
+    </React.Fragment>
+  );
+};

--- a/src/admin/index.tsx
+++ b/src/admin/index.tsx
@@ -10,7 +10,7 @@ import { ModalProvider, ModalContainer } from '@faceless-ui/modal';
 import { ToastContainer, Slide } from 'react-toastify';
 import { ConfigProvider, AuthProvider } from '@payloadcms/config-provider';
 import { PreferencesProvider } from './components/utilities/Preferences';
-import { Provider } from './components/utilities/Provider';
+import { CustomProvider } from './components/utilities/CustomProvider';
 import { SearchParamsProvider } from './components/utilities/SearchParams';
 import { LocaleProvider } from './components/utilities/Locale';
 import Routes from './components/Routes';
@@ -29,27 +29,27 @@ const Index = () => (
       }}
       >
         <ScrollInfoProvider>
-          <Provider>
-            <Router>
-              <ModalProvider
-                classPrefix="payload"
-                zIndex={50}
-              >
-                <AuthProvider>
-                  <PreferencesProvider>
-                    <SearchParamsProvider>
-                      <LocaleProvider>
-                        <StepNavProvider>
+          <Router>
+            <ModalProvider
+              classPrefix="payload"
+              zIndex={50}
+            >
+              <AuthProvider>
+                <PreferencesProvider>
+                  <SearchParamsProvider>
+                    <LocaleProvider>
+                      <StepNavProvider>
+                        <CustomProvider>
                           <Routes />
-                        </StepNavProvider>
-                      </LocaleProvider>
-                    </SearchParamsProvider>
-                    <ModalContainer />
-                  </PreferencesProvider>
-                </AuthProvider>
-              </ModalProvider>
-            </Router>
-          </Provider>
+                        </CustomProvider>
+                      </StepNavProvider>
+                    </LocaleProvider>
+                  </SearchParamsProvider>
+                  <ModalContainer />
+                </PreferencesProvider>
+              </AuthProvider>
+            </ModalProvider>
+          </Router>
         </ScrollInfoProvider>
       </WindowInfoProvider>
     </ConfigProvider>

--- a/src/admin/index.tsx
+++ b/src/admin/index.tsx
@@ -10,6 +10,7 @@ import { ModalProvider, ModalContainer } from '@faceless-ui/modal';
 import { ToastContainer, Slide } from 'react-toastify';
 import { ConfigProvider, AuthProvider } from '@payloadcms/config-provider';
 import { PreferencesProvider } from './components/utilities/Preferences';
+import { Provider } from './components/utilities/Provider';
 import { SearchParamsProvider } from './components/utilities/SearchParams';
 import { LocaleProvider } from './components/utilities/Locale';
 import Routes from './components/Routes';
@@ -28,25 +29,27 @@ const Index = () => (
       }}
       >
         <ScrollInfoProvider>
-          <Router>
-            <ModalProvider
-              classPrefix="payload"
-              zIndex={50}
-            >
-              <AuthProvider>
-                <PreferencesProvider>
-                  <SearchParamsProvider>
-                    <LocaleProvider>
-                      <StepNavProvider>
-                        <Routes />
-                      </StepNavProvider>
-                    </LocaleProvider>
-                  </SearchParamsProvider>
-                  <ModalContainer />
-                </PreferencesProvider>
-              </AuthProvider>
-            </ModalProvider>
-          </Router>
+          <Provider>
+            <Router>
+              <ModalProvider
+                classPrefix="payload"
+                zIndex={50}
+              >
+                <AuthProvider>
+                  <PreferencesProvider>
+                    <SearchParamsProvider>
+                      <LocaleProvider>
+                        <StepNavProvider>
+                          <Routes />
+                        </StepNavProvider>
+                      </LocaleProvider>
+                    </SearchParamsProvider>
+                    <ModalContainer />
+                  </PreferencesProvider>
+                </AuthProvider>
+              </ModalProvider>
+            </Router>
+          </Provider>
         </ScrollInfoProvider>
       </WindowInfoProvider>
     </ConfigProvider>

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -59,6 +59,7 @@ export default joi.object({
               sensitive: joi.bool(),
             }),
           ),
+        providers: joi.array().items(component),
         beforeDashboard: joi.array().items(component),
         afterDashboard: joi.array().items(component),
         beforeLogin: joi.array().items(component),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -102,6 +102,7 @@ export type Config = {
     dateFormat?: string
     components?: {
       routes?: AdminRoute[]
+      providers?: React.ComponentType[]
       beforeDashboard?: React.ComponentType[]
       afterDashboard?: React.ComponentType[]
       beforeLogin?: React.ComponentType[]


### PR DESCRIPTION
## Description

Adds providers to `admin.components` so that you can build in your own context providers that wrap the admin UI for other custom components to use.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
