### PR TITLE
Improves contributing doc

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -49,7 +49,9 @@ The directory split up in this way specifically to reduce friction when creating
 
 The following command will start Payload with your config: `yarn dev my-test-dir`. This command will start up Payload using your config and refresh a test database on every restart.
 
-NOTE: It is recommended to add the test credentials to your autofill for `localhost:3000/admin` as this will be required on every nodemon restart.
+When switching between test directories, you will want to remove your `node_modules/.cache ` manually or by running `yarn clean:cache`.
+
+NOTE: It is recommended to add the test credentials (located in `test/credentials.ts`) to your autofill for `localhost:3000/admin` as this will be required on every nodemon restart.
 
 ## Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:e2e:headed": "cross-env DISABLE_LOGGING=true playwright test --headed",
     "test:e2e:debug": "cross-env PWDEBUG=1 DISABLE_LOGGING=true playwright test",
     "test:components": "cross-env jest --config=jest.components.config.js",
+    "clean:cache": "rimraf node_modules/.cache",
     "clean": "rimraf dist",
     "release": "release-it",
     "release:patch": "release-it patch",


### PR DESCRIPTION
## Description

- Adds note about clearing node modules cache folder when switching between test directories. Adds script for ease of use.
- Spells out where to find the test login credentials.

- [x] I have read and understand the CONTRIBUTING.md document in this repository