### PR TITLE
fix(style): system dark scrollbars

### DIFF
--- a/src/admin/scss/app.scss
+++ b/src/admin/scss/app.scss
@@ -54,6 +54,7 @@ html {
     --theme-bg: var(--theme-elevation-0);
     --theme-text: var(--theme-elevation-1000);
     --theme-input-bg: var(--theme-elevation-50);
+    color-scheme: dark;
 
     ::selection {
       color: var(--color-base-1000);


### PR DESCRIPTION
## Description

Adds `color-scheme: dark` to html element when page is in dark mode, which enables system dark styles to be set on scroll bars

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Admin panel style
