### PR TITLE
docs: add access control examples

### DIFF
--- a/docs/access-control/collections.mdx
+++ b/docs/access-control/collections.mdx
@@ -46,52 +46,124 @@ export default {
 
 Returns a boolean which allows/denies access to the `create` request.
 
-**Available argument properties :**
+**Available argument properties:**
 
 | Option     | Description |
 | ---------- | ----------- |
 | **`req`**  | The Express `request` object containing the currently authenticated `user` |
 | **`data`** | The data passed to create the document with. |
 
+**Example:**
+
+```js
+const PublicUsers = {
+  slug: 'public-users',
+  access: {
+    // highlight-start
+    // allow guest users to self-registration
+    create: () => true,
+    // highlight-end
+    ...
+  },
+  fields: [ ... ],
+}
+```
+
 ### Read
 
 Read access functions can return a boolean result or optionally return a [query constraint](/docs/queries/overview) which limits the documents that are returned to only those that match the constraint you provide. This can be helpful to restrict users' access to only certain documents however you specify.
 
-**Available argument properties :**
+**Available argument properties:**
 
 | Option    | Description |
 | --------- | ----------- |
 | **`req`** | The Express `request` object containing the currently authenticated `user` |
-| **`id`**  | `id` of document requested, if within `findByID`. |
+| **`id`**  | `id` of document requested, if within `findByID` |
+
+**Example:**
+
+```js
+const canReadPage = ({ req: { user } }) => {
+  // allow authenticated users
+  if (user) {
+    return true;
+  }
+  // using a query constraint, guest users can access when a field named 'isPublic' is set to true
+  return {
+    where: {
+      // assumes we have a checkbox field named 'isPublic'
+      isPublic: {
+        equals: true
+      }
+    }
+  }
+};
+```
 
 ### Update
 
 Update access functions can return a boolean result or optionally return a [query constraint](/docs/queries/overview) to limit the document(s) that can be updated by the currently authenticated user. For example, returning a `query` from the `update` Access Control is helpful in cases where you would like to restrict a user to only being able to update the documents containing a `createdBy` relationship field equal to the user's ID.
 
-**Available argument properties :**
+**Available argument properties:**
 
 | Option     | Description |
 | ---------- | ----------- |
 | **`req`**  | The Express `request` object containing the currently authenticated `user` |
 | **`id`**   | `id` of document requested to update |
-| **`data`** | The data passed to update the document with. |
+| **`data`** | The data passed to update the document with |
+
+**Example:**
+
+```js
+
+const canUpdateUser = ({ req: { user }, id }) => {
+  // allow users with a role of 'admin'
+  if (user.roles && user.roles.some((role) => role === 'admin')) {
+    return true;
+  }
+  // allow any other users to update only oneself
+  return user.id === id;
+};
+```
 
 ### Delete
 
 Similarly to the Update function, returns a boolean or a [query constraint](/docs/queries/overview) to limit which documents can be deleted by which users.
 
-**Available argument properties :**
+**Available argument properties:**
 
 | Option    | Description |
 | --------- | ----------- |
 | **`req`** | The Express `request` object with additional `user` property, which is the currently logged in user |
 | **`id`**  | `id` of document requested to delete |
 
+**Example:**
+
+```js
+const canDeleteCustomer = async ({ req, id }) => {
+  if (!id) {
+    // allow the admin UI to show controls to delete since it is indeterminate without the id
+    return true;
+  }
+  // query another collection using the id
+  const result = await req.payload.find({
+    collection: 'contracts',
+    limit: 0,
+    depth: 0,
+    where: {
+      customer: { equals: id },
+    },
+  });
+
+  return result.totalDocs === 0;
+};
+```
+
 ### Admin
 
 If the Collection is [used to access the Payload Admin panel](/docs/admin/overview#the-admin-user-collection), the `Admin` Access Control function determines whether or not the currently logged in user can access the admin UI.
 
-**Available argument properties :**
+**Available argument properties:**
 
 | Option    | Description |
 | --------- | ----------- |
@@ -101,7 +173,7 @@ If the Collection is [used to access the Payload Admin panel](/docs/admin/overvi
 
 Determines which users can [unlock](/docs/authentication/operations#unlock) other users who may be blocked from authenticating successfully due to [failing too many login attempts](/docs/authentication/config#options).
 
-**Available argument properties :**
+**Available argument properties:**
 
 | Option    | Description |
 | --------- | ----------- |

--- a/docs/access-control/overview.mdx
+++ b/docs/access-control/overview.mdx
@@ -50,7 +50,7 @@ You can manage access within Payload on three different levels:
 <Banner type="success">
   <strong>Note:</strong><br/>
   Access control functions are utilized in two places. It's important to understand how and when your access control is executed.
-<Banner />
+</Banner>
 
 #### As you execute operations
 
@@ -67,6 +67,6 @@ To accomplish this, Payload ships with an `Access` operation, which is executed 
 <Banner type="warning">
   <strong>Important:</strong><br/>
   When your access control functions are executed via the <strong>access</strong> operation, the <strong>id</strong> and <strong>data</strong> arguments will be <strong>undefined</strong>, because Payload is executing your functions without referencing a specific document.
-<Banner />
+</Banner>
 
 If you use `id` or `data` within your access control functions, make sure to check that they are defined first. If they are not, then you can assume that your access control is being executed via the `access` operation, to determine solely what the user can do within the Admin UI.


### PR DESCRIPTION
## Description

Improves documentation of access control by adding more examples

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
