### PR TITLE
fix: ignore Yarn Berry files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,15 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
+# Yarn Berry
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+.pnp.*
+
 # dotenv environment variables file
 .env
 


### PR DESCRIPTION
## Description

I've setup Payload as a sub-package in a monorepo with Yarn 3. To avoid commiting .yarn cache etc, this adds the respective folders to .gitignore

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

n/a
