### PR TITLE
fix: removes old media when replaced and re-renders on save

### DIFF
--- a/src/admin/components/elements/FileDetails/index.tsx
+++ b/src/admin/components/elements/FileDetails/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import AnimateHeight from 'react-animate-height';
 import { useTranslation } from 'react-i18next';
 import Thumbnail from '../Thumbnail';
@@ -6,10 +6,26 @@ import Button from '../Button';
 import Meta from './Meta';
 import Chevron from '../../icons/Chevron';
 import { Props } from './types';
+import { FileSizes, Upload } from '../../../../uploads/types';
 
 import './index.scss';
 
 const baseClass = 'file-details';
+
+// sort to the same as imageSizes
+const sortSizes = (sizes: FileSizes, imageSizes: Upload['imageSizes']) => {
+  if (!imageSizes || imageSizes.length === 0) return sizes;
+
+  const orderedSizes: FileSizes = {};
+
+  imageSizes.forEach(({ name }) => {
+    if (sizes[name]) {
+      orderedSizes[name] = sizes[name];
+    }
+  });
+
+  return orderedSizes;
+};
 
 const FileDetails: React.FC<Props> = (props) => {
   const {
@@ -21,6 +37,7 @@ const FileDetails: React.FC<Props> = (props) => {
   const {
     upload: {
       staticURL,
+      imageSizes,
     },
   } = collection;
 
@@ -33,6 +50,12 @@ const FileDetails: React.FC<Props> = (props) => {
     sizes,
     url,
   } = doc;
+
+  const [orderedSizes, setOrderedSizes] = useState<FileSizes>(() => sortSizes(sizes, imageSizes));
+
+  useEffect(() => {
+    setOrderedSizes(sortSizes(sizes, imageSizes));
+  }, [sizes, imageSizes]);
 
   const [moreInfoOpen, setMoreInfoOpen] = useState(false);
   const { t } = useTranslation('upload');
@@ -94,7 +117,7 @@ const FileDetails: React.FC<Props> = (props) => {
           height={moreInfoOpen ? 'auto' : 0}
         >
           <ul className={`${baseClass}__sizes`}>
-            {Object.entries(sizes).map(([key, val]) => {
+            {Object.entries(orderedSizes).map(([key, val]) => {
               if (val?.filename) {
                 return (
                   <li key={key}>

--- a/src/admin/components/elements/FileDetails/types.ts
+++ b/src/admin/components/elements/FileDetails/types.ts
@@ -1,7 +1,11 @@
 import { SanitizedCollectionConfig } from '../../../../collections/config/types';
+import { FileSizes } from '../../../../uploads/types';
+import { Data } from '../../forms/Form/types';
 
 export type Props = {
   collection: SanitizedCollectionConfig
-  doc: Record<string, unknown>
+  doc: Data & {
+    sizes?: FileSizes
+  }
   handleRemove?: () => void,
 }

--- a/src/admin/components/views/collections/Edit/Default.tsx
+++ b/src/admin/components/views/collections/Edit/Default.tsx
@@ -46,7 +46,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
     onSave,
     permissions,
     isLoading,
-    initialState,
+    internalState,
     apiURL,
     action,
     hasSavePermission,
@@ -90,7 +90,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
             action={action}
             onSuccess={onSave}
             disabled={!hasSavePermission}
-            initialState={initialState}
+            initialState={internalState}
           >
             <FormLoadingOverlayToggle
               formIsLoading={isLoading}
@@ -149,6 +149,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                       <Upload
                         data={data}
                         collection={collection}
+                        internalState={internalState}
                       />
                     )}
                     <RenderFields

--- a/src/admin/components/views/collections/Edit/Upload/index.tsx
+++ b/src/admin/components/views/collections/Edit/Upload/index.tsx
@@ -7,9 +7,9 @@ import Button from '../../../../elements/Button';
 import FileDetails from '../../../../elements/FileDetails';
 import Error from '../../../../forms/Error';
 import { Props } from './types';
+import reduceFieldsToValues from '../../../../forms/Form/reduceFieldsToValues';
 
 import './index.scss';
-import reduceFieldsToValues from '../../../../forms/Form/reduceFieldsToValues';
 
 const baseClass = 'file-field';
 
@@ -30,9 +30,6 @@ const Upload: React.FC<Props> = (props) => {
   const {
     collection,
     internalState,
-    internalState: {
-      filename,
-    },
   } = props;
 
   const inputRef = useRef(null);
@@ -42,7 +39,7 @@ const Upload: React.FC<Props> = (props) => {
   const [dragCounter, setDragCounter] = useState(0);
   const [replacingFile, setReplacingFile] = useState(false);
   const { t } = useTranslation('upload');
-  const [doc, setDoc] = useState(reduceFieldsToValues(internalState));
+  const [doc, setDoc] = useState(reduceFieldsToValues(internalState || {}, true));
 
   const {
     value,
@@ -103,7 +100,7 @@ const Upload: React.FC<Props> = (props) => {
   }, [selectingFile, inputRef, setSelectingFile]);
 
   useEffect(() => {
-    setDoc(reduceFieldsToValues(internalState));
+    setDoc(reduceFieldsToValues(internalState || {}, true));
     setReplacingFile(false);
   }, [internalState]);
 
@@ -138,7 +135,7 @@ const Upload: React.FC<Props> = (props) => {
         showError={showError}
         message={errorMessage}
       />
-      {(filename && !replacingFile) && (
+      {(doc.filename && !replacingFile) && (
         <FileDetails
           doc={doc}
           collection={collection}
@@ -148,7 +145,7 @@ const Upload: React.FC<Props> = (props) => {
           }}
         />
       )}
-      {(!filename || replacingFile) && (
+      {(!doc.filename || replacingFile) && (
         <div className={`${baseClass}__upload`}>
           {value && (
             <div className={`${baseClass}__file-selected`}>

--- a/src/admin/components/views/collections/Edit/Upload/index.tsx
+++ b/src/admin/components/views/collections/Edit/Upload/index.tsx
@@ -6,9 +6,10 @@ import useField from '../../../../forms/useField';
 import Button from '../../../../elements/Button';
 import FileDetails from '../../../../elements/FileDetails';
 import Error from '../../../../forms/Error';
-import { Props, Data } from './types';
+import { Props } from './types';
 
 import './index.scss';
+import reduceFieldsToValues from '../../../../forms/Form/reduceFieldsToValues';
 
 const baseClass = 'file-field';
 
@@ -26,6 +27,14 @@ const validate = (value) => {
 };
 
 const Upload: React.FC<Props> = (props) => {
+  const {
+    collection,
+    internalState,
+    internalState: {
+      filename,
+    },
+  } = props;
+
   const inputRef = useRef(null);
   const dropRef = useRef(null);
   const [selectingFile, setSelectingFile] = useState(false);
@@ -33,13 +42,7 @@ const Upload: React.FC<Props> = (props) => {
   const [dragCounter, setDragCounter] = useState(0);
   const [replacingFile, setReplacingFile] = useState(false);
   const { t } = useTranslation('upload');
-
-  const {
-    data = {} as Data,
-    collection,
-  } = props;
-
-  const { filename } = data;
+  const [doc, setDoc] = useState(reduceFieldsToValues(internalState));
 
   const {
     value,
@@ -100,6 +103,11 @@ const Upload: React.FC<Props> = (props) => {
   }, [selectingFile, inputRef, setSelectingFile]);
 
   useEffect(() => {
+    setDoc(reduceFieldsToValues(internalState));
+    setReplacingFile(false);
+  }, [internalState]);
+
+  useEffect(() => {
     const div = dropRef.current;
     if (div) {
       div.addEventListener('dragenter', handleDragIn);
@@ -118,10 +126,6 @@ const Upload: React.FC<Props> = (props) => {
     return () => null;
   }, [handleDragIn, handleDragOut, handleDrop, value]);
 
-  useEffect(() => {
-    setReplacingFile(false);
-  }, [data]);
-
   const classes = [
     baseClass,
     dragging && `${baseClass}--dragging`,
@@ -136,7 +140,7 @@ const Upload: React.FC<Props> = (props) => {
       />
       {(filename && !replacingFile) && (
         <FileDetails
-          doc={data}
+          doc={doc}
           collection={collection}
           handleRemove={() => {
             setReplacingFile(true);

--- a/src/admin/components/views/collections/Edit/Upload/types.ts
+++ b/src/admin/components/views/collections/Edit/Upload/types.ts
@@ -1,13 +1,9 @@
 import { SanitizedCollectionConfig } from '../../../../../../collections/config/types';
-
-export type Data = {
-  filename: string
-  mimeType: string
-  filesize: number
-}
+import { Fields } from '../../../../forms/Form/types';
 
 export type Props = {
-  data?: Data
+  internalState?: Fields
+  data?: Fields
   collection: SanitizedCollectionConfig
   adminThumbnail?: string
   mimeTypes?: string[];

--- a/src/admin/components/views/collections/Edit/types.ts
+++ b/src/admin/components/views/collections/Edit/types.ts
@@ -15,7 +15,7 @@ export type Props = IndexProps & {
   id?: string
   permissions: CollectionPermission
   isLoading: boolean
-  initialState?: Fields
+  internalState?: Fields
   apiURL: string
   action: string
   hasSavePermission: boolean

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -53,7 +53,7 @@ export default buildConfig({
           {
             name: 'maintainedAspectRatio',
             width: 1024,
-            height: null,
+            height: undefined,
             crop: 'center',
             position: 'center',
             formatOptions: { format: 'png', options: { quality: 90 } },
@@ -61,7 +61,7 @@ export default buildConfig({
           {
             name: 'differentFormatFromMainImage',
             width: 200,
-            height: null,
+            height: undefined,
             formatOptions: { format: 'jpg', options: { quality: 90 } },
           },
           {

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -67,6 +67,10 @@ describe('uploads', () => {
     await saveDocAndAssert(page);
   });
 
+  test('should update file upload', async () => {
+    await page.goto(mediaURL.edit(mediaDoc.id));
+  });
+
   test('should show resized images', async () => {
     await page.goto(mediaURL.edit(mediaDoc.id));
 

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -7,7 +7,6 @@ import { RESTClient } from '../helpers/rest';
 import config, { mediaSlug, relationSlug } from './config';
 import payload from '../../src';
 import getFileByPath from '../../src/uploads/getFileByPath';
-import type { Media } from './payload-types';
 
 const stat = promisify(fs.stat);
 
@@ -176,9 +175,9 @@ describe('Collections - Uploads', () => {
 
     expect(status).toBe(200);
 
-    // Check that previously existing files weren't affected
-    expect(await fileExists(path.join(__dirname, './media', mediaDoc.filename))).toBe(true);
-    expect(await fileExists(path.join(__dirname, './media', mediaDoc.sizes.icon.filename))).toBe(true);
+    // Check that previously existing files were removed
+    expect(await fileExists(path.join(__dirname, './media', mediaDoc.filename))).toBe(false);
+    expect(await fileExists(path.join(__dirname, './media', mediaDoc.sizes.icon.filename))).toBe(false);
   });
 
   it('should remove extra sizes on update', async () => {
@@ -186,13 +185,13 @@ describe('Collections - Uploads', () => {
     const file = await getFileByPath(filePath);
     const small = await getFileByPath(path.resolve(__dirname, './small.png'));
 
-    const { id } = await payload.create<Media>({
+    const { id } = await payload.create({
       collection: mediaSlug,
       data: {},
       file,
     });
 
-    const doc = await payload.update<Media>({
+    const doc = await payload.update({
       collection: mediaSlug,
       id,
       data: {},


### PR DESCRIPTION
## Description

Resolves #1897 by removing old media files from the disk after replacement. This PR also fixes #2011 where media was not re-rendering after being replaced and the document re-saved.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
