### PR TITLE
Fix/1441 options type

### DIFF
--- a/components/fields/Select.ts
+++ b/components/fields/Select.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/named
-export { Props, Option } from '../../dist/admin/components/forms/field-types/Select/types';
+export { Props } from '../../dist/admin/components/forms/field-types/Select/types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,10 @@
       ],
       "payload/types": [
         "./src/types/index.ts"
-      ]
+      ],
+      "payload/types": [
+        "./src/fields/config/index.ts"
+      ],
     },
     "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,10 +21,7 @@
         "./src/auth/types.ts"
       ],
       "payload/types": [
-        "./src/types/index.ts"
-      ],
-      "payload/types": [
-        "./src/fields/config/index.ts"
+        "./src/types/index.ts",
       ],
     },
     "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */


### PR DESCRIPTION
## Description

Fixes #1441 
Removes import/export of `Option` type as it is no longer exported from components/fields/Select.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
