### PR TITLE
fix: refine type generation for relationships

### DIFF
--- a/src/bin/generateTypes.ts
+++ b/src/bin/generateTypes.ts
@@ -131,33 +131,50 @@ function generateFieldTypes(config: SanitizedConfig, fields: Field[]): {
             if (Array.isArray(field.relationTo)) {
               if (field.hasMany) {
                 fieldSchema = {
-                  type: 'array',
-                  items: {
-                    oneOf: field.relationTo.map((relation) => {
-                      const idFieldType = getCollectionIDType(config.collections, relation);
+                  oneOf: [
+                    {
+                      type: 'array',
+                      items: {
+                        oneOf: field.relationTo.map((relation) => {
+                          const idFieldType = getCollectionIDType(config.collections, relation);
 
-                      return {
-                        type: 'object',
-                        additionalProperties: false,
-                        properties: {
-                          value: {
-                            oneOf: [
-                              {
+                          return {
+                            type: 'object',
+                            additionalProperties: false,
+                            properties: {
+                              value: {
                                 type: idFieldType,
                               },
-                              {
+                              relationTo: {
+                                const: relation,
+                              },
+                            },
+                            required: ['value', 'relationTo'],
+                          };
+                        }),
+                      },
+                    },
+                    {
+                      type: 'array',
+                      items: {
+                        oneOf: field.relationTo.map((relation) => {
+                          return {
+                            type: 'object',
+                            additionalProperties: false,
+                            properties: {
+                              value: {
                                 $ref: `#/definitions/${relation}`,
                               },
-                            ],
-                          },
-                          relationTo: {
-                            const: relation,
-                          },
-                        },
-                        required: ['value', 'relationTo'],
-                      };
-                    }),
-                  },
+                              relationTo: {
+                                const: relation,
+                              },
+                            },
+                            required: ['value', 'relationTo'],
+                          };
+                        }),
+                      },
+                    },
+                  ],
                 };
               } else {
                 fieldSchema = {
@@ -192,17 +209,20 @@ function generateFieldTypes(config: SanitizedConfig, fields: Field[]): {
 
               if (field.hasMany) {
                 fieldSchema = {
-                  type: 'array',
-                  items: {
-                    oneOf: [
-                      {
+                  oneOf: [
+                    {
+                      type: 'array',
+                      items: {
                         type: idFieldType,
                       },
-                      {
+                    },
+                    {
+                      type: 'array',
+                      items: {
                         $ref: `#/definitions/${field.relationTo}`,
                       },
-                    ],
-                  },
+                    },
+                  ],
                 };
               } else {
                 fieldSchema = {


### PR DESCRIPTION
## Description

The purpose of this update is to generate more accurate TypeScript types for relationship fields, specifically when `hasMany: true`.

For example these field definition:

```ts
…
  {
    name: 'simple',
    type: 'relationship',
    relationTo: 'users',
    hasMany: true,
  },
…
```

currently yields this code:

```ts
…
  simple?: (number | User)[];
…
```

But this is too generic, because the actual array either contains document IDs only, or resolved documents only. It'll never contain some IDs and some documents as this type would allow.

A more precise type would be:

```ts
…
  simple?: number[] | User[];
…
```

More accurate typings allow for simpler and safer code, for instance:
```ts

declare function isArrayOfTypeWithID(x: unknown[]): x is TypeWithID[];

type MyDoc = {
  id: string;
  n: number;
};

// With a type like the currently generated ones narrowing fails
function f(x: (number | MyDoc)[]) {
  if (isArrayOfTypeWithID(x)) {
    const a = x[0];
    const id = a.id; // it should be a string, instead it's inferred as string | number
    const n = a.n;   // it should be a number, instead it's undefined:
                     // Property 'n' does not exist on type '(number | A) & TypeWithID'.
                     //   Property 'n' does not exist on type 'number & TypeWithID'.
  }
}

// With a more accurate type everything works fine
function g(x: number[] | MyDoc[]) {
  if (isArrayOfTypeWithID(x)) {
    const a = x[0];
    const id = a.id; // a string
    const n = a.n;   // a number
  }
}
```

The same idea applies when `relationTo` is an array:

```ts
…
  {
    name: 'mixed',
    type: 'relationship',
    relationTo: ['users', 'products'],
    hasMany: true,
  },
…
```

The current generate code:

```ts
…
  mixed?: (
    | {
        value: number | User;
        relationTo: 'users';
      }
    | {
        value: string | Products;
        relationTo: 'products';
      }
  )[];
…
```

The present proposal:

```ts
…
  mixed?:
    | (
        | {
            value: number;
            relationTo: 'users';
          }
        | {
            value: string;
            relationTo: 'products';
          }
      )[]
    | (
        | {
            value: User;
            relationTo: 'users';
          }
        | {
            value: Products;
            relationTo: 'products';
          }
      )[];
…
```

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation

