### PR TITLE
fix: useFacet config option to disable $facet aggregation

### DIFF
--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -47,7 +47,7 @@ Before running in Production, you need to have built a production-ready copy of 
 {
   "name": "project-name-here",
   "scripts": {
-    "build": "payload build",
+    "build": "payload build"
   },
   "dependencies": {
     // your dependencies
@@ -70,6 +70,8 @@ Payload comes with a robust set of built-in anti-abuse measures, such as locking
 
 ## MongoDB
 
+Payload can be used with any MongoDB compatible database including AWS DocumentDB or Azure Cosmos DB.
+
 ##### Managing MongoDB yourself
 
 If you are using a [persistent filesystem-based cloud host](#persistent-vs-ephemeral-filesystems) such as a [DigitalOcean Droplet](https://www.digitalocean.com/products/droplets/) or an [Amazon EC2](https://aws.amazon.com/ec2/?ec2-whats-new.sort-by=item.additionalFields.postDateTime&ec2-whats-new.sort-order=desc) server, you might opt to install MongoDB directly on that server itself so that Node can communicate with it locally. With this approach, you can benefit from faster response times, but scaling can become more involved as your app's user base grows.
@@ -78,10 +80,11 @@ If you are using a [persistent filesystem-based cloud host](#persistent-vs-ephem
 
 Alternatively, you can rely on a third-party MongoDB host such as [MongoDB Atlas](https://www.mongodb.com/). With Atlas or a similar cloud provider, you can trust them to take care of your database's availability, security, redundancy, and backups.
 
-<Banner type="warning">
-  <strong>Note regarding Azure Cosmos:</strong><br/>
-  When using Azure Cosmos, MongoDB requires an index on any field being sorted on. To make this easier, see the <a href="/docs/configuration/overview">indexSortableFields</a> configuration option.
-</Banner>
+##### DocumentDB
+When using AWS DocumentDB, you will need to configure connection options for authentication in the `mongoOptions` passed to `payload.init`. You also need to set `mongoOptions.useFacet` to `false` to disable use of the unsupported `$facet` aggregation.
+
+##### CosmosDB
+When using Azure Cosmos DB, an index is needed for any field you may want to sort on. To add the sort index for all fields that may be sorted in the admin UI use the <a href="/docs/configuration/overview">indexSortableFields</a> configuration option.
 
 ## File storage
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -77,7 +77,10 @@ export type InitOptions = {
   /** Mongo connection URL, starts with `mongo` */
   mongoURL: string | false;
   /** Extra configuration options that will be passed to Mongo */
-  mongoOptions?: ConnectOptions;
+  mongoOptions?: ConnectOptions & {
+    /** Set false to disable $facet aggregation in non-supporting databases, Defaults to true */
+    useFacet?: boolean
+  };
 
   /** Secure string that Payload will use for any encryption workflows */
   secret: string;

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -90,6 +90,8 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
 
   mongoURL: string | false;
 
+  mongoOptions: InitOptions['mongoOptions'];
+
   mongoMemoryServer: any
 
   local: boolean;
@@ -140,6 +142,7 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
   async init(options: InitOptions): Promise<Payload> {
     this.logger = Logger('payload', options.loggerOptions);
     this.mongoURL = options.mongoURL;
+    this.mongoOptions = options.mongoOptions;
 
     if (this.mongoURL) {
       mongoose.set('strictQuery', false);

--- a/src/versions/drafts/queryDrafts.ts
+++ b/src/versions/drafts/queryDrafts.ts
@@ -1,3 +1,4 @@
+import { PaginateOptions } from 'mongoose';
 import { AccessResult } from '../../config/types';
 import { Where } from '../../types';
 import { Payload } from '../../payload';
@@ -17,7 +18,7 @@ type Args = {
   accessResult: AccessResult
   collection: Collection
   locale: string
-  paginationOptions: any
+  paginationOptions: PaginateOptions
   payload: Payload
   where: Where
 }
@@ -76,7 +77,8 @@ export const queryDrafts = async <T extends TypeWithID>({
   const result = await VersionModel.aggregatePaginate(aggregate, {
     ...paginationOptions,
     sort: paginationSort,
-  });
+    useFacet: payload.mongoOptions?.useFacet,
+  } as PaginateOptions);
 
   return {
     ...result,


### PR DESCRIPTION
## Description

#2092 
I added the `useFacet` option directly to `mongoOptions` and assigned `mongoOptions` to the Payload class to access the new property.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
