### PR TITLE
Typo in middleware.mdx, change "ist" to "it"

### DIFF
--- a/docs/authentication/using-middleware.mdx
+++ b/docs/authentication/using-middleware.mdx
@@ -6,7 +6,7 @@ desc: Make full use of Payload's built-in authentication with your own custom Ex
 keywords: authentication, middleware, config, configuration, documentation, Content Management System, cms, headless, javascript, node, react, express
 ---
 
-Because Payload uses your existing Express server, you are free to add whatever logic you need to your app through endpoints of your own. However, Payload does not add its middleware to your Express app itself—instead, ist scopes all of its middleware to Payload-specific routers.
+Because Payload uses your existing Express server, you are free to add whatever logic you need to your app through endpoints of your own. However, Payload does not add its middleware to your Express app itself—instead, it scopes all of its middleware to Payload-specific routers.
 
 This approach has a ton of benefits - it's great for isolation of concerns and limiting scope, but it also means that your additional routes won't have access to Payload's user authentication.
 


### PR DESCRIPTION
## Description

Small typo on middleware page

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
