### PR TITLE
Fix: Avoid app crashing when code block is not filled (data is undefined)

### DIFF
--- a/src/admin/components/views/collections/List/Cell/field-types/Code/index.tsx
+++ b/src/admin/components/views/collections/List/Cell/field-types/Code/index.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import './index.scss';
 
 const CodeCell = ({ data }) => {
-  const textToShow = data.length > 100 ? `${data.substr(0, 100)}\u2026` : data;
+  let textToShow = '';
+
+  if (data) textToShow = data.length > 100 ? `${data.substr(0, 100)}\u2026` : data;
+
   return (
     <code className="code-cell">
       <span>{textToShow}</span>


### PR DESCRIPTION
## Description

During exploration I noticed an app crash (white screen). Then I found I was using a (not required) code field which was not filled and saved. Then, the app crashed when getting back to the list because data was undefined.

I'm not sure the way you want this issue fixed.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
