### PR TITLE
Ensure empty objects are preserved within fields with sub schemas

### DIFF
--- a/src/mongoose/buildSchema.ts
+++ b/src/mongoose/buildSchema.ts
@@ -335,6 +335,7 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
               options: {
                 _id: false,
                 id: false,
+                minimize: false,
               },
               disableUnique: buildSchemaOptions.disableUnique,
               draftsEnabled: buildSchemaOptions.draftsEnabled,
@@ -364,7 +365,11 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
         config,
         field.fields,
         {
-          options: { _id: false, id: false },
+          options: {
+            _id: false,
+            id: false,
+            minimize: false,
+          },
           allowIDField: true,
           disableUnique: buildSchemaOptions.disableUnique,
           draftsEnabled: buildSchemaOptions.draftsEnabled,
@@ -388,6 +393,7 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
           options: {
             _id: false,
             id: false,
+            minimize: false,
           },
           disableUnique: buildSchemaOptions.disableUnique,
           draftsEnabled: buildSchemaOptions.draftsEnabled,

--- a/test/fields/collections/JSON/index.tsx
+++ b/test/fields/collections/JSON/index.tsx
@@ -10,6 +10,9 @@ type JSONField = {
 
 const JSON: CollectionConfig = {
   slug: 'json-fields',
+  versions: {
+    maxPerDoc: 1,
+  },
   fields: [
     {
       name: 'json',

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -86,7 +86,7 @@ describe('fields', () => {
       const json = page.locator('.json-field .inputarea');
       await json.fill(input);
 
-      await saveDocAndAssert(page);
+      await saveDocAndAssert(page, '.form-submit button');
       await expect(page.locator('.json-field')).toContainText('"foo": "bar"');
     });
   });

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -12,11 +12,14 @@ import { localizedTextValue, namedTabDefaultValue, namedTabText, tabsDoc, tabsSl
 import { defaultNumber, numberDoc } from './collections/Number';
 
 let client;
+let serverURL;
+let config;
 
 describe('Fields', () => {
   beforeAll(async () => {
-    const { serverURL } = await initPayloadTest({ __dirname, init: { local: false } });
-    const config = await configPromise;
+    ({ serverURL } = await initPayloadTest({ __dirname, init: { local: false } }));
+    config = await configPromise;
+
     client = new RESTClient(config, { serverURL, defaultSlug: 'point-fields' });
     await client.login();
   });
@@ -536,6 +539,37 @@ describe('Fields', () => {
       });
 
       expect(createdJSON.json.state).toEqual({});
+    });
+
+    it('should save empty json objects via REST', async () => {
+      const jsonClient = new RESTClient(config, { serverURL, defaultSlug: 'json-fields' });
+      await jsonClient.login();
+
+      const { doc: ogDoc } = await jsonClient.create({
+        auth: true,
+        data: {
+          json: {
+            empty: {},
+            state: {
+              foo: 'bar',
+            },
+          },
+        },
+      });
+
+      expect(ogDoc.json.empty).toEqual({});
+
+      const { doc } = await jsonClient.update({
+        auth: true,
+        id: ogDoc.id,
+        data: {
+          json: {
+            state: {},
+          },
+        },
+      });
+
+      expect(doc.json.state).toEqual({});
     });
   });
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -529,7 +529,7 @@ describe('Fields', () => {
     });
 
     it('should save empty json objects', async () => {
-      const createdJSON = await payload.create({
+      const jsonFieldsDoc = await payload.create({
         collection: 'json-fields',
         data: {
           json: {
@@ -538,30 +538,11 @@ describe('Fields', () => {
         },
       });
 
-      expect(createdJSON.json.state).toEqual({});
-    });
+      expect(jsonFieldsDoc.json.state).toEqual({});
 
-    it('should save empty json objects via REST', async () => {
-      const jsonClient = new RESTClient(config, { serverURL, defaultSlug: 'json-fields' });
-      await jsonClient.login();
-
-      const { doc: ogDoc } = await jsonClient.create({
-        auth: true,
-        data: {
-          json: {
-            empty: {},
-            state: {
-              foo: 'bar',
-            },
-          },
-        },
-      });
-
-      expect(ogDoc.json.empty).toEqual({});
-
-      const { doc } = await jsonClient.update({
-        auth: true,
-        id: ogDoc.id,
+      const updatedJsonFieldsDoc = await payload.update({
+        collection: 'json-fields',
+        id: jsonFieldsDoc.id,
         data: {
           json: {
             state: {},
@@ -569,7 +550,7 @@ describe('Fields', () => {
         },
       });
 
-      expect(doc.json.state).toEqual({});
+      expect(updatedJsonFieldsDoc.json.state).toEqual({});
     });
   });
 

--- a/test/globals/int.spec.ts
+++ b/test/globals/int.spec.ts
@@ -57,6 +57,19 @@ describe('globals', () => {
       expect(doc.array).toMatchObject(array);
       expect(doc.id).toBeDefined();
     });
+
+    it('should save empty json objects', async () => {
+      const { doc } = await client.updateGlobal({
+        slug,
+        data: {
+          json: {
+            state: {},
+          },
+        },
+      });
+
+      expect(doc.json.state).toEqual({});
+    });
   });
 
   describe('local', () => {

--- a/test/globals/int.spec.ts
+++ b/test/globals/int.spec.ts
@@ -57,19 +57,6 @@ describe('globals', () => {
       expect(doc.array).toMatchObject(array);
       expect(doc.id).toBeDefined();
     });
-
-    it('should save empty json objects', async () => {
-      const { doc } = await client.updateGlobal({
-        slug,
-        data: {
-          json: {
-            state: {},
-          },
-        },
-      });
-
-      expect(doc.json.state).toEqual({});
-    });
   });
 
   describe('local', () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -36,8 +36,8 @@ export async function login(args: LoginArgs): Promise<void> {
   await page.waitForURL(`${serverURL}/admin`);
 }
 
-export async function saveDocAndAssert(page: Page): Promise<void> {
-  await page.click('#action-save', { delay: 100 });
+export async function saveDocAndAssert(page: Page, selector = '#action-save'): Promise<void> {
+  await page.click(selector, { delay: 100 });
   await expect(page.locator('.Toastify')).toContainText('successfully');
   expect(page.url()).not.toContain('create');
 }


### PR DESCRIPTION
## Description

Fixes #2218 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

Ensures empty objects are preserved on field types with sub schemas

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
