### PR TITLE
fix: set overflow payload modal container to auto

### DIFF
--- a/src/admin/scss/app.scss
+++ b/src/admin/scss/app.scss
@@ -163,7 +163,7 @@ dialog {
 }
 
 .payload__modal-container--enterDone {
-  overflow: scroll;
+  overflow: auto;
 }
 
 .payload__modal-item--enter,


### PR DESCRIPTION
## Description

Minor aesthetic detail:
![image](https://user-images.githubusercontent.com/10504064/180675305-606340a8-759f-43bc-b1a3-455355871118.png)

The payload-modal had these scrollbars for unknown reasons which are quite glaring, especially on windows.
I replaced `overflow: scroll` with `overflow: auto`, which should take care of all cases I believe.

![image](https://user-images.githubusercontent.com/10504064/180675608-a0ce49e7-1611-429b-872b-f2755ac58101.png)


- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
