### PR TITLE
chore: richtext p tag reference

### DIFF
--- a/src/admin/components/forms/field-types/RichText/plugins/withHTML.tsx
+++ b/src/admin/components/forms/field-types/RichText/plugins/withHTML.tsx
@@ -12,6 +12,7 @@ const ELEMENT_TAGS = {
   H6: () => ({ type: 'h6' }),
   LI: () => ({ type: 'li' }),
   OL: () => ({ type: 'ol' }),
+  P: () => ({}),
   PRE: () => ({ type: 'code' }),
   UL: () => ({ type: 'ul' }),
 };

--- a/src/admin/components/forms/field-types/RichText/plugins/withHTML.tsx
+++ b/src/admin/components/forms/field-types/RichText/plugins/withHTML.tsx
@@ -12,7 +12,6 @@ const ELEMENT_TAGS = {
   H6: () => ({ type: 'h6' }),
   LI: () => ({ type: 'li' }),
   OL: () => ({ type: 'ol' }),
-  P: () => ({ type: 'p' }),
   PRE: () => ({ type: 'code' }),
   UL: () => ({ type: 'ul' }),
 };


### PR DESCRIPTION
## Description

Instead of removing entire `P` element tag, only removes `type` from `P` tag.

**Before (shape of data when removing entire element):**
![Screen Shot 2023-02-13 at 4 37 16 PM](https://user-images.githubusercontent.com/35232443/218580827-d9290681-8a9c-4e19-947d-a868c240901b.png)

**After (only removing type):** 
![Screen Shot 2023-02-13 at 4 37 03 PM](https://user-images.githubusercontent.com/35232443/218580819-fc769f8a-9413-4d17-8d18-9798985e10ef.png)


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
