### PR TITLE
fix: me auth route breaks with query params

### DIFF
--- a/src/auth/graphql/resolvers/me.ts
+++ b/src/auth/graphql/resolvers/me.ts
@@ -1,10 +1,11 @@
 import me from '../../operations/me';
+import { Collection } from '../../../collections/config/types';
 
-function meResolver(collectionSlug: string): any {
+function meResolver(collection: Collection): any {
   async function resolver(_, args, context) {
     const options = {
+      collection,
       req: context.req,
-      collectionSlug,
     };
     return me(options);
   }

--- a/src/auth/operations/me.ts
+++ b/src/auth/operations/me.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken';
 import { PayloadRequest } from '../../express/types';
 import getExtractJWT from '../getExtractJWT';
 import { User } from '../types';
+import { Collection } from '../../collections/config/types';
 
 export type Result = {
   user?: User,
@@ -11,20 +12,20 @@ export type Result = {
 }
 
 export type Arguments = {
-  req: PayloadRequest,
-  collectionSlug: string
+  req: PayloadRequest
+  collection: Collection
 }
 
 async function me({
   req,
-  collectionSlug,
+  collection,
 }: Arguments): Promise<Result> {
   const extractJWT = getExtractJWT(req.payload.config);
 
   if (req.user) {
     const user = { ...req.user };
 
-    if (user.collection !== collectionSlug) {
+    if (user.collection !== collection.config.slug) {
       return {
         user: null,
       };

--- a/src/auth/requestHandlers/logout.ts
+++ b/src/auth/requestHandlers/logout.ts
@@ -5,7 +5,6 @@ import logout from '../operations/logout';
 
 export default async function logoutHandler(req: PayloadRequest, res: Response, next: NextFunction): Promise<Response<{ message: string}> | void> {
   try {
-    debugger;
     const message = await logout({
       collection: req.collection,
       res,

--- a/src/auth/requestHandlers/me.ts
+++ b/src/auth/requestHandlers/me.ts
@@ -4,12 +4,9 @@ import me from '../operations/me';
 
 export default async function meHandler(req: PayloadRequest, res: Response, next: NextFunction): Promise<any> {
   try {
-    const collectionSlugMatch = req.originalUrl.match(/\/([^/]+)\/me\/?$/);
-    const [, collectionSlug] = collectionSlugMatch;
-
     const response = await me({
       req,
-      collectionSlug,
+      collection: req.collection,
     });
     return res.status(200).json(response);
   } catch (err) {

--- a/src/collections/graphql/init.ts
+++ b/src/collections/graphql/init.ts
@@ -299,7 +299,7 @@ function initCollectionsGraphQL(payload: Payload): void {
             },
           },
         }),
-        resolve: me(slug),
+        resolve: me(collection),
       };
 
       if (collection.config.auth.maxLoginAttempts > 0) {


### PR DESCRIPTION
## Description

This fixes an error if you try to call `/api/[auth-collection]/me` with a query param. Makes the collection binding responsible for the collection slug rather than the request handler. Also updates the resolver params to be more consistent.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] Existing test suite passes locally with my changes

