### PR TITLE
fix: require min 1 option in field schema validation

### DIFF
--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -131,13 +131,15 @@ export const code = baseField.keys({
 export const select = baseField.keys({
   type: joi.string().valid('select').required(),
   name: joi.string().required(),
-  options: joi.array().items(joi.alternatives().try(
-    joi.string(),
-    joi.object({
-      value: joi.string().required().allow(''),
-      label: joi.string().required(),
-    }),
-  )).required(),
+  options: joi.array().min(1).items(
+    joi.alternatives().try(
+      joi.string(),
+      joi.object({
+        value: joi.string().required().allow(''),
+        label: joi.string().required(),
+      }),
+    ),
+  ).required(),
   hasMany: joi.boolean().default(false),
   defaultValue: joi.alternatives().try(
     joi.string().allow(''),
@@ -153,13 +155,15 @@ export const select = baseField.keys({
 export const radio = baseField.keys({
   type: joi.string().valid('radio').required(),
   name: joi.string().required(),
-  options: joi.array().items(joi.alternatives().try(
-    joi.string(),
-    joi.object({
-      value: joi.string().required().allow(''),
-      label: joi.string().required(),
-    }),
-  )).required(),
+  options: joi.array().min(1).items(
+    joi.alternatives().try(
+      joi.string(),
+      joi.object({
+        value: joi.string().required().allow(''),
+        label: joi.string().required(),
+      }),
+    ),
+  ).required(),
   defaultValue: joi.alternatives().try(
     joi.string().allow(''),
     joi.func(),


### PR DESCRIPTION
## Description

It is possible to have a select or radio button configured with no options. With this change Payload will throw a validation error when this configuration is given.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes