### PR TITLE
fix: hidden fields being mutated on patch

### DIFF
--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -140,7 +140,7 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
     entityConfig: collectionConfig,
     req,
     overrideAccess: true,
-    showHiddenFields,
+    showHiddenFields: true,
   });
 
   // /////////////////////////////////////

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -11,6 +11,7 @@ export const restrictedVersionsSlug = 'restricted-versions';
 export const siblingDataSlug = 'sibling-data';
 export const relyOnRequestHeadersSlug = 'rely-on-request-headers';
 export const docLevelAccessSlug = 'doc-level-access';
+export const hiddenFieldsSlug = 'hidden-fields';
 
 const openAccess = {
   create: () => true,
@@ -239,6 +240,31 @@ export default buildConfig({
           name: 'lockTitle',
           type: 'checkbox',
           defaultValue: false,
+        },
+      ],
+    },
+    {
+      slug: hiddenFieldsSlug,
+      access: openAccess,
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+        {
+          name: 'partiallyHidden',
+          type: 'array',
+          fields: [
+            {
+              name: 'name',
+              type: 'text',
+            },
+            {
+              name: 'value',
+              type: 'text',
+              hidden: true,
+            },
+          ],
         },
       ],
     },

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -252,7 +252,22 @@ export default buildConfig({
           type: 'text',
         },
         {
-          name: 'partiallyHidden',
+          name: 'partiallyHiddenGroup',
+          type: 'group',
+          fields: [
+            {
+              name: 'name',
+              type: 'text',
+            },
+            {
+              name: 'value',
+              type: 'text',
+              hidden: true,
+            },
+          ],
+        },
+        {
+          name: 'partiallyHiddenArray',
           type: 'array',
           fields: [
             {

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -37,10 +37,14 @@ describe('Access Control', () => {
     const doc = await payload.create({
       collection: hiddenFieldsSlug,
       data: {
-        partiallyHidden: [{
+        partiallyHiddenArray: [{
           name: 'public_name',
           value: 'private_value',
         }],
+        partiallyHiddenGroup: {
+          name: 'public_name',
+          value: 'private_value',
+        },
       },
     });
 
@@ -58,7 +62,8 @@ describe('Access Control', () => {
       showHiddenFields: true,
     });
 
-    expect(updatedDoc.partiallyHidden[0].value).toEqual('private_value');
+    expect(updatedDoc.partiallyHiddenGroup.value).toEqual('private_value');
+    expect(updatedDoc.partiallyHiddenArray[0].value).toEqual('private_value');
   });
 
   it('should be able to restrict access based upon siblingData', async () => {

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -1,10 +1,9 @@
 import mongoose from 'mongoose';
 import payload from '../../src';
-import type { Options as CreateOptions } from '../../src/collections/operations/local/create';
 import { Forbidden } from '../../src/errors';
 import type { PayloadRequest } from '../../src/types';
 import { initPayloadTest } from '../helpers/configHelpers';
-import { relyOnRequestHeadersSlug, requestHeaders, restrictedSlug, siblingDataSlug, slug } from './config';
+import { hiddenFieldsSlug, relyOnRequestHeadersSlug, requestHeaders, restrictedSlug, siblingDataSlug, slug } from './config';
 import type { Restricted, Post, RelyOnRequestHeader } from './payload-types';
 import { firstArrayText, secondArrayText } from './shared';
 
@@ -34,7 +33,33 @@ describe('Access Control', () => {
     await payload.mongoMemoryServer.stop();
   });
 
-  it.todo('should properly prevent / allow public users from reading a restricted field');
+  it('should not affect hidden fields when patching data', async () => {
+    const doc = await payload.create({
+      collection: hiddenFieldsSlug,
+      data: {
+        partiallyHidden: [{
+          name: 'public_name',
+          value: 'private_value',
+        }],
+      },
+    });
+
+    await payload.update({
+      collection: hiddenFieldsSlug,
+      id: doc.id,
+      data: {
+        title: 'Doc Title',
+      },
+    });
+
+    const updatedDoc = await payload.findByID({
+      collection: hiddenFieldsSlug,
+      id: doc.id,
+      showHiddenFields: true,
+    });
+
+    expect(updatedDoc.partiallyHidden[0].value).toEqual('private_value');
+  });
 
   it('should be able to restrict access based upon siblingData', async () => {
     const { id } = await payload.create({
@@ -220,7 +245,7 @@ describe('Access Control', () => {
   });
 });
 
-async function createDoc<Collection>(data: Partial<Collection>, overrideSlug = slug, options?: Partial<CreateOptions<Collection>>): Promise<Collection> {
+async function createDoc<Collection>(data: Partial<Collection>, overrideSlug = slug, options?: Partial<Collection>): Promise<Collection> {
   return payload.create({
     ...options,
     collection: overrideSlug,

--- a/test/access-control/payload-types.ts
+++ b/test/access-control/payload-types.ts
@@ -86,7 +86,11 @@ export interface DocLevelAccess {
 export interface HiddenField {
   id: string;
   title?: string;
-  partiallyHidden?: {
+  partiallyHiddenGroup?: {
+    name?: string;
+    value?: string;
+  };
+  partiallyHiddenArray?: {
     name?: string;
     value?: string;
     id?: string;

--- a/test/access-control/payload-types.ts
+++ b/test/access-control/payload-types.ts
@@ -5,11 +5,20 @@
  * and re-run `payload generate:types` to regenerate this file.
  */
 
-export interface Config {}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "users".
- */
+export interface Config {
+  collections: {
+    users: User;
+    posts: Post;
+    restricted: Restricted;
+    'read-only-collection': ReadOnlyCollection;
+    'restricted-versions': RestrictedVersion;
+    'sibling-data': SiblingDatum;
+    'rely-on-request-headers': RelyOnRequestHeader;
+    'doc-level-access': DocLevelAccess;
+    'hidden-fields': HiddenField;
+  };
+  globals: {};
+}
 export interface User {
   id: string;
   email?: string;
@@ -19,15 +28,12 @@ export interface User {
   lockUntil?: string;
   createdAt: string;
   updatedAt: string;
+  password?: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "posts".
- */
 export interface Post {
   id: string;
   restrictedField?: string;
-  group: {
+  group?: {
     restrictedGroupText?: string;
   };
   restrictedRowText?: string;
@@ -35,43 +41,27 @@ export interface Post {
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "restricted".
- */
 export interface Restricted {
   id: string;
   name?: string;
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "read-only-collection".
- */
 export interface ReadOnlyCollection {
   id: string;
   name?: string;
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "restricted-versions".
- */
 export interface RestrictedVersion {
   id: string;
   name?: string;
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "sibling-data".
- */
 export interface SiblingDatum {
   id: string;
-  array: {
+  array?: {
     allowPublicReadability?: boolean;
     text?: string;
     id?: string;
@@ -79,25 +69,28 @@ export interface SiblingDatum {
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "rely-on-request-headers".
- */
 export interface RelyOnRequestHeader {
   id: string;
   name?: string;
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "doc-level-access".
- */
 export interface DocLevelAccess {
   id: string;
   approvedForRemoval?: boolean;
   approvedTitle?: string;
   lockTitle?: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+export interface HiddenField {
+  id: string;
+  title?: string;
+  partiallyHidden?: {
+    name?: string;
+    value?: string;
+    id?: string;
+  }[];
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Description

In some scenarios, patching data would mutate hidden fields. This could happen when a field was nested within a field that was not hidden. 

The solution was to set `showHiddenFields: true` when fetching the originalDoc.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
