### PR TITLE
fix: allow thumbnails in upload gallery to show useAsTitle value

### DIFF
--- a/src/admin/components/elements/ThumbnailCard/index.tsx
+++ b/src/admin/components/elements/ThumbnailCard/index.tsx
@@ -13,11 +13,6 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
     onClick,
     doc,
     collection,
-    collection: {
-      admin: {
-        useAsTitle,
-      },
-    },
     thumbnail,
     label,
     alignLabel,
@@ -33,7 +28,7 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
     alignLabel && `${baseClass}--align-label-${alignLabel}`,
   ].filter(Boolean).join(' ');
 
-  const title: any = doc?.[useAsTitle] || doc?.filename || `[${t('untitled')}]`;
+  const title: any = doc?.[collection?.admin?.useAsTitle] || doc?.filename || `[${t('untitled')}]`;
 
   return (
     <div

--- a/src/admin/components/elements/ThumbnailCard/index.tsx
+++ b/src/admin/components/elements/ThumbnailCard/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Props } from './types';
 import Thumbnail from '../Thumbnail';
@@ -13,6 +13,11 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
     onClick,
     doc,
     collection,
+    collection: {
+      admin: {
+        useAsTitle,
+      },
+    },
     thumbnail,
     label,
     alignLabel,
@@ -27,6 +32,8 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
     typeof onClick === 'function' && `${baseClass}--has-on-click`,
     alignLabel && `${baseClass}--align-label-${alignLabel}`,
   ].filter(Boolean).join(' ');
+
+  const title: any = doc?.[useAsTitle] || doc?.filename || `[${t('untitled')}]`;
 
   return (
     <div
@@ -45,12 +52,7 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
         )}
       </div>
       <div className={`${baseClass}__label`}>
-        {label && label}
-        {!label && doc && (
-          <Fragment>
-            {typeof doc?.filename === 'string' ? doc?.filename : `[${t('untitled')}]`}
-          </Fragment>
-        )}
+        {label || title}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

#2270 

The upload gallery thumbnails only showed the filename - updated to show `useAsTitle` value if set.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes (fields>uploads)
- [ ] I have made corresponding changes to the documentation
