### PR TITLE
chore: check version config before version delete attempt

### DIFF
--- a/src/collections/operations/delete.ts
+++ b/src/collections/operations/delete.ts
@@ -173,11 +173,13 @@ async function deleteOperation<TSlug extends keyof GeneratedTypes['collections']
   // Delete versions
   // /////////////////////////////////////
 
-  deleteCollectionVersions({
-    payload,
-    id,
-    slug: collectionConfig.slug,
-  });
+  if (collectionConfig.versions) {
+    deleteCollectionVersions({
+      payload,
+      id,
+      slug: collectionConfig.slug,
+    });
+  }
 
   // /////////////////////////////////////
   // afterDelete - Collection


### PR DESCRIPTION
## Description

Checking if the collection has versions enabled before attempting to delete a version. This was causing an unneeded error log.