### PR TITLE
chore: set webpack name from test suite for caching

### DIFF
--- a/src/webpack/getDevConfig.ts
+++ b/src/webpack/getDevConfig.ts
@@ -1,4 +1,5 @@
 import webpack, { Configuration } from 'webpack';
+import md5 from 'md5';
 import { SanitizedConfig } from '../config/types';
 import getBaseConfig from './getBaseConfig';
 
@@ -9,6 +10,8 @@ export default (payloadConfig: SanitizedConfig): Configuration => {
     ...baseConfig,
     cache: {
       type: 'filesystem',
+      // version cache when there are changes to aliases
+      version: md5(Object.entries(baseConfig.resolve.alias).join()),
       buildDependencies: {
         config: [__filename],
       },

--- a/test/buildConfig.ts
+++ b/test/buildConfig.ts
@@ -1,33 +1,33 @@
-import merge from 'deepmerge';
 import { Config, SanitizedConfig } from '../src/config/types';
 import { buildConfig as buildPayloadConfig } from '../src/config/build';
 
-const baseConfig: Config = {
-  telemetry: false,
-};
+export function buildConfig(config?: Partial<Config>): SanitizedConfig {
+  const [name] = process.argv.slice(2);
+  const baseConfig: Config = {
+    telemetry: false,
+    ...config,
+  };
 
-export function buildConfig(overrides?: Partial<Config>): SanitizedConfig {
-  if (process.env.NODE_ENV === 'test') {
-    baseConfig.admin = {
-      ...(baseConfig.admin || {}),
-      webpack: (config) => {
-        const existingConfig = typeof overrides?.admin?.webpack === 'function'
-          ? overrides.admin.webpack(config)
-          : config;
-        return {
-          ...existingConfig,
-          cache: {
-            type: 'memory',
-          },
-        };
-      },
-    };
-  }
+  baseConfig.admin = {
+    ...(baseConfig.admin || {}),
+    webpack: (webpackConfig) => {
+      const existingConfig = typeof config?.admin?.webpack === 'function'
+        ? config.admin.webpack(webpackConfig)
+        : webpackConfig;
+      return {
+        ...existingConfig,
+        name,
+        cache: process.env.NODE_ENV === 'test' ? {
+          type: 'memory',
+        } : existingConfig.cache,
+      };
+    },
+  };
 
   if (process.env.PAYLOAD_DISABLE_ADMIN === 'true') {
     if (typeof baseConfig.admin !== 'object') baseConfig.admin = {};
     baseConfig.admin.disable = true;
   }
 
-  return buildPayloadConfig(merge(baseConfig, overrides || {}));
+  return buildPayloadConfig(baseConfig);
 }


### PR DESCRIPTION
## Description

Payload core dev DX improvement. On master when switching between different dev configs webpack fails to correctly invalidate the cache resulting in the same admin UI being loaded. With this change we are giving webpack a name from the test being run and that is used in the cache name. With this change we no longer will need to manually `rm -rf node_modules/.cache` as we have been.

This is the result of running several different suites: 
![image](https://user-images.githubusercontent.com/6434612/217056800-ec72c444-8de1-41f6-8c26-cc0daf0f1490.png)


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Checklist:

- [x] Existing test suite passes locally with my changes
