### PR TITLE
fix: field level access for nested fields

### DIFF
--- a/src/admin/components/forms/RenderFields/types.ts
+++ b/src/admin/components/forms/RenderFields/types.ts
@@ -6,7 +6,7 @@ export type Props = {
   className?: string
   readOnly?: boolean
   forceRender?: boolean
-  permissions?: {
+  permissions?: FieldPermissions | {
     [field: string]: FieldPermissions
   }
   filter?: (field: Field) => boolean

--- a/src/admin/components/forms/field-types/Collapsible/index.tsx
+++ b/src/admin/components/forms/field-types/Collapsible/index.tsx
@@ -75,7 +75,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
         <RenderFields
           forceRender
           readOnly={readOnly}
-          permissions={permissions?.fields}
+          permissions={permissions}
           fieldTypes={fieldTypes}
           fieldSchema={fields.map((field) => ({
             ...field,

--- a/src/admin/components/forms/field-types/Row/index.tsx
+++ b/src/admin/components/forms/field-types/Row/index.tsx
@@ -28,7 +28,7 @@ const Row: React.FC<Props> = (props) => {
     <RenderFields
       readOnly={readOnly}
       className={classes}
-      permissions={permissions?.fields}
+      permissions={permissions}
       fieldTypes={fieldTypes}
       fieldSchema={fields.map((field) => ({
         ...field,

--- a/src/admin/components/forms/field-types/Tabs/index.tsx
+++ b/src/admin/components/forms/field-types/Tabs/index.tsx
@@ -71,7 +71,7 @@ const TabsField: React.FC<Props> = (props) => {
                 key={String(activeTab.label)}
                 forceRender
                 readOnly={readOnly}
-                permissions={permissions?.fields}
+                permissions={tabHasName(activeTab) ? permissions[activeTab.name].fields : permissions}
                 fieldTypes={fieldTypes}
                 fieldSchema={activeTab.fields.map((field) => ({
                   ...field,

--- a/src/auth/operations/access.ts
+++ b/src/auth/operations/access.ts
@@ -1,6 +1,7 @@
 import { PayloadRequest } from '../../express/types';
 import { Permissions } from '../types';
 import { adminInit as adminInitTelemetry } from '../../utilities/telemetry/events/adminInit';
+import { tabHasName } from '../../fields/config/types';
 
 const allOperations = ['create', 'read', 'update', 'delete'];
 
@@ -66,7 +67,12 @@ async function accessOperation(args: Arguments): Promise<Permissions> {
         executeFieldPolicies(updatedObj, field.fields, operation);
       } else if (field.type === 'tabs') {
         field.tabs.forEach((tab) => {
-          executeFieldPolicies(updatedObj, tab.fields, operation);
+          if (tabHasName(tab)) {
+            if (!updatedObj[tab.name]) updatedObj[tab.name] = { fields: {} };
+            executeFieldPolicies(updatedObj[tab.name].fields, tab.fields, operation);
+          } else {
+            executeFieldPolicies(updatedObj, tab.fields, operation);
+          }
         });
       }
     });

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -25,7 +25,7 @@ const PublicReadabilityAccess: FieldAccess = ({ req: { user }, siblingData }) =>
   return false;
 };
 
-export const requestHeaders = {authorization: 'Bearer testBearerToken'};
+export const requestHeaders = { authorization: 'Bearer testBearerToken' };
 const UseRequestHeadersAccess: FieldAccess = ({ req: { headers } }) => {
   return !!headers && headers.authorization === requestHeaders.authorization;
 };
@@ -46,6 +46,50 @@ export default buildConfig({
             read: () => false,
             update: () => false,
           },
+        },
+        {
+          type: 'group',
+          name: 'group',
+          fields: [
+            {
+              name: 'restrictedGroupText',
+              type: 'text',
+              access: {
+                read: () => false,
+                update: () => false,
+                create: () => false,
+              },
+            },
+          ],
+        },
+        {
+          type: 'row',
+          fields: [
+            {
+              name: 'restrictedRowText',
+              type: 'text',
+              access: {
+                read: () => false,
+                update: () => false,
+                create: () => false,
+              },
+            },
+          ],
+        },
+        {
+          type: 'collapsible',
+          label: 'Access',
+          fields: [
+            {
+              name: 'restrictedCollapsibleText',
+              type: 'text',
+              access: {
+                read: () => false,
+                update: () => false,
+                create: () => false,
+              },
+            },
+          ],
         },
       ],
     },

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -44,7 +44,31 @@ describe('access control', () => {
 
     await page.goto(url.edit(id));
 
-    await expect(page.locator('input[name="restrictedField"]')).toHaveCount(0);
+    await expect(page.locator('#field-restrictedField')).toHaveCount(0);
+  });
+
+  test('field without read access inside a group should not show', async () => {
+    const { id } = await createDoc({ restrictedField: 'restricted' });
+
+    await page.goto(url.edit(id));
+
+    await expect(page.locator('#field-group__restrictedGroupText')).toHaveCount(0);
+  });
+
+  test('field without read access inside a collapsible should not show', async () => {
+    const { id } = await createDoc({ restrictedField: 'restricted' });
+
+    await page.goto(url.edit(id));
+
+    await expect(page.locator('#field-restrictedRowText')).toHaveCount(0);
+  });
+
+  test('field without read access inside a row should not show', async () => {
+    const { id } = await createDoc({ restrictedField: 'restricted' });
+
+    await page.goto(url.edit(id));
+
+    await expect(page.locator('#field-restrictedCollapsibleText')).toHaveCount(0);
   });
 
   describe('restricted collection', () => {


### PR DESCRIPTION
## Description

Field level access control for fields inside of rows, collapsible and tabs wasn't hiding fields properly.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
