### PR TITLE
feature: provide refresh permissions

### DIFF
--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -226,14 +226,15 @@ const Greeting: React.FC = () => {
 
 Useful to retrieve info about the currently logged in user as well as methods for interacting with it. It sends back an object with the following properties:
 
-| Property            | Description                                                                             |
-|---------------------|-----------------------------------------------------------------------------------------|
-| **`user`**          | The currently logged in user                                                            |
-| **`logOut`**        | A method to log out the currently logged in user                                        |
-| **`refreshCookie`** | A method to trigger the silent refreshing of a user's auth token                        |
-| **`setToken`**      | Set the token of the user, to be decoded and used to reset the user and token in memory |
-| **`token`**         | The logged in user's token (useful for creating preview links, etc.)                    |
-| **`permissions`**   | The permissions of the current user                                                     |
+| Property                 | Description                                                                             |
+|--------------------------|-----------------------------------------------------------------------------------------|
+| **`user`**               | The currently logged in user                                                            |
+| **`logOut`**             | A method to log out the currently logged in user                                        |
+| **`refreshCookie`**      | A method to trigger the silent refreshing of a user's auth token                        |
+| **`setToken`**           | Set the token of the user, to be decoded and used to reset the user and token in memory |
+| **`token`**              | The logged in user's token (useful for creating preview links, etc.)                    |
+| **`refreshPermissions`** | Load new permissions (useful when content that effects permissions has been changed)    |
+| **`permissions`**        | The permissions of the current user                                                     |
 
 ```tsx
 import { useAuth } from 'payload/components/utilities';

--- a/src/admin/components/utilities/Auth/index.tsx
+++ b/src/admin/components/utilities/Auth/index.tsx
@@ -81,6 +81,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     requests.post(`${serverURL}${api}/${userSlug}/logout`);
   }, [serverURL, api, userSlug]);
 
+  const refreshPermissions = useCallback(async () => {
+    const request = await requests.get(`${serverURL}${api}/access`, {
+      headers: {
+        'Accept-Language': i18n.language,
+      },
+    });
+
+    if (request.status === 200) {
+      const json: Permissions = await request.json();
+      setPermissions(json);
+    } else {
+      throw new Error("Fetching permissions failed with status code " + request.status);
+    }
+  }, [serverURL, api, i18n]);
+
   // On mount, get user and set
   useEffect(() => {
     const fetchMe = async () => {
@@ -117,21 +132,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   // When user changes, get new access
   useEffect(() => {
-    async function getPermissions() {
-      const request = await requests.get(`${serverURL}${api}/access`, {
-        headers: {
-          'Accept-Language': i18n.language,
-        },
-      });
-
-      if (request.status === 200) {
-        const json: Permissions = await request.json();
-        setPermissions(json);
-      }
-    }
-
     if (id) {
-      getPermissions();
+      refreshPermissions();
     }
   }, [i18n, id, api, serverURL]);
 
@@ -174,6 +176,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       user,
       logOut,
       refreshCookie,
+      refreshPermissions,
       permissions,
       setToken,
       token: tokenInMemory,

--- a/src/admin/components/utilities/Auth/types.ts
+++ b/src/admin/components/utilities/Auth/types.ts
@@ -6,5 +6,6 @@ export type AuthContext<T = User> = {
   refreshCookie: () => void
   setToken: (token: string) => void
   token?: string
+  refreshPermissions: () => Promise<void>
   permissions?: Permissions
 }

--- a/test/refresh-permissions/GlobalViewWithRefresh.tsx
+++ b/test/refresh-permissions/GlobalViewWithRefresh.tsx
@@ -1,0 +1,22 @@
+import React, { useCallback } from 'react';
+import { useAuth } from '../../src/admin/components/utilities/Auth';
+import { Props } from '../../src/admin/components/views/Global/types';
+import DefaultGlobalView from '../../src/admin/components/views/Global/Default';
+
+const GlobalView: React.FC<Props> = (props) => {
+  const { onSave } = props;
+  const { refreshPermissions } = useAuth();
+  const modifiedOnSave = useCallback((...args) => {
+    onSave.call(null, ...args);
+    refreshPermissions();
+  }, [onSave, refreshPermissions]);
+
+  return (
+    <DefaultGlobalView
+      {...props}
+      onSave={modifiedOnSave}
+    />
+  );
+};
+
+export default GlobalView;

--- a/test/refresh-permissions/config.ts
+++ b/test/refresh-permissions/config.ts
@@ -1,0 +1,53 @@
+import { buildConfig } from '../buildConfig';
+import { devUser } from '../credentials';
+import GlobalViewWithRefresh from './GlobalViewWithRefresh';
+
+export const pagesSlug = 'pages';
+
+export default buildConfig({
+  globals: [
+    {
+      slug: 'settings',
+      fields: [
+        {
+          type: 'checkbox',
+          name: 'test',
+          label: 'Allow access to test global',
+        },
+      ],
+      admin: {
+        components: {
+          views: {
+            Edit: GlobalViewWithRefresh,
+          },
+        },
+      },
+    },
+    {
+      slug: 'test',
+      fields: [],
+      access: {
+        read: async ({ req: { payload } }) => {
+          const access = await payload.findGlobal({ slug: 'settings' });
+          return access.test;
+        },
+      },
+    },
+  ],
+  collections: [
+    {
+      slug: 'users',
+      auth: true,
+      fields: [],
+    },
+  ],
+  onInit: async (payload) => {
+    await payload.create({
+      collection: 'users',
+      data: {
+        email: devUser.email,
+        password: devUser.password,
+      },
+    });
+  },
+});

--- a/test/refresh-permissions/e2e.spec.ts
+++ b/test/refresh-permissions/e2e.spec.ts
@@ -1,0 +1,35 @@
+import { expect, Page, test } from '@playwright/test';
+import { login } from '../helpers';
+import { initPayloadE2E } from '../helpers/configHelpers';
+
+const { beforeAll, describe } = test;
+
+describe('refresh-permissions', () => {
+  let serverURL: string;
+  let page: Page;
+
+  beforeAll(async ({ browser }) => {
+    ({ serverURL } = await initPayloadE2E(__dirname));
+    const context = await browser.newContext();
+    page = await context.newPage();
+    await login({ page, serverURL });
+  });
+
+  test('should show test global immediately after allowing access', async () => {
+    await page.goto(`${serverURL}/admin/globals/settings`);
+
+    // Ensure that we have loaded accesses by checking that settings collection
+    // at least is visible in the menu.
+    await expect(page.locator('#nav-global-settings')).toBeVisible();
+
+    // Test collection should be hidden at first.
+    await expect(page.locator('#nav-global-test')).toBeHidden();
+
+    // Allow access to test global.
+    await page.locator('.custom-checkbox:has(#field-test) button').click();
+    await page.locator('#action-save').click();
+
+    // Now test collection should appear in the menu.
+    await expect(page.locator('#nav-global-test')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

This PR provides and exposes function named `refreshPermissions` in auth context that can be used to get latest permissions after actions made in admin panel that effects those permissions. `refreshPermissions` is called automatically by Payload CMS only when the user changes, but can be used by plugin or project developers for other means. The feature is needed to overcome problems presented in dicussion #2191 and is related to an issue in plugin I'm developing: https://github.com/joas8211/payload-tenancy/issues/2.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
