### PR TITLE
fix: ignores admin and components from swc

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -25,6 +25,9 @@ const loadConfig = (logger?: pino.Logger): SanitizedConfig => {
         tsx: true,
       },
     },
+    ignore: [
+      /node_modules[\\/](?!.pnpm[\\/].*[\\/]node_modules[\\/])(?!payload[\\/]dist[\\/]admin|payload[\\/]components).*/,
+    ],
     module: {
       type: 'commonjs',
     },


### PR DESCRIPTION
## Description

Fixes the `SyntaxError: Unexpected token 'export'` when upgrading to `v1.5.0`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 
## Checklist:

- [x] Existing test suite passes locally with my changes
