### PR TITLE
docs: update custom endpoints link

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -39,7 +39,7 @@ Payload is a *config-based*, code-first CMS and application framework. The Paylo
 | `rateLimit`          | Control IP-based rate limiting for all Payload resources. Used to prevent DDoS attacks and [more](/docs/production/preventing-abuse#rate-limiting-requests). |
 | `hooks`              | Tap into Payload-wide hooks. [More](/docs/hooks/overview) |
 | `plugins`            | An array of Payload plugins. [More](/docs/plugins/overview) |
-| `endpoints`          | An array of custom API endpoints added to the Payload router. [More](/docs/plugins/overview) |
+| `endpoints`          | An array of custom API endpoints added to the Payload router. [More](/docs/rest-api/overview#custom-endpoints) |
 
 #### Simple example
 


### PR DESCRIPTION
## Description

Fixes the 'More' hyperlink next to the 'endpoints' table row on the Configuration Overview documentation page that was previously pointing to the Plugin Overview page. It now points to the relevant documentation page (/docs/rest-api/overview#custom-endpoints).

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->
- [X] This change requires a documentation update

## Checklist:

- [X] I have made corresponding changes to the documentation
