### PR TITLE
feat: dynamic image resize

### DIFF
--- a/src/collections/buildEndpoints.ts
+++ b/src/collections/buildEndpoints.ts
@@ -18,6 +18,7 @@ import deleteHandler from './requestHandlers/delete';
 import findByID from './requestHandlers/findByID';
 import update from './requestHandlers/update';
 import logoutHandler from '../auth/requestHandlers/logout';
+import createResizeHandler from './requestHandlers/resize';
 
 const buildEndpoints = (collection: SanitizedCollectionConfig): Endpoint[] => {
   let { endpoints } = collection;
@@ -86,6 +87,14 @@ const buildEndpoints = (collection: SanitizedCollectionConfig): Endpoint[] => {
         handler: refreshHandler,
       },
     ]);
+  }
+
+  if (collection.upload) {
+    endpoints.push({
+      path: '/resize/:id',
+      method: 'get',
+      handler: createResizeHandler(collection),
+    });
   }
 
   if (collection.versions) {

--- a/src/collections/buildEndpoints.ts
+++ b/src/collections/buildEndpoints.ts
@@ -18,7 +18,7 @@ import deleteHandler from './requestHandlers/delete';
 import findByID from './requestHandlers/findByID';
 import update from './requestHandlers/update';
 import logoutHandler from '../auth/requestHandlers/logout';
-import createResizeHandler from './requestHandlers/resize';
+import resizeHandler from './requestHandlers/resize';
 
 const buildEndpoints = (collection: SanitizedCollectionConfig): Endpoint[] => {
   let { endpoints } = collection;
@@ -93,7 +93,7 @@ const buildEndpoints = (collection: SanitizedCollectionConfig): Endpoint[] => {
     endpoints.push({
       path: '/resize/:id',
       method: 'get',
-      handler: createResizeHandler(collection),
+      handler: resizeHandler,
     });
   }
 

--- a/src/collections/requestHandlers/resize.ts
+++ b/src/collections/requestHandlers/resize.ts
@@ -5,7 +5,9 @@ import { FileData } from '../../uploads/types';
 import { SanitizedCollectionConfig } from '../config/types';
 import fetch from 'node-fetch';
 import { TypeWithID } from '../../globals/config/types';
-import sharp from 'sharp';
+import sharp, { ResizeOptions } from 'sharp';
+import fs from 'fs';
+import path from 'path';
 
 export default (collection: SanitizedCollectionConfig) =>
   async function resizeHandler(
@@ -20,41 +22,44 @@ export default (collection: SanitizedCollectionConfig) =>
           id: req.params.id,
         });
 
-      if (!image.url) {
-        const errorMessage = 'No url property found';
-        payload.logger.error(errorMessage);
-        res.status(500).send(errorMessage);
-      }
+      let imageBuffer: Buffer;
 
-      let imageUrl = image.url;
-      const relativeUrl = imageUrl?.indexOf('http') === -1;
-
-      if (relativeUrl) {
-        imageUrl = [req.protocol, '://', req.get('host'), image.url].join('');
+      if (collection.upload.disableLocalStorage) {
+        if (!image.url) {
+          const errorMessage = 'No url property found';
+          payload.logger.error(errorMessage);
+          res.status(500).send(errorMessage);
+        }
+        payload.logger.info(`Fetching image to resize from ${image.url}`);
+        const response = await fetch(image.url);
+        const arrayBuffer = await response.arrayBuffer();
+        imageBuffer = Buffer.from(arrayBuffer);
+      } else {
+        let imagePath = path.resolve(
+          payload.config.paths.configDir,
+          collection.upload.staticDir,
+          image.filename
+        );
+        imageBuffer = fs.readFileSync(imagePath);
       }
 
       const width = parseInt(req.query.width as string);
       const height = parseInt(req.query.height as string);
       const position = (req.query.position as string) || 'centre';
 
+      const options: ResizeOptions = {
+        position,
+      };
+
       payload.logger.info(
-        `Resizing image from source: ${imageUrl} with parameters: ${JSON.stringify(
-          {
-            width,
-            height,
-            position,
-          }
-        )}`
+        `Resizing image ${image.id} with parameters: ${JSON.stringify({
+          width,
+          height,
+          options,
+        })}`
       );
 
-      const response = await fetch(imageUrl);
-      const arrayBuffer = await response.arrayBuffer();
-      const buffer = Buffer.from(arrayBuffer);
-
-      const resized = sharp(buffer).resize(width, height, {
-        position,
-      });
-
+      const resized = sharp(imageBuffer).resize(width, height, options);
       const resizedBuffer = await resized.toBuffer({
         resolveWithObject: true,
       });

--- a/src/collections/requestHandlers/resize.ts
+++ b/src/collections/requestHandlers/resize.ts
@@ -1,0 +1,68 @@
+import { Response, NextFunction } from 'express';
+import payload from '../..';
+import { PayloadRequest } from '../../express/types';
+import { FileData } from '../../uploads/types';
+import { SanitizedCollectionConfig } from '../config/types';
+import fetch from 'node-fetch';
+import { TypeWithID } from '../../globals/config/types';
+import sharp from 'sharp';
+
+export default (collection: SanitizedCollectionConfig) =>
+  async function resizeHandler(
+    req: PayloadRequest,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response<{}> | void> {
+    try {
+      const image: TypeWithID & FileData & { url?: string } =
+        await payload.findByID({
+          collection: collection.slug,
+          id: req.params.id,
+        });
+
+      if (!image.url) {
+        const errorMessage = 'No url property found';
+        payload.logger.error(errorMessage);
+        res.status(500).send(errorMessage);
+      }
+
+      let imageUrl = image.url;
+      const relativeUrl = imageUrl?.indexOf('http') === -1;
+
+      if (relativeUrl) {
+        imageUrl = [req.protocol, '://', req.get('host'), image.url].join('');
+      }
+
+      const width = parseInt(req.query.width as string);
+      const height = parseInt(req.query.height as string);
+      const position = (req.query.position as string) || 'centre';
+
+      payload.logger.info(
+        `Resizing image from source: ${imageUrl} with parameters: ${JSON.stringify(
+          {
+            width,
+            height,
+            position,
+          }
+        )}`
+      );
+
+      const response = await fetch(imageUrl);
+      const arrayBuffer = await response.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+
+      const resized = sharp(buffer).resize(width, height, {
+        position,
+      });
+
+      const resizedBuffer = await resized.toBuffer({
+        resolveWithObject: true,
+      });
+
+      res.setHeader('Content-Type', image.mimeType);
+      res.setHeader('Content-Length', resizedBuffer.data.length);
+      res.send(resizedBuffer.data);
+    } catch (error) {
+      return next(error);
+    }
+  };

--- a/src/collections/requestHandlers/resize.ts
+++ b/src/collections/requestHandlers/resize.ts
@@ -1,77 +1,77 @@
 import { Response, NextFunction } from 'express';
 import { PayloadRequest } from '../../express/types';
 import { FileData } from '../../uploads/types';
-import { SanitizedCollectionConfig } from '../config/types';
 import fetch from 'node-fetch';
 import { TypeWithID } from '../../globals/config/types';
 import sharp from 'sharp';
 import fs from 'fs';
 import path from 'path';
 
-export default (collection: SanitizedCollectionConfig) =>
-  async function resizeHandler(
-    req: PayloadRequest,
-    res: Response,
-    next: NextFunction
-  ): Promise<Response<{}> | void> {
-    try {
-      const payload = req.payload;
-      const image: TypeWithID & FileData & { url?: string } =
-        await payload.findByID({
-          collection: collection.slug,
-          id: req.params.id,
-        });
+export default async function resizeHandler(
+  req: PayloadRequest,
+  res: Response,
+  next: NextFunction
+): Promise<Response<{}> | void> {
+  try {
+    const payload = req.payload;
+    const collection = req.collection!.config;
 
-      let imageBuffer: Buffer;
-
-      if (collection.upload.disableLocalStorage) {
-        if (!image.url) {
-          const errorMessage = 'No url property found';
-          payload.logger.error(errorMessage);
-          res.status(500).send(errorMessage);
-        }
-        payload.logger.info(`Fetching image to resize from ${image.url}`);
-        const response = await fetch(image.url);
-        const arrayBuffer = await response.arrayBuffer();
-        imageBuffer = Buffer.from(arrayBuffer);
-      } else {
-        let imagePath = path.resolve(
-          payload.config.paths.configDir,
-          collection.upload.staticDir,
-          image.filename
-        );
-        imageBuffer = fs.readFileSync(imagePath);
-      }
-
-      const width = parseInt(req.query.width as string);
-      const height = parseInt(req.query.height as string);
-      const fit = req.query.fit as keyof sharp.FitEnum;
-      const background = req.query.background as string;
-      const position = (req.query.position as string) || 'centre';
-
-      const options: sharp.ResizeOptions = {
-        background,
-        position,
-        fit,
-      };
-
-      payload.logger.info(
-        `Resizing image ${image.id} with parameters: ${JSON.stringify({
-          width,
-          height,
-          options,
-        })}`
-      );
-
-      const resized = sharp(imageBuffer).resize(width, height, options);
-      const resizedBuffer = await resized.toBuffer({
-        resolveWithObject: true,
+    const image: TypeWithID & FileData & { url?: string } =
+      await payload.findByID({
+        collection: collection.slug,
+        id: req.params.id,
       });
 
-      res.setHeader('Content-Type', image.mimeType);
-      res.setHeader('Content-Length', resizedBuffer.data.length);
-      res.send(resizedBuffer.data);
-    } catch (error) {
-      return next(error);
+    let imageBuffer: Buffer;
+
+    if (collection.upload.disableLocalStorage) {
+      if (!image.url) {
+        const errorMessage = 'No url property found';
+        payload.logger.error(errorMessage);
+        res.status(500).send(errorMessage);
+      }
+      payload.logger.info(`Fetching image to resize from ${image.url}`);
+      const response = await fetch(image.url);
+      const arrayBuffer = await response.arrayBuffer();
+      imageBuffer = Buffer.from(arrayBuffer);
+    } else {
+      let imagePath = path.resolve(
+        payload.config.paths.configDir,
+        collection.upload.staticDir,
+        image.filename
+      );
+      imageBuffer = fs.readFileSync(imagePath);
     }
-  };
+
+    const width = parseInt(req.query.width as string);
+    const height = parseInt(req.query.height as string);
+    const fit = req.query.fit as keyof sharp.FitEnum;
+    const background = req.query.background as string;
+    const position = (req.query.position as string) || 'centre';
+
+    const options: sharp.ResizeOptions = {
+      background,
+      position,
+      fit,
+    };
+
+    payload.logger.info(
+      `Resizing image ${image.id} with parameters: ${JSON.stringify({
+        width,
+        height,
+        options,
+      })}`
+    );
+
+    const resized = sharp(imageBuffer).resize(width, height, options);
+    const resizedBuffer = await resized.toBuffer({
+      resolveWithObject: true,
+    });
+
+    res.setHeader('Content-Type', image.mimeType);
+    res.setHeader('Content-Length', resizedBuffer.data.length);
+    res.send(resizedBuffer.data);
+  } catch (error) {
+    return next(error);
+  }
+}

--- a/src/collections/requestHandlers/resize.ts
+++ b/src/collections/requestHandlers/resize.ts
@@ -1,11 +1,10 @@
 import { Response, NextFunction } from 'express';
-import payload from '../..';
 import { PayloadRequest } from '../../express/types';
 import { FileData } from '../../uploads/types';
 import { SanitizedCollectionConfig } from '../config/types';
 import fetch from 'node-fetch';
 import { TypeWithID } from '../../globals/config/types';
-import sharp, { ResizeOptions } from 'sharp';
+import sharp from 'sharp';
 import fs from 'fs';
 import path from 'path';
 
@@ -16,6 +15,7 @@ export default (collection: SanitizedCollectionConfig) =>
     next: NextFunction
   ): Promise<Response<{}> | void> {
     try {
+      const payload = req.payload;
       const image: TypeWithID & FileData & { url?: string } =
         await payload.findByID({
           collection: collection.slug,
@@ -45,10 +45,14 @@ export default (collection: SanitizedCollectionConfig) =>
 
       const width = parseInt(req.query.width as string);
       const height = parseInt(req.query.height as string);
+      const fit = req.query.fit as keyof sharp.FitEnum;
+      const background = req.query.background as string;
       const position = (req.query.position as string) || 'centre';
 
-      const options: ResizeOptions = {
+      const options: sharp.ResizeOptions = {
+        background,
         position,
+        fit,
       };
 
       payload.logger.info(

--- a/src/collections/requestHandlers/resize.ts
+++ b/src/collections/requestHandlers/resize.ts
@@ -14,17 +14,17 @@ export default async function resizeHandler(
 ): Promise<Response<{}> | void> {
   try {
     const payload = req.payload;
-    const collection = req.collection!.config;
+    const collectionConfig = req.collection!.config;
 
     const image: TypeWithID & FileData & { url?: string } =
       await payload.findByID({
-        collection: collection.slug,
+        collection: collectionConfig.slug,
         id: req.params.id,
       });
 
     let imageBuffer: Buffer;
 
-    if (collection.upload.disableLocalStorage) {
+    if (collectionConfig.upload.disableLocalStorage) {
       if (!image.url) {
         const errorMessage = 'No url property found';
         payload.logger.error(errorMessage);
@@ -37,7 +37,7 @@ export default async function resizeHandler(
     } else {
       let imagePath = path.resolve(
         payload.config.paths.configDir,
-        collection.upload.staticDir,
+        collectionConfig.upload.staticDir,
         image.filename
       );
       imageBuffer = fs.readFileSync(imagePath);

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -36,6 +36,9 @@ export default buildConfig({
     },
     {
       slug: mediaSlug,
+      access: {
+        read: () => true,
+      },
       upload: {
         staticURL: '/media',
         staticDir: './media',


### PR DESCRIPTION
## Description

This PR exposes an express route for all collections with upload configuration, which will return the image resized from the parameters from the query string.

The motivation for this change is to allow for a frontend to query for sizes that are not known beforehand and defined as named crops in the collection config.

### Implemented in this PR

- [x] Express route `/resize/:id` for all collections with upload configuration. Query parameters `width`, `height`, `position`, `fit`, `background` are passed to the image resizer and the resulting image is returned. e.g:
  ```
  /api/{collectionSlug}/resize/{id}?width=160&height=100&position=centre&fit=cover&background=white
  ```
- [x] It accounts for the `disableLocalStorage` option in the upload config.

  - If `false`: The image is loaded from disk, resized and returned.
  - If `true`: The image is pulled from the `url` property, resized and returned. This only works if consumer has configured a `url` property, e.g. from an afterRead hook. This is the same property that is used by the payload dashboard to show the image correctly.

    ```ts
    import { AfterReadHook } from 'payload/dist/collections/config/types';

    const afterRead: AfterReadHook[] = [
      ({ doc }) => {
        doc.url = `https://.../${doc.filename}`;
      },
    ];
    ```

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
