### PR TITLE
DateTime picker default to 'dayAndTime' to match docs

### DIFF
--- a/src/admin/components/elements/DatePicker/DatePicker.tsx
+++ b/src/admin/components/elements/DatePicker/DatePicker.tsx
@@ -23,7 +23,7 @@ const DateTime: React.FC<Props> = (props) => {
     value,
     onChange,
     displayFormat,
-    pickerAppearance,
+    pickerAppearance = 'dayAndTime',
     minDate,
     maxDate,
     monthsToShow = 1,
@@ -47,7 +47,7 @@ const DateTime: React.FC<Props> = (props) => {
 
   let dateTimeFormat = displayFormat;
 
-  if (dateTimeFormat === undefined && pickerAppearance) {
+  if (dateTimeFormat === undefined) {
     if (pickerAppearance === 'dayAndTime') dateTimeFormat = 'MMM d, yyy h:mm a';
     else if (pickerAppearance === 'timeOnly') dateTimeFormat = 'h:mm a';
     else if (pickerAppearance === 'dayOnly') dateTimeFormat = 'dd';


### PR DESCRIPTION
This was changed in 3bc67e338bfcce9627487fff5d102c0f54dd1d42

After that commit it defaults to a day-only picker, contrary to the docs (my project was relying on this default). Probably @JessChowdhury has better context on this change?

Alternatively, the docs could be changed and a note made in the changelog.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
