### PR TITLE
fix: collection view pagination with limits resulting in empty list

### DIFF
--- a/src/admin/components/elements/PerPage/index.tsx
+++ b/src/admin/components/elements/PerPage/index.tsx
@@ -18,9 +18,10 @@ export type Props = {
   limit: number
   handleChange?: (limit: number) => void
   modifySearchParams?: boolean
+  resetPage?: boolean
 }
 
-const PerPage: React.FC<Props> = ({ limits = defaultLimits, limit, handleChange, modifySearchParams = true }) => {
+const PerPage: React.FC<Props> = ({ limits = defaultLimits, limit, handleChange, modifySearchParams = true, resetPage = false }) => {
   const params = useSearchParams();
   const history = useHistory();
   const { t } = useTranslation('general');
@@ -56,6 +57,7 @@ const PerPage: React.FC<Props> = ({ limits = defaultLimits, limit, handleChange,
                         history.replace({
                           search: qs.stringify({
                             ...params,
+                            page: resetPage ? 1 : params.page,
                             limit: limitNumber,
                           }, { addQueryPrefix: true }),
                         });

--- a/src/admin/components/views/collections/List/Default.tsx
+++ b/src/admin/components/views/collections/List/Default.tsx
@@ -175,6 +175,7 @@ const DefaultList: React.FC<Props> = (props) => {
                 limit={limit}
                 modifySearchParams={modifySearchParams}
                 handleChange={handlePerPageChange}
+                resetPage={data.totalDocs <= data.pagingCounter}
               />
             </Fragment>
           )}


### PR DESCRIPTION
## Description

#1912 - page limit in collection view can result in empty page when the limit/page query exceeds their total number of documents.

This fix checks that `totalDocs` is not less than the current `pagingCounter` when the `perPage` limit is increased. 

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [n/a] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [n/a] I have made corresponding changes to the documentation
