### PR TITLE
fix: bug when clearing relationship field without hasMany: true

### DIFF
--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -297,7 +297,7 @@ export type ValueWithRelation = {
 }
 
 export function valueIsValueWithRelation(value: unknown): value is ValueWithRelation {
-  return typeof value === 'object' && 'relationTo' in value && 'value' in value;
+  return value !== null && typeof value === 'object' && 'relationTo' in value && 'value' in value;
 }
 
 export type RelationshipValue = (string | number)

--- a/src/fields/hooks/beforeValidate/promise.ts
+++ b/src/fields/hooks/beforeValidate/promise.ts
@@ -100,7 +100,7 @@ export const promise = async ({
               }
             });
           }
-          if (field.type === 'relationship' && field.hasMany !== true && valueIsValueWithRelation(value)) {
+          if (field.type === 'relationship' && field.hasMany !== true && value && valueIsValueWithRelation(value)) {
             const relatedCollection = req.payload.config.collections.find((collection) => collection.slug === value.relationTo);
             const relationshipIDField = relatedCollection.fields.find((collectionField) => fieldAffectsData(collectionField) && collectionField.name === 'id');
             if (relationshipIDField?.type === 'number') {

--- a/src/fields/hooks/beforeValidate/promise.ts
+++ b/src/fields/hooks/beforeValidate/promise.ts
@@ -100,7 +100,7 @@ export const promise = async ({
               }
             });
           }
-          if (field.type === 'relationship' && field.hasMany !== true && value && valueIsValueWithRelation(value)) {
+          if (field.type === 'relationship' && field.hasMany !== true && valueIsValueWithRelation(value)) {
             const relatedCollection = req.payload.config.collections.find((collection) => collection.slug === value.relationTo);
             const relationshipIDField = relatedCollection.fields.find((collectionField) => fieldAffectsData(collectionField) && collectionField.name === 'id');
             if (relationshipIDField?.type === 'number') {


### PR DESCRIPTION
## Description

When clearing a relationship field that does not have `hasMany: true` it is passing `null` to the `valueIsValueWithRelation` function and causing an error.

Reported on Discord [here](https://discord.com/channels/967097582721572934/1058419539114741860).

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes - **_relationship-field_**
