### PR TITLE
Keep original request and add properties to it, instead of copy

### DIFF
--- a/src/auth/operations/local/forgotPassword.ts
+++ b/src/auth/operations/local/forgotPassword.ts
@@ -19,15 +19,12 @@ async function localForgotPassword(payload: Payload, options: Options): Promise<
     data,
     expiration,
     disableEmail,
-    req: incomingReq = {},
+    req = {} as PayloadRequest,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const req = {
-    ...incomingReq,
-    payloadAPI: 'local',
-  } as PayloadRequest;
+  req.payloadAPI = 'local';
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 

--- a/src/auth/operations/local/login.ts
+++ b/src/auth/operations/local/login.ts
@@ -23,7 +23,7 @@ export type Options = {
 async function localLogin<T extends TypeWithID = any>(payload: Payload, options: Options): Promise<Result & { user: T}> {
   const {
     collection: collectionSlug,
-    req: incomingReq = {},
+    req = {} as PayloadRequest,
     res,
     depth,
     locale,
@@ -35,13 +35,10 @@ async function localLogin<T extends TypeWithID = any>(payload: Payload, options:
 
   const collection = payload.collections[collectionSlug];
 
-  const req = {
-    ...incomingReq,
-    payloadAPI: 'local',
-    payload,
-    locale: undefined,
-    fallbackLocale: undefined,
-  } as PayloadRequest;
+  req.payloadAPI = 'local';
+  req.payload = payload;
+  req.locale = undefined;
+  req.fallbackLocale = undefined;
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 

--- a/src/auth/operations/local/resetPassword.ts
+++ b/src/auth/operations/local/resetPassword.ts
@@ -18,16 +18,13 @@ async function localResetPassword(payload: Payload, options: Options): Promise<R
     collection: collectionSlug,
     data,
     overrideAccess,
-    req: incomingReq = {},
+    req = {} as PayloadRequest,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const req = {
-    ...incomingReq,
-    payload,
-    payloadAPI: 'local',
-  } as PayloadRequest;
+  req.payload = payload;
+  req.payloadAPI = 'local';
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 

--- a/src/auth/operations/local/unlock.ts
+++ b/src/auth/operations/local/unlock.ts
@@ -17,16 +17,13 @@ async function localUnlock(payload: Payload, options: Options): Promise<boolean>
     collection: collectionSlug,
     data,
     overrideAccess = true,
-    req: incomingReq = {},
+    req = {} as PayloadRequest,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const req = {
-    ...incomingReq,
-    payload,
-    payloadAPI: 'local',
-  } as PayloadRequest;
+  req.payload = payload;
+  req.payloadAPI = 'local';
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 

--- a/src/collections/operations/local/find.ts
+++ b/src/collections/operations/local/find.ts
@@ -43,19 +43,15 @@ export default async function findLocal<T extends TypeWithID = any>(payload: Pay
     sort,
     draft = false,
     pagination = true,
-    req: incomingReq,
+    req = {} as PayloadRequest,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const req = {
-    user: undefined,
-    ...incomingReq || {},
-    payloadAPI: 'local',
-    locale: locale || incomingReq?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
-    fallbackLocale: fallbackLocale || incomingReq?.fallbackLocale || null,
-    payload,
-  } as PayloadRequest;
+  req.payloadAPI = 'local';
+  req.locale = locale || req?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null);
+  req.fallbackLocale = fallbackLocale || req?.fallbackLocale || null;
+  req.payload = payload;
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 

--- a/src/collections/operations/local/findByID.ts
+++ b/src/collections/operations/local/findByID.ts
@@ -33,20 +33,16 @@ export default async function findByIDLocal<T extends TypeWithID = any>(payload:
     overrideAccess = true,
     disableErrors = false,
     showHiddenFields,
-    req: incomingReq,
+    req = {} as PayloadRequest,
     draft = false,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const req = {
-    user: undefined,
-    ...incomingReq || {},
-    payloadAPI: 'local',
-    locale: locale || incomingReq?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null),
-    fallbackLocale: fallbackLocale || incomingReq?.fallbackLocale || null,
-    payload,
-  } as PayloadRequest;
+  req.payloadAPI = 'local';
+  req.locale = locale || req?.locale || (payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null);
+  req.fallbackLocale = fallbackLocale || req?.fallbackLocale || null;
+  req.payload = payload;
 
   if (typeof user !== 'undefined') req.user = user;
 

--- a/src/collections/operations/local/findVersionByID.ts
+++ b/src/collections/operations/local/findVersionByID.ts
@@ -28,18 +28,15 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
     overrideAccess = true,
     disableErrors = false,
     showHiddenFields,
-    req: incomingReq,
+    req = {} as PayloadRequest,
   } = options;
 
   const collection = payload.collections[collectionSlug];
 
-  const req = {
-    ...incomingReq || {},
-    payloadAPI: 'local',
-    locale: locale || incomingReq?.locale || this?.config?.localization?.defaultLocale,
-    fallbackLocale: fallbackLocale || incomingReq?.fallbackLocale || null,
-    payload,
-  } as PayloadRequest;
+  req.payloadAPI = 'local';
+  req.locale = locale || req?.locale || this?.config?.localization?.defaultLocale;
+  req.fallbackLocale = fallbackLocale || req?.fallbackLocale || null;
+  req.payload = payload;
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -9,6 +9,7 @@ export const readOnlySlug = 'read-only-collection';
 export const restrictedSlug = 'restricted';
 export const restrictedVersionsSlug = 'restricted-versions';
 export const siblingDataSlug = 'sibling-data';
+export const relyOnRequestHeadersSlug = 'rely-on-request-headers';
 
 const openAccess = {
   create: () => true,
@@ -22,6 +23,11 @@ const PublicReadabilityAccess: FieldAccess = ({ req: { user }, siblingData }) =>
   if (siblingData?.allowPublicReadability) return true;
 
   return false;
+};
+
+export const requestHeaders = {authorization: 'Bearer testBearerToken'};
+const UseRequestHeadersAccess: FieldAccess = ({ req: { headers } }) => {
+  return !!headers && headers.authorization === requestHeaders.authorization;
 };
 
 export default buildConfig({
@@ -112,6 +118,21 @@ export default buildConfig({
               ],
             },
           ],
+        },
+      ],
+    },
+    {
+      slug: relyOnRequestHeadersSlug,
+      access: {
+        create: UseRequestHeadersAccess,
+        read: UseRequestHeadersAccess,
+        update: UseRequestHeadersAccess,
+        delete: UseRequestHeadersAccess,
+      },
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
         },
       ],
     },

--- a/test/access-control/payload-types.ts
+++ b/test/access-control/payload-types.ts
@@ -62,6 +62,16 @@ export interface SiblingDatum {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "rely-on-request-headers".
+ */
+export interface RelyOnRequestHeader {
+  id: string;
+  name?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {


### PR DESCRIPTION
resolves #971
## Description

Node 15 changed certain properties on the Request object to be "non-enumerable", meaning said properties will be skipped when looped over. This resulted in a request object passed to access control functions that was missing properties from the original request object.

Instead of creating a new request object when performing operations through the local API, we use the original request object and add our own properties to it.

Tests added.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
