### PR TITLE
Fix: updatedAt and createdAt fields change 

### DIFF
--- a/src/admin/components/elements/DuplicateDocument/index.tsx
+++ b/src/admin/components/elements/DuplicateDocument/index.tsx
@@ -47,6 +47,9 @@ const Duplicate: React.FC<Props> = ({ slug, collection, id }) => {
       });
       let data = await response.json();
 
+      if ('createdAt' in data) delete data.createdAt;
+      if ('updatedAt' in data) delete data.updatedAt;
+
       if (typeof collection.admin.hooks?.beforeDuplicate === 'function') {
         data = await collection.admin.hooks.beforeDuplicate({
           data,

--- a/src/admin/components/views/Global/Default.tsx
+++ b/src/admin/components/views/Global/Default.tsx
@@ -34,7 +34,7 @@ const DefaultGlobalView: React.FC<Props> = (props) => {
   const { t, i18n } = useTranslation('general');
 
   const {
-    global, data, onSave, permissions, action, apiURL, initialState, isLoading,
+    global, data, onSave, permissions, action, apiURL, initialState, isLoading, updatedAt,
   } = props;
 
   const {
@@ -170,10 +170,10 @@ const DefaultGlobalView: React.FC<Props> = (props) => {
                         </a>
                       </li>
                     )}
-                    {data.updatedAt && (
+                    {updatedAt && (
                       <li>
                         <div className={`${baseClass}__label`}>{t('lastModified')}</div>
-                        <div>{format(new Date(data.updatedAt as string), dateFormat)}</div>
+                        <div>{format(new Date(updatedAt as string), dateFormat)}</div>
                       </li>
                     )}
                   </ul>

--- a/src/admin/components/views/Global/index.tsx
+++ b/src/admin/components/views/Global/index.tsx
@@ -22,6 +22,7 @@ const GlobalView: React.FC<IndexProps> = (props) => {
   const { setStepNav } = useStepNav();
   const { user } = useAuth();
   const [initialState, setInitialState] = useState<Fields>();
+  const [updatedAt, setUpdatedAt] = useState<string>();
   const { getVersions, preferencesKey, docPermissions, getDocPermissions } = useDocumentInfo();
   const { getPreference } = usePreferences();
   const { t } = useTranslation();
@@ -51,6 +52,7 @@ const GlobalView: React.FC<IndexProps> = (props) => {
   const onSave = useCallback(async (json) => {
     getVersions();
     getDocPermissions();
+    setUpdatedAt(json?.result?.updatedAt);
     const state = await buildStateFromSchema({ fieldSchema: fields, data: json.result, operation: 'update', user, locale, t });
     setInitialState(state);
   }, [getVersions, fields, user, locale, t, getDocPermissions]);
@@ -93,6 +95,7 @@ const GlobalView: React.FC<IndexProps> = (props) => {
         onSave,
         apiURL: `${serverURL}${api}/globals/${slug}${global.versions?.drafts ? '?draft=true' : ''}`,
         action: `${serverURL}${api}/globals/${slug}?locale=${locale}&depth=0&fallback-locale=null`,
+        updatedAt: updatedAt || dataToRender?.updatedAt,
       }}
     />
   );

--- a/src/admin/components/views/Global/types.ts
+++ b/src/admin/components/views/Global/types.ts
@@ -17,4 +17,5 @@ export type Props = {
   initialState: Fields
   isLoading: boolean
   autosaveEnabled: boolean
+  updatedAt: string
 }

--- a/src/admin/components/views/collections/Edit/Default.tsx
+++ b/src/admin/components/views/collections/Edit/Default.tsx
@@ -55,6 +55,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
     disableLeaveWithoutSaving,
     customHeader,
     id,
+    updatedAt,
   } = props;
 
   const {
@@ -262,10 +263,10 @@ const DefaultEditView: React.FC<Props> = (props) => {
                         )}
                         {timestamps && (
                           <React.Fragment>
-                            {data.updatedAt && (
+                            {updatedAt && (
                               <li>
                                 <div className={`${baseClass}__label`}>{t('lastModified')}</div>
-                                <div>{format(new Date(data.updatedAt), dateFormat)}</div>
+                                <div>{format(new Date(updatedAt), dateFormat)}</div>
                               </li>
                             )}
                             {(publishedDoc?.createdAt || data?.createdAt) && (

--- a/src/admin/components/views/collections/Edit/index.tsx
+++ b/src/admin/components/views/collections/Edit/index.tsx
@@ -113,7 +113,7 @@ const EditView: React.FC<IndexProps> = (props) => {
           hasSavePermission,
           apiURL,
           action,
-          updatedAt,
+          updatedAt: updatedAt || dataToRender?.updatedAt,
         }}
       />
     </EditDepthContext.Provider>

--- a/src/admin/components/views/collections/Edit/index.tsx
+++ b/src/admin/components/views/collections/Edit/index.tsx
@@ -41,6 +41,7 @@ const EditView: React.FC<IndexProps> = (props) => {
   const { state: locationState } = useLocation();
   const history = useHistory();
   const [initialState, setInitialState] = useState<Fields>();
+  const [updatedAt, setUpdatedAt] = useState<string>();
   const { user } = useAuth();
   const { getVersions, preferencesKey, getDocPermissions, docPermissions } = useDocumentInfo();
   const { getPreference } = usePreferences();
@@ -49,6 +50,7 @@ const EditView: React.FC<IndexProps> = (props) => {
   const onSave = useCallback(async (json: any) => {
     getVersions();
     getDocPermissions();
+    setUpdatedAt(json?.doc?.updatedAt);
     if (!isEditing) {
       setRedirect(`${admin}/collections/${collection.slug}/${json?.doc?.id}`);
     } else {
@@ -69,6 +71,7 @@ const EditView: React.FC<IndexProps> = (props) => {
       return;
     }
     const awaitInitialState = async () => {
+      setUpdatedAt(dataToRender?.updatedAt);
       const state = await buildStateFromSchema({ fieldSchema: fields, data: dataToRender, user, operation: isEditing ? 'update' : 'create', id, locale, t });
       await getPreference(preferencesKey);
       setInitialState(state);
@@ -110,6 +113,7 @@ const EditView: React.FC<IndexProps> = (props) => {
           hasSavePermission,
           apiURL,
           action,
+          updatedAt,
         }}
       />
     </EditDepthContext.Provider>

--- a/src/admin/components/views/collections/Edit/types.ts
+++ b/src/admin/components/views/collections/Edit/types.ts
@@ -24,4 +24,5 @@ export type Props = IndexProps & {
   disableActions?: boolean
   disableLeaveWithoutSaving?: boolean
   customHeader?: React.ReactNode
+  updatedAt?: string
 }


### PR DESCRIPTION
Fixes #1753 

## Description

When duplicating a document, updatedAt and createdAt would copy the data from the doc being duplicated.

Also ensures updatedAt is reactive for collections and globals

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
