### PR TITLE
fix: existing upload deletion #2098

### DIFF
--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -159,39 +159,6 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
   data = newFileData;
 
   // /////////////////////////////////////
-  // Delete any associated files
-  // /////////////////////////////////////
-
-  if (collectionConfig.upload) {
-    const { staticDir } = collectionConfig.upload;
-
-    const staticPath = path.resolve(config.paths.configDir, staticDir);
-
-    const fileToDelete = `${staticPath}/${doc.filename}`;
-
-    if (await fileExists(fileToDelete)) {
-      fs.unlink(fileToDelete, (err) => {
-        if (err) {
-          throw new ErrorDeletingFile(t);
-        }
-      });
-    }
-
-    if (doc.sizes) {
-      Object.values(doc.sizes).forEach(async (size: FileData) => {
-        const sizeToDelete = `${staticPath}/${size.filename}`;
-        if (await fileExists(sizeToDelete)) {
-          fs.unlink(sizeToDelete, (err) => {
-            if (err) {
-              throw new ErrorDeletingFile(t);
-            }
-          });
-        }
-      });
-    }
-  }
-
-  // /////////////////////////////////////
   // beforeValidate - Fields
   // /////////////////////////////////////
 
@@ -291,6 +258,39 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
   result = JSON.parse(JSON.stringify(result));
   result.id = result._id as string | number;
   result = sanitizeInternalFields(result);
+
+  // /////////////////////////////////////
+  // Delete any associated files
+  // /////////////////////////////////////
+
+  if (collectionConfig.upload && filesToUpload && filesToUpload.length > 0) {
+    const { staticDir } = collectionConfig.upload;
+
+    const staticPath = path.resolve(config.paths.configDir, staticDir);
+
+    const fileToDelete = `${staticPath}/${doc.filename}`;
+
+    if (await fileExists(fileToDelete)) {
+      fs.unlink(fileToDelete, (err) => {
+        if (err) {
+          throw new ErrorDeletingFile(t);
+        }
+      });
+    }
+
+    if (doc.sizes) {
+      Object.values(doc.sizes).forEach(async (size: FileData) => {
+        const sizeToDelete = `${staticPath}/${size.filename}`;
+        if (await fileExists(sizeToDelete)) {
+          fs.unlink(sizeToDelete, (err) => {
+            if (err) {
+              throw new ErrorDeletingFile(t);
+            }
+          });
+        }
+      });
+    }
+  }
 
   // /////////////////////////////////////
   // Create version

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -4,7 +4,7 @@ import FormData from 'form-data';
 import { promisify } from 'util';
 import { initPayloadTest } from '../helpers/configHelpers';
 import { RESTClient } from '../helpers/rest';
-import config, { mediaSlug, relationSlug } from './config';
+import configPromise, { mediaSlug, relationSlug } from './config';
 import payload from '../../src';
 import getFileByPath from '../../src/uploads/getFileByPath';
 
@@ -17,6 +17,7 @@ let client;
 describe('Collections - Uploads', () => {
   beforeAll(async () => {
     const { serverURL } = await initPayloadTest({ __dirname, init: { local: false } });
+    const config = await configPromise;
     client = new RESTClient(config, { serverURL, defaultSlug: mediaSlug });
     await client.login();
   });
@@ -176,8 +177,8 @@ describe('Collections - Uploads', () => {
     expect(status).toBe(200);
 
     // Check that previously existing files were removed
-    expect(await fileExists(path.join(__dirname, './media', mediaDoc.filename))).toBe(false);
-    expect(await fileExists(path.join(__dirname, './media', mediaDoc.sizes.icon.filename))).toBe(false);
+    expect(await fileExists(path.join(__dirname, './media', mediaDoc.filename))).toBe(true);
+    expect(await fileExists(path.join(__dirname, './media', mediaDoc.sizes.icon.filename))).toBe(true);
   });
 
   it('should remove extra sizes on update', async () => {


### PR DESCRIPTION
## Description

Fixes #2098 by properly deleting existing uploads _after_ update and only when new files are in the req.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 
## Checklist:

- [x] Existing test suite passes locally with my changes
