### PR TITLE
chore: update de.json

### DIFF
--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -180,7 +180,7 @@
     "newPassword": "Neues Passwort",
     "noFiltersSet": "Keine Filter gesetzt",
     "noLabel": "<Kein {{label}}>",
-    "noResults": "Kein {{label}} gefunden. Entweder kein {{label}} existiert oder es gibt keine Übereinstimmung zu den von dir verwendeten Filtern.",
+    "noResults": "Keine {{label}} gefunden. Entweder es existieren keine {{label}} oder es gibt keine Übereinstimmung zu den von dir verwendeten Filtern.",
     "noValue": "Kein Wert",
     "none": "Kein",
     "notFound": "Nicht gefunden",


### PR DESCRIPTION
## Description

Since `label` always(?) holds a plural form of the collection, it should be "keine" instead of "kein". But even with the singular form the structure of the seconds sentence would still be slightly of :-)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Just a tiny typo fix
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
