### PR TITLE
chore: Revert "chore: allow empty string route.api"

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -36,7 +36,7 @@ export default joi.object({
   cookiePrefix: joi.string(),
   routes: joi.object({
     admin: joi.string(),
-    api: joi.string().allow(''),
+    api: joi.string(),
     graphQL: joi.string(),
     graphQLPlayground: joi.string(),
   }),


### PR DESCRIPTION
Reverts payloadcms/payload#1488

The change to allow empty string as the api route is causing other issues.
https://github.com/payloadcms/payload/issues/1623

This could be addressed as part of the work involved here: https://github.com/payloadcms/payload/discussions/1571