### PR TITLE
fix: checks locale is valid for monaco code editor

### DIFF
--- a/docs/fields/code.mdx
+++ b/docs/fields/code.mdx
@@ -42,7 +42,7 @@ In addition to the default [field admin config](/docs/fields/overview#admin-conf
 | Option                 | Description                                                                                                                                                                         |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`language`**         | This property can be set to any language listed [here](https://github.com/microsoft/monaco-editor/tree/main/src/basic-languages).                                           |
-| **`editorOptions`**    | Options that can be passed to the monaco editor, [view the full list](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IDiffEditorConstructionOptions.html).  |
+| **`editorOptions`**    | Options that can be passed to the monaco editor, [view the full list](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IDiffEditorConstructionOptions.html).  |
 
 ### Example
 

--- a/src/admin/components/forms/field-types/Code/index.tsx
+++ b/src/admin/components/forms/field-types/Code/index.tsx
@@ -8,7 +8,6 @@ import { Props } from './types';
 import useField from '../../useField';
 import withCondition from '../../withCondition';
 import { CodeEditor } from '../../../elements/CodeEditor';
-import { ShimmerEffect } from '../../../elements/ShimmerEffect';
 
 import './index.scss';
 

--- a/src/admin/components/utilities/I18n/index.tsx
+++ b/src/admin/components/utilities/I18n/index.tsx
@@ -6,6 +6,7 @@ import { initReactI18next } from 'react-i18next';
 import deepmerge from 'deepmerge';
 import { defaultOptions } from '../../../../translations/defaultOptions';
 import { useConfig } from '../Config';
+import { getSupportedMonacoLocale } from '../../../utilities/getSupportedMonacoLocale';
 
 export const I18n: React.FC = () => {
   const config = useConfig();
@@ -18,7 +19,7 @@ export const I18n: React.FC = () => {
     .use(LanguageDetector)
     .use(initReactI18next)
     .init(deepmerge(defaultOptions, config.i18n || {}));
-  loader.config({ 'vs/nls': { availableLanguages: { '*': i18n.language === 'en' ? '' : i18n.language } } });
+  loader.config({ 'vs/nls': { availableLanguages: { '*': getSupportedMonacoLocale(i18n.language) } } });
   return null;
 };
 

--- a/src/admin/utilities/getSupportedMonacoLocale.ts
+++ b/src/admin/utilities/getSupportedMonacoLocale.ts
@@ -1,0 +1,15 @@
+export const getSupportedMonacoLocale = (locale: string): string => {
+  const supportedLocales = {
+    de: 'de',
+    es: 'es',
+    fr: 'fr',
+    it: 'it',
+    ja: 'ja',
+    ko: 'ko',
+    ru: 'ru',
+    zh: 'zh-cn',
+    'zh-tw': 'zh-tw',
+  };
+
+  return supportedLocales[locale];
+};


### PR DESCRIPTION
## Description

Fixes #2116 

Checks locale is supported by Monaco Editor otherwise returns the default.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
