### PR TITLE
fix: allow passing of autoIndex mongoose connectionOptions

### DIFF
--- a/src/mongoose/connect.ts
+++ b/src/mongoose/connect.ts
@@ -11,9 +11,9 @@ const connectMongoose = async (
   let urlToConnect = url;
   let successfulConnectionMessage = 'Connected to Mongo server successfully!';
   const connectionOptions = {
+    autoIndex: true,
     ...options,
     useNewUrlParser: true,
-    autoIndex: true,
   };
 
   if (process.env.NODE_ENV === 'test' || process.env.MEMORY_SERVER) {


### PR DESCRIPTION
## Description

Related to issue #571. This change allows setting autoIndex to false for projects that want to disable it in mongoose connection options to avoid mongo indexes to be created on startup.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
