### PR TITLE
fix: safely clears sort #1736

### DIFF
--- a/src/admin/components/elements/SortComplex/index.tsx
+++ b/src/admin/components/elements/SortComplex/index.tsx
@@ -36,7 +36,8 @@ const SortComplex: React.FC<Props> = (props) => {
   }, []));
 
   const [sortField, setSortField] = useState(sortFields[0]);
-  const [sortOrder, setSortOrder] = useState({ label: t('descending'), value: '-' });
+  const [initialSort] = useState(() => ({ label: t('descending'), value: '-' }));
+  const [sortOrder, setSortOrder] = useState(initialSort);
 
   useEffect(() => {
     if (sortField?.value) {
@@ -80,7 +81,9 @@ const SortComplex: React.FC<Props> = (props) => {
             <ReactSelect
               value={sortOrder}
               options={sortOptions}
-              onChange={setSortOrder}
+              onChange={(incomingSort) => {
+                setSortOrder(incomingSort || initialSort);
+              }}
             />
           </div>
         </div>


### PR DESCRIPTION
## Description

Fixes #1736 by safely clearing sort. Previously, clearing sort would set the field value to `null`, but now falls back to initial sort instead.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes