### PR TITLE
Passing context and giving names to custom auth strategies. Adding in…

### DIFF
--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -2,6 +2,7 @@ import { Strategy } from 'passport';
 import { DeepRequired } from 'ts-essentials';
 import { PayloadRequest } from '../express/types';
 import { Where, PayloadMongooseDocument } from '../types';
+import { Payload } from '..';
 
 export type Permission = {
   permission: boolean
@@ -67,6 +68,8 @@ type GenerateVerifyEmailSubject = (args: { req: PayloadRequest, token: string, u
 type GenerateForgotPasswordEmailHTML = (args?: { req?: PayloadRequest, token?: string, user?: unknown}) => Promise<string> | string
 type GenerateForgotPasswordEmailSubject = (args?: { req?: PayloadRequest, token?: string, user?: any }) => Promise<string> | string
 
+type AuthStrategy = (ctx: Payload) => Strategy | Strategy;
+
 export interface IncomingAuthType {
   tokenExpiration?: number;
   verify?:
@@ -90,7 +93,8 @@ export interface IncomingAuthType {
   }
   disableLocalStrategy?: true
   strategies?: {
-    strategy: Strategy
+    name?: string
+    strategy: AuthStrategy
     refresh?: boolean
     logout?: boolean
   }[]

--- a/src/collections/config/schema.ts
+++ b/src/collections/config/schema.ts
@@ -89,7 +89,11 @@ const collectionSchema = joi.object().keys({
       maxLoginAttempts: joi.number(),
       disableLocalStrategy: joi.boolean().valid(true),
       strategies: joi.array().items(joi.object().keys({
-        strategy: joi.object().required(),
+        name: joi.string(),
+        strategy: joi.alternatives().try(
+          joi.func().maxArity(1).required(),
+          joi.object()
+        ),
         refresh: joi.boolean(),
         logout: joi.boolean(),
       })),

--- a/src/collections/init.ts
+++ b/src/collections/init.ts
@@ -106,8 +106,9 @@ export default function registerCollections(ctx: Payload): void {
         }
 
         if (Array.isArray(collection.auth.strategies)) {
-          collection.auth.strategies.forEach(({ strategy }) => {
-            passport.use(strategy);
+          collection.auth.strategies.forEach(({ name, strategy }, index) => {
+            const passportStrategy = typeof strategy === 'object' ? strategy : strategy(ctx);
+            passport.use(`${AuthCollection.config.slug}-${name ?? index}`, passportStrategy);
           });
         }
       }

--- a/src/express/middleware/authenticate.ts
+++ b/src/express/middleware/authenticate.ts
@@ -12,8 +12,8 @@ export default (config: SanitizedConfig): PayloadAuthenticate => {
       const collectionMethods = [...enabledMethods];
 
       if (Array.isArray(collection.auth.strategies)) {
-        collection.auth.strategies.forEach(({ strategy }) => {
-          collectionMethods.unshift(strategy.name);
+        collection.auth.strategies.forEach(({ name }, index) => {
+          collectionMethods.unshift(`${collection.slug}-${name ?? index}`);
         });
       }
 

--- a/test/auth/custom-strategy/config.ts
+++ b/test/auth/custom-strategy/config.ts
@@ -1,0 +1,96 @@
+import { Request } from 'express';
+import { Strategy } from 'passport-strategy';
+import { Payload } from '../../../src';
+import { buildConfig } from '../../buildConfig';
+
+export const slug = 'users';
+export const strategyName = 'test-local'
+
+export class CustomStrategy extends Strategy {
+
+  ctx: Payload;
+
+  constructor(ctx: Payload) {
+    super();
+    this.ctx = ctx;
+  }
+
+  authenticate(req: Request, options?: any): void {
+    if(!req.headers.code && !req.headers.secret) {
+      return this.success(null);
+    }
+    this.ctx.find({
+      collection: slug,
+      where: {
+        code: {
+          equals: req.headers.code
+        },
+        secret: {
+          equals: req.headers.secret
+        }
+      }
+    }).then((users) => {
+      if(users.docs && users.docs.length) {
+        const user = users.docs[0];
+        user.collection = slug;
+        user._strategy = `${slug}-${strategyName}`;
+        this.success(user)
+      } else {
+        this.error(null)
+      }
+    })
+  }
+}
+
+export default buildConfig({
+  admin: {
+    user: 'users',
+  },
+  collections: [
+    {
+      slug,
+      auth: {
+        disableLocalStrategy: true,
+        strategies: [
+          {
+            name: strategyName,
+            strategy: (ctx) => new CustomStrategy(ctx)
+          }
+        ]
+      },
+      access: {
+        create: () => true
+      },
+      fields: [
+        {
+          name: 'code',
+          label: 'Code',
+          type: 'text',
+          unique: true,
+          index: true,
+        },
+        {
+          name: 'secret',
+          label: 'Secret',
+          type: 'text',
+        },
+        {
+          name: 'name',
+          label: 'Name',
+          type: 'text',
+        },
+        {
+          name: 'roles',
+          label: 'Role',
+          type: 'select',
+          options: ['admin', 'editor', 'moderator', 'user', 'viewer'],
+          defaultValue: 'user',
+          required: true,
+          saveToJWT: true,
+          hasMany: true,
+        },
+
+      ],
+    },
+  ],
+});

--- a/test/auth/custom-strategy/int.spec.ts
+++ b/test/auth/custom-strategy/int.spec.ts
@@ -1,0 +1,57 @@
+import mongoose from 'mongoose';
+import payload from '../../../src';
+import { initPayloadTest } from '../../helpers/configHelpers';
+import { slug } from './config';
+
+require('isomorphic-fetch');
+
+let apiUrl;
+
+const [ code, secret, name ] = [ 'test', 'strategy', 'Tester' ];
+
+const headers = {
+  'Content-Type': 'application/json',
+};
+
+describe('AuthStrategies', () => {
+  beforeAll(async () => {
+    const { serverURL } = await initPayloadTest({ __dirname, init: { local: false } });
+    apiUrl = `${serverURL}/api`;
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.dropDatabase();
+    await mongoose.connection.close();
+    await payload.mongoMemoryServer.stop();
+  });
+
+  describe('create user', () => {
+    beforeAll(async () => {
+      await fetch(`${apiUrl}/${slug}`, {
+        body: JSON.stringify({
+          code,
+          secret,
+          name
+        }),
+        headers,
+        method: 'post',
+      });
+    });
+
+    it('should return a logged in user from /me', async () => {
+      const response = await fetch(`${apiUrl}/${slug}/me`, {
+        headers: {
+          ...headers,
+          code,
+          secret
+        },
+      });
+
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.user.name).toBe(name)
+    });
+
+  });
+});


### PR DESCRIPTION
…itial tests for custom auth strategies

## Description

Initializing custom auth strategies with Payload context object and adding it a name to behave like embedded ones.

Custom strategies might need to access Payload configuration and it might not be already initialized. I had to extend/replace the existing JwtStrategy with a custom one while using 'disableLocalStrategy', because it wrongly assumes there will be an email in the token, and I the Sanitized config wasn't initialized at that point if I called the build function directly from the CollectionConfig.

I hope this test foundation can also be helpful to be enhanced with more examples about custom strategies too.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
