### PR TITLE
fix: adds optional chaining to safely read drafts setting on versions

### DIFF
--- a/src/globals/operations/update.ts
+++ b/src/globals/operations/update.ts
@@ -32,7 +32,7 @@ async function update<T extends TypeWithID = any>(this: Payload, args): Promise<
 
   let { data } = args;
 
-  const shouldSaveDraft = Boolean(draftArg && globalConfig.versions.drafts);
+  const shouldSaveDraft = Boolean(draftArg && globalConfig.versions?.drafts);
 
   // /////////////////////////////////////
   // 1. Retrieve and execute access


### PR DESCRIPTION
## Description

Safely accesses `versions.drafts` on global config in the update operation.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)