### PR TITLE
fix: Keep drop zone active when hovering inner elements

### DIFF
--- a/src/admin/components/views/collections/Edit/Upload/index.scss
+++ b/src/admin/components/views/collections/Edit/Upload/index.scss
@@ -59,6 +59,10 @@
     .file-field__drop-zone {
       border-color: var(--theme-success-500);
       background: var(--theme-success-150);
+
+      * {
+        pointer-events: none;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/45725915/224518374-085ee188-9bb8-465d-a49a-75e0d6efda87.mp4" /> | <video src="https://user-images.githubusercontent.com/45725915/224518373-d0120bbd-3a6d-4e41-a48f-a033d234b6eb.mp4" /> |

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
