### PR TITLE
fix: removes duplicative fields from table columns #2221

### DIFF
--- a/src/admin/components/elements/ColumnSelector/index.tsx
+++ b/src/admin/components/elements/ColumnSelector/index.tsx
@@ -27,6 +27,7 @@ const ColumnSelector: React.FC<Props> = (props) => {
   const { i18n } = useTranslation();
   const uuid = useId();
   const editDepth = useEditDepth();
+
   if (!columns) { return null; }
 
   return (

--- a/src/admin/components/elements/TableColumns/buildColumns.tsx
+++ b/src/admin/components/elements/TableColumns/buildColumns.tsx
@@ -19,8 +19,8 @@ const buildColumns = ({
   t: TFunction,
   cellProps?: Partial<CellProps>[]
 }): Column[] => {
-  const flattenedFields = flattenFields([
-    ...collection.fields,
+  // combine the configured fields with the base fields then remove duplicates
+  const combinedFields = collection.fields.concat([
     {
       name: 'id',
       type: 'text',
@@ -36,7 +36,9 @@ const buildColumns = ({
       type: 'date',
       label: t('createdAt'),
     },
-  ]);
+  ]).filter((field, index, self) => self.findIndex((thisField) => 'name' in thisField && 'name' in field && thisField.name === field.name) === index);
+
+  const flattenedFields = flattenFields(combinedFields);
 
   // sort the fields to the order of activeColumns
   const sortedFields = flattenedFields.sort((a, b) => {


### PR DESCRIPTION
## Description

Resolves #2221 by removing duplicative fields from table columns. This could happen when supplying a custom `id` field to a collection, for instance.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
