### PR TITLE
fix: #2077 useAPIKey UI missing with disableLocalStrategy

### DIFF
--- a/src/admin/components/views/collections/Edit/Auth/index.tsx
+++ b/src/admin/components/views/collections/Edit/Auth/index.tsx
@@ -67,56 +67,60 @@ const Auth: React.FC<Props> = (props) => {
     }
   }, [modified]);
 
-  if (collection.auth.disableLocalStrategy) {
+  if (collection.auth.disableLocalStrategy && !collection.auth.useAPIKey) {
     return null;
   }
 
   return (
     <div className={baseClass}>
-      <Email
-        required
-        name="email"
-        label={t('general:email')}
-        admin={{ autoComplete: 'email' }}
-      />
-      {(changingPassword || requirePassword) && (
-        <div className={`${baseClass}__changing-password`}>
-          <Password
-            autoComplete="off"
+      { !collection.auth.disableLocalStrategy && (
+        <React.Fragment>
+          <Email
             required
-            name="password"
-            label={t('newPassword')}
+            name="email"
+            label={t('general:email')}
+            admin={{ autoComplete: 'email' }}
           />
-          <ConfirmPassword />
-          {!requirePassword && (
+          {(changingPassword || requirePassword) && (
+            <div className={`${baseClass}__changing-password`}>
+              <Password
+                autoComplete="off"
+                required
+                name="password"
+                label={t('newPassword')}
+              />
+              <ConfirmPassword />
+              {!requirePassword && (
+                <Button
+                  size="small"
+                  buttonStyle="secondary"
+                  onClick={() => handleChangePassword(false)}
+                >
+                  {t('general:cancel')}
+                </Button>
+              )}
+            </div>
+          )}
+          {(!changingPassword && !requirePassword) && (
+            <Button
+              id="change-password"
+              size="small"
+              buttonStyle="secondary"
+              onClick={() => handleChangePassword(true)}
+            >
+              {t('changePassword')}
+            </Button>
+          )}
+          {operation === 'update' && (
             <Button
               size="small"
               buttonStyle="secondary"
-              onClick={() => handleChangePassword(false)}
+              onClick={() => unlock()}
             >
-              {t('general:cancel')}
+              {t('forceUnlock')}
             </Button>
           )}
-        </div>
-      )}
-      {(!changingPassword && !requirePassword) && (
-        <Button
-          id="change-password"
-          size="small"
-          buttonStyle="secondary"
-          onClick={() => handleChangePassword(true)}
-        >
-          {t('changePassword')}
-        </Button>
-      )}
-      {operation === 'update' && (
-        <Button
-          size="small"
-          buttonStyle="secondary"
-          onClick={() => unlock()}
-        >
-          {t('forceUnlock')}
-        </Button>
+        </React.Fragment>
       )}
       {useAPIKey && (
         <div className={`${baseClass}__api-key`}>

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -36,6 +36,14 @@ export default buildConfig({
         },
       ],
     },
+    {
+      slug: 'api-keys',
+      auth: {
+        disableLocalStrategy: true,
+        useAPIKey: true,
+      },
+      fields: [],
+    },
   ],
   onInit: async (payload) => {
     await payload.create({


### PR DESCRIPTION
## Description

Given a collection: 
```ts
    {
      slug: 'api-keys',
      auth: {
        disableLocalStrategy: true,
        useAPIKey: true,
      },
      fields: [],
    },
```
You would not see the UI for api keys: 

![image](https://user-images.githubusercontent.com/6434612/218574592-dcc0918d-3982-4fa8-be27-a00b070cc2c1.png)

After: 
![image](https://user-images.githubusercontent.com/6434612/218574405-168a82fb-5d99-40ee-ad98-a64ceb25855b.png)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes