### PR TITLE
fix: updates richtext toolbar position if inside a drawer

### DIFF
--- a/src/admin/components/forms/field-types/RichText/RichText.tsx
+++ b/src/admin/components/forms/field-types/RichText/RichText.tsx
@@ -23,6 +23,7 @@ import listTypes from './elements/listTypes';
 import mergeCustomFunctions from './mergeCustomFunctions';
 import withEnterBreakOut from './plugins/withEnterBreakOut';
 import { getTranslation } from '../../../../../utilities/getTranslation';
+import { useEditDepth } from '../../../utilities/EditDepth';
 
 import './index.scss';
 
@@ -73,6 +74,9 @@ const RichText: React.FC<Props> = (props) => {
   const [enabledLeaves, setEnabledLeaves] = useState({});
   const editorRef = useRef(null);
   const toolbarRef = useRef(null);
+
+  const drawerDepth = useEditDepth();
+  const drawerIsOpen = drawerDepth > 1;
 
   const renderElement = useCallback(({ attributes, children, element }) => {
     const matchedElement = enabledElements[element?.type];
@@ -261,7 +265,10 @@ const RichText: React.FC<Props> = (props) => {
         >
           <div className={`${baseClass}__wrapper`}>
             <div
-              className={`${baseClass}__toolbar`}
+              className={[
+                `${baseClass}__toolbar`,
+                drawerIsOpen && `${baseClass}__drawerIsOpen`,
+              ].filter(Boolean).join(' ')}
               ref={toolbarRef}
             >
               <div className={`${baseClass}__toolbar-wrap`}>

--- a/src/admin/components/forms/field-types/RichText/index.scss
+++ b/src/admin/components/forms/field-types/RichText/index.scss
@@ -150,9 +150,17 @@
     }
   }
 
+  &__drawerIsOpen {
+    top: base(1);
+  }
+
   @include mid-break {
     &__toolbar {
       top: base(3);
+    }
+
+    &__drawerIsOpen {
+      top: base(1);
     }
   }
 }


### PR DESCRIPTION
## Description

Updates the `top` position of the richtext field toolbar if inside a drawer because the drawer does not render the `stepnav`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
