### PR TITLE
fix: allows querying incomplete drafts in graphql

### DIFF
--- a/src/globals/graphql/init.ts
+++ b/src/globals/graphql/init.ts
@@ -21,18 +21,22 @@ function initGlobalsGraphQL(payload: Payload): void {
       const {
         label,
         fields,
+        versions,
       } = global;
 
       const formattedLabel = formatName(label);
 
       global.graphQL = {};
 
-      global.graphQL.type = buildObjectType(
+      const forceNullableObjectType = Boolean(versions?.drafts);
+
+      global.graphQL.type = buildObjectType({
         payload,
-        formattedLabel,
+        name: formattedLabel,
+        parentName: formattedLabel,
         fields,
-        formattedLabel,
-      );
+        forceNullable: forceNullableObjectType,
+      });
 
       global.graphQL.mutationInputType = new GraphQLNonNull(buildMutationInputType(
         payload,
@@ -80,13 +84,15 @@ function initGlobalsGraphQL(payload: Payload): void {
             type: 'date',
           },
         ];
-        global.graphQL.versionType = buildObjectType(
+
+        global.graphQL.versionType = buildObjectType({
           payload,
-          `${formattedLabel}Version`,
-          versionGlobalFields,
-          `${formattedLabel}Version`,
-          {},
-        );
+          name: `${formattedLabel}Version`,
+          parentName: `${formattedLabel}Version`,
+          fields: versionGlobalFields,
+          forceNullable: forceNullableObjectType,
+        });
+
         payload.Query.fields[`version${formatName(formattedLabel)}`] = {
           type: global.graphQL.versionType,
           args: {

--- a/src/graphql/schema/buildBlockType.ts
+++ b/src/graphql/schema/buildBlockType.ts
@@ -4,7 +4,17 @@ import { Block } from '../../fields/config/types';
 import formatName from '../utilities/formatName';
 import buildObjectType from './buildObjectType';
 
-function buildBlockType(payload: Payload, block: Block): void {
+type Args = {
+  payload: Payload
+  block: Block
+  forceNullable?: boolean
+}
+
+function buildBlockType({
+  payload,
+  block,
+  forceNullable,
+}: Args): void {
   const {
     slug,
     labels: {
@@ -14,18 +24,19 @@ function buildBlockType(payload: Payload, block: Block): void {
 
   if (!payload.types.blockTypes[slug]) {
     const formattedBlockName = formatName(singular);
-    payload.types.blockTypes[slug] = buildObjectType(
+    payload.types.blockTypes[slug] = buildObjectType({
       payload,
-      formattedBlockName,
-      [
+      name: formattedBlockName,
+      parentName: formattedBlockName,
+      fields: [
         ...block.fields,
         {
           name: 'blockType',
           type: 'text',
         },
       ],
-      formattedBlockName,
-    );
+      forceNullable,
+    });
   }
 }
 


### PR DESCRIPTION
## Description

Allows incomplete drafts to be queried in GraphQL by forcing nullable for all fields if drafts are enabled.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
