### PR TITLE
fix: allows useListDrawer to work without collectionSlugs defined

### DIFF
--- a/src/admin/components/elements/ListDrawer/index.tsx
+++ b/src/admin/components/elements/ListDrawer/index.tsx
@@ -4,6 +4,7 @@ import { ListDrawerProps, ListTogglerProps, UseListDrawer } from './types';
 import { Drawer, DrawerToggler } from '../Drawer';
 import { useEditDepth } from '../../utilities/EditDepth';
 import { ListDrawerContent } from './DrawerContent';
+import { useConfig } from '../../utilities/Config';
 
 import './index.scss';
 
@@ -49,21 +50,26 @@ export const ListDrawer: React.FC<ListDrawerProps> = (props) => {
       header={false}
       gutter={false}
     >
-      <ListDrawerContent {...props} />
+      <ListDrawerContent
+        {...props}
+      />
     </Drawer>
   );
 };
 
 export const useListDrawer: UseListDrawer = ({
-  collectionSlugs,
+  collectionSlugs: collectionSlugsFromProps,
   uploads,
   selectedCollection,
   filterOptions,
 }) => {
+  const { collections } = useConfig();
   const drawerDepth = useEditDepth();
   const uuid = useId();
   const { modalState, toggleModal, closeModal, openModal } = useModal();
   const [isOpen, setIsOpen] = useState(false);
+  const [collectionSlugs, setCollectionSlugs] = useState(collectionSlugsFromProps);
+
   const drawerSlug = formatListDrawerSlug({
     depth: drawerDepth,
     uuid,
@@ -73,6 +79,18 @@ export const useListDrawer: UseListDrawer = ({
     setIsOpen(Boolean(modalState[drawerSlug]?.isOpen));
   }, [modalState, drawerSlug]);
 
+  useEffect(() => {
+    if (!collectionSlugs || collectionSlugs.length === 0) {
+      const filteredCollectionSlugs = collections.filter(({ upload }) => {
+        if (uploads) {
+          return Boolean(upload) === true;
+        }
+        return true;
+      });
+
+      setCollectionSlugs(filteredCollectionSlugs.map(({ slug }) => slug));
+    }
+  }, [collectionSlugs, uploads, collections]);
   const toggleDrawer = useCallback(() => {
     toggleModal(drawerSlug);
   }, [toggleModal, drawerSlug]);

--- a/src/admin/components/elements/ListDrawer/types.ts
+++ b/src/admin/components/elements/ListDrawer/types.ts
@@ -22,7 +22,7 @@ export type ListTogglerProps = HTMLAttributes<HTMLButtonElement> & {
 }
 
 export type UseListDrawer = (args: {
-  collectionSlugs: string[]
+  collectionSlugs?: string[]
   selectedCollection?: string
   uploads?: boolean // finds all collections with upload: true
   filterOptions?: FilterOptionsResult


### PR DESCRIPTION
## Description

#2292 

Allows `useListDrawer` to be used without defining `collectionSlugs`, the `upload` prop can now be passed on its own and will return only upload enabled collections.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
