### PR TITLE
fix: E11000 duplicate key error has no keyValue

### DIFF
--- a/src/collections/operations/create.ts
+++ b/src/collections/operations/create.ts
@@ -187,7 +187,7 @@ async function create(incomingArgs: Arguments): Promise<Document> {
       doc = await Model.create(resultWithLocales);
     } catch (error) {
       // Handle uniqueness error from MongoDB
-      throw error.code === 11000
+      throw error.code === 11000 && error.keyValue
         ? new ValidationError([{ message: 'Value must be unique', field: Object.keys(error.keyValue)[0] }])
         : error;
     }

--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -261,7 +261,7 @@ async function update(incomingArgs: Arguments): Promise<Document> {
       });
 
       // Handle uniqueness error from MongoDB
-      throw error.code === 11000
+      throw error.code === 11000 && error.keyValue
         ? new ValidationError([{ message: 'Value must be unique', field: Object.keys(error.keyValue)[0] }])
         : error;
     }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->
This fix make code to be compatible with E11000 duplicate key error has no keyValue.
Fixes https://github.com/payloadcms/payload/issues/915

![image](https://user-images.githubusercontent.com/57319837/184060865-6f01025e-2e9b-4f5a-b54c-77b08798da2f.png)


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
