### PR TITLE
Fix/trim login email

### DIFF
--- a/src/auth/operations/login.ts
+++ b/src/auth/operations/login.ts
@@ -70,7 +70,7 @@ async function login<T>(incomingArgs: Arguments): Promise<Result & { user: T}> {
 
   const { email: unsanitizedEmail, password } = data;
 
-  const email = unsanitizedEmail ? (unsanitizedEmail as string).toLowerCase() : null;
+  const email = unsanitizedEmail ? (unsanitizedEmail as string).toLowerCase().trim() : null;
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore Improper typing in library, additional args should be optional


### PR DESCRIPTION
## Description

I propose to trim trailing whitespaces from the email in the login. A simple quality-of-life fix.
I couldn't login at some point because of a trailing whitespace in the end, which is a bit tricky to see.
I didn't add any tests because I didn't really know how to integrate it with the existing test-suite.

- [ X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
