### PR TITLE
docs: Correct “autheticate” misspelling in docs

### DIFF
--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -62,7 +62,7 @@ const Admins: CollectionConfig = {
 }
 ```
 
-**By enabling Authetication on a config, the following modifications will automatically be made to your Collection:**
+**By enabling Authentication on a config, the following modifications will automatically be made to your Collection:**
 
 1. `email` as well as password `salt` & `hash` fields will be added to your Collection's schema
 1. The Admin panel will feature a new set of corresponding UI to allow for changing password and editing email


### PR DESCRIPTION
## Description

This PR corrects a typo in the overview docs for Payload’s authentication framework.

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have made corresponding changes to the documentation
