### PR TITLE
feat: File argument in create/update operation

### DIFF
--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -102,6 +102,10 @@ const post = await payload.create({
   // a file directly through the Local API by providing
   // its full, absolute file path.
   filePath: path.resolve(__dirname, './path-to-image.jpg'),
+
+  // Alternatively, you can directly pass a File,
+  // if file is provided, filePath will be omitted
+  file: uploadedFile,
 })
 ```
 

--- a/src/collections/operations/local/create.ts
+++ b/src/collections/operations/local/create.ts
@@ -4,6 +4,8 @@ import { PayloadRequest } from '../../../express/types';
 import { Document } from '../../../types';
 import getFileByPath from '../../../uploads/getFileByPath';
 import create from '../create';
+import { File } from '../../../uploads/types';
+
 
 export type Options<T> = {
   collection: string
@@ -59,7 +61,7 @@ export default async function createLocal<T = any>(payload: Payload, options: Op
       fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
       payload,
       files: {
-        file: file ?? getFileByPath(filePath) as UploadedFile,
+        file: file ?? getFileByPath(filePath),
       },
     } as PayloadRequest,
   });

--- a/src/collections/operations/local/create.ts
+++ b/src/collections/operations/local/create.ts
@@ -16,6 +16,7 @@ export type Options<T> = {
   disableVerificationEmail?: boolean
   showHiddenFields?: boolean
   filePath?: string
+  file?: File
   overwriteExistingFiles?: boolean
   req?: PayloadRequest
   draft?: boolean
@@ -33,6 +34,7 @@ export default async function createLocal<T = any>(payload: Payload, options: Op
     disableVerificationEmail,
     showHiddenFields,
     filePath,
+    file,
     overwriteExistingFiles = false,
     req,
     draft,
@@ -57,7 +59,7 @@ export default async function createLocal<T = any>(payload: Payload, options: Op
       fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
       payload,
       files: {
-        file: getFileByPath(filePath) as UploadedFile,
+        file: file ?? getFileByPath(filePath) as UploadedFile,
       },
     } as PayloadRequest,
   });

--- a/src/collections/operations/local/local.spec.ts
+++ b/src/collections/operations/local/local.spec.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
+import { UploadedFile } from 'express-fileupload';
 import payload from '../../..';
+import getFileByPath from '../../../uploads/getFileByPath';
 
 let createdMediaID;
 
@@ -31,6 +33,32 @@ describe('Collections - Local', () => {
       expect(result.id).toBeDefined();
       expect(result.alt).toStrictEqual(alt);
       expect(result.filename).toStrictEqual('generic-block-image.svg');
+      expect(result.filesize).toStrictEqual(size);
+      createdMediaID = result.id;
+    });
+
+    it('should allow an upload-enabled file to be created from file instead of filepath', async () => {
+      const name = 'upload-local.svg';
+      const alt = 'Alt Text Here';
+      const filePath = path.resolve(
+        __dirname,
+        '../../../admin/assets/images/generic-block-image.svg',
+      );
+      const { size } = fs.statSync(filePath);
+      const file = getFileByPath(filePath);
+      file.name = name;
+
+      const result: Media = await payload.create({
+        collection: 'media',
+        data: {
+          alt,
+        },
+        file,
+      });
+
+      expect(result.id).toBeDefined();
+      expect(result.alt).toStrictEqual(alt);
+      expect(result.filename).toStrictEqual(name);
       expect(result.filesize).toStrictEqual(size);
       createdMediaID = result.id;
     });

--- a/src/collections/operations/local/update.ts
+++ b/src/collections/operations/local/update.ts
@@ -15,6 +15,7 @@ export type Options<T> = {
   overrideAccess?: boolean
   showHiddenFields?: boolean
   filePath?: string
+  file?: File
   overwriteExistingFiles?: boolean
   draft?: boolean
   autosave?: boolean
@@ -32,6 +33,7 @@ export default async function updateLocal<T = any>(payload: Payload, options: Op
     overrideAccess = true,
     showHiddenFields,
     filePath,
+    file,
     overwriteExistingFiles = false,
     draft,
     autosave,
@@ -57,7 +59,7 @@ export default async function updateLocal<T = any>(payload: Payload, options: Op
       fallbackLocale,
       payload,
       files: {
-        file: getFileByPath(filePath),
+        file: file ?? getFileByPath(filePath),
       },
     } as PayloadRequest,
   };


### PR DESCRIPTION
## Description

- Following [this discussion](https://github.com/payloadcms/payload/discussions/693), create/update API now accept `file: File` as argument. `filePath` will be omitted if `file` is provided
- Update corresponding docs

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation

PS: I did not add any test because I didn't know where to add