### PR TITLE
fix: relationship labels and page stepnav

### DIFF
--- a/src/admin/components/elements/DocumentDrawer/index.tsx
+++ b/src/admin/components/elements/DocumentDrawer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useId, useMemo, useReducer, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { useModal } from '@faceless-ui/modal';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
@@ -83,8 +83,7 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = ({
     setFields(formatFields(collectionConfig, true));
   }, [collectionSlug, collectionConfig]);
 
-  const [cacheBust, dispatchCacheBust] = useReducer((state) => state + 1, 0); // used to rerun the API call even though the URL hasn't changed
-  const [{ data, isLoading: isLoadingDocument, isError }, { setParams }] = usePayloadAPI(
+  const [{ data, isLoading: isLoadingDocument, isError }] = usePayloadAPI(
     (id ? `${serverURL}${api}/${collectionSlug}/${id}` : null),
     { initialParams: { 'fallback-locale': 'null', depth: 0, draft: 'true' } },
   );
@@ -122,15 +121,13 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = ({
   }, [isError, t, isOpen, data, drawerSlug, closeModal, isLoadingDocument]);
 
   const onSave = useCallback<DocumentDrawerProps['onSave']>((args) => {
-    setParams({ 'fallback-locale': 'null', depth: 0, draft: 'true', cacheBust });
-    dispatchCacheBust();
     if (typeof onSaveFromProps === 'function') {
       onSaveFromProps({
         ...args,
         collectionConfig,
       });
     }
-  }, [onSaveFromProps, cacheBust, setParams, collectionConfig]);
+  }, [collectionConfig, onSaveFromProps]);
 
   if (isError) return null;
 

--- a/src/admin/components/elements/DocumentDrawer/index.tsx
+++ b/src/admin/components/elements/DocumentDrawer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useId, useMemo, useReducer, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useReducer, useState } from 'react';
 import { useModal } from '@faceless-ui/modal';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
@@ -74,7 +74,6 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = ({
   const { permissions, user } = useAuth();
   const [initialState, setInitialState] = useState<Fields>();
   const { t, i18n } = useTranslation(['fields', 'general']);
-  const hasInitializedState = useRef(false);
   const [isOpen, setIsOpen] = useState(false);
   const [collectionConfig] = useRelatedCollections(collectionSlug);
 
@@ -91,7 +90,7 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = ({
   );
 
   useEffect(() => {
-    if (isLoadingDocument || hasInitializedState.current === true) {
+    if (isLoadingDocument) {
       return;
     }
 
@@ -109,7 +108,6 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = ({
     };
 
     awaitInitialState();
-    hasInitializedState.current = true;
   }, [data, fields, id, user, locale, isLoadingDocument, t]);
 
   useEffect(() => {
@@ -123,7 +121,7 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = ({
     }
   }, [isError, t, isOpen, data, drawerSlug, closeModal, isLoadingDocument]);
 
-  const onSave = useCallback((args: { doc: any, message: string }) => {
+  const onSave = useCallback<DocumentDrawerProps['onSave']>((args) => {
     setParams({ 'fallback-locale': 'null', depth: 0, draft: 'true', cacheBust });
     dispatchCacheBust();
     if (typeof onSaveFromProps === 'function') {

--- a/src/admin/components/elements/DocumentDrawer/types.ts
+++ b/src/admin/components/elements/DocumentDrawer/types.ts
@@ -1,9 +1,14 @@
 import React, { HTMLAttributes } from 'react';
+import { SanitizedCollectionConfig } from '../../../../collections/config/types';
 
 export type DocumentDrawerProps = {
   collectionSlug: string
   id?: string
-  onSave?: (json: Record<string, unknown>) => void
+  onSave?: (args: {
+    doc: Record<string, any>
+    collectionConfig: SanitizedCollectionConfig
+    message: string,
+  }) => void
   customHeader?: React.ReactNode
   drawerSlug?: string
 }

--- a/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -25,6 +25,7 @@ import { findOptionsByValue } from './findOptionsByValue';
 import { GetFilterOptions } from './GetFilterOptions';
 import { SingleValue } from './select-components/SingleValue';
 import { MultiValueLabel } from './select-components/MultiValueLabel';
+import { DocumentDrawerProps } from '../../../elements/DocumentDrawer/types';
 
 import './index.scss';
 
@@ -300,6 +301,10 @@ const Relationship: React.FC<Props> = (props) => {
     setHasLoadedFirstPage(false);
   }, [relationTo, filterOptionsResult]);
 
+  const onSave = useCallback<DocumentDrawerProps['onSave']>((args) => {
+    dispatchOptions({ type: 'UPDATE', doc: args.doc, collection: args.collectionConfig, i18n });
+  }, [i18n]);
+
   const classes = [
     'field-type',
     baseClass,
@@ -383,6 +388,7 @@ const Relationship: React.FC<Props> = (props) => {
               disableMouseDown: drawerIsOpen,
               disableKeyDown: drawerIsOpen,
               setDrawerIsOpen,
+              onSave,
             }}
             onMenuOpen={() => {
               if (!hasLoadedFirstPage) {

--- a/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
+++ b/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
@@ -29,6 +29,22 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
       return [];
     }
 
+    case 'UPDATE': {
+      const { collection, doc, i18n } = action;
+      const relation = collection.slug;
+      const newOptions = [...state];
+      const labelKey = collection.admin.useAsTitle || 'id';
+      const foundOptionGroup = newOptions.find((optionGroup) => optionGroup.label === collection.labels.plural);
+      const foundOption = foundOptionGroup?.options?.find((option) => option.value === doc.id);
+
+      if (foundOption) {
+        foundOption.label = doc[labelKey] || `${i18n.t('general:untitled')} - ID: ${doc.id}`;
+        foundOption.relationTo = relation;
+      }
+
+      return newOptions;
+    }
+
     case 'ADD': {
       const { collection, docs, sort, ids = [], i18n } = action;
       const relation = collection.slug;

--- a/src/admin/components/forms/field-types/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/select-components/MultiValueLabel/index.tsx
@@ -20,6 +20,7 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
     selectProps: {
       setDrawerIsOpen,
       draggableProps,
+      onSave,
     },
   } = props;
 
@@ -65,7 +66,7 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
             </Tooltip>
             <Edit />
           </DocumentDrawerToggler>
-          <DocumentDrawer />
+          <DocumentDrawer onSave={onSave} />
         </Fragment>
       )}
     </div>

--- a/src/admin/components/forms/field-types/Relationship/select-components/SingleValue/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/select-components/SingleValue/index.tsx
@@ -21,6 +21,7 @@ export const SingleValue: React.FC<SingleValueProps<Option>> = (props) => {
     selectProps: {
       selectProps: {
         setDrawerIsOpen,
+        onSave,
       },
     },
   } = props;
@@ -69,7 +70,7 @@ export const SingleValue: React.FC<SingleValueProps<Option>> = (props) => {
         </SelectComponents.SingleValue>
       </div>
       {relationTo && hasReadPermission && (
-        <DocumentDrawer />
+        <DocumentDrawer onSave={onSave} />
       )}
     </div>
   );

--- a/src/admin/components/forms/field-types/Relationship/types.ts
+++ b/src/admin/components/forms/field-types/Relationship/types.ts
@@ -28,6 +28,13 @@ type CLEAR = {
   type: 'CLEAR'
 }
 
+type UPDATE = {
+  type: 'UPDATE'
+  doc: any
+  collection: SanitizedCollectionConfig
+  i18n: typeof i18n
+}
+
 type ADD = {
   type: 'ADD'
   docs: any[]
@@ -37,7 +44,7 @@ type ADD = {
   i18n: typeof i18n
 }
 
-export type Action = CLEAR | ADD
+export type Action = CLEAR | ADD | UPDATE
 
 export type ValueWithRelation = {
   relationTo: string

--- a/src/admin/components/views/collections/Edit/Default.tsx
+++ b/src/admin/components/views/collections/Edit/Default.tsx
@@ -94,11 +94,13 @@ const DefaultEditView: React.FC<Props> = (props) => {
             disabled={!hasSavePermission}
             initialState={initialState}
           >
-            <SetStepNav
-              collection={collection}
-              isEditing={isEditing}
-              id={data.id}
-            />
+            {!disableEyebrow && (
+              <SetStepNav
+                collection={collection}
+                isEditing={isEditing}
+                id={data.id}
+              />
+            )}
             <div className={`${baseClass}__main`}>
               <Meta
                 title={`${isEditing ? t('editing') : t('creating')} - ${getTranslation(collection.labels.singular, i18n)}`}


### PR DESCRIPTION
## Description

Resolves https://github.com/payloadcms/payload/issues/1730 in two ways:
  - Relationship labels are now automatically updated when document drawers are saved 
  - The document drawer no longer interferes with the page step nav
  
- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes