### PR TITLE
feat: async admin access control

### DIFF
--- a/src/auth/operations/access.ts
+++ b/src/auth/operations/access.ts
@@ -78,7 +78,7 @@ async function accessOperation(args: Arguments): Promise<Permissions> {
     });
   };
 
-  const executeEntityPolicies = (entity, operations, type) => {
+  const executeEntityPolicies = async (entity, operations, type) => {
     if (!results[type]) results[type] = {};
 
     results[type][entity.slug] = {
@@ -99,7 +99,7 @@ async function accessOperation(args: Arguments): Promise<Permissions> {
   };
 
   if (userCollectionConfig) {
-    results.canAccessAdmin = userCollectionConfig.access.admin ? userCollectionConfig.access.admin(args) : isLoggedIn;
+    results.canAccessAdmin = userCollectionConfig.access.admin ? await userCollectionConfig.access.admin(args) : isLoggedIn;
   } else {
     results.canAccessAdmin = false;
   }

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -236,7 +236,7 @@ export type CollectionConfig = {
     readVersions?: Access;
     update?: Access;
     delete?: Access;
-    admin?: (args?: any) => boolean;
+    admin?: (args?: any) => boolean | Promise<boolean>;
     unlock?: Access;
   };
   /**

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -31,7 +31,22 @@ const UseRequestHeadersAccess: FieldAccess = ({ req: { headers } }) => {
 };
 
 export default buildConfig({
+  admin: {
+    user: 'users'
+  },
   collections: [
+    {
+      slug: 'users',
+      auth: true,
+      access: {
+        // admin: () => true,
+        admin: async () => new Promise((resolve) => {
+          // Simulate a request to an external service to determine access, i.e. another instance of Payload
+          setTimeout(resolve, 50, true); // set to 'true' or 'false' here to simulate the response
+        }),
+      },
+      fields: []
+    },
     {
       slug,
       access: {


### PR DESCRIPTION
## Description

Enabled `admin` access control to run asynchronously. This way, requests to external services can be made to determine access, i.e. another instance of Payload.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
