### PR TITLE
Chore/simplify indexes

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,7 +271,6 @@
     "get-port": "5.1.1",
     "glob": "^8.0.3",
     "graphql-request": "^3.4.0",
-    "mongodb": "^3.6.2",
     "mongodb-memory-server": "^7.2.0",
     "nodemon": "^2.0.6",
     "passport-strategy": "^1.0.0",

--- a/src/collections/init.ts
+++ b/src/collections/init.ts
@@ -1,9 +1,8 @@
-import mongoose, { UpdateAggregationStage } from 'mongoose';
+import mongoose, { UpdateAggregationStage, UpdateQuery } from 'mongoose';
 import paginate from 'mongoose-paginate-v2';
 import express from 'express';
 import passport from 'passport';
 import passportLocalMongoose from 'passport-local-mongoose';
-import { UpdateQuery } from 'mongodb';
 import { buildVersionCollectionFields } from '../versions/buildCollectionFields';
 import buildQueryPlugin from '../mongoose/buildQuery';
 import apiKeyStrategy from '../auth/strategies/apiKey';

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -369,7 +369,8 @@ export type FieldAffectingData =
   | CodeField
   | PointField
 
-export type NonPresentationalField = TextField
+export type NonPresentationalField =
+  TextField
   | NumberField
   | EmailField
   | TextareaField

--- a/src/mongoose/buildSchema.ts
+++ b/src/mongoose/buildSchema.ts
@@ -14,7 +14,7 @@ export type BuildSchemaOptions = {
   global?: boolean
 }
 
-type FieldSchemaGenerator = (field: Field, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions) => void;
+type FieldSchemaGenerator = (field: Field, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]) => void;
 
 type Index = {
   index: IndexDefinition
@@ -44,13 +44,11 @@ const localizeSchema = (field: NonPresentationalField, schema, localization) => 
   return schema;
 };
 
-const buildSchema = (config: SanitizedConfig, configFields: Field[], buildSchemaOptions: BuildSchemaOptions = {}): Schema => {
+const buildSchema = (config: SanitizedConfig, configFields: Field[], buildSchemaOptions: BuildSchemaOptions = {}, indexes: Index[] = []): Schema => {
   const { allowIDField, options } = buildSchemaOptions;
   let fields = {};
 
-
   let schemaFields = configFields;
-  const indexFields: Index[] = [];
 
   if (!allowIDField) {
     const idField = schemaFields.find((field) => fieldAffectsData(field) && field.name === 'id');
@@ -69,103 +67,84 @@ const buildSchema = (config: SanitizedConfig, configFields: Field[], buildSchema
       const addFieldSchema: FieldSchemaGenerator = fieldToSchemaMap[field.type];
 
       if (addFieldSchema) {
-        addFieldSchema(field, schema, config, buildSchemaOptions);
-      }
-
-      // geospatial field index must be created after the schema is created
-      if (fieldIndexMap[field.type]) {
-        indexFields.push(...fieldIndexMap[field.type](field, config));
-      }
-
-      if (config.indexSortableFields && !buildSchemaOptions.global && !field.index && !field.hidden && sortableFieldTypes.indexOf(field.type) > -1 && fieldAffectsData(field)) {
-        indexFields.push({ index: { [field.name]: 1 } });
-      } else if (field.unique && fieldAffectsData(field)) {
-        indexFields.push({ index: { [field.name]: 1 }, options: { unique: !buildSchemaOptions.disableUnique, sparse: field.localized || false } });
-      } else if (field.index && fieldAffectsData(field)) {
-        indexFields.push({ index: { [field.name]: 1 } });
+        addFieldSchema(field, schema, config, buildSchemaOptions, indexes);
       }
     }
   });
 
   if (buildSchemaOptions?.options?.timestamps) {
-    indexFields.push({ index: { createdAt: 1 } });
-    indexFields.push({ index: { updatedAt: 1 } });
+    indexes.push({ index: { createdAt: 1 } });
+    indexes.push({ index: { updatedAt: 1 } });
   }
 
-  indexFields.forEach((indexField) => {
+  // mongoose on mongoDB 5 or 6 need to call this to make the index in the database, schema indexes alone are not enough
+  indexes.forEach((indexField) => {
     schema.index(indexField.index, indexField.options);
   });
 
   return schema;
 };
 
-const fieldIndexMap = {
-  point: (field: PointField, config: SanitizedConfig) => {
-    let direction: boolean | '2dsphere';
-    const options: IndexOptions = {
-      unique: field.unique || false,
-      sparse: (field.localized && field.unique) || false,
-    };
-    if (field.index === true || field.index === undefined) {
-      direction = '2dsphere';
-    }
-    if (field.localized && config.localization) {
-      return config.localization.locales.map((locale) => ({
-        index: { [`${field.name}.${locale}`]: direction },
-        options,
-      }));
-    }
-    if (field.unique) {
-      options.unique = true;
-    }
-    return [{ index: { [field.name]: direction }, options }];
-  },
+const addFieldIndex = (field: NonPresentationalField, indexFields: Index[], config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions) => {
+  if (config.indexSortableFields && !buildSchemaOptions.global && !field.index && !field.hidden && sortableFieldTypes.indexOf(field.type) > -1 && fieldAffectsData(field)) {
+    indexFields.push({ index: { [field.name]: 1 } });
+  } else if (field.unique && fieldAffectsData(field)) {
+    indexFields.push({ index: { [field.name]: 1 }, options: { unique: !buildSchemaOptions.disableUnique, sparse: field.localized || false } });
+  } else if (field.index && fieldAffectsData(field)) {
+    indexFields.push({ index: { [field.name]: 1 } });
+  }
 };
 
-const fieldToSchemaMap = {
-  number: (field: NumberField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
+  number: (field: NumberField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = { ...formatBaseSchema(field, buildSchemaOptions), type: Number };
 
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  text: (field: TextField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  text: (field: TextField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = { ...formatBaseSchema(field, buildSchemaOptions), type: String };
 
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  email: (field: EmailField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  email: (field: EmailField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = { ...formatBaseSchema(field, buildSchemaOptions), type: String };
 
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  textarea: (field: TextareaField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  textarea: (field: TextareaField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = { ...formatBaseSchema(field, buildSchemaOptions), type: String };
 
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  richText: (field: RichTextField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  richText: (field: RichTextField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = { ...formatBaseSchema(field, buildSchemaOptions), type: Schema.Types.Mixed };
 
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  code: (field: CodeField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  code: (field: CodeField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = { ...formatBaseSchema(field, buildSchemaOptions), type: String };
 
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  point: (field: PointField, schema: Schema, config: SanitizedConfig): void => {
+  point: (field: PointField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = {
       type: {
         type: String,
@@ -173,8 +152,8 @@ const fieldToSchemaMap = {
       },
       coordinates: {
         type: [Number],
-        sparse: field.unique && field.localized,
-        unique: field.unique || false,
+        sparse: (buildSchemaOptions.disableUnique && field.unique) && field.localized,
+        unique: (buildSchemaOptions.disableUnique && field.unique) || false,
         required: false,
         default: field.defaultValue || undefined,
       },
@@ -183,8 +162,30 @@ const fieldToSchemaMap = {
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+
+    // creates geospatial 2dsphere index by default
+    let direction;
+    const options: IndexOptions = {
+      unique: field.unique || false,
+      sparse: (field.localized && field.unique) || false,
+    };
+    if (field.index === true || field.index === undefined) {
+      direction = '2dsphere';
+    }
+    if (field.localized && config.localization) {
+      indexes.push(
+        ...config.localization.locales.map((locale) => ({
+          index: { [`${field.name}.${locale}`]: direction },
+          options,
+        })),
+      );
+    }
+    if (field.unique) {
+      options.unique = true;
+    }
+    indexes.push({ index: { [field.name]: direction }, options });
   },
-  radio: (field: RadioField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  radio: (field: RadioField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = {
       ...formatBaseSchema(field, buildSchemaOptions),
       type: String,
@@ -197,22 +198,25 @@ const fieldToSchemaMap = {
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  checkbox: (field: CheckboxField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  checkbox: (field: CheckboxField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = { ...formatBaseSchema(field, buildSchemaOptions), type: Boolean };
 
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  date: (field: DateField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  date: (field: DateField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = { ...formatBaseSchema(field, buildSchemaOptions), type: Date };
 
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  upload: (field: UploadField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  upload: (field: UploadField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = {
       ...formatBaseSchema(field, buildSchemaOptions),
       type: Schema.Types.Mixed,
@@ -222,8 +226,9 @@ const fieldToSchemaMap = {
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  relationship: (field: RelationshipField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions) => {
+  relationship: (field: RelationshipField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]) => {
     const hasManyRelations = Array.isArray(field.relationTo);
     let schemaToReturn: { [key: string]: any } = {};
 
@@ -276,51 +281,57 @@ const fieldToSchemaMap = {
     schema.add({
       [field.name]: schemaToReturn,
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  row: (field: RowField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  row: (field: RowField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     field.fields.forEach((subField: Field) => {
       const addFieldSchema: FieldSchemaGenerator = fieldToSchemaMap[subField.type];
 
       if (addFieldSchema) {
-        addFieldSchema(subField, schema, config, buildSchemaOptions);
+        addFieldSchema(subField, schema, config, buildSchemaOptions, indexes);
       }
     });
   },
-  collapsible: (field: CollapsibleField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  collapsible: (field: CollapsibleField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     field.fields.forEach((subField: Field) => {
       const addFieldSchema: FieldSchemaGenerator = fieldToSchemaMap[subField.type];
 
       if (addFieldSchema) {
-        addFieldSchema(subField, schema, config, buildSchemaOptions);
+        addFieldSchema(subField, schema, config, buildSchemaOptions, indexes);
       }
     });
   },
-  tabs: (field: TabsField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  tabs: (field: TabsField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     field.tabs.forEach((tab) => {
       tab.fields.forEach((subField: Field) => {
         const addFieldSchema: FieldSchemaGenerator = fieldToSchemaMap[subField.type];
 
         if (addFieldSchema) {
-          addFieldSchema(subField, schema, config, buildSchemaOptions);
+          addFieldSchema(subField, schema, config, buildSchemaOptions, indexes);
         }
       });
     });
   },
-  array: (field: ArrayField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions) => {
+  array: (field: ArrayField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]) => {
     const baseSchema = {
       ...formatBaseSchema(field, buildSchemaOptions),
-      type: [buildSchema(config, field.fields, {
-        options: { _id: false, id: false },
-        allowIDField: true,
-        disableUnique: buildSchemaOptions.disableUnique,
-      })],
+      type: [buildSchema(
+        config,
+        field.fields,
+        {
+          options: { _id: false, id: false },
+          allowIDField: true,
+          disableUnique: buildSchemaOptions.disableUnique,
+        },
+        indexes,
+      )],
     };
 
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
   },
-  group: (field: GroupField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  group: (field: GroupField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     let { required } = field;
     if (field?.admin?.condition || field?.localized || field?.access?.create) required = false;
 
@@ -329,20 +340,25 @@ const fieldToSchemaMap = {
     const baseSchema = {
       ...formattedBaseSchema,
       required: required && field.fields.some((subField) => (!fieldIsPresentationalOnly(subField) && subField.required && !subField.localized && !subField?.admin?.condition && !subField?.access?.create)),
-      type: buildSchema(config, field.fields, {
-        options: {
-          _id: false,
-          id: false,
+      type: buildSchema(
+        config,
+        field.fields,
+        {
+          options: {
+            _id: false,
+            id: false,
+          },
+          disableUnique: buildSchemaOptions.disableUnique,
         },
-        disableUnique: buildSchemaOptions.disableUnique,
-      }),
+        indexes,
+      ),
     };
 
     schema.add({
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
   },
-  select: (field: SelectField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  select: (field: SelectField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = {
       ...formatBaseSchema(field, buildSchemaOptions),
       type: String,
@@ -356,8 +372,9 @@ const fieldToSchemaMap = {
     schema.add({
       [field.name]: field.hasMany ? [schemaToReturn] : schemaToReturn,
     });
+    addFieldIndex(field, indexes, config, buildSchemaOptions);
   },
-  blocks: (field: BlockField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
+  blocks: (field: BlockField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const fieldSchema = [new Schema({}, { _id: false, discriminatorKey: 'blockType' })];
     let schemaToReturn;
 
@@ -380,7 +397,7 @@ const fieldToSchemaMap = {
       blockItem.fields.forEach((blockField) => {
         const addFieldSchema: FieldSchemaGenerator = fieldToSchemaMap[blockField.type];
         if (addFieldSchema) {
-          addFieldSchema(blockField, blockSchema, config, buildSchemaOptions);
+          addFieldSchema(blockField, blockSchema, config, buildSchemaOptions, indexes);
         }
       });
 

--- a/src/mongoose/buildSchema.ts
+++ b/src/mongoose/buildSchema.ts
@@ -89,7 +89,13 @@ const addFieldIndex = (field: NonPresentationalField, indexFields: Index[], conf
   if (config.indexSortableFields && !buildSchemaOptions.global && !field.index && !field.hidden && sortableFieldTypes.indexOf(field.type) > -1 && fieldAffectsData(field)) {
     indexFields.push({ index: { [field.name]: 1 } });
   } else if (field.unique && fieldAffectsData(field)) {
-    indexFields.push({ index: { [field.name]: 1 }, options: { unique: !buildSchemaOptions.disableUnique, sparse: field.localized || false } });
+    indexFields.push({
+      index: { [field.name]: 1 },
+      options: {
+        unique: !buildSchemaOptions.disableUnique,
+        sparse: field.localized || false,
+      },
+    });
   } else if (field.index && fieldAffectsData(field)) {
     indexFields.push({ index: { [field.name]: 1 } });
   }
@@ -179,11 +185,12 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
           options,
         })),
       );
+    } else {
+      if (field.unique) {
+        options.unique = true;
+      }
+      indexes.push({ index: { [field.name]: direction }, options });
     }
-    if (field.unique) {
-      options.unique = true;
-    }
-    indexes.push({ index: { [field.name]: direction }, options });
   },
   radio: (field: RadioField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
     const baseSchema = {

--- a/src/mongoose/buildSchema.ts
+++ b/src/mongoose/buildSchema.ts
@@ -44,9 +44,10 @@ const localizeSchema = (field: NonPresentationalField, schema, localization) => 
   return schema;
 };
 
-const buildSchema = (config: SanitizedConfig, configFields: Field[], buildSchemaOptions: BuildSchemaOptions = {}, indexes: Index[] = []): Schema => {
+const buildSchema = (config: SanitizedConfig, configFields: Field[], buildSchemaOptions: BuildSchemaOptions = {}): Schema => {
   const { allowIDField, options } = buildSchemaOptions;
   let fields = {};
+  const indexes: Index[] = [];
 
   let schemaFields = configFields;
 
@@ -319,7 +320,7 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
       });
     });
   },
-  array: (field: ArrayField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]) => {
+  array: (field: ArrayField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions) => {
     const baseSchema = {
       ...formatBaseSchema(field, buildSchemaOptions),
       type: [buildSchema(
@@ -330,7 +331,6 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
           allowIDField: true,
           disableUnique: buildSchemaOptions.disableUnique,
         },
-        indexes,
       )],
     };
 
@@ -338,7 +338,7 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
       [field.name]: localizeSchema(field, baseSchema, config.localization),
     });
   },
-  group: (field: GroupField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions, indexes: Index[]): void => {
+  group: (field: GroupField, schema: Schema, config: SanitizedConfig, buildSchemaOptions: BuildSchemaOptions): void => {
     let { required } = field;
     if (field?.admin?.condition || field?.localized || field?.access?.create) required = false;
 
@@ -357,7 +357,6 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
           },
           disableUnique: buildSchemaOptions.disableUnique,
         },
-        indexes,
       ),
     };
 

--- a/test/fields/collections/Indexed/index.ts
+++ b/test/fields/collections/Indexed/index.ts
@@ -34,6 +34,24 @@ const IndexedFields: CollectionConfig = {
         },
       ],
     },
+    {
+      type: 'collapsible',
+      label: 'Collapsible',
+      fields: [
+        {
+          name: 'collapsibleLocalizedUnique',
+          type: 'text',
+          unique: true,
+          localized: true,
+        },
+        {
+          name: 'collapsibleTextUnique',
+          type: 'text',
+          label: 'collapsibleTextUnique',
+          unique: true,
+        },
+      ],
+    },
   ],
 };
 

--- a/test/fields/collections/Point/index.ts
+++ b/test/fields/collections/Point/index.ts
@@ -19,6 +19,7 @@ const PointFields: CollectionConfig = {
       name: 'localized',
       type: 'point',
       label: 'Localized Point',
+      unique: true,
       localized: true,
     },
     {
@@ -36,7 +37,7 @@ const PointFields: CollectionConfig = {
 
 export const pointDoc = {
   point: [7, -7],
-  localized: [5, -2],
+  localized: [15, -12],
   group: { point: [1, 9] },
 };
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -118,6 +118,9 @@ describe('Fields', () => {
     const options: Record<string, IndexOptions> = {};
 
     beforeAll(() => {
+      // mongoose model schema indexes do not always create indexes in the actual database
+      // see: https://github.com/payloadcms/payload/issues/571
+
       indexes = payload.collections['indexed-fields'].Model.schema.indexes() as [Record<string, IndexDirection>, IndexOptions];
 
       indexes.forEach((index) => {
@@ -146,6 +149,12 @@ describe('Fields', () => {
       expect(options['group.localizedUnique.en']).toMatchObject({ unique: true, sparse: true });
       expect(definitions['group.localizedUnique.es']).toEqual(1);
       expect(options['group.localizedUnique.es']).toMatchObject({ unique: true, sparse: true });
+    });
+    it('should have unique indexes in a collapsible', () => {
+      expect(definitions['collapsibleLocalizedUnique.en']).toEqual(1);
+      expect(options['collapsibleLocalizedUnique.en']).toMatchObject({ unique: true, sparse: true });
+      expect(definitions.collapsibleTextUnique).toEqual(1);
+      expect(options.collapsibleTextUnique).toMatchObject({ unique: true });
     });
   });
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -160,6 +160,9 @@ describe('Fields', () => {
 
   describe('point', () => {
     let doc;
+    const point = [7, -7];
+    const localized = [5, -2];
+    const group = { point: [1, 9] };
 
     beforeAll(async () => {
       const findDoc = await payload.find({
@@ -183,9 +186,6 @@ describe('Fields', () => {
     });
 
     it('should create', async () => {
-      const point = [7, -7];
-      const localized = [5, -2];
-      const group = { point: [1, 9] };
       doc = await payload.create({
         collection: 'point-fields',
         data: {
@@ -194,6 +194,30 @@ describe('Fields', () => {
           group,
         },
       });
+
+      expect(doc.point).toEqual(point);
+      expect(doc.localized).toEqual(localized);
+      expect(doc.group).toMatchObject(group);
+    });
+
+    it('should not create duplicate point when unique', async () => {
+      await expect(() => payload.create({
+        collection: 'point-fields',
+        data: {
+          point,
+          localized,
+          group,
+        },
+      }))
+        .rejects
+        .toThrow(Error);
+
+      await expect(async () => payload.create({
+        collection: 'number-fields',
+        data: {
+          min: 5,
+        },
+      })).rejects.toThrow('The following field is invalid: min');
 
       expect(doc.point).toEqual(point);
       expect(doc.localized).toEqual(localized);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8658,7 +8658,7 @@ mongodb@4.8.1:
   optionalDependencies:
     saslprep "^1.0.3"
 
-mongodb@^3.6.2, mongodb@^3.7.3:
+mongodb@^3.7.3:
   version "3.7.3"
   resolved "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz#b7949cfd0adc4cc7d32d3f2034214d4475f175a5"
   integrity sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==


### PR DESCRIPTION
## Description

The way we were creating indexes was more complex than necessary. When mongoose schemas have `sparse` set to false index creation bahaves unexepectedly. Handling sparse conditionally fixes index schema in a simpler way.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Checklist:

- [x] Existing test suite passes locally with my changes
