### PR TITLE
chore: defaults maxVersions to 100

### DIFF
--- a/docs/versions/overview.mdx
+++ b/docs/versions/overview.mdx
@@ -52,7 +52,7 @@ Configuring Versions is done by adding the `versions` key to your Collection con
 
 | Option                       | Description  |
 | ---------------------------- | -------------|
-| `maxPerDoc`                  | Use this setting to control how many versions to keep on a document by document basis. Must be an integer. |
+| `maxPerDoc`                  | Use this setting to control how many versions to keep on a document by document basis. Must be an integer. Defaults to 100, use 0 to save all versions. |
 | `retainDeleted`              | Boolean to determine if, when a document is deleted, you'd like to retain versions of that document, or go through and automatically delete all versions that are associated with the deleted document. |
 | `drafts `                    | Enable [Drafts](/docs/versions/drafts) mode for this collection. To enable, set to `true` or pass an object with `draft` [options](/docs/versions/drafts#options). |
 

--- a/src/versions/saveVersion.ts
+++ b/src/versions/saveVersion.ts
@@ -94,12 +94,12 @@ export const saveVersion = async ({
     payload.logger.error(err);
   }
 
-  let max: number;
+  let max = 100;
 
   if (collection && typeof collection.versions.maxPerDoc === 'number') max = collection.versions.maxPerDoc;
   if (global && typeof global.versions.max === 'number') max = global.versions.max;
 
-  if (collection && collection.versions.maxPerDoc) {
+  if (max > 0) {
     enforceMaxVersions({
       id,
       payload,


### PR DESCRIPTION
## Description

Defaults the maximum versions saved to 100.

Previously payload would save every version ever created, this leads to bloat in the versions collection by _default_. That behavior should be an opt-in, if you would still like to store an unlimited amount of versions you can:

```ts
// collection config
{
  ...
  versions: {
    maxPerDoc: 0, // setting 0 will store all versions without limit
  }
  ...
}
```

```ts
// global config
{
  ...
  versions: {
    max: 0, // setting 0 will store all versions without limit
  }
  ...
}
```


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
