### PR TITLE
fix: sharpens radio input edges

### DIFF
--- a/src/admin/components/forms/field-types/RadioGroup/RadioInput/index.scss
+++ b/src/admin/components/forms/field-types/RadioGroup/RadioInput/index.scss
@@ -20,13 +20,13 @@
     border-radius: 50%;
 
     &:before {
-      content: ' ';
+      content: " ";
       display: block;
       border-radius: 100%;
       background-color: var(--theme-elevation-800);
-      width: 100%;
-      height: 100%;
-      box-shadow: inset 0 0 0 base(.1875) var(--theme-elevation-0);
+      width: calc(100% - 10px);
+      height: calc(100% - 10px);
+      border: 5px solid var(--theme-elevation-0);
       opacity: 0;
     }
   }


### PR DESCRIPTION
## Description

Replaces box-shadow trick with actual border for radio input. I opted to use whole numbers - since not all screens can render fractional pixels.

#### Before
![Screen Shot 2022-07-18 at 12 15 28 PM](https://user-images.githubusercontent.com/30633324/179560016-d3ed43a2-3f6b-48e8-a227-47ac32fd44cc.png)


#### After
![Screen Shot 2022-07-18 at 12 15 19 PM](https://user-images.githubusercontent.com/30633324/179560036-2c11e7db-df5a-4842-9e36-4ac4e330a1ef.png)


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

UI improvement
