### PR TITLE
collapsable default state for array, block, collapsable fields

### DIFF
--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -7,8 +7,9 @@ keywords: overview, fields, config, configuration, documentation, Content Manage
 ---
 
 <Banner type="info">
-  Fields are the building blocks of Payload. Collections and Globals both use Fields to define the shape of the data
-  that they store. Payload offers a wide variety of field types - both simple and complex.
+  Fields are the building blocks of Payload. Collections and Globals both use
+  Fields to define the shape of the data that they store. Payload offers a wide
+  variety of field types - both simple and complex.
 </Banner>
 
 Fields are defined as an array on Collections and Globals via the `fields` key. They define the shape of the data that will be stored as well as automatically construct the corresponding Admin UI.
@@ -16,21 +17,22 @@ Fields are defined as an array on Collections and Globals via the `fields` key. 
 The required `type` property on a field determines what values it can accept, how it is presented in the API, and how the field will be rendered in the admin interface.
 
 **Simple collection with two fields:**
+
 ```ts
-import { CollectionConfig } from 'payload/types';
+import { CollectionConfig } from "payload/types";
 
 const Page: CollectionConfig = {
-	slug: 'pages',
-	fields: [
-		{
-			name: 'myField',
-			type: 'text', // highlight-line
-		},
-		{
-			name: 'otherField',
-			type: 'checkbox', // highlight-line
-		},
-	],
+  slug: "pages",
+  fields: [
+    {
+      name: "myField",
+      type: "text", // highlight-line
+    },
+    {
+      name: "otherField",
+      type: "checkbox", // highlight-line
+    },
+  ],
 };
 ```
 
@@ -69,30 +71,32 @@ In addition to being able to define access control on a document-level, you can 
 Field validation is enforced automatically based on the field type and other properties such as `required` or `min` and `max` value constraints on certain field types. This default behavior can be replaced by providing your own validate function for any field. It will be used on both the frontend and the backend, so it should not rely on any Node-specific packages. The validation function can be either synchronous or asynchronous and expects to return either `true` or a string error message to display in both API responses and within the Admin panel.
 
 There are two arguments available to custom validation functions.
+
 1. The value which is currently assigned to the field
 2. An optional object with dynamic properties for more complex validation having the following:
 
-| Property      | Description  |
-| ------------- | -------------|
-| `data`             | An object of the full collection or global document |
-| `siblingData`      | An object of the document data limited to fields within the same parent to the field |
-| `operation`        | Will be "create" or "update" depending on the UI action or API call |
-| `id`               | The value of the collection `id`, will be `undefined` on create request |
-| `user`             | The currently authenticated user object |
-| `payload`          | If the `validate` function is being executed on the server, Payload will be exposed for easily running local operations. |
+| Property      | Description                                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `data`        | An object of the full collection or global document                                                                      |
+| `siblingData` | An object of the document data limited to fields within the same parent to the field                                     |
+| `operation`   | Will be "create" or "update" depending on the UI action or API call                                                      |
+| `id`          | The value of the collection `id`, will be `undefined` on create request                                                  |
+| `user`        | The currently authenticated user object                                                                                  |
+| `payload`     | If the `validate` function is being executed on the server, Payload will be exposed for easily running local operations. |
 
 Example:
+
 ```ts
-import { CollectionConfig } from 'payload/types';
+import { CollectionConfig } from "payload/types";
 
 const Orders: CollectionConfig = {
-  slug: 'orders',
+  slug: "orders",
   fields: [
     {
-      name: 'customerNumber',
-      type: 'text',
+      name: "customerNumber",
+      type: "text",
       validate: async (val, { operation }) => {
-        if (operation !== 'create') {
+        if (operation !== "create") {
           // skip validation on update
           return true;
         }
@@ -101,7 +105,7 @@ const Orders: CollectionConfig = {
           return true;
         }
 
-        return 'The customer number provided does not match any customers within our records.';
+        return "The customer number provided does not match any customers within our records.";
       },
     },
   ],
@@ -111,14 +115,15 @@ const Orders: CollectionConfig = {
 When supplying a field `validate` function, Payload will use yours in place of the default. To make use of the default field validation in your custom logic you can import, call and return the result as needed.
 
 For example:
+
 ```ts
-import { text } from 'payload/fields/validations';
+import { text } from "payload/fields/validations";
 
 const field: Field = {
-  name: 'notBad',
-  type: 'text',
+  name: "notBad",
+  type: "text",
   validate: (val, args) => {
-    if (val === 'bad') {
+    if (val === "bad") {
       return 'This cannot be "bad"';
     }
     // highlight-start
@@ -135,6 +140,7 @@ Users are then required to provide a custom ID value when creating a record thro
 Valid ID types are `number` and `text`.
 
 Example:
+
 ```ts
 {
   fields: [
@@ -150,18 +156,19 @@ Example:
 
 In addition to each field's base configuration, you can define specific traits and properties for fields that only have effect on how they are rendered in the Admin panel. The following properties are available for all fields within the `admin` property:
 
-| Option        | Description  |
-| ------------- | -------------|
-| `condition`   | You can programmatically show / hide fields based on what other fields are doing. [Click here](#conditional-logic) for more info. |
-| `components`  | All field components can be completely and easily swapped out for custom components that you define. [Click here](#custom-components) for more info. |
-| `description` | Helper text to display with the field to provide more information for the editor user. [Click here](#description) for more info. |
-| `position`    | Specify if the field should be rendered in the sidebar by defining `position: 'sidebar'`. |
-| `width`       | Restrict the width of a field. you can pass any string-based value here, be it pixels, percentages, etc. This property is especially useful when fields are nested within a `Row` type where they can be organized horizontally. |
-| `style`       | Attach raw CSS style properties to the root DOM element of a field. |
-| `className`   | Attach a CSS class name to the root DOM element of a field. |
-| `readOnly`    | Setting a field to `readOnly` has no effect on the API whatsoever but disables the admin component's editability to prevent editors from modifying the field's value. |
-| `disabled`    | If a field is `disabled`, it is completely omitted from the Admin panel. |
-| `hidden`      | Setting a field's `hidden` property on its `admin` config will transform it into a `hidden` input type. Its value will still submit with the Admin panel's requests, but the field itself will not be visible to editors. |
+| Option          | Description                                                                                                                                                                                                                      |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `condition`     | You can programmatically show / hide fields based on what other fields are doing. [Click here](#conditional-logic) for more info.                                                                                                |
+| `components`    | All field components can be completely and easily swapped out for custom components that you define. [Click here](#custom-components) for more info.                                                                             |
+| `description`   | Helper text to display with the field to provide more information for the editor user. [Click here](#description) for more info.                                                                                                 |
+| `position`      | Specify if the field should be rendered in the sidebar by defining `position: 'sidebar'`.                                                                                                                                        |
+| `width`         | Restrict the width of a field. you can pass any string-based value here, be it pixels, percentages, etc. This property is especially useful when fields are nested within a `Row` type where they can be organized horizontally. |
+| `style`         | Attach raw CSS style properties to the root DOM element of a field.                                                                                                                                                              |
+| `className`     | Attach a CSS class name to the root DOM element of a field.                                                                                                                                                                      |
+| `readOnly`      | Setting a field to `readOnly` has no effect on the API whatsoever but disables the admin component's editability to prevent editors from modifying the field's value.                                                            |
+| `initCollapsed` | Setting the default collapsble state of block/collapsble/array fields.                                                                                                                                                           |
+| `disabled`      | If a field is `disabled`, it is completely omitted from the Admin panel.                                                                                                                                                         |
+| `hidden`        | Setting a field's `hidden` property on its `admin` config will transform it into a `hidden` input type. Its value will still submit with the Admin panel's requests, but the field itself will not be visible to editors.        |
 
 ### Custom components
 
@@ -182,13 +189,13 @@ The `condition` function should return a boolean that will control if the field 
 {
   fields: [
     {
-      name: 'enableGreeting',
-      type: 'checkbox',
+      name: "enableGreeting",
+      type: "checkbox",
       defaultValue: false,
     },
     {
-      name: 'greeting',
-      type: 'text',
+      name: "greeting",
+      type: "text",
       admin: {
         // highlight-start
         condition: (data, siblingData) => {
@@ -197,11 +204,11 @@ The `condition` function should return a boolean that will control if the field 
           } else {
             return false;
           }
-        }
+        },
         // highlight-end
-      }
-    }
-  ]
+      },
+    },
+  ];
 }
 ```
 
@@ -218,28 +225,30 @@ Here is an example of a defaultValue function that uses both:
 
 ```ts
 const translation: {
-  en: 'Written by',
-  es: 'Escrito por',
+  en: "Written by";
+  es: "Escrito por";
 };
 
 const field = {
-  name: 'attribution',
-  type: 'text',
+  name: "attribution",
+  type: "text",
   admin: {
     // highlight-start
-    defaultValue: ({ user, locale }) => (`${translation[locale]} ${user.name}`)
+    defaultValue: ({ user, locale }) => `${translation[locale]} ${user.name}`,
     // highlight-end
-  }
+  },
 };
 ```
 
 <Banner type="success">
-  You can use async defaultValue functions to fill fields with data from API requests.
+  You can use async defaultValue functions to fill fields with data from API
+  requests.
 </Banner>
 
 ### Description
 
 A description can be configured three ways.
+
 - As a string
 - As a function that accepts an object containing the field's value, which returns a string
 - As a React component that accepts value as a prop
@@ -252,41 +261,41 @@ As shown above, you can simply provide a string that will show by the field, but
 {
   fields: [
     {
-      name: 'message',
-      type: 'text',
+      name: "message",
+      type: "text",
       maxLength: 20,
       admin: {
         description: ({ value }) =>
-          (`${typeof value === 'string' ? 20 - value.length : '20'} characters left`)
-      }
-    }
-  ]
+          `${
+            typeof value === "string" ? 20 - value.length : "20"
+          } characters left`,
+      },
+    },
+  ];
 }
 ```
+
 This example will display the number of characters allowed as the user types.
 
 **Component Example:**
+
 ```ts
 {
   fields: [
     {
-      name: 'message',
-      type: 'text',
+      name: "message",
+      type: "text",
       maxLength: 20,
       admin: {
-        description:
-          ({ value }) => (
-            <div>
-              Character count:
-              {' '}
-              { value?.length || 0 }
-            </div>
-          )
-      }
-    }
-  ]
+        description: ({ value }) => (
+          <div>Character count: {value?.length || 0}</div>
+        ),
+      },
+    },
+  ];
 }
 ```
+
 This component will count the number of characters entered.
 
 ### TypeScript
@@ -294,7 +303,5 @@ This component will count the number of characters entered.
 You can import the internal Payload `Field` type as well as other common field types as follows:
 
 ```ts
-import type {
-  Field,
-} from 'payload/types';
+import type { Field } from "payload/types";
 ```

--- a/src/admin/components/forms/field-types/Array/index.tsx
+++ b/src/admin/components/forms/field-types/Array/index.tsx
@@ -42,6 +42,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
       readOnly,
       description,
       condition,
+      initCollapsed,
       className,
     },
   } = props;
@@ -178,12 +179,23 @@ const ArrayFieldType: React.FC<Props> = (props) => {
   useEffect(() => {
     const initializeRowState = async () => {
       const data = formContext.getDataByPath<Row[]>(path);
-      const preferences = await getPreference(preferencesKey) || { fields: {} };
+      const collapseDefaultState = initCollapsed
+        ? {
+          fields: {
+            [path]: {
+              collapsed: data.map((item) => item.id),
+            },
+          },
+        }
+        : {
+          fields: {},
+        };
+      const preferences = await getPreference(preferencesKey) || collapseDefaultState;
       dispatchRows({ type: 'SET_ALL', data: data || [], collapsedState: preferences?.fields?.[path]?.collapsed });
     };
 
     initializeRowState();
-  }, [formContext, path, getPreference, preferencesKey]);
+  }, [formContext, path, getPreference, preferencesKey, initCollapsed]);
 
   useEffect(() => {
     setValue(rows?.length || 0, true);

--- a/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -54,6 +54,7 @@ const Index: React.FC<Props> = (props) => {
       readOnly,
       description,
       condition,
+      initCollapsed,
       className,
     },
   } = props;
@@ -187,12 +188,23 @@ const Index: React.FC<Props> = (props) => {
   useEffect(() => {
     const initializeRowState = async () => {
       const data = formContext.getDataByPath<Row[]>(path);
-      const preferences = await getPreference(preferencesKey) || { fields: {} };
+      const collapseDefaultState = initCollapsed
+        ? {
+          fields: {
+            [path]: {
+              collapsed: data.map((item) => item.id),
+            },
+          },
+        }
+        : {
+          fields: {},
+        };
+      const preferences = await getPreference(preferencesKey) || collapseDefaultState;
       dispatchRows({ type: 'SET_ALL', data: data || [], collapsedState: preferences?.fields?.[path]?.collapsed });
     };
 
     initializeRowState();
-  }, [formContext, path, getPreference, preferencesKey]);
+  }, [formContext, path, getPreference, preferencesKey, initCollapsed]);
 
   useEffect(() => {
     setValue(rows?.length || 0, true);

--- a/src/admin/components/forms/field-types/Collapsible/index.tsx
+++ b/src/admin/components/forms/field-types/Collapsible/index.tsx
@@ -24,13 +24,14 @@ const CollapsibleField: React.FC<Props> = (props) => {
     admin: {
       readOnly,
       className,
+      initCollapsed,
       description,
     },
   } = props;
 
   const { getPreference, setPreference } = usePreferences();
   const { preferencesKey } = useDocumentInfo();
-  const [initCollapsed, setInitCollapsed] = useState<boolean>();
+  const [initCollapsedValue, setInitCollapsed] = useState<boolean>();
   const [fieldPreferencesKey] = useState(() => `collapsible-${toKebabCase(label)}`);
 
   const onToggle = useCallback(async (newCollapsedState: boolean) => {
@@ -51,18 +52,21 @@ const CollapsibleField: React.FC<Props> = (props) => {
   useEffect(() => {
     const fetchInitialState = async () => {
       const preferences = await getPreference(preferencesKey);
-      setInitCollapsed(Boolean(preferences?.fields?.[fieldPreferencesKey]?.collapsed));
+      const collapseDefaultState = preferences != null
+        ? Boolean(preferences?.fields?.[fieldPreferencesKey]?.collapsed)
+        : initCollapsed;
+      setInitCollapsed(collapseDefaultState);
     };
 
     fetchInitialState();
-  }, [getPreference, preferencesKey, fieldPreferencesKey]);
+  }, [getPreference, preferencesKey, fieldPreferencesKey, initCollapsed]);
 
-  if (typeof initCollapsed !== 'boolean') return null;
+  if (typeof initCollapsedValue !== 'boolean') return null;
 
   return (
     <React.Fragment>
       <Collapsible
-        initCollapsed={initCollapsed}
+        initCollapsed={initCollapsedValue}
         className={[
           'field-type',
           baseClass,

--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -11,6 +11,7 @@ export const baseAdminFields = joi.object().keys({
   style: joi.object().unknown(),
   className: joi.string(),
   readOnly: joi.boolean().default(false),
+  initCollapsed: joi.boolean().default(false),
   hidden: joi.boolean().default(false),
   disabled: joi.boolean().default(false),
   condition: joi.func(),

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -177,6 +177,9 @@ export type CollapsibleField = Omit<FieldBase, 'name'> & {
   type: 'collapsible';
   label: string
   fields: Field[];
+  admin?: Admin & {
+    initCollapsed?: boolean | false;
+  }
 }
 
 export type TabsAdmin = Omit<Admin, 'description'>;
@@ -302,6 +305,9 @@ export type ArrayField = FieldBase & {
   maxRows?: number;
   labels?: Labels;
   fields: Field[];
+  admin?: Admin & {
+    initCollapsed?: boolean | false;
+  }
 }
 
 export type RadioField = FieldBase & {
@@ -327,6 +333,10 @@ export type BlockField = FieldBase & {
   blocks: Block[];
   defaultValue?: unknown
   labels?: Labels
+  admin?: Admin & {
+    initCollapsed?: boolean | false;
+  }
+
 }
 
 export type PointField = FieldBase & {

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -24,6 +24,26 @@ const ArrayFields: CollectionConfig = {
       ],
     },
     {
+      name: 'items-collapsed-by-default',
+      labels: {
+        singular: 'Item',
+        plural: 'Items',
+      },
+      type: 'array',
+      required: true,
+      defaultValue: arrayDefaultValue,
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+          required: true,
+        },
+      ],
+      admin: {
+        initCollapsed: true,
+      },
+    },
+    {
       name: 'localized',
       type: 'array',
       required: true,

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -1,6 +1,36 @@
 import type { CollectionConfig } from '../../../../src/collections/config/types';
 import { Field } from '../../../../src/fields/config/types';
 
+export const blocksFieldSeedData = [
+  {
+    blockName: 'First block',
+    blockType: 'text',
+    text: 'first block',
+    richText: [],
+  },
+  {
+    blockName: 'Second block',
+    blockType: 'number',
+    number: 342,
+  },
+  {
+    blockName: 'Sub-block demonstration',
+    blockType: 'subBlocks',
+    subBlocks: [
+      {
+        blockName: 'First sub block',
+        blockType: 'number',
+        number: 123,
+      },
+      {
+        blockName: 'Second sub block',
+        blockType: 'text',
+        text: 'second sub block',
+      },
+    ],
+  },
+] as const;
+
 export const blocksField: Field = {
   name: 'blocks',
   type: 'blocks',
@@ -104,6 +134,7 @@ export const blocksField: Field = {
       ],
     },
   ],
+  defaultValue: blocksFieldSeedData,
 };
 
 const BlockFields: CollectionConfig = {
@@ -112,41 +143,19 @@ const BlockFields: CollectionConfig = {
     blocksField,
     {
       ...blocksField,
+      name: 'collapsedByDefaultBlocks',
+      localized: true,
+      admin: {
+        initCollapsed: true,
+      },
+    },
+    {
+      ...blocksField,
       name: 'localizedBlocks',
       localized: true,
     },
   ],
 };
-
-export const blocksFieldSeedData = [
-  {
-    blockName: 'First block',
-    blockType: 'text',
-    text: 'first block',
-    richText: [],
-  },
-  {
-    blockName: 'Second block',
-    blockType: 'number',
-    number: 342,
-  },
-  {
-    blockName: 'Sub-block demonstration',
-    blockType: 'subBlocks',
-    subBlocks: [
-      {
-        blockName: 'First sub block',
-        blockType: 'number',
-        number: 123,
-      },
-      {
-        blockName: 'Second sub block',
-        blockType: 'text',
-        text: 'second sub block',
-      },
-    ],
-  },
-] as const;
 
 export const blocksDoc = {
   blocks: blocksFieldSeedData,

--- a/test/fields/collections/Collapsible/index.ts
+++ b/test/fields/collections/Collapsible/index.ts
@@ -9,12 +9,47 @@ const CollapsibleFields: CollectionConfig = {
       type: 'collapsible',
       admin: {
         description: 'This is a collapsible field.',
+        initCollapsed: false,
       },
       fields: [
         {
           name: 'text',
           type: 'text',
           required: true,
+        },
+        {
+          name: 'group',
+          type: 'group',
+          fields: [
+            {
+              name: 'textWithinGroup',
+              type: 'text',
+            },
+            {
+              name: 'subGroup',
+              type: 'group',
+              fields: [
+                {
+                  name: 'textWithinSubGroup',
+                  type: 'text',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: 'Collapsible Field - Collapsed by Default',
+      type: 'collapsible',
+      admin: {
+        description: 'This is a collapsible field.',
+        initCollapsed: true,
+      },
+      fields: [
+        {
+          name: 'someText',
+          type: 'text',
         },
         {
           name: 'group',

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -72,6 +72,13 @@ export interface BlockField {
         blockName?: string;
         blockType: 'subBlocks';
       }
+    | {
+        textInCollapsible?: string;
+        textInRow?: string;
+        id?: string;
+        blockName?: string;
+        blockType: 'tabs';
+      }
   )[];
   localizedBlocks: (
     | {
@@ -107,6 +114,13 @@ export interface BlockField {
         id?: string;
         blockName?: string;
         blockType: 'subBlocks';
+      }
+    | {
+        textInCollapsible?: string;
+        textInRow?: string;
+        id?: string;
+        blockName?: string;
+        blockType: 'tabs';
       }
   )[];
   createdAt: string;
@@ -272,6 +286,13 @@ export interface TabsField {
         id?: string;
         blockName?: string;
         blockType: 'subBlocks';
+      }
+    | {
+        textInCollapsible?: string;
+        textInRow?: string;
+        id?: string;
+        blockName?: string;
+        blockType: 'tabs';
       }
   )[];
   group: {


### PR DESCRIPTION
add support for setting collapsable fields (array, block, collapsable) to "collapsed" state by default

## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
