### PR TITLE
fix: unflattens fields in filterOptions callback

### DIFF
--- a/src/admin/components/forms/field-types/Relationship/GetFilterOptions/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/GetFilterOptions/index.tsx
@@ -29,7 +29,7 @@ export const GetFilterOptions = ({
   const { user } = useAuth();
 
   useEffect(() => {
-    const data = reduceFieldsToValues(fields);
+    const data = reduceFieldsToValues(fields, true);
     const siblingData = getSiblingData(fields, path);
 
     const newFilterOptionsResult = getFilterOptionsQuery(filterOptions, {


### PR DESCRIPTION
## Description

Resolves #1605 by unflattening fields in the `filterOptions` callback.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
