### PR TITLE
fix: Fix relationships using nested field as title not being displayed

### DIFF
--- a/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
+++ b/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
@@ -23,6 +23,17 @@ const sortOptions = (options: Option[]): Option[] => options.sort((a: Option, b:
   return 0;
 });
 
+const getNestedTitle = (obj, prop) => {
+  var _prop = prop.split(".")
+  for (var i = 0; i < _prop.length; i++) {
+    if (_prop[i] in obj)
+      obj = obj[_prop[i]]
+    else
+      return;
+  }
+  return obj;
+}
+
 const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => {
   switch (action.type) {
     case 'CLEAR': {
@@ -38,7 +49,7 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
       const foundOption = foundOptionGroup?.options?.find((option) => option.value === doc.id);
 
       if (foundOption) {
-        foundOption.label = doc[labelKey] || `${i18n.t('general:untitled')} - ID: ${doc.id}`;
+        foundOption.label = getNestedTitle(doc, labelKey) || `${i18n.t('general:untitled')} - ID: ${doc.id}`;
         foundOption.relationTo = relation;
       }
 
@@ -60,7 +71,7 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
           return [
             ...docSubOptions,
             {
-              label: doc[labelKey] || `${i18n.t('general:untitled')} - ID: ${doc.id}`,
+              label: getNestedTitle(doc, labelKey) || `${i18n.t('general:untitled')} - ID: ${doc.id}`,
               relationTo: relation,
               value: doc.id,
             },


### PR DESCRIPTION
## Description

This PR fixes #2333 by allowing the `optionsReducer` of the relationship form field to use nested group fields as a title.

Before, if you set `admin.useAsTitle` to something like `author.name` which is a nested field inside of a group, the relationship form field selector would show as if it had no title, when it actually does.

I added a basic helper function that allows to use dot notation inside of the options reducer to get a nested title and it doesn't break if you use it as a top level field.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
