### PR TITLE
fix: disables escapeValue for i18n

### DIFF
--- a/src/translations/defaultOptions.ts
+++ b/src/translations/defaultOptions.ts
@@ -6,4 +6,7 @@ export const defaultOptions: InitOptions = {
   debug: false,
   supportedLngs: Object.keys(translations),
   resources: translations,
+  interpolation: {
+    escapeValue: false,
+  },
 };


### PR DESCRIPTION
## Description

Issue #1844 

I18next escapes special characters [by default,](i18next.com/translation-function/interpolation#additional-options) this was causing inconsistent labels across the dashboard. 
This has been updated to `escapeValue: false` by default - the user can still reenable this through the i18n property in their payload config.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [n/a] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [n/a] I have made corresponding changes to the documentation
