### PR TITLE
fix: hides fallback locale checkbox when field localization is set to false

### DIFF
--- a/src/admin/components/forms/NullifyField/index.tsx
+++ b/src/admin/components/forms/NullifyField/index.tsx
@@ -6,11 +6,11 @@ import { useLocale } from '../../utilities/Locale';
 import { useConfig } from '../../utilities/Config';
 import { useForm } from '../Form/context';
 
-type NullifyFieldProps = {
+type NullifyLocaleFieldProps = {
   path: string
   fieldValue?: null | [] | number
 }
-export const NullifyField: React.FC<NullifyFieldProps> = ({ path, fieldValue }) => {
+export const NullifyLocaleField: React.FC<NullifyLocaleFieldProps> = ({ path, fieldValue }) => {
   const { dispatchFields, setModified } = useForm();
   const currentLocale = useLocale();
   const { localization } = useConfig();
@@ -31,7 +31,7 @@ export const NullifyField: React.FC<NullifyFieldProps> = ({ path, fieldValue }) 
   };
 
   if (currentLocale === defaultLocale || (localization && !localization.fallback)) {
-    // hide when editing default locale
+    // hide when editing default locale or when fallback is disabled
     return null;
   }
 

--- a/src/admin/components/forms/NullifyField/index.tsx
+++ b/src/admin/components/forms/NullifyField/index.tsx
@@ -30,7 +30,7 @@ export const NullifyField: React.FC<NullifyFieldProps> = ({ path, fieldValue }) 
     setChecked(useFallback);
   };
 
-  if (currentLocale === defaultLocale) {
+  if (currentLocale === defaultLocale || (localization && !localization.fallback)) {
     // hide when editing default locale
     return null;
   }

--- a/src/admin/components/forms/field-types/Array/index.tsx
+++ b/src/admin/components/forms/field-types/Array/index.tsx
@@ -44,6 +44,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
     minRows,
     permissions,
     indexPath,
+    localized = false,
     admin: {
       readOnly,
       description,
@@ -265,10 +266,13 @@ const ArrayFieldType: React.FC<Props> = (props) => {
           />
         </header>
 
-        <NullifyField
-          path={path}
-          fieldValue={value}
-        />
+        {localized
+          && (
+            <NullifyField
+              path={path}
+              fieldValue={value}
+            />
+          )}
 
         <Droppable droppableId="array-drop">
           {(provided) => (

--- a/src/admin/components/forms/field-types/Array/index.tsx
+++ b/src/admin/components/forms/field-types/Array/index.tsx
@@ -44,7 +44,6 @@ const ArrayFieldType: React.FC<Props> = (props) => {
     minRows,
     permissions,
     indexPath,
-    localized = false,
     admin: {
       readOnly,
       description,
@@ -77,8 +76,9 @@ const ArrayFieldType: React.FC<Props> = (props) => {
   const checkSkipValidation = useCallback((value) => {
     const defaultLocale = (localization && localization.defaultLocale) ? localization.defaultLocale : 'en';
     const isEditingDefaultLocale = locale === defaultLocale;
+    const fallbackEnabled = (localization && localization.fallback);
 
-    if (value === null && !isEditingDefaultLocale) return true;
+    if (value === null && !isEditingDefaultLocale && fallbackEnabled) return true;
     return false;
   }, [locale, localization]);
 
@@ -266,13 +266,10 @@ const ArrayFieldType: React.FC<Props> = (props) => {
           />
         </header>
 
-        {localized
-          && (
-            <NullifyField
-              path={path}
-              fieldValue={value}
-            />
-          )}
+        <NullifyField
+          path={path}
+          fieldValue={value}
+        />
 
         <Droppable droppableId="array-drop">
           {(provided) => (

--- a/src/admin/components/forms/field-types/Array/index.tsx
+++ b/src/admin/components/forms/field-types/Array/index.tsx
@@ -26,7 +26,7 @@ import { RowLabel } from '../../RowLabel';
 import { getTranslation } from '../../../../../utilities/getTranslation';
 import { createNestedFieldPath } from '../../Form/createNestedFieldPath';
 import { useConfig } from '../../../utilities/Config';
-import { NullifyField } from '../../NullifyField';
+import { NullifyLocaleField } from '../../NullifyField';
 
 import './index.scss';
 
@@ -266,7 +266,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
           />
         </header>
 
-        <NullifyField
+        <NullifyLocaleField
           path={path}
           fieldValue={value}
         />

--- a/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -54,7 +54,6 @@ const BlocksField: React.FC<Props> = (props) => {
     validate = blocksValidator,
     permissions,
     indexPath,
-    localized = false,
     admin: {
       readOnly,
       description,
@@ -82,8 +81,9 @@ const BlocksField: React.FC<Props> = (props) => {
   const checkSkipValidation = useCallback((value) => {
     const defaultLocale = (localization && localization.defaultLocale) ? localization.defaultLocale : 'en';
     const isEditingDefaultLocale = locale === defaultLocale;
+    const fallbackEnabled = (localization && localization.fallback);
 
-    if (value === null && !isEditingDefaultLocale) return true;
+    if (value === null && !isEditingDefaultLocale && fallbackEnabled) return true;
     return false;
   }, [locale, localization]);
 
@@ -264,13 +264,10 @@ const BlocksField: React.FC<Props> = (props) => {
           />
         </header>
 
-        {localized
-          && (
-            <NullifyField
-              path={path}
-              fieldValue={value}
-            />
-          )}
+        <NullifyField
+          path={path}
+          fieldValue={value}
+        />
 
         <Droppable
           droppableId="blocks-drop"

--- a/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -28,7 +28,7 @@ import Pill from '../../../elements/Pill';
 import { scrollToID } from '../../../../utilities/scrollToID';
 import HiddenInput from '../HiddenInput';
 import { getTranslation } from '../../../../../utilities/getTranslation';
-import { NullifyField } from '../../NullifyField';
+import { NullifyLocaleField } from '../../NullifyField';
 import { useConfig } from '../../../utilities/Config';
 import { createNestedFieldPath } from '../../Form/createNestedFieldPath';
 
@@ -264,7 +264,7 @@ const BlocksField: React.FC<Props> = (props) => {
           />
         </header>
 
-        <NullifyField
+        <NullifyLocaleField
           path={path}
           fieldValue={value}
         />

--- a/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -54,6 +54,7 @@ const BlocksField: React.FC<Props> = (props) => {
     validate = blocksValidator,
     permissions,
     indexPath,
+    localized = false,
     admin: {
       readOnly,
       description,
@@ -263,10 +264,13 @@ const BlocksField: React.FC<Props> = (props) => {
           />
         </header>
 
-        <NullifyField
-          path={path}
-          fieldValue={value}
-        />
+        {localized
+          && (
+            <NullifyField
+              path={path}
+              fieldValue={value}
+            />
+          )}
 
         <Droppable
           droppableId="blocks-drop"


### PR DESCRIPTION
## Description

The recent 'Fallback to default locale' checkbox on Array and Block fields shows up even when the field localization is set to false. 

Flagged in this discussion: https://github.com/payloadcms/payload/discussions/1868

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
