### PR TITLE
fix: sibling data in after read hook

### DIFF
--- a/src/fields/hooks/afterRead/promise.ts
+++ b/src/fields/hooks/afterRead/promise.ts
@@ -127,7 +127,7 @@ export const promise = async ({
               value,
               originalDoc: doc,
               data: doc,
-              siblingData: siblingDoc[field.name],
+              siblingData: siblingDoc,
               operation: 'read',
               req,
             });
@@ -144,7 +144,7 @@ export const promise = async ({
             findMany,
             originalDoc: doc,
             operation: 'read',
-            siblingData: siblingDoc[field.name],
+            siblingData: siblingDoc,
             req,
             value: siblingDoc[field.name],
           });


### PR DESCRIPTION
## Description

Related Discussion: https://github.com/payloadcms/payload/discussions/1162

Related Commit: https://github.com/payloadcms/payload/commit/18489facebe5d7b0abc87dcc30fae28510b6bb19

found this fix with support from @milamer

siblingData in afterRead hook is currently wrong as it only returns the edited field, not the whole siblingData. This changes it, so the data is the same as in the other hooks.

Not sure if this is the cleanest fix, please feel free to give some feedback.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
