### PR TITLE
feat: adds doc permissions to account view

### DIFF
--- a/src/admin/components/utilities/DocumentInfo/index.tsx
+++ b/src/admin/components/utilities/DocumentInfo/index.tsx
@@ -188,7 +188,7 @@ export const DocumentInfoProvider: React.FC<Props> = ({
       const json = await res.json();
       setDocPermissions(json);
     } else {
-      // fallback to permissions from the collection
+      // fallback to permissions from the entity type
       // (i.e. create has no id)
       setDocPermissions(permissions[pluralType][slug]);
     }

--- a/src/admin/components/views/Account/Default.tsx
+++ b/src/admin/components/views/Account/Default.tsx
@@ -37,6 +37,7 @@ const DefaultAccount: React.FC<Props> = (props) => {
     initialState,
     isLoading,
     action,
+    onSave,
   } = props;
 
   const {
@@ -72,6 +73,7 @@ const DefaultAccount: React.FC<Props> = (props) => {
             className={`${baseClass}__form`}
             method="patch"
             action={action}
+            onSuccess={onSave}
             initialState={initialState}
             disabled={!hasSavePermission}
           >

--- a/src/admin/components/views/Account/index.tsx
+++ b/src/admin/components/views/Account/index.tsx
@@ -20,7 +20,7 @@ const AccountView: React.FC = () => {
   const { setStepNav } = useStepNav();
   const { user } = useAuth();
   const [initialState, setInitialState] = useState<Fields>();
-  const { id, preferencesKey, docPermissions, slug } = useDocumentInfo();
+  const { id, preferencesKey, docPermissions, getDocPermissions, slug } = useDocumentInfo();
   const { getPreference } = usePreferences();
 
   const {
@@ -58,6 +58,12 @@ const AccountView: React.FC = () => {
   const apiURL = `${serverURL}${api}/${slug}/${data?.id}`;
 
   const action = `${serverURL}${api}/${slug}/${data?.id}?locale=${locale}&depth=0`;
+
+  const onSave = React.useCallback(async (json: any) => {
+    getDocPermissions();
+    const state = await buildStateFromSchema({ fieldSchema: collection.fields, data: json.doc, user, id, operation: 'update', locale, t });
+    setInitialState(state);
+  }, [collection, user, id, t, locale, getDocPermissions]);
 
   useEffect(() => {
     const nav = [{
@@ -98,6 +104,7 @@ const AccountView: React.FC = () => {
         initialState,
         apiURL,
         isLoading: !initialState || !docPermissions,
+        onSave,
       }}
     />
   );

--- a/src/admin/components/views/Account/types.ts
+++ b/src/admin/components/views/Account/types.ts
@@ -11,4 +11,5 @@ export type Props = {
   initialState: Fields
   isLoading: boolean
   action: string
+  onSave?: () => void
 }


### PR DESCRIPTION
## Description

Resolves #1727

Threads docPermissions through to the Account view so doc permissions are respected. Fields now react the same as they do when viewing them in the related auth collection.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
