### PR TITLE
fix: icon appears above select field's option list

### DIFF
--- a/src/admin/components/elements/DatePicker/index.scss
+++ b/src/admin/components/elements/DatePicker/index.scss
@@ -10,7 +10,7 @@ $cal-icon-width: 18px;
 
   &__icon-wrap {
     position: relative;
-    z-index: 2;
+    z-index: 1;
 
     .icon {
       pointer-events: none;


### PR DESCRIPTION
## Description

When you have date field below the select field, the icon of the date field appears above the option list

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
