### PR TITLE
fix: accented label char sanitization for GraphQL

### DIFF
--- a/src/graphql/utilities/formatName.spec.ts
+++ b/src/graphql/utilities/formatName.spec.ts
@@ -1,0 +1,18 @@
+/* eslint-disable indent */
+/* eslint-disable jest/prefer-strict-equal */
+import formatName from './formatName';
+
+describe('formatName', () => {
+  it.each`
+    char   | expected
+    ${'á'} | ${'a'}
+    ${'è'} | ${'e'}
+    ${'í'} | ${'i'}
+    ${'ó'} | ${'o'}
+    ${'ú'} | ${'u'}
+    ${'ñ'} | ${'n'}
+    ${'ü'} | ${'u'}
+  `('should convert accented character: $char', ({ char, expected }) => {
+    expect(formatName(char)).toEqual(expected);
+  });
+});

--- a/src/graphql/utilities/formatName.ts
+++ b/src/graphql/utilities/formatName.ts
@@ -10,6 +10,10 @@ const formatName = (string: string): string => {
   }
 
   const formatted = sanitizedString
+    // Convert accented characters
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+
     .replace(/\./g, '_')
     .replace(/-|\//g, '_')
     .replace(/\+/g, '_')


### PR DESCRIPTION
## Description

Properly sanitizes accented characters for GraphQL

Fixes #1064 
