### PR TITLE
fix: versions error on cosmos db

### DIFF
--- a/src/versions/buildCollectionFields.ts
+++ b/src/versions/buildCollectionFields.ts
@@ -17,6 +17,7 @@ export const buildVersionCollectionFields = (collection: SanitizedCollectionConf
     {
       name: 'createdAt',
       type: 'date',
+      index: true,
       admin: {
         disabled: true,
       },
@@ -24,6 +25,7 @@ export const buildVersionCollectionFields = (collection: SanitizedCollectionConf
     {
       name: 'updatedAt',
       type: 'date',
+      index: true,
       admin: {
         disabled: true,
       },


### PR DESCRIPTION
## Description

Cosmos DB requires indexes for any `sort` on a field. The timestamps for createdAt and updatedAt were missing `index` causing an error when using versions on cosmos DB.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
