### PR TITLE
feat: add default value to richtext props

### DIFF
--- a/src/admin/components/forms/field-types/RichText/RichText.tsx
+++ b/src/admin/components/forms/field-types/RichText/RichText.tsx
@@ -47,6 +47,7 @@ const RichText: React.FC<Props> = (props) => {
     required,
     validate = richText,
     label,
+    defaultValue: defaultValueFromProps,
     admin,
     admin: {
       readOnly,
@@ -250,7 +251,7 @@ const RichText: React.FC<Props> = (props) => {
     }
   }
 
-  if (!valueToRender) valueToRender = defaultValue;
+  if (!valueToRender) valueToRender = defaultValueFromProps || defaultValue;
 
   return (
     <div


### PR DESCRIPTION
## Description

Currently, It's not possible to set a default value for the richText as It's now importing it from a file so this PR allows that
 
- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
