### PR TITLE
fix: Increase textarea click area

### DIFF
--- a/src/admin/components/forms/field-types/Textarea/Input.tsx
+++ b/src/admin/components/forms/field-types/Textarea/Input.tsx
@@ -66,7 +66,10 @@ const TextareaInput: React.FC<TextAreaInputProps> = (props) => {
         label={label}
         required={required}
       />
-      <div className="textarea-outer">
+      <label
+        className="textarea-outer"
+        htmlFor={`field-${path.replace(/\./gi, '__')}`}
+      >
         <div className="textarea-inner">
           <div
             className="textarea-clone"
@@ -83,7 +86,7 @@ const TextareaInput: React.FC<TextAreaInputProps> = (props) => {
             rows={rows}
           />
         </div>
-      </div>
+      </label>
       <FieldDescription
         value={value}
         description={description}

--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -6,13 +6,13 @@
 
   .textarea-outer {
     @include formInput();
-    display: block;
+    display: flex;
     resize: vertical;
-    height: auto;
     min-height: base(3);
+    height: 100%;
 
     // Scrollbar for giant content
-    max-height: 90vh;
+    max-height: calc(100vh - $top-header-offset - calc(#{base(5)}));
     overflow: auto;
 
     @include mid-break {

--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -32,7 +32,6 @@
     position: relative;
     line-height: inherit;
     flex-grow: 1;
-    box-sizing: border-box;
     background: none;
     outline: none;
   }
@@ -50,7 +49,6 @@
     line-height: inherit;
     color: inherit;
     background: none;
-    box-sizing: border-box;
     overflow: auto;
     resize: none;
     outline: none;
@@ -66,8 +64,6 @@
     vertical-align: top;
     display: inline-block;
     flex-grow: 1;
-    white-space: pre;
-    box-sizing: border-box;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: pre-wrap;

--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -6,6 +6,7 @@
 
   .textarea-outer {
     @include formInput();
+    display: block;
     resize: vertical;
     height: auto;
     min-height: base(3);


### PR DESCRIPTION
## Description

The bottom part of the textarea does not focus it when clicked.
Also when using the resizer, the newly create space does not focus the textarea.
This fix makes the focus behaviour identical to a normal textarea.

Speaking of identical, also fixed the error & focus state, old:
<img width="795" alt="Screenshot 2022-11-16 at 01 45 46" src="https://user-images.githubusercontent.com/1109982/202055678-4f848916-6288-4223-a41b-bb864aa2af06.png">

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
