### PR TITLE
chore: bumps @faceless-ui/modal to v1.3.2 #1070

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@babel/preset-typescript": "^7.12.1",
     "@babel/register": "^7.11.5",
     "@date-io/date-fns": "^2.10.6",
-    "@faceless-ui/modal": "1.2.0",
+    "@faceless-ui/modal": "^1.3.2",
     "@faceless-ui/scroll-info": "^1.2.3",
     "@faceless-ui/window-info": "^2.0.2",
     "@types/is-plain-object": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,12 +1271,13 @@
   resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@faceless-ui/modal@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@faceless-ui/modal/-/modal-1.2.0.tgz#0ca43e480f83d307dcd84c033fbc82c0619f5d8c"
-  integrity sha512-92LQw1ZIaphzCVaHyhxrzbRtn9LXnm5GOJVXJ4tDUpuz7j1B05QTSOuYWjBd8AZKsBR0MQhgr11BVVgJ70DEhw==
+"@faceless-ui/modal@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@faceless-ui/modal/-/modal-1.3.2.tgz#a085b3b8d18f11ee9a39cfa115453f985e2f9735"
+  integrity sha512-3KZ/1BLWgAiTrAkRKbMqVW8EEsAX/M6ElpwRZWT1d0usKLvhyUw9o/2SVmkJZp9/a/rP9RGh4xQwgUwDN7TEiA==
   dependencies:
     body-scroll-lock "^3.1.5"
+    focus-trap "^6.9.2"
     qs "^6.9.1"
     react-transition-group "^4.4.2"
 
@@ -6012,6 +6013,13 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+focus-trap@^6.9.2:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.9.4.tgz#436da1a1d935c48b97da63cd8f361c6f3aa16444"
+  integrity sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==
+  dependencies:
+    tabbable "^5.3.3"
 
 follow-redirects@^1.14.0:
   version "1.15.1"
@@ -11889,6 +11897,11 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+tabbable@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
+  integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
## Description

Fixes issue related to unreachable DOM after closing a modal window from the admin UI, such as a rich text relationship as described in #1070. The following screen recording follows the steps outlined in that ticket, but without issue:

https://user-images.githubusercontent.com/15735305/188961071-d920e1b3-fb94-42cd-a167-1d8a4e79eb3a.mp4

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
