### PR TITLE
fix: saving multiple versions

### DIFF
--- a/src/mongoose/buildSchema.ts
+++ b/src/mongoose/buildSchema.ts
@@ -80,7 +80,7 @@ const buildSchema = (config: SanitizedConfig, configFields: Field[], buildSchema
       if (config.indexSortableFields && !buildSchemaOptions.global && !field.index && !field.hidden && sortableFieldTypes.indexOf(field.type) > -1 && fieldAffectsData(field)) {
         indexFields.push({ index: { [field.name]: 1 } });
       } else if (field.unique && fieldAffectsData(field)) {
-        indexFields.push({ index: { [field.name]: 1 }, options: { unique: true, sparse: field.localized || false } });
+        indexFields.push({ index: { [field.name]: 1 }, options: { unique: !buildSchemaOptions.disableUnique, sparse: field.localized || false } });
       } else if (field.index && fieldAffectsData(field)) {
         indexFields.push({ index: { [field.name]: 1 } });
       }

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -82,6 +82,35 @@ describe('Versions', () => {
         expect(collectionLocalVersionID).toBeDefined();
       });
 
+      it(" should allow saving multiple versions of models with unique fields", async () => {
+        const autosavePost = await payload.create({
+          collection,
+          data: {
+            title: "unique unchanging title",
+            description: "description 1",
+          },
+        });
+
+        const firstUpdate = await payload.update<any>({
+          id: autosavePost.id,
+          collection,
+          data: {
+            description: "description 2",
+          },
+        });
+        const finalDescription = "final description";
+
+        const secondUpdate = await payload.update<any>({
+          id: autosavePost.id,
+          collection,
+          data: {
+            description: finalDescription,
+          },
+        });
+
+        expect(secondUpdate.description).toBe(finalDescription);
+      });
+
       it('should allow a version to be retrieved by ID', async () => {
         const version = await payload.findVersionByID({
           collection,

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -62,7 +62,7 @@ describe('Versions', () => {
 
         collectionLocalPostID = autosavePost.id;
 
-        const updatedPost = await payload.update<any>({
+        const updatedPost = await payload.update({
           id: collectionLocalPostID,
           collection,
           data: {
@@ -82,25 +82,25 @@ describe('Versions', () => {
         expect(collectionLocalVersionID).toBeDefined();
       });
 
-      it(" should allow saving multiple versions of models with unique fields", async () => {
+      it('should allow saving multiple versions of models with unique fields', async () => {
         const autosavePost = await payload.create({
           collection,
           data: {
-            title: "unique unchanging title",
-            description: "description 1",
+            title: 'unique unchanging title',
+            description: 'description 1',
           },
         });
 
-        const firstUpdate = await payload.update<any>({
+        await payload.update({
           id: autosavePost.id,
           collection,
           data: {
-            description: "description 2",
+            description: 'description 2',
           },
         });
-        const finalDescription = "final description";
+        const finalDescription = 'final description';
 
-        const secondUpdate = await payload.update<any>({
+        const secondUpdate = await payload.update({
           id: autosavePost.id,
           collection,
           data: {


### PR DESCRIPTION
## Description

Version schemas were getting produced with uniqueness constraints, causing updates on versioned models to fail if the successive version had common unique field values (particularly ident keys like slug) with previous versions.

This was due to `mongoose.buildSchema` not respecting `BuildSchemaOptions.disableUnique`.

I confirmed this regression was introduced at commit c175476e for PR #867.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
