### PR TITLE
fix: stringifies date in DateTime field for useAsTitle

### DIFF
--- a/src/admin/components/forms/field-types/DateTime/index.tsx
+++ b/src/admin/components/forms/field-types/DateTime/index.tsx
@@ -88,7 +88,9 @@ const DateTime: React.FC<Props> = (props) => {
           {...date}
           placeholder={getTranslation(placeholder, i18n)}
           readOnly={readOnly}
-          onChange={readOnly ? undefined : setValue}
+          onChange={(incomingDate) => {
+            if (!readOnly) setValue(incomingDate.toISOString());
+          }}
           value={value as Date}
         />
       </div>

--- a/test/fields/collections/Date/index.ts
+++ b/test/fields/collections/Date/index.ts
@@ -5,7 +5,7 @@ export const defaultText = 'default-text';
 const DateFields: CollectionConfig = {
   slug: 'date-fields',
   admin: {
-    useAsTitle: 'date',
+    useAsTitle: 'default',
   },
   fields: [
     {


### PR DESCRIPTION
## Description

Currently, the app crashes when using a date field as `useAtTitle`. This is because the field sends a full date object to form context instead of a string, causing the `RenderTitle` component to break while parsing the value.

Here's a screen recording of the crash:

https://user-images.githubusercontent.com/15735305/207886253-edb2e112-2b10-4959-b4d6-0fc5f0c9f806.mov

This is after my change:

https://user-images.githubusercontent.com/15735305/207886301-8e6efded-ed99-4b55-ae71-851511227d0b.mov

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
