### PR TITLE
fix(doc): corrects  doc to match underlying Access type

### DIFF
--- a/docs/access-control/collections.mdx
+++ b/docs/access-control/collections.mdx
@@ -90,11 +90,9 @@ const canReadPage = ({ req: { user } }) => {
   }
   // using a query constraint, guest users can access when a field named 'isPublic' is set to true
   return {
-    where: {
-      // assumes we have a checkbox field named 'isPublic'
-      isPublic: {
-        equals: true
-      }
+    // assumes we have a checkbox field named 'isPublic'
+    isPublic: {
+      equals: true
     }
   }
 };


### PR DESCRIPTION
## Description

Corrects **Read** access control example when returning a query constraint to match underlying type.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Documentation
