### PR TITLE
fix: DateField admin type

### DIFF
--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -170,7 +170,6 @@ export type DateField = FieldBase & {
   admin?: Admin & {
     placeholder?: Record<string, string> | string
     date?: ConditionalDateProps
-    displayFormat?: string
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->
The types for the DateField had a bug. `displayFormat` was a property outside the `admin.date` object, which led to a validation error when set. There exists already a `displayFormat` as a property `admin.date` which is correct. So I removed the other one.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
