### PR TITLE
fix: #1666 use the slug for authentication header API Key

### DIFF
--- a/docs/authentication/config.mdx
+++ b/docs/authentication/config.mdx
@@ -43,21 +43,21 @@ To enable API keys on a collection, set the `useAPIKey` auth option to `true`. F
   is compromised, your API keys will not be.
 </Banner>
 
-##### Authenticating via API Key
+#### Authenticating via API Key
 
-To utilize your API key while interacting with the REST or GraphQL API, add the `Authorization` header.
+To authenticate REST or GraphQL API requests using an API key, set the `Authorization` header. The header is case-sensitive and needs the slug of the `auth.useAPIKey` enabled collection, then " API-Key ", followed by the `apiKey` that has been assigned. Payload's built-in middleware will then assign the user document to `req.user` and handle requests with the proper access control.
 
 **For example, using Fetch:**
 
 ```ts
+import User from '../collections/User';
+
 const response = await fetch("http://localhost:3000/api/pages", {
   headers: {
-    Authorization: `${collection.labels.singular} API-Key ${YOUR_API_KEY}`,
+    Authorization: `${User.slug} API-Key ${YOUR_API_KEY}`,
   },
 });
 ```
-
-Note: The label portion of the header is case-sensitive and will likely have a capitalized first character unless the label has been customized.
 
 ### Forgot Password
 

--- a/src/auth/strategies/apiKey.ts
+++ b/src/auth/strategies/apiKey.ts
@@ -8,7 +8,7 @@ export default (payload: Payload, { Model, config }): PassportAPIKey => {
   const { secret } = payload;
   const opts = {
     header: 'Authorization',
-    prefix: `${config.labels.singular} API-Key `,
+    prefix: `${config.slug} API-Key `,
   };
 
   return new PassportAPIKey(opts, true, async (apiKey, done, req) => {

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -96,6 +96,31 @@ describe('Auth', () => {
         expect(data.user.email).toBeDefined();
       });
 
+
+      it('should allow authentication with an API key with useAPIKey', async () => {
+        const apiKey = '0123456789ABCDEFGH';
+        const user = await payload.create({
+          collection: slug,
+          data: {
+            email: 'dev@example.com',
+            password: 'test',
+            apiKey,
+          },
+        });
+        const response = await fetch(`${apiUrl}/${slug}/me`, {
+          headers: {
+            ...headers,
+            Authorization: `${slug} API-Key ${user.apiKey}`,
+          },
+        });
+
+        const data = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(data.user.email).toBeDefined();
+        expect(data.user.apiKey).toStrictEqual(apiKey);
+      });
+
       it('should refresh a token and reset its expiration', async () => {
         const response = await fetch(`${apiUrl}/${slug}/refresh-token`, {
           method: 'post',


### PR DESCRIPTION
BREAKING CHANGE: replaced the useAPIKey authentication header format to use the collection slug instead of the collection label. Previous: `${collection.labels.singular} API-Key ${apiKey}`, updated: `${collection.slug} API-Key ${apiKey}`

Closes #1666 

## Description

Use the collection slug instead of `collection.labels.singluar` in the authentication header.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
