### PR TITLE
Prop-drill required prop for select field

### DIFF
--- a/src/admin/components/forms/field-types/Select/index.tsx
+++ b/src/admin/components/forms/field-types/Select/index.tsx
@@ -90,6 +90,7 @@ const Select: React.FC<Props> = (props) => {
       label={label}
       showError={showError}
       errorMessage={errorMessage}
+      required={required}
       description={description}
       style={style}
       className={className}


### PR DESCRIPTION
## Description

Pass `required` prop down to select input component, enabling label's asterisk.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
