### PR TITLE
Feat/default max length

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -5,9 +5,7 @@ export const defaults: Config = {
   serverURL: '',
   defaultDepth: 2,
   maxDepth: 10,
-  defaultMaxTextLength: 500,
-  defaultMaxNum: 9007199254740991, // 2^53 - 1 which is the MAX_SAFE_INTEGER for JS
-  defaultMinNum: -9007199254740991,
+  defaultMaxTextLength: 40000,
   collections: [],
   globals: [],
   endpoints: [],

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -6,8 +6,8 @@ export const defaults: Config = {
   defaultDepth: 2,
   maxDepth: 10,
   defaultMaxTextLength: 500,
-  defaultMaxNum: 2147483647, // 32 bit integer ranges
-  defaultMinNum: -2147483648,
+  defaultMaxNum: 9007199254740991, // 2^53 - 1 which is the MAX_SAFE_INTEGER for JS
+  defaultMinNum: -9007199254740991,
   collections: [],
   globals: [],
   endpoints: [],

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -5,6 +5,7 @@ export const defaults: Config = {
   serverURL: '',
   defaultDepth: 2,
   maxDepth: 10,
+  defaultMaxFieldLength : 500,
   collections: [],
   globals: [],
   endpoints: [],

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -5,9 +5,9 @@ export const defaults: Config = {
   serverURL: '',
   defaultDepth: 2,
   maxDepth: 10,
-  defaultMaxTextLength : 500,
-  defaultMaxNum : 2147483647, //32 bit integer ranges
-  defaultMinNum : -2147483648,
+  defaultMaxTextLength: 500,
+  defaultMaxNum: 2147483647, // 32 bit integer ranges
+  defaultMinNum: -2147483648,
   collections: [],
   globals: [],
   endpoints: [],

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -5,7 +5,9 @@ export const defaults: Config = {
   serverURL: '',
   defaultDepth: 2,
   maxDepth: 10,
-  defaultMaxFieldLength : 500,
+  defaultMaxTextLength : 500,
+  defaultMaxNum : 2147483647, //32 bit integer ranges
+  defaultMinNum : -2147483648,
   collections: [],
   globals: [],
   endpoints: [],

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -99,9 +99,9 @@ export default joi.object({
   maxDepth: joi.number()
     .min(0)
     .max(100),
-  defaultMaxTextLength : joi.number(),
-  defaultMaxNum : joi.number(),
-  defaultMinNum : joi.number(),
+  defaultMaxTextLength: joi.number(),
+  defaultMaxNum: joi.number(),
+  defaultMinNum: joi.number(),
   csrf: joi.array()
     .items(joi.string().allow(''))
     .sparse(),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -100,8 +100,6 @@ export default joi.object({
     .min(0)
     .max(100),
   defaultMaxTextLength: joi.number(),
-  defaultMaxNum: joi.number(),
-  defaultMinNum: joi.number(),
   csrf: joi.array()
     .items(joi.string().allow(''))
     .sparse(),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -99,6 +99,7 @@ export default joi.object({
   maxDepth: joi.number()
     .min(0)
     .max(100),
+  defaultMaxFieldLength : joi.number(),
   csrf: joi.array()
     .items(joi.string().allow(''))
     .sparse(),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -99,7 +99,9 @@ export default joi.object({
   maxDepth: joi.number()
     .min(0)
     .max(100),
-  defaultMaxFieldLength : joi.number(),
+  defaultMaxTextLength : joi.number(),
+  defaultMaxNum : joi.number(),
+  defaultMinNum : joi.number(),
   csrf: joi.array()
     .items(joi.string().allow(''))
     .sparse(),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -181,6 +181,7 @@ export type Config = {
   },
   defaultDepth?: number;
   maxDepth?: number;
+  defaultMaxFieldLength: number;
   indexSortableFields?: boolean;
   rateLimit?: {
     window?: number;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -182,8 +182,6 @@ export type Config = {
   defaultDepth?: number;
   maxDepth?: number;
   defaultMaxTextLength: number;
-  defaultMaxNum : number;
-  defaultMinNum : number;
   indexSortableFields?: boolean;
   rateLimit?: {
     window?: number;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -181,7 +181,9 @@ export type Config = {
   },
   defaultDepth?: number;
   maxDepth?: number;
-  defaultMaxFieldLength: number;
+  defaultMaxTextLength: number;
+  defaultMaxNum : number;
+  defaultMinNum : number;
   indexSortableFields?: boolean;
   rateLimit?: {
     window?: number;

--- a/src/fields/validations.spec.ts
+++ b/src/fields/validations.spec.ts
@@ -1,5 +1,6 @@
 import { text, textarea, password, select, point, number } from './validations';
 import { ValidateOptions } from './config/types';
+import payload from '..';
 
 const minLengthMessage = (length: number) => `This value must be longer than the minimum length of ${length} characters.`;
 const maxLengthMessage = (length: number) => `This value must be shorter than the max length of ${length} characters.`;
@@ -11,6 +12,7 @@ let options: ValidateOptions<any, any, any> = {
   operation: 'create',
   data: undefined,
   siblingData: undefined,
+  payload,
 };
 
 describe('Field Validations', () => {
@@ -325,7 +327,7 @@ describe('Field Validations', () => {
       const result = number(val, options);
       expect(result).toBe(true);
     });
-    it('should validate', () => {
+    it('should validate 2', () => {
       const val = 1.5;
       const result = number(val, options);
       expect(result).toBe(true);
@@ -336,23 +338,37 @@ describe('Field Validations', () => {
       expect(result).toBe(validNumberMessage);
     });
     it('should handle empty value', () => {
-      const val = "";
+      const val = '';
       const result = number(val, { ...options });
       expect(result).toBe(true);
     });
+
+
+    it('should not accept number above default max', async () => {
+      const val = 99999999999999;
+      const result = number(val, { ...options, required: true });
+      expect(result).toBe(maxValueMessage(val, 2147483647));
+    });
+    it('should not accept number below default min', async () => {
+      const val = -99999999999999;
+      const result = number(val, { ...options, required: true });
+      expect(result).toBe(minValueMessage(val, -2147483648));
+    });
+
+    // These 2 below are when the default max and mins are overwritten
     it('should handle required value', () => {
-      const val = "";
+      const val = '';
       const result = number(val, { ...options, required: true });
       expect(result).toBe(validNumberMessage);
     });
     it('should validate minValue', () => {
       const val = 2.4;
-      const result = number(val, { ...options, min: 2.5});
+      const result = number(val, { ...options, min: 2.5 });
       expect(result).toBe(minValueMessage(val, 2.5));
     });
     it('should validate maxValue', () => {
       const val = 1.25;
-      const result = number(val, { ...options, max: 1});
+      const result = number(val, { ...options, max: 1 });
       expect(result).toBe(maxValueMessage(val, 1));
     });
   });

--- a/src/fields/validations.spec.ts
+++ b/src/fields/validations.spec.ts
@@ -1,6 +1,5 @@
 import { text, textarea, password, select, point, number } from './validations';
 import { ValidateOptions } from './config/types';
-import payload from '..';
 
 const minLengthMessage = (length: number) => `This value must be longer than the minimum length of ${length} characters.`;
 const maxLengthMessage = (length: number) => `This value must be shorter than the max length of ${length} characters.`;
@@ -12,7 +11,6 @@ let options: ValidateOptions<any, any, any> = {
   operation: 'create',
   data: undefined,
   siblingData: undefined,
-  payload,
 };
 
 describe('Field Validations', () => {

--- a/src/fields/validations.spec.ts
+++ b/src/fields/validations.spec.ts
@@ -342,20 +342,6 @@ describe('Field Validations', () => {
       const result = number(val, { ...options });
       expect(result).toBe(true);
     });
-
-
-    it('should not accept number above default max', async () => {
-      const val = 99999999999999;
-      const result = number(val, { ...options, required: true });
-      expect(result).toBe(maxValueMessage(val, 2147483647));
-    });
-    it('should not accept number below default min', async () => {
-      const val = -99999999999999;
-      const result = number(val, { ...options, required: true });
-      expect(result).toBe(minValueMessage(val, -2147483648));
-    });
-
-    // These 2 below are when the default max and mins are overwritten
     it('should handle required value', () => {
       const val = '';
       const result = number(val, { ...options, required: true });

--- a/src/fields/validations.ts
+++ b/src/fields/validations.ts
@@ -45,13 +45,15 @@ export const number: Validate<unknown, unknown, NumberField> = (value: string, {
     return defaultMessage;
   }
 
+  
+
   return true;
 };
 
 export const text: Validate<unknown, unknown, TextField> = (value: string, { minLength, maxLength : fieldMaxLength, required, payload }) => {
   let maxLength: number;
 
-  if (typeof payload?.config?.defaultMaxFieldLength === 'number') maxLength = payload.config.defaultMaxFieldLength;
+  if (typeof payload?.config?.defaultMaxTextLength === 'number') maxLength = payload.config.defaultMaxTextLength;
   if (typeof fieldMaxLength === 'number') maxLength = fieldMaxLength;
   if (value && maxLength && value.length > maxLength) {
     return `This value must be shorter than the max length of ${maxLength} characters.`;
@@ -73,7 +75,7 @@ export const text: Validate<unknown, unknown, TextField> = (value: string, { min
 export const password: Validate<unknown, unknown, TextField> = (value: string, { required, maxLength : fieldMaxLength, minLength , payload }) => {
   let maxLength: number;
 
-  if (typeof payload?.config?.defaultMaxFieldLength === 'number') maxLength = payload.config.defaultMaxFieldLength;
+  if (typeof payload?.config?.defaultMaxTextLength === 'number') maxLength = payload.config.defaultMaxTextLength;
   if (typeof fieldMaxLength === 'number') maxLength = fieldMaxLength;
 
   if (value && maxLength && value.length > maxLength) {
@@ -108,7 +110,7 @@ export const textarea: Validate<unknown, unknown, TextareaField> = (value: strin
 }) => {
   let maxLength: number;
 
-  if (typeof payload?.config?.defaultMaxFieldLength === 'number') maxLength = payload.config.defaultMaxFieldLength;
+  if (typeof payload?.config?.defaultMaxTextLength === 'number') maxLength = payload.config.defaultMaxTextLength;
   if (typeof fieldMaxLength === 'number') maxLength = fieldMaxLength;
   if (value && maxLength && value.length > maxLength) {
     return `This value must be shorter than the max length of ${maxLength} characters.`;

--- a/src/fields/validations.ts
+++ b/src/fields/validations.ts
@@ -26,15 +26,22 @@ import { getIDType } from '../utilities/getIDType';
 
 const defaultMessage = 'This field is required.';
 
-export const number: Validate<unknown, unknown, NumberField> = (value: string, { required, min, max , payload}) => {
+export const number: Validate<unknown, unknown, NumberField> = (value: string, { required, min: setMin, max: setMax, payload }) => {
   const parsedValue = parseFloat(value);
+  let max: number;
+  let min: number;
 
-  if (typeof max !== 'number' && typeof payload?.config?.defaultMaxNum === 'number') {
+  if (typeof payload?.config?.defaultMaxNum === 'number') {
     max = payload.config.defaultMaxNum;
   }
-
-  if (typeof min !== 'number' && typeof payload?.config?.defaultMinNum === 'number') {
+  if (typeof setMax === 'number') {
+    max = setMax;
+  }
+  if (typeof payload?.config?.defaultMinNum === 'number') {
     min = payload.config.defaultMinNum;
+  }
+  if (typeof min === 'number') {
+    min = setMin;
   }
 
   if ((value && typeof parsedValue !== 'number') || (required && Number.isNaN(parsedValue)) || (value && Number.isNaN(parsedValue))) {
@@ -53,12 +60,10 @@ export const number: Validate<unknown, unknown, NumberField> = (value: string, {
     return defaultMessage;
   }
 
-  
-
   return true;
 };
 
-export const text: Validate<unknown, unknown, TextField> = (value: string, { minLength, maxLength : fieldMaxLength, required, payload }) => {
+export const text: Validate<unknown, unknown, TextField> = (value: string, { minLength, maxLength: fieldMaxLength, required, payload }) => {
   let maxLength: number;
 
   if (typeof payload?.config?.defaultMaxTextLength === 'number') maxLength = payload.config.defaultMaxTextLength;
@@ -80,7 +85,7 @@ export const text: Validate<unknown, unknown, TextField> = (value: string, { min
   return true;
 };
 
-export const password: Validate<unknown, unknown, TextField> = (value: string, { required, maxLength : fieldMaxLength, minLength , payload }) => {
+export const password: Validate<unknown, unknown, TextField> = (value: string, { required, maxLength: fieldMaxLength, minLength, payload }) => {
   let maxLength: number;
 
   if (typeof payload?.config?.defaultMaxTextLength === 'number') maxLength = payload.config.defaultMaxTextLength;
@@ -112,9 +117,9 @@ export const email: Validate<unknown, unknown, EmailField> = (value: string, { r
 
 export const textarea: Validate<unknown, unknown, TextareaField> = (value: string, {
   required,
-  maxLength : fieldMaxLength,
+  maxLength: fieldMaxLength,
   minLength,
-  payload
+  payload,
 }) => {
   let maxLength: number;
 

--- a/src/fields/validations.ts
+++ b/src/fields/validations.ts
@@ -26,8 +26,18 @@ import { getIDType } from '../utilities/getIDType';
 
 const defaultMessage = 'This field is required.';
 
-export const number: Validate<unknown, unknown, NumberField> = (value: string, { required, min, max }) => {
+export const number: Validate<unknown, unknown, NumberField> = (value: string, { required, min, max , payload}) => {
   const parsedValue = parseFloat(value);
+
+  if (typeof max !== 'number' && typeof payload?.config?.defaultMaxNum === 'number') {
+    max = payload.config.defaultMaxNum;
+    return `"${value}" is greater than the DEFAULT max allowed value of ${max}.`;
+  }
+
+  if (typeof min !== 'number' && typeof payload?.config?.defaultMinNum === 'number') {
+    min = payload.config.defaultMinNum;
+    return `"${value}" is less than the DEFAULT min allowed value of ${min}.`;
+  }
 
   if ((value && typeof parsedValue !== 'number') || (required && Number.isNaN(parsedValue)) || (value && Number.isNaN(parsedValue))) {
     return 'Please enter a valid number.';

--- a/src/fields/validations.ts
+++ b/src/fields/validations.ts
@@ -31,12 +31,10 @@ export const number: Validate<unknown, unknown, NumberField> = (value: string, {
 
   if (typeof max !== 'number' && typeof payload?.config?.defaultMaxNum === 'number') {
     max = payload.config.defaultMaxNum;
-    return `"${value}" is greater than the DEFAULT max allowed value of ${max}.`;
   }
 
   if (typeof min !== 'number' && typeof payload?.config?.defaultMinNum === 'number') {
     min = payload.config.defaultMinNum;
-    return `"${value}" is less than the DEFAULT min allowed value of ${min}.`;
   }
 
   if ((value && typeof parsedValue !== 'number') || (required && Number.isNaN(parsedValue)) || (value && Number.isNaN(parsedValue))) {

--- a/src/fields/validations.ts
+++ b/src/fields/validations.ts
@@ -26,23 +26,8 @@ import { getIDType } from '../utilities/getIDType';
 
 const defaultMessage = 'This field is required.';
 
-export const number: Validate<unknown, unknown, NumberField> = (value: string, { required, min: setMin, max: setMax, payload }) => {
+export const number: Validate<unknown, unknown, NumberField> = (value: string, { required, min, max }) => {
   const parsedValue = parseFloat(value);
-  let max: number;
-  let min: number;
-
-  if (typeof payload?.config?.defaultMaxNum === 'number') {
-    max = payload.config.defaultMaxNum;
-  }
-  if (typeof setMax === 'number') {
-    max = setMax;
-  }
-  if (typeof payload?.config?.defaultMinNum === 'number') {
-    min = payload.config.defaultMinNum;
-  }
-  if (typeof min === 'number') {
-    min = setMin;
-  }
 
   if ((value && typeof parsedValue !== 'number') || (required && Number.isNaN(parsedValue)) || (value && Number.isNaN(parsedValue))) {
     return 'Please enter a valid number.';

--- a/src/fields/validations.ts
+++ b/src/fields/validations.ts
@@ -48,7 +48,11 @@ export const number: Validate<unknown, unknown, NumberField> = (value: string, {
   return true;
 };
 
-export const text: Validate<unknown, unknown, TextField> = (value: string, { minLength, maxLength, required }) => {
+export const text: Validate<unknown, unknown, TextField> = (value: string, { minLength, maxLength : fieldMaxLength, required, payload }) => {
+  let maxLength: number;
+
+  if (typeof payload?.config?.defaultMaxFieldLength === 'number') maxLength = payload.config.defaultMaxFieldLength;
+  if (typeof fieldMaxLength === 'number') maxLength = fieldMaxLength;
   if (value && maxLength && value.length > maxLength) {
     return `This value must be shorter than the max length of ${maxLength} characters.`;
   }
@@ -66,7 +70,12 @@ export const text: Validate<unknown, unknown, TextField> = (value: string, { min
   return true;
 };
 
-export const password: Validate<unknown, unknown, TextField> = (value: string, { required, maxLength, minLength }) => {
+export const password: Validate<unknown, unknown, TextField> = (value: string, { required, maxLength : fieldMaxLength, minLength , payload }) => {
+  let maxLength: number;
+
+  if (typeof payload?.config?.defaultMaxFieldLength === 'number') maxLength = payload.config.defaultMaxFieldLength;
+  if (typeof fieldMaxLength === 'number') maxLength = fieldMaxLength;
+
   if (value && maxLength && value.length > maxLength) {
     return `This value must be shorter than the max length of ${maxLength} characters.`;
   }
@@ -93,9 +102,14 @@ export const email: Validate<unknown, unknown, EmailField> = (value: string, { r
 
 export const textarea: Validate<unknown, unknown, TextareaField> = (value: string, {
   required,
-  maxLength,
+  maxLength : fieldMaxLength,
   minLength,
+  payload
 }) => {
+  let maxLength: number;
+
+  if (typeof payload?.config?.defaultMaxFieldLength === 'number') maxLength = payload.config.defaultMaxFieldLength;
+  if (typeof fieldMaxLength === 'number') maxLength = fieldMaxLength;
   if (value && maxLength && value.length > maxLength) {
     return `This value must be shorter than the max length of ${maxLength} characters.`;
   }

--- a/test/fields/collections/Number/index.ts
+++ b/test/fields/collections/Number/index.ts
@@ -47,6 +47,18 @@ const NumberFields: CollectionConfig = {
       type: 'number',
       defaultValue: defaultNumber,
     },
+    {
+      name: 'defaultMinMaxOverrideTest',
+      type : 'number',
+      min : -200,
+      max : 999999999999999,
+    },
+    {
+      name: 'defaultMinMaxOverrideTest2',
+      type : 'number',
+      min : -99999999999999,
+      max : 999,
+    }
   ],
 };
 

--- a/test/fields/collections/Number/index.ts
+++ b/test/fields/collections/Number/index.ts
@@ -47,18 +47,6 @@ const NumberFields: CollectionConfig = {
       type: 'number',
       defaultValue: defaultNumber,
     },
-    {
-      name: 'defaultMinMaxOverrideTest',
-      type: 'number',
-      min: -200,
-      max: 999999999999999,
-    },
-    {
-      name: 'defaultMinMaxOverrideTest2',
-      type: 'number',
-      min: -99999999999999,
-      max: 999,
-    },
   ],
 };
 

--- a/test/fields/collections/Number/index.ts
+++ b/test/fields/collections/Number/index.ts
@@ -49,16 +49,16 @@ const NumberFields: CollectionConfig = {
     },
     {
       name: 'defaultMinMaxOverrideTest',
-      type : 'number',
-      min : -200,
-      max : 999999999999999,
+      type: 'number',
+      min: -200,
+      max: 999999999999999,
     },
     {
       name: 'defaultMinMaxOverrideTest2',
-      type : 'number',
-      min : -99999999999999,
-      max : 999,
-    }
+      type: 'number',
+      min: -99999999999999,
+      max: 999,
+    },
   ],
 };
 

--- a/test/fields/collections/Text/index.ts
+++ b/test/fields/collections/Text/index.ts
@@ -32,6 +32,11 @@ const TextFields: CollectionConfig = {
         }, 1));
       },
     },
+    {
+      name: 'Override the 40k text length default (This one has 50k max length)',
+      type: 'text',
+      maxLength: 50000,
+    },
   ],
 };
 


### PR DESCRIPTION
## Description

Alright, so I talked about this to @jmikrut , he talks about it here 

[
](https://github.com/payloadcms/payload/discussions/1219)

So I want to talk about what I did, essentially payload currently has no global "Default max length" for fields, this means unless you explicitly specify a max length for your text and number fields people can overload you with data. There should be a reasonable "Default max length" that can be overwritten in the payload defaults config.

Anyway, so I only did this for Text , Text Area and Number as the other fields don't even have an option to set a max length so it is impossible for me to set a default max length without furhter guidance from jmi.

The tests I wrote fail because I have no idea how to bring in the payload defaults config during the test. Due to this, I have instead created 2 additional test fields in test/fields/collections/Number/index.ts  that people can use to test my change via the admin panel. Just do yarn dev fields and test the Number Fields

The reason I marked this as a "Breaking Change" is because if you have fields that you haven't set max or mins for, and they happen to be intended to be above the max and min I set then you will need to "override" the fields themselves, or override the actual payload defaults config.

The max and min number I set is set to the bounds for the MAX_SAFE_INTEGER in JS [Here is the link to the docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER#:~:text=The%20MAX_SAFE_INTEGER%20constant%20has%20a,)
The text field max lengths are 500

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
