### PR TITLE
fix: missing state in document drawers when opened

### DIFF
--- a/src/admin/components/elements/DocumentDrawer/DrawerContent.tsx
+++ b/src/admin/components/elements/DocumentDrawer/DrawerContent.tsx
@@ -31,7 +31,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   const { toggleModal, modalState, closeModal } = useModal();
   const locale = useLocale();
   const { permissions, user } = useAuth();
-  const [initialState, setInitialState] = useState<Fields>();
+  const [internalState, setInternalState] = useState<Fields>();
   const { t, i18n } = useTranslation(['fields', 'general']);
   const hasInitializedState = useRef(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -63,7 +63,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
         locale,
         t,
       });
-      setInitialState(state);
+      setInternalState(state);
     };
 
     awaitInitialState();
@@ -98,7 +98,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
         DefaultComponent={DefaultEdit}
         CustomComponent={collectionConfig.admin?.components?.views?.Edit}
         componentProps={{
-          isLoading: !initialState,
+          isLoading: !internalState,
           data,
           id,
           collection: collectionConfig,
@@ -106,7 +106,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
           isEditing: Boolean(id),
           apiURL: id ? `${serverURL}${api}/${collectionSlug}/${id}` : null,
           onSave,
-          initialState,
+          internalState,
           hasSavePermission: true,
           action: `${serverURL}${api}/${collectionSlug}${id ? `/${id}` : ''}?locale=${locale}&depth=0&fallback-locale=null`,
           disableEyebrow: true,


### PR DESCRIPTION
## Description

Fixes #2040 

Relationship drawer state was not being passed properly when opened.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
