### PR TITLE
fix: ensures draft operations save as drafts

### DIFF
--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -78,7 +78,6 @@ async function update(incomingArgs: Arguments): Promise<Document> {
   }
 
   const shouldSaveDraft = Boolean(draftArg && collectionConfig.versions.drafts);
-  if (shouldSaveDraft) data._status = 'draft';
 
   // /////////////////////////////////////
   // Access

--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -78,6 +78,7 @@ async function update(incomingArgs: Arguments): Promise<Document> {
   }
 
   const shouldSaveDraft = Boolean(draftArg && collectionConfig.versions.drafts);
+  if (shouldSaveDraft) data._status = 'draft';
 
   // /////////////////////////////////////
   // Access

--- a/src/versions/drafts/saveCollectionDraft.ts
+++ b/src/versions/drafts/saveCollectionDraft.ts
@@ -21,6 +21,8 @@ export const saveCollectionDraft = async ({
 }: Args): Promise<Record<string, unknown>> => {
   const VersionsModel = payload.versions[config.slug];
 
+  const dataAsDraft = { ...data, _status: 'draft' };
+
   let existingAutosaveVersion;
 
   if (autosave) {
@@ -40,7 +42,7 @@ export const saveCollectionDraft = async ({
           _id: existingAutosaveVersion._id,
         },
         {
-          version: data,
+          version: dataAsDraft,
         },
         { new: true, lean: true },
       );
@@ -48,7 +50,7 @@ export const saveCollectionDraft = async ({
     } else {
       result = await VersionsModel.create({
         parent: id,
-        version: data,
+        version: dataAsDraft,
         autosave: Boolean(autosave),
       });
     }

--- a/src/versions/drafts/saveGlobalDraft.ts
+++ b/src/versions/drafts/saveGlobalDraft.ts
@@ -17,6 +17,8 @@ export const saveGlobalDraft = async ({
 }: Args): Promise<void> => {
   const VersionsModel = payload.versions[config.slug];
 
+  const dataAsDraft = { ...data, _status: 'draft' };
+
   let existingAutosaveVersion;
 
   if (autosave) {
@@ -34,14 +36,14 @@ export const saveGlobalDraft = async ({
           _id: existingAutosaveVersion._id,
         },
         {
-          version: data,
+          version: dataAsDraft,
         },
         { new: true, lean: true },
       );
     // Otherwise, create a new one
     } else {
       result = await VersionsModel.create({
-        version: data,
+        version: dataAsDraft,
         autosave: Boolean(autosave),
       });
     }

--- a/src/versions/ensurePublishedCollectionVersion.ts
+++ b/src/versions/ensurePublishedCollectionVersion.ts
@@ -51,6 +51,7 @@ export const ensurePublishedCollectionVersion = async ({
         req,
         overrideAccess: true,
         showHiddenFields: true,
+        flattenLocales: false,
       });
 
       try {

--- a/src/versions/ensurePublishedGlobalVersion.ts
+++ b/src/versions/ensurePublishedGlobalVersion.ts
@@ -46,6 +46,7 @@ export const ensurePublishedGlobalVersion = async ({
         req,
         overrideAccess: true,
         showHiddenFields: true,
+        flattenLocales: false,
       });
 
       try {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -488,6 +488,44 @@ describe('Versions', () => {
         expect(restoredGlobal.title).toBe(restore.title);
       });
     });
+
+    describe('Patch', () => {
+      it('should allow a draft to be patched', async () => {
+        const originalTitle = 'Here is a published global';
+
+        await payload.updateGlobal({
+          slug: globalSlug,
+          data: {
+            title: originalTitle,
+            description: 'kjnjyhbbdsfseankuhsjsfghb',
+            _status: 'published',
+          },
+        });
+
+        const publishedGlobal = await payload.findGlobal({
+          slug: globalSlug,
+          draft: true,
+        });
+
+        const updatedTitle = 'Here is a draft global with a patched title';
+
+        await payload.updateGlobal({
+          slug: globalSlug,
+          data: {
+            title: updatedTitle,
+          },
+          draft: true,
+        });
+
+        const updatedGlobal = await payload.findGlobal({
+          slug: globalSlug,
+          draft: true,
+        });
+
+        expect(publishedGlobal.title).toBe(originalTitle);
+        expect(updatedGlobal.title).toBe(updatedTitle);
+      });
+    });
   });
 
   describe('Globals - GraphQL', () => {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -62,7 +62,10 @@ describe('Versions', () => {
 
         collectionLocalPostID = autosavePost.id;
 
-        const updatedPost = await payload.update({
+        const updatedPost: {
+          title: string
+          _status?: string
+        } = await payload.update({
           id: collectionLocalPostID,
           collection,
           data: {
@@ -541,6 +544,48 @@ describe('Versions', () => {
         const response = await graphQLClient.request(query);
         const data = response.AutosaveGlobal;
         expect(data.title).toStrictEqual(globalGraphQLOriginalTitle);
+      });
+    });
+
+    describe('Update', () => {
+      it('should allow a draft to be patched', async () => {
+        const originalTitle = 'Here is a published post';
+
+        const originalPublishedPost = await payload.create({
+          collection,
+          data: {
+            title: originalTitle,
+            description: 'kjnjyhbbdsfseankuhsjsfghb',
+            _status: 'published',
+          },
+        });
+
+        const updatedTitle = 'Here is a draft post with a patched title';
+
+        collectionLocalPostID = originalPublishedPost.id;
+
+        await payload.update({
+          id: collectionLocalPostID,
+          collection,
+          data: {
+            title: updatedTitle,
+          },
+          draft: true,
+        });
+
+        const publishedPost = await payload.findByID({
+          collection,
+          id: collectionLocalPostID,
+        });
+
+        const draftPost = await payload.findByID({
+          collection,
+          id: collectionLocalPostID,
+          draft: true,
+        });
+
+        expect(publishedPost.title).toBe(originalTitle);
+        expect(draftPost.title).toBe(updatedTitle);
       });
     });
   });

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -2,7 +2,7 @@ import { request, GraphQLClient } from 'graphql-request';
 import { initPayloadTest } from '../helpers/configHelpers';
 import payload from '../../src';
 import config from './config';
-import DraftPosts from './collections/Autosave';
+import AutosavePosts from './collections/Autosave';
 import AutosaveGlobal from './globals/Autosave';
 import { devUser } from '../credentials';
 
@@ -18,7 +18,7 @@ let collectionGraphQLPostID;
 let collectionGraphQLVersionID;
 const collectionGraphQLOriginalTitle = 'autosave title';
 
-const collection = DraftPosts.slug;
+const collection = AutosavePosts.slug;
 const globalSlug = AutosaveGlobal.slug;
 
 let globalLocalVersionID;
@@ -198,6 +198,48 @@ describe('Versions', () => {
         });
 
         expect(restoredPost.title).toBe(restore.title);
+      });
+    });
+
+    describe('Update', () => {
+      it('should allow a draft to be patched', async () => {
+        const originalTitle = 'Here is a published post';
+
+        const originalPublishedPost = await payload.create({
+          collection,
+          data: {
+            title: originalTitle,
+            description: 'kjnjyhbbdsfseankuhsjsfghb',
+            _status: 'published',
+          },
+        });
+
+        const updatedTitle = 'Here is a draft post with a patched title';
+
+        collectionLocalPostID = originalPublishedPost.id;
+
+        await payload.update({
+          id: collectionLocalPostID,
+          collection,
+          data: {
+            title: updatedTitle,
+          },
+          draft: true,
+        });
+
+        const publishedPost = await payload.findByID({
+          collection,
+          id: collectionLocalPostID,
+        });
+
+        const draftPost = await payload.findByID({
+          collection,
+          id: collectionLocalPostID,
+          draft: true,
+        });
+
+        expect(publishedPost.title).toBe(originalTitle);
+        expect(draftPost.title).toBe(updatedTitle);
       });
     });
   });
@@ -544,48 +586,6 @@ describe('Versions', () => {
         const response = await graphQLClient.request(query);
         const data = response.AutosaveGlobal;
         expect(data.title).toStrictEqual(globalGraphQLOriginalTitle);
-      });
-    });
-
-    describe('Update', () => {
-      it('should allow a draft to be patched', async () => {
-        const originalTitle = 'Here is a published post';
-
-        const originalPublishedPost = await payload.create({
-          collection,
-          data: {
-            title: originalTitle,
-            description: 'kjnjyhbbdsfseankuhsjsfghb',
-            _status: 'published',
-          },
-        });
-
-        const updatedTitle = 'Here is a draft post with a patched title';
-
-        collectionLocalPostID = originalPublishedPost.id;
-
-        await payload.update({
-          id: collectionLocalPostID,
-          collection,
-          data: {
-            title: updatedTitle,
-          },
-          draft: true,
-        });
-
-        const publishedPost = await payload.findByID({
-          collection,
-          id: collectionLocalPostID,
-        });
-
-        const draftPost = await payload.findByID({
-          collection,
-          id: collectionLocalPostID,
-          draft: true,
-        });
-
-        expect(publishedPost.title).toBe(originalTitle);
-        expect(draftPost.title).toBe(updatedTitle);
       });
     });
   });


### PR DESCRIPTION
## Description

Closes issue #1415 by forcing `_status: 'draft'` when creating versions. Also flattens locales before auto-saving previously published docs as version.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
