### PR TITLE
fix: theme flicker on code editor

### DIFF
--- a/src/admin/components/elements/CodeEditor/index.tsx
+++ b/src/admin/components/elements/CodeEditor/index.tsx
@@ -22,6 +22,7 @@ const CodeEditor: React.FC<Props> = (props) => {
     <Editor
       height="35vh"
       className={classes}
+      theme={theme === 'dark' ? 'vs-dark' : 'vs'}
       options={
         {
           detectIndentation: true,

--- a/src/admin/components/elements/CodeEditor/index.tsx
+++ b/src/admin/components/elements/CodeEditor/index.tsx
@@ -32,7 +32,6 @@ const CodeEditor: React.FC<Props> = (props) => {
           readOnly: Boolean(readOnly),
           scrollBeyondLastLine: false,
           tabSize: 2,
-          theme: theme === 'dark' ? 'vs-dark' : 'vs',
           wordWrap: 'on',
           ...options,
         }

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -10,6 +10,10 @@ export const arrayFieldsSlug = 'array-fields';
 
 const ArrayFields: CollectionConfig = {
   slug: arrayFieldsSlug,
+  labels: {
+    singular: 'Activity Page',
+    plural: 'Activity Pages',
+  },
   fields: [
     {
       name: 'items',

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -10,10 +10,6 @@ export const arrayFieldsSlug = 'array-fields';
 
 const ArrayFields: CollectionConfig = {
   slug: arrayFieldsSlug,
-  labels: {
-    singular: 'Activity Page',
-    plural: 'Activity Pages',
-  },
   fields: [
     {
       name: 'items',


### PR DESCRIPTION
## Description

The code editor used in the Code and Json field shows a flash of light theme before loading the dark theme.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
