### PR TITLE
chore: resolves env path in redirects example

### DIFF
--- a/examples/redirects/cms/src/payload.config.ts
+++ b/examples/redirects/cms/src/payload.config.ts
@@ -5,8 +5,6 @@ import { Users } from './collections/Users';
 import { Pages } from './collections/Pages';
 import { MainMenu } from './globals/MainMenu';
 
-require('dotenv').config();
-
 export default buildConfig({
   collections: [
     Pages,

--- a/examples/redirects/cms/src/server.ts
+++ b/examples/redirects/cms/src/server.ts
@@ -1,8 +1,11 @@
+import path from 'path';
 import express from 'express';
 import payload from 'payload';
 import { seed } from './seed';
 
-require('dotenv').config();
+require('dotenv').config({
+  path: path.resolve(__dirname, '../.env'),
+});
 
 const app = express();
 

--- a/examples/redirects/cms/tsconfig.json
+++ b/examples/redirects/cms/tsconfig.json
@@ -14,7 +14,10 @@
     "rootDir": "./src",
     "jsx": "react",
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "paths": {
+      "payload/generated-types": ["./src/payload-types.ts"]
+    },
   },
   "include": [
     "src"
@@ -26,5 +29,5 @@
   ],
   "ts-node": {
     "transpileOnly": true
-  }
+  },
 }


### PR DESCRIPTION
## Description

Fixes the redirects example cms where the admin panel would crash after a fresh install. Does so by resolving the env paths used in the config. This PR also defines the path to the generated types within `tsconfig.json`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
