### PR TITLE
fix: #1786, relationship with hasMany no longer sets empty array as default value

### DIFF
--- a/src/mongoose/buildSchema.ts
+++ b/src/mongoose/buildSchema.ts
@@ -249,7 +249,7 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
 
           return {
             ...locales,
-            [locale]: field.hasMany ? [localeSchema] : localeSchema,
+            [locale]: field.hasMany ? { type: [localeSchema], default: undefined } : localeSchema,
           };
         }, {}),
         localized: true,
@@ -262,7 +262,12 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
       };
       schemaToReturn.relationTo = { type: String, enum: field.relationTo };
 
-      if (field.hasMany) schemaToReturn = [schemaToReturn];
+      if (field.hasMany) {
+        schemaToReturn = {
+          type: [schemaToReturn],
+          default: undefined,
+        };
+      }
     } else {
       schemaToReturn = {
         ...formatBaseSchema(field, buildSchemaOptions),
@@ -270,7 +275,12 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
         ref: field.relationTo,
       };
 
-      if (field.hasMany) schemaToReturn = [schemaToReturn];
+      if (field.hasMany) {
+        schemaToReturn = {
+          type: [schemaToReturn],
+          default: undefined,
+        };
+      }
     }
 
     schema.add({


### PR DESCRIPTION
## Description

Fixes #1786 - no longer allows Mongoose to set empty arrays as default values, which was preventing the `exists` operator from functioning

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
