### PR TITLE
fix: creates backup of current version after restoring draft

### DIFF
--- a/src/collections/operations/restoreVersion.ts
+++ b/src/collections/operations/restoreVersion.ts
@@ -9,6 +9,7 @@ import { Where } from '../../types';
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields';
 import { afterChange } from '../../fields/hooks/afterChange';
 import { afterRead } from '../../fields/hooks/afterRead';
+import { getLatestCollectionVersion } from '../../versions/getLatestCollectionVersion';
 
 export type Arguments = {
   collection: Collection
@@ -23,6 +24,7 @@ export type Arguments = {
 
 async function restoreVersion<T extends TypeWithID = any>(args: Arguments): Promise<T> {
   const {
+    collection,
     collection: {
       Model,
       config: collectionConfig,
@@ -99,10 +101,11 @@ async function restoreVersion<T extends TypeWithID = any>(args: Arguments): Prom
   // fetch previousDoc
   // /////////////////////////////////////
 
-  const previousDoc = await payload.findByID({
-    collection: collectionConfig.slug,
+  const prevDocWithLocales = await getLatestCollectionVersion({
+    payload,
+    collection,
     id: parentDocID,
-    depth,
+    query,
   });
 
   // /////////////////////////////////////
@@ -122,6 +125,22 @@ async function restoreVersion<T extends TypeWithID = any>(args: Arguments): Prom
   result = JSON.stringify(result);
   result = JSON.parse(result);
   result = sanitizeInternalFields(result);
+
+  // /////////////////////////////////////
+  // Save `previousDoc` as a version after restoring
+  // /////////////////////////////////////
+
+  const prevVersion = { ...prevDocWithLocales };
+
+  delete prevVersion.id;
+
+  await VersionModel.create({
+    parent: parentDocID,
+    version: prevVersion,
+    autosave: false,
+    createdAt: prevVersion.createdAt,
+    updatedAt: new Date().toISOString(),
+  });
 
   // /////////////////////////////////////
   // afterRead - Fields
@@ -156,7 +175,7 @@ async function restoreVersion<T extends TypeWithID = any>(args: Arguments): Prom
   result = await afterChange({
     data: result,
     doc: result,
-    previousDoc,
+    previousDoc: prevDocWithLocales,
     entityConfig: collectionConfig,
     operation: 'update',
     req,
@@ -172,7 +191,7 @@ async function restoreVersion<T extends TypeWithID = any>(args: Arguments): Prom
     result = await hook({
       doc: result,
       req,
-      previousDoc,
+      previousDoc: prevDocWithLocales,
       operation: 'update',
     }) || result;
   }, Promise.resolve());

--- a/src/versions/getLatestCollectionVersion.ts
+++ b/src/versions/getLatestCollectionVersion.ts
@@ -30,11 +30,10 @@ export const getLatestCollectionVersion = async <T extends TypeWithID = any>({
       lean,
     });
   }
-  let collection = await Model.findOne(query, {}, { lean }) as Document;
+  const collection = await Model.findOne(query, {}, { lean }) as Document;
   version = await version;
   if (!version || version.updatedAt < collection.updatedAt) {
     collection.id = collection._id;
-    collection = sanitizeInternalFields(collection);
     return collection;
   }
   return {

--- a/src/versions/getLatestCollectionVersion.ts
+++ b/src/versions/getLatestCollectionVersion.ts
@@ -1,6 +1,7 @@
 import { Document } from '../types';
 import { Payload } from '../payload';
 import { Collection, TypeWithID } from '../collections/config/types';
+import sanitizeInternalFields from '../utilities/sanitizeInternalFields';
 
 type Args = {
   payload: Payload
@@ -29,13 +30,16 @@ export const getLatestCollectionVersion = async <T extends TypeWithID = any>({
       lean,
     });
   }
-  const collection = await Model.findOne(query, {}, { lean }) as Document;
+  let collection = await Model.findOne(query, {}, { lean }) as Document;
   version = await version;
   if (!version || version.updatedAt < collection.updatedAt) {
+    collection.id = collection._id;
+    collection = sanitizeInternalFields(collection);
     return collection;
   }
   return {
     ...version.version,
+    id,
     updatedAt: version.updatedAt,
     createdAt: version.createdAt,
   };

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -202,7 +202,7 @@ describe('Versions', () => {
           draft: true,
         });
 
-        expect(latestDraft.title).toBe(versions.docs[1].version.title);
+        expect(latestDraft.title).toBe(versions.docs[0].version.title);
       });
     });
 

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -47,7 +47,7 @@ describe('Versions', () => {
 
   describe('Collections - Local', () => {
     describe('Create', () => {
-      it('should allow a new version to be created', async () => {
+      it('should allow a new version to be created and updated', async () => {
         const autosavePost = await payload.create({
           collection,
           data: {
@@ -56,9 +56,9 @@ describe('Versions', () => {
           },
         });
 
-        const updatedTitle = 'Here is an updated post title in EN';
-
         collectionLocalPostID = autosavePost.id;
+
+        const updatedTitle = 'Here is an updated post title in EN';
 
         const updatedPost: {
           title: string
@@ -71,14 +71,14 @@ describe('Versions', () => {
           },
         });
 
+        expect(updatedPost.title).toBe(updatedTitle);
+        expect(updatedPost._status).toStrictEqual('draft');
+
         const versions = await payload.findVersions({
           collection,
         });
 
         collectionLocalVersionID = versions.docs[0].id;
-
-        expect(updatedPost.title).toBe(updatedTitle);
-        expect(updatedPost._status).toStrictEqual('draft');
 
         expect(collectionLocalVersionID).toBeDefined();
       });
@@ -99,6 +99,7 @@ describe('Versions', () => {
             description: 'description 2',
           },
         });
+
         const finalDescription = 'final description';
 
         const secondUpdate = await payload.update({
@@ -187,20 +188,21 @@ describe('Versions', () => {
           collection,
         });
 
-        const restore = await payload.restoreVersion({
+        // restore to latest version
+        const restoredVersion = await payload.restoreVersion({
           collection,
           id: versions.docs[1].id,
         });
 
-        expect(restore.title).toBeDefined();
+        expect(restoredVersion.title).toBeDefined();
 
-        const restoredPost = await payload.findByID({
+        const latestDraft = await payload.findByID({
           collection,
           id: collectionLocalPostID,
           draft: true,
         });
 
-        expect(restoredPost.title).toBe(versions.docs[1].version.title);
+        expect(latestDraft.title).toBe(versions.docs[1].version.title);
       });
     });
 


### PR DESCRIPTION
## Description

Fixes #1873 by saving the latest version after restoring a draft.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
