### PR TITLE
fix: prevents special characters breaking relationship field search

### DIFF
--- a/src/utilities/wordBoundariesRegex.ts
+++ b/src/utilities/wordBoundariesRegex.ts
@@ -4,9 +4,9 @@ export default (input: string): RegExp => {
   // Regex word boundaries that work for cyrillic characters - https://stackoverflow.com/a/47062016/1717697
   const wordBoundaryBefore = '(?:(?:[^\\p{L}\\p{N}])|^)'; // Converted to a non-matching group instead of positive lookbehind for Safari
   const wordBoundaryAfter = '(?=[^\\p{L}\\p{N}]|$)';
-
   const regex = words.reduce((pattern, word, i) => {
-    return `${pattern}(?=.*${wordBoundaryBefore}${word}.*${wordBoundaryAfter})${i + 1 === words.length ? '.+' : ''}`;
+    const escapedWord = word.replace(/[\\^$*+?\\.()|[\]{}]/g, '\\$&');
+    return `${pattern}(?=.*${wordBoundaryBefore}.*${escapedWord}.*${wordBoundaryAfter})${i + 1 === words.length ? '.+' : ''}`;
   }, '');
   return new RegExp(regex, 'i');
 };

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -373,6 +373,31 @@ describe('collections-rest', () => {
         expect(result.totalDocs).toEqual(1);
       });
 
+
+      describe('like - special characters', () => {
+        const specialCharacters = '~!@#$%^&*()_+-+[]{}|;:"<>,.?/})';
+
+        it.each(specialCharacters.split(''))('like - special characters - %s', async (character) => {
+          const post1 = await createPost({
+            title: specialCharacters,
+          });
+
+          const query = {
+            query: {
+              title: {
+                like: character,
+              },
+            },
+          };
+
+          const { status, result } = await client.find<Post>(query);
+
+          expect(status).toEqual(200);
+          expect(result.docs).toEqual([post1]);
+          expect(result.totalDocs).toEqual(1);
+        });
+      });
+
       it('like - cyrillic characters', async () => {
         const post1 = await createPost({ title: 'Тест' });
 


### PR DESCRIPTION
## Description

This fixes prevents the relationship field breaking when special characters are used to search.
Closes issue #1704 

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
