### PR TITLE
docs: field hook example configuration is wrong

### DIFF
--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -27,9 +27,9 @@ Field-level hooks offer incredible potential for encapsulating your logic. They 
 
 Example field configuration:
 ```ts
-import { CollectionConfig } from 'payload/types';
+import { Field } from 'payload/types';
 
-const ExampleCollection: CollectionConfig = {
+const ExampleField: Field = {
   name: 'name',
   type: 'text',
   // highlight-start


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->
The current field hook configuration example is wrong. The object is typed as `CollectionConfig`, but it is supposed to be a `Field`. It threw me off when I was reading it, so i figure other people may be affected by this as well.
link: https://payloadcms.com/docs/hooks/fields#config

Here's what happened when I copied the code into my project:
<img width="352" alt="Screenshot 2022-11-01 at 9 54 22 AM" src="https://user-images.githubusercontent.com/24814968/199148604-8933274e-cf33-401d-bdb2-a2663d343288.png">

Here's what (I believe) it should be:
<img width="286" alt="Screenshot 2022-11-01 at 9 39 22 AM" src="https://user-images.githubusercontent.com/24814968/199148769-b8a97873-a9d1-4667-80a1-1f503e3bb6bc.png">

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
