### PR TITLE
chore: removes leftover p tag reference

### DIFF
--- a/src/admin/components/forms/field-types/RichText/plugins/withHTML.tsx
+++ b/src/admin/components/forms/field-types/RichText/plugins/withHTML.tsx
@@ -12,7 +12,6 @@ const ELEMENT_TAGS = {
   H6: () => ({ type: 'h6' }),
   LI: () => ({ type: 'li' }),
   OL: () => ({ type: 'ol' }),
-  P: () => ({ type: 'p' }),
   PRE: () => ({ type: 'code' }),
   UL: () => ({ type: 'ul' }),
 };


### PR DESCRIPTION
## Description

Removes leftover `p` tag reference causing text in richtext editor to receive `type: p`.

**Before:**
![Screen Shot 2023-02-13 at 11 17 04 AM](https://user-images.githubusercontent.com/35232443/218515108-e845e76f-63c1-4e0b-bf4e-99bffba8f1e3.png)

**After:**
![Screen Shot 2023-02-13 at 11 19 05 AM](https://user-images.githubusercontent.com/35232443/218515119-a3577dcd-2b97-4b2a-b54a-399e49940323.png)


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
