### PR TITLE
Better error message if the relationTo collection for the upload type does not exist

### DIFF
--- a/src/fields/config/sanitize.ts
+++ b/src/fields/config/sanitize.ts
@@ -22,7 +22,7 @@ const sanitizeFields = (fields, validRelationships: string[]) => {
       field.defaultValue = false;
     }
 
-    if (field.type === 'relationship') {
+    if (field.type === 'relationship' || field.type === 'upload') {
       const relationships = Array.isArray(field.relationTo) ? field.relationTo : [field.relationTo];
       relationships.forEach((relationship: string) => {
         if (!validRelationships.includes(relationship)) {

--- a/src/graphql/schema/buildObjectType.ts
+++ b/src/graphql/schema/buildObjectType.ts
@@ -80,6 +80,10 @@ function buildObjectType(name: string, fields: Field[], parentName: string, base
       // to itself. Therefore, we set the relationshipType equal to the blockType
       // that is currently being created.
 
+      if (!this.collections[relationTo]) {
+        throw new Error(`Error: the relationTo collection "${relationTo}" for the field "${field.name}" of collection "${parentName}" does not exist.`);
+      }
+
       const type = this.collections[relationTo].graphQL.type || newlyCreatedBlockType;
 
       const uploadArgs = {} as LocaleInputType;

--- a/src/graphql/schema/buildObjectType.ts
+++ b/src/graphql/schema/buildObjectType.ts
@@ -73,16 +73,16 @@ function buildObjectType(name: string, fields: Field[], parentName: string, base
     upload: (field: UploadField) => {
       const { relationTo, label } = field;
 
+      if (!this.collections[relationTo]) {
+        throw new Error(`The relationTo collection "${relationTo}" for the field "${field.name}" of collection "${parentName}" does not exist.`);
+      }
+
       const uploadName = combineParentName(parentName, label === false ? toWords(field.name, true) : label);
 
       // If the relationshipType is undefined at this point,
       // it can be assumed that this blockType can have a relationship
       // to itself. Therefore, we set the relationshipType equal to the blockType
       // that is currently being created.
-
-      if (!this.collections[relationTo]) {
-        throw new Error(`The relationTo collection "${relationTo}" for the field "${field.name}" of collection "${parentName}" does not exist.`);
-      }
 
       const type = this.collections[relationTo].graphQL.type || newlyCreatedBlockType;
 

--- a/src/graphql/schema/buildObjectType.ts
+++ b/src/graphql/schema/buildObjectType.ts
@@ -73,10 +73,6 @@ function buildObjectType(name: string, fields: Field[], parentName: string, base
     upload: (field: UploadField) => {
       const { relationTo, label } = field;
 
-      if (!this.collections[relationTo]) {
-        throw new Error(`The relationTo collection "${relationTo}" for the field "${field.name}" of collection "${parentName}" does not exist.`);
-      }
-
       const uploadName = combineParentName(parentName, label === false ? toWords(field.name, true) : label);
 
       // If the relationshipType is undefined at this point,

--- a/src/graphql/schema/buildObjectType.ts
+++ b/src/graphql/schema/buildObjectType.ts
@@ -81,7 +81,7 @@ function buildObjectType(name: string, fields: Field[], parentName: string, base
       // that is currently being created.
 
       if (!this.collections[relationTo]) {
-        throw new Error(`Error: the relationTo collection "${relationTo}" for the field "${field.name}" of collection "${parentName}" does not exist.`);
+        throw new Error(`The relationTo collection "${relationTo}" for the field "${field.name}" of collection "${parentName}" does not exist.`);
       }
 
       const type = this.collections[relationTo].graphQL.type || newlyCreatedBlockType;


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->
I have accidentally specified a non-existant relationTo for my upload field. It splurt out this error message:
```
C:\Coding\GitHub\payload\src\graphql\schema\buildObjectType.ts:83
      const type = this.collections[relationTo].graphQL.type || newlyCreatedBlockType;
                                                ^

TypeError: Cannot read properties of undefined (reading 'graphQL')
    at upload (C:\Coding\GitHub\payload\src\graphql\schema\buildObjectType.ts:83:49)
    at C:\Coding\GitHub\payload\src\graphql\schema\buildObjectType.ts:454:55
    at Array.reduce (<anonymous>)
    at fields (C:\Coding\GitHub\payload\src\graphql\schema\buildObjectType.ts:447:26)
    at resolveThunk (C:\Coding\GitHub\payload\node_modules\graphql\type\definition.js:480:40)
    at defineFieldMap (C:\Coding\GitHub\payload\node_modules\graphql\type\definition.js:692:18)
    at GraphQLObjectType.getFields (C:\Coding\GitHub\payload\node_modules\graphql\type\definition.js:633:27)
    at collectReferencedTypes (C:\Coding\GitHub\payload\node_modules\graphql\type\schema.js:366:81)
    at collectReferencedTypes (C:\Coding\GitHub\payload\node_modules\graphql\type\schema.js:368:9)
    at new GraphQLSchema (C:\Coding\GitHub\payload\node_modules\graphql\type\schema.js:153:7)
[nodemon] app crashed - waiting for file changes before starting...
```

GraphQL is undefined? Well, as you can see this error message tells me nothing about what the actual problem is. Way too cryptic. So, I added the Invalid Field relationship error checking which already exists for relationships to 'upload' as well:
```
C:\Coding\GitHub\payload\src\fields\config\sanitize.ts:29
          throw new _errors.InvalidFieldRelationship(field, relationship);
InvalidFieldRelationship: Field Avatar has invalid relationship 'media'.
    at new ExtendableError (C:\Coding\GitHub\payload\src\errors\APIError.ts:26:11)
    at new APIError (C:\Coding\GitHub\payload\src\errors\APIError.ts:43:5)
    at new InvalidFieldRelationship (C:\Coding\GitHub\payload\src\errors\InvalidFieldRelationship.ts:6:5)
    at C:\Coding\GitHub\payload\src\fields\config\sanitize.ts:29:17
    at Array.forEach (<anonymous>)
    at C:\Coding\GitHub\payload\src\fields\config\sanitize.ts:27:21
    at Array.map (<anonymous>)
    at sanitizeFields (C:\Coding\GitHub\payload\src\fields\config\sanitize.ts:11
                                                                               1:17)
    at sanitizeCollection (C:\Coding\GitHub\payload\src\collections\config\sanit
                                                                               tize.ts:106:44)
    at C:\Coding\GitHub\payload\src\config\sanitize.ts:21:103 {

```
- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
