### PR TITLE
feat: dynamic relationship `filterOptions`

### DIFF
--- a/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
+++ b/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
@@ -30,16 +30,16 @@ const optionsReducer = (state: Option[], action: Action): Option[] => {
     }
 
     case 'ADD': {
-      const { hasMultipleRelations, collection, docs, sort, ids = [], i18n } = action;
+      const { hasMultipleRelations, collection, docs, sort, ids = [], i18n, reset } = action;
       const relation = collection.slug;
 
       const labelKey = collection.admin.useAsTitle || 'id';
 
-      const loadedIDs = reduceToIDs(state);
+      const loadedIDs = reduceToIDs(!reset ? state : []);
 
       if (!hasMultipleRelations) {
         const options = [
-          ...state,
+          ...!reset ? state : [],
           ...docs.reduce((docOptions, doc) => {
             if (loadedIDs.indexOf(doc.id) === -1) {
               loadedIDs.push(doc.id);
@@ -67,7 +67,7 @@ const optionsReducer = (state: Option[], action: Action): Option[] => {
         return sort ? sortOptions(options) : options;
       }
 
-      const newOptions = [...state];
+      const newOptions = !reset ? [...state] : [];
       const optionsToAddTo = newOptions.find((optionGroup) => optionGroup.label === collection.labels.plural);
 
       const newSubOptions = docs.reduce((docSubOptions, doc) => {

--- a/src/admin/components/forms/field-types/Relationship/types.ts
+++ b/src/admin/components/forms/field-types/Relationship/types.ts
@@ -25,6 +25,7 @@ type ADD = {
   sort?: boolean
   ids?: unknown[]
   i18n: typeof i18n
+  reset?: boolean
 }
 
 export type Action = CLEAR | ADD
@@ -40,4 +41,5 @@ export type GetResults = (args: {
   search?: string
   value?: unknown
   sort?: boolean
+  reset?: boolean
 }) => Promise<void>

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -2,7 +2,7 @@
 import { CSSProperties } from 'react';
 import { Editor } from 'slate';
 import type { TFunction } from 'i18next';
-import { Operation, Where } from '../../types';
+import { Document, Operation, Where } from '../../types';
 import { TypeWithID } from '../../collections/config/types';
 import { PayloadRequest } from '../../express/types';
 import { ConditionalDateProps } from '../../admin/components/elements/DatePicker/types';
@@ -45,15 +45,15 @@ export type FieldAccess<T extends TypeWithID = any, P = any, U = any> = (args: {
 
 export type Condition<T extends TypeWithID = any, P = any> = (data: Partial<T>, siblingData: Partial<P>) => boolean;
 
-export type FilterOptionsProps = {
+export type FilterOptionsProps<T = any> = {
   id: string | number,
   user: Partial<User>,
-  data: unknown,
+  data: T,
   siblingData: unknown,
   relationTo: string | string[],
 }
 
-export type FilterOptions = Where | ((options: FilterOptionsProps) => Where);
+export type FilterOptions<T = any> = Where | ((options: FilterOptionsProps<T>) => Where);
 
 type Admin = {
   position?: 'sidebar';

--- a/test/relationships/config.ts
+++ b/test/relationships/config.ts
@@ -109,11 +109,13 @@ export default buildConfig({
           name: 'filteredBySibling',
           type: 'relationship',
           relationTo: relationSlug,
-          filterOptions: (args: FilterOptionsProps<Post>) => ({
-            id: {
-              equals: args?.data?.filteredRelation,
-            },
-          }),
+          filterOptions: (args: FilterOptionsProps<Post>) => {
+            return ({
+              id: {
+                equals: args?.data?.filteredRelation,
+              },
+            });
+          },
         },
       ],
     },
@@ -181,14 +183,21 @@ export default buildConfig({
     const rel1 = await payload.create<Relation>({
       collection: relationSlug,
       data: {
-        name: 'name',
+        name: 'Relation 1',
       },
     });
 
-    const filteredRelation = await payload.create<Relation>({
+    const rel2 = await payload.create<Relation>({
       collection: relationSlug,
       data: {
-        name: 'filtered',
+        name: 'Relation 2',
+      },
+    });
+
+    const rel3 = await payload.create<Relation>({
+      collection: relationSlug,
+      data: {
+        name: 'Relation 3',
       },
     });
 
@@ -259,7 +268,7 @@ export default buildConfig({
         maxDepthRelation: rel1.id,
         customIdRelation: customIdRelation.id,
         customIdNumberRelation: customIdNumberRelation.id,
-        filteredRelation: filteredRelation.id,
+        filteredRelation: rel2.id,
       },
     });
   },

--- a/test/relationships/config.ts
+++ b/test/relationships/config.ts
@@ -3,6 +3,7 @@ import { devUser } from '../credentials';
 import { buildConfig } from '../buildConfig';
 import type { CustomIdNumberRelation, CustomIdRelation, Post, Relation } from './payload-types';
 import { ChainedRelation } from './payload-types';
+import { FilterOptions, FilterOptionsProps } from '../../src/fields/config/types';
 
 const openAccess = {
   create: () => true,
@@ -17,6 +18,9 @@ const collectionWithName = (collectionSlug: string): CollectionConfig => {
   return {
     slug: collectionSlug,
     access: openAccess,
+    admin: {
+      useAsTitle: 'name',
+    },
     fields: [
       {
         name: 'name',
@@ -100,6 +104,16 @@ export default buildConfig({
               not_equals: true,
             },
           },
+        },
+        {
+          name: 'filteredBySibling',
+          type: 'relationship',
+          relationTo: relationSlug,
+          filterOptions: (args: FilterOptionsProps<Post>) => ({
+            id: {
+              equals: args?.data?.filteredRelation,
+            },
+          }),
         },
       ],
     },

--- a/test/relationships/payload-types.ts
+++ b/test/relationships/payload-types.ts
@@ -22,6 +22,7 @@ export interface Post {
   customIdRelation?: string | CustomIdRelation;
   customIdNumberRelation?: number | CustomIdNumberRelation;
   filteredRelation?: string | Relation;
+  filteredBySibling?: string | Relation;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Description

WIP

Resolves #1454 by passing live document data through the `filterOptions` method on relationship fields. This is a WIP because #1475 should be merged in before work on this continues, in order to avoid significant merge conflicts. Performance implications also need to be thoroughly vetted.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
