### PR TITLE
Fix/#1479 edit view sidebar styles

### DIFF
--- a/src/admin/components/views/Global/index.scss
+++ b/src/admin/components/views/Global/index.scss
@@ -29,17 +29,6 @@
     margin-top: base(.25);
   }
 
-  &__collection-actions {
-    list-style: none;
-    margin: 0;
-    padding: base(1.5) 0 base(.5);
-    display: flex;
-
-    li {
-      margin-right: base(.75);
-    }
-  }
-
   &__edit {
     padding-top: base(1);
     padding-bottom: base(2);
@@ -72,6 +61,17 @@
   &__meta,
   &__sidebar-fields {
     padding-left: base(1.5);
+  }
+
+  &__sidebar-fields {
+    padding-right: $baseline;
+    margin-bottom: base(1);
+
+    .preview-btn {
+      display: inline-block;
+      margin-top: 0;
+      width: calc(50% - #{base(.5)});
+    }
   }
 
   &__document-actions {
@@ -113,7 +113,6 @@
 
   &__api-url {
     margin-bottom: base(1.5);
-    padding-right: base(1.5);
 
     a {
       display: block;
@@ -125,10 +124,15 @@
   &__meta {
     margin: auto 0 $baseline;
     padding-top: $baseline;
+    padding-right: $baseline;
     list-style: none;
 
     li {
       margin-bottom: base(.5);
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
   }
 
@@ -136,7 +140,6 @@
     color: var(--theme-elevation-400);
   }
 
-  &__collection-actions,
   &__api-url {
 
     a,
@@ -169,6 +172,10 @@
       height: initial;
     }
 
+    &__meta {
+      border-top: 1px solid var(--theme-elevation-100);
+    }
+
     &__form {
       display: block;
     }
@@ -190,24 +197,24 @@
     &__meta,
     &__sidebar-fields {
       padding-left: var(--gutter-h);
+      padding-right: var(--gutter-h);
+    }
+
+    &__sidebar-fields {
+      margin-bottom: base(1);
+      padding-top: base(1);
+
+      .preview-btn {
+        width: 100%;
+      }
     }
 
     &__api-url {
       margin-bottom: base(.5);
     }
 
-    &__collection-actions {
-      border-top: 1px solid var(--theme-elevation-100);
-      padding: base(1) 0 0 base(1);
-      order: 1;
-
-      li {
-        margin: 0 base(.5) 0 0;
-      }
-    }
-
     &__sidebar {
-      padding-bottom: base(4);
+      padding-bottom: base(3.5);
     }
 
     &__sidebar-sticky {

--- a/src/admin/components/views/collections/Edit/index.scss
+++ b/src/admin/components/views/collections/Edit/index.scss
@@ -108,7 +108,6 @@
 
   &__api-url {
     margin-bottom: base(1.5);
-    padding-right: base(1.5);
 
     a {
       display: block;
@@ -119,6 +118,7 @@
 
   &__sidebar-fields {
     padding-right: $baseline;
+    margin-bottom: base(1);
 
     .preview-btn {
       display: inline-block;
@@ -130,10 +130,15 @@
   &__meta {
     margin: auto 0 $baseline 0;
     padding-top: $baseline;
+    padding-right: $baseline;
     list-style: none;
 
     li {
       margin-bottom: base(.5);
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
   }
 
@@ -174,6 +179,11 @@
       height: initial;
     }
 
+    &__meta {
+      border-top: 1px solid var(--theme-elevation-100);
+      padding-right: var(--gutter-h);
+    }
+
     &__form {
       display: block;
     }
@@ -196,9 +206,14 @@
     &__meta,
     &__sidebar-fields {
       padding-left: var(--gutter-h);
+      padding-right: var(--gutter-h);
     }
 
     &__sidebar-fields {
+      margin-bottom: base(1);
+      padding-top: base(1);
+      padding-right: var(--gutter-h);
+
       .preview-btn {
         width: 100%;
       }
@@ -206,7 +221,7 @@
 
     &__collection-actions {
       border-top: 1px solid var(--theme-elevation-100);
-      padding: base(1) 0 0 base(1);
+      padding: base(1) 0 0 var(--gutter-h);
       order: 1;
 
       li {
@@ -215,7 +230,7 @@
     }
 
     &__sidebar {
-      padding-bottom: base(4);
+      padding-bottom: base(3.5);
     }
   }
 }

--- a/test/versions/globals/Autosave.ts
+++ b/test/versions/globals/Autosave.ts
@@ -3,6 +3,7 @@ import { GlobalConfig } from '../../../src/globals/config/types';
 const AutosaveGlobal: GlobalConfig = {
   slug: 'autosave-global',
   label: 'Autosave Global',
+  preview: () => 'https://payloadcms.com',
   versions: {
     max: 20,
     drafts: {

--- a/test/versions/globals/Draft.ts
+++ b/test/versions/globals/Draft.ts
@@ -3,6 +3,7 @@ import { GlobalConfig } from '../../../src/globals/config/types';
 const DraftGlobal: GlobalConfig = {
   slug: 'draft-global',
   label: 'Draft Global',
+  preview: () => 'https://payloadcms.com',
   versions: {
     max: 20,
     drafts: true,


### PR DESCRIPTION
## Description

Fixes #1479 
Corrects preview button being cut off, along with misc css updates to edit view sidebar
- adjusts gutters on mobile to align with other content on the page
- removes `collection` scoped classes from globals stylesheet
- adds top border for sidebar meta on mobile to separate it from the other sidebar content

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Style change
