### PR TITLE
fix: file detail rendering from state

### DIFF
--- a/src/admin/components/forms/Form/buildStateFromSchema/iterateFields.ts
+++ b/src/admin/components/forms/Form/buildStateFromSchema/iterateFields.ts
@@ -37,7 +37,7 @@ export const iterateFields = async ({
   const promises = [];
   fields.forEach((field) => {
     const initialData = data;
-    if (!fieldIsPresentationalOnly(field) && !field?.admin?.disabled) {
+    if (!fieldIsPresentationalOnly(field)) {
       const passesCondition = Boolean((field?.admin?.condition ? field.admin.condition(fullData || {}, initialData || {}) : true) && parentPassesCondition);
 
       promises.push(addFieldStatePromise({


### PR DESCRIPTION
## Description

FileDetail was blowing up in conjunction with the cloud plugin because it sets `admin.disabled` on the file sizes group. The component was checking this property and omitting it from state. This doesn't appear to be necessary.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
