### PR TITLE
fix: relationship field useAsTitle #2333

### DIFF
--- a/src/admin/components/elements/DeleteDocument/index.tsx
+++ b/src/admin/components/elements/DeleteDocument/index.tsx
@@ -23,9 +23,6 @@ const DeleteDocument: React.FC<Props> = (props) => {
     buttonId,
     collection,
     collection: {
-      admin: {
-        useAsTitle,
-      },
       slug,
       labels: {
         singular,
@@ -39,7 +36,7 @@ const DeleteDocument: React.FC<Props> = (props) => {
   const { toggleModal } = useModal();
   const history = useHistory();
   const { t, i18n } = useTranslation('general');
-  const title = useTitle(useAsTitle, collection.slug) || id;
+  const title = useTitle(collection);
   const titleToRender = titleFromProps || title;
 
   const modalSlug = `delete-${id}`;

--- a/src/admin/components/elements/RenderTitle/index.tsx
+++ b/src/admin/components/elements/RenderTitle/index.tsx
@@ -7,13 +7,12 @@ const baseClass = 'render-title';
 
 const RenderTitle: React.FC<Props> = (props) => {
   const {
-    useAsTitle,
     collection,
     title: titleFromProps,
     data,
     fallback = '[untitled]',
   } = props;
-  const titleFromForm = useTitle(useAsTitle, collection);
+  const titleFromForm = useTitle(collection);
 
   let title = titleFromForm;
   if (!title) title = data?.id;

--- a/src/admin/components/elements/RenderTitle/types.ts
+++ b/src/admin/components/elements/RenderTitle/types.ts
@@ -1,3 +1,5 @@
+import { SanitizedCollectionConfig } from '../../../../collections/config/types';
+
 export type Props = {
   useAsTitle?: string
   data?: {
@@ -5,5 +7,5 @@ export type Props = {
   }
   title?: string
   fallback?: string
-  collection?: string
+  collection?: SanitizedCollectionConfig
 }

--- a/src/admin/components/forms/field-types/Relationship/AddNew/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/AddNew/index.tsx
@@ -10,9 +10,9 @@ import Plus from '../../../../icons/Plus';
 import { getTranslation } from '../../../../../../utilities/getTranslation';
 import Tooltip from '../../../../elements/Tooltip';
 import { useDocumentDrawer } from '../../../../elements/DocumentDrawer';
+import { useConfig } from '../../../../utilities/Config';
 
 import './index.scss';
-import { useConfig } from '../../../../utilities/Config';
 
 const baseClass = 'relationship-add-new';
 

--- a/src/admin/components/forms/field-types/Relationship/AddNew/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/AddNew/index.tsx
@@ -12,6 +12,7 @@ import Tooltip from '../../../../elements/Tooltip';
 import { useDocumentDrawer } from '../../../../elements/DocumentDrawer';
 
 import './index.scss';
+import { useConfig } from '../../../../utilities/Config';
 
 const baseClass = 'relationship-add-new';
 
@@ -25,6 +26,8 @@ export const AddNewRelation: React.FC<Props> = ({ path, hasMany, relationTo, val
   const [popupOpen, setPopupOpen] = useState(false);
   const { t, i18n } = useTranslation('fields');
   const [showTooltip, setShowTooltip] = useState(false);
+  const config = useConfig();
+
   const [
     DocumentDrawer,
     DocumentDrawerToggler,
@@ -47,6 +50,7 @@ export const AddNewRelation: React.FC<Props> = ({ path, hasMany, relationTo, val
       ],
       sort: true,
       i18n,
+      config,
     });
 
     if (hasMany) {
@@ -56,7 +60,7 @@ export const AddNewRelation: React.FC<Props> = ({ path, hasMany, relationTo, val
     }
 
     setSelectedCollection(undefined);
-  }, [relationTo, collectionConfig, dispatchOptions, i18n, hasMany, setValue, value]);
+  }, [relationTo, collectionConfig, dispatchOptions, i18n, hasMany, setValue, value, config]);
 
   const onPopopToggle = useCallback((state) => {
     setPopupOpen(state);

--- a/src/admin/components/forms/field-types/Relationship/createRelationMap.ts
+++ b/src/admin/components/forms/field-types/Relationship/createRelationMap.ts
@@ -1,7 +1,7 @@
 import { Value } from './types';
 
 type RelationMap = {
-  [relation: string]: unknown[]
+  [relation: string]: (string | number)[]
 }
 
 type CreateRelationMap = (args: {

--- a/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
+++ b/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
@@ -1,8 +1,6 @@
 import { Option, Action, OptionGroup } from './types';
 import { getTranslation } from '../../../../../utilities/getTranslation';
 import { formatUseAsTitle } from '../../../../hooks/useTitle';
-import { getObjectDotNotation } from '../../../../../utilities/getObjectDotNotation';
-import { Field } from '../../Form/types';
 
 const reduceToIDs = (options) => options.reduce((ids, option) => {
   if (option.options) {
@@ -38,7 +36,7 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
       const newOptions = [...state];
 
       const docTitle = formatUseAsTitle({
-        field: getObjectDotNotation<Field>(doc, collection.admin.useAsTitle),
+        doc,
         collection,
         i18n,
         config,
@@ -67,7 +65,7 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
           loadedIDs.push(doc.id);
 
           const docTitle = formatUseAsTitle({
-            field: getObjectDotNotation<Field>(doc, collection.admin.useAsTitle),
+            doc,
             collection,
             i18n,
             config,

--- a/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
+++ b/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
@@ -1,5 +1,8 @@
 import { Option, Action, OptionGroup } from './types';
 import { getTranslation } from '../../../../../utilities/getTranslation';
+import { formatUseAsTitle } from '../../../../hooks/useTitle';
+import { getObjectDotNotation } from '../../../../../utilities/getObjectDotNotation';
+import { Field } from '../../Form/types';
 
 const reduceToIDs = (options) => options.reduce((ids, option) => {
   if (option.options) {
@@ -30,15 +33,22 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
     }
 
     case 'UPDATE': {
-      const { collection, doc, i18n } = action;
+      const { collection, doc, i18n, config } = action;
       const relation = collection.slug;
       const newOptions = [...state];
-      const labelKey = collection.admin.useAsTitle || 'id';
+
+      const docTitle = formatUseAsTitle({
+        field: getObjectDotNotation<Field>(doc, collection.admin.useAsTitle),
+        collection,
+        i18n,
+        config,
+      });
+
       const foundOptionGroup = newOptions.find((optionGroup) => optionGroup.label === collection.labels.plural);
       const foundOption = foundOptionGroup?.options?.find((option) => option.value === doc.id);
 
       if (foundOption) {
-        foundOption.label = doc[labelKey] || `${i18n.t('general:untitled')} - ID: ${doc.id}`;
+        foundOption.label = docTitle || `${i18n.t('general:untitled')} - ID: ${doc.id}`;
         foundOption.relationTo = relation;
       }
 
@@ -46,9 +56,8 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
     }
 
     case 'ADD': {
-      const { collection, docs, sort, ids = [], i18n } = action;
+      const { collection, docs, sort, ids = [], i18n, config } = action;
       const relation = collection.slug;
-      const labelKey = collection.admin.useAsTitle || 'id';
       const loadedIDs = reduceToIDs(state);
       const newOptions = [...state];
       const optionsToAddTo = newOptions.find((optionGroup) => optionGroup.label === collection.labels.plural);
@@ -57,10 +66,17 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
         if (loadedIDs.indexOf(doc.id) === -1) {
           loadedIDs.push(doc.id);
 
+          const docTitle = formatUseAsTitle({
+            field: getObjectDotNotation<Field>(doc, collection.admin.useAsTitle),
+            collection,
+            i18n,
+            config,
+          });
+
           return [
             ...docSubOptions,
             {
-              label: doc[labelKey] || `${i18n.t('general:untitled')} - ID: ${doc.id}`,
+              label: docTitle || `${i18n.t('general:untitled')} - ID: ${doc.id}`,
               relationTo: relation,
               value: doc.id,
             },
@@ -74,7 +90,7 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
         if (!loadedIDs.includes(id)) {
           newSubOptions.push({
             relationTo: relation,
-            label: labelKey === 'id' ? id : `${i18n.t('general:untitled')} - ID: ${id}`,
+            label: `${i18n.t('general:untitled')} - ID: ${id}`,
             value: id,
           });
         }

--- a/src/admin/components/forms/field-types/Relationship/types.ts
+++ b/src/admin/components/forms/field-types/Relationship/types.ts
@@ -2,6 +2,7 @@ import i18n from 'i18next';
 import { SanitizedCollectionConfig } from '../../../../../collections/config/types';
 import { RelationshipField } from '../../../../../fields/config/types';
 import { Where } from '../../../../../types';
+import { SanitizedConfig } from '../../../../../config/types';
 
 export type Props = Omit<RelationshipField, 'type'> & {
   path?: string
@@ -35,6 +36,7 @@ type UPDATE = {
   doc: any
   collection: SanitizedCollectionConfig
   i18n: typeof i18n
+  config: SanitizedConfig
 }
 
 type ADD = {
@@ -42,8 +44,9 @@ type ADD = {
   docs: any[]
   collection: SanitizedCollectionConfig
   sort?: boolean
-  ids?: unknown[]
+  ids?: (string | number)[]
   i18n: typeof i18n
+  config: SanitizedConfig
 }
 
 export type Action = CLEAR | ADD | UPDATE

--- a/src/admin/components/views/Account/Default.tsx
+++ b/src/admin/components/views/Account/Default.tsx
@@ -96,7 +96,7 @@ const DefaultAccount: React.FC<Props> = (props) => {
                     <h1>
                       <RenderTitle
                         data={data}
-                        collection={collection.slug}
+                        collection={collection}
                         useAsTitle={useAsTitle}
                         fallback={`[${t('general:untitled')}]`}
                       />

--- a/src/admin/components/views/collections/Edit/Default.tsx
+++ b/src/admin/components/views/collections/Edit/Default.tsx
@@ -128,7 +128,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                         <h1>
                           <RenderTitle
                             data={data}
-                            collection={collection.slug}
+                            collection={collection}
                             useAsTitle={useAsTitle}
                             fallback={`[${t('untitled')}]`}
                           />

--- a/src/admin/components/views/collections/Edit/SetStepNav.tsx
+++ b/src/admin/components/views/collections/Edit/SetStepNav.tsx
@@ -26,7 +26,7 @@ export const SetStepNav: React.FC<{
   const { t, i18n } = useTranslation('general');
   const { routes: { admin } } = useConfig();
 
-  const title = useTitle(useAsTitle, collection.slug);
+  const title = useTitle(collection);
 
   useEffect(() => {
     const nav: StepNavItem[] = [{

--- a/src/admin/components/views/collections/List/Cell/field-types/Relationship/index.tsx
+++ b/src/admin/components/views/collections/List/Cell/field-types/Relationship/index.tsx
@@ -5,7 +5,6 @@ import useIntersect from '../../../../../../../hooks/useIntersect';
 import { useListRelationships } from '../../../RelationshipProvider';
 import { getTranslation } from '../../../../../../../../utilities/getTranslation';
 import { formatUseAsTitle } from '../../../../../../../hooks/useTitle';
-import { getObjectDotNotation } from '../../../../../../../../utilities/getObjectDotNotation';
 import { Props as DefaultCellProps } from '../../types';
 
 import './index.scss';
@@ -61,7 +60,7 @@ const RelationshipCell: React.FC<{
         const relatedCollection = collections.find(({ slug }) => slug === relationTo);
 
         const label = formatUseAsTitle({
-          field: getObjectDotNotation(document || {}, relatedCollection.admin.useAsTitle),
+          doc: document === false ? null : document,
           collection: relatedCollection,
           i18n,
           config,

--- a/src/admin/components/views/collections/List/Cell/field-types/Relationship/index.tsx
+++ b/src/admin/components/views/collections/List/Cell/field-types/Relationship/index.tsx
@@ -4,6 +4,9 @@ import { useConfig } from '../../../../../../utilities/Config';
 import useIntersect from '../../../../../../../hooks/useIntersect';
 import { useListRelationships } from '../../../RelationshipProvider';
 import { getTranslation } from '../../../../../../../../utilities/getTranslation';
+import { formatUseAsTitle } from '../../../../../../../hooks/useTitle';
+import { getObjectDotNotation } from '../../../../../../../../utilities/getObjectDotNotation';
+import { Props as DefaultCellProps } from '../../types';
 
 import './index.scss';
 
@@ -11,9 +14,13 @@ type Value = { relationTo: string, value: number | string };
 const baseClass = 'relationship-cell';
 const totalToShow = 3;
 
-const RelationshipCell = (props) => {
+const RelationshipCell: React.FC<{
+  field: DefaultCellProps['field']
+  data: DefaultCellProps['cellData']
+}> = (props) => {
   const { field, data: cellData } = props;
-  const { collections, routes } = useConfig();
+  const config = useConfig();
+  const { collections, routes } = config;
   const [intersectionRef, entry] = useIntersect();
   const [values, setValues] = useState<Value[]>([]);
   const { getRelationships, documents } = useListRelationships();
@@ -31,7 +38,7 @@ const RelationshipCell = (props) => {
         if (typeof cell === 'object' && 'relationTo' in cell && 'value' in cell) {
           formattedValues.push(cell);
         }
-        if ((typeof cell === 'number' || typeof cell === 'string') && typeof field.relationTo === 'string') {
+        if ((typeof cell === 'number' || typeof cell === 'string') && 'relationTo' in field && typeof field.relationTo === 'string') {
           formattedValues.push({
             value: cell,
             relationTo: field.relationTo,
@@ -52,13 +59,19 @@ const RelationshipCell = (props) => {
       {values.map(({ relationTo, value }, i) => {
         const document = documents[relationTo][value];
         const relatedCollection = collections.find(({ slug }) => slug === relationTo);
-        const label = document?.[relatedCollection.admin.useAsTitle] ? document[relatedCollection.admin.useAsTitle] : `${t('untitled')} - ID: ${value}`;
+
+        const label = formatUseAsTitle({
+          field: getObjectDotNotation(document || {}, relatedCollection.admin.useAsTitle),
+          collection: relatedCollection,
+          i18n,
+          config,
+        });
 
         return (
           <React.Fragment key={i}>
             {document === false && `${t('untitled')} - ID: ${value}`}
             {document === null && `${t('loading')}...`}
-            {document && label}
+            {document && (label || `${t('untitled')} - ID: ${value}`)}
             {values.length > i + 1 && ', '}
           </React.Fragment>
         );
@@ -67,7 +80,7 @@ const RelationshipCell = (props) => {
         Array.isArray(cellData) && cellData.length > totalToShow
         && t('fields:itemsAndMore', { items: '', count: cellData.length - totalToShow })
       }
-      {values.length === 0 && t('noLabel', { label: getTranslation(field.label, i18n) })}
+      {values.length === 0 && t('noLabel', { label: getTranslation(field?.label || '', i18n) })}
     </div>
   );
 };

--- a/src/admin/hooks/useTitle.tsx
+++ b/src/admin/hooks/useTitle.tsx
@@ -1,29 +1,53 @@
+import i18next from 'i18next';
 import { useTranslation } from 'react-i18next';
-import { useRelatedCollections } from '../components/forms/field-types/Relationship/AddNew/useRelatedCollections';
+import { SanitizedConfig } from '../../config/types';
+import { SanitizedCollectionConfig } from '../../collections/config/types';
 import { useFormFields } from '../components/forms/Form/context';
+import { Field } from '../components/forms/Form/types';
 import { useConfig } from '../components/utilities/Config';
 import { formatDate } from '../utilities/formatDate';
 
-const useTitle = (useAsTitle: string, collection: string): string => {
-  const titleField = useFormFields(([fields]) => fields[useAsTitle]);
-  const value: string = titleField?.value as string || '';
+type GetTitleArgs = {
+  field: Field
+  collection: SanitizedCollectionConfig
+  i18n: typeof i18next
+  config: SanitizedConfig
+}
 
-  const { admin: { dateFormat: dateFormatFromConfig } } = useConfig();
-  const collectionConfig = useRelatedCollections(collection)?.[0];
-  const fieldConfig = collectionConfig?.fields?.find((field) => 'name' in field && field?.name === useAsTitle);
+export const formatUseAsTitle = (args: GetTitleArgs): string => {
+  const {
+    field,
+    collection,
+    collection: {
+      admin: { useAsTitle },
+    },
+    i18n,
+    config: {
+      admin: {
+        dateFormat: dateFormatFromConfig,
+      },
+    },
+  } = args;
 
-  const { i18n } = useTranslation();
+  let title = typeof field === 'string' ? field : field?.value as string;
 
+  const fieldConfig = collection?.fields?.find((f) => 'name' in f && f?.name === useAsTitle);
   const isDate = fieldConfig?.type === 'date';
 
-  let title = value;
-
-  if (isDate && value) {
+  if (title && isDate) {
     const dateFormat = fieldConfig?.admin?.date?.displayFormat || dateFormatFromConfig;
-    title = formatDate(value, dateFormat, i18n?.language);
+    title = formatDate(title, dateFormat, i18n?.language);
   }
 
   return title;
+};
+
+const useTitle = (collection: SanitizedCollectionConfig): string => {
+  const { i18n } = useTranslation();
+  const field = useFormFields(([formFields]) => formFields[collection?.admin?.useAsTitle]);
+  const config = useConfig();
+
+  return formatUseAsTitle({ field, collection, i18n, config });
 };
 
 export default useTitle;

--- a/src/admin/hooks/useTitle.tsx
+++ b/src/admin/hooks/useTitle.tsx
@@ -6,15 +6,19 @@ import { useFormFields } from '../components/forms/Form/context';
 import { Field } from '../components/forms/Form/types';
 import { useConfig } from '../components/utilities/Config';
 import { formatDate } from '../utilities/formatDate';
+import { getObjectDotNotation } from '../../utilities/getObjectDotNotation';
 
+// either send a `field` or an entire `doc`
 export const formatUseAsTitle = (args: {
-  field: Field
+  field?: Field
+  doc?: Record<string, any>
   collection: SanitizedCollectionConfig
   i18n: typeof i18next
   config: SanitizedConfig
 }): string => {
   const {
-    field,
+    field: fieldFromProps,
+    doc,
     collection,
     collection: {
       admin: { useAsTitle },
@@ -26,6 +30,12 @@ export const formatUseAsTitle = (args: {
       },
     },
   } = args;
+
+  if (!fieldFromProps && !doc) {
+    return '';
+  }
+
+  const field = fieldFromProps || getObjectDotNotation<Field>(doc, collection.admin.useAsTitle);
 
   let title = typeof field === 'string' ? field : field?.value as string;
 

--- a/src/admin/hooks/useTitle.tsx
+++ b/src/admin/hooks/useTitle.tsx
@@ -7,14 +7,12 @@ import { Field } from '../components/forms/Form/types';
 import { useConfig } from '../components/utilities/Config';
 import { formatDate } from '../utilities/formatDate';
 
-type GetTitleArgs = {
+export const formatUseAsTitle = (args: {
   field: Field
   collection: SanitizedCollectionConfig
   i18n: typeof i18next
   config: SanitizedConfig
-}
-
-export const formatUseAsTitle = (args: GetTitleArgs): string => {
+}): string => {
   const {
     field,
     collection,

--- a/src/utilities/getObjectDotNotation.ts
+++ b/src/utilities/getObjectDotNotation.ts
@@ -1,4 +1,5 @@
 export const getObjectDotNotation = <T>(obj: Record<string, unknown>, path: string, defaultValue?: T): T => {
-  const result = path.split('.').reduce((o, i) => o[i], obj);
+  if (!path || !obj) return defaultValue;
+  const result = path.split('.').reduce((o, i) => o?.[i], obj);
   return result === undefined ? defaultValue : result as T;
 };

--- a/src/utilities/getObjectDotNotation.ts
+++ b/src/utilities/getObjectDotNotation.ts
@@ -1,0 +1,4 @@
+export const getObjectDotNotation = <T>(obj: Record<string, unknown>, path: string, defaultValue?: T): T => {
+  const result = path.split('.').reduce((o, i) => o[i], obj);
+  return result === undefined ? defaultValue : result as T;
+};

--- a/test/fields-relationship/config.ts
+++ b/test/fields-relationship/config.ts
@@ -142,9 +142,22 @@ export default buildConfig({
     {
       slug: relationWithTitleSlug,
       admin: {
-        useAsTitle: 'name',
+        useAsTitle: 'meta.title',
       },
-      fields: baseRelationshipFields,
+      fields: [
+        ...baseRelationshipFields,
+        {
+          name: 'meta',
+          type: 'group',
+          fields: [
+            {
+              name: 'title',
+              label: 'Meta Title',
+              type: 'text',
+            },
+          ],
+        },
+      ],
     },
     {
       slug: relationUpdatedExternallySlug,
@@ -297,6 +310,9 @@ export default buildConfig({
         collection: relationWithTitleSlug,
         data: {
           name: title,
+          meta: {
+            title,
+          },
         },
       });
       relationsWithTitle.push(id);

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -17,7 +17,6 @@ import wait from '../../src/utilities/wait';
 
 const { beforeAll, beforeEach, describe } = test;
 
-
 describe('fields - relationship', () => {
   let url: AdminUrlUtil;
   let page: Page;
@@ -309,7 +308,7 @@ describe('fields - relationship', () => {
       const options = page.locator('#field-relationshipWithTitle .rs__menu .rs__option');
       await expect(options).toHaveCount(1);
 
-      await input.fill('non-occuring-string');
+      await input.fill('non-occurring-string');
       await expect(options).toHaveCount(0);
     });
 

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -79,6 +79,9 @@ describe('fields - relationship', () => {
       collection: relationWithTitleSlug,
       data: {
         name: 'relation-title',
+        meta: {
+          title: 'relation-title',
+        },
       },
     });
 
@@ -87,6 +90,9 @@ describe('fields - relationship', () => {
       collection: relationWithTitleSlug,
       data: {
         name: 'word boundary search',
+        meta: {
+          title: 'word boundary search',
+        },
       },
     });
 


### PR DESCRIPTION
## Description

Fixes #2333 by formatting `useAsTitle` from within the relationship field. This pattern also ensures that any additional formatting to the `useAsTitle` field going forward is applied globally to all instances. Issue #2270 and various other places throughout the admin panel that need render the `useAsTitle` field can now be updated to this pattern but that is out of scope for this PR.

Related:
- #2205 
- #2334

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
