### PR TITLE
Fix destructuring of args in field hooks documentation

### DIFF
--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -94,7 +94,7 @@ const exampleFieldHook: ExampleFieldHook = (args) => {
     originalDoc, // Typed as ExampleDocumentType
     operation,
     req,
-  }
+  } = args;
 
   // Do something here...
 


### PR DESCRIPTION
## Description

Fix destructuring of args inside exampleFieldHook function in Payload hooks docs

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
