### PR TITLE
fix: #1656 remove size data

### DIFF
--- a/src/collections/operations/local/update.ts
+++ b/src/collections/operations/local/update.ts
@@ -4,6 +4,7 @@ import getFileByPath from '../../../uploads/getFileByPath';
 import update from '../update';
 import { PayloadRequest } from '../../../express/types';
 import { getDataLoader } from '../../dataloader';
+import { File } from '../../../uploads/types';
 import i18nInit from '../../../translations/init';
 
 export type Options<T> = {

--- a/src/uploads/types.ts
+++ b/src/uploads/types.ts
@@ -7,10 +7,8 @@ export type FileSize = {
   filename: string;
   filesize: number;
   mimeType: string;
-  name: string;
   width: number;
   height: number;
-  crop: string;
 }
 
 export type FileSizes = {

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -7,6 +7,7 @@ import { RESTClient } from '../helpers/rest';
 import config, { mediaSlug, relationSlug } from './config';
 import payload from '../../src';
 import getFileByPath from '../../src/uploads/getFileByPath';
+import type { Media } from './payload-types';
 
 const stat = promisify(fs.stat);
 
@@ -76,7 +77,7 @@ describe('Collections - Uploads', () => {
       expect(await fileExists(path.join(__dirname, './media', doc.sizes.icon.filename))).toBe(true);
 
       // Check api response
-      expect(doc.sizes.tablet.filename).toBeUndefined();
+      expect(doc.sizes.tablet.filename).toBeNull();
       expect(doc.sizes.icon.filename).toBeDefined();
     });
 
@@ -157,6 +158,28 @@ describe('Collections - Uploads', () => {
     // Check that previously existing files weren't affected
     expect(await fileExists(path.join(__dirname, './media', mediaDoc.filename))).toBe(true);
     expect(await fileExists(path.join(__dirname, './media', mediaDoc.sizes.icon.filename))).toBe(true);
+  });
+
+  it('should remove extra sizes on update', async () => {
+    const filePath = path.resolve(__dirname, './image.png');
+    const file = await getFileByPath(filePath);
+    const small = await getFileByPath(path.resolve(__dirname, './small.png'));
+
+    const { id } = await payload.create<Media>({
+      collection: mediaSlug,
+      data: {},
+      file,
+    });
+
+    const doc = await payload.update<Media>({
+      collection: mediaSlug,
+      id,
+      data: {},
+      file: small,
+    });
+
+    expect(doc.sizes.icon).toBeDefined();
+    expect(doc.sizes.tablet.width).toBeNull();
   });
 
   it('should allow update removing a relationship', async () => {


### PR DESCRIPTION
## Description

#1656 

With this change a small sized upload will overwrite the resize data after update with:

```json
"sizes": {
  "tablet": {
      "url": null,
      "width": null,
      "height": null,
      "mimeType": null,
      "filesize": null,
      "filename": null
    },
    "icon": {
      "url": "/media/logo-tiny-16x16.png",
      "width": 16,
      "height": 16,
      "mimeType": "image/png",
      "filesize": 473,
      "filename": "logo-tiny-16x16.png"
    }
},
```

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
