### PR TITLE
Collection preroute support

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -25,6 +25,7 @@ It's often best practice to write your Collections in separate files and then im
 | **`upload`**     | Specify options if you would like this Collection to support file uploads. For more, consult the [Uploads](/docs/upload/overview) documentation. |
 | **`timestamps`** | Set to false to disable documents' automatically generated `createdAt` and `updatedAt` timestamps. |
 | **`versions`**   | Set to true to enable default options, or configure with object properties. [More](/docs/versions/overview#collection-config)|
+| **`preRoute`**   | Provide a callback function that will recieve the collection's router as a parameter for custom routing. |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -25,7 +25,7 @@ It's often best practice to write your Collections in separate files and then im
 | **`upload`**     | Specify options if you would like this Collection to support file uploads. For more, consult the [Uploads](/docs/upload/overview) documentation. |
 | **`timestamps`** | Set to false to disable documents' automatically generated `createdAt` and `updatedAt` timestamps. |
 | **`versions`**   | Set to true to enable default options, or configure with object properties. [More](/docs/versions/overview#collection-config)|
-| **`preRoute`**   | Provide a callback function that will recieve the collection's router as a parameter for custom routing. |
+| **`preRoute`**   | Provide a callback function that will receive the collection's router as a parameter for custom routing. |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/src/auth/requestHandlers/me.ts
+++ b/src/auth/requestHandlers/me.ts
@@ -3,7 +3,9 @@ import { PayloadRequest } from '../../express/types';
 
 export default async function me(req: PayloadRequest, res: Response, next: NextFunction): Promise<any> {
   try {
-    const collectionSlug = req.route.path.split('/').filter((r) => r !== '')[0];
+    const collectionSlugMatch = req.originalUrl.match(/\/([^/]+)\/me\/?$/);
+    const [, collectionSlug] = collectionSlugMatch;
+
     const response = await this.operations.collections.auth.me({
       req,
       collectionSlug,

--- a/src/collections/config/defaults.ts
+++ b/src/collections/config/defaults.ts
@@ -35,6 +35,7 @@ export const defaults = {
   auth: false,
   upload: false,
   versions: false,
+  preRoute: (): unknown => null,
 };
 
 export const authDefaults = {

--- a/src/collections/config/sanitize.ts
+++ b/src/collections/config/sanitize.ts
@@ -98,10 +98,6 @@ const sanitizeCollection = (config: Config, collection: CollectionConfig): Sanit
     ];
   }
 
-  if (!sanitized.preRoute) {
-    sanitized.preRoute = () => null;
-  }
-
   // /////////////////////////////////
   // Sanitize fields
   // /////////////////////////////////

--- a/src/collections/config/sanitize.ts
+++ b/src/collections/config/sanitize.ts
@@ -98,6 +98,10 @@ const sanitizeCollection = (config: Config, collection: CollectionConfig): Sanit
     ];
   }
 
+  if (!sanitized.preRoute) {
+    sanitized.preRoute = () => null;
+  }
+
   // /////////////////////////////////
   // Sanitize fields
   // /////////////////////////////////

--- a/src/collections/config/schema.ts
+++ b/src/collections/config/schema.ts
@@ -17,6 +17,7 @@ const collectionSchema = joi.object().keys({
     admin: joi.func(),
   }),
   timestamps: joi.boolean(),
+  preRoute: joi.func(),
   admin: joi.object({
     useAsTitle: joi.string(),
     defaultColumns: joi.array().items(joi.string()),

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -2,6 +2,7 @@
 import { DeepRequired } from 'ts-essentials';
 import { PaginateModel } from 'mongoose';
 import { GraphQLType } from 'graphql';
+import { Router } from 'express';
 import { Access, GeneratePreviewURL, EntityDescription } from '../../config/types';
 import { Field } from '../../fields/config/types';
 import { PayloadRequest } from '../../express/types';
@@ -217,6 +218,7 @@ export type CollectionConfig = {
   upload?: IncomingUploadType | boolean;
   versions?: IncomingCollectionVersions | boolean;
   timestamps?: boolean
+  preRoute?: (router: Router) => void;
 };
 
 export interface SanitizedCollectionConfig extends Omit<DeepRequired<CollectionConfig>, 'auth' | 'upload' | 'fields' | 'versions'> {

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -3,6 +3,7 @@ import { DeepRequired } from 'ts-essentials';
 import { PaginateModel } from 'mongoose';
 import { GraphQLType } from 'graphql';
 import { Router } from 'express';
+
 import { Access, GeneratePreviewURL, EntityDescription } from '../../config/types';
 import { Field } from '../../fields/config/types';
 import { PayloadRequest } from '../../express/types';

--- a/src/collections/init.ts
+++ b/src/collections/init.ts
@@ -95,9 +95,11 @@ export default function registerCollections(ctx: Payload): void {
     // If not local, open routes
     if (!ctx.local) {
       const router = express.Router();
-      const { slug } = collection;
+      const { slug, preRoute } = collection;
 
-      router.all(`/${slug}*`, bindCollectionMiddleware(ctx.collections[formattedCollection.slug]));
+      router.all('*', bindCollectionMiddleware(ctx.collections[formattedCollection.slug]));
+
+      preRoute(router);
 
       const {
         create,
@@ -133,68 +135,68 @@ export default function registerCollections(ctx: Payload): void {
 
         if (collection.auth.verify) {
           router
-            .route(`/${slug}/verify/:token`)
+            .route('/verify/:token')
             .post(verifyEmail);
         }
 
         if (collection.auth.maxLoginAttempts > 0) {
           router
-            .route(`/${slug}/unlock`)
+            .route('/unlock')
             .post(unlock);
         }
 
         router
-          .route(`/${slug}/init`)
+          .route('/init')
           .get(init);
 
         router
-          .route(`/${slug}/login`)
+          .route('/login')
           .post(login);
 
         router
-          .route(`/${slug}/logout`)
+          .route('/logout')
           .post(logout);
 
         router
-          .route(`/${slug}/refresh-token`)
+          .route('/refresh-token')
           .post(refresh);
 
         router
-          .route(`/${slug}/me`)
+          .route('/me')
           .get(me);
 
         router
-          .route(`/${slug}/first-register`)
+          .route('/first-register')
           .post(registerFirstUser);
 
         router
-          .route(`/${slug}/forgot-password`)
+          .route('/forgot-password')
           .post(forgotPassword);
 
         router
-          .route(`/${slug}/reset-password`)
+          .route('/reset-password')
           .post(resetPassword);
       }
 
       if (collection.versions) {
-        router.route(`/${slug}/versions`)
+        router.route('/versions')
           .get(findVersions);
 
-        router.route(`/${slug}/versions/:id`)
+        router.route('/versions/:id')
           .get(findVersionByID)
           .post(restoreVersion);
       }
 
-      router.route(`/${slug}`)
-        .get(find)
-        .post(create);
-
-      router.route(`/${slug}/:id`)
+      router.route('/:id')
         .put(update)
         .get(findByID)
         .delete(deleteHandler);
 
-      ctx.router.use(router);
+      router.route('/')
+        .get(find)
+        .post(create);
+
+      ctx.router.use(`/${slug}`, router);
     }
 
     return formattedCollection;


### PR DESCRIPTION
## Description

This PR introduces the preRoute collection configuration property. It takes a callback that can be used to define custom routes to be matched before default Payload routes.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
