### PR TITLE
docs: rateLimit defaults

### DIFF
--- a/docs/production/preventing-abuse.mdx
+++ b/docs/production/preventing-abuse.mdx
@@ -18,12 +18,12 @@ Set the max number of failed login attempts before a user account is locked out 
 
 To prevent DDoS, brute-force, and similar attacks, you can set IP-based rate limits so that once a certain threshold of requests has been hit by a single IP, further requests from the same IP will be ignored. The Payload config `rateLimit` property accepts an object with the following properties:
 
-| Option                       | Description  |
-| ---------------------------- | -------------|
-| **`window`**                 | Time in milliseconds to track requests per IP |
-| **`max`**                    | Number of requests served from a single IP before limiting |
-| **`skip`**                   | Express middleware function that can return true (or promise resulting in true) that will bypass limit |
-| **`trustProxy`**             | True or false, to enable to allow requests to pass through a proxy such as a load balancer or an `nginx` reverse proxy |
+| Option                       | Description |
+| ---------------------------- | ----------- |
+| **`window`**                 | Time in milliseconds to track requests per IP. Defaults to `90000` (15 minutes). |
+| **`max`**                    | Number of requests served from a single IP before limiting. Defaults to `500`. |
+| **`skip`**                   | Express middleware function that can return true (or promise resulting in true) that will bypass limit. |
+| **`trustProxy`**             | True or false, to enable to allow requests to pass through a proxy such as a load balancer or an `nginx` reverse proxy. |
 
 <Banner type="warning">
   <strong>Warning:</strong><br/>


### PR DESCRIPTION
## Description

Includes the [rateLimit defaults](https://github.com/payloadcms/payload/blob/a0d03667c5a91c81eceefc39039577eff8eea8b1/src/config/defaults.ts#L43) in the `preventing-abuse.mdx` documentation.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
