### PR TITLE
Fix: responsive fileupload width

### DIFF
--- a/src/admin/components/forms/field-types/Upload/index.scss
+++ b/src/admin/components/forms/field-types/Upload/index.scss
@@ -1,9 +1,8 @@
-@import '../../../../scss/styles';
+@import "../../../../scss/styles";
 
 .upload {
   position: relative;
   margin-bottom: $baseline;
-  min-width: base(15);
 
   &__wrap {
     display: flex;
@@ -11,16 +10,14 @@
     background: var(--theme-elevation-50);
 
     .btn {
-      margin: 0 $baseline base(.5) 0;
+      margin: 0 $baseline base(0.5) 0;
     }
   }
 
   @include mid-break {
-    min-width: calc(100vw - #{base(2)});
-
     &__wrap {
       display: block;
-      padding: $baseline $baseline base(.5);
+      padding: $baseline $baseline base(0.5);
 
       .btn {
         width: 100%;

--- a/src/admin/components/forms/field-types/Upload/index.scss
+++ b/src/admin/components/forms/field-types/Upload/index.scss
@@ -1,4 +1,4 @@
-@import "../../../../scss/styles";
+@import '../../../../scss/styles';
 
 .upload {
   position: relative;
@@ -8,16 +8,17 @@
     display: flex;
     padding: base(1.5) base(1.5) $baseline;
     background: var(--theme-elevation-50);
-
+    flex-wrap: wrap;
+    
     .btn {
-      margin: 0 $baseline base(0.5) 0;
+      margin: 0 $baseline base(.5) 0;
     }
   }
 
   @include mid-break {
     &__wrap {
       display: block;
-      padding: $baseline $baseline base(0.5);
+      padding: $baseline $baseline base(.5);
 
       .btn {
         width: 100%;


### PR DESCRIPTION
## Description

the upload-buttons-container had a hard-coded `min-width` which was causing lay-out issues, especially when used in combination with nested arrays.

for example:
![afbeelding](https://user-images.githubusercontent.com/10504064/192359311-564f8471-01fa-454c-86b7-448fb7389963.png)
![afbeelding](https://user-images.githubusercontent.com/10504064/192359435-5bc2b5b0-2be2-4fa0-bfc4-1cfcadf42e59.png)

I removed the `min-width` and added `flex-wrap: wrap` to the upload-buttons-container which results in a much cleaner lay-out

![afbeelding](https://user-images.githubusercontent.com/10504064/192359742-7d94d6ad-40d2-4671-b56d-c77e93d5b316.png)
![afbeelding](https://user-images.githubusercontent.com/10504064/192359783-51ed4762-359d-4b10-b959-503f8fb041ec.png)

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist:
