### PR TITLE
Saves tabs to user preferences

### DIFF
--- a/src/admin/components/forms/RenderFields/index.tsx
+++ b/src/admin/components/forms/RenderFields/index.tsx
@@ -20,7 +20,7 @@ const RenderFields: React.FC<Props> = (props) => {
     readOnly: readOnlyOverride,
     className,
     forceRender,
-    pathByIndex: incomingFieldIndex
+    indexPath: incomingIndexPath
   } = props;
 
   const [hasRendered, setHasRendered] = useState(Boolean(forceRender));
@@ -91,7 +91,7 @@ const RenderFields: React.FC<Props> = (props) => {
                           ...field,
                           path: field.path || (isFieldAffectingData ? field.name : ''),
                           fieldTypes,
-                          pathByIndex: incomingFieldIndex ? `${incomingFieldIndex}[${fieldIndex}]` : `[${fieldIndex}]`,
+                          indexPath: incomingIndexPath ? `${incomingIndexPath}.${fieldIndex}` : `${fieldIndex}`,
                           admin: {
                             ...(field.admin || {}),
                             readOnly,

--- a/src/admin/components/forms/RenderFields/index.tsx
+++ b/src/admin/components/forms/RenderFields/index.tsx
@@ -20,6 +20,7 @@ const RenderFields: React.FC<Props> = (props) => {
     readOnly: readOnlyOverride,
     className,
     forceRender,
+    pathByIndex: incomingFieldIndex
   } = props;
 
   const [hasRendered, setHasRendered] = useState(Boolean(forceRender));
@@ -48,7 +49,7 @@ const RenderFields: React.FC<Props> = (props) => {
         className={classes}
       >
         {hasRendered && (
-          fieldSchema.map((field, i) => {
+          fieldSchema.map((field, fieldIndex) => {
             const fieldIsPresentational = fieldIsPresentationalOnly(field);
             let FieldComponent = fieldTypes[field.type];
 
@@ -58,7 +59,7 @@ const RenderFields: React.FC<Props> = (props) => {
                   return (
                     <FieldComponent
                       {...field}
-                      key={i}
+                      key={fieldIndex}
                     />
                   );
                 }
@@ -83,13 +84,14 @@ const RenderFields: React.FC<Props> = (props) => {
                   if (FieldComponent) {
                     return (
                       <RenderCustomComponent
-                        key={i}
+                        key={fieldIndex}
                         CustomComponent={field?.admin?.components?.Field}
                         DefaultComponent={FieldComponent}
                         componentProps={{
                           ...field,
                           path: field.path || (isFieldAffectingData ? field.name : ''),
                           fieldTypes,
+                          pathByIndex: incomingFieldIndex ? `${incomingFieldIndex}[${fieldIndex}]` : `[${fieldIndex}]`,
                           admin: {
                             ...(field.admin || {}),
                             readOnly,
@@ -103,7 +105,7 @@ const RenderFields: React.FC<Props> = (props) => {
                   return (
                     <div
                       className="missing-field"
-                      key={i}
+                      key={fieldIndex}
                     >
                       No matched field found for
                       {' '}

--- a/src/admin/components/forms/RenderFields/types.ts
+++ b/src/admin/components/forms/RenderFields/types.ts
@@ -12,5 +12,5 @@ export type Props = {
   filter?: (field: Field) => boolean
   fieldSchema: FieldWithPath[]
   fieldTypes: FieldTypes
-  pathByIndex: string
+  indexPath?: string
 }

--- a/src/admin/components/forms/RenderFields/types.ts
+++ b/src/admin/components/forms/RenderFields/types.ts
@@ -12,4 +12,5 @@ export type Props = {
   filter?: (field: Field) => boolean
   fieldSchema: FieldWithPath[]
   fieldTypes: FieldTypes
+  pathByIndex: string
 }

--- a/src/admin/components/forms/field-types/Array/index.tsx
+++ b/src/admin/components/forms/field-types/Array/index.tsx
@@ -38,6 +38,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
     maxRows,
     minRows,
     permissions,
+    indexPath,
     admin: {
       readOnly,
       description,
@@ -292,6 +293,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
                             readOnly={readOnly}
                             fieldTypes={fieldTypes}
                             permissions={permissions?.fields}
+                            indexPath={indexPath}
                             fieldSchema={fields.map((field) => ({
                               ...field,
                               path: `${path}.${i}${fieldAffectsData(field) ? `.${field.name}` : ''}`,

--- a/src/admin/components/forms/field-types/Array/types.ts
+++ b/src/admin/components/forms/field-types/Array/types.ts
@@ -7,4 +7,5 @@ export type Props = Omit<ArrayField, 'type'> & {
   fieldTypes: FieldTypes
   permissions: FieldPermissions
   label: string | false
+  indexPath: string
 }

--- a/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -50,6 +50,7 @@ const BlocksField: React.FC<Props> = (props) => {
     required,
     validate = blocksValidator,
     permissions,
+    indexPath,
     admin: {
       readOnly,
       description,
@@ -345,6 +346,7 @@ const BlocksField: React.FC<Props> = (props) => {
                                 ...field,
                                 path: `${path}.${i}${fieldAffectsData(field) ? `.${field.name}` : ''}`,
                               }))}
+                              indexPath={indexPath}
                             />
 
                           </Collapsible>

--- a/src/admin/components/forms/field-types/Blocks/types.ts
+++ b/src/admin/components/forms/field-types/Blocks/types.ts
@@ -6,4 +6,5 @@ export type Props = Omit<BlockField, 'type'> & {
   path?: string
   fieldTypes: FieldTypes
   permissions: FieldPermissions
+  indexPath: string
 }

--- a/src/admin/components/forms/field-types/Collapsible/index.tsx
+++ b/src/admin/components/forms/field-types/Collapsible/index.tsx
@@ -21,7 +21,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
     fieldTypes,
     path,
     permissions,
-    pathByIndex,
+    indexPath,
     admin: {
       readOnly,
       className,
@@ -78,7 +78,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
           readOnly={readOnly}
           permissions={permissions}
           fieldTypes={fieldTypes}
-          pathByIndex={pathByIndex}
+          indexPath={indexPath}
           fieldSchema={fields.map((field) => ({
             ...field,
             path: getFieldPath(path, field),

--- a/src/admin/components/forms/field-types/Collapsible/index.tsx
+++ b/src/admin/components/forms/field-types/Collapsible/index.tsx
@@ -21,6 +21,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
     fieldTypes,
     path,
     permissions,
+    pathByIndex,
     admin: {
       readOnly,
       className,
@@ -77,6 +78,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
           readOnly={readOnly}
           permissions={permissions}
           fieldTypes={fieldTypes}
+          pathByIndex={pathByIndex}
           fieldSchema={fields.map((field) => ({
             ...field,
             path: getFieldPath(path, field),

--- a/src/admin/components/forms/field-types/Collapsible/types.ts
+++ b/src/admin/components/forms/field-types/Collapsible/types.ts
@@ -6,4 +6,5 @@ export type Props = Omit<CollapsibleField, 'type'> & {
   path?: string
   fieldTypes: FieldTypes
   permissions: FieldPermissions
+  pathByIndex: string
 }

--- a/src/admin/components/forms/field-types/Collapsible/types.ts
+++ b/src/admin/components/forms/field-types/Collapsible/types.ts
@@ -6,5 +6,5 @@ export type Props = Omit<CollapsibleField, 'type'> & {
   path?: string
   fieldTypes: FieldTypes
   permissions: FieldPermissions
-  pathByIndex: string
+  indexPath: string
 }

--- a/src/admin/components/forms/field-types/Group/index.tsx
+++ b/src/admin/components/forms/field-types/Group/index.tsx
@@ -19,6 +19,7 @@ const Group: React.FC<Props> = (props) => {
     name,
     path: pathFromProps,
     fieldTypes,
+    indexPath,
     admin: {
       readOnly,
       style,
@@ -70,6 +71,7 @@ const Group: React.FC<Props> = (props) => {
             permissions={permissions?.fields}
             readOnly={readOnly}
             fieldTypes={fieldTypes}
+            indexPath={indexPath}
             fieldSchema={fields.map((subField) => ({
               ...subField,
               path: `${path}${fieldAffectsData(subField) ? `.${subField.name}` : ''}`,

--- a/src/admin/components/forms/field-types/Group/types.ts
+++ b/src/admin/components/forms/field-types/Group/types.ts
@@ -6,4 +6,5 @@ export type Props = Omit<GroupField, 'type'> & {
   path?: string
   fieldTypes: FieldTypes
   permissions: FieldPermissions
+  indexPath: string
 }

--- a/src/admin/components/forms/field-types/Row/index.tsx
+++ b/src/admin/components/forms/field-types/Row/index.tsx
@@ -16,6 +16,7 @@ const Row: React.FC<Props> = (props) => {
       readOnly,
       className,
     },
+    indexPath
   } = props;
 
   const classes = [
@@ -30,6 +31,7 @@ const Row: React.FC<Props> = (props) => {
       className={classes}
       permissions={permissions}
       fieldTypes={fieldTypes}
+      indexPath={indexPath}
       fieldSchema={fields.map((field) => ({
         ...field,
         path: getFieldPath(path, field),

--- a/src/admin/components/forms/field-types/Row/types.ts
+++ b/src/admin/components/forms/field-types/Row/types.ts
@@ -6,4 +6,5 @@ export type Props = Omit<RowField, 'type'> & {
   path?: string
   fieldTypes: FieldTypes
   permissions: FieldPermissions
+  indexPath: string
 }

--- a/src/admin/components/forms/field-types/Tabs/index.tsx
+++ b/src/admin/components/forms/field-types/Tabs/index.tsx
@@ -44,35 +44,31 @@ const TabsField: React.FC<Props> = (props) => {
     getInitialPref();
   }, [path, indexPath])
 
-  const handleTabChange = useCallback((incomingTabIndex: number) => {
+  const handleTabChange = useCallback(async (incomingTabIndex: number) => {
     setActiveTabIndex(incomingTabIndex)
 
-    const handlePref = async () => {
-      const existingPreferences: DocumentPreferences = await getPreference(preferencesKey);
+    const existingPreferences: DocumentPreferences = await getPreference(preferencesKey);
 
-      setPreference(preferencesKey, {
-        ...existingPreferences,
-        ...path ? {
-          fields: {
-            ...existingPreferences?.fields || {},
-            [path]: {
-              ...existingPreferences?.fields?.[path],
-              tabIndex: incomingTabIndex,
-            },
+    setPreference(preferencesKey, {
+      ...existingPreferences,
+      ...path ? {
+        fields: {
+          ...existingPreferences?.fields || {},
+          [path]: {
+            ...existingPreferences?.fields?.[path],
+            tabIndex: incomingTabIndex,
           },
-        } : {
-          fields: {
-            ...existingPreferences?.fields,
-            [tabsPrefKey]: {
-              ...existingPreferences?.fields?.[tabsPrefKey],
-              tabIndex: incomingTabIndex,
-            }
-          },
-        }
-      });
-    }
-
-    handlePref();
+        },
+      } : {
+        fields: {
+          ...existingPreferences?.fields,
+          [tabsPrefKey]: {
+            ...existingPreferences?.fields?.[tabsPrefKey],
+            tabIndex: incomingTabIndex,
+          }
+        },
+      }
+    });
   }, [indexPath, preferencesKey, getPreference, setPreference, path])
 
   const activeTabConfig = tabs[activeTabIndex];

--- a/src/admin/components/forms/field-types/Tabs/index.tsx
+++ b/src/admin/components/forms/field-types/Tabs/index.tsx
@@ -21,7 +21,7 @@ const TabsField: React.FC<Props> = (props) => {
     fieldTypes,
     path,
     permissions,
-    pathByIndex,
+    indexPath,
     admin: {
       readOnly,
       className,
@@ -33,15 +33,16 @@ const TabsField: React.FC<Props> = (props) => {
 
   const isWithinCollapsible = useCollapsible();
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
+  const tabsPrefKey = `tabs-${indexPath}`;
 
   useEffect(() => {
     const getInitialPref = async () => {
       const existingPreferences: DocumentPreferences = await getPreference(preferencesKey);
-      const initialIndex = path ? existingPreferences?.fields?.[path]?.tabIndex : existingPreferences?.fields?.[pathByIndex]?.tabIndex;
+      const initialIndex = path ? existingPreferences?.fields?.[path]?.tabIndex : existingPreferences?.fields?.[tabsPrefKey]?.tabIndex;
       setActiveTabIndex(initialIndex || 0)
     }
     getInitialPref();
-  }, [path, pathByIndex])
+  }, [path, indexPath])
 
   const handleTabChange = useCallback((incomingTabIndex: number) => {
     setActiveTabIndex(incomingTabIndex)
@@ -62,8 +63,8 @@ const TabsField: React.FC<Props> = (props) => {
         } : {
           fields: {
             ...existingPreferences?.fields,
-            [pathByIndex]: {
-              ...existingPreferences?.fields?.[pathByIndex],
+            [tabsPrefKey]: {
+              ...existingPreferences?.fields?.[tabsPrefKey],
               tabIndex: incomingTabIndex,
             }
           },
@@ -72,7 +73,7 @@ const TabsField: React.FC<Props> = (props) => {
     }
 
     handlePref();
-  }, [pathByIndex, preferencesKey, getPreference, setPreference, path])
+  }, [indexPath, preferencesKey, getPreference, setPreference, path])
 
   const activeTabConfig = tabs[activeTabIndex];
 
@@ -126,7 +127,7 @@ const TabsField: React.FC<Props> = (props) => {
                   ...field,
                   path: `${path ? `${path}.` : ''}${tabHasName(activeTabConfig) ? `${activeTabConfig.name}.` : ''}${fieldAffectsData(field) ? field.name : ''}`,
                 }))}
-                pathByIndex={pathByIndex}
+                indexPath={indexPath}
               />
             </div>
           )}

--- a/src/admin/components/forms/field-types/Tabs/types.ts
+++ b/src/admin/components/forms/field-types/Tabs/types.ts
@@ -6,5 +6,5 @@ export type Props = Omit<TabsField, 'type'> & {
   path?: string
   fieldTypes: FieldTypes
   permissions: FieldPermissions
-  pathByIndex: string
+  indexPath: string
 }

--- a/src/admin/components/forms/field-types/Tabs/types.ts
+++ b/src/admin/components/forms/field-types/Tabs/types.ts
@@ -6,4 +6,5 @@ export type Props = Omit<TabsField, 'type'> & {
   path?: string
   fieldTypes: FieldTypes
   permissions: FieldPermissions
+  pathByIndex: string
 }

--- a/src/preferences/types.ts
+++ b/src/preferences/types.ts
@@ -26,8 +26,13 @@ export type PreferenceUpdateRequest = PreferenceRequest & {value: undefined};
 
 export type CollapsedPreferences = string[]
 
+export type TabsPreferences = Array<{
+  [path: string]: number
+}>
+
 export type FieldsPreferences = {
   [key: string]: {
+    tabIndex: number
     collapsed: CollapsedPreferences
   }
 }


### PR DESCRIPTION
## Description

Saves `tabIndex` per field to the user preferences as they navigate tabbed content within the admin panel. When the user reloads the page, their tabs will be restored back to their last-known position. Works for both top-level and nested tabs.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
