### PR TITLE
fix: properly set req.payload on forgotPassword in local API

### DIFF
--- a/src/auth/operations/local/forgotPassword.ts
+++ b/src/auth/operations/local/forgotPassword.ts
@@ -35,6 +35,7 @@ async function localForgotPassword<T extends keyof GeneratedTypes['collections']
   }
 
   req.payloadAPI = 'local';
+  req.payload = payload;
   req.i18n = i18n(payload.config.i18n);
 
   if (!req.t) req.t = req.i18n.t;


### PR DESCRIPTION
## Description

`req.payload` was not being set properly for the forgotPassword local operation.

Closes #2170 . 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
