### PR TITLE
fix: Improve UI for the BlocksDrawer with long labels

### DIFF
--- a/src/admin/components/elements/ThumbnailCard/index.tsx
+++ b/src/admin/components/elements/ThumbnailCard/index.tsx
@@ -33,6 +33,7 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
       className={classes}
       onClick={typeof onClick === 'function' ? onClick : undefined}
       onKeyDown={typeof onKeyDown === 'function' ? onKeyDown : undefined}
+      title={label ? label : typeof doc?.filename === 'string' ? doc?.filename : `[${t('untitled')}]`}
     >
       <div className={`${baseClass}__thumbnail`}>
         {thumbnail && thumbnail}

--- a/src/admin/components/elements/ThumbnailCard/index.tsx
+++ b/src/admin/components/elements/ThumbnailCard/index.tsx
@@ -14,9 +14,9 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
     doc,
     collection,
     thumbnail,
-    label,
     alignLabel,
     onKeyDown,
+    label: labelFromProps,
   } = props;
 
   const { t } = useTranslation('general');
@@ -28,12 +28,15 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
     alignLabel && `${baseClass}--align-label-${alignLabel}`,
   ].filter(Boolean).join(' ');
 
+  let label = labelFromProps;
+  if (!label) label = typeof doc?.filename === 'string' ? doc?.filename : `[${t('untitled')}]`;
+
   return (
     <div
+      title={label}
       className={classes}
       onClick={typeof onClick === 'function' ? onClick : undefined}
       onKeyDown={typeof onKeyDown === 'function' ? onKeyDown : undefined}
-      title={label ? label : typeof doc?.filename === 'string' ? doc?.filename : `[${t('untitled')}]`}
     >
       <div className={`${baseClass}__thumbnail`}>
         {thumbnail && thumbnail}
@@ -46,12 +49,7 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
         )}
       </div>
       <div className={`${baseClass}__label`}>
-        {label && label}
-        {!label && doc && (
-          <Fragment>
-            {typeof doc?.filename === 'string' ? doc?.filename : `[${t('untitled')}]`}
-          </Fragment>
-        )}
+        {label}
       </div>
     </div>
   );

--- a/src/admin/components/elements/ThumbnailCard/index.tsx
+++ b/src/admin/components/elements/ThumbnailCard/index.tsx
@@ -12,11 +12,11 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
     className,
     onClick,
     doc,
+    label,
     collection,
     thumbnail,
     alignLabel,
     onKeyDown,
-    label: labelFromProps,
   } = props;
 
   const { t } = useTranslation('general');
@@ -28,13 +28,12 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
     alignLabel && `${baseClass}--align-label-${alignLabel}`,
   ].filter(Boolean).join(' ');
 
-  let label = labelFromProps;
-  if (!label) label = typeof doc?.filename === 'string' ? doc?.filename : `[${t('untitled')}]`;
+  const defaultTitle: any = doc?.[collection?.admin?.useAsTitle] || doc?.filename || `[${t('untitled')}]`;
 
   return (
     <div
-      title={label}
       className={classes}
+      title={label || defaultTitle}
       onClick={typeof onClick === 'function' ? onClick : undefined}
       onKeyDown={typeof onKeyDown === 'function' ? onKeyDown : undefined}
     >
@@ -49,7 +48,7 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
         )}
       </div>
       <div className={`${baseClass}__label`}>
-        {label}
+        {label || defaultTitle}
       </div>
     </div>
   );

--- a/src/admin/components/forms/field-types/Blocks/BlocksDrawer/index.scss
+++ b/src/admin/components/forms/field-types/Blocks/BlocksDrawer/index.scss
@@ -17,7 +17,7 @@
 
   &__block {
     margin: base(0.5);
-    width: calc(12.5% - #{base(1)});
+    width: calc((100% / 6) - #{base(1)});
   }
 
   &__default-image {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

Fixes #2343 

I made the `BlocksDrawer` fit 6 blocks per row on XL screens to fit a bit more of the labels in it and implemented the `title` HTML property on the `ThumbnailCard` so that even when the title gets cut by the `overflow: hidden; text-overflow: ellipsis;` combo, if the user hovers over the card, every browser shows a small tooltip with the full label, which was the issue mentioned by @AlessioGr 

![Screenshot 2023-03-18 at 10 14 03 p m](https://user-images.githubusercontent.com/47041342/226153282-ff531b62-3bd2-43d3-bf1f-707922449c0b.png)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
