### PR TITLE
fix: renders presentational table columns

### DIFF
--- a/src/admin/components/elements/TableColumns/buildColumns.tsx
+++ b/src/admin/components/elements/TableColumns/buildColumns.tsx
@@ -44,7 +44,7 @@ const buildColumns = ({
     return [...acc, field];
   }, collection.fields);
 
-  const flattenedFields = flattenFields(combinedFields);
+  const flattenedFields = flattenFields(combinedFields, true);
 
   // sort the fields to the order of activeColumns
   const sortedFields = flattenedFields.sort((a, b) => {

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -9,6 +9,8 @@ import BeforeLogin from './components/BeforeLogin';
 import AfterNavLinks from './components/AfterNavLinks';
 import { slug, globalSlug } from './shared';
 import Logout from './components/Logout';
+import DemoUIFieldField from './components/DemoUIField/Field';
+import DemoUIFieldCell from './components/DemoUIField/Cell';
 
 export interface Post {
   id: string;
@@ -83,7 +85,7 @@ export default buildConfig({
         listSearchableFields: ['title', 'description', 'number'],
         group: { en: 'One', es: 'Una' },
         useAsTitle: 'title',
-        defaultColumns: ['id', 'number', 'title', 'description'],
+        defaultColumns: ['id', 'number', 'title', 'description', 'demoUIField'],
       },
       fields: [
         {
@@ -109,6 +111,17 @@ export default buildConfig({
             elements: [
               'relationship',
             ],
+          },
+        },
+        {
+          type: 'ui',
+          name: 'demoUIField',
+          label: 'Demo UI Field',
+          admin: {
+            components: {
+              Field: DemoUIFieldField,
+              Cell: DemoUIFieldCell,
+            },
           },
         },
       ],

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -409,6 +409,12 @@ describe('admin', () => {
         // ensure that the "number" column is still deselected
         await expect(await page.locator('[id^=list-drawer_1_] .list-controls .column-selector .column-selector__column').first()).not.toHaveClass('column-selector__column--active');
       });
+
+      test('should render custom table cell component', async () => {
+        await createPost();
+        await page.goto(url.list);
+        await expect(await page.locator('table >> thead >> tr >> th >> text=Demo UI Field')).toBeVisible();
+      });
     });
 
     describe('pagination', () => {


### PR DESCRIPTION
## Description

Fixes an bug where presentational fields were not rendered as table columns, first reported here: https://discord.com/channels/967097582721572934/1083490322358747178

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
