### PR TITLE
fix: allows empty objects to be retained in db

### DIFF
--- a/src/collections/buildSchema.ts
+++ b/src/collections/buildSchema.ts
@@ -11,7 +11,11 @@ const buildCollectionSchema = (collection: SanitizedCollectionConfig, config: Sa
     collection.fields,
     {
       draftsEnabled: Boolean(typeof collection?.versions === 'object' && collection.versions.drafts),
-      options: { timestamps: collection.timestamps !== false, ...schemaOptions },
+      options: {
+        timestamps: collection.timestamps !== false,
+        minimize: false,
+        ...schemaOptions,
+      },
       indexSortableFields: config.indexSortableFields,
     },
   );

--- a/src/collections/initLocal.ts
+++ b/src/collections/initLocal.ts
@@ -70,6 +70,7 @@ export default function initCollectionsLocal(ctx: Payload): void {
           draftsEnabled: true,
           options: {
             timestamps: false,
+            minimize: false,
           },
         },
       );

--- a/src/globals/buildModel.ts
+++ b/src/globals/buildModel.ts
@@ -6,14 +6,22 @@ import { GlobalModel } from './config/types';
 
 const buildModel = (config: SanitizedConfig): GlobalModel | null => {
   if (config.globals && config.globals.length > 0) {
-    const globalsSchema = new mongoose.Schema({}, { discriminatorKey: 'globalType', timestamps: true });
+    const globalsSchema = new mongoose.Schema({}, { discriminatorKey: 'globalType', timestamps: true, minimize: false });
 
     globalsSchema.plugin(buildQueryPlugin);
 
     const Globals = mongoose.model('globals', globalsSchema) as unknown as GlobalModel;
 
     Object.values(config.globals).forEach((globalConfig) => {
-      const globalSchema = buildSchema(config, globalConfig.fields, { global: true });
+      const globalSchema = buildSchema(
+        config,
+        globalConfig.fields,
+        {
+          options: {
+            minimize: false,
+          },
+        },
+      );
       Globals.discriminator(globalConfig.slug, globalSchema);
     });
 

--- a/src/globals/initLocal.ts
+++ b/src/globals/initLocal.ts
@@ -27,6 +27,7 @@ export default function initGlobalsLocal(ctx: Payload): void {
             draftsEnabled: true,
             options: {
               timestamps: false,
+              minimize: false,
             },
           },
         );

--- a/src/mongoose/buildSchema.ts
+++ b/src/mongoose/buildSchema.ts
@@ -40,7 +40,6 @@ export type BuildSchemaOptions = {
   allowIDField?: boolean
   disableUnique?: boolean
   draftsEnabled?: boolean
-  global?: boolean
   indexSortableFields?: boolean
 }
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -524,6 +524,19 @@ describe('Fields', () => {
         },
       })).rejects.toThrow('The following field is invalid: json');
     });
+
+    it('should save empty json objects', async () => {
+      const createdJSON = await payload.create({
+        collection: 'json-fields',
+        data: {
+          json: {
+            state: {},
+          },
+        },
+      });
+
+      expect(createdJSON.json.state).toBeDefined();
+    });
   });
 
   describe('richText', () => {

--- a/test/globals/config.ts
+++ b/test/globals/config.ts
@@ -25,6 +25,10 @@ export default buildConfig({
       access,
       fields: [
         {
+          name: 'json',
+          type: 'json',
+        },
+        {
           name: 'title',
           type: 'text',
         },

--- a/test/globals/int.spec.ts
+++ b/test/globals/int.spec.ts
@@ -60,6 +60,19 @@ describe('globals', () => {
   });
 
   describe('local', () => {
+    it('should save empty json objects', async () => {
+      const createdJSON = await payload.updateGlobal({
+        slug,
+        data: {
+          json: {
+            state: {},
+          },
+        },
+      });
+
+      expect(createdJSON.json.state).toBeDefined();
+    });
+
     it('should create', async () => {
       const data = {
         title: 'title',


### PR DESCRIPTION
## Description

Fixes: #2189 

Retains empty objects in db.

Related GH issue on the [mongoose repo](https://github.com/Automattic/mongoose/issues/8505).

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
