### PR TITLE
fix: sanitizes null select value on the server

### DIFF
--- a/src/fields/hooks/beforeChange/promise.ts
+++ b/src/fields/hooks/beforeChange/promise.ts
@@ -154,6 +154,14 @@ export const promise = async ({
   }
 
   switch (field.type) {
+    case 'select': {
+      if (siblingData[field.name] === null) {
+        siblingData[field.name] = undefined;
+      }
+
+      break;
+    }
+
     case 'point': {
       // Transform point data for storage
       if (Array.isArray(siblingData[field.name]) && siblingData[field.name][0] !== null && siblingData[field.name][1] !== null) {


### PR DESCRIPTION
## Description
Fixes #1424 
Allows `isClearable` Select inputs to be cleared without validation errors.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
