### PR TITLE
fix: add a mention to the possibility of accessing nested properties

### DIFF
--- a/docs/queries/overview.mdx
+++ b/docs/queries/overview.mdx
@@ -105,6 +105,18 @@ const query = {
 
 Written in plain English, if the above query were passed to a `find` operation, it would translate to finding posts where either the `color` is `mint` OR the `color` is `white` AND `featured` is set to false.
 
+### Nested properties
+
+When working with nested properties, which can happen when using relational fields, it is possible to use the dot notation to access the nested property. For example, when working with a `Song` collection that has a `artists` field which is related to an `Artists` collection using the `name: 'artists'`. You can access a property within the collection `Artists` like so:
+
+```js
+const query = {
+  'artists.featured': { // nested property name to filter on
+    exists: true, // operator to use and boolean value that needs to be true
+  },
+}
+```
+
 ### GraphQL Find Queries
 
 All GraphQL `find` queries support the `where` argument, which accepts queries exactly as detailed above.


### PR DESCRIPTION
It took me a fair bit of time to figure out it is possible to access nested properties when working with related fields. It is currently not mentioned in the docs it is possible to do so.
This issue brought me on the right track https://github.com/payloadcms/payload/issues/2150#issue-1592868070 - thanks @jpmadrigal07!

## Type of change

This change is a documentation update only, the functionality works already.

