### PR TITLE
fix: update dateTimeFormat for dayOnly pickerAppearance option

### DIFF
--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -18,7 +18,7 @@ This field uses [`react-datepicker`](https://www.npmjs.com/package/react-datepic
 | Option             | Description                                                                                                                                                                                         |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`name`** \*      | To be used as the property name when stored and retrieved from the database. [More](/docs/fields/overview#field-names)                                                                              |
-| **`label`**        | Text used as a field label in the Admin panel or an object with keys for each language.                                                                                                                    |
+| **`label`**        | Text used as a field label in the Admin panel or an object with keys for each language.                                                                                                             |
 | **`index`**        | Build a [MongoDB index](https://docs.mongodb.com/manual/indexes/) for this field to produce faster queries. Set this field to `true` if your users will perform queries on this field's data often. |
 | **`validate`**     | Provide a custom validation function that will be executed on both the Admin panel and the backend. [More](/docs/fields/overview#validation)                                                        |
 | **`saveToJWT`**    | If this field is top-level and nested in a config supporting [Authentication](/docs/authentication/config), include its data in the user JWT.                                                       |
@@ -28,7 +28,7 @@ This field uses [`react-datepicker`](https://www.npmjs.com/package/react-datepic
 | **`defaultValue`** | Provide data to be used for this field's default value. [More](/docs/fields/overview#default-values)                                                                                                |
 | **`localized`**    | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config.                                                                     |
 | **`required`**     | Require this field to have a value.                                                                                                                                                                 |
-| **`admin`**        | Admin-specific configuration. See below for [more detail](#admin-config).                                                                                                                                  |
+| **`admin`**        | Admin-specific configuration. See below for [more detail](#admin-config).                                                                                                                           |
 
 _\* An asterisk denotes that a property is required._
 
@@ -36,18 +36,18 @@ _\* An asterisk denotes that a property is required._
 
 In addition to the default [field admin config](/docs/fields/overview#admin-config), you can customize the following fields that will adjust how the component displays in the admin panel via the `date` property.
 
-| Option                 | Description                                                                                                                                         |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`pickerAppearance`** | Determines the appearance of the datepicker: `dayAndTime` `timeOnly` `dayOnly` `monthOnly`. Defaults to a calendar day picker - see `displayFormat`.                                           |
-| **`displayFormat`**    | Determines how the date is presented. dayAndTime default to `MMM d, yyy h:mm a` timeOnly defaults to `h:mm a` dayOnly defaults to `dd` and monthOnly defaults to `MMMM`. Defaults to `MMM d, yyy` when `pickerAppearance` is not set. |
-| **`placeholder`**      | Placeholder text for the field.                                                                                                                     |
-| **`monthsToShow`**     | Number of months to display max is 2. Defaults to 1.                                                                                                |
-| **`minDate`**          | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md).                               |
-| **`maxDate`**          | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md).                               |
-| **`minTime`**          | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md).                               |
-| **`maxTime`**          | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md).                               |
-| **`timeIntervals`**    | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md). Defaults to 30 minutes.       |
-| **`timeFormat`**       | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md). Defaults to `'h:mm aa'`.      |
+| Option                 | Description                                                                                                                                                                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`pickerAppearance`** | Determines the appearance of the datepicker: `dayAndTime` `timeOnly` `dayOnly` `monthOnly`. Defaults to a calendar day picker - see `displayFormat`.                                                                                          |
+| **`displayFormat`**    | Determines how the date is presented. dayAndTime default to `MMM d, yyy h:mm a` timeOnly defaults to `h:mm a` dayOnly defaults to `MMM d, yyy` and monthOnly defaults to `MMMM`. Defaults to `MMM d, yyy` when `pickerAppearance` is not set. |
+| **`placeholder`**      | Placeholder text for the field.                                                                                                                                                                                                               |
+| **`monthsToShow`**     | Number of months to display max is 2. Defaults to 1.                                                                                                                                                                                          |
+| **`minDate`**          | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md).                                                                                                                         |
+| **`maxDate`**          | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md).                                                                                                                         |
+| **`minTime`**          | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md).                                                                                                                         |
+| **`maxTime`**          | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md).                                                                                                                         |
+| **`timeIntervals`**    | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md). Defaults to 30 minutes.                                                                                                 |
+| **`timeFormat`**       | Passed directly to [react-datepicker](https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md). Defaults to `'h:mm aa'`.                                                                                                |
 
 _\* An asterisk denotes that a property is required._
 
@@ -58,23 +58,23 @@ Common use cases for customizing the `date` property are to restrict your field 
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload/types';
+import { CollectionConfig } from "payload/types";
 
 const ExampleCollection: CollectionConfig = {
-  slug: 'example-collection',
+  slug: "example-collection",
   fields: [
     {
-      name: 'time', // required
-      type: 'date', // required
-      label: 'Event Start Time',
-      defaultValue: '1988-11-05T8:00:00.000+05:00',
+      name: "time", // required
+      type: "date", // required
+      label: "Event Start Time",
+      defaultValue: "1988-11-05T8:00:00.000+05:00",
       admin: {
         date: {
           // All config options above should be placed here
-          pickerAppearance: 'timeOnly',
-        }
-      }
-    }
-  ]
+          pickerAppearance: "timeOnly",
+        },
+      },
+    },
+  ],
 };
 ```

--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -72,9 +72,9 @@ const ExampleCollection: CollectionConfig = {
         date: {
           // All config options above should be placed here
           pickerAppearance: 'timeOnly',
-        },
-      },
-    },
-  ],
+        }
+      }
+    }
+  ]
 };
 ```

--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -58,20 +58,20 @@ Common use cases for customizing the `date` property are to restrict your field 
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from "payload/types";
+import { CollectionConfig } from 'payload/types';
 
 const ExampleCollection: CollectionConfig = {
-  slug: "example-collection",
+  slug: 'example-collection',
   fields: [
     {
-      name: "time", // required
-      type: "date", // required
-      label: "Event Start Time",
-      defaultValue: "1988-11-05T8:00:00.000+05:00",
+      name: 'time', // required
+      type: 'date', // required
+      label: 'Event Start Time',
+      defaultValue: '1988-11-05T8:00:00.000+05:00',
       admin: {
         date: {
           // All config options above should be placed here
-          pickerAppearance: "timeOnly",
+          pickerAppearance: 'timeOnly',
         },
       },
     },

--- a/src/admin/components/elements/DatePicker/DatePicker.tsx
+++ b/src/admin/components/elements/DatePicker/DatePicker.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import DatePicker, { registerLocale } from 'react-datepicker';
-import * as Locales from 'date-fns/locale';
-import { useTranslation } from 'react-i18next';
-import CalendarIcon from '../../icons/Calendar';
-import XIcon from '../../icons/X';
-import { Props } from './types';
-import { getSupportedDateLocale } from '../../../utilities/formatDate/getSupportedDateLocale';
+import React from "react";
+import DatePicker, { registerLocale } from "react-datepicker";
+import * as Locales from "date-fns/locale";
+import { useTranslation } from "react-i18next";
+import CalendarIcon from "../../icons/Calendar";
+import XIcon from "../../icons/X";
+import { Props } from "./types";
+import { getSupportedDateLocale } from "../../../utilities/formatDate/getSupportedDateLocale";
 
-import 'react-datepicker/dist/react-datepicker.css';
-import './index.scss';
+import "react-datepicker/dist/react-datepicker.css";
+import "./index.scss";
 
-const baseClass = 'date-time-picker';
+const baseClass = "date-time-picker";
 
 const DateTime: React.FC<Props> = (props) => {
   const {
@@ -24,7 +24,7 @@ const DateTime: React.FC<Props> = (props) => {
     minTime,
     maxTime,
     timeIntervals = 30,
-    timeFormat = 'h:mm aa',
+    timeFormat = "h:mm aa",
     readOnly,
     placeholder: placeholderText,
   } = props;
@@ -42,11 +42,11 @@ const DateTime: React.FC<Props> = (props) => {
   let dateTimeFormat = displayFormat;
 
   if (dateTimeFormat === undefined && pickerAppearance) {
-    if (pickerAppearance === 'dayAndTime') dateTimeFormat = 'MMM d, yyy h:mm a';
-    else if (pickerAppearance === 'timeOnly') dateTimeFormat = 'h:mm a';
-    else if (pickerAppearance === 'dayOnly') dateTimeFormat = 'dd';
-    else if (pickerAppearance === 'monthOnly') dateTimeFormat = 'MMMM';
-    else dateTimeFormat = 'MMM d, yyy';
+    if (pickerAppearance === "dayAndTime") dateTimeFormat = "MMM d, yyy h:mm a";
+    else if (pickerAppearance === "timeOnly") dateTimeFormat = "h:mm a";
+    else if (pickerAppearance === "dayOnly") dateTimeFormat = "MMM d, yyyy";
+    else if (pickerAppearance === "monthOnly") dateTimeFormat = "MMMM";
+    else dateTimeFormat = "MMM d, yyy";
   }
 
   const dateTimePickerProps = {
@@ -54,7 +54,8 @@ const DateTime: React.FC<Props> = (props) => {
     maxDate,
     dateFormat: dateTimeFormat,
     monthsShown: Math.min(2, monthsToShow),
-    showTimeSelect: pickerAppearance === 'dayAndTime' || pickerAppearance === 'timeOnly',
+    showTimeSelect:
+      pickerAppearance === "dayAndTime" || pickerAppearance === "timeOnly",
     minTime,
     maxTime,
     timeIntervals,
@@ -64,14 +65,13 @@ const DateTime: React.FC<Props> = (props) => {
     onChange,
     showPopperArrow: false,
     selected: value && new Date(value),
-    customInputRef: 'ref',
-    showMonthYearPicker: pickerAppearance === 'monthOnly',
+    customInputRef: "ref",
+    showMonthYearPicker: pickerAppearance === "monthOnly",
   };
 
-  const classes = [
-    baseClass,
-    `${baseClass}__appearance--${pickerAppearance}`,
-  ].filter(Boolean).join(' ');
+  const classes = [baseClass, `${baseClass}__appearance--${pickerAppearance}`]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <div className={classes}>
@@ -94,7 +94,7 @@ const DateTime: React.FC<Props> = (props) => {
           locale={locale}
           popperModifiers={[
             {
-              name: 'preventOverflow',
+              name: "preventOverflow",
               enabled: true,
             },
           ]}

--- a/src/admin/components/elements/DatePicker/DatePicker.tsx
+++ b/src/admin/components/elements/DatePicker/DatePicker.tsx
@@ -1,16 +1,16 @@
-import React from "react";
-import DatePicker, { registerLocale } from "react-datepicker";
-import * as Locales from "date-fns/locale";
-import { useTranslation } from "react-i18next";
-import CalendarIcon from "../../icons/Calendar";
-import XIcon from "../../icons/X";
-import { Props } from "./types";
-import { getSupportedDateLocale } from "../../../utilities/formatDate/getSupportedDateLocale";
+import React from 'react';
+import DatePicker, { registerLocale } from 'react-datepicker';
+import * as Locales from 'date-fns/locale';
+import { useTranslation } from 'react-i18next';
+import CalendarIcon from '../../icons/Calendar';
+import XIcon from '../../icons/X';
+import { Props } from './types';
+import { getSupportedDateLocale } from '../../../utilities/formatDate/getSupportedDateLocale';
 
-import "react-datepicker/dist/react-datepicker.css";
-import "./index.scss";
+import 'react-datepicker/dist/react-datepicker.css';
+import './index.scss';
 
-const baseClass = "date-time-picker";
+const baseClass = 'date-time-picker';
 
 const DateTime: React.FC<Props> = (props) => {
   const {
@@ -24,7 +24,7 @@ const DateTime: React.FC<Props> = (props) => {
     minTime,
     maxTime,
     timeIntervals = 30,
-    timeFormat = "h:mm aa",
+    timeFormat = 'h:mm aa',
     readOnly,
     placeholder: placeholderText,
   } = props;
@@ -42,11 +42,11 @@ const DateTime: React.FC<Props> = (props) => {
   let dateTimeFormat = displayFormat;
 
   if (dateTimeFormat === undefined && pickerAppearance) {
-    if (pickerAppearance === "dayAndTime") dateTimeFormat = "MMM d, yyy h:mm a";
-    else if (pickerAppearance === "timeOnly") dateTimeFormat = "h:mm a";
-    else if (pickerAppearance === "dayOnly") dateTimeFormat = "MMM d, yyyy";
-    else if (pickerAppearance === "monthOnly") dateTimeFormat = "MMMM";
-    else dateTimeFormat = "MMM d, yyy";
+    if (pickerAppearance === 'dayAndTime') dateTimeFormat = 'MMM d, yyy h:mm a';
+    else if (pickerAppearance === 'timeOnly') dateTimeFormat = 'h:mm a';
+    else if (pickerAppearance === 'dayOnly') dateTimeFormat = 'MMM d, yyy';
+    else if (pickerAppearance === 'monthOnly') dateTimeFormat = 'MMMM';
+    else dateTimeFormat = 'MMM d, yyy';
   }
 
   const dateTimePickerProps = {
@@ -54,8 +54,7 @@ const DateTime: React.FC<Props> = (props) => {
     maxDate,
     dateFormat: dateTimeFormat,
     monthsShown: Math.min(2, monthsToShow),
-    showTimeSelect:
-      pickerAppearance === "dayAndTime" || pickerAppearance === "timeOnly",
+    showTimeSelect: pickerAppearance === 'dayAndTime' || pickerAppearance === 'timeOnly',
     minTime,
     maxTime,
     timeIntervals,
@@ -65,13 +64,14 @@ const DateTime: React.FC<Props> = (props) => {
     onChange,
     showPopperArrow: false,
     selected: value && new Date(value),
-    customInputRef: "ref",
-    showMonthYearPicker: pickerAppearance === "monthOnly",
+    customInputRef: 'ref',
+    showMonthYearPicker: pickerAppearance === 'monthOnly',
   };
 
-  const classes = [baseClass, `${baseClass}__appearance--${pickerAppearance}`]
-    .filter(Boolean)
-    .join(" ");
+  const classes = [
+    baseClass,
+    `${baseClass}__appearance--${pickerAppearance}`,
+  ].filter(Boolean).join(' ');
 
   return (
     <div className={classes}>
@@ -94,7 +94,7 @@ const DateTime: React.FC<Props> = (props) => {
           locale={locale}
           popperModifiers={[
             {
-              name: "preventOverflow",
+              name: 'preventOverflow',
               enabled: true,
             },
           ]}


### PR DESCRIPTION
## Description

Currently `dayOnly` pickerAppearance option of the DateField looks like:
<img width="354" alt="Screenshot 2023-03-17 at 11 41 49 AM" src="https://user-images.githubusercontent.com/101012384/226060100-33caff45-5cf8-477f-9263-c510903902de.png">

Why `dayOnly`'s default should be `MMM d, yyy` instead of `dd`:
- `dd` alone is ambiguous and error prone
  - e.g. a user accidentially selects the 17th of April instead of March — they wouldn't know in the current format
- displayFormat should directly reflect what the user is selecting, and in this case they're selecting Month-Day-Year


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
