### PR TITLE
Feature/transaction sessions

### DIFF
--- a/src/collections/operations/create.ts
+++ b/src/collections/operations/create.ts
@@ -59,7 +59,6 @@ async function create<TSlug extends keyof GeneratedTypes['collections']>(
   }, Promise.resolve());
 
   const {
-    session,
     collection,
     collection: {
       Model,
@@ -81,6 +80,8 @@ async function create<TSlug extends keyof GeneratedTypes['collections']>(
     draft = false,
     autosave = false,
   } = args;
+
+  const session = args.session || req.session;
 
   let { data } = args;
 

--- a/src/collections/operations/delete.ts
+++ b/src/collections/operations/delete.ts
@@ -44,7 +44,6 @@ async function deleteOperation<TSlug extends keyof GeneratedTypes['collections']
   }, Promise.resolve());
 
   const {
-    session,
     depth,
     collection: {
       Model,
@@ -65,6 +64,7 @@ async function deleteOperation<TSlug extends keyof GeneratedTypes['collections']
     showHiddenFields,
   } = args;
 
+  const session = args.session || req.session;
   const sessionOpts = session ? { session } : undefined;
 
   // /////////////////////////////////////

--- a/src/collections/operations/find.ts
+++ b/src/collections/operations/find.ts
@@ -48,7 +48,6 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
   }, Promise.resolve());
 
   const {
-    session,
     where,
     page,
     limit,
@@ -70,6 +69,8 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
     showHiddenFields,
     pagination = true,
   } = args;
+
+  const session = args.session || req.session;
 
   // /////////////////////////////////////
   // Access

--- a/src/collections/operations/find.ts
+++ b/src/collections/operations/find.ts
@@ -10,8 +10,10 @@ import { buildSortParam } from '../../mongoose/buildSortParam';
 import { AccessResult } from '../../config/types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { queryDrafts } from '../../versions/drafts/queryDrafts';
+import { ClientSession } from 'mongoose';
 
 export type Arguments = {
+  session?: ClientSession
   collection: Collection
   where?: Where
   page?: number
@@ -46,6 +48,7 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
   }, Promise.resolve());
 
   const {
+    session,
     where,
     page,
     limit,
@@ -157,6 +160,7 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
     options: {
       // limit must also be set here, it's ignored when pagination is false
       limit: limitToUse,
+      ...(session ? { session } : {}),
     },
   };
 
@@ -167,6 +171,7 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
       locale,
       paginationOptions,
       payload,
+      session,
       where,
     });
   } else {

--- a/src/collections/operations/findByID.ts
+++ b/src/collections/operations/findByID.ts
@@ -43,7 +43,6 @@ async function findByID<T extends TypeWithID>(
   }, Promise.resolve());
 
   const {
-    session,
     depth,
     collection: {
       Model,
@@ -62,6 +61,8 @@ async function findByID<T extends TypeWithID>(
     showHiddenFields,
     draft: draftEnabled = false,
   } = args;
+
+  const session = args.session || req.session;
 
   // /////////////////////////////////////
   // Access

--- a/src/collections/operations/findVersionByID.ts
+++ b/src/collections/operations/findVersionByID.ts
@@ -9,8 +9,10 @@ import { Where } from '../../types';
 import { hasWhereAccessResult } from '../../auth/types';
 import { TypeWithVersion } from '../../versions/types';
 import { afterRead } from '../../fields/hooks/afterRead';
+import { ClientSession } from 'mongoose';
 
 export type Arguments = {
+  session?: ClientSession
   collection: Collection
   id: string | number
   req: PayloadRequest
@@ -23,6 +25,7 @@ export type Arguments = {
 
 async function findVersionByID<T extends TypeWithVersion<T> = any>(args: Arguments): Promise<T> {
   const {
+    session,
     depth,
     collection: {
       config: collectionConfig,
@@ -81,7 +84,7 @@ async function findVersionByID<T extends TypeWithVersion<T> = any>(args: Argumen
 
   if (!query.$and[0]._id) throw new NotFound(t);
 
-  let result = await VersionsModel.findOne(query, {}).lean();
+  let result = await VersionsModel.findOne(query, {}, session ? { session } : undefined).lean();
 
   if (!result) {
     if (!disableErrors) {

--- a/src/collections/operations/findVersionByID.ts
+++ b/src/collections/operations/findVersionByID.ts
@@ -25,7 +25,6 @@ export type Arguments = {
 
 async function findVersionByID<T extends TypeWithVersion<T> = any>(args: Arguments): Promise<T> {
   const {
-    session,
     depth,
     collection: {
       config: collectionConfig,
@@ -42,6 +41,8 @@ async function findVersionByID<T extends TypeWithVersion<T> = any>(args: Argumen
     overrideAccess,
     showHiddenFields,
   } = args;
+
+  const session = args.session || req.session;
 
   if (!id) {
     throw new APIError('Missing ID of version.', httpStatus.BAD_REQUEST);

--- a/src/collections/operations/findVersions.ts
+++ b/src/collections/operations/findVersions.ts
@@ -29,7 +29,6 @@ async function findVersions<T extends TypeWithVersion<T>>(
   args: Arguments,
 ): Promise<PaginatedDocs<T>> {
   const {
-    session,
     where,
     page,
     limit,
@@ -45,6 +44,8 @@ async function findVersions<T extends TypeWithVersion<T>>(
     overrideAccess,
     showHiddenFields,
   } = args;
+
+  const session = args.session || req.session;
 
   const VersionsModel = payload.versions[collectionConfig.slug] as CollectionModel;
 

--- a/src/collections/operations/findVersions.ts
+++ b/src/collections/operations/findVersions.ts
@@ -10,8 +10,10 @@ import { PaginatedDocs } from '../../mongoose/types';
 import { TypeWithVersion } from '../../versions/types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { buildVersionCollectionFields } from '../../versions/buildCollectionFields';
+import { ClientSession } from 'mongoose';
 
 export type Arguments = {
+  session?: ClientSession
   collection: Collection
   where?: Where
   page?: number
@@ -27,6 +29,7 @@ async function findVersions<T extends TypeWithVersion<T>>(
   args: Arguments,
 ): Promise<PaginatedDocs<T>> {
   const {
+    session,
     where,
     page,
     limit,
@@ -109,6 +112,7 @@ async function findVersions<T extends TypeWithVersion<T>>(
     lean: true,
     leanWithId: true,
     useEstimatedCount,
+    ...(session ? { options: { session }} : {}),
   });
 
   // /////////////////////////////////////

--- a/src/collections/operations/local/create.ts
+++ b/src/collections/operations/local/create.ts
@@ -10,8 +10,10 @@ import { getDataLoader } from '../../dataloader';
 import { File } from '../../../uploads/types';
 import i18n from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<TSlug extends keyof GeneratedTypes['collections']> = {
+  session?: ClientSession
   collection: TSlug
   data: MarkOptional<GeneratedTypes['collections'][TSlug], 'id' | 'updatedAt' | 'createdAt'>
   depth?: number
@@ -33,6 +35,7 @@ export default async function createLocal<TSlug extends keyof GeneratedTypes['co
   options: Options<TSlug>,
 ): Promise<GeneratedTypes['collections'][TSlug]> {
   const {
+    session,
     collection: collectionSlug,
     depth,
     locale = null,
@@ -71,6 +74,7 @@ export default async function createLocal<TSlug extends keyof GeneratedTypes['co
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return create<TSlug>({
+    session,
     depth,
     data,
     collection,

--- a/src/collections/operations/local/delete.ts
+++ b/src/collections/operations/local/delete.ts
@@ -6,8 +6,10 @@ import deleteOperation from '../delete';
 import { getDataLoader } from '../../dataloader';
 import i18n from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
+  session?: ClientSession
   collection: T
   id: string
   depth?: number
@@ -23,6 +25,7 @@ export default async function deleteLocal<TSlug extends keyof GeneratedTypes['co
   options: Options<TSlug>,
 ): Promise<GeneratedTypes['collections'][TSlug]> {
   const {
+    session,
     collection: collectionSlug,
     depth,
     id,
@@ -54,6 +57,7 @@ export default async function deleteLocal<TSlug extends keyof GeneratedTypes['co
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return deleteOperation<TSlug>({
+    session,
     depth,
     id,
     collection,

--- a/src/collections/operations/local/find.ts
+++ b/src/collections/operations/local/find.ts
@@ -7,8 +7,10 @@ import find from '../find';
 import { getDataLoader } from '../../dataloader';
 import i18n from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
+  session?: ClientSession
   collection: T
   depth?: number
   currentDepth?: number
@@ -32,6 +34,7 @@ export default async function findLocal<T extends keyof GeneratedTypes['collecti
   options: Options<T>,
 ): Promise<PaginatedDocs<GeneratedTypes['collections'][T]>> {
   const {
+    session,
     collection: collectionSlug,
     depth,
     currentDepth,
@@ -69,6 +72,7 @@ export default async function findLocal<T extends keyof GeneratedTypes['collecti
   if (typeof user !== 'undefined') req.user = user;
 
   return find<GeneratedTypes['collections'][T]>({
+    session,
     depth,
     currentDepth,
     sort,

--- a/src/collections/operations/local/findByID.ts
+++ b/src/collections/operations/local/findByID.ts
@@ -6,8 +6,10 @@ import { Payload } from '../../../payload';
 import { getDataLoader } from '../../dataloader';
 import i18n from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
+  session?: ClientSession
   collection: T
   id: string | number
   depth?: number
@@ -27,6 +29,7 @@ export default async function findByIDLocal<T extends keyof GeneratedTypes['coll
   options: Options<T>,
 ): Promise<GeneratedTypes['collections'][T]> {
   const {
+    session,
     collection: collectionSlug,
     depth,
     currentDepth,
@@ -60,6 +63,7 @@ export default async function findByIDLocal<T extends keyof GeneratedTypes['coll
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findByID<GeneratedTypes['collections'][T]>({
+    session,
     depth,
     currentDepth,
     id,

--- a/src/collections/operations/local/findVersionByID.ts
+++ b/src/collections/operations/local/findVersionByID.ts
@@ -7,8 +7,10 @@ import findVersionByID from '../findVersionByID';
 import { getDataLoader } from '../../dataloader';
 import i18n from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
+  session?: ClientSession
   collection: T
   id: string
   depth?: number
@@ -26,6 +28,7 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
   options: Options<T>,
 ): Promise<TypeWithVersion<GeneratedTypes['collections'][T]>> {
   const {
+    session,
     collection: collectionSlug,
     depth,
     id,
@@ -54,6 +57,7 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findVersionByID({
+    session,
     depth,
     id,
     collection,

--- a/src/collections/operations/local/findVersions.ts
+++ b/src/collections/operations/local/findVersions.ts
@@ -8,8 +8,10 @@ import findVersions from '../findVersions';
 import { getDataLoader } from '../../dataloader';
 import i18nInit from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
+  session?: ClientSession
   collection: T
   depth?: number
   page?: number
@@ -28,6 +30,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   options: Options<T>,
 ): Promise<PaginatedDocs<TypeWithVersion<GeneratedTypes['collections'][T]>>> {
   const {
+    session,
     collection: collectionSlug,
     depth,
     page,
@@ -62,6 +65,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findVersions({
+    session,
     where,
     page,
     limit,

--- a/src/collections/operations/local/restoreVersion.ts
+++ b/src/collections/operations/local/restoreVersion.ts
@@ -6,8 +6,10 @@ import { getDataLoader } from '../../dataloader';
 import restoreVersion from '../restoreVersion';
 import i18nInit from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
+  session?: ClientSession
   collection: T
   id: string
   depth?: number
@@ -23,6 +25,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   options: Options<T>,
 ): Promise<GeneratedTypes['collections'][T]> {
   const {
+    session,
     collection: collectionSlug,
     depth,
     locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
@@ -53,6 +56,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   const args = {
+    session,
     payload,
     depth,
     collection,

--- a/src/collections/operations/local/update.ts
+++ b/src/collections/operations/local/update.ts
@@ -8,8 +8,10 @@ import { getDataLoader } from '../../dataloader';
 import { File } from '../../../uploads/types';
 import i18nInit from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<TSlug extends keyof GeneratedTypes['collections']> = {
+  session?: ClientSession
   collection: TSlug
   id: string | number
   data: Partial<GeneratedTypes['collections'][TSlug]>
@@ -31,6 +33,7 @@ export default async function updateLocal<TSlug extends keyof GeneratedTypes['co
   options: Options<TSlug>,
 ): Promise<GeneratedTypes['collections'][TSlug]> {
   const {
+    session,
     collection: collectionSlug,
     depth,
     locale = null,
@@ -72,6 +75,7 @@ export default async function updateLocal<TSlug extends keyof GeneratedTypes['co
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   const args = {
+    session,
     depth,
     data,
     collection,

--- a/src/collections/operations/restoreVersion.ts
+++ b/src/collections/operations/restoreVersion.ts
@@ -26,7 +26,6 @@ export type Arguments = {
 
 async function restoreVersion<T extends TypeWithID = any>(args: Arguments): Promise<T> {
   const {
-    session,
     collection: {
       Model,
       config: collectionConfig,
@@ -42,6 +41,8 @@ async function restoreVersion<T extends TypeWithID = any>(args: Arguments): Prom
     },
     req,
   } = args;
+
+  const session = args.session || req.session;
 
   if (!id) {
     throw new APIError('Missing ID of version to restore.', httpStatus.BAD_REQUEST);

--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -59,7 +59,6 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
   }, Promise.resolve());
 
   const {
-    session,
     depth,
     collection,
     collection: {
@@ -82,6 +81,8 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
     draft: draftArg = false,
     autosave = false,
   } = args;
+
+  const session = args.session || req.session;
 
   if (!id) {
     throw new APIError('Missing ID of document to update.', httpStatus.BAD_REQUEST);

--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -21,10 +21,12 @@ import { getLatestEntityVersion } from '../../versions/getLatestCollectionVersio
 import { mapAsync } from '../../utilities/mapAsync';
 import fileExists from '../../uploads/fileExists';
 import { FileData } from '../../uploads/types';
+import { ClientSession } from 'mongoose';
 
 const unlinkFile = promisify(fs.unlink);
 
 export type Arguments<T extends { [field: string | number | symbol]: unknown }> = {
+  session?: ClientSession
   collection: Collection
   req: PayloadRequest
   id: string | number
@@ -57,6 +59,7 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
   }, Promise.resolve());
 
   const {
+    session,
     depth,
     collection,
     collection: {
@@ -121,6 +124,7 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
 
   const doc = await getLatestEntityVersion({
     payload,
+    session,
     Model,
     config: collectionConfig,
     id,
@@ -299,6 +303,7 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
   if (collectionConfig.versions) {
     result = await saveVersion({
       payload,
+      session,
       collection: collectionConfig,
       req,
       docWithLocales: {

--- a/src/express/types.ts
+++ b/src/express/types.ts
@@ -6,6 +6,7 @@ import { Payload } from '../payload';
 import { Collection, TypeWithID } from '../collections/config/types';
 import { User } from '../auth/types';
 import { Document } from '../types';
+import { ClientSession } from 'mongoose';
 
 /** Express request with some Payload related context added */
 export declare type PayloadRequest<U = any> = Request & {
@@ -20,6 +21,8 @@ export declare type PayloadRequest<U = any> = Request & {
   locale?: string;
   /** The locale that should be used for a field when it is not translated to the requested locale */
   fallbackLocale?: string;
+  /** The request default Mongoose session */
+  session?: ClientSession;
   /** Information about the collection that is being accessed
    * - Configuration from payload-config.ts
    * - Mongo model for this collection

--- a/src/globals/operations/findOne.ts
+++ b/src/globals/operations/findOne.ts
@@ -7,9 +7,11 @@ import replaceWithDraftIfAvailable from '../../versions/drafts/replaceWithDraftI
 import { afterRead } from '../../fields/hooks/afterRead';
 import { SanitizedGlobalConfig } from '../config/types';
 import { PayloadRequest } from '../../express/types';
+import { ClientSession } from 'mongoose';
 
 type Args = {
   globalConfig: SanitizedGlobalConfig
+  session?: ClientSession
   locale?: string
   req: PayloadRequest
   slug: string
@@ -22,6 +24,7 @@ type Args = {
 async function findOne<T extends Record<string, unknown>>(args: Args): Promise<T> {
   const {
     globalConfig,
+    session,
     locale,
     req,
     req: {
@@ -68,7 +71,7 @@ async function findOne<T extends Record<string, unknown>>(args: Args): Promise<T
   // Perform database operation
   // /////////////////////////////////////
 
-  let doc = await Model.findOne(query).lean() as any;
+  let doc: any = await Model.findOne(query, {}, session ? { session } : undefined).lean();
 
   if (!doc) {
     doc = {};

--- a/src/globals/operations/findOne.ts
+++ b/src/globals/operations/findOne.ts
@@ -24,7 +24,6 @@ type Args = {
 async function findOne<T extends Record<string, unknown>>(args: Args): Promise<T> {
   const {
     globalConfig,
-    session,
     locale,
     req,
     req: {
@@ -36,6 +35,8 @@ async function findOne<T extends Record<string, unknown>>(args: Args): Promise<T
     draft: draftEnabled = false,
     overrideAccess = false,
   } = args;
+
+  const session = args.session || req.session;
 
   const { globals: { Model } } = payload;
 

--- a/src/globals/operations/findVersionByID.ts
+++ b/src/globals/operations/findVersionByID.ts
@@ -8,9 +8,11 @@ import { hasWhereAccessResult } from '../../auth/types';
 import { TypeWithVersion } from '../../versions/types';
 import { SanitizedGlobalConfig } from '../config/types';
 import { afterRead } from '../../fields/hooks/afterRead';
+import { ClientSession } from 'mongoose';
 
 export type Arguments = {
   globalConfig: SanitizedGlobalConfig
+  session?: ClientSession
   id: string | number
   req: PayloadRequest
   disableErrors?: boolean
@@ -24,6 +26,7 @@ async function findVersionByID<T extends TypeWithVersion<T> = any>(args: Argumen
   const {
     depth,
     globalConfig,
+    session,
     id,
     req,
     req: {
@@ -74,7 +77,7 @@ async function findVersionByID<T extends TypeWithVersion<T> = any>(args: Argumen
 
   if (!query.$and[0]._id) throw new NotFound(t);
 
-  let result = await VersionsModel.findOne(query, {}).lean();
+  let result = await VersionsModel.findOne(query, {}, session ? { session } : undefined).lean();
 
   if (!result) {
     if (!disableErrors) {

--- a/src/globals/operations/findVersionByID.ts
+++ b/src/globals/operations/findVersionByID.ts
@@ -26,7 +26,6 @@ async function findVersionByID<T extends TypeWithVersion<T> = any>(args: Argumen
   const {
     depth,
     globalConfig,
-    session,
     id,
     req,
     req: {
@@ -39,6 +38,8 @@ async function findVersionByID<T extends TypeWithVersion<T> = any>(args: Argumen
     overrideAccess,
     showHiddenFields,
   } = args;
+
+  const session = args.session || req.session;
 
   const VersionsModel = payload.versions[globalConfig.slug];
 

--- a/src/globals/operations/findVersions.ts
+++ b/src/globals/operations/findVersions.ts
@@ -10,9 +10,11 @@ import { SanitizedGlobalConfig } from '../config/types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { buildVersionGlobalFields } from '../../versions/buildGlobalFields';
 import { TypeWithVersion } from '../../versions/types';
+import { ClientSession } from 'mongoose';
 
 export type Arguments = {
   globalConfig: SanitizedGlobalConfig
+  session?: ClientSession
   where?: Where
   page?: number
   limit?: number
@@ -32,6 +34,7 @@ async function findVersions<T extends TypeWithVersion<T>>(
     limit,
     depth,
     globalConfig,
+    session,
     req,
     req: {
       locale,
@@ -104,6 +107,7 @@ async function findVersions<T extends TypeWithVersion<T>>(
     sort: {
       [sortProperty]: sortOrder,
     },
+    ...(session ? { options: { session }} : {}),
     lean: true,
     leanWithId: true,
     useEstimatedCount,

--- a/src/globals/operations/findVersions.ts
+++ b/src/globals/operations/findVersions.ts
@@ -34,7 +34,6 @@ async function findVersions<T extends TypeWithVersion<T>>(
     limit,
     depth,
     globalConfig,
-    session,
     req,
     req: {
       locale,
@@ -43,6 +42,8 @@ async function findVersions<T extends TypeWithVersion<T>>(
     overrideAccess,
     showHiddenFields,
   } = args;
+
+  const session = args.session || req.session;
 
   const VersionsModel = payload.versions[globalConfig.slug];
 

--- a/src/globals/operations/local/findOne.ts
+++ b/src/globals/operations/local/findOne.ts
@@ -6,8 +6,10 @@ import { Document } from '../../../types';
 import findOne from '../findOne';
 import i18nInit from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
+  session?: ClientSession
   slug: T
   depth?: number
   locale?: string
@@ -23,6 +25,7 @@ export default async function findOneLocal<T extends keyof GeneratedTypes['globa
   options: Options<T>,
 ): Promise<GeneratedTypes['globals'][T]> {
   const {
+    session,
     slug: globalSlug,
     depth,
     locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
@@ -54,6 +57,7 @@ export default async function findOneLocal<T extends keyof GeneratedTypes['globa
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findOne({
+    session,
     slug: globalSlug as string,
     depth,
     globalConfig,

--- a/src/globals/operations/local/findVersionByID.ts
+++ b/src/globals/operations/local/findVersionByID.ts
@@ -7,8 +7,10 @@ import { TypeWithVersion } from '../../../versions/types';
 import findVersionByID from '../findVersionByID';
 import i18nInit from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
+  session?: ClientSession
   slug: T
   id: string
   depth?: number
@@ -25,6 +27,7 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
   options: Options<T>,
 ): Promise<TypeWithVersion<GeneratedTypes['globals'][T]>> {
   const {
+    session,
     slug: globalSlug,
     depth,
     id,
@@ -56,6 +59,7 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findVersionByID({
+    session,
     depth,
     id,
     globalConfig,

--- a/src/globals/operations/local/findVersions.ts
+++ b/src/globals/operations/local/findVersions.ts
@@ -8,8 +8,10 @@ import { getDataLoader } from '../../../collections/dataloader';
 import i18nInit from '../../../translations/init';
 import { APIError } from '../../../errors';
 import { TypeWithVersion } from '../../../versions/types';
+import { ClientSession } from 'mongoose';
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
+  session?: ClientSession
   slug: T
   depth?: number
   page?: number
@@ -28,6 +30,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   options: Options<T>,
 ): Promise<PaginatedDocs<TypeWithVersion<GeneratedTypes['globals'][T]>>> {
   const {
+    session,
     slug: globalSlug,
     depth,
     page,
@@ -61,6 +64,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return findVersions({
+    session,
     where,
     page,
     limit,

--- a/src/globals/operations/local/restoreVersion.ts
+++ b/src/globals/operations/local/restoreVersion.ts
@@ -6,8 +6,10 @@ import { Document } from '../../../types';
 import restoreVersion from '../restoreVersion';
 import i18nInit from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
+  session?: ClientSession
   slug: string
   id: string
   depth?: number
@@ -23,6 +25,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   options: Options<T>,
 ): Promise<GeneratedTypes['globals'][T]> {
   const {
+    session,
     slug: globalSlug,
     depth,
     id,
@@ -53,6 +56,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return restoreVersion({
+    session,
     depth,
     globalConfig,
     overrideAccess,

--- a/src/globals/operations/local/update.ts
+++ b/src/globals/operations/local/update.ts
@@ -6,8 +6,10 @@ import update from '../update';
 import { getDataLoader } from '../../../collections/dataloader';
 import i18nInit from '../../../translations/init';
 import { APIError } from '../../../errors';
+import { ClientSession } from 'mongoose';
 
 export type Options<TSlug extends keyof GeneratedTypes['globals']> = {
+  session?: ClientSession
   slug: TSlug
   depth?: number
   locale?: string
@@ -24,6 +26,7 @@ export default async function updateLocal<TSlug extends keyof GeneratedTypes['gl
   options: Options<TSlug>,
 ): Promise<GeneratedTypes['globals'][TSlug]> {
   const {
+    session,
     slug: globalSlug,
     depth,
     locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
@@ -55,6 +58,7 @@ export default async function updateLocal<TSlug extends keyof GeneratedTypes['gl
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req);
 
   return update<TSlug>({
+    session,
     slug: globalSlug,
     data,
     depth,

--- a/src/globals/operations/restoreVersion.ts
+++ b/src/globals/operations/restoreVersion.ts
@@ -23,7 +23,6 @@ async function restoreVersion<T extends TypeWithVersion<T> = any>(args: Argument
     id,
     depth,
     globalConfig,
-    session,
     req,
     req: {
       t,
@@ -38,6 +37,7 @@ async function restoreVersion<T extends TypeWithVersion<T> = any>(args: Argument
     showHiddenFields,
   } = args;
 
+  const session = args.session || req.session;
   const sessionOpts = session ? { session } : undefined;
 
   // /////////////////////////////////////

--- a/src/globals/operations/update.ts
+++ b/src/globals/operations/update.ts
@@ -31,7 +31,6 @@ async function update<TSlug extends keyof GeneratedTypes['globals']>(
 ): Promise<GeneratedTypes['globals'][TSlug]> {
   const {
     globalConfig,
-    session,
     slug,
     req,
     req: {
@@ -50,6 +49,7 @@ async function update<TSlug extends keyof GeneratedTypes['globals']>(
     autosave,
   } = args;
 
+  const session = args.session || req.session;
   const sessionOpts = session ? { session } : undefined;
 
   let { data } = args;

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -90,6 +90,8 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
 
   mongoURL: string | false;
 
+  mongooseConnection: mongoose.Connection;
+
   mongoMemoryServer: any
 
   local: boolean;
@@ -141,10 +143,7 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
     this.logger = Logger('payload', options.loggerOptions);
     this.mongoURL = options.mongoURL;
 
-    if (this.mongoURL) {
-      mongoose.set('strictQuery', false);
-      this.mongoMemoryServer = await connectMongoose(this.mongoURL, options.mongoOptions, this.logger);
-    }
+    await connectMongoose(this, options.mongoOptions);
 
     this.logger.info('Starting Payload...');
     if (!options.secret) {

--- a/src/versions/deleteCollectionVersions.ts
+++ b/src/versions/deleteCollectionVersions.ts
@@ -1,13 +1,16 @@
+import { ClientSession } from 'mongoose';
 import { Payload } from '../payload';
 
 type Args = {
   payload: Payload
+  session?: ClientSession
   slug: string
   id?: string | number
 }
 
 export const deleteCollectionVersions = async ({
   payload,
+  session,
   slug,
   id,
 }: Args): Promise<void> => {
@@ -18,7 +21,7 @@ export const deleteCollectionVersions = async ({
       parent: {
         $eq: id,
       },
-    });
+    }, session ? { session } : undefined);
   } catch (err) {
     payload.logger.error(`There was an error removing versions for the deleted ${slug} document with ID ${id}.`);
   }

--- a/src/versions/drafts/queryDrafts.ts
+++ b/src/versions/drafts/queryDrafts.ts
@@ -5,6 +5,7 @@ import { PaginatedDocs } from '../../mongoose/types';
 import { Collection, CollectionModel, TypeWithID } from '../../collections/config/types';
 import { hasWhereAccessResult } from '../../auth';
 import { appendVersionToQueryKey } from './appendVersionToQueryKey';
+import { ClientSession } from 'mongoose';
 
 type AggregateVersion<T> = {
   _id: string
@@ -14,6 +15,7 @@ type AggregateVersion<T> = {
 }
 
 type Args = {
+  session?: ClientSession
   accessResult: AccessResult
   collection: Collection
   locale: string
@@ -23,6 +25,7 @@ type Args = {
 }
 
 export const queryDrafts = async <T extends TypeWithID>({
+  session,
   accessResult,
   collection,
   locale,
@@ -64,7 +67,7 @@ export const queryDrafts = async <T extends TypeWithID>({
     },
     // Filter based on incoming query
     { $match: versionQuery },
-  ]);
+  ], session ? { session } : undefined);
 
   const paginationSort = Object.entries(paginationOptions.sort).reduce((sort, [key, order]) => {
     return {
@@ -76,6 +79,7 @@ export const queryDrafts = async <T extends TypeWithID>({
   const result = await VersionModel.aggregatePaginate(aggregate, {
     ...paginationOptions,
     sort: paginationSort,
+    ...(session ? { options: { session }} : {}),
   });
 
   return {

--- a/src/versions/drafts/replaceWithDraftIfAvailable.ts
+++ b/src/versions/drafts/replaceWithDraftIfAvailable.ts
@@ -6,9 +6,11 @@ import { CollectionModel, SanitizedCollectionConfig, TypeWithID } from '../../co
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields';
 import { appendVersionToQueryKey } from './appendVersionToQueryKey';
 import { SanitizedGlobalConfig } from '../../globals/config/types';
+import { ClientSession } from 'mongoose';
 
 type Arguments<T> = {
   payload: Payload
+  session?: ClientSession
   entity: SanitizedCollectionConfig | SanitizedGlobalConfig
   entityType: 'collection' | 'global'
   doc: T
@@ -18,6 +20,7 @@ type Arguments<T> = {
 
 const replaceWithDraftIfAvailable = async <T extends TypeWithID>({
   payload,
+  session,
   entity,
   entityType,
   doc,
@@ -64,6 +67,7 @@ const replaceWithDraftIfAvailable = async <T extends TypeWithID>({
   let draft = await VersionModel.findOne(query, {}, {
     lean: true,
     sort: { updatedAt: 'desc' },
+    ...(session ? { session } : {}),
   });
 
   if (!draft) {

--- a/src/versions/enforceMaxVersions.ts
+++ b/src/versions/enforceMaxVersions.ts
@@ -1,9 +1,10 @@
-import { FilterQuery } from 'mongoose';
+import { ClientSession, FilterQuery } from 'mongoose';
 import { Payload } from '../payload';
 import { CollectionModel } from '../collections/config/types';
 
 type Args = {
   payload: Payload
+  session?: ClientSession
   Model: CollectionModel
   max: number
   slug: string
@@ -13,6 +14,7 @@ type Args = {
 
 export const enforceMaxVersions = async ({
   payload,
+  session,
   Model,
   max,
   slug,
@@ -20,11 +22,17 @@ export const enforceMaxVersions = async ({
   id,
 }: Args): Promise<void> => {
   try {
+    const sessionOpts = session ? { session } : undefined;
+
     const query: { parent?: string | number } = {};
 
     if (entityType === 'collection') query.parent = id;
 
-    const oldestAllowedDoc = await Model.find(query).limit(1).skip(max).sort({ updatedAt: -1 });
+    const oldestAllowedDoc = await Model
+      .find(query, {}, sessionOpts)
+      .limit(1)
+      .skip(max)
+      .sort({ updatedAt: -1 });
 
     if (oldestAllowedDoc?.[0]?.updatedAt) {
       const deleteQuery: FilterQuery<unknown> = {
@@ -35,7 +43,7 @@ export const enforceMaxVersions = async ({
 
       if (entityType === 'collection') deleteQuery.parent = id;
 
-      await Model.deleteMany(deleteQuery);
+      await Model.deleteMany(deleteQuery, sessionOpts);
     }
   } catch (err) {
     payload.logger.error(`There was an error cleaning up old versions for the ${entityType} ${slug}`);

--- a/src/versions/saveVersion.ts
+++ b/src/versions/saveVersion.ts
@@ -27,7 +27,9 @@ export const saveVersion = async ({
   docWithLocales: doc,
   autosave,
   draft,
+  req,
 }: Args): Promise<TypeWithID> => {
+  session ||= req.session;
   const sessionOpts = session ? { session } : undefined;
 
   let result;


### PR DESCRIPTION
## Description

- add `payload.mongooseConnection`
- instrument globals, collections, and versions operations with `session`
- instrument globals and collections local API with `session`
- add `PayloadRequest.session` and instrument operations to use it

Passing `session` explicitly:

```ts
const session = await payload.mongooseConnection.startSession();
await session.withTransaction(() => {
  const user = payload.findById({
    session,
    collection: 'users',
    id: '...',
  });
  payload.update({
    session,
    collection: 'users',
    id: user.id,
    data: {...},
  });
});
await session.endSession();
```

Passing `session` implicitly on `req` is also possible; it will be picked up if not overridden by the explicit `session` parameter. This allows straightforward transaction-per-request with an Express middleware. I have a plugin ready for release after this is merged.

This 100% needs docs and tests.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation

## Related

- https://github.com/payloadcms/payload/discussions/1487
- https://github.com/payloadcms/payload/pull/1527