### PR TITLE
ci: run actions on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,10 @@
 name: build
 
 on:
-  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
   push:
+    branches: ['master']
 
 jobs:
   build_yarn:


### PR DESCRIPTION
- Run actions on PR events
- Only run on `push` event if master