### PR TITLE
docs: Update uploads example based on Sharp types

### DIFF
--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -81,11 +81,11 @@ const Media: CollectionConfig = {
       {
         name: 'tablet',
         width: 1024,
-        // By specifying `null` or leaving a height undefined,
+        // By specifying `undefined` or leaving a height undefined,
         // the image will be sized to a certain width,
         // but it will retain its original aspect ratio
         // and calculate a height automatically.
-        height: null,
+        height: undefined,
         position: 'centre',
       },
     ],


### PR DESCRIPTION
## Description

This is a very small update to the docs that I don't know if it's entirely relevant, but it also might be...

In the [docs for Uploads collections](https://payloadcms.com/docs/upload/overview), it currently says that you can set `null` for either the width and height of the `imageSizes` property, which makes sense because the [Sharp docs](https://sharp.pixelplumbing.com/api-resize#parameters) also say that. However, if you set `strict: true` on your `tsconfig.json` it throws an error because the actual `sharp.ResizeOptions` type only accepts a number or undefined.

Also, in your own tests directory for the uploads you set `undefined` instead of `null` because `null` throws a type error. But for some reason the production build doesn't throw the same type error unless you use `strict: true`.

```ts
// This is in your "test/uploads/config.ts" file
{
  name: 'maintainedAspectRatio',
  width: 1024,
  height: undefined,
  crop: 'center',
  position: 'center',
  formatOptions: { format: 'png', options: { quality: 90 } },
},
```

So I just updated the example on the docs page to use `undefined` instead of `null` in case it could cause some issues. I had the idea because on the issue #2088 they used `null` and they're getting an aspect ratio error, but I can't test it with `null`, only with `undefined` because of the type error and with `undefined` the issue doesn't occur.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
