### PR TITLE
feat: greatly enhances performance by using dataloader pattern to batch populations

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "connect-history-api-fallback": "^1.6.0",
     "css-loader": "^5.0.1",
     "css-minimizer-webpack-plugin": "^3.4.1",
+    "dataloader": "^2.1.0",
     "date-fns": "^2.14.0",
     "deep-equal": "^2.0.5",
     "deepmerge": "^4.2.2",

--- a/src/auth/operations/local/forgotPassword.ts
+++ b/src/auth/operations/local/forgotPassword.ts
@@ -1,6 +1,7 @@
 import { PayloadRequest } from '../../../express/types';
 import forgotPassword, { Result } from '../forgotPassword';
 import { Payload } from '../../..';
+import { getDataLoader } from '../../../collections/dataloader';
 
 export type Options = {
   collection: string
@@ -23,15 +24,19 @@ async function localForgotPassword(payload: Payload, options: Options): Promise<
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    ...req,
+    payloadAPI: 'local',
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return forgotPassword({
     data,
     collection,
     disableEmail,
     expiration,
-    req: {
-      ...req,
-      payloadAPI: 'local',
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }
 

--- a/src/auth/operations/local/forgotPassword.ts
+++ b/src/auth/operations/local/forgotPassword.ts
@@ -19,24 +19,24 @@ async function localForgotPassword(payload: Payload, options: Options): Promise<
     data,
     expiration,
     disableEmail,
-    req = {},
+    req: incomingReq = {},
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
-    ...req,
+  const req = {
+    ...incomingReq,
     payloadAPI: 'local',
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return forgotPassword({
     data,
     collection,
     disableEmail,
     expiration,
-    req: reqToUse,
+    req,
   });
 }
 

--- a/src/auth/operations/local/login.ts
+++ b/src/auth/operations/local/login.ts
@@ -23,7 +23,7 @@ export type Options = {
 async function localLogin<T extends TypeWithID = any>(payload: Payload, options: Options): Promise<Result & { user: T}> {
   const {
     collection: collectionSlug,
-    req = {},
+    req: incomingReq = {},
     res,
     depth,
     locale,
@@ -35,15 +35,15 @@ async function localLogin<T extends TypeWithID = any>(payload: Payload, options:
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
-    ...req,
+  const req = {
+    ...incomingReq,
     payloadAPI: 'local',
     payload,
     locale: undefined,
     fallbackLocale: undefined,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   const args = {
     depth,
@@ -51,7 +51,7 @@ async function localLogin<T extends TypeWithID = any>(payload: Payload, options:
     overrideAccess,
     showHiddenFields,
     data,
-    req: reqToUse,
+    req,
     res,
   };
 

--- a/src/auth/operations/local/login.ts
+++ b/src/auth/operations/local/login.ts
@@ -3,6 +3,7 @@ import login, { Result } from '../login';
 import { PayloadRequest } from '../../../express/types';
 import { TypeWithID } from '../../../collections/config/types';
 import { Payload } from '../../..';
+import { getDataLoader } from '../../../collections/dataloader';
 
 export type Options = {
   collection: string
@@ -34,19 +35,23 @@ async function localLogin<T extends TypeWithID = any>(payload: Payload, options:
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    ...req,
+    payloadAPI: 'local',
+    payload,
+    locale: undefined,
+    fallbackLocale: undefined,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   const args = {
     depth,
     collection,
     overrideAccess,
     showHiddenFields,
     data,
-    req: {
-      ...req,
-      payloadAPI: 'local',
-      payload,
-      locale: undefined,
-      fallbackLocale: undefined,
-    } as PayloadRequest,
+    req: reqToUse,
     res,
   };
 

--- a/src/auth/operations/local/resetPassword.ts
+++ b/src/auth/operations/local/resetPassword.ts
@@ -1,6 +1,7 @@
 import { Payload } from '../../..';
 import resetPassword, { Result } from '../resetPassword';
 import { PayloadRequest } from '../../../express/types';
+import { getDataLoader } from '../../../collections/dataloader';
 
 export type Options = {
   collection: string
@@ -22,15 +23,19 @@ async function localResetPassword(payload: Payload, options: Options): Promise<R
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    ...req,
+    payload,
+    payloadAPI: 'local',
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return resetPassword({
     collection,
     data,
     overrideAccess,
-    req: {
-      ...req,
-      payload,
-      payloadAPI: 'local',
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }
 

--- a/src/auth/operations/local/resetPassword.ts
+++ b/src/auth/operations/local/resetPassword.ts
@@ -18,24 +18,24 @@ async function localResetPassword(payload: Payload, options: Options): Promise<R
     collection: collectionSlug,
     data,
     overrideAccess,
-    req,
+    req: incomingReq = {},
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
-    ...req,
+  const req = {
+    ...incomingReq,
     payload,
     payloadAPI: 'local',
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return resetPassword({
     collection,
     data,
     overrideAccess,
-    req: reqToUse,
+    req,
   });
 }
 

--- a/src/auth/operations/local/unlock.ts
+++ b/src/auth/operations/local/unlock.ts
@@ -17,24 +17,24 @@ async function localUnlock(payload: Payload, options: Options): Promise<boolean>
     collection: collectionSlug,
     data,
     overrideAccess = true,
-    req,
+    req: incomingReq = {},
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
-    ...req,
+  const req = {
+    ...incomingReq,
     payload,
     payloadAPI: 'local',
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return unlock({
     data,
     collection,
     overrideAccess,
-    req: reqToUse,
+    req,
   });
 }
 

--- a/src/auth/operations/local/unlock.ts
+++ b/src/auth/operations/local/unlock.ts
@@ -1,6 +1,7 @@
 import { PayloadRequest } from '../../../express/types';
 import { Payload } from '../../..';
 import unlock from '../unlock';
+import { getDataLoader } from '../../../collections/dataloader';
 
 export type Options = {
   collection: string
@@ -21,15 +22,19 @@ async function localUnlock(payload: Payload, options: Options): Promise<boolean>
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    ...req,
+    payload,
+    payloadAPI: 'local',
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return unlock({
     data,
     collection,
     overrideAccess,
-    req: {
-      ...req,
-      payload,
-      payloadAPI: 'local',
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }
 

--- a/src/auth/strategies/jwt.ts
+++ b/src/auth/strategies/jwt.ts
@@ -31,7 +31,7 @@ export default ({ secret, config, collections }: Payload): PassportStrategy => {
         depth: isGraphQL ? 0 : collection.config.auth.depth,
       });
 
-      if(user && (!collection.config.auth.verify || user._verified)) {
+      if (user && (!collection.config.auth.verify || user._verified)) {
         user.collection = collection.config.slug;
         user._strategy = 'local-jwt';
         done(null, user);

--- a/src/collections/dataloader.ts
+++ b/src/collections/dataloader.ts
@@ -1,4 +1,3 @@
-import { Response, NextFunction } from 'express';
 import DataLoader, { BatchLoadFn } from 'dataloader';
 import { PayloadRequest } from '../express/types';
 import { TypeWithID } from '../globals/config/types';

--- a/src/collections/dataloader.ts
+++ b/src/collections/dataloader.ts
@@ -70,6 +70,7 @@ const batchAndLoadDocs = (req: PayloadRequest): BatchLoadFn<string, TypeWithID> 
       fallbackLocale,
       depth,
       currentDepth,
+      pagination: false,
       where: {
         id: {
           in: ids,

--- a/src/collections/dataloader.ts
+++ b/src/collections/dataloader.ts
@@ -1,0 +1,105 @@
+import { Response, NextFunction } from 'express';
+import DataLoader, { BatchLoadFn } from 'dataloader';
+import { PayloadRequest } from '../express/types';
+import { TypeWithID } from '../globals/config/types';
+
+// Payload uses `dataloader` to solve the classic GraphQL N+1 problem.
+
+// We keep a list of all documents requested to be populated for any given request
+// and then batch together documents within the same collection,
+// making only 1 find per each collection, rather than `findByID` per each requested doc.
+
+// This dramatically improves performance for REST and Local API `depth` populations,
+// and also ensures complex GraphQL queries perform lightning-fast.
+
+const batchAndLoadDocs = (req: PayloadRequest): BatchLoadFn<string, TypeWithID> => async (keys: string[]): Promise<TypeWithID[]> => {
+  const { payload } = req;
+
+  // Create docs array of same length as keys, using null as value
+  // We will replace nulls with injected docs as they are retrieved
+  const docs: (TypeWithID | null)[] = keys.map(() => null);
+
+  // Batch IDs by their `find` args
+  // so we can make one find query per combination of collection, depth, locale, and fallbackLocale.
+
+  // Resulting shape will be as follows:
+
+  // {
+  //   // key is stringified set of find args
+  //   '["pages",2,0,"es","en",false,false]': [
+  //     // value is array of IDs to find with these args
+  //     'q34tl23462346234524',
+  //     '435523540194324280',
+  //     '2346245j35l3j5234532li',
+  //   ],
+  //   // etc
+  // };
+
+  const batchByFindArgs = keys.reduce((batches, key) => {
+    const [collection, id, depth, currentDepth, locale, fallbackLocale, overrideAccess, showHiddenFields] = JSON.parse(key);
+
+    const batchKeyArray = [
+      collection,
+      depth,
+      currentDepth,
+      locale,
+      fallbackLocale,
+      overrideAccess,
+      showHiddenFields,
+    ];
+
+    const batchKey = JSON.stringify(batchKeyArray);
+
+    return {
+      ...batches,
+      [batchKey]: [
+        ...batches[batchKey] || [],
+        id,
+      ],
+    };
+  }, {});
+
+  // Run find requests in parallel
+
+  const results = Object.entries(batchByFindArgs).map(async ([batchKey, ids]) => {
+    const [collection, depth, currentDepth, locale, fallbackLocale, overrideAccess, showHiddenFields] = JSON.parse(batchKey);
+
+    const result = await payload.find({
+      collection,
+      locale,
+      fallbackLocale,
+      depth,
+      currentDepth,
+      where: {
+        id: {
+          in: ids,
+        },
+      },
+      overrideAccess: Boolean(overrideAccess),
+      showHiddenFields: Boolean(showHiddenFields),
+      disableErrors: true,
+      req,
+    });
+
+    // For each returned doc, find index in original keys
+    // Inject doc within docs array if index exists
+
+    result.docs.forEach((doc) => {
+      const docKey = JSON.stringify([collection, doc.id, depth, currentDepth, locale, fallbackLocale, overrideAccess, showHiddenFields]);
+      const docsIndex = keys.findIndex((key) => key === docKey);
+
+      if (docsIndex > -1) {
+        docs[docsIndex] = doc;
+      }
+    });
+  });
+
+  await Promise.all(results);
+
+  // Return docs array,
+  // which has now been injected with all fetched docs
+  // and should match the length of the incoming keys arg
+  return docs;
+};
+
+export const getDataLoader = (req: PayloadRequest) => new DataLoader(batchAndLoadDocs(req));

--- a/src/collections/operations/local/create.ts
+++ b/src/collections/operations/local/create.ts
@@ -38,25 +38,25 @@ export default async function createLocal<T = any>(payload: Payload, options: Op
     filePath,
     file,
     overwriteExistingFiles = false,
-    req,
+    req: incomingReq,
     draft,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
-    ...req || {},
+  const req = {
+    ...incomingReq || {},
     user,
     payloadAPI: 'local',
-    locale: locale || req?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
-    fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
+    locale: locale || incomingReq?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
+    fallbackLocale: fallbackLocale || incomingReq?.fallbackLocale || null,
     payload,
     files: {
       file: file ?? getFileByPath(filePath),
     },
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return create({
     depth,
@@ -67,6 +67,6 @@ export default async function createLocal<T = any>(payload: Payload, options: Op
     showHiddenFields,
     overwriteExistingFiles,
     draft,
-    req: reqToUse,
+    req,
   });
 }

--- a/src/collections/operations/local/create.ts
+++ b/src/collections/operations/local/create.ts
@@ -4,6 +4,7 @@ import { Document } from '../../../types';
 import getFileByPath from '../../../uploads/getFileByPath';
 import create from '../create';
 import { File } from '../../../uploads/types';
+import { getDataLoader } from '../../dataloader';
 
 
 export type Options<T> = {
@@ -43,6 +44,20 @@ export default async function createLocal<T = any>(payload: Payload, options: Op
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    ...req || {},
+    user,
+    payloadAPI: 'local',
+    locale: locale || req?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
+    fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
+    payload,
+    files: {
+      file: file ?? getFileByPath(filePath),
+    },
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return create({
     depth,
     data,
@@ -52,16 +67,6 @@ export default async function createLocal<T = any>(payload: Payload, options: Op
     showHiddenFields,
     overwriteExistingFiles,
     draft,
-    req: {
-      ...req || {},
-      user,
-      payloadAPI: 'local',
-      locale: locale || req?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
-      fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
-      payload,
-      files: {
-        file: file ?? getFileByPath(filePath),
-      },
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }

--- a/src/collections/operations/local/delete.ts
+++ b/src/collections/operations/local/delete.ts
@@ -30,7 +30,7 @@ export default async function deleteLocal<T extends TypeWithID = any>(payload: P
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
+  const req = {
     user,
     payloadAPI: 'local',
     locale,
@@ -38,7 +38,7 @@ export default async function deleteLocal<T extends TypeWithID = any>(payload: P
     payload,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return deleteOperation({
     depth,
@@ -46,6 +46,6 @@ export default async function deleteLocal<T extends TypeWithID = any>(payload: P
     collection,
     overrideAccess,
     showHiddenFields,
-    req: reqToUse,
+    req,
   });
 }

--- a/src/collections/operations/local/delete.ts
+++ b/src/collections/operations/local/delete.ts
@@ -3,6 +3,7 @@ import { Document } from '../../../types';
 import { PayloadRequest } from '../../../express/types';
 import { Payload } from '../../../index';
 import deleteOperation from '../delete';
+import { getDataLoader } from '../../dataloader';
 
 export type Options = {
   collection: string
@@ -29,18 +30,22 @@ export default async function deleteLocal<T extends TypeWithID = any>(payload: P
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    user,
+    payloadAPI: 'local',
+    locale,
+    fallbackLocale,
+    payload,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return deleteOperation({
     depth,
     id,
     collection,
     overrideAccess,
     showHiddenFields,
-    req: {
-      user,
-      payloadAPI: 'local',
-      locale,
-      fallbackLocale,
-      payload,
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }

--- a/src/collections/operations/local/find.ts
+++ b/src/collections/operations/local/find.ts
@@ -4,21 +4,25 @@ import { Document, Where } from '../../../types';
 import { Payload } from '../../..';
 import { PayloadRequest } from '../../../express/types';
 import find from '../find';
+import { getDataLoader } from '../../dataloader';
 
 export type Options = {
   collection: string
   depth?: number
+  currentDepth?: number
   page?: number
   limit?: number
   locale?: string
   fallbackLocale?: string
   user?: Document
   overrideAccess?: boolean
+  disableErrors?: boolean
   showHiddenFields?: boolean
   pagination?: boolean
   sort?: string
   where?: Where
   draft?: boolean
+  req?: PayloadRequest
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -26,6 +30,7 @@ export default async function findLocal<T extends TypeWithID = any>(payload: Pay
   const {
     collection: collectionSlug,
     depth,
+    currentDepth,
     page,
     limit,
     where,
@@ -33,31 +38,42 @@ export default async function findLocal<T extends TypeWithID = any>(payload: Pay
     fallbackLocale = null,
     user,
     overrideAccess = true,
+    disableErrors,
     showHiddenFields,
     sort,
     draft = false,
     pagination = true,
+    req,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    user: undefined,
+    ...req || {},
+    payloadAPI: 'local',
+    locale: locale || req?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
+    fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
+    payload,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
+  if (typeof user !== 'undefined') reqToUse.user = user;
+
   return find({
     depth,
+    currentDepth,
     sort,
     page,
     limit,
     where,
     collection,
     overrideAccess,
+    disableErrors,
     showHiddenFields,
     draft,
     pagination,
-    req: {
-      user,
-      payloadAPI: 'local',
-      locale,
-      fallbackLocale,
-      payload,
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }

--- a/src/collections/operations/local/find.ts
+++ b/src/collections/operations/local/find.ts
@@ -43,23 +43,23 @@ export default async function findLocal<T extends TypeWithID = any>(payload: Pay
     sort,
     draft = false,
     pagination = true,
-    req,
+    req: incomingReq,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
+  const req = {
     user: undefined,
-    ...req || {},
+    ...incomingReq || {},
     payloadAPI: 'local',
-    locale: locale || req?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
-    fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
+    locale: locale || incomingReq?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
+    fallbackLocale: fallbackLocale || incomingReq?.fallbackLocale || null,
     payload,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
-  if (typeof user !== 'undefined') reqToUse.user = user;
+  if (typeof user !== 'undefined') req.user = user;
 
   return find({
     depth,
@@ -74,6 +74,6 @@ export default async function findLocal<T extends TypeWithID = any>(payload: Pay
     showHiddenFields,
     draft,
     pagination,
-    req: reqToUse,
+    req,
   });
 }

--- a/src/collections/operations/local/findByID.ts
+++ b/src/collections/operations/local/findByID.ts
@@ -33,24 +33,24 @@ export default async function findByIDLocal<T extends TypeWithID = any>(payload:
     overrideAccess = true,
     disableErrors = false,
     showHiddenFields,
-    req,
+    req: incomingReq,
     draft = false,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
+  const req = {
     user: undefined,
-    ...req || {},
+    ...incomingReq || {},
     payloadAPI: 'local',
-    locale: locale || req?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
-    fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
+    locale: locale || incomingReq?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
+    fallbackLocale: fallbackLocale || incomingReq?.fallbackLocale || null,
     payload,
   } as PayloadRequest;
 
-  if (typeof user !== 'undefined') reqToUse.user = user;
+  if (typeof user !== 'undefined') req.user = user;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findByID({
     depth,
@@ -60,7 +60,7 @@ export default async function findByIDLocal<T extends TypeWithID = any>(payload:
     overrideAccess,
     disableErrors,
     showHiddenFields,
-    req: reqToUse,
+    req,
     draft,
   });
 }

--- a/src/collections/operations/local/findByID.ts
+++ b/src/collections/operations/local/findByID.ts
@@ -3,6 +3,7 @@ import { PayloadRequest } from '../../../express/types';
 import { Document } from '../../../types';
 import findByID from '../findByID';
 import { Payload } from '../../..';
+import { getDataLoader } from '../../dataloader';
 
 export type Options = {
   collection: string
@@ -45,9 +46,11 @@ export default async function findByIDLocal<T extends TypeWithID = any>(payload:
     locale: locale || req?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
     fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
     payload,
-  };
+  } as PayloadRequest;
 
   if (typeof user !== 'undefined') reqToUse.user = user;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
 
   return findByID({
     depth,
@@ -57,7 +60,7 @@ export default async function findByIDLocal<T extends TypeWithID = any>(payload:
     overrideAccess,
     disableErrors,
     showHiddenFields,
-    req: reqToUse as PayloadRequest,
+    req: reqToUse,
     draft,
   });
 }

--- a/src/collections/operations/local/findVersionByID.ts
+++ b/src/collections/operations/local/findVersionByID.ts
@@ -28,20 +28,20 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
     overrideAccess = true,
     disableErrors = false,
     showHiddenFields,
-    req,
+    req: incomingReq,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
-    ...req || {},
+  const req = {
+    ...incomingReq || {},
     payloadAPI: 'local',
-    locale: locale || req?.locale || this?.config?.localization?.defaultLocale,
-    fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
+    locale: locale || incomingReq?.locale || this?.config?.localization?.defaultLocale,
+    fallbackLocale: fallbackLocale || incomingReq?.fallbackLocale || null,
     payload,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findVersionByID({
     depth,
@@ -50,6 +50,6 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
     overrideAccess,
     disableErrors,
     showHiddenFields,
-    req: reqToUse,
+    req,
   });
 }

--- a/src/collections/operations/local/findVersionByID.ts
+++ b/src/collections/operations/local/findVersionByID.ts
@@ -3,6 +3,7 @@ import { Document } from '../../../types';
 import { PayloadRequest } from '../../../express/types';
 import { TypeWithVersion } from '../../../versions/types';
 import findVersionByID from '../findVersionByID';
+import { getDataLoader } from '../../dataloader';
 
 export type Options = {
   collection: string
@@ -32,6 +33,16 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    ...req || {},
+    payloadAPI: 'local',
+    locale: locale || req?.locale || this?.config?.localization?.defaultLocale,
+    fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
+    payload,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return findVersionByID({
     depth,
     id,
@@ -39,12 +50,6 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
     overrideAccess,
     disableErrors,
     showHiddenFields,
-    req: {
-      ...req || {},
-      payloadAPI: 'local',
-      locale: locale || req?.locale || this?.config?.localization?.defaultLocale,
-      fallbackLocale: fallbackLocale || req?.fallbackLocale || null,
-      payload,
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }

--- a/src/collections/operations/local/findVersions.ts
+++ b/src/collections/operations/local/findVersions.ts
@@ -4,6 +4,7 @@ import { PaginatedDocs } from '../../../mongoose/types';
 import { TypeWithVersion } from '../../../versions/types';
 import { PayloadRequest } from '../../../express/types';
 import findVersions from '../findVersions';
+import { getDataLoader } from '../../dataloader';
 
 export type Options = {
   collection: string
@@ -36,6 +37,16 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    user,
+    payloadAPI: 'local',
+    locale,
+    fallbackLocale,
+    payload,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return findVersions({
     where,
     page,
@@ -45,12 +56,6 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
     sort,
     overrideAccess,
     showHiddenFields,
-    req: {
-      user,
-      payloadAPI: 'local',
-      locale,
-      fallbackLocale,
-      payload,
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }

--- a/src/collections/operations/local/findVersions.ts
+++ b/src/collections/operations/local/findVersions.ts
@@ -37,7 +37,7 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
+  const req = {
     user,
     payloadAPI: 'local',
     locale,
@@ -45,7 +45,7 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
     payload,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findVersions({
     where,
@@ -56,6 +56,6 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
     sort,
     overrideAccess,
     showHiddenFields,
-    req: reqToUse,
+    req,
   });
 }

--- a/src/collections/operations/local/restoreVersion.ts
+++ b/src/collections/operations/local/restoreVersion.ts
@@ -30,7 +30,7 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
+  const req = {
     user,
     payloadAPI: 'local',
     locale,
@@ -38,7 +38,7 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
     payload,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   const args = {
     payload,
@@ -47,7 +47,7 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
     overrideAccess,
     id,
     showHiddenFields,
-    req: reqToUse,
+    req,
   };
 
   return restoreVersion(args);

--- a/src/collections/operations/local/restoreVersion.ts
+++ b/src/collections/operations/local/restoreVersion.ts
@@ -2,6 +2,7 @@ import { Payload } from '../../..';
 import { PayloadRequest } from '../../../express/types';
 import { Document } from '../../../types';
 import { TypeWithVersion } from '../../../versions/types';
+import { getDataLoader } from '../../dataloader';
 import restoreVersion from '../restoreVersion';
 
 export type Options = {
@@ -29,6 +30,16 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    user,
+    payloadAPI: 'local',
+    locale,
+    fallbackLocale,
+    payload,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   const args = {
     payload,
     depth,
@@ -36,13 +47,7 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
     overrideAccess,
     id,
     showHiddenFields,
-    req: {
-      user,
-      payloadAPI: 'local',
-      locale,
-      fallbackLocale,
-      payload,
-    } as PayloadRequest,
+    req: reqToUse,
   };
 
   return restoreVersion(args);

--- a/src/collections/operations/local/update.ts
+++ b/src/collections/operations/local/update.ts
@@ -3,6 +3,7 @@ import { Document } from '../../../types';
 import getFileByPath from '../../../uploads/getFileByPath';
 import update from '../update';
 import { PayloadRequest } from '../../../express/types';
+import { getDataLoader } from '../../dataloader';
 
 export type Options<T> = {
   collection: string
@@ -41,6 +42,19 @@ export default async function updateLocal<T = any>(payload: Payload, options: Op
 
   const collection = payload.collections[collectionSlug];
 
+  const reqToUse = {
+    user,
+    payloadAPI: 'local',
+    locale,
+    fallbackLocale,
+    payload,
+    files: {
+      file: file ?? getFileByPath(filePath),
+    },
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   const args = {
     depth,
     data,
@@ -52,16 +66,7 @@ export default async function updateLocal<T = any>(payload: Payload, options: Op
     draft,
     autosave,
     payload,
-    req: {
-      user,
-      payloadAPI: 'local',
-      locale,
-      fallbackLocale,
-      payload,
-      files: {
-        file: file ?? getFileByPath(filePath),
-      },
-    } as PayloadRequest,
+    req: reqToUse,
   };
 
   return update(args);

--- a/src/collections/operations/local/update.ts
+++ b/src/collections/operations/local/update.ts
@@ -42,7 +42,7 @@ export default async function updateLocal<T = any>(payload: Payload, options: Op
 
   const collection = payload.collections[collectionSlug];
 
-  const reqToUse = {
+  const req = {
     user,
     payloadAPI: 'local',
     locale,
@@ -53,7 +53,7 @@ export default async function updateLocal<T = any>(payload: Payload, options: Op
     },
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   const args = {
     depth,
@@ -66,7 +66,7 @@ export default async function updateLocal<T = any>(payload: Payload, options: Op
     draft,
     autosave,
     payload,
-    req: reqToUse,
+    req,
   };
 
   return update(args);

--- a/src/express/types.ts
+++ b/src/express/types.ts
@@ -1,12 +1,15 @@
 import { Request } from 'express';
+import DataLoader from 'dataloader';
 import { UploadedFile } from 'express-fileupload';
 import { Payload } from '../index';
 import { Collection } from '../collections/config/types';
 import { User } from '../auth/types';
 import { Document } from '../types';
+import { TypeWithID } from '../globals/config/types';
 
 export type PayloadRequest = Request & {
   payload: Payload;
+  payloadDataLoader: DataLoader<string, TypeWithID>
   locale?: string;
   fallbackLocale?: string;
   collection?: Collection;

--- a/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -29,30 +29,30 @@ const populate = async ({
   const relatedCollection = req.payload.collections[relation];
 
   if (relatedCollection) {
-    let idString = Array.isArray(field.relationTo) ? data.value : data;
+    let id = Array.isArray(field.relationTo) ? data.value : data;
     let relationshipValue;
     const shouldPopulate = depth && currentDepth <= depth;
 
-    if (typeof idString !== 'string' && typeof idString?.toString === 'function') {
-      idString = idString.toString();
+    if (typeof id !== 'string' && typeof id !== 'number' && typeof id?.toString === 'function') {
+      id = id.toString();
     }
 
     if (shouldPopulate) {
-      relationshipValue = await req.payload.findByID({
-        req,
-        collection: relatedCollection.config.slug,
-        id: idString as string,
-        currentDepth: currentDepth + 1,
-        overrideAccess: typeof overrideAccess === 'undefined' ? false : overrideAccess,
-        disableErrors: true,
+      relationshipValue = await req.payloadDataLoader.load(JSON.stringify([
+        relatedCollection.config.slug,
+        id,
         depth,
+        currentDepth + 1,
+        req.locale,
+        req.fallbackLocale,
+        overrideAccess,
         showHiddenFields,
-      });
+      ]));
     }
 
     if (!relationshipValue) {
       // ids are visible regardless of access controls
-      relationshipValue = idString;
+      relationshipValue = id;
     }
 
     if (typeof index === 'number') {

--- a/src/globals/operations/local/findOne.ts
+++ b/src/globals/operations/local/findOne.ts
@@ -30,7 +30,7 @@ export default async function findOneLocal<T extends TypeWithID = any>(payload: 
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
 
-  const reqToUse = {
+  const req = {
     user,
     payloadAPI: 'local',
     locale,
@@ -38,7 +38,7 @@ export default async function findOneLocal<T extends TypeWithID = any>(payload: 
     payload,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findOne({
     slug: globalSlug,
@@ -47,6 +47,6 @@ export default async function findOneLocal<T extends TypeWithID = any>(payload: 
     overrideAccess,
     showHiddenFields,
     draft,
-    req: reqToUse,
+    req,
   });
 }

--- a/src/globals/operations/local/findOne.ts
+++ b/src/globals/operations/local/findOne.ts
@@ -1,4 +1,5 @@
 import { Payload } from '../../..';
+import { getDataLoader } from '../../../collections/dataloader';
 import { PayloadRequest } from '../../../express/types';
 import { Document } from '../../../types';
 import { TypeWithID } from '../../config/types';
@@ -29,6 +30,16 @@ export default async function findOneLocal<T extends TypeWithID = any>(payload: 
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
 
+  const reqToUse = {
+    user,
+    payloadAPI: 'local',
+    locale,
+    fallbackLocale,
+    payload,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return findOne({
     slug: globalSlug,
     depth,
@@ -36,12 +47,6 @@ export default async function findOneLocal<T extends TypeWithID = any>(payload: 
     overrideAccess,
     showHiddenFields,
     draft,
-    req: {
-      user,
-      payloadAPI: 'local',
-      locale,
-      fallbackLocale,
-      payload,
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }

--- a/src/globals/operations/local/findVersionByID.ts
+++ b/src/globals/operations/local/findVersionByID.ts
@@ -32,7 +32,7 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
 
-  const reqToUse = {
+  const req = {
     user,
     payloadAPI: 'local',
     locale,
@@ -40,7 +40,7 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
     payload,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findVersionByID({
     depth,
@@ -49,6 +49,6 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
     overrideAccess,
     disableErrors,
     showHiddenFields,
-    req: reqToUse,
+    req,
   });
 }

--- a/src/globals/operations/local/findVersionByID.ts
+++ b/src/globals/operations/local/findVersionByID.ts
@@ -1,4 +1,5 @@
 import { Payload } from '../../..';
+import { getDataLoader } from '../../../collections/dataloader';
 import { PayloadRequest } from '../../../express/types';
 import { Document } from '../../../types';
 import { TypeWithVersion } from '../../../versions/types';
@@ -31,6 +32,16 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
 
+  const reqToUse = {
+    user,
+    payloadAPI: 'local',
+    locale,
+    fallbackLocale,
+    payload,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return findVersionByID({
     depth,
     id,
@@ -38,12 +49,6 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
     overrideAccess,
     disableErrors,
     showHiddenFields,
-    req: {
-      user,
-      payloadAPI: 'local',
-      locale,
-      fallbackLocale,
-      payload,
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }

--- a/src/globals/operations/local/findVersions.ts
+++ b/src/globals/operations/local/findVersions.ts
@@ -37,7 +37,7 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
 
-  const reqToUse = {
+  const req = {
     user,
     payloadAPI: 'local',
     locale,
@@ -45,7 +45,7 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
     payload,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findVersions({
     where,
@@ -56,6 +56,6 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
     sort,
     overrideAccess,
     showHiddenFields,
-    req: reqToUse,
+    req,
   });
 }

--- a/src/globals/operations/local/findVersions.ts
+++ b/src/globals/operations/local/findVersions.ts
@@ -4,6 +4,7 @@ import { TypeWithVersion } from '../../../versions/types';
 import { Payload } from '../../..';
 import { PayloadRequest } from '../../../express/types';
 import findVersions from '../findVersions';
+import { getDataLoader } from '../../../collections/dataloader';
 
 export type Options = {
   slug: string
@@ -36,6 +37,16 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
 
+  const reqToUse = {
+    user,
+    payloadAPI: 'local',
+    locale,
+    fallbackLocale,
+    payload,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return findVersions({
     where,
     page,
@@ -45,12 +56,6 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
     sort,
     overrideAccess,
     showHiddenFields,
-    req: {
-      user,
-      payloadAPI: 'local',
-      locale,
-      fallbackLocale,
-      payload,
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }

--- a/src/globals/operations/local/restoreVersion.ts
+++ b/src/globals/operations/local/restoreVersion.ts
@@ -30,7 +30,7 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
 
-  const reqToUse = {
+  const req = {
     user,
     payloadAPI: 'local',
     payload,
@@ -38,7 +38,7 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
     fallbackLocale,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return restoreVersion({
     depth,
@@ -46,6 +46,6 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
     overrideAccess,
     id,
     showHiddenFields,
-    req: reqToUse,
+    req,
   });
 }

--- a/src/globals/operations/local/restoreVersion.ts
+++ b/src/globals/operations/local/restoreVersion.ts
@@ -1,4 +1,5 @@
 import { Payload } from '../../..';
+import { getDataLoader } from '../../../collections/dataloader';
 import { PayloadRequest } from '../../../express/types';
 import { Document } from '../../../types';
 import { TypeWithVersion } from '../../../versions/types';
@@ -29,18 +30,22 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
 
+  const reqToUse = {
+    user,
+    payloadAPI: 'local',
+    payload,
+    locale,
+    fallbackLocale,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return restoreVersion({
     depth,
     globalConfig,
     overrideAccess,
     id,
     showHiddenFields,
-    req: {
-      user,
-      payloadAPI: 'local',
-      payload,
-      locale,
-      fallbackLocale,
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }

--- a/src/globals/operations/local/update.ts
+++ b/src/globals/operations/local/update.ts
@@ -3,6 +3,7 @@ import { Document } from '../../../types';
 import { PayloadRequest } from '../../../express/types';
 import { TypeWithID } from '../../config/types';
 import update from '../update';
+import { getDataLoader } from '../../../collections/dataloader';
 
 export type Options = {
   slug: string
@@ -31,6 +32,16 @@ export default async function updateLocal<T extends TypeWithID = any>(payload: P
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
 
+  const reqToUse = {
+    user,
+    payloadAPI: 'local',
+    locale,
+    fallbackLocale,
+    payload,
+  } as PayloadRequest;
+
+  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+
   return update({
     slug: globalSlug,
     data,
@@ -39,12 +50,6 @@ export default async function updateLocal<T extends TypeWithID = any>(payload: P
     overrideAccess,
     showHiddenFields,
     draft,
-    req: {
-      user,
-      payloadAPI: 'local',
-      locale,
-      fallbackLocale,
-      payload,
-    } as PayloadRequest,
+    req: reqToUse,
   });
 }

--- a/src/globals/operations/local/update.ts
+++ b/src/globals/operations/local/update.ts
@@ -32,7 +32,7 @@ export default async function updateLocal<T extends TypeWithID = any>(payload: P
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
 
-  const reqToUse = {
+  const req = {
     user,
     payloadAPI: 'local',
     locale,
@@ -40,7 +40,7 @@ export default async function updateLocal<T extends TypeWithID = any>(payload: P
     payload,
   } as PayloadRequest;
 
-  reqToUse.payloadDataLoader = getDataLoader(reqToUse);
+  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return update({
     slug: globalSlug,
@@ -50,6 +50,6 @@ export default async function updateLocal<T extends TypeWithID = any>(payload: P
     overrideAccess,
     showHiddenFields,
     draft,
-    req: reqToUse,
+    req,
   });
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import express, { Response } from 'express';
+import express, { NextFunction, Response } from 'express';
 import crypto from 'crypto';
 import {
 
@@ -29,6 +29,7 @@ import { serverInit as serverInitTelemetry } from './utilities/telemetry/events/
 import { Payload } from '.';
 import loadConfig from './config/load';
 import Logger from './utilities/logger';
+import { getDataLoader } from './collections/dataloader';
 
 export const init = (payload: Payload, options: InitOptions): void => {
   payload.logger.info('Starting Payload...');
@@ -76,6 +77,11 @@ export const init = (payload: Payload, options: InitOptions): void => {
     options.express.use((req: PayloadRequest, res, next) => {
       req.payload = payload;
       next();
+    });
+
+    options.express.use((req: PayloadRequest, res: Response, next: NextFunction): void => {
+      req.payloadDataLoader = getDataLoader(req);
+      return next();
     });
 
     payload.express = options.express;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4676,6 +4676,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dataloader@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz#c69c538235e85e7ac6c6c444bae8ecabf5de9df7"
+  integrity sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==
+
 date-fns@^2.0.1, date-fns@^2.14.0:
   version "2.28.0"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"


### PR DESCRIPTION
## Description

[The GraphQL N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a) is a common issue that GraphQL APIs often come up against. 

We've now implemented [DataLoader](https://github.com/graphql/dataloader) Payload-wide, which greatly enhances the performance of large and complex queries with many populations. This affects each of the REST, GraphQL, and Local APIs.

👍 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
