### PR TITLE
fix: save resized image file when equal to upload size

### DIFF
--- a/src/uploads/imageResizer.ts
+++ b/src/uploads/imageResizer.ts
@@ -49,7 +49,7 @@ export default async function resizeAndSave({
   const { imageSizes, disableLocalStorage } = config.upload;
 
   const sizes = imageSizes
-    .filter((desiredSize) => desiredSize.width < dimensions.width || desiredSize.height < dimensions.height)
+    .filter((desiredSize) => desiredSize.width <= dimensions.width || desiredSize.height <= dimensions.height)
     .map(async (desiredSize) => {
       const resized = await sharp(file)
         .resize(desiredSize.width, desiredSize.height, {


### PR DESCRIPTION
## Description

Fixes a rare bug that can occur when a file image upload has the same width and height as an imageSizes supplied in the config.
Possibly related: https://github.com/payloadcms/payload/discussions/467

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
