### PR TITLE
feat!: no longer sanitize collection slugs to kebab case

### DIFF
--- a/src/collections/config/sanitize.ts
+++ b/src/collections/config/sanitize.ts
@@ -2,7 +2,6 @@ import merge from 'deepmerge';
 import { isPlainObject } from 'is-plain-object';
 import { SanitizedCollectionConfig, CollectionConfig } from './types';
 import sanitizeFields from '../../fields/config/sanitize';
-import toKebabCase from '../../utilities/toKebabCase';
 import baseAuthFields from '../../auth/baseFields/auth';
 import baseAPIKeyFields from '../../auth/baseFields/apiKey';
 import baseVerificationFields from '../../auth/baseFields/verification';
@@ -25,7 +24,6 @@ const sanitizeCollection = (config: Config, collection: CollectionConfig): Sanit
     isMergeableObject: isPlainObject,
   });
 
-  sanitized.slug = toKebabCase(sanitized.slug);
   sanitized.labels = sanitized.labels || formatLabels(sanitized.slug);
 
   if (sanitized.versions) {


### PR DESCRIPTION
Remove automatic sanitization of collection slugs to kebab case.

BREAKING CHANGE: collection slugs are no longer automatically sanitized to be kebab case. This will only be an issue if your current slugs were in camel case. The upgrade path will be to change those slugs to the kebab case version that the slug was automatically being sanitized to on the backend.

If you only use kebab case or single word slugs: no action needed.

If you have existing slugs with camel case and populated data: you'll need to convert these to the kebab case version to match the previously sanitized value.

ie. `myOldSlug` is your slug, you should convert it to `my-old-slug`.

Any future slugs after updating will be used as-is.



Related issues: #1306 

Closes #1316 
Closes #1511 

Previous related PRs: #1322 #1325 

## Description

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
