### PR TITLE
chore: fix query typo in documentation

### DIFF
--- a/docs/queries/overview.mdx
+++ b/docs/queries/overview.mdx
@@ -148,7 +148,7 @@ const getPosts = async () => {
     where: query // ensure that `qs` adds the `where` property, too!
   }, { addQueryPrefix: true });
 
-  const response = await fetch(`http://localhost:3000/api/posts${stringifiedQuery}`);
+  const response = await fetch(`http://localhost:3000/api/posts?${stringifiedQuery}`);
   // Continue to handle the response below...
 }
 ```


### PR DESCRIPTION
## Description

Fix a little typo inside the query overview examples

- [x] I have read and understand the CONTRIBUTING.md document in this repository
