### PR TITLE
fix: limits and sorts within pagination and not on initial aggregation

### DIFF
--- a/src/versions/drafts/queryDrafts.ts
+++ b/src/versions/drafts/queryDrafts.ts
@@ -64,20 +64,19 @@ export const queryDrafts = async <T extends TypeWithID>({
     },
     // Filter based on incoming query
     { $match: versionQuery },
-    // Re-sort based on incoming sort
-    {
-      $sort: Object.entries(paginationOptions.sort).reduce((sort, [key, order]) => {
-        return {
-          ...sort,
-          [key]: order === 'asc' ? 1 : -1,
-        };
-      }, {}),
-    },
-    // Add pagination limit
-    { $limit: paginationOptions.limit },
   ]);
 
-  const result = await VersionModel.aggregatePaginate(aggregate, paginationOptions);
+  const paginationSort = Object.entries(paginationOptions.sort).reduce((sort, [key, order]) => {
+    return {
+      ...sort,
+      [key]: order === 'asc' ? 1 : -1,
+    };
+  }, {});
+
+  const result = await VersionModel.aggregatePaginate(aggregate, {
+    ...paginationOptions,
+    sort: paginationSort,
+  });
 
   return {
     ...result,


### PR DESCRIPTION
## Description

Fixes issue on canary where draft query aggregation was being limited and sorted on its way out, the logic needed to be within the aggregatePagination function instead. 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
