### PR TITLE
fix: prevent floating point number in image sizes

### DIFF
--- a/src/collections/config/schema.ts
+++ b/src/collections/config/schema.ts
@@ -153,8 +153,8 @@ const collectionSchema = joi.object().keys({
       imageSizes: joi.array().items(
         joi.object().keys({
           name: joi.string(),
-          width: joi.number().allow(null),
-          height: joi.number().allow(null),
+          width: joi.number().integer().allow(null),
+          height: joi.number().integer().allow(null),
           crop: joi.string(), // TODO: add further specificity with joi.xor
         }).unknown(),
       ),


### PR DESCRIPTION
## Description

Prevent the usage of floating point number in the `width` and `height` fields of the payload's configuration file.
When they are used, sharp throw an error when resizing: https://github.com/lovell/sharp/issues/2406

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

-  Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
