### PR TITLE
Add allowDiskUse parameter for aggregate query for draft versions

### DIFF
--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -80,6 +80,13 @@ If you are using a [persistent filesystem-based cloud host](#persistent-vs-ephem
 
 Alternatively, you can rely on a third-party MongoDB host such as [MongoDB Atlas](https://www.mongodb.com/). With Atlas or a similar cloud provider, you can trust them to take care of your database's availability, security, redundancy, and backups.
 
+<Banner type="warning">
+  <strong>Note:</strong>
+  <br />
+  If versions are enabled and a collection has many documents you may need a minimum of an m10 mongoDB atlas cluster if you reach a sorting `exceeded memory limit` error to view a collection list in the admin UI. The limitations of the m2 and m5 tier clusters are here:
+  <a href="https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/?_ga=2.176267877.1329169847.1677683154-860992573.1647438381#operational-limitations">Atlas M0 (Free Cluster), M2, and M5 Limitations</a>
+</Banner>
+
 ##### DocumentDB
 When using AWS DocumentDB, you will need to configure connection options for authentication in the `mongoOptions` passed to `payload.init`. You also need to set `mongoOptions.useFacet` to `false` to disable use of the unsupported `$facet` aggregation.
 

--- a/src/versions/drafts/queryDrafts.ts
+++ b/src/versions/drafts/queryDrafts.ts
@@ -65,7 +65,9 @@ export const queryDrafts = async <T extends TypeWithID>({
     },
     // Filter based on incoming query
     { $match: versionQuery },
-  ]);
+  ], {
+    allowDiskUse: true,
+  });
 
   const aggregatePaginateOptions = {
     ...paginationOptions,


### PR DESCRIPTION
## Description

@jmikrut 

I was having an issue with a large collection of over 8500 documents in the payload admin UI list view.  The error message when trying to get the data from our mongoDB m5 cluster was `MongoServerError: PlanExecutor error during aggregation :: caused by :: Sort exceeded memory limit of 33554432 bytes, but did not opt in to external sorting.`

The limitations are discussed here with the shared clusters on mongo atlas:
https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/?_ga=2.176267877.1329169847.1677683154-860992573.1647438381#operational-limitations

I've updated the query to add the parameter `allowDiskUse` in the aggregate query in drafts and updated the docs in the deployment section about mongo atlas 

- [  x ] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [ x ] This change requires a documentation update

## Checklist:

- [ x ] I have made corresponding changes to the documentation
