### PR TITLE
fix: conditionally renders draggable pill

### DIFF
--- a/src/admin/components/elements/Pill/index.tsx
+++ b/src/admin/components/elements/Pill/index.tsx
@@ -7,9 +7,34 @@ import './index.scss';
 
 const baseClass = 'pill';
 
-const Pill: React.FC<Props> = (props) => {
-  const {
+const DraggablePill: React.FC<Props> = (props) => {
+  const { className, id } = props;
+
+  const { attributes, listeners, transform, setNodeRef, isDragging } = useDraggableSortable({
     id,
+  });
+
+  return (
+    <StaticPill
+      {...props}
+      className={[
+        isDragging && `${baseClass}--is-dragging`,
+        className,
+      ].filter(Boolean).join(' ')}
+      elementProps={{
+        ...listeners,
+        ...attributes,
+        style: {
+          transform,
+        },
+        ref: setNodeRef,
+      }}
+    />
+  );
+};
+
+const StaticPill: React.FC<Props> = (props) => {
+  const {
     className,
     to,
     icon,
@@ -18,11 +43,8 @@ const Pill: React.FC<Props> = (props) => {
     pillStyle = 'light',
     draggable,
     children,
+    elementProps,
   } = props;
-
-  const { attributes, listeners, transform, setNodeRef, isDragging } = useDraggableSortable({
-    id,
-  });
 
   const classes = [
     baseClass,
@@ -33,7 +55,6 @@ const Pill: React.FC<Props> = (props) => {
     icon && `${baseClass}--has-icon`,
     icon && `${baseClass}--align-icon-${alignIcon}`,
     draggable && `${baseClass}--draggable`,
-    isDragging && `${baseClass}--is-dragging`,
   ].filter(Boolean).join(' ');
 
   let Element: ElementType | React.FC<RenderedTypeProps> = 'div';
@@ -43,17 +64,10 @@ const Pill: React.FC<Props> = (props) => {
 
   return (
     <Element
+      {...elementProps}
       className={classes}
       type={Element === 'button' ? 'button' : undefined}
       to={to || undefined}
-      {...draggable ? {
-        ...listeners,
-        ...attributes,
-        style: {
-          transform,
-        },
-        ref: setNodeRef,
-      } : {}}
       onClick={onClick}
     >
       {(icon && alignIcon === 'left') && (
@@ -69,6 +83,13 @@ const Pill: React.FC<Props> = (props) => {
       )}
     </Element>
   );
+};
+
+const Pill: React.FC<Props> = (props) => {
+  const { draggable } = props;
+
+  if (draggable) return <DraggablePill {...props} />;
+  return <StaticPill {...props} />;
 };
 
 export default Pill;

--- a/src/admin/components/elements/Pill/types.ts
+++ b/src/admin/components/elements/Pill/types.ts
@@ -1,3 +1,5 @@
+import { HTMLAttributes } from 'react';
+
 export type Props = {
   children?: React.ReactNode,
   className?: string,
@@ -8,6 +10,9 @@ export type Props = {
   pillStyle?: 'white' | 'light' | 'dark' | 'light-gray' | 'warning' | 'success',
   draggable?: boolean,
   id?: string
+  elementProps?: HTMLAttributes<HTMLElement> & {
+    ref: React.RefCallback<HTMLElement>
+  }
 }
 
 export type RenderedTypeProps = {


### PR DESCRIPTION
## Description

Conditionally renders a draggable pill only when `draggable: true`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
