### PR TITLE
chore: removes isLocked since not being defined and always returning false

### DIFF
--- a/src/collections/init.ts
+++ b/src/collections/init.ts
@@ -48,7 +48,7 @@ export default function registerCollections(ctx: Payload): void {
 
           const updates: UpdateQuery<LoginSchema> = { $inc: { loginAttempts: 1 } };
           // Lock the account if at max attempts and not already locked
-          if (this.loginAttempts + 1 >= maxLoginAttempts && !this.isLocked) {
+          if (this.loginAttempts + 1 >= maxLoginAttempts) {
             updates.$set = { lockUntil: Date.now() + lockTime };
           }
           return this.updateOne(updates as UpdateAggregationStage, cb);


### PR DESCRIPTION
## Description

This PR removes the check `!this.isLocked` as `isLocked` is not being defined and always returning false.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
