### PR TITLE
Fix a regression that makes collection items not unpublishable

### DIFF
--- a/src/admin/components/elements/Status/index.tsx
+++ b/src/admin/components/elements/Status/index.tsx
@@ -55,7 +55,7 @@ const Status: React.FC<Props> = () => {
 
     if (collection) {
       url = `${serverURL}${api}/${collection.slug}/${id}?depth=0&locale=${locale}&fallback-locale=null`;
-      method = 'PATCH';
+      method = 'patch';
     }
     if (global) {
       url = `${serverURL}${api}/globals/${global.slug}?depth=0&locale=${locale}&fallback-locale=null`;


### PR DESCRIPTION
## Description

ccada2e changes an update method when unpublishing an item from `put` (lower case) to `PATCH` (upper case). This causes the UI to freeze and an item is not unpublishable.

![image](https://user-images.githubusercontent.com/62678592/187061035-54e0688f-9b5f-411a-b84d-4ad3049622d0.png)

The correct method should be `patch` (lower case), and this PR fixes that. The latest method definition is as seen below.

https://github.com/payloadcms/payload/blob/cf2eb3e482434de0e4bce257b23f26dcbf0bbcb7/src/admin/api.ts#L37
___

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
