### PR TITLE
fix: #1762 select field crash on missing value option

### DIFF
--- a/src/admin/components/forms/field-types/Select/Input.tsx
+++ b/src/admin/components/forms/field-types/Select/Input.tsx
@@ -65,15 +65,15 @@ const SelectInput: React.FC<SelectInputProps> = (props) => {
     valueToRender = value.map((val) => {
       const matchingOption = options.find((option) => option.value === val);
       return {
-        label: getTranslation(matchingOption.label, i18n),
-        value: matchingOption.value,
+        label: matchingOption ? getTranslation(matchingOption.label, i18n) : val,
+        value: matchingOption?.value ?? val,
       };
     });
   } else if (value) {
     const matchingOption = options.find((option) => option.value === value);
     valueToRender = {
-      label: getTranslation(matchingOption.label, i18n),
-      value: matchingOption.value,
+      label: matchingOption ? getTranslation(matchingOption.label, i18n) : value,
+      value: matchingOption?.value ?? value,
     };
   }
 


### PR DESCRIPTION
## Description

With this change if a value does not match one of the options, the admin UI won't crash and the value(s) will appear in the field even though they aren't available.

On save, validation will stops the user:
![image](https://user-images.githubusercontent.com/6434612/209570780-fba0d26d-667f-453f-9f10-e1379637b212.png)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
