### PR TITLE
fix: accesses payload config correctly in gql refresh resolver

### DIFF
--- a/src/auth/graphql/resolvers/refresh.ts
+++ b/src/auth/graphql/resolvers/refresh.ts
@@ -6,7 +6,7 @@ function refreshResolver(collection: Collection) {
   async function resolver(_, args, context) {
     let token;
 
-    const extractJWT = getExtractJWT(context.req.config);
+    const extractJWT = getExtractJWT(context.req.payload.config);
     token = extractJWT(context.req);
 
     if (args.token) {


### PR DESCRIPTION
## Description

In `auth/graphql/resolvers/refresh`, the `extractJWT` variable was always undefined - corrects the way the payload config is accessed, `context.req.payload.config` instead of `context.req.config`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes

