### PR TITLE
fix: #1738 save image dimensions to svg uploads

### DIFF
--- a/src/uploads/imageResizer.ts
+++ b/src/uploads/imageResizer.ts
@@ -5,13 +5,14 @@ import sharp from 'sharp';
 import { SanitizedCollectionConfig } from '../collections/config/types';
 import { PayloadRequest } from '../express/types';
 import fileExists from './fileExists';
-import { ProbedImageSize } from './getImageSize';
 import { FileSizes, FileToSave, ImageSize } from './types';
+
+type Dimensions = { width?: number, height?: number }
 
 type Args = {
   req: PayloadRequest
   file: Buffer
-  dimensions: ProbedImageSize
+  dimensions: Dimensions
   staticPath: string
   config: SanitizedCollectionConfig
   savedFilename: string
@@ -118,7 +119,7 @@ function createImageName(
   return `${outputImage.name}-${bufferObject.info.width}x${bufferObject.info.height}.${extension}`;
 }
 
-function needsResize(desiredSize: ImageSize, dimensions: ProbedImageSize): boolean {
+function needsResize(desiredSize: ImageSize, dimensions: Dimensions): boolean {
   return (typeof desiredSize.width === 'number' && desiredSize.width <= dimensions.width)
     || (typeof desiredSize.height === 'number' && desiredSize.height <= dimensions.height);
 }

--- a/test/uploads/image.svg
+++ b/test/uploads/image.svg
@@ -1,0 +1,15 @@
+<svg width="260" height="260" viewBox="0 0 260 260" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    path {
+      fill: #333333;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      path {
+        fill: white;
+      }
+    }
+  </style>
+	<path d="M120.59 8.5824L231.788 75.6142V202.829L148.039 251.418V124.203L36.7866 57.2249L120.59 8.5824Z" />
+	<path d="M112.123 244.353V145.073L28.2114 193.769L112.123 244.353Z" />
+</svg>

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -26,7 +26,7 @@ describe('Collections - Uploads', () => {
 
   describe('REST', () => {
     describe('create', () => {
-      it('creates from form data', async () => {
+      it('creates from form data given a png', async () => {
         const formData = new FormData();
         formData.append('file', fs.createReadStream(path.join(__dirname, './image.png')));
 
@@ -55,6 +55,29 @@ describe('Collections - Uploads', () => {
         expect(doc.sizes).toHaveProperty('tablet');
         expect(doc.sizes).toHaveProperty('mobile');
         expect(doc.sizes).toHaveProperty('icon');
+      });
+
+      it('creates from form data given an svg', async () => {
+        const formData = new FormData();
+        formData.append('file', fs.createReadStream(path.join(__dirname, './image.svg')));
+
+        const { status, doc } = await client.create({
+          file: true,
+          data: formData,
+          auth: true,
+          headers: {},
+        });
+
+        expect(status).toBe(201);
+
+        // Check for files
+        expect(await fileExists(path.join(__dirname, './media', doc.filename))).toBe(true);
+
+        // Check api response
+        expect(doc.mimeType).toEqual('image/svg+xml');
+        expect(doc.sizes.maintainedAspectRatio.url).toBeUndefined();
+        expect(doc.width).toBeDefined();
+        expect(doc.height).toBeDefined();
       });
     });
 


### PR DESCRIPTION
## Description

#1738 

Uploaded SVG data after changes:
![image](https://user-images.githubusercontent.com/6434612/209369124-33ccba4c-e1da-43e5-a128-35afe5156217.png)


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
