### PR TITLE
fix: resize textarea only vertically

### DIFF
--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -8,6 +8,7 @@
     @include formInput();
     height: auto;
     min-height: base(3);
+    resize: vertical;
   }
 
   &.error {


### PR DESCRIPTION
## Description

textarea fields are capable of resizing horizontally at the moment.

this causes layout issues:

![afbeelding](https://user-images.githubusercontent.com/10504064/193085158-c798e529-d34f-40b6-a08a-e4699c75a70c.png)

which even become worse when resizing the window as the textarea has a fixed horizontal width after resizing.

![afbeelding](https://user-images.githubusercontent.com/10504064/193085313-46cc2fc6-9ee4-4a62-866b-6ef80154dd52.png)

this PR adds `resize: vertical` to `.field-type.textarea textarea` which solves this problem.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
