### PR TITLE
Fix/merge drafts

### DIFF
--- a/src/collections/operations/find.ts
+++ b/src/collections/operations/find.ts
@@ -161,13 +161,9 @@ async function find<T extends TypeWithID = any>(incomingArgs: Arguments): Promis
 
   if (collectionConfig.versions?.drafts && draftsEnabled) {
     result = await mergeDrafts({
-      accessResult,
       collection,
-      locale,
       paginationOptions,
-      payload,
       query,
-      where,
     });
   } else {
     result = await Model.paginate(query, paginationOptions);

--- a/src/versions/drafts/mergeDrafts.ts
+++ b/src/versions/drafts/mergeDrafts.ts
@@ -2,228 +2,212 @@ import { AccessResult } from '../../config/types';
 import { Where } from '../../types';
 import { Payload } from '../..';
 import { PaginatedDocs } from '../../mongoose/types';
-import { Collection, CollectionModel, TypeWithID } from '../../collections/config/types';
+import { Collection } from '../../collections/config/types';
 import { hasWhereAccessResult } from '../../auth';
-import { appendVersionToQueryKey } from './appendVersionToQueryKey';
-import replaceWithDraftIfAvailable from './replaceWithDraftIfAvailable';
-
-type AggregateVersion<T> = {
-  _id: string
-  version: T
-  updatedAt: string
-  createdAt: string
-}
-
-type VersionCollectionMatchMap<T> = {
-  [_id: string | number]: {
-    updatedAt: string
-    createdAt: string
-    version: T
-  }
-}
 
 type Args = {
-  accessResult: AccessResult
-  collection: Collection
-  locale: string
-  paginationOptions: any
-  payload: Payload
-  query: Record<string, unknown>
-  where: Where
-}
+  accessResult: AccessResult;
+  collection: Collection;
+  locale: string;
+  paginationOptions: any;
+  payload: Payload;
+  query: Record<string, unknown>;
+  where: Where;
+};
 
-export const mergeDrafts = async <T extends TypeWithID>({
+// This function makes it possible to filter documents by their newest
+// version. Regardless if it is in the versions collection or not.
+// This is done by first joining the versions collection on the parent
+// and then replacing the document with the newest version if there is a
+// newer version.
+// This version also handles pagination for all documents, including
+// versions. This means that the pagination is done on the newest version
+// of each document.
+async function findNewest({
   accessResult,
   collection,
   locale,
-  payload,
   paginationOptions,
   query,
   where: incomingWhere,
-}: Args): Promise<PaginatedDocs<T>> => {
-  // Query the main collection for any IDs that match the query
-  // Create object "map" for performant lookup
-  const mainCollectionMatchMap = await collection.Model.find(query, { updatedAt: 1 }, { limit: paginationOptions.limit, sort: paginationOptions.sort })
-    .lean().then((res) => res.reduce((map, { _id, updatedAt }) => {
-      const newMap = map;
-      newMap[_id] = updatedAt;
-      return newMap;
-    }, {}));
-
-  // Query the versions collection with a version-specific query
-  const VersionModel = payload.versions[collection.config.slug] as CollectionModel;
-
-  const where = appendVersionToQueryKey(incomingWhere || {});
-
-  const versionQueryToBuild: { where: Where } = {
-    where: {
-      ...where,
-      and: [
-        ...where?.and || [],
-        {
-          'version._status': {
-            equals: 'draft',
-          },
-        },
-      ],
-    },
-  };
-
-  if (hasWhereAccessResult(accessResult)) {
-    const versionAccessResult = appendVersionToQueryKey(accessResult);
-    versionQueryToBuild.where.and.push(versionAccessResult);
-  }
-
-  const versionQuery = await VersionModel.buildQuery(versionQueryToBuild, locale);
-  const includedParentIDs: (string | number)[] = [];
-
-  // Create version "map" for performant lookup
-  // and in the same loop, check if there are matched versions without a matched parent
-  // This means that the newer version's parent should appear in the main query.
-  // To do so, add the version's parent ID into an explicit `includedIDs` array
-  const versionCollectionMatchMap = await VersionModel.aggregate<AggregateVersion<T>>([
-    {
-      $sort: Object.entries(paginationOptions.sort).reduce((sort, [key, order]) => {
-        return {
-          ...sort,
-          [key]: order === 'asc' ? 1 : -1,
-        };
-      }, {}),
-    },
-    {
-      $group: {
-        _id: '$parent',
-        versionID: { $first: '$_id' },
-        version: { $first: '$version' },
-        updatedAt: { $first: '$updatedAt' },
-        createdAt: { $first: '$createdAt' },
-      },
-    },
-    {
-      $addFields: {
-        id: {
-          $toObjectId: '$_id',
-        },
-      },
-    },
-    {
-      $lookup: {
-        from: collection.config.slug,
-        localField: 'id',
-        foreignField: '_id',
-        as: 'parent',
-      },
-    },
-    {
-      $match: {
-        parent: {
-          $size: 1,
-        },
-      },
-    },
-    { $match: versionQuery },
-    { $limit: paginationOptions.limit },
-  ]).then((res) => res.reduce<VersionCollectionMatchMap<T>>((map, { _id, updatedAt, createdAt, version }) => {
-    const newMap = map;
-    newMap[_id] = { version, updatedAt, createdAt };
-
-    const matchedParent = mainCollectionMatchMap[_id];
-    if (!matchedParent) includedParentIDs.push(_id);
-    return newMap;
-  }, {}));
-
-  // Now we need to explicitly exclude any parent matches that have newer versions
-  // which did NOT appear in the versions query
-  const excludedParentIDs = await Promise.all(Object.entries(mainCollectionMatchMap).map(async ([parentDocID, parentDocUpdatedAt]) => {
-    // If there is a matched version, and it's newer, this parent should remain
-    if (versionCollectionMatchMap[parentDocID] && versionCollectionMatchMap[parentDocID].updatedAt > parentDocUpdatedAt) {
-      return null;
-    }
-
-    // Otherwise, we need to check if there are newer versions present
-    // that did not get returned from the versions query
-    const versionsQuery = await VersionModel.find({
-      updatedAt: {
-        $gt: parentDocUpdatedAt,
-      },
-      parent: {
-        $eq: parentDocID,
-      },
-    }, {}, { limit: 1 }).lean();
-
-    // If there are,
-    // this says that the newest version does not match the incoming query,
-    // and the parent ID should be excluded
-    if (versionsQuery.length > 0) {
-      return parentDocID;
-    }
-
-    return null;
-  })).then((res) => res.filter((result) => Boolean(result)));
-
-  // Run a final query against the main collection,
-  // passing in any ids to exclude and include
-  // so that they appear properly paginated
+}: Args): Promise<PaginatedDocs> {
   const finalQueryToBuild: { where: Where } = {
     where: {
-      and: [],
+      and: [{ or: [] }],
     },
   };
-
-  finalQueryToBuild.where.and.push({ or: [] });
-
   if (hasWhereAccessResult(accessResult)) {
     finalQueryToBuild.where.and.push(accessResult);
   }
-
   if (incomingWhere) {
     finalQueryToBuild.where.and[0].or.push(incomingWhere);
   }
+  // await seems to be needed -> wrong type
+  const finalQuery = await collection.Model.buildQuery(
+    finalQueryToBuild,
+    locale,
+  );
+  const project = query && Object.keys(query).length > 0 ? query : undefined;
 
-  if (includedParentIDs.length > 0) {
-    finalQueryToBuild.where.and[0].or.push({
-      id: {
-        in: includedParentIDs,
+  const page = paginationOptions.page ?? 1;
+  const limit = paginationOptions.limit ?? 10;
+  const skip = (page - 1) * limit;
+
+  const results = await collection.Model.aggregate([
+    // transform _id to string, so it can be used in the $lookup
+    {
+      $addFields: { _id: { $toString: '$_id' } },
+    },
+    // check if there is a newer version
+    {
+      $lookup: {
+        // TODO: query from somewhere
+        from: `_${collection.config.slug}_versions`,
+        as: '_versions',
+        // join _id on parent
+        localField: '_id',
+        foreignField: 'parent',
+        let: {
+          // define updatedAt to be used in the pipeline
+          updatedAt: '$updatedAt',
+        },
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                // only match versions that are newer than the document
+                $gt: ['$updatedAt', '$$updatedAt'],
+              },
+            },
+          },
+          // sort by updatedAt descending
+          { $sort: { updatedAt: -1 } },
+          // take the first (newest) version
+          { $limit: 1 },
+        ],
       },
-    });
-  }
-
-  if (excludedParentIDs.length > 0) {
-    finalQueryToBuild.where.and.push({
-      id: {
-        not_in: excludedParentIDs,
+    },
+    // write the newest version to _version
+    // and the size of _versions to _versionsSize
+    {
+      $addFields: {
+        _version: {
+          $arrayElemAt: ['$_versions', 0],
+        },
+        _versionsSize: {
+          $size: '$_versions',
+        },
       },
-    });
-  }
+    },
+    // replace the document with the newest version if there is one
+    {
+      $replaceRoot: {
+        newRoot: {
+          $cond: {
+            // if there is no newer version
+            if: {
+              $eq: ['$_versionsSize', 0],
+            },
+            // then keep the document
+            then: '$$ROOT',
+            // otherwise replace the document with the newest version
+            else: {
+              $mergeObjects: [
+                // take the newest _version.version,
+                '$_version.version',
+                // but keep the createdAt, and _id of the document
+                // and use the updatedAt of the version
+                {
+                  _id: '$_id',
+                  updatedAt: '$_version.updatedAt',
+                  createdAt: '$createdAt',
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    // remove the _version, _versionsSize and _versions fields
+    {
+      $project: {
+        _versionsSize: 0,
+        _version: 0,
+        _versions: 0,
+      },
+    },
+    // filter before counting the total number of documents
+    {
+      $match: finalQuery,
+    },
+    // sort before counting the total number of documents
+    {
+      $sort: Object.entries(paginationOptions.sort).reduce(
+        (sort, [key, order]) => {
+          return {
+            ...sort,
+            [key]: order === 'asc' ? 1 : -1,
+          };
+        },
+        {},
+      ),
+    },
+    // we need to simulate the pagination in this query
+    // so we need to know the total number of documents
+    // and the documents for the current page
+    // we do this with a $facet to split the pipeline
+    // in a lookup and a count
+    {
+      $facet: {
+        docs: [
+          // skip and limit
+          {
+            $skip: skip,
+          },
+          {
+            $limit: limit,
+          },
+          // select fields by project
+          ...(project ? [{ $project: project }] : []),
+        ],
+        totalDocs: [
+          {
+            // counts all filtered documents, but only the newest version
+            // as we already replaced the document with the newest version
+            // in the previous step
+            $count: 'count',
+          },
+        ],
+      },
+    },
+  ]);
 
-  const finalQuery = await collection.Model.buildQuery(finalQueryToBuild, locale);
+  const [
+    {
+      totalDocs: [{ count: totalDocs }],
+      docs,
+    },
+  ] = results;
+  // create the other pagination fields from totalDocs, limit and page
+  const pagingCounter = Math.ceil(totalDocs / limit);
+  const totalPages = pagingCounter;
+  const hasPrevPage = page > 1;
+  const prevPage = hasPrevPage ? page - 1 : null;
+  const hasNextPage = page < totalPages;
+  const nextPage = hasNextPage ? page + 1 : null;
 
-  let result = await collection.Model.paginate(finalQuery, paginationOptions);
-
-  result = {
-    ...result,
-    docs: await Promise.all(result.docs.map(async (doc) => {
-      const matchedVersion = versionCollectionMatchMap[doc.id];
-
-      if (matchedVersion && matchedVersion.updatedAt > doc.updatedAt) {
-        return {
-          ...doc,
-          ...matchedVersion.version,
-          createdAt: matchedVersion.createdAt,
-          updatedAt: matchedVersion.updatedAt,
-        };
-      }
-
-      return replaceWithDraftIfAvailable({
-        accessResult,
-        payload,
-        entity: collection.config,
-        entityType: 'collection',
-        doc,
-        locale,
-      });
-    })),
+  return {
+    docs,
+    totalDocs,
+    limit,
+    totalPages,
+    page,
+    pagingCounter,
+    hasPrevPage,
+    hasNextPage,
+    prevPage,
+    nextPage,
   };
+}
 
-  return result;
-};
+export const mergeDrafts = findNewest;


### PR DESCRIPTION
## Description

See [Discord Discussion](https://discord.com/channels/967097582721572934/1062809605257826406)

There is a wrong behavior in the `mergeDrafts` function.

The new version builds onto the old behavior (1.5.3 and earlier) and fixes some bugs that were found in that version. It simulates pagination by only counting the newest docs that match the query.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
