### PR TITLE
feat: let textarea grow based on value

### DIFF
--- a/src/admin/components/forms/field-types/Textarea/Input.tsx
+++ b/src/admin/components/forms/field-types/Textarea/Input.tsx
@@ -66,15 +66,24 @@ const TextareaInput: React.FC<TextAreaInputProps> = (props) => {
         label={label}
         required={required}
       />
-      <textarea
-        id={`field-${path.replace(/\./gi, '__')}`}
-        value={value || ''}
-        onChange={onChange}
-        disabled={readOnly}
-        placeholder={placeholder}
-        name={path}
-        rows={rows}
-      />
+      <div className="textarea-outer">
+        <div className="textarea-inner">
+          <div
+            className="textarea-clone"
+            data-value={value || placeholder || ''}
+          />
+          <textarea
+            className="textarea-element"
+            id={`field-${path.replace(/\./gi, '__')}`}
+            value={value || ''}
+            onChange={onChange}
+            disabled={readOnly}
+            placeholder={placeholder}
+            name={path}
+            rows={rows}
+          />
+        </div>
+      </div>
       <FieldDescription
         value={value}
         description={description}

--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -1,19 +1,76 @@
-@import '../../../../scss/styles.scss';
+@import "../../../../scss/styles.scss";
 
 .field-type.textarea {
   position: relative;
   margin-bottom: $baseline;
 
-  textarea {
+  .textarea-outer {
     @include formInput();
-    height: auto;
-    min-height: base(3);
     resize: vertical;
+
+    // Scrollbar for giant content
+    max-height: 90vh;
+    overflow: auto;
   }
 
   &.error {
     textarea {
       background-color: var(--theme-error-200);
     }
+  }
+
+  // This element takes exactly the same dimensions as the clone
+  .textarea-inner {
+    display: block;
+    position: relative;
+    line-height: inherit;
+    flex-grow: 1;
+    box-sizing: border-box;
+    background: none;
+    outline: none;
+  }
+
+  // Unstyle the textarea, the border is rendered on .textarea-outer
+  .textarea-element {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: inherit;
+    padding: inherit;
+    font: inherit;
+    line-height: inherit;
+    color: inherit;
+    background: none;
+    box-sizing: border-box;
+    overflow: auto;
+    resize: none;
+    outline: none;
+    text-transform: inherit;
+  }
+
+  // Clone of textarea with same height
+  .textarea-clone {
+    vertical-align: top;
+    display: inline-block;
+    flex-grow: 1;
+    white-space: pre;
+    box-sizing: border-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: pre-wrap;
+    pointer-events: none;
+  }
+  .textarea-clone::before {
+    content: attr(data-value) " ";
+    visibility: hidden;
+    opacity: 0;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+  }
+  .textarea-clone::after {
+    content: attr(data-after);
+    opacity: 0.5;
   }
 }

--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -7,10 +7,16 @@
   .textarea-outer {
     @include formInput();
     resize: vertical;
+    height: auto;
+    min-height: base(3);
 
     // Scrollbar for giant content
     max-height: 90vh;
     overflow: auto;
+
+    @include mid-break {
+      max-height: 60vh;
+    }
   }
 
   &.error {
@@ -48,6 +54,10 @@
     resize: none;
     outline: none;
     text-transform: inherit;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 
   // Clone of textarea with same height
@@ -62,6 +72,7 @@
     white-space: pre-wrap;
     pointer-events: none;
   }
+
   .textarea-clone::before {
     content: attr(data-value) " ";
     visibility: hidden;
@@ -69,6 +80,7 @@
     white-space: pre-wrap;
     overflow-wrap: break-word;
   }
+
   .textarea-clone::after {
     content: attr(data-after);
     opacity: 0.5;


### PR DESCRIPTION
## Description

Let textareas grow upto 90vh based on their content. This approach may seem more complex than the minHeight=outerHeight method, but it avoids jankiness by being declarative and letting CSS do the heavy lifting.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
