### PR TITLE
fix: empty cell data renders in list

### DIFF
--- a/src/admin/components/views/collections/List/Cell/field-types/Code/index.tsx
+++ b/src/admin/components/views/collections/List/Cell/field-types/Code/index.tsx
@@ -3,9 +3,7 @@ import React from 'react';
 import './index.scss';
 
 const CodeCell = ({ data }) => {
-  let textToShow = '';
-
-  if (data) textToShow = data.length > 100 ? `${data.substr(0, 100)}\u2026` : data;
+  const textToShow = data.length > 100 ? `${data.substring(0, 100)}\u2026` : data;
 
   return (
     <code className="code-cell">

--- a/src/admin/components/views/collections/List/Cell/index.tsx
+++ b/src/admin/components/views/collections/List/Cell/index.tsx
@@ -31,7 +31,7 @@ const DefaultCell: React.FC<Props> = (props) => {
     wrapElementProps.to = `${admin}/collections/${slug}/${id}`;
   }
 
-  const CellComponent = cellComponents[field.type];
+  const CellComponent = cellData && cellComponents[field.type];
 
   if (!CellComponent) {
     return (


### PR DESCRIPTION
## Description

When a document has no field data defined, most field types are not showing in the cell of the list view. This causes two issues:
1. There is no clickable link text when the undefined values are the first column
2. some fields might not gracefully handle empty state and error

The solution in this PR is to not use the CellComponent when field data is undefined and instead fallback to the `<No Field Label>` text.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
