### PR TITLE
fix: dev:generate-types on all test configs

### DIFF
--- a/src/bin/generateTypes.ts
+++ b/src/bin/generateTypes.ts
@@ -390,6 +390,7 @@ function configToJsonSchema(config: SanitizedConfig): JSONSchema4 {
 export function generateTypes(): void {
   const logger = Logger();
   const config = loadConfig();
+  const outputFile = process.env.PAYLOAD_TS_OUTPUT_PATH || config.typescript.outputFile;
 
   logger.info('Compiling TS types for Collections and Globals...');
 
@@ -402,8 +403,8 @@ export function generateTypes(): void {
       singleQuote: true,
     },
   }).then((compiled) => {
-    fs.writeFileSync(config.typescript.outputFile, compiled);
-    logger.info(`Types written to ${config.typescript.outputFile}`);
+    fs.writeFileSync(outputFile, compiled);
+    logger.info(`Types written to ${outputFile}`);
   });
 }
 

--- a/test/access-control/payload-types.ts
+++ b/test/access-control/payload-types.ts
@@ -52,7 +52,7 @@ export interface RestrictedVersion {
  */
 export interface SiblingDatum {
   id: string;
-  array?: {
+  array: {
     allowPublicReadability?: boolean;
     text?: string;
     id?: string;

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -8,6 +8,14 @@
 export interface Config {}
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "global".
+ */
+export interface Global {
+  id: string;
+  title?: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "posts".
  */
 export interface Post {

--- a/test/array-update/payload-types.ts
+++ b/test/array-update/payload-types.ts
@@ -12,7 +12,7 @@ export interface Config {}
  */
 export interface Array {
   id: string;
-  array?: {
+  array: {
     required: string;
     optional?: string;
     id?: string;

--- a/test/auth/payload-types.ts
+++ b/test/auth/payload-types.ts
@@ -12,6 +12,7 @@ export interface Config {}
  */
 export interface User {
   id: string;
+  roles: ('admin' | 'editor' | 'moderator' | 'user' | 'viewer')[];
   enableAPIKey?: boolean;
   apiKey?: string;
   apiKeyIndex?: string;
@@ -20,7 +21,6 @@ export interface User {
   resetPasswordExpiration?: string;
   loginAttempts?: number;
   lockUntil?: string;
-  roles: ('admin' | 'editor' | 'moderator' | 'user' | 'viewer')[];
   createdAt: string;
   updatedAt: string;
 }

--- a/test/buildConfig.ts
+++ b/test/buildConfig.ts
@@ -3,9 +3,6 @@ import { Config, SanitizedConfig } from '../src/config/types';
 import { buildConfig as buildPayloadConfig } from '../src/config/build';
 
 const baseConfig: Config = {
-  typescript: {
-    outputFile: process.env.PAYLOAD_TS_OUTPUT_PATH,
-  },
   telemetry: false,
 };
 

--- a/test/fields-relationship/payload-types.ts
+++ b/test/fields-relationship/payload-types.ts
@@ -80,32 +80,6 @@ export interface RelationWithTitle {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "group-nested-relation-with-title".
- */
-export interface GroupNestedRelationWithTitle {
-  id: string;
-  group?: {
-    relation?: string | NestedRelationWithTitle;
-  };
-  createdAt: string;
-  updatedAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "nested-relation-with-title".
- */
-export interface NestedRelationWithTitle {
-  id: string;
-  group?: {
-    subGroup?: {
-      relation?: string | RelationOne;
-    };
-  };
-  createdAt: string;
-  updatedAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {

--- a/test/globals/payload-types.ts
+++ b/test/globals/payload-types.ts
@@ -8,36 +8,22 @@
 export interface Config {}
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "autosave-global".
+ * via the `definition` "global".
  */
-export interface AutosaveGlobal {
+export interface Global {
   id: string;
-  title: string;
-  _status?: 'draft' | 'published';
+  title?: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "autosave-posts".
+ * via the `definition` "array".
  */
-export interface AutosavePost {
+export interface Array {
   id: string;
-  title: string;
-  description: string;
-  _status?: 'draft' | 'published';
-  createdAt: string;
-  updatedAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "draft-posts".
- */
-export interface DraftPost {
-  id: string;
-  title: string;
-  description: string;
-  _status?: 'draft' | 'published';
-  createdAt: string;
-  updatedAt: string;
+  array: {
+    text?: string;
+    id?: string;
+  }[];
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -8,6 +8,21 @@
 export interface Config {}
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users".
+ */
+export interface User {
+  id: string;
+  relation?: string | LocalizedPost;
+  email?: string;
+  resetPasswordToken?: string;
+  resetPasswordExpiration?: string;
+  loginAttempts?: number;
+  lockUntil?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "localized-posts".
  */
 export interface LocalizedPost {
@@ -78,20 +93,6 @@ export interface WithLocalizedRelationship {
 export interface Dummy {
   id: string;
   name?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "users".
- */
-export interface User {
-  id: string;
-  email?: string;
-  resetPasswordToken?: string;
-  resetPasswordExpiration?: string;
-  loginAttempts?: number;
-  lockUntil?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/test/uploads/payload-types.ts
+++ b/test/uploads/payload-types.ts
@@ -28,8 +28,8 @@ export interface Media {
   filesize?: number;
   width?: number;
   height?: number;
-  sizes?: {
-    maintainedAspectRatio?: {
+  sizes: {
+    maintainedAspectRatio: {
       url?: string;
       width?: number;
       height?: number;
@@ -37,7 +37,7 @@ export interface Media {
       filesize?: number;
       filename?: string;
     };
-    tablet?: {
+    tablet: {
       url?: string;
       width?: number;
       height?: number;
@@ -45,7 +45,7 @@ export interface Media {
       filesize?: number;
       filename?: string;
     };
-    mobile?: {
+    mobile: {
       url?: string;
       width?: number;
       height?: number;
@@ -53,7 +53,7 @@ export interface Media {
       filesize?: number;
       filename?: string;
     };
-    icon?: {
+    icon: {
       url?: string;
       width?: number;
       height?: number;
@@ -62,6 +62,19 @@ export interface Media {
       filename?: string;
     };
   };
+  createdAt: string;
+  updatedAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "unstored-media".
+ */
+export interface UnstoredMedia {
+  id: string;
+  url?: string;
+  filename?: string;
+  mimeType?: string;
+  filesize?: number;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Description

With this change, running `dev:generate-types` outputs all of the payload-types files from `test` as intended.
