### PR TITLE
fix: aligns global preview config with the docs

### DIFF
--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -85,7 +85,7 @@ If the function is specified, a Preview button will automatically appear in the 
 ```ts
 import { GlobalConfig } from "payload/types";
 
-const MyGlobal: CollectionConfig = {
+const MyGlobal: GlobalConfig = {
   slug: "my-global",
   fields: [
     {

--- a/src/admin/components/views/Global/Default.tsx
+++ b/src/admin/components/views/Global/Default.tsx
@@ -39,12 +39,12 @@ const DefaultGlobalView: React.FC<Props> = (props) => {
 
   const {
     fields,
-    preview,
     versions,
     label,
     admin: {
       description,
       hideAPIURL,
+      preview,
     } = {},
   } = global;
 

--- a/src/globals/config/schema.ts
+++ b/src/globals/config/schema.ts
@@ -23,6 +23,7 @@ const globalSchema = joi.object().keys({
         Edit: componentSchema,
       }),
     }),
+    preview: joi.func(),
   }),
   typescript: joi.object().keys({
     interface: joi.string(),

--- a/src/globals/config/types.ts
+++ b/src/globals/config/types.ts
@@ -45,6 +45,33 @@ export interface GlobalModel extends Model<Document> {
   buildQuery: (query: unknown, locale?: string) => Record<string, unknown>
 }
 
+export type GlobalAdminOptions = {
+  /**
+   * Place globals into a navigational group
+   * */
+  group?: Record<string, string> | string;
+  /**
+   * Custom description for collection
+   */
+  description?: EntityDescription;
+  /**
+   * Hide the API URL within the Edit view
+   */
+  hideAPIURL?: boolean
+  /**
+   * Custom admin components
+   */
+  components?: {
+    views?: {
+      Edit?: React.ComponentType<any>
+    }
+  };
+  /**
+   * Function to generate custom preview URL
+   */
+  preview?: GeneratePreviewURL
+}
+
 export type GlobalConfig = {
   slug: string
   label?: Record<string, string> | string
@@ -60,7 +87,6 @@ export type GlobalConfig = {
      */
     interface?: string
   }
-  preview?: GeneratePreviewURL
   versions?: IncomingGlobalVersions | boolean
   hooks?: {
     beforeValidate?: BeforeValidateHook[]
@@ -77,16 +103,7 @@ export type GlobalConfig = {
     update?: Access;
   }
   fields: Field[];
-  admin?: {
-    description?: EntityDescription;
-    group?: Record<string, string> | string;
-    hideAPIURL?: boolean;
-    components?: {
-      views?: {
-        Edit?: React.ComponentType<any>
-      }
-    }
-  }
+  admin?: GlobalAdminOptions
 }
 
 export interface SanitizedGlobalConfig extends Omit<DeepRequired<GlobalConfig>, 'fields' | 'versions'> {


### PR DESCRIPTION
## Description

Fixes #1929 

The documentation was correct, but the implementation was incorrect. Moved the global configs top level `preview` property to `admin.preview` to align with documentation and the collection config.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
