### PR TITLE
fix: safely coerces limit and depth to number or undefined

### DIFF
--- a/src/collections/requestHandlers/findVersions.ts
+++ b/src/collections/requestHandlers/findVersions.ts
@@ -4,6 +4,7 @@ import { Where } from '../../types';
 import { PayloadRequest } from '../../express/types';
 import { TypeWithID } from '../config/types';
 import { PaginatedDocs } from '../../mongoose/types';
+import { isNumber } from '../../utilities/isNumber';
 import findVersions from '../operations/findVersions';
 
 export default async function findVersionsHandler<T extends TypeWithID = any>(req: PayloadRequest, res: Response, next: NextFunction): Promise<Response<PaginatedDocs<T>> | void> {
@@ -23,9 +24,9 @@ export default async function findVersionsHandler<T extends TypeWithID = any>(re
       collection: req.collection,
       where: req.query.where as Where, // This is a little shady,
       page,
-      limit: parseInt(String(req.query.limit), 10),
+      limit: isNumber(req.query.limit) ? Number(req.query.limit) : undefined,
       sort: req.query.sort as string,
-      depth: parseInt(String(req.query.depth), 10),
+      depth: isNumber(req.query.depth) ? Number(req.query.depth) : undefined,
       payload: req.payload,
     };
 

--- a/src/globals/requestHandlers/findVersions.ts
+++ b/src/globals/requestHandlers/findVersions.ts
@@ -6,6 +6,7 @@ import { PaginatedDocs } from '../../mongoose/types';
 import { SanitizedGlobalConfig } from '../config/types';
 import findVersions from '../operations/findVersions';
 import { Where } from '../../types';
+import { isNumber } from '../../utilities/isNumber';
 
 export default function findVersionsHandler(global: SanitizedGlobalConfig) {
   return async function handler<T extends TypeWithID = any>(req: PayloadRequest, res: Response, next: NextFunction): Promise<Response<PaginatedDocs<T>> | void> {
@@ -25,9 +26,9 @@ export default function findVersionsHandler(global: SanitizedGlobalConfig) {
         globalConfig: global,
         where: req.query.where as Where,
         page,
-        limit: Number(req.query.limit),
+        limit: isNumber(req.query.limit) ? Number(req.query.limit) : undefined,
         sort: req.query.sort as string,
-        depth: Number(req.query.depth),
+        depth: isNumber(req.query.depth) ? Number(req.query.depth) : undefined,
       };
 
       const result = await findVersions(options);


### PR DESCRIPTION
## Description

When querying versions limit and depth were incorrectly being turned into a string before checking if they were valid numbers, resulting in NaN and a blank result set when querying without setting the properties.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
