### PR TITLE
chore: log full error on transport configuration error

### DIFF
--- a/src/email/build.ts
+++ b/src/email/build.ts
@@ -10,7 +10,7 @@ async function handleTransport(transport: Transporter, email: EmailTransport, lo
     await transport.verify();
   } catch (err) {
     logger.error(
-      `There is an error with the email configuration you have provided. ${err.message}`,
+      `There is an error with the email configuration you have provided. ${err}`,
     );
   }
 


### PR DESCRIPTION
## Description

Email transport logging was not showing full error stack in certain scenarios. This change logs the entire error in the output.
