### PR TITLE
feat(logging): allow pino logger options to be passed into init

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -38,6 +38,7 @@ Payload is a *config-based*, code-first CMS and application framework. The Paylo
 | `rateLimit`          | Control IP-based rate limiting for all Payload resources. Used to prevent DDoS attacks and [more](/docs/production/preventing-abuse#rate-limiting-requests). |
 | `hooks`              | Tap into Payload-wide hooks. [More](/docs/hooks/overview) |
 | `plugins`            | An array of Payload plugins. [More](/docs/plugins/overview) |
+| `loggerOptions`     | Pino that will be passed through and used on Payload's logger. See [Pino Docs](https://getpino.io/#/docs/api?id=options) for more info on what is available.
 
 #### Simple example
 

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,6 +1,8 @@
 /* eslint-disable import/no-dynamic-require */
 /* eslint-disable global-require */
 import path from 'path';
+import pino from 'pino';
+import Logger from '../utilities/logger';
 import { SanitizedConfig } from './types';
 import findConfig from './find';
 import validate from './validate';
@@ -8,7 +10,8 @@ import babelConfig from '../babel.config';
 
 const removedExtensions = ['.scss', '.css', '.svg', '.png', '.jpg', '.eot', '.ttf', '.woff', '.woff2'];
 
-const loadConfig = (): SanitizedConfig => {
+const loadConfig = (logger?: pino.Logger): SanitizedConfig => {
+  const localLogger = logger ?? Logger();
   const configPath = findConfig();
 
   removedExtensions.forEach((ext) => {
@@ -35,7 +38,7 @@ const loadConfig = (): SanitizedConfig => {
 
   if (config.default) config = config.default;
 
-  const validatedConfig = validate(config);
+  const validatedConfig = validate(config, localLogger);
 
   return {
     ...validatedConfig,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -7,6 +7,7 @@ import SMTPConnection from 'nodemailer/lib/smtp-connection';
 import GraphQL from 'graphql';
 import { ConnectionOptions } from 'mongoose';
 import React from 'react';
+import { LoggerOptions } from 'pino';
 import { Payload } from '..';
 import { AfterErrorHook, CollectionConfig, SanitizedCollectionConfig } from '../collections/config/types';
 import { GlobalConfig, SanitizedGlobalConfig } from '../globals/config/types';
@@ -68,6 +69,8 @@ export type InitOptions = {
   email?: EmailOptions;
   local?: boolean;
   onInit?: (payload: Payload) => void;
+  /** Pino LoggerOptions */
+  loggerOptions?: LoggerOptions;
 };
 
 export type AccessResult = boolean | Where;

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -1,15 +1,13 @@
 import { ValidationResult } from 'joi';
+import { Logger } from 'pino';
 import schema from './schema';
 import collectionSchema from '../collections/config/schema';
-import Logger from '../utilities/logger';
 import { SanitizedConfig } from './types';
 import { SanitizedCollectionConfig } from '../collections/config/types';
 import fieldSchema, { idField } from '../fields/config/schema';
 import { SanitizedGlobalConfig } from '../globals/config/types';
 import globalSchema from '../globals/config/schema';
 import { fieldAffectsData } from '../fields/config/types';
-
-const logger = Logger();
 
 const validateFields = (context: string, entity: SanitizedCollectionConfig | SanitizedGlobalConfig): string[] => {
   const errors: string[] = [];
@@ -65,7 +63,7 @@ const validateGlobals = (globals: SanitizedGlobalConfig[]): string[] => {
   return errors;
 };
 
-const validateSchema = (config: SanitizedConfig): SanitizedConfig => {
+const validateSchema = (config: SanitizedConfig, logger: Logger): SanitizedConfig => {
   const result = schema.validate(config, {
     abortEarly: false,
   });

--- a/src/express/middleware/errorHandler.spec.ts
+++ b/src/express/middleware/errorHandler.spec.ts
@@ -5,7 +5,7 @@ import { APIError } from '../../errors';
 import { PayloadRequest } from '../types';
 import { SanitizedConfig } from '../../config/types';
 
-const logger = Logger();
+const logger = Logger('payload');
 
 const testError = new APIError('test error', 503);
 

--- a/src/mongoose/connect.ts
+++ b/src/mongoose/connect.ts
@@ -1,10 +1,13 @@
 import mongoose, { ConnectOptions } from 'mongoose';
-import Logger from '../utilities/logger';
+import pino from 'pino';
 import { connection } from './testCredentials';
 
-const logger = Logger();
-
-const connectMongoose = async (url: string, options: ConnectOptions, local: boolean): Promise<void> => {
+const connectMongoose = async (
+  url: string,
+  options: ConnectOptions,
+  local: boolean,
+  logger: pino.Logger,
+): Promise<void> => {
   let urlToConnect = url;
   let successfulConnectionMessage = 'Connected to Mongo server successfully!';
   const connectionOptions = {

--- a/src/utilities/logger.ts
+++ b/src/utilities/logger.ts
@@ -4,11 +4,17 @@ import memoize from 'micro-memoize';
 
 export type PayloadLogger = pino.Logger;
 
-export default memoize((name = 'payload') => pino({
-  name,
-  enabled: falsey(process.env.DISABLE_LOGGING),
-  prettyPrint: {
-    ignore: 'pid,hostname',
-    translateTime: 'HH:MM:ss',
-  },
-}) as PayloadLogger);
+export default memoize(
+  (name = 'payload', options?: pino.LoggerOptions) => pino({
+    name,
+    enabled: falsey(process.env.DISABLE_LOGGING),
+    ...(options
+      ? { options }
+      : {
+        prettyPrint: {
+          ignore: 'pid,hostname',
+          translateTime: 'HH:MM:ss',
+        },
+      }),
+  }) as PayloadLogger,
+);


### PR DESCRIPTION
## Description

Add ability to pass in pino logging options. Options can be sent in via an optional `loggerOptions` property when calling `payload.init`

```ts
payload.init({
  secret: 'SECRET_KEY',
  mongoURL: 'mongodb://localhost/payload',
  express: app,
  loggerOptions: { } // Pass in any logging options here
})
```

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
