### PR TITLE
fix: #806, allow partial word matches using 'like' operator

### DIFF
--- a/src/mongoose/sanitizeFormattedValue.ts
+++ b/src/mongoose/sanitizeFormattedValue.ts
@@ -98,7 +98,7 @@ export const sanitizeQueryValue = (schemaType: SchemaType, path: string, operato
     if (operator === 'like' && typeof formattedValue === 'string') {
       const words = formattedValue.split(' ');
       const regex = words.reduce((pattern, word, i) => {
-        return `${pattern}(?=.*\\b${word}\\b)${i + 1 === words.length ? '.+' : ''}`;
+        return `${pattern}(?=.*\\b${word}.*\\b)${i + 1 === words.length ? '.+' : ''}`;
       }, '');
 
       formattedValue = { $regex: new RegExp(regex), $options: 'i' };

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -357,7 +357,7 @@ describe('collections-rest', () => {
 
       it('like', async () => {
         const post1 = await createPost({ title: 'prefix-value' });
-        await createPost();
+
         const { status, result } = await client.find<Post>({
           query: {
             title: {
@@ -368,6 +368,22 @@ describe('collections-rest', () => {
 
         expect(status).toEqual(200);
         expect(result.docs).toEqual([post1]);
+        expect(result.totalDocs).toEqual(1);
+      });
+
+      it('like - partial word match', async () => {
+        const post = await createPost({ title: 'separate words should partially match' });
+
+        const { status, result } = await client.find<Post>({
+          query: {
+            title: {
+              like: 'words partial',
+            },
+          },
+        });
+
+        expect(status).toEqual(200);
+        expect(result.docs).toEqual([post]);
         expect(result.totalDocs).toEqual(1);
       });
 


### PR DESCRIPTION
## Description

Fixes #806.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
