### PR TITLE
fix: add height/width if imageSizes not specified

### DIFF
--- a/src/uploads/getBaseFields.ts
+++ b/src/uploads/getBaseFields.ts
@@ -92,6 +92,8 @@ const getBaseUploadFields = ({ config, collection }: Options): Field[] => {
     filename,
     mimeType,
     filesize,
+    width,
+    height,
   ];
 
   if (uploadOptions.mimeTypes) {
@@ -100,8 +102,6 @@ const getBaseUploadFields = ({ config, collection }: Options): Field[] => {
 
   if (uploadOptions.imageSizes) {
     uploadFields = uploadFields.concat([
-      width,
-      height,
       {
         name: 'sizes',
         label: 'Sizes',


### PR DESCRIPTION
## Description

Include height and width when `imageSizes` not specified. Fixes #1072 