### PR TITLE
re-added the beforeLogin hook

### DIFF
--- a/docs/hooks/collections.mdx
+++ b/docs/hooks/collections.mdx
@@ -190,7 +190,7 @@ const afterDeleteHook: CollectionAfterDeleteHook = async ({
 
 ### beforeLogin
 
-For auth-enabled Collections, this hook runs after successful `login` operations. You can optionally modify the user that is returned.
+For auth-enabled Collections, this hook runs during `login` operations where a user with the provided credentials exist, but before a token is generated and added too the response. You can optionally modify the user that is returned, or throw an error in order to deny the login operation.
 
 ```ts
 import { CollectionBeforeLoginHook } from 'payload/types';
@@ -198,7 +198,6 @@ import { CollectionBeforeLoginHook } from 'payload/types';
 const beforeLoginHook: CollectionBeforeLoginHook = async ({
   req, // full express request
   user, // user being logged in
-  token, // user token
 }) => {
   return user;
 }
@@ -213,6 +212,8 @@ import { CollectionAfterLoginHook } from 'payload/types';
 
 const afterLoginHook: CollectionAfterLoginHook = async ({
   req, // full express request
+  user, // user that was logged in
+  token, // user token
 }) => {...}
 ```
 

--- a/src/auth/operations/login.ts
+++ b/src/auth/operations/login.ts
@@ -133,6 +133,15 @@ async function login<T>(incomingArgs: Arguments): Promise<Result & { user: T}> {
     collection: collectionConfig.slug,
   });
 
+  await collectionConfig.hooks.beforeLogin.reduce(async (priorHook, hook) => {
+    await priorHook;
+
+    user = (await hook({
+      user,
+      req: args.req,
+    })) || user;
+  }, Promise.resolve());
+
   const token = jwt.sign(
     fieldsToSign,
     secret,
@@ -166,7 +175,7 @@ async function login<T>(incomingArgs: Arguments): Promise<Result & { user: T}> {
     await priorHook;
 
     user = await hook({
-      doc: user,
+      user,
       req: args.req,
       token,
     }) || user;

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -112,13 +112,14 @@ export type AfterDeleteHook<T extends TypeWithID = any> = (args: {
 
 export type AfterErrorHook = (err: Error, res: unknown) => { response: any, status: number } | void;
 
-export type BeforeLoginHook = (args: {
+export type BeforeLoginHook<T extends TypeWithID = any> = (args: {
   req: PayloadRequest;
+  user: T
 }) => any;
 
 export type AfterLoginHook<T extends TypeWithID = any> = (args: {
   req: PayloadRequest;
-  doc: T;
+  user: T;
   token: string;
 }) => any;
 

--- a/test/credentials.ts
+++ b/test/credentials.ts
@@ -3,3 +3,8 @@ export const devUser = {
   password: 'test',
   roles: ['admin'],
 };
+export const regularUser = {
+  email: 'user@payloadcms.com',
+  password: 'test2',
+  roles: ['user'],
+};

--- a/test/hooks/collections/Users/index.ts
+++ b/test/hooks/collections/Users/index.ts
@@ -1,0 +1,46 @@
+import { Payload } from '../../../../src';
+import { BeforeLoginHook, CollectionConfig } from '../../../../src/collections/config/types';
+import { AuthenticationError } from '../../../../src/errors';
+import { devUser, regularUser } from '../../../credentials';
+
+const beforeLoginHook: BeforeLoginHook = ({ user }) => {
+  const isAdmin = user.roles.includes('admin') ? user : undefined;
+  if (!isAdmin) {
+    throw new AuthenticationError();
+  }
+  return user;
+};
+
+export const seedHooksUsers = async (payload: Payload) => {
+  await payload.create({
+    collection: hooksUsersSlug,
+    data: devUser,
+  });
+  await payload.create({
+    collection: hooksUsersSlug,
+    data: regularUser,
+  });
+};
+
+export const hooksUsersSlug = 'hooks-users';
+const Users: CollectionConfig = {
+  slug: hooksUsersSlug,
+  auth: true,
+  fields: [
+    {
+      name: 'roles',
+      label: 'Role',
+      type: 'select',
+      options: ['admin', 'user'],
+      defaultValue: 'user',
+      required: true,
+      saveToJWT: true,
+      hasMany: true,
+    },
+  ],
+  hooks: {
+    beforeLogin: [beforeLoginHook],
+  },
+};
+
+export default Users;

--- a/test/hooks/config.ts
+++ b/test/hooks/config.ts
@@ -3,6 +3,7 @@ import TransformHooks from './collections/Transform';
 import Hooks, { hooksSlug } from './collections/Hook';
 import NestedAfterReadHooks from './collections/NestedAfterReadHooks';
 import Relations from './collections/Relations';
+import Users, { seedHooksUsers } from './collections/Users';
 
 export default buildConfig({
   collections: [
@@ -10,8 +11,10 @@ export default buildConfig({
     Hooks,
     NestedAfterReadHooks,
     Relations,
+    Users,
   ],
   onInit: async (payload) => {
+    await seedHooksUsers(payload);
     await payload.create({
       collection: hooksSlug,
       data: {

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -8,6 +8,9 @@ import { hooksSlug } from './collections/Hook';
 import { generatedAfterReadText, nestedAfterReadHooksSlug } from './collections/NestedAfterReadHooks';
 import { relationsSlug } from './collections/Relations';
 import type { NestedAfterReadHook } from './payload-types';
+import { hooksUsersSlug } from './collections/Users';
+import { devUser, regularUser } from '../credentials';
+import { AuthenticationError } from '../../src/errors';
 
 let client: RESTClient;
 
@@ -115,6 +118,22 @@ describe('Hooks', () => {
 
       expect(retrievedDoc.group.array[0].shouldPopulate.title).toEqual(relation.title);
       expect(retrievedDoc.group.subGroup.shouldPopulate.title).toEqual(relation.title);
+    });
+  });
+  describe('auth collection hooks', () => {
+    it('allow admin login', async () => {
+      const { user } = await payload.login({
+        collection: hooksUsersSlug,
+        data: {
+          email: devUser.email,
+          password: devUser.password,
+        },
+      });
+      expect(user).toBeDefined();
+    });
+
+    it('deny user login', async () => {
+      await expect(() => payload.login({ collection: hooksUsersSlug, data: { email: regularUser.email, password: regularUser.password } })).rejects.toThrow(AuthenticationError);
     });
   });
 });


### PR DESCRIPTION
## Description
I have re-added a slightly modified `beforeLogin` hook that can be used to extend logic into the login operation.
`afterLogin` provides similar possibilities, but when this hook is called the user have already been logged in (cookie added to the request object).
Similarly, the `beforeOperation` can not be used either, since the provided credentials havn't been verified at that point.

Here is a usage example:

```ts
const beforeLoginHook: BeforeLoginHook = ({ user }) => {
  const isAdmin = user.roles.includes('admin') ? user : undefined;
  if (!isAdmin) {
    throw new AuthenticationError();
  }
  return user;
};

export const hooksUsersSlug = 'hooks-users';
const Users: CollectionConfig = {
  slug: hooksUsersSlug,
  auth: true,
  fields: [
    ...
  ],
  hooks: {
    beforeLogin: [beforeLoginHook],
  },
};
```

The most relevant use-case I can think of is for multi-tenant applications where organizations only should be able to log in to their own admin UI.

I introduces a small breaking change for the `afterLogin` hook. The documentation didn't specify all the props passed to the hook, but if someone implemented the hook and accepted the `doc` props, this is now passed as `user` instead to make it more readable.

- [x ] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ x] I have added tests that prove my fix is effective or that my feature works
- [x ] Existing test suite passes locally with my changes
- [ x] I have made corresponding changes to the documentation
