### PR TITLE
docs: gql me query

### DIFF
--- a/docs/authentication/operations.mdx
+++ b/docs/authentication/operations.mdx
@@ -94,7 +94,7 @@ Example response:
 
 ```graphql
 query {
-  Me[collection-singular-label] {
+  me[collection-singular-label] {
     user {
       email
     }


### PR DESCRIPTION
## Description

Fixes the example GraphQL `me` query in the docs on [this page](https://payloadcms.com/docs/authentication/operations#me). It shows the wrong casing—for example `MeUser` is actually `meUser`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have made corresponding changes to the documentation
