### PR TITLE
Fix/auth me gql relationships

### DIFF
--- a/src/auth/strategies/jwt.ts
+++ b/src/auth/strategies/jwt.ts
@@ -37,12 +37,14 @@ export default ({ secret, config, collections }: Payload): PassportStrategy => {
         };
       }
 
+      const isGraphQL = req.url === config.routes.graphQL;
+
       const userQuery = await find({
         where,
         collection,
         req,
         overrideAccess: true,
-        depth: collection.config.auth.depth,
+        depth: isGraphQL ? 0 : collection.config.auth.depth,
       });
 
       if (userQuery.docs && userQuery.docs.length > 0) {

--- a/src/auth/strategies/jwt.ts
+++ b/src/auth/strategies/jwt.ts
@@ -37,7 +37,7 @@ export default ({ secret, config, collections }: Payload): PassportStrategy => {
         };
       }
 
-      const isGraphQL = req.url === config.routes.graphQL;
+      const isGraphQL = (req.url || '').replace(/\/$/, '') === config.routes.graphQL.replace(/\/$/, '');
 
       const userQuery = await find({
         where,


### PR DESCRIPTION
## Description

Fixes a bug within the JWT strategy which was preventing GraphQL from querying relationship fields from a `me` query.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
