### PR TITLE
fix: version comparison view errors on old select value

### DIFF
--- a/src/admin/components/views/Version/RenderFieldsToDiff/fields/Select/index.tsx
+++ b/src/admin/components/views/Version/RenderFieldsToDiff/fields/Select/index.tsx
@@ -14,9 +14,9 @@ const baseClass = 'select-diff';
 
 const getOptionsToRender = (value: string, options: SelectField['options'], hasMany: boolean): string | OptionObject | (OptionObject | string)[] => {
   if (hasMany && Array.isArray(value)) {
-    return value.map((val) => options.find((option) => (typeof option === 'string' ? option : option.value) === val));
+    return value.map((val) => options.find((option) => (typeof option === 'string' ? option : option.value) === val) || val);
   }
-  return options.find((option) => (typeof option === 'string' ? option : option.value) === value);
+  return options.find((option) => (typeof option === 'string' ? option : option.value) === value) || value;
 };
 
 const getTranslatedOptions = (options: string | OptionObject | (OptionObject | string)[], i18n: Ii18n): string => {


### PR DESCRIPTION
## Description

#2162 
Fix in place:
![image](https://user-images.githubusercontent.com/6434612/220661029-99f3e631-ce2d-4fd8-90be-830b0af43380.png)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
