### PR TITLE
fix: file upload safely handles missing mimeTypes

### DIFF
--- a/src/uploads/mimeTypeValidator.spec.ts
+++ b/src/uploads/mimeTypeValidator.spec.ts
@@ -52,4 +52,11 @@ describe('mimeTypeValidator', () => {
     expect(validate('video/mp4')).toBe('Invalid file type: \'video/mp4\'');
     expect(validate('application/pdf')).toBe('Invalid file type: \'application/pdf\'');
   });
+
+  it('should not error when mimeType is missing', () => {
+    const mimeTypes = ['image/*', 'application/pdf'];
+    const validate = mimeTypeValidator(mimeTypes);
+    let value;
+    expect(validate(value)).toBe('Invalid file type');
+  });
 });

--- a/src/uploads/mimeTypeValidator.ts
+++ b/src/uploads/mimeTypeValidator.ts
@@ -3,6 +3,10 @@ import { Validate } from '../fields/config/types';
 export const mimeTypeValidator = (mimeTypes: string[]): Validate => (val: string) => {
   const cleanedMimeTypes = mimeTypes.map((v) => v.replace('*', ''));
 
+  if (!val) {
+    return 'Invalid file type';
+  }
+
   return !cleanedMimeTypes.some((v) => val.startsWith(v))
     ? `Invalid file type: '${val}'`
     : true;

--- a/src/uploads/uploadFile.ts
+++ b/src/uploads/uploadFile.ts
@@ -1,5 +1,6 @@
 import mkdirp from 'mkdirp';
 import path from 'path';
+import mime from 'mime';
 import { SanitizedConfig } from '../config/types';
 import { Collection } from '../collections/config/types';
 import { FileUploadError, MissingFile } from '../errors';
@@ -64,7 +65,7 @@ const uploadFile = async ({
 
         fileData.filename = fsSafeName;
         fileData.filesize = file.size;
-        fileData.mimeType = file.mimetype;
+        fileData.mimeType = file.mimetype || mime.getType(fsSafeName);
 
         if (isImage(file.mimetype)) {
           const dimensions = await getImageSize(file);


### PR DESCRIPTION
## Description

Issue https://github.com/payloadcms/payload/issues/539
For upload collections that restrict files to certain mimeTypes, Payload should validate it even if the file is missing the mimeType instead of erroring.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
