### PR TITLE
Add option to require number as integer

### DIFF
--- a/docs/fields/number.mdx
+++ b/docs/fields/number.mdx
@@ -18,6 +18,7 @@ keywords: number, fields, config, configuration, documentation, Content Manageme
 | **`label`**          | Text used as a field label in the Admin panel or an object with keys for each language. |
 | **`min`**            | Minimum value accepted. Used in the default `validation` function. |
 | **`max`**            | Maximum value accepted. Used in the default `validation` function. |
+| **`integer`**        | Require the value to be an integer. |
 | **`unique`**         | Enforce that each entry in the Collection has a unique value for this field. |
 | **`index`**          | Build a [MongoDB index](https://docs.mongodb.com/manual/indexes/) for this field to produce faster queries. Set this field to `true` if your users will perform queries on this field's data often. |
 | **`validate`**       | Provide a custom validation function that will be executed on both the Admin panel and the backend. [More](/docs/fields/overview#validation) |
@@ -61,6 +62,7 @@ const ExampleCollection: CollectionConfig = {
       name: 'age', // required
       type: 'number', // required
       required: true,
+      integer: true,
       admin: {
         step: 1,
       }

--- a/src/admin/components/forms/field-types/Number/index.tsx
+++ b/src/admin/components/forms/field-types/Number/index.tsx
@@ -20,6 +20,7 @@ const NumberField: React.FC<Props> = (props) => {
     label,
     max,
     min,
+    integer,
     admin: {
       readOnly,
       style,
@@ -56,6 +57,8 @@ const NumberField: React.FC<Props> = (props) => {
 
     if (Number.isNaN(val)) {
       setValue('');
+    } else if (integer && !Number.isInteger(val)) {
+      setValue(Math.round(val));
     } else {
       setValue(val);
     }

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -130,6 +130,7 @@ export type NumberField = FieldBase & {
   }
   min?: number
   max?: number
+  integer?: boolean
 }
 
 export type TextField = FieldBase & {

--- a/src/fields/validations.spec.ts
+++ b/src/fields/validations.spec.ts
@@ -352,5 +352,10 @@ describe('Field Validations', () => {
       const result = number(val, { ...options, max: 1 });
       expect(result).toBe('validation:greaterThanMax');
     });
+    it('should validate integer', () => {
+      const val = 1.25;
+      const result = number(val, { ...options, integer: true });
+      expect(result).toBe('validation:notAnInteger');
+    });
   });
 });

--- a/src/fields/validations.ts
+++ b/src/fields/validations.ts
@@ -24,7 +24,7 @@ import canUseDOM from '../utilities/canUseDOM';
 import { isValidID } from '../utilities/isValidID';
 import { getIDType } from '../utilities/getIDType';
 
-export const number: Validate<unknown, unknown, NumberField> = (value: string, { t, required, min, max }) => {
+export const number: Validate<unknown, unknown, NumberField> = (value: string, { t, required, min, max, integer }) => {
   const parsedValue = parseFloat(value);
 
   if ((value && typeof parsedValue !== 'number') || (required && Number.isNaN(parsedValue)) || (value && Number.isNaN(parsedValue))) {
@@ -37,6 +37,10 @@ export const number: Validate<unknown, unknown, NumberField> = (value: string, {
 
   if (typeof min === 'number' && parsedValue < min) {
     return t('validation:lessThanMin', { value, min });
+  }
+
+  if (integer && !Number.isInteger(value)) {
+    return t('validation:notAnInteger')
   }
 
   if (required && typeof parsedValue !== 'number') {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -236,6 +236,7 @@
     "enterNumber": "Please enter a valid number.",
     "fieldHasNo": "This field has no {{label}}",
     "greaterThanMax": "\"{{value}}\" is greater than the max allowed value of {{max}}.",
+    "notAnInteger": "This value must be an integer",
     "invalidInput": "This field has an invalid input.",
     "invalidSelection": "This field has an invalid selection.",
     "invalidSelections": "This field has the following invalid selections:",

--- a/src/translations/translation-schema.json
+++ b/src/translations/translation-schema.json
@@ -942,6 +942,9 @@
         "greaterThanMax": {
           "type": "string"
         },
+        "notAnInteger": {
+          "type": "string"
+        },
         "invalidInput": {
           "type": "string"
         },


### PR DESCRIPTION
## Description

Forgive me, I have no yet discussed this on the discussions (but will cross-post this change there to determine whether it's something other people would want. Essentially, I want to be able to validate that a number provided to payload is an integer. My use case is that these number correspond to episode & season numbers of podcasts, and I want to ensure nobody accidentally submits Season 1.2, because that will start to look odd when it gets rendered on a website. Let me know if there are additional tests needed. 

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [X] I have made corresponding changes to the documentation
