### PR TITLE
fix: word boundaries, no regex lookbehind support for Safari

### DIFF
--- a/src/utilities/wordBoundariesRegex.ts
+++ b/src/utilities/wordBoundariesRegex.ts
@@ -2,7 +2,7 @@ export default (input: string): RegExp => {
   const words = input.split(' ');
 
   // Regex word boundaries that work for cyrillic characters - https://stackoverflow.com/a/47062016/1717697
-  const wordBoundaryBefore = '(?:(?<=[^\\p{L}\\p{N}])|^)';
+  const wordBoundaryBefore = '(?:(?:[^\\p{L}\\p{N}])|^)'; // Converted to a non-matching group instead of positive lookbehind for Safari
   const wordBoundaryAfter = '(?=[^\\p{L}\\p{N}]|$)';
 
   const regex = words.reduce((pattern, word, i) => {


### PR DESCRIPTION
## Description

Safari does not support positive lookbehind regex. This adjusts our wordboundary regex to accommodate Safari.