### PR TITLE
fix: adds query constraint to ensureMaxVersions query

### DIFF
--- a/src/versions/enforceMaxVersions.ts
+++ b/src/versions/enforceMaxVersions.ts
@@ -27,9 +27,16 @@ export const enforceMaxVersions = async ({
 
     if (oldestAllowedDoc?.[0]?.updatedAt) {
       await Model.deleteMany({
-        updatedAt: {
-          $lte: oldestAllowedDoc[0].updatedAt,
-        },
+        $and: [
+          {
+            parent: id,
+          },
+          {
+            updatedAt: {
+              $lte: oldestAllowedDoc[0].updatedAt,
+            },
+          },
+        ],
       });
     }
   } catch (err) {

--- a/src/versions/enforceMaxVersions.ts
+++ b/src/versions/enforceMaxVersions.ts
@@ -22,22 +22,18 @@ export const enforceMaxVersions = async ({
   try {
     const query: { parent?: string | number } = {};
 
-    if (id) query.parent = id;
+    if (entityType === 'collection') query.parent = id;
 
     const oldestAllowedDoc = await Model.find(query).limit(1).skip(max).sort({ updatedAt: -1 });
 
     if (oldestAllowedDoc?.[0]?.updatedAt) {
       const deleteQuery: FilterQuery<unknown> = {
-        $and: [
-          {
-            updatedAt: {
-              $lte: oldestAllowedDoc[0].updatedAt,
-            },
-          },
-        ],
+        updatedAt: {
+          $lte: oldestAllowedDoc[0].updatedAt,
+        },
       };
 
-      if (id) deleteQuery.$and.push({ parent: id });
+      if (entityType === 'collection') deleteQuery.parent = id;
 
       await Model.deleteMany(deleteQuery);
     }


### PR DESCRIPTION
## Description

When more than max versions are in the collection versions table, all other versions get removed if their updatedAt timestamp is less than the max version. It should only be deleting versions _with the same parent_ and updatedAt less than the max doc.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
