### PR TITLE
feat: throws descriptive error when collection or global slug not found

### DIFF
--- a/src/auth/operations/local/forgotPassword.ts
+++ b/src/auth/operations/local/forgotPassword.ts
@@ -3,6 +3,7 @@ import forgotPassword, { Result } from '../forgotPassword';
 import { Payload } from '../../..';
 import { getDataLoader } from '../../../collections/dataloader';
 import i18n from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   collection: string
@@ -24,6 +25,10 @@ async function localForgotPassword(payload: Payload, options: Options): Promise<
   } = options;
 
   const collection = payload.collections[collectionSlug];
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   req.payloadAPI = 'local';
   req.i18n = i18n(payload.config.i18n);

--- a/src/auth/operations/local/login.ts
+++ b/src/auth/operations/local/login.ts
@@ -5,6 +5,7 @@ import { TypeWithID } from '../../../collections/config/types';
 import { Payload } from '../../..';
 import { getDataLoader } from '../../../collections/dataloader';
 import i18n from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   collection: string
@@ -21,7 +22,7 @@ export type Options = {
   showHiddenFields?: boolean
 }
 
-async function localLogin<T extends TypeWithID = any>(payload: Payload, options: Options): Promise<Result & { user: T}> {
+async function localLogin<T extends TypeWithID = any>(payload: Payload, options: Options): Promise<Result & { user: T }> {
   const {
     collection: collectionSlug,
     req = {} as PayloadRequest,
@@ -35,6 +36,10 @@ async function localLogin<T extends TypeWithID = any>(payload: Payload, options:
   } = options;
 
   const collection = payload.collections[collectionSlug];
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   req.payloadAPI = 'local';
   req.payload = payload;

--- a/src/auth/operations/local/resetPassword.ts
+++ b/src/auth/operations/local/resetPassword.ts
@@ -3,6 +3,7 @@ import resetPassword, { Result } from '../resetPassword';
 import { PayloadRequest } from '../../../express/types';
 import { getDataLoader } from '../../../collections/dataloader';
 import i18n from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   collection: string
@@ -23,6 +24,10 @@ async function localResetPassword(payload: Payload, options: Options): Promise<R
   } = options;
 
   const collection = payload.collections[collectionSlug];
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   req.payload = payload;
   req.payloadAPI = 'local';

--- a/src/auth/operations/local/unlock.ts
+++ b/src/auth/operations/local/unlock.ts
@@ -3,6 +3,7 @@ import { Payload } from '../../..';
 import unlock from '../unlock';
 import { getDataLoader } from '../../../collections/dataloader';
 import i18n from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   collection: string
@@ -22,6 +23,10 @@ async function localUnlock(payload: Payload, options: Options): Promise<boolean>
   } = options;
 
   const collection = payload.collections[collectionSlug];
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   req.payload = payload;
   req.payloadAPI = 'local';

--- a/src/auth/operations/local/verifyEmail.ts
+++ b/src/auth/operations/local/verifyEmail.ts
@@ -1,3 +1,4 @@
+import { APIError } from '../../../errors';
 import { Payload } from '../../../index';
 import verifyEmail from '../verifyEmail';
 
@@ -13,6 +14,10 @@ async function localVerifyEmail(payload: Payload, options: Options): Promise<boo
   } = options;
 
   const collection = payload.collections[collectionSlug];
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   return verifyEmail({
     token,

--- a/src/collections/operations/local/create.ts
+++ b/src/collections/operations/local/create.ts
@@ -7,6 +7,7 @@ import create from '../create';
 import { getDataLoader } from '../../dataloader';
 import { File } from '../../../uploads/types';
 import i18n from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options<T> = {
   collection: string
@@ -45,6 +46,10 @@ export default async function createLocal<T = any>(payload: Payload, options: Op
 
   const collection = payload.collections[collectionSlug];
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   req.payloadAPI = 'local';
   req.locale = locale ?? req?.locale ?? defaultLocale;

--- a/src/collections/operations/local/delete.ts
+++ b/src/collections/operations/local/delete.ts
@@ -5,6 +5,7 @@ import { Payload } from '../../../index';
 import deleteOperation from '../delete';
 import { getDataLoader } from '../../dataloader';
 import i18n from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   collection: string
@@ -31,6 +32,11 @@ export default async function deleteLocal<T extends TypeWithID = any>(payload: P
 
   const collection = payload.collections[collectionSlug];
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
+
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   const req = {
     user,

--- a/src/collections/operations/local/find.ts
+++ b/src/collections/operations/local/find.ts
@@ -6,6 +6,7 @@ import { PayloadRequest } from '../../../express/types';
 import find from '../find';
 import { getDataLoader } from '../../dataloader';
 import i18n from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   collection: string
@@ -49,6 +50,10 @@ export default async function findLocal<T extends TypeWithID = any>(payload: Pay
 
   const collection = payload.collections[collectionSlug];
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   req.payloadAPI = 'local';
   req.locale = locale ?? req?.locale ?? defaultLocale;

--- a/src/collections/operations/local/findByID.ts
+++ b/src/collections/operations/local/findByID.ts
@@ -5,6 +5,7 @@ import findByID from '../findByID';
 import { Payload } from '../../..';
 import { getDataLoader } from '../../dataloader';
 import i18n from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   collection: string
@@ -40,6 +41,10 @@ export default async function findByIDLocal<T extends TypeWithID = any>(payload:
 
   const collection = payload.collections[collectionSlug];
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   req.payloadAPI = 'local';
   req.locale = locale ?? req?.locale ?? defaultLocale;

--- a/src/collections/operations/local/findVersionByID.ts
+++ b/src/collections/operations/local/findVersionByID.ts
@@ -5,6 +5,7 @@ import { TypeWithVersion } from '../../../versions/types';
 import findVersionByID from '../findVersionByID';
 import { getDataLoader } from '../../dataloader';
 import i18n from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   collection: string
@@ -34,6 +35,10 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
 
   const collection = payload.collections[collectionSlug];
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   req.payloadAPI = 'local';
   req.locale = locale ?? req?.locale ?? defaultLocale;

--- a/src/collections/operations/local/findVersions.ts
+++ b/src/collections/operations/local/findVersions.ts
@@ -6,6 +6,7 @@ import { PayloadRequest } from '../../../express/types';
 import findVersions from '../findVersions';
 import { getDataLoader } from '../../dataloader';
 import i18nInit from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   collection: string
@@ -38,6 +39,10 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
 
   const collection = payload.collections[collectionSlug];
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
 
   const i18n = i18nInit(payload.config.i18n);
   const req = {

--- a/src/collections/operations/local/restoreVersion.ts
+++ b/src/collections/operations/local/restoreVersion.ts
@@ -5,6 +5,7 @@ import { TypeWithVersion } from '../../../versions/types';
 import { getDataLoader } from '../../dataloader';
 import restoreVersion from '../restoreVersion';
 import i18nInit from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   collection: string
@@ -30,6 +31,11 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
   } = options;
 
   const collection = payload.collections[collectionSlug];
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
+
   const i18n = i18nInit(payload.config.i18n);
   const req = {
     user,

--- a/src/collections/operations/local/update.ts
+++ b/src/collections/operations/local/update.ts
@@ -6,6 +6,7 @@ import { PayloadRequest } from '../../../express/types';
 import { getDataLoader } from '../../dataloader';
 import { File } from '../../../uploads/types';
 import i18nInit from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options<T> = {
   collection: string
@@ -43,6 +44,11 @@ export default async function updateLocal<T = any>(payload: Payload, options: Op
   } = options;
 
   const collection = payload.collections[collectionSlug];
+
+  if (!collection) {
+    throw new APIError(`The collection with slug ${collectionSlug} can't be found.`);
+  }
+
   const i18n = i18nInit(payload.config.i18n);
   const defaultLocale = payload.config.localization ? payload.config.localization?.defaultLocale : null;
 

--- a/src/globals/operations/local/findOne.ts
+++ b/src/globals/operations/local/findOne.ts
@@ -5,6 +5,7 @@ import { Document } from '../../../types';
 import { TypeWithID } from '../../config/types';
 import findOne from '../findOne';
 import i18nInit from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   slug: string
@@ -31,6 +32,11 @@ export default async function findOneLocal<T extends TypeWithID = any>(payload: 
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
   const i18n = i18nInit(payload.config.i18n);
+
+
+  if (!globalConfig) {
+    throw new APIError(`The global with slug ${globalSlug} can't be found.`);
+  }
 
   const req = {
     user,

--- a/src/globals/operations/local/findVersionByID.ts
+++ b/src/globals/operations/local/findVersionByID.ts
@@ -5,6 +5,7 @@ import { Document } from '../../../types';
 import { TypeWithVersion } from '../../../versions/types';
 import findVersionByID from '../findVersionByID';
 import i18nInit from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   slug: string
@@ -33,6 +34,10 @@ export default async function findVersionByIDLocal<T extends TypeWithVersion<T> 
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
   const i18n = i18nInit(payload.config.i18n);
+
+  if (!globalConfig) {
+    throw new APIError(`The global with slug ${globalSlug} can't be found.`);
+  }
 
   const req = {
     user,

--- a/src/globals/operations/local/findVersions.ts
+++ b/src/globals/operations/local/findVersions.ts
@@ -6,6 +6,7 @@ import { PayloadRequest } from '../../../express/types';
 import findVersions from '../findVersions';
 import { getDataLoader } from '../../../collections/dataloader';
 import i18nInit from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   slug: string
@@ -38,6 +39,10 @@ export default async function findVersionsLocal<T extends TypeWithVersion<T> = a
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
   const i18n = i18nInit(payload.config.i18n);
+
+  if (!globalConfig) {
+    throw new APIError(`The global with slug ${globalSlug} can't be found.`);
+  }
 
   const req = {
     user,

--- a/src/globals/operations/local/restoreVersion.ts
+++ b/src/globals/operations/local/restoreVersion.ts
@@ -5,6 +5,7 @@ import { Document } from '../../../types';
 import { TypeWithVersion } from '../../../versions/types';
 import restoreVersion from '../restoreVersion';
 import i18nInit from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   slug: string
@@ -31,6 +32,10 @@ export default async function restoreVersionLocal<T extends TypeWithVersion<T> =
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
   const i18n = i18nInit(payload.config.i18n);
+
+  if (!globalConfig) {
+    throw new APIError(`The global with slug ${globalSlug} can't be found.`);
+  }
 
   const req = {
     user,

--- a/src/globals/operations/local/update.ts
+++ b/src/globals/operations/local/update.ts
@@ -5,6 +5,7 @@ import { TypeWithID } from '../../config/types';
 import update from '../update';
 import { getDataLoader } from '../../../collections/dataloader';
 import i18nInit from '../../../translations/init';
+import { APIError } from '../../../errors';
 
 export type Options = {
   slug: string
@@ -33,6 +34,10 @@ export default async function updateLocal<T extends TypeWithID = any>(payload: P
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug);
   const i18n = i18nInit(payload.config.i18n);
+
+  if (!globalConfig) {
+    throw new APIError(`The global with slug ${globalSlug} can't be found.`);
+  }
 
   const req = {
     user,


### PR DESCRIPTION
## Description

Adds a more descriptive error message when collection/global slug is not found using the local API. https://github.com/payloadcms/payload/discussions/1285

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [N/A] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [N/A] I have made corresponding changes to the documentation
