### PR TITLE
wrapped data loader to make it error prove

### DIFF
--- a/src/collections/dataloader.ts
+++ b/src/collections/dataloader.ts
@@ -1,4 +1,5 @@
 import DataLoader, { BatchLoadFn } from 'dataloader';
+import { ObjectId } from 'mongoose';
 import { PayloadRequest } from '../express/types';
 import { TypeWithID } from './config/types';
 import { isValidID } from '../utilities/isValidID';
@@ -16,28 +17,23 @@ import { fieldAffectsData } from '../fields/config/types';
 
 const batchAndLoadDocs = (req: PayloadRequest): BatchLoadFn<string, TypeWithID> => async (keys: string[]): Promise<TypeWithID[]> => {
   const { payload } = req;
-
-  // Create docs array of same length as keys, using null as value
-  // We will replace nulls with injected docs as they are retrieved
-  const docs: (TypeWithID | null)[] = keys.map(() => null);
-
   // Batch IDs by their `find` args
   // so we can make one find query per combination of collection, depth, locale, and fallbackLocale.
 
   // Resulting shape will be as follows:
-
   // {
   //   // key is stringified set of find args
   //   '["pages",2,0,"es","en",false,false]': [
-  //     // value is array of IDs to find with these args
-  //     'q34tl23462346234524',
-  //     '435523540194324280',
-  //     '2346245j35l3j5234532li',
+  //     // value is array of ID, key, resolve, reject to find with these args
+  //     {id: 'q34tl23462346234524', key: '["pages",'q34tl23462346234524',2,0,"es","en",false,false]', resolve: [Function], reject: [Function]},
+  //     {id: '435523540194324280', key: '["pages",'435523540194324280',2,0,"es","en",false,false]', resolve: [Function], reject: [Function]},
+  //     {id: '2346245j35l3j5234532li', key: '["pages",'2346245j35l3j5234532li',2,0,"es","en",false,false]', resolve: [Function], reject: [Function]},
   //   ],
   //   // etc
   // };
 
-  const batchByFindArgs = keys.reduce((batches, key) => {
+  const results: (Promise<TypeWithID>)[] = [];
+  const batchByFindArgs = keys.reduce<Record<string, Array<{ id: string; key: string; resolve:(value: TypeWithID) => void; reject: (reason?: any) => void}>>>((batches, key) => {
     const [collection, id, depth, currentDepth, locale, fallbackLocale, overrideAccess, showHiddenFields] = JSON.parse(key);
 
     const batchKeyArray = [
@@ -51,63 +47,153 @@ const batchAndLoadDocs = (req: PayloadRequest): BatchLoadFn<string, TypeWithID> 
     ];
 
     const batchKey = JSON.stringify(batchKeyArray);
-
-    const idField = payload.collections?.[collection].config.fields.find((field) => fieldAffectsData(field) && field.name === 'id');
-
-    if (isValidID(id, getIDType(idField))) {
-      return {
-        ...batches,
-        [batchKey]: [
-          ...batches[batchKey] || [],
-          id,
-        ],
-      };
-    }
+    let res: (value: TypeWithID) => void;
+    let rej: (reason?: any) => void;
+    results.push(new Promise<TypeWithID>((resolve, reject) => {
+      res = resolve;
+      rej = reject;
+    }));
+    // eslint-disable-next-line no-param-reassign
+    batches[batchKey] = [
+      ...batches[batchKey] || [],
+      {
+        id,
+        key,
+        resolve: res,
+        reject: rej,
+      },
+    ];
     return batches;
   }, {});
 
   // Run find requests in parallel
+  Object.entries(batchByFindArgs).forEach(async ([batchKey, ids]) => {
+    try {
+      const [collection, depth, currentDepth, locale, fallbackLocale, overrideAccess, showHiddenFields] = JSON.parse(batchKey);
 
-  const results = Object.entries(batchByFindArgs).map(async ([batchKey, ids]) => {
-    const [collection, depth, currentDepth, locale, fallbackLocale, overrideAccess, showHiddenFields] = JSON.parse(batchKey);
+      // copy req object to avoid mutating it
+      // override payloadDataLoader to prevent infinite recursion
 
-    const result = await payload.find({
-      collection,
-      locale,
-      fallbackLocale,
-      depth,
-      currentDepth,
-      pagination: false,
-      where: {
-        id: {
-          in: ids,
+      const result = await payload.find({
+        collection,
+        locale,
+        fallbackLocale,
+        depth,
+        currentDepth,
+        pagination: false,
+        where: {
+          id: {
+            in: ids.map(({ id }) => id),
+          },
         },
-      },
-      overrideAccess: Boolean(overrideAccess),
-      showHiddenFields: Boolean(showHiddenFields),
-      disableErrors: true,
-      req,
+        overrideAccess: Boolean(overrideAccess),
+        showHiddenFields: Boolean(showHiddenFields),
+        disableErrors: true,
+        req,
+      });
+
+      const keyToDoc = result.docs.reduce<Record<string, TypeWithID>>((map, doc) => {
+        const key = stringifyLoadArgs({
+          collection,
+          id: doc.id,
+          depth,
+          currentDepth,
+          locale,
+          fallbackLocale,
+          overrideAccess,
+          showHiddenFields,
+        });
+        // eslint-disable-next-line no-param-reassign
+        map[key] = doc;
+        return map;
+      }, {});
+
+      ids.forEach(({ key, resolve }) => {
+        const doc = keyToDoc[key];
+        if (doc) {
+          resolve(doc);
+        } else {
+          resolve(null);
+        }
+      });
+    } catch (error) {
+      // reject all promises in this batch
+      ids.forEach(({ reject }) => {
+        reject(error);
+      });
+    }
+  });
+  const timeoutId = setTimeout(() => {
+    // reject all promises after 30 seconds
+    Object.entries(batchByFindArgs).forEach(([, ids]) => {
+      ids.forEach(({ reject }) => {
+        reject(new Error('Data loader timed out'));
+      });
     });
+  }, 30_000);
 
-    // For each returned doc, find index in original keys
-    // Inject doc within docs array if index exists
-
-    result.docs.forEach((doc) => {
-      const docKey = JSON.stringify([collection, doc.id, depth, currentDepth, locale, fallbackLocale, overrideAccess, showHiddenFields]);
-      const docsIndex = keys.findIndex((key) => key === docKey);
-
-      if (docsIndex > -1) {
-        docs[docsIndex] = doc;
-      }
-    });
+  // Wait for all promises to resolve or reject
+  Promise.allSettled(results).then(() => {
+    clearTimeout(timeoutId);
   });
 
-  await Promise.all(results);
-
-  // Return docs array,
-  // which has now been injected with all fetched docs
-  // and should match the length of the incoming keys arg
-  return docs;
+  // Return array of promises
+  // dataload supports promises as values
+  // but has a wrong type definition
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - dataloader has wrong type definition
+  return results;
 };
 
-export const getDataLoader = (req: PayloadRequest) => new DataLoader(batchAndLoadDocs(req));
+export type LoadArgs = string | {
+  collection: string;
+  id: string | number;
+  depth: number;
+  currentDepth: number;
+  locale: string;
+  fallbackLocale: string;
+  overrideAccess: boolean;
+  showHiddenFields: boolean;
+}
+
+function stringifyLoadArgs(args: LoadArgs): string {
+  if (typeof args === 'string') {
+    return args;
+  }
+  const { collection, id, depth, currentDepth, locale, fallbackLocale, overrideAccess, showHiddenFields } = args;
+  return JSON.stringify([collection, id, depth, currentDepth, locale, fallbackLocale, overrideAccess, showHiddenFields]);
+}
+
+export const getDataLoader = (req: PayloadRequest) => {
+  const dataloader = new DataLoader(batchAndLoadDocs(req));
+
+  const { payload } = req;
+  // wrap the load function to ensure we always stringify the key
+  // with the correct fields
+  // we also need to check if the id is valid
+  // for backwards compatibility we need to support strings as well
+  function load(key: LoadArgs): Promise<TypeWithID> {
+    let collection: string;
+    let id: string | number;
+    if (typeof key === 'string') {
+      [collection, id] = JSON.parse(key);
+    } else {
+      ({ collection, id } = key);
+    }
+    const idField = payload.collections?.[collection].config.fields.find((field) => fieldAffectsData(field) && field.name === 'id');
+    if (!isValidID(id, getIDType(idField))) {
+      // should probably throw an error here, but this would be a breaking change
+      // throw new Error(`Invalid ID ${id} for collection ${collection}`);
+      return null;
+    }
+    return dataloader.load(stringifyLoadArgs(key));
+  }
+
+  return {
+    load,
+    loadAll: (keys: Array<LoadArgs>) => Promise.all(keys.map(load)),
+    clear: dataloader.clear,
+    clearAll: dataloader.clearAll,
+    prime: dataloader.prime,
+  };
+};

--- a/src/express/types.ts
+++ b/src/express/types.ts
@@ -2,7 +2,7 @@ import { Request } from 'express';
 import type { i18n as Ii18n, TFunction } from 'i18next';
 import { UploadedFile } from 'express-fileupload';
 import { Payload } from '../payload';
-import { Collection, TypeWithID } from '../collections/config/types';
+import { Collection } from '../collections/config/types';
 import { User } from '../auth/types';
 import { Document } from '../types';
 import { getDataLoader } from '../collections/dataloader';

--- a/src/express/types.ts
+++ b/src/express/types.ts
@@ -1,18 +1,18 @@
 import { Request } from 'express';
 import type { i18n as Ii18n, TFunction } from 'i18next';
-import DataLoader from 'dataloader';
 import { UploadedFile } from 'express-fileupload';
 import { Payload } from '../payload';
 import { Collection, TypeWithID } from '../collections/config/types';
 import { User } from '../auth/types';
 import { Document } from '../types';
+import { getDataLoader } from '../collections/dataloader';
 
 /** Express request with some Payload related context added */
 export declare type PayloadRequest<U = any> = Request & {
   /** The global payload object */
   payload: Payload;
   /** Optimized document loader */
-  payloadDataLoader: DataLoader<string, TypeWithID>;
+  payloadDataLoader: ReturnType<typeof getDataLoader>;
   /**
    * The requested locale if specified
    * Only available for localised collections

--- a/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -40,16 +40,18 @@ const populate = async ({
     }
 
     if (shouldPopulate) {
-      relationshipValue = await req.payloadDataLoader.load(JSON.stringify([
-        relatedCollection.config.slug,
-        id,
-        depth,
-        currentDepth + 1,
-        req.locale,
-        req.fallbackLocale,
-        overrideAccess,
-        showHiddenFields,
-      ]));
+      relationshipValue = await req.payloadDataLoader.load(
+        {
+          collection: relatedCollection.config.slug,
+          id: id as string,
+          depth,
+          currentDepth: currentDepth + 1,
+          locale: req.locale,
+          fallbackLocale: req.fallbackLocale,
+          overrideAccess,
+          showHiddenFields,
+        },
+      );
     }
 
     if (!relationshipValue) {

--- a/src/fields/richText/populate.ts
+++ b/src/fields/richText/populate.ts
@@ -31,16 +31,16 @@ export const populate = async ({
 }): Promise<void> => {
   const dataRef = data as Record<string, unknown>;
 
-  const doc = await req.payloadDataLoader.load(JSON.stringify([
-    collection.config.slug,
+  const doc = await req.payloadDataLoader.load({
+    collection: collection.config.slug,
     id,
     depth,
-    currentDepth + 1,
-    req.locale,
-    req.fallbackLocale,
-    typeof overrideAccess === 'undefined' ? false : overrideAccess,
+    currentDepth: currentDepth + 1,
+    locale: req.locale,
+    fallbackLocale: req.fallbackLocale,
+    overrideAccess: typeof overrideAccess === 'undefined' ? false : overrideAccess,
     showHiddenFields,
-  ]));
+  });
 
   if (doc) {
     dataRef[key] = doc;

--- a/test/dataloader/config.ts
+++ b/test/dataloader/config.ts
@@ -60,6 +60,27 @@ export default buildConfig({
         },
       ],
     },
+    {
+      slug: 'infinite-loop',
+      labels: {
+        singular: 'Infinite Loop',
+        plural: 'Infinite Loops',
+      },
+      fields: [
+        {
+          name: 'textRelationships',
+          type: 'text',
+          hooks: {
+            afterRead: [
+              async ({ value, req: { payloadDataLoader } }) => {
+                const ids = value.split(' $_$ ').map((id) => id.trim());
+                return payloadDataLoader.loadAll(ids);
+              },
+            ],
+          },
+        },
+      ],
+    },
   ],
   onInit: async (payload) => {
     const user = await payload.create({


### PR DESCRIPTION
## Description

I changed the dataloader to be wrapped in our own wrapper to ensure:
- no recursion
- no wrong keys
- Possible to use object instead of string

Used the undocumented feature of the dataloader to return an array of Promises instead of one Promise

Added timeout to dataloader batch to reject all promises after 30s

Added recursion check

Changed richtext population from payload.findById to dataloader.load

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
