### PR TITLE
fix: updates syntax colors for light theme

### DIFF
--- a/src/admin/components/forms/field-types/Code/Code.tsx
+++ b/src/admin/components/forms/field-types/Code/Code.tsx
@@ -17,6 +17,7 @@ import Error from '../../Error';
 import FieldDescription from '../../FieldDescription';
 import { code } from '../../../../../fields/validations';
 import { Props } from './types';
+import { useTheme } from '../../../utilities/Theme';
 
 import './index.scss';
 
@@ -63,12 +64,16 @@ const Code: React.FC<Props> = (props) => {
     condition,
   });
 
+
+  const { theme } = useTheme();
+
   const classes = [
     'field-type',
     'code',
     className,
     showError && 'error',
     readOnly && 'read-only',
+    theme && theme,
   ].filter(Boolean).join(' ');
 
   return (

--- a/src/admin/components/forms/field-types/Code/Code.tsx
+++ b/src/admin/components/forms/field-types/Code/Code.tsx
@@ -17,9 +17,10 @@ import Error from '../../Error';
 import FieldDescription from '../../FieldDescription';
 import { code } from '../../../../../fields/validations';
 import { Props } from './types';
-import { useTheme } from '../../../utilities/Theme';
 
 import './index.scss';
+
+const baseClass = 'code-field';
 
 const Code: React.FC<Props> = (props) => {
   const {
@@ -65,8 +66,8 @@ const Code: React.FC<Props> = (props) => {
   });
 
   const classes = [
+    baseClass,
     'field-type',
-    'code',
     className,
     showError && 'error',
     readOnly && 'read-only',
@@ -90,7 +91,7 @@ const Code: React.FC<Props> = (props) => {
         required={required}
       />
       <Editor
-        className="input"
+        className={`${baseClass}__input`}
         id={`field-${path.replace(/\./gi, '__')}`}
         value={value as string || ''}
         onValueChange={readOnly ? () => null : setValue}

--- a/src/admin/components/forms/field-types/Code/Code.tsx
+++ b/src/admin/components/forms/field-types/Code/Code.tsx
@@ -64,16 +64,12 @@ const Code: React.FC<Props> = (props) => {
     condition,
   });
 
-
-  const { theme } = useTheme();
-
   const classes = [
     'field-type',
     'code',
     className,
     showError && 'error',
     readOnly && 'read-only',
-    theme && theme,
   ].filter(Boolean).join(' ');
 
   return (
@@ -94,14 +90,13 @@ const Code: React.FC<Props> = (props) => {
         required={required}
       />
       <Editor
+        className="input"
         id={`field-${path.replace(/\./gi, '__')}`}
         value={value as string || ''}
         onValueChange={readOnly ? () => null : setValue}
         highlight={highlighter}
         padding={25}
         style={{
-          backgroundColor: 'var(--theme-base-850)',
-          color: 'var(--theme-base-0)',
           fontFamily: '"Consolas", "Monaco", monospace',
           fontSize: 12,
           pointerEvents: readOnly ? 'none' : 'auto',

--- a/src/admin/components/forms/field-types/Code/index.scss
+++ b/src/admin/components/forms/field-types/Code/index.scss
@@ -4,6 +4,11 @@
   position: relative;
   margin-bottom: $baseline;
 
+  .input {
+    @include formInput();
+    height: unset;
+  }
+
   &.error {
     textarea {
       border: 1px solid var(--theme-error-500) !important;
@@ -66,7 +71,7 @@ pre[class*="language-"] {
   font-style: italic;
 }
 
-.dark {
+html[data-theme=dark] {
 
   :not(pre)>code[class*="language-"],
   pre[class*="language-"] {
@@ -158,7 +163,7 @@ pre[class*="language-"] {
   }
 }
 
-.light {
+html[data-theme=light] {
 
   .token.comment,
   .token.prolog,

--- a/src/admin/components/forms/field-types/Code/index.scss
+++ b/src/admin/components/forms/field-types/Code/index.scss
@@ -47,103 +47,14 @@ pre[class*="language-"] {
   border-radius: 0.3em;
 }
 
-:not(pre)>code[class*="language-"],
-pre[class*="language-"] {
-  background: var(--theme-base-100);
-}
-
 /* Inline code */
 :not(pre)>code[class*="language-"] {
   padding: 0.1em;
   border-radius: 0.3em;
 }
 
-.token.comment,
-.token.prolog,
-.token.doctype,
-.token.cdata {
-  color: #7c7c7c;
-}
-
-.token.punctuation {
-  color: #c5c8c6;
-}
-
 .namespace {
   opacity: 0.7;
-}
-
-.token.property,
-.token.keyword,
-.token.tag {
-  color: #96cbfe;
-}
-
-.token.class-name {
-  color: #ffffb6;
-  text-decoration: underline;
-}
-
-.token.boolean,
-.token.constant {
-  color: #99cc99;
-}
-
-.token.symbol,
-.token.deleted {
-  color: #f92672;
-}
-
-.token.number {
-  color: #ff73fd;
-}
-
-.token.selector,
-.token.attr-name,
-.token.string,
-.token.char,
-.token.builtin,
-.token.inserted {
-  color: #a8ff60;
-}
-
-.token.variable {
-  color: #c6c5fe;
-}
-
-.token.operator {
-  color: #ededed;
-}
-
-.token.entity {
-  color: #ffffb6;
-  cursor: help;
-}
-
-.token.url {
-  color: #96cbfe;
-}
-
-.language-css .token.string,
-.style .token.string {
-  color: #87c38a;
-}
-
-.token.atrule,
-.token.attr-value {
-  color: #f9ee98;
-}
-
-.token.function {
-  color: #dad085;
-}
-
-.token.regex {
-  color: #e9c062;
-}
-
-.token.important {
-  color: #fd971f;
 }
 
 .token.important,
@@ -153,4 +64,183 @@ pre[class*="language-"] {
 
 .token.italic {
   font-style: italic;
+}
+
+.dark {
+
+  :not(pre)>code[class*="language-"],
+  pre[class*="language-"] {
+    background: var(--theme-base-100);
+  }
+
+  .token.comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata {
+    color: #7c7c7c;
+  }
+
+  .token.punctuation {
+    color: #c5c8c6;
+  }
+
+  .token.property,
+  .token.keyword,
+  .token.tag {
+    color: #96cbfe;
+  }
+
+  .token.class-name {
+    color: #ffffb6;
+    text-decoration: underline;
+  }
+
+  .token.boolean,
+  .token.constant {
+    color: #99cc99;
+  }
+
+  .token.symbol,
+  .token.deleted {
+    color: #f92672;
+  }
+
+  .token.number {
+    color: #ff73fd;
+  }
+
+  .token.selector,
+  .token.attr-name,
+  .token.string,
+  .token.char,
+  .token.builtin,
+  .token.inserted {
+    color: #a8ff60;
+  }
+
+  .token.variable {
+    color: #c6c5fe;
+  }
+
+  .token.operator {
+    color: #ededed;
+  }
+
+  .token.entity {
+    color: #ffffb6;
+    cursor: help;
+  }
+
+  .token.url {
+    color: #96cbfe;
+  }
+
+  .language-css .token.string,
+  .style .token.string {
+    color: #87c38a;
+  }
+
+  .token.atrule,
+  .token.attr-value {
+    color: #f9ee98;
+  }
+
+  .token.function {
+    color: #dad085;
+  }
+
+  .token.regex {
+    color: #e9c062;
+  }
+
+  .token.important {
+    color: #fd971f;
+  }
+}
+
+.light {
+
+  .token.comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata {
+    color: #666666;
+  }
+
+  .token.punctuation {
+    color: #797979;
+  }
+
+  .token.property,
+  .token.keyword,
+  .token.tag {
+    color: #0167c5;
+  }
+
+  .token.class-name {
+    color: #b2ac00;
+    text-decoration: underline;
+  }
+
+  .token.boolean,
+  .token.constant {
+    color: #008600;
+  }
+
+  .token.symbol,
+  .token.deleted {
+    color: #ab003f;
+  }
+
+  .token.number {
+    color: #970195;
+  }
+
+  .token.selector,
+  .token.attr-name,
+  .token.string,
+  .token.char,
+  .token.builtin,
+  .token.inserted {
+    color: #418c03;
+  }
+
+  .token.variable {
+    color: #4643e3;
+  }
+
+  .token.operator {
+    color: #3c3c3c;
+  }
+
+  .token.entity {
+    color: #b2ac00;
+    cursor: help;
+  }
+
+  .token.url {
+    color: #0084ff;
+  }
+
+  .language-css .token.string,
+  .style .token.string {
+    color: #386b3a;
+  }
+
+  .token.atrule,
+  .token.attr-value {
+    color: #b5a108;
+  }
+
+  .token.function {
+    color: #8c1aea;
+  }
+
+  .token.regex {
+    color: #e5a205;
+  }
+
+  .token.important {
+    color: #ac0900;
+  }
 }

--- a/src/admin/components/forms/field-types/Code/index.scss
+++ b/src/admin/components/forms/field-types/Code/index.scss
@@ -1,10 +1,10 @@
 @import '../../../../scss/styles.scss';
 
-.field-type.code {
+.code-field {
   position: relative;
   margin-bottom: $baseline;
 
-  .input {
+  &__input {
     @include formInput();
     height: unset;
   }
@@ -70,6 +70,8 @@ pre[class*="language-"] {
 .token.italic {
   font-style: italic;
 }
+
+// DARK
 
 html[data-theme=dark] {
 
@@ -162,6 +164,8 @@ html[data-theme=dark] {
     color: #fd971f;
   }
 }
+
+// LIGHT
 
 html[data-theme=light] {
 


### PR DESCRIPTION
## Description

Syntax colors are not suitable while using the Light theme - reported in [issue #1425](https://github.com/payloadcms/payload/issues/1425).

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes - test suite used: **Fields**

Screenshot below shows the updated colors:
<img width="584" alt="Screen Shot 2022-11-28 at 4 26 22 PM" src="https://user-images.githubusercontent.com/67977755/204329562-3ee9ebc5-f566-47b3-a912-3e51b0984327.png">
