### PR TITLE
Small example typo in documentation

### DIFF
--- a/docs/fields/tabs.mdx
+++ b/docs/fields/tabs.mdx
@@ -44,7 +44,7 @@ Each tab has its own required `label` and `fields` array. You can also optionall
       tabs: [ // required
         {
           label: 'Tab One Label', // required
-          description: 'This will appear within the tab above the fields.'
+          description: 'This will appear within the tab above the fields.',
           fields: [ // required
             {
               name: 'someTextField',


### PR DESCRIPTION
## Description

A comma was missing.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Irrelevant typo
