### PR TITLE
Feat: field validation original doc

### DIFF
--- a/demo/collections/Validations.ts
+++ b/demo/collections/Validations.ts
@@ -15,7 +15,14 @@ const Validations: CollectionConfig = {
       type: 'text',
       label: 'Text with siblingData Validation',
       required: true,
-      validate: (value: string, { data, siblingData, id, operation, user }) => {
+      validate: (value: string, {
+        data,
+        siblingData,
+        id,
+        operation,
+        user,
+        originalDoc,
+      }): string | true => {
         if (typeof value === 'undefined') {
           return 'Validation is missing value';
         }
@@ -33,6 +40,9 @@ const Validations: CollectionConfig = {
         }
         if (operation === 'update' && typeof id === 'undefined') {
           return 'ValidationOptions is missing "id"';
+        }
+        if (!originalDoc?.validationOptions && operation === 'update') {
+          return 'ValidationOptions is missing "originalDoc"';
         }
 
         return true;

--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -73,6 +73,7 @@ There are two arguments available to custom validation functions.
 | ------------- | -------------|
 | `data`             | An object of the full collection or global document |
 | `siblingData`      | An object of the document data limited to fields within the same parent to the field |
+| `originalDoc`      | The full original document in `update` operations |
 | `operation`        | Will be "create" or "update" depending on the UI action or API call |
 | `id`               | The value of the collection `id`, will be `undefined` on create request |
 | `user`             | The currently authenticated user object |

--- a/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
+++ b/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
@@ -51,6 +51,7 @@ export const addFieldStatePromise = async ({
     let validationResult: boolean | string = true;
 
     if (typeof fieldState.validate === 'function') {
+      const originalDoc = { ...fullData };
       validationResult = await fieldState.validate(data?.[field.name], {
         ...field,
         data: fullData,
@@ -58,6 +59,7 @@ export const addFieldStatePromise = async ({
         siblingData: data,
         id,
         operation,
+        originalDoc,
       });
     }
 

--- a/src/admin/components/forms/Form/index.tsx
+++ b/src/admin/components/forms/Form/index.tsx
@@ -42,7 +42,6 @@ const Form: React.FC<Props> = (props) => {
     initialState, // fully formed initial field state
     initialData, // values only, paths are required as key - form should build initial state as convenience
     waitForAutocomplete,
-    log,
   } = props;
 
   const history = useHistory();
@@ -54,6 +53,7 @@ const Form: React.FC<Props> = (props) => {
   const [modified, setModified] = useState(false);
   const [processing, setProcessing] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [originalDoc, setOriginalDoc] = useState<Record<string, unknown> | undefined>();
   const [formattedInitialData, setFormattedInitialData] = useState(buildInitialState(initialData));
 
   const formRef = useRef<HTMLFormElement>(null);
@@ -89,6 +89,7 @@ const Form: React.FC<Props> = (props) => {
           validationResult = await field.validate(field.value, {
             data,
             siblingData: contextRef.current.getSiblingData(path),
+            originalDoc,
             user,
             id,
             operation,
@@ -112,7 +113,7 @@ const Form: React.FC<Props> = (props) => {
     }
 
     return isValid;
-  }, [contextRef, id, user, operation]);
+  }, [contextRef, id, user, originalDoc, operation]);
 
   const submit = useCallback(async (options: SubmitOptions = {}, e): Promise<void> => {
     const {
@@ -208,6 +209,7 @@ const Form: React.FC<Props> = (props) => {
 
           history.push(destination);
         } else if (!disableSuccessStatus) {
+          setOriginalDoc(json);
           toast.success(json.message || 'Submission successful.', { autoClose: 3000 });
         }
       } else {
@@ -350,6 +352,7 @@ const Form: React.FC<Props> = (props) => {
 
   useEffect(() => {
     if (initialState) {
+      setOriginalDoc(reduceFieldsToValues(initialState, true));
       contextRef.current = { ...initContextState } as FormContextType;
       dispatchFields({ type: 'REPLACE_STATE', state: initialState });
     }

--- a/src/admin/components/forms/useField/index.tsx
+++ b/src/admin/components/forms/useField/index.tsx
@@ -7,6 +7,7 @@ import useDebounce from '../../../hooks/useDebounce';
 import { Options, FieldType } from './types';
 import { useDocumentInfo } from '../../utilities/DocumentInfo';
 import { useOperation } from '../../utilities/OperationProvider';
+import reduceFieldsToValues from '../Form/reduceFieldsToValues';
 
 const useField = <T extends unknown>(options: Options): FieldType<T> => {
   const {
@@ -30,6 +31,7 @@ const useField = <T extends unknown>(options: Options): FieldType<T> => {
     getField,
     getData,
     getSiblingData,
+    initialState,
     setModified,
   } = formContext || {};
 
@@ -78,6 +80,7 @@ const useField = <T extends unknown>(options: Options): FieldType<T> => {
       user,
       data: getData(),
       siblingData: getSiblingData(path),
+      originalDoc: initialState ? reduceFieldsToValues(initialState) : {},
       operation,
     };
 
@@ -103,6 +106,7 @@ const useField = <T extends unknown>(options: Options): FieldType<T> => {
     getData,
     getSiblingData,
     id,
+    initialState,
     initialValue,
     operation,
     path,

--- a/src/admin/components/views/collections/Edit/Auth/APIKey.tsx
+++ b/src/admin/components/views/collections/Edit/Auth/APIKey.tsx
@@ -10,7 +10,7 @@ import GenerateConfirmation from '../../../../elements/GenerateConfirmation';
 
 const path = 'apiKey';
 const baseClass = 'api-key';
-const validate = (val) => text(val, { minLength: 24, maxLength: 48, data: {}, siblingData: {} });
+const validate = (val) => text(val, { minLength: 24, maxLength: 48, data: {}, siblingData: {}, originalDoc: {} });
 
 const APIKey: React.FC = () => {
   const [initialAPIKey, setInitialAPIKey] = useState(null);

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -66,6 +66,7 @@ export type Labels = {
 export type ValidateOptions<T, S, F> = {
   data: Partial<T>
   siblingData: Partial<S>
+  originalDoc: Partial<T>
   id?: string | number
   user?: Partial<User>
   operation?: Operation

--- a/src/fields/getDefaultValue.ts
+++ b/src/fields/getDefaultValue.ts
@@ -16,8 +16,6 @@ const getValueWithDefault = async ({ value, defaultValue, locale, user }: Args):
     return defaultValue({ locale, user });
   }
   return defaultValue;
-
-  return undefined;
 };
 
 export default getValueWithDefault;

--- a/src/fields/hooks/beforeChange/promise.ts
+++ b/src/fields/hooks/beforeChange/promise.ts
@@ -113,6 +113,7 @@ export const promise = async ({
         operation,
         user: req.user,
         payload: req.payload,
+        originalDoc: doc,
       });
 
       if (typeof validationResult === 'string') {


### PR DESCRIPTION
## Description

Adds the originalDoc to field validation props. This makes it possible to limit updates to fields based on what was previously saved.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
