### PR TITLE
fix: apply field condition to custom components

### DIFF
--- a/cypress/integration/conditions.e2e.ts
+++ b/cypress/integration/conditions.e2e.ts
@@ -1,0 +1,25 @@
+describe('Collections', () => {
+  before(() => {
+    cy.apiLogin();
+  });
+
+  beforeEach(() => {
+    cy.visit('/admin/collections/conditions/create');
+  });
+
+  it('can see conditional fields', () => {
+    cy.get('#simpleCondition')
+      .should('not.be.visible');
+
+    cy.get('#customComponent')
+      .should('not.be.visible');
+
+    cy.get('#enableTest').click();
+
+    cy.get('#simpleCondition')
+      .should('be.visible');
+
+    cy.get('#customComponent')
+      .should('be.visible');
+  });
+});

--- a/demo/collections/Conditions.ts
+++ b/demo/collections/Conditions.ts
@@ -3,6 +3,7 @@ import Email from '../blocks/Email';
 import Quote from '../blocks/Quote';
 import NumberBlock from '../blocks/Number';
 import CallToAction from '../blocks/CallToAction';
+import Text from './CustomComponents/components/fields/Text/Field';
 
 const Conditions: CollectionConfig = {
   slug: 'conditions',
@@ -65,6 +66,18 @@ const Conditions: CollectionConfig = {
       required: true,
       admin: {
         condition: (_, siblings) => siblings?.enableTest === true,
+      },
+    },
+    {
+      name: 'customComponent',
+      type: 'text',
+      label: 'Custom Component with Enable Test is checked',
+      required: true,
+      admin: {
+        condition: (_, siblings) => siblings?.enableTest === true,
+        components: {
+          Field: Text,
+        },
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:client": "cross-env PAYLOAD_CONFIG_PATH=demo/payload.config.ts NODE_ENV=test jest --config=jest.react.config.js",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "test:e2e": "DISABLE_LOGGING=true MONGO_URL=mongodb://localhost/payload-integration start-server-and-test dev http-get://localhost:3000/admin cy:run",
+    "test:e2e": "cross-env DISABLE_LOGGING=true MONGO_URL=mongodb://localhost/payload-integration start-server-and-test dev http-get://localhost:3000/admin cy:run",
     "clean": "rimraf dist",
     "release": "release-it",
     "release:patch": "release-it patch",

--- a/src/admin/components/utilities/RenderCustomComponent/index.tsx
+++ b/src/admin/components/utilities/RenderCustomComponent/index.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { Props } from './types';
+import withCondition from '../../forms/withCondition';
 
 const RenderCustomComponent: React.FC<Props> = (props) => {
   const { CustomComponent, DefaultComponent, componentProps } = props;
 
   if (CustomComponent) {
+    const ConditionalCustomComponent = withCondition(CustomComponent);
     return (
-      <CustomComponent {...componentProps} />
+      <ConditionalCustomComponent {...componentProps} />
     );
   }
 


### PR DESCRIPTION
## Description

Makes it possible to use both `admin.condition` and `admin.components.Field` on a field. Prior to this change the condition would not be used on a custom field component.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
