### PR TITLE
fix: #2091 admin translations for filter operators

### DIFF
--- a/src/admin/components/elements/WhereBuilder/field-types.tsx
+++ b/src/admin/components/elements/WhereBuilder/field-types.tsx
@@ -4,7 +4,7 @@ const boolean = [
     value: 'equals',
   },
   {
-    label: 'is not equal to',
+    label: 'isNotEqualTo',
     value: 'not_equals',
   },
 ];
@@ -12,11 +12,11 @@ const boolean = [
 const base = [
   ...boolean,
   {
-    label: 'is in',
+    label: 'isIn',
     value: 'in',
   },
   {
-    label: 'is not in',
+    label: 'isNotIn',
     value: 'not_in',
   },
   {
@@ -28,19 +28,19 @@ const base = [
 const numeric = [
   ...base,
   {
-    label: 'is greater than',
+    label: 'isGreaterThan',
     value: 'greater_than',
   },
   {
-    label: 'is less than',
+    label: 'isLessThan',
     value: 'less_than',
   },
   {
-    label: 'is less than or equal to',
+    label: 'isLessThanOrEqualTo',
     value: 'less_than_equal',
   },
   {
-    label: 'is greater than or equal to',
+    label: 'isGreaterThanOrEqualTo',
     value: 'greater_than_equals',
   },
 ];
@@ -58,7 +58,7 @@ const geo = [
 ];
 
 const like = {
-  label: 'is like',
+  label: 'isLike',
   value: 'like',
 };
 

--- a/src/admin/components/elements/WhereBuilder/index.tsx
+++ b/src/admin/components/elements/WhereBuilder/index.tsx
@@ -24,6 +24,11 @@ const reduceFields = (fields, i18n) => flattenTopLevelFields(fields).reduce((red
       label: getTranslation(field.label || field.name, i18n),
       value: field.name,
       ...fieldTypes[field.type],
+      operators: fieldTypes[field.type].operators.map((operator) => ({
+        ...operator,
+        label: i18n.t(`operators:${operator.label}`),
+      }
+      )),
       props: {
         ...field,
       },

--- a/src/translations/cs.json
+++ b/src/translations/cs.json
@@ -225,6 +225,20 @@
     "users": "Uživatelé",
     "welcome": "Vítejte"
   },
+  "operators": {
+    "equals": "rovná se",
+    "isNotEqualTo": "není rovno",
+    "isIn": "je v",
+    "isNotIn": "není in",
+    "exists": "existuje",
+    "isGreaterThan": "je větší než",
+    "isLessThan": "je menší než",
+    "isLessThanOrEqualTo": "je menší nebo rovno",
+    "isGreaterThanOrEqualTo": "je větší nebo rovno",
+    "near": "blízko",
+    "isLike": "je jako",
+    "contains": "obsahuje"
+  },
   "upload": {
     "dragAndDropHere": "nebo sem přetáhněte soubor",
     "fileName": "Název souboru",

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -226,6 +226,20 @@
     "users": "Benutzer",
     "welcome": "Willkommen"
   },
+  "operators": {
+    "equals": "gleich",
+    "isNotEqualTo": "ist nicht gleich",
+    "isIn": "ist drin",
+    "isNotIn": "ist nicht drin",
+    "exists": "existiert",
+    "isGreaterThan": "ist größer als",
+    "isLessThan": "ist kleiner als",
+    "isLessThanOrEqualTo": "ist kleiner oder gleich",
+    "isGreaterThanOrEqualTo": "ist größer oder gleich",
+    "near": "in der Nähe",
+    "isLike": "ist wie",
+    "contains": "enthält"
+  },
   "upload": {
     "dragAndDropHere": "oder ziehe eine Datei hier",
     "fileName": "Dateiname",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -228,6 +228,20 @@
     "users": "Users",
     "welcome": "Welcome"
   },
+  "operators": {
+    "equals": "equals",
+    "isNotEqualTo": "is not equal to",
+    "isIn": "is in",
+    "isNotIn": "is not in",
+    "exists": "exists",
+    "isGreaterThan": "is greater than",
+    "isLessThan": "is less than",
+    "isLessThanOrEqualTo": "is less than or equal to",
+    "isGreaterThanOrEqualTo": "is greater than or equal to",
+    "near": "near",
+    "isLike": "is like",
+    "contains": "contains"
+  },
   "upload": {
     "dragAndDropHere": "or drag and drop a file here",
     "fileName": "File Name",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -228,6 +228,20 @@
     "users": "Usuarios",
     "welcome": "Bienvenido"
   },
+  "operators": {
+    "equals": "igual",
+    "isNotEqualTo": "no es igual a",
+    "isIn": "está en",
+    "isNotIn": "no está en",
+    "exists": "existe",
+    "isGreaterThan": "es mayor que",
+    "isLessThan": "es menor que",
+    "isLessThanOrEqualTo": "es menor o igual que",
+    "isGreaterThanOrEqualTo": "es mayor o igual que",
+    "near": "cerca",
+    "isLike": "es como",
+    "contains": "contiene"
+  },
   "upload": {
     "dragAndDropHere": "o arrastra un archivo aquí",
     "fileName": "Nombre del archivo",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -218,6 +218,20 @@
     "users": "Utilisateurs",
     "welcome": "Bienvenu(e)"
   },
+  "operators": {
+    "equals": "est égal à",
+    "isNotEqualTo": "n'est pas égal à",
+    "isIn": "est dans",
+    "isNotIn": "n'est pas dans",
+    "exists": "existe",
+    "isGreaterThan": "est supérieur à",
+    "isLessThan": "est inférieur à",
+    "isLessThanOrEqualTo": "est inférieur ou égal à",
+    "isGreaterThanOrEqualTo": "est supérieur ou égal à",
+    "near": "proche",
+    "isLike": "est comme",
+    "contains": "contient"
+  },
   "upload": {
     "dragAndDropHere": "ou glissez-déposez un fichier ici",
     "fileName": "Nom du fichier",

--- a/src/translations/hr.json
+++ b/src/translations/hr.json
@@ -228,6 +228,20 @@
     "users": "Korisnici",
     "welcome": "Dobrodošli"
   },
+  "operators": {
+    "equals": "jednako",
+    "isNotEqualTo": "nije jednako",
+    "isIn": "je u",
+    "isNotIn": "nije unutra",
+    "exists": "postoji",
+    "isGreaterThan": "je veće od",
+    "isLessThan": "manje je od",
+    "isLessThanOrEqualTo": "manje je ili jednako",
+    "isGreaterThanOrEqualTo": "je veće od ili jednako",
+    "near": "blizu",
+    "isLike": "je kao",
+    "contains": "sadrži"
+  },
   "upload": {
     "dragAndDropHere": "ili povucite i ispustite datoteku ovdje",
     "fileName": "Ime datoteke",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -218,6 +218,20 @@
     "users": "Utenti",
     "welcome": "Benvenuto"
   },
+  "operators": {
+    "equals": "uguale",
+    "isNotEqualTo": "non è uguale a",
+    "isIn": "è in",
+    "isNotIn": "non è in",
+    "exists": "esiste",
+    "isGreaterThan": "è maggiore di",
+    "isLessThan": "è minore di",
+    "isLessThanOrEqualTo": "è minore o uguale a",
+    "isGreaterThanOrEqualTo": "è maggiore o uguale a",
+    "near": "vicino",
+    "isLike": "è come",
+    "contains": "contiene"
+  },
   "upload": {
     "dragAndDropHere": "oppure trascina e rilascia un file qui",
     "fileName": "Nome File",

--- a/src/translations/ja.json
+++ b/src/translations/ja.json
@@ -217,6 +217,20 @@
     "users": "ユーザー",
     "welcome": "ようこそ"
   },
+  "operators": {
+    "equals": "等しい",
+    "isNotEqualTo": "等しくない",
+    "isIn": "あります",
+    "isNotIn": "入っていません",
+    "exists": "存在す",
+    "isGreaterThan": "より大きい",
+    "isLessThan": "より小さい",
+    "isLessThanOrEqualTo": "以下",
+    "isGreaterThanOrEqualTo": "以上",
+    "near": "近く",
+    "isLike": "のような",
+    "contains": "含む"
+  },
   "upload": {
     "dragAndDropHere": "または、このエリアにファイルをドラッグ & ドロップ",
     "fileName": "ファイル名",

--- a/src/translations/my.json
+++ b/src/translations/my.json
@@ -217,6 +217,20 @@
     "users": "အသုံးပြုသူများ",
     "welcome": "ကြိုဆိုပါတယ်။"
   },
+  "operators": {
+    "equals": "ညီမျှ",
+    "isNotEqualTo": "ညီမျှသည်",
+    "isIn": "ရှိ",
+    "isNotIn": "မဝင်ပါ",
+    "exists": "တည်ရှိသည်",
+    "isGreaterThan": "ထက်ကြီးသည်",
+    "isLessThan": "ထက်နည်းသည်",
+    "isLessThanOrEqualTo": "ထက်နည်းသည် သို့မဟုတ် ညီမျှသည်",
+    "isGreaterThanOrEqualTo": "ထက်ကြီးသည် သို့မဟုတ် ညီမျှသည်",
+    "near": "နီး",
+    "isLike": "တူသည်",
+    "contains": "ပါဝင်သည်"
+  },
   "upload": {
     "dragAndDropHere": "သို့မဟုတ် ဖိုင်တစ်ခုကို ဤနေရာတွင် ဆွဲချပါ။",
     "fileName": "ဖိုင် နာမည်",

--- a/src/translations/nb.json
+++ b/src/translations/nb.json
@@ -227,6 +227,20 @@
     "users": "Brukere",
     "welcome": "Velkommen"
   },
+  "operators": {
+    "equals": "lik",
+    "isNotEqualTo": "er ikke lik",
+    "isIn": "er i",
+    "isNotIn": "er ikke med",
+    "exists": "eksisterer",
+    "isGreaterThan": "er større enn",
+    "isLessThan": "er mindre enn",
+    "isLessThanOrEqualTo": "er mindre enn eller lik",
+    "isGreaterThanOrEqualTo": "er større enn eller lik",
+    "near": "nær",
+    "isLike": "er som",
+    "contains": "contains"
+  },
   "upload": {
     "dragAndDropHere": "eller dra og slipp en fil her",
     "fileName": "Filnavn",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -218,6 +218,20 @@
     "users": "Gebruikers",
     "welcome": "Welkom"
   },
+  "operators": {
+    "equals": "is gelijk aan",
+    "isNotEqualTo": "is niet gelijk aan",
+    "isIn": "is binnen",
+    "isNotIn": "zit er niet in",
+    "exists": "bestaat",
+    "isGreaterThan": "is groter dan",
+    "isLessThan": "is kleiner dan",
+    "isLessThanOrEqualTo": "is kleiner dan of gelijk aan",
+    "isGreaterThanOrEqualTo": "is groter dan of gelijk aan",
+    "near": "nabij",
+    "isLike": "is als",
+    "contains": "bevat"
+  },
   "upload": {
     "dragAndDropHere": "of sleep een bestand naar hier",
     "fileName": "Bestandsnaam",

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -217,6 +217,20 @@
     "users": "użytkownicy",
     "welcome": "Witaj"
   },
+  "operators": {
+    "equals": "równe",
+    "isNotEqualTo": "nie jest równe",
+    "isIn": "jest w",
+    "isNotIn": "nie ma go w",
+    "exists": "istnieje",
+    "isGreaterThan": "jest większy niż",
+    "isLessThan": "jest mniejsze niż",
+    "isLessThanOrEqualTo": "jest mniejsze lub równe",
+    "isGreaterThanOrEqualTo": "jest większe lub równe",
+    "near": "blisko",
+    "isLike": "jest jak",
+    "contains": "zawiera"
+  },
   "upload": {
     "dragAndDropHere": "lub złap i upuść plik tutaj",
     "fileName": "Nazwa pliku",

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -217,6 +217,20 @@
     "users": "usuários",
     "welcome": "Boas vindas"
   },
+  "operators": {
+    "equals": "igual",
+    "isNotEqualTo": "não é igual a",
+    "isIn": "está em",
+    "isNotIn": "não está em",
+    "exists": "existe",
+    "isGreaterThan": "é maior que",
+    "isLessThan": "é menor que",
+    "isLessThanOrEqualTo": "é menor ou igual a",
+    "isGreaterThanOrEqualTo": "é maior ou igual a",
+    "near": "perto",
+    "isLike": "é como",
+    "contains": "contém"
+  },
   "upload": {
     "dragAndDropHere": "ou arraste um arquivo aqui",
     "fileName": "Nome do Arquivo",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -227,6 +227,20 @@
     "users": "пользователи",
     "welcome": "Добро пожаловать"
   },
+  "operators": {
+    "equals": "равно",
+    "isNotEqualTo": "не равно",
+    "isIn": "находится",
+    "isNotIn": "нет в",
+    "exists": "существует",
+    "isGreaterThan": "больше чем",
+    "isLessThan": "меньше чем",
+    "isLessThanOrEqualTo": "меньше или равно",
+    "isGreaterThanOrEqualTo": "больше или равно",
+    "near": "рядом",
+    "isLike": "похоже",
+    "contains": "содержит"
+  },
   "upload": {
     "dragAndDropHere": "или перетащите файл сюда",
     "fileName": "Имя файла",

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -218,6 +218,20 @@
     "users": "Användare",
     "welcome": "Välkommen"
   },
+  "operators": {
+    "equals": "likar med",
+    "isNotEqualTo": "är inte lika med",
+    "isIn": "är med",
+    "isNotIn": "är inte med",
+    "exists": "finns",
+    "isGreaterThan": "är större än",
+    "isLessThan": "är mindre än",
+    "isLessThanOrEqualTo": "är mindre än eller lika med",
+    "isGreaterThanOrEqualTo": "är större än eller lika med",
+    "near": "nära",
+    "isLike": "är som",
+    "contains": "innehåller"
+  },
   "upload": {
     "dragAndDropHere": "eller dra och släpp en fil här",
     "fileName": "Filnamn",

--- a/src/translations/th.json
+++ b/src/translations/th.json
@@ -228,6 +228,20 @@
     "users": "ผู้ใช้",
     "welcome": "ยินดีต้อนรับ"
   },
+  "operators": {
+    "equals": "เท่ากับ",
+    "isNotEqualTo": "ไม่เท่ากับ",
+    "isIn": "อยู่ใน",
+    "isNotIn": "ไม่ได้อยู่ใน",
+    "exists": "มีอยู่",
+    "isGreaterThan": "มากกว่า",
+    "isLessThan": "น้อยกว่า",
+    "isLessThanOrEqualTo": "น้อยกว่าหรือเท่ากับ",
+    "isGreaterThanOrEqualTo": "มากกว่าหรือเท่ากับ",
+    "near": "ใกล้",
+    "isLike": "เหมือน",
+    "contains": "มี"
+  },
   "upload": {
     "dragAndDropHere": "หรือลากและวางไฟล์ที่นี่",
     "fileName": "ชื่อไฟล์",

--- a/src/translations/tr.json
+++ b/src/translations/tr.json
@@ -227,6 +227,20 @@
     "users": "kullanıcı",
     "welcome": "Hoşgeldiniz"
   },
+  "operators": {
+    "equals": "eşittir",
+    "isNotEqualTo": "eşit değildir",
+    "isIn": "içinde",
+    "isNotIn": "içinde değil",
+    "exists": "var",
+    "isGreaterThan": "şundan büyüktür",
+    "isLessThan": "küçüktür",
+    "isLessThanOrEqualTo": "küçüktür veya eşittir",
+    "isGreaterThanOrEqualTo": "büyüktür veya eşittir",
+    "near": "yakın",
+    "isLike": "gibidir",
+    "contains": "içerir"
+  },
   "upload": {
     "dragAndDrop": "Bir dosya sürükleyip bırakabilirsiniz",
     "dragAndDropHere": "veya buraya bir dosya sürükleyip bırakabilirsiniz",

--- a/src/translations/translation-schema.json
+++ b/src/translations/translation-schema.json
@@ -1,7 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "authentication": {
       "type": "object",
       "additionalProperties": false,
@@ -905,6 +909,62 @@
         "welcome"
       ]
     },
+    "operators": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "equals": {
+          "type": "string"
+        },
+        "isNotEqualTo":{
+          "type": "string"
+        },
+        "isIn": {
+          "type": "string"
+        },
+        "isNotIn":{
+          "type": "string"
+        },
+        "exists": {
+          "type": "string"
+        },
+        "isGreaterThan":{
+          "type": "string"
+        },
+        "isLessThan": {
+          "type": "string"
+        },
+        "isLessThanOrEqualTo":{
+          "type": "string"
+        },
+        "isGreaterThanOrEqualTo": {
+          "type": "string"
+        },
+        "near":{
+          "type": "string"
+        },
+        "isLike": {
+          "type": "string"
+        },
+        "contains":{
+          "type": "string"
+        }
+      },
+      "required": [
+        "equals",
+        "isNotEqualTo",
+        "isIn",
+        "isNotIn",
+        "exists",
+        "isGreaterThan",
+        "isLessThan",
+        "isLessThanOrEqualTo",
+        "isGreaterThanOrEqualTo",
+        "near",
+        "isLike",
+        "contains"
+      ]
+    },
     "upload": {
       "type": "object",
       "additionalProperties": false,
@@ -1239,6 +1299,7 @@
     "error",
     "fields",
     "general",
+    "operators",
     "upload",
     "validation",
     "version"

--- a/src/translations/ua.json
+++ b/src/translations/ua.json
@@ -224,6 +224,20 @@
     "users": "Користувачі",
     "welcome": "Вітаю"
   },
+  "operators": {
+    "equals": "дорівнює",
+    "isNotEqualTo": "не дорівнює",
+    "isIn": "є в",
+    "isNotIn": "не в",
+    "exists": "існує",
+    "isGreaterThan": "більше ніж",
+    "isLessThan": "менше ніж",
+    "isLessThanOrEqualTo": "менше або дорівнює",
+    "isGreaterThanOrEqualTo": "більше або дорівнює",
+    "near": "поруч",
+    "isLike": "схоже",
+    "contains": "містить"
+  },
   "upload": {
     "dragAndDropHere": "або перемістіть сюди файл",
     "fileName": "Назва файлу",

--- a/src/translations/vi.json
+++ b/src/translations/vi.json
@@ -218,6 +218,20 @@
     "users": "Những người dùng",
     "welcome": "Xin chào"
   },
+  "operators": {
+    "equals": "bằng",
+    "isNotEqualTo": "không bằng",
+    "isIn": "đang ở",
+    "isNotIn": "không có trong",
+    "exists": "tồn tại",
+    "isGreaterThan": "lớn hơn",
+    "isLessThan": "nhỏ hơn",
+    "isLessThanOrEqualTo": "nhỏ hơn hoặc bằng",
+    "isGreaterThanOrEqualTo": "lớn hơn hoặc bằng",
+    "near": "gần",
+    "isLike": "giống như",
+    "contains": "chứa"
+  },
   "upload": {
     "dragAndDropHere": "hoặc kéo và thả file vào đây",
     "fileName": "Tên file",

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -226,6 +226,20 @@
     "users": "用户",
     "welcome": "欢迎"
   },
+  "operators": {
+    "equals": "等于",
+    "isNotEqualTo": "不等于",
+    "isIn": "在",
+    "isNotIn": "不在",
+    "exists": "存在",
+    "isGreaterThan": "大于",
+    "isLessThan": "小于",
+    "isLessThanOrEqualTo": "小于或等于",
+    "isGreaterThanOrEqualTo": "大于等于",
+    "near": "附近",
+    "isLike": "就像",
+    "contains": "包含"
+  },
   "upload": {
     "dragAndDropHere": "或在这里拖放一个文件",
     "fileName": "文件名",


### PR DESCRIPTION
## Description

#2091 

- Changes operator *Labels* to translation keys
- Changed WhereBuilder to translate operator labels
- Adds "Operators" translation namespace
- Added Operators to all translation files from google translate

![image](https://user-images.githubusercontent.com/6434612/220012241-722ec3e5-8f56-42b3-8a17-7cb750ce2c77.png)


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes