### PR TITLE
Add missing comma to example

### DIFF
--- a/docs/fields/radio.mdx
+++ b/docs/fields/radio.mdx
@@ -62,7 +62,7 @@ The `layout` property allows for the radio group to be styled as a horizonally o
           label: 'Dark Gray',
           value: 'dark_gray',
         },
-      ]
+      ],
       defaultValue: 'option_1',
       admin: {
         layout: 'horizontal',


### PR DESCRIPTION
Missing comma in example, leading to syntax error when copied by user.