### PR TITLE
chore: Add 'credentials: include' to all fetch calls

### DIFF
--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -3,15 +3,16 @@ import qs from 'qs';
 export const requests = {
   get: (url: string, params: unknown = {}): Promise<Response> => {
     const query = qs.stringify(params, { addQueryPrefix: true });
-    return fetch(`${url}${query}`);
+    return fetch(`${url}${query}`, { credentials: 'include' });
   },
 
   post: (url: string, options: RequestInit = { headers: {} }): Promise<Response> => {
     const headers = options && options.headers ? { ...options.headers } : {};
 
-    const formattedOptions = {
+    const formattedOptions: RequestInit = {
       ...options,
       method: 'post',
+      credentials: 'include',
       headers: {
         ...headers,
       },
@@ -23,9 +24,10 @@ export const requests = {
   put: (url: string, options: RequestInit = { headers: {} }): Promise<Response> => {
     const headers = options && options.headers ? { ...options.headers } : {};
 
-    const formattedOptions = {
+    const formattedOptions: RequestInit = {
       ...options,
       method: 'put',
+      credentials: 'include',
       headers: {
         ...headers,
       },
@@ -37,9 +39,10 @@ export const requests = {
   patch: (url: string, options: RequestInit = { headers: {} }): Promise<Response> => {
     const headers = options && options.headers ? { ...options.headers } : {};
 
-    const formattedOptions = {
+    const formattedOptions: RequestInit = {
       ...options,
       method: 'PATCH',
+      credentials: 'include',
       headers: {
         ...headers,
       },
@@ -50,12 +53,16 @@ export const requests = {
 
   delete: (url: string, options: RequestInit = { headers: {} }): Promise<Response> => {
     const headers = options && options.headers ? { ...options.headers } : {};
-    return fetch(url, {
+
+    const formattedOptions: RequestInit = {
       ...options,
       method: 'delete',
+      credentials: 'include',
       headers: {
         ...headers,
       },
-    });
+    };
+
+    return fetch(url, formattedOptions);
   },
 };

--- a/src/admin/components/elements/Autosave/index.tsx
+++ b/src/admin/components/elements/Autosave/index.tsx
@@ -39,6 +39,7 @@ const Autosave: React.FC<Props> = ({ collection, global, id, publishedDocUpdated
   const createCollectionDoc = useCallback(async () => {
     const res = await fetch(`${serverURL}${api}/${collection.slug}?locale=${locale}&fallback-locale=null&depth=0&draft=true`, {
       method: 'POST',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -94,6 +95,7 @@ const Autosave: React.FC<Props> = ({ collection, global, id, publishedDocUpdated
           setTimeout(async () => {
             const res = await fetch(url, {
               method,
+              credentials: 'include',
               headers: {
                 'Content-Type': 'application/json',
               },

--- a/src/admin/components/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/src/admin/components/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -60,7 +60,7 @@ const RelationshipField: React.FC<Props> = (props) => {
           const fieldToSearch = collection?.admin?.useAsTitle || 'id';
           const searchParam = searchArg ? `&where[${fieldToSearch}][like]=${searchArg}` : '';
 
-          const response = await fetch(`${serverURL}${api}/${relation}?limit=${maxResultsPerRequest}&page=${lastLoadedPageToUse}&depth=0${searchParam}`);
+          const response = await fetch(`${serverURL}${api}/${relation}?limit=${maxResultsPerRequest}&page=${lastLoadedPageToUse}&depth=0${searchParam}`, { credentials: 'include' });
 
           if (response.ok) {
             const data: PaginatedDocs<any> = await response.json();
@@ -152,7 +152,7 @@ const RelationshipField: React.FC<Props> = (props) => {
 
   const addOptionByID = useCallback(async (id, relation) => {
     if (!errorLoading && id !== 'null') {
-      const response = await fetch(`${serverURL}${api}/${relation}/${id}?depth=0`);
+      const response = await fetch(`${serverURL}${api}/${relation}/${id}?depth=0`, { credentials: 'include' });
 
       if (response.ok) {
         const data = await response.json();

--- a/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -148,7 +148,7 @@ const Relationship: React.FC<Props> = (props) => {
             query.where.and.push(optionFilters[relation]);
           }
 
-          const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(query)}`);
+          const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(query)}`, { credentials: 'include' });
 
           if (response.ok) {
             const data: PaginatedDocs<unknown> = await response.json();
@@ -284,7 +284,7 @@ const Relationship: React.FC<Props> = (props) => {
           };
 
           if (!errorLoading) {
-            const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(query)}`);
+            const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(query)}`, { credentials: 'include' });
             const collection = collections.find((coll) => coll.slug === relation);
             if (response.ok) {
               const data = await response.json();

--- a/src/admin/components/forms/field-types/Upload/Input.tsx
+++ b/src/admin/components/forms/field-types/Upload/Input.tsx
@@ -77,7 +77,7 @@ const UploadInput: React.FC<UploadInputProps> = (props) => {
   useEffect(() => {
     if (typeof value === 'string' && value !== '') {
       const fetchFile = async () => {
-        const response = await fetch(`${serverURL}${api}/${relationTo}/${value}`);
+        const response = await fetch(`${serverURL}${api}/${relationTo}/${value}`, { credentials: 'include' });
         if (response.ok) {
           const json = await response.json();
           setFile(json);

--- a/src/admin/components/utilities/DocumentInfo/index.tsx
+++ b/src/admin/components/utilities/DocumentInfo/index.tsx
@@ -112,14 +112,14 @@ export const DocumentInfoProvider: React.FC<Props> = ({
     }
 
     if (shouldFetch) {
-      let publishedJSON = await fetch(publishedFetchURL).then((res) => res.json());
+      let publishedJSON = await fetch(publishedFetchURL, { credentials: 'include' }).then((res) => res.json());
 
       if (collection) {
         publishedJSON = publishedJSON?.docs?.[0];
       }
 
       if (shouldFetchVersions) {
-        versionJSON = await fetch(`${versionFetchURL}?${qs.stringify(versionParams)}`).then((res) => res.json());
+        versionJSON = await fetch(`${versionFetchURL}?${qs.stringify(versionParams)}`, { credentials: 'include' }).then((res) => res.json());
 
         if (publishedJSON?.updatedAt) {
           const newerVersionParams = {
@@ -138,7 +138,7 @@ export const DocumentInfoProvider: React.FC<Props> = ({
           };
 
           // Get any newer versions available
-          const newerVersionRes = await fetch(`${versionFetchURL}?${qs.stringify(newerVersionParams)}`);
+          const newerVersionRes = await fetch(`${versionFetchURL}?${qs.stringify(newerVersionParams)}`, { credentials: 'include' });
 
           if (newerVersionRes.status === 200) {
             unpublishedVersionJSON = await newerVersionRes.json();

--- a/src/admin/components/views/Verify/index.tsx
+++ b/src/admin/components/views/Verify/index.tsx
@@ -25,7 +25,7 @@ const Verify: React.FC<{ collection: SanitizedCollectionConfig }> = ({ collectio
 
   useEffect(() => {
     async function verifyToken() {
-      const result = await fetch(`${serverURL}/api/${collectionSlug}/verify/${token}`, { method: 'POST' });
+      const result = await fetch(`${serverURL}/api/${collectionSlug}/verify/${token}`, { method: 'POST', credentials: 'include' });
       setVerifyResult(result);
     }
     verifyToken();

--- a/src/admin/components/views/Version/Compare/index.tsx
+++ b/src/admin/components/views/Version/Compare/index.tsx
@@ -61,7 +61,7 @@ const CompareVersion: React.FC<Props> = (props) => {
     }
 
     const search = qs.stringify(query);
-    const response = await fetch(`${baseURL}?${search}`);
+    const response = await fetch(`${baseURL}?${search}`, { credentials: 'include' });
 
     if (response.ok) {
       const data: PaginatedDocs<any> = await response.json();

--- a/src/admin/components/views/collections/Edit/Auth/index.tsx
+++ b/src/admin/components/views/collections/Edit/Auth/index.tsx
@@ -42,6 +42,7 @@ const Auth: React.FC<Props> = (props) => {
   const unlock = useCallback(async () => {
     const url = `${serverURL}${api}/${slug}/unlock`;
     const response = await fetch(url, {
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/admin/components/views/collections/List/RelationshipProvider/index.tsx
+++ b/src/admin/components/views/collections/List/RelationshipProvider/index.tsx
@@ -52,7 +52,7 @@ export const RelationshipProvider: React.FC<{ children?: React.ReactNode }> = ({
         };
 
         const query = querystring.stringify(params, { addQueryPrefix: true });
-        const result = await fetch(`${url}${query}`);
+        const result = await fetch(`${url}${query}`, { credentials: 'include' });
         if (result.ok) {
           const json = await result.json();
           if (json.docs) {


### PR DESCRIPTION
## Description

Hi! As per our discussion thread on Discord @jmikrut I've added `credentials: 'include'` to all fetch calls inside the admin UI. I ran `yarn test` before and after my changes and it's failing in both cases, is that alright?

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
