### PR TITLE
Fix/radio-field-validation

### DIFF
--- a/src/fields/validations.ts
+++ b/src/fields/validations.ts
@@ -342,9 +342,12 @@ export const select: Validate<unknown, unknown, SelectField> = (value, { t, opti
 };
 
 export const radio: Validate<unknown, unknown, RadioField> = (value, { t, options, required }) => {
-  const stringValue = String(value);
-  if ((typeof value !== 'undefined' || !required) && (options.find((option) => String(typeof option !== 'string' && option?.value) === stringValue))) return true;
-  return t('validation:required');
+  if (value) {
+    const valueMatchesOption = options.some((option) => (option === value || (typeof option !== 'string' && option.value === value)));
+    return valueMatchesOption || t('validation:invalidSelection');
+  }
+
+  return required ? t('validation:required') : true;
 };
 
 export const blocks: Validate<unknown, unknown, BlockField> = (value, { t, maxRows, minRows, required }) => {


### PR DESCRIPTION
## Description

Fixes #1701 

Previous validation would search for `'undefined'` in the options array if no value was selected, making it always required when defaultValue was not set. 

This PR simplifies the validation, and fixes the issue.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
