### PR TITLE
WIP: add cascade feature to relationships

### DIFF
--- a/src/collections/config/sanitize.ts
+++ b/src/collections/config/sanitize.ts
@@ -100,8 +100,7 @@ const sanitizeCollection = (config: Config, collection: CollectionConfig): Sanit
   // Sanitize fields
   // /////////////////////////////////
 
-  const validRelationships = config.collections.map((c) => c.slug);
-  sanitized.fields = sanitizeFields(sanitized.fields, validRelationships);
+  sanitized.fields = sanitizeFields(sanitized.fields, config, sanitized);
 
   return sanitized as SanitizedCollectionConfig;
 };

--- a/src/config/sanitize.ts
+++ b/src/config/sanitize.ts
@@ -30,7 +30,7 @@ const sanitizeConfig = (config: Config): SanitizedConfig => {
   checkDuplicateCollections(sanitizedConfig.collections);
 
   if (sanitizedConfig.globals.length > 0) {
-    sanitizedConfig.globals = sanitizeGlobals(sanitizedConfig.collections, sanitizedConfig.globals);
+    sanitizedConfig.globals = sanitizeGlobals(config);
   }
 
   if (typeof sanitizedConfig.serverURL === 'undefined') {

--- a/src/fields/afterDeleteCascadeHook.ts
+++ b/src/fields/afterDeleteCascadeHook.ts
@@ -1,0 +1,44 @@
+import { Where } from '../types';
+import { RelationshipField, UploadField } from './config/types';
+import { AfterDeleteHook, CollectionConfig } from '../collections/config/types';
+
+const afterDeleteCascadeHook = (field: RelationshipField | UploadField, collection: CollectionConfig, path: string): AfterDeleteHook => (
+  async ({ doc, req }) => {
+    const withPath = path ? `${path}.` : '';
+    const where: Where = {
+      [`${withPath}${field.name}`]: { [`equals${Array.isArray(field.relationTo) ? '.value' : ''}`]: doc.id },
+    };
+    const { docs } = await req.payload.find({
+      collection: collection.slug,
+      where,
+      depth: 0,
+    });
+
+    docs.forEach((document) => {
+      let updatedValue;
+      // TODO: handle deeper depth relationships using path
+      const previousValue = document?.[field.name];
+      if (Array.isArray(previousValue)) {
+        updatedValue = previousValue.filter((existingRelation) => {
+          if (typeof existingRelation === 'object') {
+            return existingRelation.value !== doc.id;
+          }
+          return existingRelation !== doc.id;
+        });
+      } else {
+        updatedValue = null;
+      }
+      req.payload.update({
+        collection: collection.slug,
+        id: document.id,
+        depth: 0,
+        data: {
+          // TODO: handle deeper depth relationships using path
+          [field.name]: updatedValue,
+        },
+      });
+    });
+  }
+);
+
+export default afterDeleteCascadeHook;

--- a/src/fields/config/sanitize.spec.ts
+++ b/src/fields/config/sanitize.spec.ts
@@ -16,16 +16,16 @@ describe('sanitizeFields', () => {
       sanitizeFields(fields, []);
     }).toThrow(MissingFieldType);
   });
-  it("should throw on invalid field name", () => {
+  it('should throw on invalid field name', () => {
     const fields: Field[] = [
       {
-        label: "some.collection",
-        name: "some.collection",
-        type: "text",
-      }
+        label: 'some.collection',
+        name: 'some.collection',
+        type: 'text',
+      },
     ];
     expect(() => {
-      sanitizeFields(fields, []);
+      sanitizeFields(fields, {}, { slug: 'slug', fields: [] });
     }).toThrow(InvalidFieldName);
   });
 
@@ -35,7 +35,7 @@ describe('sanitizeFields', () => {
         name: 'someField',
         type: 'text',
       }];
-      const sanitizedField = sanitizeFields(fields, [])[0] as TextField;
+      const sanitizedField = sanitizeFields(fields, {}, { slug: 'slug', fields: [] })[0] as TextField;
       expect(sanitizedField.name).toStrictEqual('someField');
       expect(sanitizedField.label).toStrictEqual('Some Field');
       expect(sanitizedField.type).toStrictEqual('text');
@@ -46,7 +46,7 @@ describe('sanitizeFields', () => {
         type: 'text',
         label: 'Do not label',
       }];
-      const sanitizedField = sanitizeFields(fields, [])[0] as TextField;
+      const sanitizedField = sanitizeFields(fields, {}, { slug: 'slug', fields: [] })[0] as TextField;
       expect(sanitizedField.name).toStrictEqual('someField');
       expect(sanitizedField.label).toStrictEqual('Do not label');
       expect(sanitizedField.type).toStrictEqual('text');
@@ -59,7 +59,7 @@ describe('sanitizeFields', () => {
           type: 'text',
           label: false,
         }];
-        const sanitizedField = sanitizeFields(fields, [])[0] as TextField;
+        const sanitizedField = sanitizeFields(fields, {}, { slug: 'slug', fields: [] })[0] as TextField;
         expect(sanitizedField.name).toStrictEqual('someField');
         expect(sanitizedField.label).toStrictEqual(false);
         expect(sanitizedField.type).toStrictEqual('text');
@@ -77,7 +77,7 @@ describe('sanitizeFields', () => {
             },
           ],
         };
-        const sanitizedField = sanitizeFields([arrayField], [])[0] as ArrayField;
+        const sanitizedField = sanitizeFields([arrayField], {}, { slug: 'slug', fields: [] })[0] as ArrayField;
         expect(sanitizedField.name).toStrictEqual('items');
         expect(sanitizedField.label).toStrictEqual(false);
         expect(sanitizedField.type).toStrictEqual('array');
@@ -100,7 +100,7 @@ describe('sanitizeFields', () => {
             },
           ],
         }];
-        const sanitizedField = sanitizeFields(fields, [])[0] as BlockField;
+        const sanitizedField = sanitizeFields(fields, {}, { slug: 'slug', fields: [] })[0] as BlockField;
         expect(sanitizedField.name).toStrictEqual('noLabelBlock');
         expect(sanitizedField.label).toStrictEqual(false);
         expect(sanitizedField.type).toStrictEqual('blocks');
@@ -120,7 +120,7 @@ describe('sanitizeFields', () => {
           },
         ],
       }];
-      const sanitizedField = sanitizeFields(fields, [])[0] as ArrayField;
+      const sanitizedField = sanitizeFields(fields, {}, { slug: 'slug', fields: [] })[0] as ArrayField;
       expect(sanitizedField.name).toStrictEqual('items');
       expect(sanitizedField.label).toStrictEqual('Items');
       expect(sanitizedField.type).toStrictEqual('array');
@@ -138,7 +138,7 @@ describe('sanitizeFields', () => {
           },
         ],
       }];
-      const sanitizedField = sanitizeFields(fields, [])[0] as BlockField;
+      const sanitizedField = sanitizeFields(fields, {}, { slug: 'slug', fields: [] })[0] as BlockField;
       expect(sanitizedField.name).toStrictEqual('specialBlock');
       expect(sanitizedField.label).toStrictEqual('Special Block');
       expect(sanitizedField.type).toStrictEqual('blocks');
@@ -149,7 +149,6 @@ describe('sanitizeFields', () => {
 
   describe('relationships', () => {
     it('should not throw on valid relationship', () => {
-      const validRelationships = ['some-collection'];
       const fields: Field[] = [{
         type: 'relationship',
         label: 'my-relationship',
@@ -157,12 +156,11 @@ describe('sanitizeFields', () => {
         relationTo: 'some-collection',
       }];
       expect(() => {
-        sanitizeFields(fields, validRelationships);
+        sanitizeFields(fields, { collections: [{ slug: 'some-collection', fields: [] }] }, { slug: 'slug', fields: [] });
       }).not.toThrow();
     });
 
     it('should not throw on valid relationship - multiple', () => {
-      const validRelationships = ['some-collection', 'another-collection'];
       const fields: Field[] = [{
         type: 'relationship',
         label: 'my-relationship',
@@ -170,12 +168,11 @@ describe('sanitizeFields', () => {
         relationTo: ['some-collection', 'another-collection'],
       }];
       expect(() => {
-        sanitizeFields(fields, validRelationships);
+        sanitizeFields(fields, { collections: [{ slug: 'some-collection', fields: [] }, { slug: 'another-collection', fields: [] }] }, { slug: 'slug', fields: [] });
       }).not.toThrow();
     });
 
     it('should not throw on valid relationship inside blocks', () => {
-      const validRelationships = ['some-collection'];
       const relationshipBlock: Block = {
         slug: 'relationshipBlock',
         fields: [{
@@ -192,12 +189,11 @@ describe('sanitizeFields', () => {
         blocks: [relationshipBlock],
       }];
       expect(() => {
-        sanitizeFields(fields, validRelationships);
+        sanitizeFields(fields, { collections: [{ slug: 'some-collection', fields: [] }] }, { slug: 'slug', fields: [] });
       }).not.toThrow();
     });
 
     it('should throw on invalid relationship', () => {
-      const validRelationships = ['some-collection'];
       const fields: Field[] = [{
         type: 'relationship',
         label: 'my-relationship',
@@ -205,12 +201,11 @@ describe('sanitizeFields', () => {
         relationTo: 'not-valid',
       }];
       expect(() => {
-        sanitizeFields(fields, validRelationships);
+        sanitizeFields(fields, { collections: [{ slug: 'some-collection', fields: [] }] }, { slug: 'slug', fields: [] });
       }).toThrow(InvalidFieldRelationship);
     });
 
     it('should throw on invalid relationship - multiple', () => {
-      const validRelationships = ['some-collection', 'another-collection'];
       const fields: Field[] = [{
         type: 'relationship',
         label: 'my-relationship',
@@ -218,12 +213,11 @@ describe('sanitizeFields', () => {
         relationTo: ['some-collection', 'not-valid'],
       }];
       expect(() => {
-        sanitizeFields(fields, validRelationships);
+        sanitizeFields(fields, { collections: [{ slug: 'some-collection', fields: [] }, { slug: 'another-collection', fields: [] }] }, { slug: 'slug', fields: [] });
       }).toThrow(InvalidFieldRelationship);
     });
 
     it('should throw on invalid relationship inside blocks', () => {
-      const validRelationships = ['some-collection'];
       const relationshipBlock: Block = {
         slug: 'relationshipBlock',
         fields: [{
@@ -240,7 +234,7 @@ describe('sanitizeFields', () => {
         blocks: [relationshipBlock],
       }];
       expect(() => {
-        sanitizeFields(fields, validRelationships);
+        sanitizeFields(fields, { collections: [{ slug: 'some-collection', fields: [] }] }, { slug: 'slug', fields: [] });
       }).toThrow(InvalidFieldRelationship);
     });
 
@@ -251,12 +245,12 @@ describe('sanitizeFields', () => {
         required: true,
       }];
 
-      const sanitizedField = sanitizeFields(fields, [])[0] as CheckboxField;
+      const sanitizedField = sanitizeFields(fields, {}, { slug: 'slug', fields: [] })[0] as CheckboxField;
       expect(sanitizedField.defaultValue).toStrictEqual(false);
     });
 
     it('should return empty field array if no fields', () => {
-      const sanitizedFields = sanitizeFields([], []);
+      const sanitizedFields = sanitizeFields([], {}, { slug: 'slug', fields: [] });
       expect(sanitizedFields).toStrictEqual([]);
     });
   });

--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -283,6 +283,7 @@ export const relationship = baseField.keys({
   defaultValue: joi.alternatives().try(
     joi.func(),
   ),
+  cascade: joi.boolean(),
   admin: baseAdminFields.keys({
     isSortable: joi.boolean().default(false),
   }),

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -241,7 +241,8 @@ export type UploadField = FieldBase & {
   type: 'upload'
   relationTo: string
   maxDepth?: number
-  filterOptions?: FilterOptions;
+  cascade?: boolean
+  filterOptions?: FilterOptions
 }
 
 type CodeAdmin = Admin & {
@@ -271,6 +272,8 @@ export type RelationshipField = FieldBase & {
   hasMany?: boolean;
   maxDepth?: number;
   filterOptions?: FilterOptions;
+  /** When a related document is deleted, remove it from the relationship */
+  cascade?: boolean;
   admin?: Admin & {
     isSortable?: boolean;
   }
@@ -282,7 +285,7 @@ export type ValueWithRelation = {
 }
 
 export function valueIsValueWithRelation(value: unknown): value is ValueWithRelation {
-  return typeof value === 'object' && 'relationTo' in value && 'value' in value;
+  return value !== null && typeof value === 'object' && 'relationTo' in value && 'value' in value;
 }
 
 export type RelationshipValue = (string | number)

--- a/src/globals/config/sanitize.ts
+++ b/src/globals/config/sanitize.ts
@@ -1,15 +1,15 @@
 import merge from 'deepmerge';
 import { toWords } from '../../utilities/formatLabels';
-import { CollectionConfig } from '../../collections/config/types';
 import sanitizeFields from '../../fields/config/sanitize';
-import { GlobalConfig, SanitizedGlobalConfig } from './types';
+import { SanitizedGlobalConfig } from './types';
+import { Config } from '../../config/types';
 import defaultAccess from '../../auth/defaultAccess';
 import baseVersionFields from '../../versions/baseFields';
 import mergeBaseFields from '../../fields/mergeBaseFields';
 import { versionGlobalDefaults } from '../../versions/defaults';
 
-const sanitizeGlobals = (collections: CollectionConfig[], globals: GlobalConfig[]): SanitizedGlobalConfig[] => {
-  const sanitizedGlobals = globals.map((global) => {
+const sanitizeGlobals = (config: Config): SanitizedGlobalConfig[] => {
+  return config.globals.map((global) => {
     const sanitizedGlobal = { ...global };
 
     sanitizedGlobal.label = sanitizedGlobal.label || toWords(sanitizedGlobal.slug);
@@ -54,13 +54,10 @@ const sanitizeGlobals = (collections: CollectionConfig[], globals: GlobalConfig[
     // Sanitize fields
     // /////////////////////////////////
 
-    const validRelationships = collections.map((c) => c.slug);
-    sanitizedGlobal.fields = sanitizeFields(sanitizedGlobal.fields, validRelationships);
+    sanitizedGlobal.fields = sanitizeFields(sanitizedGlobal.fields, config, sanitizedGlobal);
 
     return sanitizedGlobal as SanitizedGlobalConfig;
   });
-
-  return sanitizedGlobals;
 };
 
 export default sanitizeGlobals;

--- a/test/fields-relationship/config.ts
+++ b/test/fields-relationship/config.ts
@@ -9,6 +9,11 @@ export const relationOneSlug = 'relation-one';
 export const relationTwoSlug = 'relation-two';
 export const relationRestrictedSlug = 'relation-restricted';
 export const relationWithTitleSlug = 'relation-with-title';
+export const cascadingSlug = 'cascading';
+export const cascadingHasManySlug = 'cascading-has-many';
+export const cascadingPolySlug = 'cascading-poly';
+export const cascadingHasManyPolySlug = 'cascading-has-many-poly';
+export const cascadingNested = 'cascading-nested';
 
 export interface FieldsRelationship {
   id: string;
@@ -82,6 +87,68 @@ export default buildConfig({
           type: 'relationship',
           name: 'relationshipWithTitle',
           relationTo: relationWithTitleSlug,
+        },
+      ],
+    },
+    {
+      slug: cascadingSlug,
+      fields: [
+        {
+          type: 'relationship',
+          name: 'relation',
+          relationTo: relationOneSlug,
+          cascade: true,
+        },
+      ],
+    },
+    {
+      slug: cascadingHasManySlug,
+      fields: [
+        {
+          type: 'relationship',
+          name: 'relation',
+          hasMany: true,
+          relationTo: relationOneSlug,
+          cascade: true,
+        },
+      ],
+    },
+    {
+      slug: cascadingPolySlug,
+      fields: [
+        {
+          type: 'relationship',
+          name: 'relation',
+          relationTo: [relationOneSlug, relationTwoSlug],
+          cascade: true,
+        },
+      ],
+    },
+    {
+      slug: cascadingHasManyPolySlug,
+      fields: [
+        {
+          type: 'relationship',
+          name: 'relation',
+          hasMany: true,
+          relationTo: [relationOneSlug, relationTwoSlug],
+          cascade: true,
+        },
+      ],
+    },
+    {
+      slug: cascadingNested,
+      fields: [
+        {
+          type: 'group',
+          name: 'group',
+          fields: [
+            {
+              type: 'relationship',
+              name: 'relation',
+              relationTo: relationOneSlug,
+              cascade: true,
+            }],
         },
       ],
     },
@@ -199,6 +266,37 @@ export default buildConfig({
           relationshipHasManyMultiple: [{ relationTo: relationTwoSlug, value: relationTwoID }],
         },
       });
+    });
+
+    // cascading hooks
+    await payload.create({
+      collection: cascadingSlug,
+      data: {
+        relation: relationOneIDs[1],
+      },
+    });
+    await payload.create({
+      collection: cascadingHasManySlug,
+      data: {
+        relation: [relationOneIDs[2], relationOneIDs[3]],
+      },
+    });
+    await payload.create({
+      collection: cascadingPolySlug,
+      data: {
+        relation: { value: relationTwoIDs[2], relationTo: relationTwoSlug },
+      },
+    });
+    await payload.create({
+      collection: cascadingHasManyPolySlug,
+      data: {
+        relation: [{
+          value: relationOneIDs[4], relationTo: relationOneSlug,
+        }, {
+          value: relationTwoIDs[5],
+          relationTo: relationTwoSlug,
+        }],
+      },
     });
   },
 });

--- a/test/helpers/rest.ts
+++ b/test/helpers/rest.ts
@@ -55,7 +55,6 @@ type UpdateArgs<T = any> = {
 };
 type DeleteArgs = {
   slug?: string;
-  id: string;
   auth?: boolean;
 };
 
@@ -145,7 +144,7 @@ export class RESTClient {
     return { status, doc };
   }
 
-  async find<T = any>(args?: FindArgs): Promise<QueryResponse<T>> {
+  async find<T = any>(args: FindArgs = {}): Promise<QueryResponse<T>> {
     const options = {
       headers: {
         ...headers,
@@ -154,7 +153,11 @@ export class RESTClient {
     };
 
     const slug = args?.slug || this.defaultSlug;
-    const whereQuery = qs.stringify(args?.query ? { where: args.query } : {}, {
+    const params: Record<string, unknown> = {};
+    if (args.depth !== undefined) {
+      params.depth = args.depth;
+    }
+    const whereQuery = qs.stringify(args?.query ? { where: args.query, ...params } : params, {
       addQueryPrefix: true,
     });
     const fetchURL = `${this.serverURL}/api/${slug}${whereQuery}`;

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -12,7 +12,7 @@ const stat = promisify(fs.stat);
 
 require('isomorphic-fetch');
 
-let client;
+let client: RESTClient;
 
 describe('Collections - Uploads', () => {
   beforeAll(async (done) => {
@@ -33,7 +33,6 @@ describe('Collections - Uploads', () => {
           file: true,
           data: formData,
           auth: true,
-          headers: {},
         });
 
         expect(status).toBe(201);
@@ -65,7 +64,6 @@ describe('Collections - Uploads', () => {
         file: true,
         data: formData,
         auth: true,
-        headers: {},
       });
 
       expect(status).toBe(201);
@@ -88,7 +86,6 @@ describe('Collections - Uploads', () => {
         file: true,
         data: formData,
         auth: true,
-        headers: {},
       });
 
       expect(status).toBe(201);
@@ -114,7 +111,6 @@ describe('Collections - Uploads', () => {
         file: true,
         data: formData,
         auth: true,
-        headers: {},
       });
 
       expect(status).toBe(201);
@@ -144,10 +140,8 @@ describe('Collections - Uploads', () => {
 
     const { status } = await client.update({
       id: mediaDoc.id,
-      file: true,
       data: formData,
       auth: true,
-      headers: {},
     });
 
     expect(status).toBe(200);
@@ -194,7 +188,6 @@ describe('Collections - Uploads', () => {
       file: true,
       data: formData,
       auth: true,
-      headers: {},
     });
 
     const { status } = await client.delete(doc.id, {


### PR DESCRIPTION
## Description

It can be difficult to manage relations to other collections and in some cases it would be better to automatically update related values when a collection is deleted. I named the config property `cascade` but that could possibly be improved.

Remaining work:
- Implement hook to work with nested paths
- Test coverage for cascade relationships on globals
- Test coverage for deeply nested relationship fields
- Test coverage for cascade relationships inside block fields
- Fix an issue where the order of the collections matters. Cascade is working only when relationship fields come before relationTo

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
