### PR TITLE
fix: safely checks for versions and drafts when accessing globalConfig

### DIFF
--- a/src/globals/operations/findOne.ts
+++ b/src/globals/operations/findOne.ts
@@ -24,7 +24,7 @@ async function findOne(args) {
   // Retrieve and execute access
   // /////////////////////////////////////
 
-  const queryToBuild: { where?: Where} = {
+  const queryToBuild: { where?: Where } = {
     where: {
       and: [
         {
@@ -69,7 +69,7 @@ async function findOne(args) {
   // Replace document with draft if available
   // /////////////////////////////////////
 
-  if (globalConfig.versions?.drafts && draftEnabled) {
+  if (globalConfig?.versions?.drafts && draftEnabled) {
     doc = await replaceWithDraftIfAvailable({
       payload: this,
       entity: globalConfig,

--- a/src/globals/operations/update.ts
+++ b/src/globals/operations/update.ts
@@ -32,7 +32,7 @@ async function update<T extends TypeWithID = any>(this: Payload, args): Promise<
 
   let { data } = args;
 
-  const shouldSaveDraft = Boolean(draftArg && globalConfig.versions.drafts);
+  const shouldSaveDraft = Boolean(draftArg && globalConfig?.versions?.drafts);
 
   // /////////////////////////////////////
   // 1. Retrieve and execute access
@@ -149,7 +149,7 @@ async function update<T extends TypeWithID = any>(this: Payload, args): Promise<
 
   let createdVersion;
 
-  if (globalConfig.versions && !shouldSaveDraft) {
+  if (globalConfig?.versions && !shouldSaveDraft) {
     createdVersion = await saveGlobalVersion({
       payload: this,
       config: globalConfig,


### PR DESCRIPTION
## Description

globalConfig was accessing `versions` and `versions.drafts` unsafely. This added optional chaining in a few places to resolve this.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
