### PR TITLE
docs: add missing S in example of i18n

### DIFF
--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -19,7 +19,7 @@ const Articles: CollectionConfig = {
       en: 'Article', es: 'Artículo',
     },
     plural: {
-      en: 'Articles', es: 'Artículo',
+      en: 'Articles', es: 'Artículos',
     },
   },
   admin: {


### PR DESCRIPTION
## Description

The translation for "articles" in Spanish is "artículos" (plural), not "artículo" (singular). The S is missing.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
