### PR TITLE
fix: reorder plugin wrapping

### DIFF
--- a/src/admin/components/forms/field-types/RichText/RichText.tsx
+++ b/src/admin/components/forms/field-types/RichText/RichText.tsx
@@ -152,10 +152,10 @@ const RichText: React.FC<Props> = (props) => {
       ),
     );
 
+    CreatedEditor = withHTML(CreatedEditor);
+
     CreatedEditor = enablePlugins(CreatedEditor, elements);
     CreatedEditor = enablePlugins(CreatedEditor, leaves);
-
-    CreatedEditor = withHTML(CreatedEditor);
 
     return CreatedEditor;
   }, [elements, leaves]);


### PR DESCRIPTION
## Description

move the built-in withHTML plugin to be executed after custom elements's plugin, so we can get a chance to execute our own custom plugin when paste content from other editors.
Fixes https://github.com/payloadcms/payload/issues/1049

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
