### PR TITLE
docs: move description prop doc to right place

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -17,7 +17,6 @@ It's often best practice to write your Collections in separate files and then im
 | **`slug`** *     | Unique, URL-friendly string that will act as an identifier for this Collection. |
 | **`fields`** *   | Array of field types that will determine the structure and functionality of the data stored within this Collection. [Click here](/docs/fields/overview) for a full list of field types as well as how to configure them. |
 | **`labels`**     | Singular and plural labels for use in identifying this Collection throughout Payload. Auto-generated from slug if not defined. |
-| **`description`**| Text or React component to display below the Collection label in the List view to give editors more information. |
 | **`admin`**      | Admin-specific configuration. See below for [more detail](#admin-options). |
 | **`hooks`**      | Entry points to "tie in" to Collection actions at specific points. [More](/docs/hooks/overview#collection-hooks) |
 | **`access`**     | Provide access control functions to define exactly who should be able to do what with Documents in this Collection. [More](/docs/access-control/overview/#collections) |
@@ -63,6 +62,7 @@ You can customize the way that the Admin panel behaves on a collection-by-collec
 | Option                       | Description  |
 | ---------------------------- | -------------|
 | `useAsTitle`                 | Specify a top-level field to use for a document title throughout the Admin panel. If no field is defined, the ID of the document is used as the title. |
+| `description`                | Text or React component to display below the Collection label in the List view to give editors more information. |
 | `defaultColumns`             | Array of field names that correspond to which columns to show by default in this collection's List view. |
 | `disableDuplicate `          | Disables the "Duplicate" button while editing documents within this collection. |
 | `enableRichTextRelationship` | The [Rich Text](/docs/fields/rich-text) field features a `Relationship` element which allows for users to automatically reference related documents within their rich text. Set to `true` by default. |


### PR DESCRIPTION
## Description

There is no `description` property in `CollectionConfig`, rather it is located in `CollectionAdminOptions` as seen in https://github.com/mfru/payload/blob/fix-collection-description-doc/src/collections/config/types.ts#L157

This commit moves the documentation for `description` to the correct section.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
