### PR TITLE
fix: max versions incorrectly sorting and removing

### DIFF
--- a/src/versions/enforceMaxVersions.ts
+++ b/src/versions/enforceMaxVersions.ts
@@ -23,14 +23,12 @@ export const enforceMaxVersions = async ({
 
     if (id) query.parent = id;
 
-    const oldestAllowedDoc = await Model.find(query).limit(1).skip(max).sort({ createdAt: -1 });
+    const oldestAllowedDoc = await Model.find(query).limit(1).skip(max).sort({ updatedAt: -1 });
 
-    if (oldestAllowedDoc?.[0]?.createdAt) {
-      const deleteLessThan = oldestAllowedDoc[0].createdAt;
-
+    if (oldestAllowedDoc?.[0]?.updatedAt) {
       await Model.deleteMany({
-        createdAt: {
-          $lte: deleteLessThan,
+        updatedAt: {
+          $lte: oldestAllowedDoc[0].updatedAt,
         },
       });
     }

--- a/src/versions/saveVersion.ts
+++ b/src/versions/saveVersion.ts
@@ -100,7 +100,7 @@ export const saveVersion = async ({
   if (global && typeof global.versions.max === 'number') max = global.versions.max;
 
   if (max > 0) {
-    enforceMaxVersions({
+    await enforceMaxVersions({
       id,
       payload,
       Model: VersionModel,

--- a/test/versions/collections/Versions.ts
+++ b/test/versions/collections/Versions.ts
@@ -9,7 +9,7 @@ const VersionPosts: CollectionConfig = {
   },
   versions: {
     drafts: false,
-    maxPerDoc: 35,
+    maxPerDoc: 2,
   },
   access: {
     read: ({ req: { user } }) => {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -318,6 +318,45 @@ describe('Versions', () => {
         expect(versions.docs).toHaveLength(3);
       });
     });
+
+    describe('Versions Count', () => {
+      it('retains correct versions', async () => {
+        const original = await payload.create({
+          collection: 'version-posts',
+          data: {
+            title: 'A',
+            description: 'A',
+          },
+        });
+
+        await payload.update({
+          collection: 'version-posts',
+          id: original.id,
+          data: {
+            title: 'B',
+            description: 'B',
+          },
+        });
+
+        await payload.update({
+          collection: 'version-posts',
+          id: original.id,
+          data: {
+            title: 'C',
+            description: 'C',
+          },
+        });
+
+        const versions = await payload.findVersions({
+          collection: 'version-posts',
+          sort: '-updatedAt',
+          depth: 1,
+        });
+
+        expect(versions.docs[versions.docs.length - 1].version.title).toStrictEqual('B');
+        expect(versions.docs).toHaveLength(2);
+      });
+    });
   });
 
   describe('Querying', () => {


### PR DESCRIPTION
## Description

When the maximum versions was reached, newer versions were not being saved in some cases. 

- ensures enforceMaxVersions function is awaited
- adds tests to catch future regressions

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
