### PR TITLE
Avoid adding password and email to schemas when disableLocalStrategy …

### DIFF
--- a/src/collections/graphql/init.ts
+++ b/src/collections/graphql/init.ts
@@ -119,7 +119,7 @@ function initCollectionsGraphQL(payload: Payload): void {
       singularLabel,
     );
 
-    if (collection.config.auth) {
+    if (collection.config.auth && !collection.config.auth.disableLocalStrategy) {
       fields.push({
         name: 'password',
         label: 'Password',
@@ -274,21 +274,23 @@ function initCollectionsGraphQL(payload: Payload): void {
     }
 
     if (collection.config.auth) {
+      const authFields: Field[] = collection.config.auth.disableLocalStrategy ? [] : [{
+        name: 'email',
+        type: 'email',
+        required: true,
+      }]
       collection.graphQL.JWT = buildObjectType({
         payload,
         name: formatName(`${slug}JWT`),
-        fields: collection.config.fields.filter((field) => fieldAffectsData(field) && field.saveToJWT).concat([
-          {
-            name: 'email',
-            type: 'email',
-            required: true,
-          },
+        fields: [
+          ...collection.config.fields.filter((field) => fieldAffectsData(field) && field.saveToJWT), 
+          ...authFields,
           {
             name: 'collection',
             type: 'text',
             required: true,
-          },
-        ]),
+          }
+        ],
         parentName: formatName(`${slug}JWT`),
       });
 


### PR DESCRIPTION
…is on

## Description

Remove automatic password and email fields from GraphQL schema when disableLocalStrategy is on.

- [ ] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
