### PR TITLE
chore: cleaned up types and docs for the beforeLogin hook

### DIFF
--- a/docs/hooks/collections.mdx
+++ b/docs/hooks/collections.mdx
@@ -19,7 +19,6 @@ Collections feature the ability to define the following hooks:
 
 Additionally, `auth`-enabled collections feature the following hooks:
 
-- [beforeLogin](#beforelogin)
 - [afterLogin](#afterlogin)
 - [afterLogout](#afterlogout)
 - [afterRefresh](#afterrefresh)
@@ -50,7 +49,6 @@ const ExampleHooks: CollectionConfig = {
     afterDelete: [(args) => {...}],
 
     // Auth-enabled hooks
-    beforeLogin: [(args) => {...}],
     afterLogin: [(args) => {...}],
     afterLogout: [(args) => {...}],
     afterRefresh: [(args) => {...}],
@@ -188,22 +186,6 @@ const afterDeleteHook: CollectionAfterDeleteHook = async ({
 }) => {...}
 ```
 
-### beforeLogin
-
-For auth-enabled Collections, this hook runs after successful `login` operations. You can optionally modify the user that is returned.
-
-```ts
-import { CollectionBeforeLoginHook } from 'payload/types';
-
-const beforeLoginHook: CollectionBeforeLoginHook = async ({
-  req, // full express request
-  user, // user being logged in
-  token, // user token
-}) => {
-  return user;
-}
-```
-
 ### afterLogin
 
 For auth-enabled Collections, this hook runs after successful `login` operations. You can optionally modify the user that is returned.
@@ -285,7 +267,6 @@ import type {
   CollectionBeforeReadHook,
   CollectionBeforeDeleteHook,
   CollectionAfterDeleteHook,
-  CollectionBeforeLoginHook,
   CollectionAfterLoginHook,
   CollectionAfterLogoutHook,
   CollectionAfterRefreshHook,

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -112,10 +112,6 @@ export type AfterDeleteHook<T extends TypeWithID = any> = (args: {
 
 export type AfterErrorHook = (err: Error, res: unknown) => { response: any, status: number } | void;
 
-export type BeforeLoginHook = (args: {
-  req: PayloadRequest;
-}) => any;
-
 export type AfterLoginHook<T extends TypeWithID = any> = (args: {
   req: PayloadRequest;
   doc: T;
@@ -229,7 +225,6 @@ export type CollectionConfig = {
     beforeDelete?: BeforeDeleteHook[];
     afterDelete?: AfterDeleteHook[];
     afterError?: AfterErrorHook;
-    beforeLogin?: BeforeLoginHook[];
     afterLogin?: AfterLoginHook[];
     afterLogout?: AfterLogoutHook[];
     afterMe?: AfterMeHook[];

--- a/types.d.ts
+++ b/types.d.ts
@@ -15,7 +15,6 @@ export {
   BeforeReadHook as CollectionBeforeReadHook,
   BeforeDeleteHook as CollectionBeforeDeleteHook,
   AfterDeleteHook as CollectionAfterDeleteHook,
-  BeforeLoginHook as CollectionBeforeLoginHook,
   AfterLoginHook as CollectionAfterLoginHook,
   AfterForgotPasswordHook as CollectionAfterForgotPasswordHook,
   BeforeDuplicate,


### PR DESCRIPTION
## Description
The hook is never called and was replaced by the `beforeOperation` hook. Removed the `beforeLogin` hook from docs and types to avoid confusion.

- [x ] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x ] Documentation and Type Update

## Checklist:

- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] Existing test suite passes locally with my changes
- [x ] I have made corresponding changes to the documentation
