### PR TITLE
fix: fix checkbox defaultValues and more typing of sanitize

### DIFF
--- a/src/fields/config/sanitize.spec.ts
+++ b/src/fields/config/sanitize.spec.ts
@@ -1,36 +1,40 @@
 import sanitizeFields from './sanitize';
 import { MissingFieldType, InvalidFieldRelationship } from '../../errors';
-import { Block } from './types';
+import { ArrayField, Block, BlockField, CheckboxField, Field, TextField } from './types';
 
 describe('sanitizeFields', () => {
   it('should throw on missing type field', () => {
-    const fields = [{
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const fields: Field[] = [{
       label: 'some-collection',
       name: 'Some Collection',
     }];
     expect(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       sanitizeFields(fields, []);
     }).toThrow(MissingFieldType);
   });
 
   describe('auto-labeling', () => {
     it('should populate label if missing', () => {
-      const fields = [{
+      const fields: Field[] = [{
         name: 'someField',
         type: 'text',
       }];
-      const sanitizedField = sanitizeFields(fields, [])[0];
+      const sanitizedField = sanitizeFields(fields, [])[0] as TextField;
       expect(sanitizedField.name).toStrictEqual('someField');
       expect(sanitizedField.label).toStrictEqual('Some Field');
       expect(sanitizedField.type).toStrictEqual('text');
     });
     it('should allow auto-label override', () => {
-      const fields = [{
+      const fields: Field[] = [{
         name: 'someField',
         type: 'text',
         label: 'Do not label',
       }];
-      const sanitizedField = sanitizeFields(fields, [])[0];
+      const sanitizedField = sanitizeFields(fields, [])[0] as TextField;
       expect(sanitizedField.name).toStrictEqual('someField');
       expect(sanitizedField.label).toStrictEqual('Do not label');
       expect(sanitizedField.type).toStrictEqual('text');
@@ -38,19 +42,19 @@ describe('sanitizeFields', () => {
 
     describe('opt-out', () => {
       it('should allow label opt-out', () => {
-        const fields = [{
+        const fields: Field[] = [{
           name: 'someField',
           type: 'text',
           label: false,
         }];
-        const sanitizedField = sanitizeFields(fields, [])[0];
+        const sanitizedField = sanitizeFields(fields, [])[0] as TextField;
         expect(sanitizedField.name).toStrictEqual('someField');
         expect(sanitizedField.label).toStrictEqual(false);
         expect(sanitizedField.type).toStrictEqual('text');
       });
 
       it('should allow label opt-out for arrays', () => {
-        const fields = [{
+        const arrayField: ArrayField = {
           name: 'items',
           type: 'array',
           label: false,
@@ -60,15 +64,15 @@ describe('sanitizeFields', () => {
               type: 'text',
             },
           ],
-        }];
-        const sanitizedField = sanitizeFields(fields, [])[0];
+        };
+        const sanitizedField = sanitizeFields([arrayField], [])[0] as ArrayField;
         expect(sanitizedField.name).toStrictEqual('items');
         expect(sanitizedField.label).toStrictEqual(false);
         expect(sanitizedField.type).toStrictEqual('array');
         expect(sanitizedField.labels).toBeUndefined();
       });
       it('should allow label opt-out for blocks', () => {
-        const fields = [{
+        const fields: Field[] = [{
           name: 'noLabelBlock',
           type: 'blocks',
           label: false,
@@ -84,7 +88,7 @@ describe('sanitizeFields', () => {
             },
           ],
         }];
-        const sanitizedField = sanitizeFields(fields, [])[0];
+        const sanitizedField = sanitizeFields(fields, [])[0] as BlockField;
         expect(sanitizedField.name).toStrictEqual('noLabelBlock');
         expect(sanitizedField.label).toStrictEqual(false);
         expect(sanitizedField.type).toStrictEqual('blocks');
@@ -94,7 +98,7 @@ describe('sanitizeFields', () => {
 
 
     it('should label arrays with plural and singular', () => {
-      const fields = [{
+      const fields: Field[] = [{
         name: 'items',
         type: 'array',
         fields: [
@@ -104,7 +108,7 @@ describe('sanitizeFields', () => {
           },
         ],
       }];
-      const sanitizedField = sanitizeFields(fields, [])[0];
+      const sanitizedField = sanitizeFields(fields, [])[0] as ArrayField;
       expect(sanitizedField.name).toStrictEqual('items');
       expect(sanitizedField.label).toStrictEqual('Items');
       expect(sanitizedField.type).toStrictEqual('array');
@@ -112,7 +116,7 @@ describe('sanitizeFields', () => {
     });
 
     it('should label blocks with plural and singular', () => {
-      const fields = [{
+      const fields: Field[] = [{
         name: 'specialBlock',
         type: 'blocks',
         blocks: [
@@ -122,7 +126,7 @@ describe('sanitizeFields', () => {
           },
         ],
       }];
-      const sanitizedField = sanitizeFields(fields, [])[0];
+      const sanitizedField = sanitizeFields(fields, [])[0] as BlockField;
       expect(sanitizedField.name).toStrictEqual('specialBlock');
       expect(sanitizedField.label).toStrictEqual('Special Block');
       expect(sanitizedField.type).toStrictEqual('blocks');
@@ -134,7 +138,7 @@ describe('sanitizeFields', () => {
   describe('relationships', () => {
     it('should not throw on valid relationship', () => {
       const validRelationships = ['some-collection'];
-      const fields = [{
+      const fields: Field[] = [{
         type: 'relationship',
         label: 'my-relationship',
         name: 'My Relationship',
@@ -147,7 +151,7 @@ describe('sanitizeFields', () => {
 
     it('should not throw on valid relationship - multiple', () => {
       const validRelationships = ['some-collection', 'another-collection'];
-      const fields = [{
+      const fields: Field[] = [{
         type: 'relationship',
         label: 'my-relationship',
         name: 'My Relationship',
@@ -169,12 +173,9 @@ describe('sanitizeFields', () => {
           relationTo: 'some-collection',
         }],
       };
-      const fields = [{
+      const fields: Field[] = [{
         name: 'layout',
         label: 'Layout Blocks',
-        labels: {
-          singular: 'Block',
-        },
         type: 'blocks',
         blocks: [relationshipBlock],
       }];
@@ -185,7 +186,7 @@ describe('sanitizeFields', () => {
 
     it('should throw on invalid relationship', () => {
       const validRelationships = ['some-collection'];
-      const fields = [{
+      const fields: Field[] = [{
         type: 'relationship',
         label: 'my-relationship',
         name: 'My Relationship',
@@ -198,7 +199,7 @@ describe('sanitizeFields', () => {
 
     it('should throw on invalid relationship - multiple', () => {
       const validRelationships = ['some-collection', 'another-collection'];
-      const fields = [{
+      const fields: Field[] = [{
         type: 'relationship',
         label: 'my-relationship',
         name: 'My Relationship',
@@ -220,18 +221,31 @@ describe('sanitizeFields', () => {
           relationTo: 'not-valid',
         }],
       };
-      const fields = [{
+      const fields: Field[] = [{
         name: 'layout',
         label: 'Layout Blocks',
-        labels: {
-          singular: 'Block',
-        },
         type: 'blocks',
         blocks: [relationshipBlock],
       }];
       expect(() => {
         sanitizeFields(fields, validRelationships);
       }).toThrow(InvalidFieldRelationship);
+    });
+
+    it('should defaultValue of checkbox to false if required and undefined', () => {
+      const fields: Field[] = [{
+        type: 'checkbox',
+        name: 'My Checkbox',
+        required: true,
+      }];
+
+      const sanitizedField = sanitizeFields(fields, [])[0] as CheckboxField;
+      expect(sanitizedField.defaultValue).toStrictEqual(false);
+    });
+
+    it('should return empty field array if no fields', () => {
+      const sanitizedFields = sanitizeFields([], []);
+      expect(sanitizedFields).toStrictEqual([]);
     });
   });
 });

--- a/src/fields/config/sanitize.ts
+++ b/src/fields/config/sanitize.ts
@@ -3,22 +3,22 @@ import { MissingFieldType, InvalidFieldRelationship } from '../../errors';
 import { baseBlockFields } from '../baseFields/baseBlockFields';
 import validations from '../validations';
 import { baseIDField } from '../baseFields/baseIDField';
-import { fieldAffectsData } from './types';
+import { Field, fieldAffectsData } from './types';
 
-const sanitizeFields = (fields, validRelationships: string[]) => {
+const sanitizeFields = (fields: Field[], validRelationships: string[]): Field[] => {
   if (!fields) return [];
 
   return fields.map((unsanitizedField) => {
-    const field = { ...unsanitizedField };
+    const field: Field = { ...unsanitizedField };
 
     if (!field.type) throw new MissingFieldType(field);
 
     // Auto-label
-    if (field.name && typeof field.label !== 'string' && field.label !== false) {
+    if ('name' in field && field.name && typeof field.label !== 'string' && field.label !== false) {
       field.label = toWords(field.name);
     }
 
-    if (field.type === 'checkbox' && typeof field.defaulValue === 'undefined' && field.required === true) {
+    if (field.type === 'checkbox' && typeof field.defaultValue === 'undefined' && field.required === true) {
       field.defaultValue = false;
     }
 
@@ -59,9 +59,9 @@ const sanitizeFields = (fields, validRelationships: string[]) => {
 
     if (!field.admin) field.admin = {};
 
-    if (field.fields) field.fields = sanitizeFields(field.fields, validRelationships);
+    if ('fields' in field && field.fields) field.fields = sanitizeFields(field.fields, validRelationships);
 
-    if (field.blocks) {
+    if ('blocks' in field && field.blocks) {
       field.blocks = field.blocks.map((block) => {
         const unsanitizedBlock = { ...block };
         unsanitizedBlock.labels = !unsanitizedBlock.labels ? formatLabels(unsanitizedBlock.slug) : unsanitizedBlock.labels;


### PR DESCRIPTION
## Description

Fix checkbox typo and add better typing to config sanitize function.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
