### PR TITLE
fix: Prevent browser initial favicon request

### DIFF
--- a/src/admin/components/utilities/Meta/index.tsx
+++ b/src/admin/components/utilities/Meta/index.tsx
@@ -4,6 +4,7 @@ import { useConfig } from '../Config';
 import { Props } from './types';
 import payloadFavicon from '../../../assets/images/favicon.svg';
 import payloadOgImage from '../../../assets/images/og-image.png';
+import useMountEffect from '../../../hooks/useMountEffect';
 
 const Meta: React.FC<Props> = ({
   description,
@@ -16,6 +17,13 @@ const Meta: React.FC<Props> = ({
   const titleSuffix = config.admin.meta?.titleSuffix ?? '- Payload';
   const favicon = config.admin.meta.favicon ?? payloadFavicon;
   const ogImage = config.admin.meta.ogImage ?? payloadOgImage;
+
+  useMountEffect(() => {
+    const faviconElement = document.querySelector<HTMLLinkElement>('link[data-placeholder-favicon]');
+    if (faviconElement) {
+      faviconElement.remove();
+    }
+  });
 
   return (
     <Helmet

--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+  <link rel="icon" href="data:," data-placeholder-favicon/>
 </head>
 
 <body>


### PR DESCRIPTION
## Description

Browsers always tries to get the favicon by requesting `/favicon.ico` because payload defines it with react on the client side.
If the call returns a 404, you end up with a useless log entry on the server. And if it returns an image, you flash the wrong favicon to the user.
To avoid this unnecessary call, you can set a default favicon to `data:,`.


Feel free to reject the PR if you don't want to use that trick.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
