### PR TITLE
Fix: when chaining hooks, afterRead does not take previous doc but original doc

### DIFF
--- a/src/collections/operations/find.ts
+++ b/src/collections/operations/find.ts
@@ -233,7 +233,7 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
       await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
         await priorHook;
 
-        docRef = await hook({ req, query, doc, findMany: true }) || doc;
+        docRef = await hook({ req, query, doc: docRef, findMany: true }) || doc;
       }, Promise.resolve());
 
       return docRef;

--- a/test/hooks/collections/ChainingHooks/index.ts
+++ b/test/hooks/collections/ChainingHooks/index.ts
@@ -1,0 +1,26 @@
+import { CollectionConfig } from '../../../../src/collections/config/types';
+
+export const chainingHooksSlug = 'chaining-hooks';
+
+const AppendTextHook = ({ doc }) => ({
+  ...doc,
+  text: `${doc.text}!`,
+});
+
+const ChainingHooks: CollectionConfig = {
+  slug: chainingHooksSlug,
+  hooks: {
+    afterRead: [
+      AppendTextHook,
+      AppendTextHook,
+    ],
+  },
+  fields: [
+    {
+      type: 'text',
+      name: 'text',
+    },
+  ],
+};
+
+export default ChainingHooks;

--- a/test/hooks/config.ts
+++ b/test/hooks/config.ts
@@ -2,6 +2,7 @@ import { buildConfig } from '../buildConfig';
 import TransformHooks from './collections/Transform';
 import Hooks, { hooksSlug } from './collections/Hook';
 import NestedAfterReadHooks from './collections/NestedAfterReadHooks';
+import ChainingHooks from './collections/ChainingHooks';
 import Relations from './collections/Relations';
 import Users, { seedHooksUsers } from './collections/Users';
 
@@ -10,6 +11,7 @@ export default buildConfig({
     TransformHooks,
     Hooks,
     NestedAfterReadHooks,
+    ChainingHooks,
     Relations,
     Users,
   ],

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -5,6 +5,7 @@ import payload from '../../src';
 import { RESTClient } from '../helpers/rest';
 import { transformSlug } from './collections/Transform';
 import { hooksSlug } from './collections/Hook';
+import { chainingHooksSlug } from './collections/ChainingHooks';
 import { generatedAfterReadText, nestedAfterReadHooksSlug } from './collections/NestedAfterReadHooks';
 import { relationsSlug } from './collections/Relations';
 import type { NestedAfterReadHook } from './payload-types';
@@ -119,7 +120,39 @@ describe('Hooks', () => {
       expect(retrievedDoc.group.array[0].shouldPopulate.title).toEqual(relation.title);
       expect(retrievedDoc.group.subGroup.shouldPopulate.title).toEqual(relation.title);
     });
+
+    it('should pass result from previous hook into next hook with findByID', async () => {
+      const document = await payload.create({
+        collection: chainingHooksSlug,
+        data: {
+          text: 'ok',
+        },
+      });
+
+      const retrievedDoc = await payload.findByID({
+        collection: chainingHooksSlug,
+        id: document.id,
+      });
+
+      expect(retrievedDoc.text).toEqual('ok!!');
+    });
+
+    it('should pass result from previous hook into next hook with find', async () => {
+      const document = await payload.create({
+        collection: chainingHooksSlug,
+        data: {
+          text: 'ok',
+        },
+      });
+
+      const { docs: retrievedDocs } = await payload.find({
+        collection: chainingHooksSlug,
+      });
+
+      expect(retrievedDocs[0].text).toEqual('ok!!');
+    });
   });
+
   describe('auth collection hooks', () => {
     it('allow admin login', async () => {
       const { user } = await payload.login({


### PR DESCRIPTION
## Description

When you have two `afterRead` hooks where one hook's result is used as input to the other, then there is different behavior when you "findByID" vs. "find".  In "findByID", it will correctly chain, but when you use "find" then each hook will receive the original doc.

Because I am lazy, I only checked this specific hook and fixed it only for the "find" endpoint.

Fixes #2222.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
