### PR TITLE
Feat/field name validation

### DIFF
--- a/src/errors/InvalidFieldName.ts
+++ b/src/errors/InvalidFieldName.ts
@@ -1,0 +1,10 @@
+import { Field } from '../fields/config/types';
+import APIError from './APIError';
+
+class InvalidFieldName extends APIError {
+  constructor(field: Field, fieldName: string) {
+    super(`Field ${field.label} has invalid name '${fieldName}'. Field names can not include periods (.) and must be alphanumeric.`);
+  }
+}
+
+export default InvalidFieldName;

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -8,6 +8,7 @@ export { default as FileUploadError } from './FileUploadError';
 export { default as Forbidden } from './Forbidden';
 export { default as LockedAuth } from './LockedAuth';
 export { default as InvalidConfiguration } from './InvalidConfiguration';
+export { default as InvalidFieldName } from './InvalidFieldName';
 export { default as InvalidFieldRelationship } from './InvalidFieldRelationship';
 export { default as MissingCollectionLabel } from './MissingCollectionLabel';
 export { default as MissingFieldInputOptions } from './MissingFieldInputOptions';

--- a/src/fields/config/sanitize.spec.ts
+++ b/src/fields/config/sanitize.spec.ts
@@ -1,5 +1,5 @@
 import sanitizeFields from './sanitize';
-import { MissingFieldType, InvalidFieldRelationship } from '../../errors';
+import { MissingFieldType, InvalidFieldRelationship, InvalidFieldName } from '../../errors';
 import { ArrayField, Block, BlockField, CheckboxField, Field, TextField } from './types';
 
 describe('sanitizeFields', () => {
@@ -15,6 +15,18 @@ describe('sanitizeFields', () => {
       // @ts-ignore
       sanitizeFields(fields, []);
     }).toThrow(MissingFieldType);
+  });
+  it("should throw on invalid field name", () => {
+    const fields: Field[] = [
+      {
+        label: "some.collection",
+        name: "some.collection",
+        type: "text",
+      }
+    ];
+    expect(() => {
+      sanitizeFields(fields, []);
+    }).toThrow(InvalidFieldName);
   });
 
   describe('auto-labeling', () => {

--- a/src/fields/config/sanitize.ts
+++ b/src/fields/config/sanitize.ts
@@ -1,5 +1,5 @@
 import { formatLabels, toWords } from '../../utilities/formatLabels';
-import { MissingFieldType, InvalidFieldRelationship } from '../../errors';
+import { MissingFieldType, InvalidFieldRelationship, InvalidFieldName } from '../../errors';
 import { baseBlockFields } from '../baseFields/baseBlockFields';
 import validations from '../validations';
 import { baseIDField } from '../baseFields/baseIDField';
@@ -13,6 +13,11 @@ const sanitizeFields = (fields: Field[], validRelationships: string[]): Field[] 
     const field: Field = { ...unsanitizedField };
 
     if (!field.type) throw new MissingFieldType(field);
+
+    // assert that field names do not contain forbidden characters
+    if ('name' in field && field.name && field.name.includes('.')) {
+      throw new InvalidFieldName(field, field.name);
+    }
 
     // Auto-label
     if ('name' in field && field.name && typeof field.label !== 'string' && field.label !== false) {


### PR DESCRIPTION
## Description

Field names can contain breaking characters such as periods (.) . This leads to bugs and unexpected behavior, which can be observed if collection `Foo` references collection `Bar` via relationship field `bars.backpopulated`.

This PR adds simple field name validation to `sanitize.ts`. In case the sanitation fails am `InvalidFieldName` is raised.
An according test can be found in `sanitize.spec.ts`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation


Note: I have not updated the documentation as I am unsure if this should be mentioned there.