### PR TITLE
feat: sets auth strategy name using strategy when provided

### DIFF
--- a/src/collections/config/schema.ts
+++ b/src/collections/config/schema.ts
@@ -1,6 +1,11 @@
 import joi from 'joi';
 import { componentSchema } from '../../utilities/componentSchema';
 
+const strategyBaseSchema = joi.object().keys({
+  refresh: joi.boolean(),
+  logout: joi.boolean(),
+});
+
 const collectionSchema = joi.object().keys({
   slug: joi.string().required(),
   labels: joi.object({
@@ -88,15 +93,18 @@ const collectionSchema = joi.object().keys({
       }),
       maxLoginAttempts: joi.number(),
       disableLocalStrategy: joi.boolean().valid(true),
-      strategies: joi.array().items(joi.object().keys({
-        name: joi.string(),
-        strategy: joi.alternatives().try(
-          joi.func().maxArity(1).required(),
-          joi.object()
-        ),
-        refresh: joi.boolean(),
-        logout: joi.boolean(),
-      })),
+      strategies: joi.array().items(joi.alternatives().try(
+        strategyBaseSchema.keys({
+          name: joi.string().required(),
+          strategy: joi.func()
+            .maxArity(1)
+            .required(),
+        }),
+        strategyBaseSchema.keys({
+          name: joi.string(),
+          strategy: joi.object().required(),
+        }),
+      )),
     }),
     joi.boolean(),
   ),

--- a/src/express/middleware/authenticate.ts
+++ b/src/express/middleware/authenticate.ts
@@ -12,8 +12,8 @@ export default (config: SanitizedConfig): PayloadAuthenticate => {
       const collectionMethods = [...enabledMethods];
 
       if (Array.isArray(collection.auth.strategies)) {
-        collection.auth.strategies.forEach(({ name }, index) => {
-          collectionMethods.unshift(`${collection.slug}-${name ?? index}`);
+        collection.auth.strategies.forEach(({ name, strategy }, index) => {
+          collectionMethods.unshift(`${collection.slug}-${name ?? strategy.name ?? index}`);
         });
       }
 

--- a/src/express/middleware/authenticate.ts
+++ b/src/express/middleware/authenticate.ts
@@ -12,8 +12,8 @@ export default (config: SanitizedConfig): PayloadAuthenticate => {
       const collectionMethods = [...enabledMethods];
 
       if (Array.isArray(collection.auth.strategies)) {
-        collection.auth.strategies.forEach(({ name, strategy }, index) => {
-          collectionMethods.unshift(`${collection.slug}-${name ?? strategy.name ?? index}`);
+        collection.auth.strategies.forEach(({ name, strategy }) => {
+          collectionMethods.unshift(`${collection.slug}-${name ?? strategy.name}`);
         });
       }
 


### PR DESCRIPTION
## Description

Better handles naming of auth strategies and validates the configuration more.

@lucianogreiner I made a few more tweaks and we're updating the docs too. 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
