### PR TITLE
fix: remove formContext from useEffect's deps

### DIFF
--- a/src/admin/components/forms/field-types/Array/Array.tsx
+++ b/src/admin/components/forms/field-types/Array/Array.tsx
@@ -178,7 +178,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
   useEffect(() => {
     const data = formContext.getDataByPath<Row[]>(path);
     dispatchRows({ type: 'SET_ALL', data: data || [], collapsedState: preferences?.fields?.[path]?.collapsed });
-  }, [/* formContext, */ path, preferences]);
+  }, [path, preferences]);
 
   useEffect(() => {
     setValue(rows?.length || 0, true);

--- a/src/admin/components/forms/field-types/Array/Array.tsx
+++ b/src/admin/components/forms/field-types/Array/Array.tsx
@@ -178,7 +178,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
   useEffect(() => {
     const data = formContext.getDataByPath<Row[]>(path);
     dispatchRows({ type: 'SET_ALL', data: data || [], collapsedState: preferences?.fields?.[path]?.collapsed });
-  }, [formContext, path, preferences]);
+  }, [/* formContext, */ path, preferences]);
 
   useEffect(() => {
     setValue(rows?.length || 0, true);


### PR DESCRIPTION
## Description

as mentioned [https://github.com/payloadcms/payload/issues/809](url) 
the array-elements would revert to the preferences every time a collection was saved.

This was due to the formContext being a part of the dependencies of this function 
in admin/components/forms/field-types/Array.tsx 
```
useEffect(() => {
    const data = formContext.getDataByPath<Row[]>(path);
    dispatchRows({ type: 'SET_ALL', data: data || [], collapsedState: preferences?.fields?.[path]?.collapsed });
}, [formContext, path, preferences]);
```
without it we have the expected behavior: 
fields stay collapsed how they were after save, and it still remembers the collapsed state when you return to the page.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
