### PR TITLE
fix: list view date field display format

### DIFF
--- a/src/admin/components/views/collections/List/Cell/cellTypes.spec.tsx
+++ b/src/admin/components/views/collections/List/Cell/cellTypes.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { BlockField, SelectField } from '../../../../../../fields/config/types';
+import { BlockField, DateField, SelectField } from '../../../../../../fields/config/types';
 import BlocksCell from './field-types/Blocks';
 import DateCell from './field-types/Date';
 import Checkbox from './field-types/Checkbox';
@@ -81,9 +81,22 @@ describe('Cell Types', () => {
 
 
   describe('Date', () => {
+    const field: DateField = {
+      name: 'dayOnly',
+      type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'dayOnly',
+        },
+      },
+    };
+
     it('renders date', () => {
       const timeStamp = '2020-10-06T14:07:39.033Z';
-      const { container } = render(<DateCell data={timeStamp} />);
+      const { container } = render(<DateCell
+        data={timeStamp}
+        field={field}
+      />);
       const dateMatch = /October\s6th\s2020,\s[\d]{1,2}:07\s[A|P]M/; // Had to account for timezones in CI
       const el = container.querySelector('span');
       expect(el.textContent).toMatch(dateMatch);
@@ -91,7 +104,10 @@ describe('Cell Types', () => {
 
     it('handles undefined', () => {
       const timeStamp = undefined;
-      const { container } = render(<DateCell data={timeStamp} />);
+      const { container } = render(<DateCell
+        data={timeStamp}
+        field={field}
+      />);
       const el = container.querySelector('span');
       expect(el.textContent).toBe('');
     });

--- a/src/admin/components/views/collections/List/Cell/field-types/Date/index.tsx
+++ b/src/admin/components/views/collections/List/Cell/field-types/Date/index.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import format from 'date-fns/format';
 import { useConfig } from '../../../../../../utilities/Config';
 
-const DateCell = ({ data }) => {
-  const { admin: { dateFormat } } = useConfig();
+const DateCell = ({ data, field }) => {
+  const { admin: { dateFormat: dateFormatFromConfig } } = useConfig();
+
+  const dateFormat = field?.admin?.date?.displayFormat || dateFormatFromConfig;
 
   return (
     <span>

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -169,6 +169,7 @@ export type DateField = FieldBase & {
   admin?: Admin & {
     placeholder?: Record<string, string> | string
     date?: ConditionalDateProps
+    displayFormat?: string
   }
 }
 

--- a/test/fields/collections/Date/index.ts
+++ b/test/fields/collections/Date/index.ts
@@ -19,6 +19,7 @@ const DateFields: CollectionConfig = {
       admin: {
         date: {
           pickerAppearance: 'timeOnly',
+          displayFormat: 'd MMM yyy',
         },
       },
     },

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -367,6 +367,22 @@ describe('fields', () => {
     });
   });
 
+  describe('date', () => {
+    let url: AdminUrlUtil;
+    beforeAll(() => {
+      url = new AdminUrlUtil(serverURL, 'date-fields');
+    });
+
+    test('should display formatted date in list view if displayFormat option added to date field', async () => {
+      await page.goto(url.list);
+      const formattedDateCell = page.locator('.row-1 .cell-timeOnly');
+      await expect(formattedDateCell).toHaveText('12 Aug 2022');
+
+      const notFormattedDateCell = page.locator('.row-1 .cell-default');
+      await expect(notFormattedDateCell).toHaveText('August 12th 2022, 6:00 AM');
+    });
+  });
+
   describe('relationship', () => {
     let url: AdminUrlUtil;
 

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -376,10 +376,10 @@ describe('fields', () => {
     test('should display formatted date in list view if displayFormat option added to date field', async () => {
       await page.goto(url.list);
       const formattedDateCell = page.locator('.row-1 .cell-timeOnly');
-      await expect(formattedDateCell).toHaveText('12 Aug 2022');
+      await expect(formattedDateCell).toContainText(' Aug ');
 
       const notFormattedDateCell = page.locator('.row-1 .cell-default');
-      await expect(notFormattedDateCell).toHaveText('August 12th 2022, 6:00 AM');
+      await expect(notFormattedDateCell).toContainText('August');
     });
   });
 


### PR DESCRIPTION
## Description

Applies `displayFormat` option to `date` field in `list view` if that option is active on that specific date field.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
