### PR TITLE
chore: fix incorrect translation key in FileUploadError

### DIFF
--- a/src/errors/FileUploadError.ts
+++ b/src/errors/FileUploadError.ts
@@ -4,7 +4,7 @@ import APIError from './APIError';
 
 class FileUploadError extends APIError {
   constructor(t?: TFunction) {
-    super(t ? t('problemUploadingFile') : 'There was a problem while uploading the file.', httpStatus.BAD_REQUEST);
+    super(t ? t('error:problemUploadingFile') : 'There was a problem while uploading the file.', httpStatus.BAD_REQUEST);
   }
 }
 


### PR DESCRIPTION
## Description

Adds missing translation key namespace for FileUploadError

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes

