### PR TITLE
fix: check relationships indexed access for undefined

### DIFF
--- a/src/admin/components/forms/field-types/Relationship/createRelationMap.ts
+++ b/src/admin/components/forms/field-types/Relationship/createRelationMap.ts
@@ -31,7 +31,11 @@ export const createRelationMap: CreateRelationMap = ({
 
   const add = (relation: string, id: unknown) => {
     if (((typeof id === 'string') || typeof id === 'number') && typeof relation === 'string') {
-      relationMap[relation].push(id);
+      if (relationMap[relation]) {
+        relationMap[relation].push(id);
+      } else {
+        relationMap[relation] = [id];
+      }
     }
   };
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

After a change of `relationTo` in a relationship field, an existing global from before the change caused a crash in the admin UI. The whole page turned blank, and the console logged a `TypeError` pointing to `relationMap[relation].push`, where `relationMap[relation]` was `undefined`.

TypeScript does not flag `undefined` as a possibility in these scenarios unless both `strict` and [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#checked-indexed-accesses---nouncheckedindexedaccess) are turned on in the compiler options. 

I tried to add `undefined` explicitly in the type definition for `RelationMap`, but it had no effect.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
