### PR TITLE
fix: relationship option

### DIFF
--- a/src/admin/components/forms/field-types/Relationship/findOptionsByValue.ts
+++ b/src/admin/components/forms/field-types/Relationship/findOptionsByValue.ts
@@ -13,13 +13,15 @@ export const findOptionsByValue = ({ value, options }: Args): Option | Option[] 
         let matchedOption: Option;
 
         options.forEach((optGroup) => {
-          matchedOption = optGroup.options.find((option) => {
-            if (typeof val === 'object') {
-              return option.value === val.value && option.relationTo === val.relationTo;
-            }
+          if (!matchedOption) {
+            matchedOption = optGroup.options.find((option) => {
+              if (typeof val === 'object') {
+                return option.value === val.value && option.relationTo === val.relationTo;
+              }
 
-            return val === option.value;
-          });
+              return val === option.value;
+            });
+          }
         });
 
         return matchedOption;
@@ -29,13 +31,14 @@ export const findOptionsByValue = ({ value, options }: Args): Option | Option[] 
     let matchedOption: Option;
 
     options.forEach((optGroup) => {
-      matchedOption = optGroup.options.find((option) => {
-        if (typeof value === 'object') {
-          return option.value === value.value && option.relationTo === value.relationTo;
-        }
-
-        return value === option.value;
-      });
+      if (!matchedOption) {
+        matchedOption = optGroup.options.find((option) => {
+          if (typeof value === 'object') {
+            return option.value === value.value && option.relationTo === value.relationTo;
+          }
+          return value === option.value;
+        });
+      }
     });
 
     return matchedOption;


### PR DESCRIPTION
## Description

Fixes `findOptionsByValue` by exiting once a value has been matched. 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
