### PR TITLE
fix: allows cleared file to be reselected

### DIFF
--- a/src/admin/components/views/collections/Edit/Upload/index.tsx
+++ b/src/admin/components/views/collections/Edit/Upload/index.tsx
@@ -160,6 +160,7 @@ const Upload: React.FC<Props> = (props) => {
                 iconStyle="with-border"
                 onClick={() => {
                   setValue(null);
+                  inputRef.current.value = null;
                 }}
               />
             </div>


### PR DESCRIPTION
## Description

Fixes the first issue described in #1737 by setting the input value to `null` on clear. Note that the file input is _uncontrolled_, which is why the value is nullified using the ref instead of state.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
