### PR TITLE
feat: allows init to accept a pre-built config

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -108,6 +108,7 @@ export type InitOptions = {
    * See Pino Docs for options: https://getpino.io/#/docs/api?id=options
    */
   loggerOptions?: LoggerOptions;
+  config?: SanitizedConfig
 };
 
 /**

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import express, { NextFunction, Response } from 'express';
 import crypto from 'crypto';
+import path from 'path';
 import mongoose from 'mongoose';
 import { InitOptions } from './config/types';
 
@@ -30,6 +31,7 @@ import Logger from './utilities/logger';
 import { getDataLoader } from './collections/dataloader';
 import mountEndpoints from './express/mountEndpoints';
 import PreferencesModel from './preferences/model';
+import findConfig from './config/find';
 
 export const init = (payload: Payload, options: InitOptions): void => {
   payload.logger.info('Starting Payload...');
@@ -52,7 +54,21 @@ export const init = (payload: Payload, options: InitOptions): void => {
 
   payload.local = options.local;
 
-  payload.config = loadConfig(payload.logger);
+  if (options.config) {
+    payload.config = options.config;
+    const configPath = findConfig();
+
+    payload.config = {
+      ...options.config,
+      paths: {
+        configDir: path.dirname(configPath),
+        config: configPath,
+        rawConfig: configPath,
+      },
+    };
+  } else {
+    payload.config = loadConfig(payload.logger);
+  }
 
   // If not initializing locally, scaffold router
   if (!payload.local) {


### PR DESCRIPTION
## Description

EXPERIMENTAL:

Allows for passing a config directly to `payload.init` and `payload.initAsync` so that Payload can reference a config directly rather than loading it by config path. 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes