### PR TITLE
fix copyfiles script on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "payload": "bin.js"
   },
   "scripts": {
-    "copyfiles": "copyfiles -u 1 src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png} dist/",
+    "copyfiles": "copyfiles -u 1 'src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png}' dist/",
     "build:tsc": "tsc --p tsconfig.admin.json && tsc --p tsconfig.server.json",
     "build:components": "webpack --config dist/webpack/components.config.js",
     "build": "yarn copyfiles && yarn build:tsc && yarn build:components",


### PR DESCRIPTION
## Description

Running `yarn copyfiles` throws error "command line too long" (translated, sorry) on Windows 10.
Wrapping the glob in single quotes fixes with issue and should have no impact on other systems.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

n/a
