### PR TITLE
feat: adds copy paste upload ability

### DIFF
--- a/src/admin/components/views/collections/Edit/Upload/index.scss
+++ b/src/admin/components/views/collections/Edit/Upload/index.scss
@@ -28,13 +28,17 @@
     padding: base(2);
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
   }
 
   &__drop-zone {
     border: 1px dotted var(--theme-elevation-400);
+    justify-content: center;
+
 
     .btn {
-      margin: 0 $baseline 0 0;
+      margin: base(.25) base(.5);
+      width: 150px;
     }
   }
 
@@ -57,6 +61,39 @@
     }
   }
 
+  &__or-other-options-container {
+    display: flex;
+    align-items: center;
+    margin: base(.25) base(.5);
+
+    p {
+      margin: 0;
+    }
+  }
+
+  &__or-text {
+    margin: 0;
+    font-size: 16px;
+    text-transform: uppercase;
+  }
+
+  &__other-options {
+    display: flex;
+    flex-direction: column;
+    margin-left: base(1);
+    align-items: center;
+
+    :first-child {
+      border-bottom: 1px solid;
+    }
+
+    :last-child {
+      border-top: 1px solid;
+      position: relative;
+      top: -1px;
+    }
+  }
+
   @include mid-break {
     &__drop-zone {
       display: block;
@@ -64,9 +101,11 @@
 
       .btn {
         margin: 0 auto;
+        width: 100%;
+        max-width: 200px;
       }
 
-      .file-field__drag-label {
+      .file-field__or-other-options-container {
         display: none;
       }
     }

--- a/src/admin/components/views/collections/Edit/Upload/index.tsx
+++ b/src/admin/components/views/collections/Edit/Upload/index.tsx
@@ -164,23 +164,38 @@ const Upload: React.FC<Props> = (props) => {
               />
             </div>
           )}
+
           {!value && (
             <React.Fragment>
               <div
                 className={`${baseClass}__drop-zone`}
                 ref={dropRef}
+                onPaste={(e) => {
+                  if (e?.clipboardData?.files.length) {
+                    const fileObject = e.clipboardData.files[0];
+                    setValue(fileObject || null);
+                  }
+                }}
               >
                 <Button
                   size="small"
                   buttonStyle="secondary"
                   onClick={() => setSelectingFile(true)}
+                  className={`${baseClass}__file-button`}
                 >
                   {t('selectFile')}
                 </Button>
-                <span className={`${baseClass}__drag-label`}>{t('dragAndDropHere')}</span>
+                <div className={`${baseClass}__or-other-options-container`}>
+                  <p className={`${baseClass}__or-text`}>{t('general:or')}</p>
+                  <div className={`${baseClass}__other-options`}>
+                    <p>{t('dragAndDrop')}</p>
+                    <p>{t('copyAndPaste')}</p>
+                  </div>
+                </div>
               </div>
             </React.Fragment>
           )}
+
           <input
             ref={inputRef}
             type="file"

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -217,6 +217,8 @@
     "moreInfo": "Mehr Info",
     "selectCollectionToBrowse": "Wähle eine Sammlung zum Durchsuchen aus",
     "selectFile": "Datei auswählen",
+    "dragAndDrop": "Ziehen Sie eine Datei per Drag-and-Drop",
+    "copyAndPaste": "Kopieren Sie eine Datei und fügen Sie sie ein",
     "sizes": "Größen",
     "width": "Breite"
   },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -218,6 +218,8 @@
     "moreInfo": "More info",
     "selectCollectionToBrowse": "Select a Collection to Browse",
     "selectFile": "Select a file",
+    "dragAndDrop": "Drag and drop a file",
+    "copyAndPaste": "Copy and paste a file",
     "sizes": "Sizes",
     "width": "Width"
   },

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -217,6 +217,8 @@
     "moreInfo": "Más info",
     "selectCollectionToBrowse": "Selecciona una Colección",
     "selectFile": "Selecciona un archivo",
+    "dragAndDrop": "Arrastra y suelta un archivo",
+    "copyAndPaste": "Copiar y pegar un archivo",
     "sizes": "Sizes",
     "width": "Width"
   },

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -218,6 +218,8 @@
     "moreInfo": "Plus d'infos",
     "selectCollectionToBrowse": "Sélectionnez une collection à parcourir",
     "selectFile": "Sélectionnez un fichier",
+    "dragAndDrop": "Glisser-déposer un fichier",
+    "copyAndPaste": "Copier et coller un fichier",
     "sizes": "Tailles",
     "width": "Largeur"
   },

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -218,6 +218,8 @@
     "moreInfo": "Più info",
     "selectCollectionToBrowse": "Seleziona una Collezione da Sfogliare",
     "selectFile": "Seleziona un file",
+    "dragAndDrop": "Trascina e rilascia un file",
+    "copyAndPaste": "Copia e incolla un file",
     "sizes": "Formati",
     "width": "Larghezza"
   },

--- a/src/translations/ja.json
+++ b/src/translations/ja.json
@@ -217,6 +217,8 @@
     "moreInfo": "詳細を表示",
     "selectCollectionToBrowse": "閲覧するコレクションを選択",
     "selectFile": "ファイルを選択",
+    "dragAndDrop": "ファイルをドラッグ アンド ドロップする",
+    "copyAndPaste": "ファイルをコピーして貼り付ける",
     "sizes": "容量",
     "width": "横幅"
   },

--- a/src/translations/my.json
+++ b/src/translations/my.json
@@ -217,6 +217,8 @@
     "moreInfo": "More info",
     "selectCollectionToBrowse": "စုစည်းမှု တစ်ခုခုကို ရွေးချယ်ပါ။",
     "selectFile": "ဖိုင်ရွေးပါ။",
+    "dragAndDrop": "ဖိုင်တစ်ဖိုင်ကို ဆွဲချလိုက်ပါ။",
+    "copyAndPaste": "ဖိုင်တစ်ခုကို ကော်ပီကူးထည့်ပါ။",
     "sizes": "အရွယ်အစားများ",
     "width": "အကျယ်"
   },

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -218,6 +218,8 @@
     "moreInfo": "Meer info",
     "selectCollectionToBrowse": "Selecteer een collectie om door te bladeren",
     "selectFile": "Selecteer een bestand",
+    "dragAndDrop": "Sleep een bestand",
+    "copyAndPaste": "Kopieer en plak een bestand",
     "sizes": "Groottes",
     "width": "Breedte"
   },

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -217,6 +217,8 @@
     "moreInfo": "Więcej informacji",
     "selectCollectionToBrowse": "Wybierz kolekcję aby przejrzeć",
     "selectFile": "Wybierz plik",
+    "dragAndDrop": "Przeciągnij i upuść plik",
+    "copyAndPaste": "Skopiuj i wklej plik",
     "sizes": "Rozmiary",
     "width": "Szerokość"
   },

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -217,6 +217,8 @@
     "moreInfo": "Ver mais",
     "selectCollectionToBrowse": "Selecione uma Coleção para Navegar",
     "selectFile": "Selecione um arquivo",
+    "dragAndDrop": "Arraste e solte um arquivo",
+    "copyAndPaste": "Copie e cole um arquivo",
     "sizes": "Tamanhos",
     "width": "Largura"
   },

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -217,6 +217,8 @@
     "moreInfo": "Больше информации",
     "selectCollectionToBrowse": "Выберите Коллекцию для просмотра",
     "selectFile": "Выберите файл",
+    "dragAndDrop": "Перетащите файл",
+    "copyAndPaste": "Скопируйте и вставьте файл",
     "sizes": "Размеры",
     "width": "Ширина"
   },

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -218,6 +218,8 @@
     "moreInfo": "Mer info",
     "selectCollectionToBrowse": "Välj en Samling att Bläddra i",
     "selectFile": "Välj en fil",
+    "dragAndDrop": "Dra och släpp en fil",
+    "copyAndPaste": "Kopiera och klistra in en fil",
     "sizes": "Storlekar",
     "width": "Bredd"
   },

--- a/src/translations/translation-schema.json
+++ b/src/translations/translation-schema.json
@@ -866,6 +866,12 @@
         "selectFile": {
           "type": "string"
         },
+        "dragAndDrop": {
+          "type": "string"
+        },
+        "copyAndPaste": {
+          "type": "string"
+        },
         "sizes": {
           "type": "string"
         },
@@ -882,6 +888,8 @@
         "moreInfo",
         "selectCollectionToBrowse",
         "selectFile",
+        "dragAndDrop",
+        "copyAndPaste",
         "sizes",
         "width"
       ]

--- a/src/translations/vi.json
+++ b/src/translations/vi.json
@@ -218,6 +218,8 @@
     "moreInfo": "Hiển thị nhiều hơn",
     "selectCollectionToBrowse": "Chọn một Collection để tìm",
     "selectFile": "Chọn một file",
+    "dragAndDrop": "Kéo và thả một tập tin",
+    "copyAndPaste": "Sao chép và dán một tập tin",
     "sizes": "Các độ phân giải",
     "width": "Chiều rộng"
   },


### PR DESCRIPTION
## Description

Allows users to copy and paste files into the upload field on an `upload` collection edit view.
Co-authored by @EasonSoong in #1422 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
