### PR TITLE
Document Fix for admin/customizing-css

### DIFF
--- a/docs/admin/customizing-css.mdx
+++ b/docs/admin/customizing-css.mdx
@@ -35,6 +35,16 @@ You can specify your own SCSS variable stylesheet that will allow for the overri
 
 To do so, provide your base Payload config with a path to your own SCSS variable sheet.
 
+**NOTE: Before you start editing your SCSS file, make sure you install 'sass-loader' & 'node-sass' as dev dependencies.**
+**Node**
+```
+npm install sass-loader node-sass --save-dev
+```
+**YARN**
+```
+yarn add sass-loader node-sass --save-dev
+```
+
 **Example in payload.config.js:**
 ```js
 import { buildConfig } from 'payload/config';


### PR DESCRIPTION
Addition of node package 'sass-loader' & 'node-sass' as dev dependencies for loading scss for customizing css variables for admin panel.

## Description

I added node packages required for loading the scss varibles for customizing css variables for admin panel.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
