### PR TITLE
fix: #1583 mismatch language condition when rendering unpublish

### DIFF
--- a/src/admin/components/elements/Status/index.tsx
+++ b/src/admin/components/elements/Status/index.tsx
@@ -41,11 +41,11 @@ const Status: React.FC<Props> = () => {
   let statusToRender;
 
   if (unpublishedVersions?.docs?.length > 0 && publishedDoc) {
-    statusToRender = t('changed');
+    statusToRender = 'changed';
   } else if (!publishedDoc) {
-    statusToRender = t('draft');
+    statusToRender = 'draft';
   } else if (publishedDoc && unpublishedVersions?.docs?.length <= 1) {
-    statusToRender = t('published');
+    statusToRender = 'published';
   }
 
   const performAction = useCallback(async (action: 'revert' | 'unpublish') => {
@@ -118,8 +118,8 @@ const Status: React.FC<Props> = () => {
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__value-wrap`}>
-          <span className={`${baseClass}__value`}>{statusToRender}</span>
-          {statusToRender === 'Published' && (
+          <span className={`${baseClass}__value`}>{t(statusToRender)}</span>
+          {statusToRender === 'published' && (
             <React.Fragment>
               &nbsp;&mdash;&nbsp;
               <Button
@@ -152,7 +152,7 @@ const Status: React.FC<Props> = () => {
               </Modal>
             </React.Fragment>
           )}
-          {statusToRender === 'Changed' && (
+          {statusToRender === 'changed' && (
             <React.Fragment>
               &nbsp;&mdash;&nbsp;
               <Button


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/1583

The variable statusToRender is assigned the translated value which is then being compared to the English counterpart to conditionally render the button.

This pull assigns the statusToRender using English and then renders the translated values when used in the DOM

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
