### PR TITLE
Fix/#1446 graphql `contains` schema

### DIFF
--- a/src/graphql/schema/fieldToWhereInputSchemaMap.ts
+++ b/src/graphql/schema/fieldToWhereInputSchemaMap.ts
@@ -45,7 +45,7 @@ const fieldToSchemaMap: (parentName: string) => any = (parentName: string) => ({
         field,
         type,
         parentName,
-        [...operators.equality, 'like', ...operators.contains],
+        [...operators.equality, ...operators.partial, ...operators.contains],
       ),
     };
   },
@@ -56,7 +56,7 @@ const fieldToSchemaMap: (parentName: string) => any = (parentName: string) => ({
         field,
         type,
         parentName,
-        [...operators.equality, 'like', ...operators.contains],
+        [...operators.equality, ...operators.partial, ...operators.contains],
       ),
     };
   },
@@ -67,7 +67,7 @@ const fieldToSchemaMap: (parentName: string) => any = (parentName: string) => ({
         field,
         type,
         parentName,
-        [...operators.equality, 'like', 'contains'],
+        [...operators.equality, ...operators.partial],
       ),
     };
   },
@@ -78,7 +78,7 @@ const fieldToSchemaMap: (parentName: string) => any = (parentName: string) => ({
         field,
         type,
         parentName,
-        [...operators.equality, 'like', 'contains'],
+        [...operators.equality, ...operators.partial],
       ),
     };
   },
@@ -89,7 +89,7 @@ const fieldToSchemaMap: (parentName: string) => any = (parentName: string) => ({
         field,
         type,
         parentName,
-        [...operators.equality, 'like', 'contains'],
+        [...operators.equality, ...operators.partial],
       ),
     };
   },
@@ -117,7 +117,7 @@ const fieldToSchemaMap: (parentName: string) => any = (parentName: string) => ({
         }, {}),
       }),
       parentName,
-      [...operators.equality, 'like', ...operators.contains],
+      [...operators.equality, ...operators.contains],
     ),
   }),
   date: (field: DateField) => {

--- a/src/graphql/schema/fieldToWhereInputSchemaMap.ts
+++ b/src/graphql/schema/fieldToWhereInputSchemaMap.ts
@@ -45,7 +45,7 @@ const fieldToSchemaMap: (parentName: string) => any = (parentName: string) => ({
         field,
         type,
         parentName,
-        [...operators.equality, 'like', 'contains'],
+        [...operators.equality, 'like', ...operators.contains],
       ),
     };
   },
@@ -56,7 +56,7 @@ const fieldToSchemaMap: (parentName: string) => any = (parentName: string) => ({
         field,
         type,
         parentName,
-        [...operators.equality, 'like', 'contains'],
+        [...operators.equality, 'like', ...operators.contains],
       ),
     };
   },
@@ -117,7 +117,7 @@ const fieldToSchemaMap: (parentName: string) => any = (parentName: string) => ({
         }, {}),
       }),
       parentName,
-      [...operators.equality, 'like', 'contains'],
+      [...operators.equality, 'like', ...operators.contains],
     ),
   }),
   date: (field: DateField) => {

--- a/src/graphql/schema/operators.ts
+++ b/src/graphql/schema/operators.ts
@@ -1,6 +1,6 @@
 const operators = {
   equality: ['equals', 'not_equals'],
-  contains: ['in', 'not_in', 'all'],
+  contains: ['contains', 'in', 'not_in', 'all'],
   comparison: ['greater_than_equal', 'greater_than', 'less_than_equal', 'less_than'],
   geo: ['near'],
 };

--- a/src/graphql/schema/operators.ts
+++ b/src/graphql/schema/operators.ts
@@ -1,6 +1,7 @@
 const operators = {
   equality: ['equals', 'not_equals'],
-  contains: ['contains', 'in', 'not_in', 'all'],
+  partial: ['like', 'contains'],
+  contains: ['in', 'not_in', 'all'],
   comparison: ['greater_than_equal', 'greater_than', 'less_than_equal', 'less_than'],
   geo: ['near'],
 };


### PR DESCRIPTION
## Description

Fixes #1446 
Allows partial operators to be used on `email/text/textarea` fields via graphql.
Removes contain operator from `select/radio`, since graphql is strict with enums.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
