### PR TITLE
Fix/upload omit create sizes

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+arch=x64
+platform=linuxmusl

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-arch=x64
-platform=linuxmusl

--- a/src/auth/operations/registerFirstUser.ts
+++ b/src/auth/operations/registerFirstUser.ts
@@ -7,7 +7,7 @@ import { Collection } from '../../collections/config/types';
 
 export type Arguments<T extends { [field: string | number | symbol]: unknown }> = {
   collection: Collection
-  data: MarkOptional<T, 'id' | 'updatedAt' | 'createdAt'> & {
+  data: MarkOptional<T, 'id' | 'updatedAt' | 'createdAt' | 'sizes'> & {
     email: string
     password: string
   }

--- a/src/collections/graphql/resolvers/create.ts
+++ b/src/collections/graphql/resolvers/create.ts
@@ -7,7 +7,7 @@ import { Collection } from '../../config/types';
 import create from '../../operations/create';
 
 export type Resolver<TSlug extends keyof GeneratedTypes['collections']> = (_: unknown, args: {
-  data: MarkOptional<GeneratedTypes['collections'][TSlug], 'id' | 'updatedAt' | 'createdAt'>,
+  data: Omit<MarkOptional<GeneratedTypes['collections'][TSlug], 'id' | 'updatedAt' | 'createdAt'>, 'sizes'>,
   locale?: string
   draft: boolean
 },

--- a/src/collections/operations/create.ts
+++ b/src/collections/operations/create.ts
@@ -32,7 +32,7 @@ export type Arguments<T extends { [field: string | number | symbol]: unknown }> 
   disableVerificationEmail?: boolean
   overrideAccess?: boolean
   showHiddenFields?: boolean
-  data: MarkOptional<T, 'id' | 'createdAt' | 'updatedAt'>
+  data: Omit<MarkOptional<T, 'id' | 'updatedAt' | 'createdAt'>, 'sizes'>
   overwriteExistingFiles?: boolean
   draft?: boolean
   autosave?: boolean

--- a/src/collections/operations/create.ts
+++ b/src/collections/operations/create.ts
@@ -32,7 +32,7 @@ export type Arguments<T extends { [field: string | number | symbol]: unknown }> 
   disableVerificationEmail?: boolean
   overrideAccess?: boolean
   showHiddenFields?: boolean
-  data: Omit<MarkOptional<T, 'id' | 'updatedAt' | 'createdAt'>, 'sizes'>
+  data: MarkOptional<T, 'id' | 'updatedAt' | 'createdAt' | 'sizes'>
   overwriteExistingFiles?: boolean
   draft?: boolean
   autosave?: boolean

--- a/src/collections/operations/local/create.ts
+++ b/src/collections/operations/local/create.ts
@@ -13,7 +13,7 @@ import { APIError } from '../../../errors';
 
 export type Options<TSlug extends keyof GeneratedTypes['collections']> = {
   collection: TSlug
-  data: MarkOptional<GeneratedTypes['collections'][TSlug], 'id' | 'updatedAt' | 'createdAt'>
+  data: Omit<MarkOptional<GeneratedTypes['collections'][TSlug], 'id' | 'updatedAt' | 'createdAt'>, 'sizes'>
   depth?: number
   locale?: string
   fallbackLocale?: string

--- a/src/collections/operations/local/create.ts
+++ b/src/collections/operations/local/create.ts
@@ -13,7 +13,7 @@ import { APIError } from '../../../errors';
 
 export type Options<TSlug extends keyof GeneratedTypes['collections']> = {
   collection: TSlug
-  data: Omit<MarkOptional<GeneratedTypes['collections'][TSlug], 'id' | 'updatedAt' | 'createdAt'>, 'sizes'>
+  data: MarkOptional<GeneratedTypes['collections'][TSlug], 'id' | 'updatedAt' | 'createdAt' | 'sizes'>
   depth?: number
   locale?: string
   fallbackLocale?: string


### PR DESCRIPTION
## Description
The inferred type when uploading files typed auto-generated sizes as mandatory.
`Omit<>` these, as users never will provide them during upload as the sizes are auto-generated.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
