### PR TITLE
fix: document type in update request handler

### DIFF
--- a/src/collections/requestHandlers/update.ts
+++ b/src/collections/requestHandlers/update.ts
@@ -2,6 +2,7 @@ import { Response, NextFunction } from 'express';
 import httpStatus from 'http-status';
 import { PayloadRequest } from '../../express/types';
 import formatSuccessResponse from '../../express/responses/formatSuccess';
+import { Document } from '../../types';
 import update from '../operations/update';
 
 export type UpdateResult = {


### PR DESCRIPTION
## Description

The `update` request handler was using the DOM `Document` type for the `UpdateResult` instead of the Payload `Document` type, like the other handlers. This imports the missing type.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
