### PR TITLE
fix: label translation in about to delete dialog

### DIFF
--- a/src/admin/components/elements/DeleteDocument/index.tsx
+++ b/src/admin/components/elements/DeleteDocument/index.tsx
@@ -102,7 +102,7 @@ const DeleteDocument: React.FC<Props> = (props) => {
             <p>
               <Trans
                 i18nKey="aboutToDelete"
-                values={{ label: singular, title: titleToRender }}
+                values={{ label: getTranslation(singular, i18n), title: titleToRender }}
                 t={t}
               >
                 aboutToDelete


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

The label in the About to Delete is display wrongly since the Payload has the admin i18n in the past few week, it shows as [object object] that is not select the language from the object. So, in this fix, I use the getTranslation function that has been created previously to choose the language to display in the about to delete dialog.

Before Changes:

![image](https://user-images.githubusercontent.com/26927973/207671748-0cac65af-d448-451c-8781-b308f4c32950.png)

After Changes:

![image](https://user-images.githubusercontent.com/26927973/207671644-5a170255-6a7b-4df2-993b-9114d66656d8.png)


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
