### PR TITLE
fix: fixed GraphQL Access query resolver to return the correct data

### DIFF
--- a/src/auth/graphql/resolvers/access.ts
+++ b/src/auth/graphql/resolvers/access.ts
@@ -20,12 +20,13 @@ function accessResolver(payload: Payload) {
       req: context.req,
     };
 
-    let accessResults = await access(options);
+    const accessResults = await access(options);
 
-    accessResults = formatConfigNames(accessResults, payload.config.collections);
-    accessResults = formatConfigNames(accessResults, payload.config.globals);
-
-    return accessResults;
+    return {
+      ...accessResults,
+      ...formatConfigNames(accessResults.collections, payload.config.collections),
+      ...formatConfigNames(accessResults.globals, payload.config.globals)
+    };
   }
 
   return resolver;

--- a/src/graphql/registerSchema.ts
+++ b/src/graphql/registerSchema.ts
@@ -39,7 +39,7 @@ export default function registerSchema(payload: Payload): void {
 
   payload.Query.fields.Access = {
     type: buildPoliciesType(payload),
-    resolve: accessResolver,
+    resolve: accessResolver(payload),
   };
 
   if (typeof payload.config.graphQL.queries === 'function') {


### PR DESCRIPTION
## Description

Fixes #1338

This fixes the object returned from the resolver and also fixes how the resolver is registered.

I used the graphql-playground to verify the fix. I'm unsure if an automated test should be set up in access-control, auth, or in a completely new test directory.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
