### PR TITLE
feat: adds timestamps to generated collection types if enabled

### DIFF
--- a/demo/payload-types.ts
+++ b/demo/payload-types.ts
@@ -85,6 +85,8 @@ export interface LocalizedPost {
     blockName?: string;
     blockType: 'richTextBlock';
   }[];
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -102,6 +104,8 @@ export interface Admin {
   lockUntil?: string;
   roles: ('admin' | 'editor' | 'moderator' | 'user' | 'viewer')[];
   publicUser?: (string | PublicUser)[];
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -117,6 +121,8 @@ export interface PublicUser {
   loginAttempts?: number;
   lockUntil?: string;
   adminOnly?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -145,6 +151,10 @@ export interface AllFields {
     arrayText2: string;
     arrayText3?: string;
     checkbox?: boolean;
+    id?: string;
+  }[];
+  readOnlyArray?: {
+    text?: string;
     id?: string;
   }[];
   blocks: (
@@ -193,6 +203,8 @@ export interface AllFields {
   slug: string;
   checkbox?: boolean;
   dateFieldExample?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -242,6 +254,8 @@ export interface Media {
   };
   alt: string;
   foundUploadSizes?: boolean;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -283,6 +297,9 @@ export interface Conditions {
         blockType: 'cta';
       }
   )[];
+  customComponent: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -314,6 +331,8 @@ export interface AutoLabel {
     textField?: string;
     id?: string;
   }[];
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -324,6 +343,8 @@ export interface AutosavePost {
   _status?: 'draft' | 'published';
   title: string;
   description: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -388,6 +409,8 @@ export interface Blocks {
         blockType: 'cta';
       }
   )[];
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -396,6 +419,8 @@ export interface Blocks {
 export interface Code {
   id: string;
   code: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -404,6 +429,8 @@ export interface Code {
 export interface CustomID {
   id: number;
   name: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -481,6 +508,8 @@ export interface DefaultValueTest {
   }[];
   asyncText?: string;
   function?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -494,6 +523,8 @@ export interface File {
   filesize?: number;
   type: 'Type 1' | 'Type 2' | 'Type 3';
   owner: string | Admin;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -506,6 +537,8 @@ export interface Geolocation {
   group?: {
     point?: [number, number];
   };
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -516,6 +549,8 @@ export interface HiddenFields {
   title: string;
   hiddenAdmin: string;
   hiddenAPI: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -525,6 +560,8 @@ export interface Hook {
   id: string;
   title: string;
   description: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -539,6 +576,8 @@ export interface LocalizedArray {
     arrayText3?: string;
     id?: string;
   }[];
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -547,6 +586,8 @@ export interface LocalizedArray {
 export interface LocalOperation {
   id: string;
   title: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -555,6 +596,8 @@ export interface LocalOperation {
 export interface Image {
   id: string;
   upload?: string | Media;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -574,6 +617,8 @@ export interface NestedArray {
     }[];
     id?: string;
   }[];
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -582,6 +627,8 @@ export interface NestedArray {
 export interface PreviewablePost {
   id: string;
   title: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -614,6 +661,8 @@ export interface RelationshipA {
   filterRelationship?: string | RelationshipB;
   files?: string | File;
   demoHiddenField?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -653,6 +702,8 @@ export interface RelationshipB {
         relationTo: 'relationship-a';
       };
   strictAccess?: string | StrictAccess;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -664,6 +715,8 @@ export interface StrictAccess {
   city: string;
   state: string;
   zip: number;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -679,6 +732,8 @@ export interface RichText {
   customRichText: {
     [k: string]: unknown;
   }[];
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -692,6 +747,8 @@ export interface Select {
   selectWithEmptyString: '' | 'option';
   radio: 'one' | 'two' | 'three';
   radioWithEmptyString: '' | 'one' | 'two';
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -711,6 +768,8 @@ export interface Validation {
     lessThan20: number;
     id?: string;
   }[];
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -720,6 +779,8 @@ export interface Unique {
   id: string;
   title: string;
   description?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -744,4 +805,6 @@ export interface UnstoredMedia {
     };
   };
   alt: string;
+  createdAt: string;
+  updatedAt: string;
 }

--- a/src/bin/generateTypes.ts
+++ b/src/bin/generateTypes.ts
@@ -8,6 +8,7 @@ import { SanitizedCollectionConfig } from '../collections/config/types';
 import { SanitizedConfig } from '../config/types';
 import loadConfig from '../config/load';
 import { SanitizedGlobalConfig } from '../globals/config/types';
+import deepCopyObject from '../utilities/deepCopyObject';
 
 function getCollectionIDType(collections: SanitizedCollectionConfig[], slug: string): 'string' | 'number' {
   const matchedCollection = collections.find((collection) => collection.slug === slug);
@@ -316,7 +317,8 @@ function generateFieldTypes(config: SanitizedConfig, fields: Field[]): {
   };
 }
 
-function entityToJsonSchema(config: SanitizedConfig, entity: SanitizedCollectionConfig | SanitizedGlobalConfig): JSONSchema4 {
+function entityToJsonSchema(config: SanitizedConfig, incomingEntity: SanitizedCollectionConfig | SanitizedGlobalConfig): JSONSchema4 {
+  const entity = deepCopyObject(incomingEntity);
   const title = 'label' in entity ? entity.label : entity.labels.singular;
 
   const idField: FieldAffectingData = { type: 'text', name: 'id', required: true };

--- a/src/bin/generateTypes.ts
+++ b/src/bin/generateTypes.ts
@@ -2,7 +2,6 @@
 import fs from 'fs';
 import type { JSONSchema4 } from 'json-schema';
 import { compile } from 'json-schema-to-typescript';
-import payload from '..';
 import Logger from '../utilities/logger';
 import { fieldAffectsData, Field, Option, FieldAffectingData } from '../fields/config/types';
 import { SanitizedCollectionConfig } from '../collections/config/types';
@@ -327,6 +326,21 @@ function entityToJsonSchema(config: SanitizedConfig, entity: SanitizedCollection
     customIdField.required = true;
   } else {
     entity.fields.unshift(idField);
+  }
+
+  if ('timestamps' in entity && entity.timestamps !== false) {
+    entity.fields.push(
+      {
+        type: 'text',
+        name: 'createdAt',
+        required: true,
+      },
+      {
+        type: 'text',
+        name: 'updatedAt',
+        required: true,
+      },
+    );
   }
 
   return {


### PR DESCRIPTION
## Description

Appends timestamps to generated collection types if they are enabled. (They are enabled by default on collections)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
