### PR TITLE
Feat/graphql localization input type

### DIFF
--- a/src/collections/graphql/init.ts
+++ b/src/collections/graphql/init.ts
@@ -177,6 +177,9 @@ function initCollectionsGraphQL(payload: Payload): void {
       args: {
         data: { type: collection.graphQL.mutationInputType },
         draft: { type: GraphQLBoolean },
+        ...(payload.config.localization ? {
+          locale: { type: payload.types.localeInputType },
+        } : {}),
       },
       resolve: createResolver(collection),
     };
@@ -188,6 +191,9 @@ function initCollectionsGraphQL(payload: Payload): void {
         data: { type: collection.graphQL.updateMutationInputType },
         draft: { type: GraphQLBoolean },
         autosave: { type: GraphQLBoolean },
+        ...(payload.config.localization ? {
+          locale: { type: payload.types.localeInputType },
+        } : {}),
       },
       resolve: updateResolver(collection),
     };

--- a/src/globals/graphql/init.ts
+++ b/src/globals/graphql/init.ts
@@ -62,6 +62,9 @@ function initGlobalsGraphQL(payload: Payload): void {
         args: {
           data: { type: global.graphQL.mutationInputType },
           draft: { type: GraphQLBoolean },
+          ...(payload.config.localization ? {
+            locale: { type: payload.types.localeInputType },
+          } : {}),
         },
         resolve: updateResolver(global),
       };

--- a/src/graphql/schema/buildFallbackLocaleInputType.ts
+++ b/src/graphql/schema/buildFallbackLocaleInputType.ts
@@ -1,11 +1,12 @@
 import { GraphQLEnumType } from 'graphql';
 import { LocalizationConfig } from '../../config/types';
+import formatName from '../utilities/formatName';
 
 const buildFallbackLocaleInputType = (localization: LocalizationConfig): GraphQLEnumType => new GraphQLEnumType({
   name: 'FallbackLocaleInputType',
   values: [...localization.locales, 'none'].reduce((values, locale) => ({
     ...values,
-    [locale]: {
+    [formatName(locale)]: {
       value: locale,
     },
   }), {}),

--- a/src/graphql/schema/buildLocaleInputType.ts
+++ b/src/graphql/schema/buildLocaleInputType.ts
@@ -1,14 +1,17 @@
-import { GraphQLEnumType } from 'graphql';
+import { GraphQLEnumType, GraphQLScalarType } from 'graphql';
 import { LocalizationConfig } from '../../config/types';
+import formatName from '../utilities/formatName';
 
-const buildLocaleInputType = (localization: LocalizationConfig): GraphQLEnumType => new GraphQLEnumType({
-  name: 'LocaleInputType',
-  values: localization.locales.reduce((values, locale) => ({
-    ...values,
-    [locale]: {
-      value: locale,
-    },
-  }), {}),
-});
+const buildLocaleInputType = (localization: LocalizationConfig): GraphQLEnumType | GraphQLScalarType => {
+  return new GraphQLEnumType({
+    name: 'LocaleInputType',
+    values: localization.locales.reduce((values, locale) => ({
+      ...values,
+      [formatName(locale)]: {
+        value: locale,
+      },
+    }), {}),
+  });
+};
 
 export default buildLocaleInputType;

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -561,6 +561,55 @@ describe('Localization', () => {
 
       expect(typeof result.user.relation.title).toStrictEqual('string');
     });
+
+    it('should create and update collections', async () => {
+      const url = `${serverURL}${config.routes.api}${config.routes.graphQL}`;
+      const client = new GraphQLClient(url);
+
+      const create = `mutation {
+        createLocalizedPost(
+          data: {
+            title: "${englishTitle}"
+          }
+          locale: ${defaultLocale}
+        ) {
+          id
+          title
+        }
+      }`;
+
+      const { createLocalizedPost: createResult } = await client.request(create, null, {
+        Authorization: `JWT ${token}`,
+      });
+
+
+      const update = `mutation {
+        updateLocalizedPost(
+          id: "${createResult.id}",
+          data: {
+            title: "${spanishTitle}"
+          }
+          locale: ${spanishLocale}
+        ) {
+          title
+        }
+      }`;
+
+      const { updateLocalizedPost: updateResult } = await client.request(update, null, {
+        Authorization: `JWT ${token}`,
+      });
+
+      const result = await payload.findByID({
+        collection: slug,
+        id: createResult.id,
+        locale: 'all',
+      });
+
+      expect(createResult.title).toStrictEqual(englishTitle);
+      expect(updateResult.title).toStrictEqual(spanishTitle);
+      expect(result.title[defaultLocale]).toStrictEqual(englishTitle);
+      expect(result.title[spanishLocale]).toStrictEqual(spanishTitle);
+    });
   });
 });
 


### PR DESCRIPTION
## Description

This fixes two things related to localization in graphql:
1. locale is conditionally added to the args for the following mutations: create collection, update collection, and update global
2. formats locale names to safe enum values, for example: `locales: ['en-us']` will make the graphql locale input type `en_us`

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
