### PR TITLE
feat: customizable title path for blocks

### DIFF
--- a/src/admin/components/forms/DraggableSection/index.tsx
+++ b/src/admin/components/forms/DraggableSection/index.tsx
@@ -35,6 +35,8 @@ const DraggableSection: React.FC<Props> = (props) => {
     permissions,
     readOnly,
     hasMaxRows,
+    titlePath,
+    titleReadOnly,
   } = props;
 
   const [isHovered, setIsHovered] = useState(false);
@@ -84,8 +86,8 @@ const DraggableSection: React.FC<Props> = (props) => {
                   />
                   <SectionTitle
                     label={label}
-                    path={`${parentPath}.${rowIndex}.blockName`}
-                    readOnly={readOnly}
+                    path={`${parentPath}.${rowIndex}.${titlePath || 'blockName'}`}
+                    readOnly={readOnly || !!titleReadOnly}
                   />
 
                   <Button

--- a/src/admin/components/forms/DraggableSection/types.ts
+++ b/src/admin/components/forms/DraggableSection/types.ts
@@ -3,23 +3,25 @@ import { FieldTypes } from '../field-types';
 import { FieldPermissions } from '../../../../auth/types';
 
 export type Props = {
-  moveRow: (fromIndex: number, toIndex: number) => void
-  addRow: (index: number, blockType?: string) => void
-  removeRow: (index: number) => void
-  rowIndex: number
-  rowCount: number
-  parentPath: string
-  fieldSchema: Field[],
-  label?: string
-  blockType?: string
-  fieldTypes: FieldTypes
-  id: string
-  isCollapsed?: boolean
-  setRowCollapse?: (id: string, open: boolean) => void
-  positionPanelVerticalAlignment?: 'top' | 'center' | 'sticky'
-  actionPanelVerticalAlignment?: 'top' | 'center' | 'sticky'
-  permissions: FieldPermissions
-  readOnly: boolean
-  blocks?: Block[]
-  hasMaxRows?: boolean
-}
+  moveRow: (fromIndex: number, toIndex: number) => void;
+  addRow: (index: number, blockType?: string) => void;
+  removeRow: (index: number) => void;
+  rowIndex: number;
+  rowCount: number;
+  parentPath: string;
+  fieldSchema: Field[];
+  label?: string;
+  blockType?: string;
+  fieldTypes: FieldTypes;
+  id: string;
+  isCollapsed?: boolean;
+  setRowCollapse?: (id: string, open: boolean) => void;
+  positionPanelVerticalAlignment?: 'top' | 'center' | 'sticky';
+  actionPanelVerticalAlignment?: 'top' | 'center' | 'sticky';
+  permissions: FieldPermissions;
+  readOnly: boolean;
+  blocks?: Block[];
+  hasMaxRows?: boolean;
+  titlePath?: string;
+  titleReadOnly?: boolean;
+};

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -305,6 +305,9 @@ export type BlockField = FieldBase & {
   blocks?: Block[];
   defaultValue?: unknown
   labels?: Labels
+  admin?: Admin & {
+    titlePath?: string;
+  }
 }
 
 export type PointField = FieldBase & {


### PR DESCRIPTION
## Description

This adds a titlePath to admin for Blocks so we can set a custom property path (instead of blockName). 
Combine that with a admin-hidden field and you can simply change (and localize) an already existing field instead of the blockName.

Example schema of parent:
```
 {
      name: "pageContent",
      type: "blocks",
      admin: {
        titlePath: "headline",
      },
      blocks: [
        AccordionBlock,
        ContactTeaserBlock,
        DownloadsBlock,
        RichTextBlock,
        TeaserBlock,
        TeaserTwoColBlock,
        TextImageBlock,
      ],
    },
```

sample block config:

```typescript
const RichTextBlock: Block = {
  slug: "rich-text",
  fields: [
    {
      name: "strapiId",
      type: "number",
    },
    {
      name: "headline",
      type: "text",
      localized: true,
      hidden: true,
    },
    {
      name: "text",
      type: "text",
      localized: true,
    },
  ],
};
```

Sorry, I'm using Webstorm and don't get it managed to have it adopt the existing code-style :( but I think semicolons are always fine... I hope...

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
