### PR TITLE
fix: corrects position of select field dropdown in mobile drawer

### DIFF
--- a/src/admin/components/elements/Drawer/index.scss
+++ b/src/admin/components/elements/Drawer/index.scss
@@ -34,10 +34,7 @@
     z-index: 1;
     overflow: auto;
     height: 100%;
-
-    @include mid-break {
-      max-height: calc(100% - #{base(4)});
-    }
+    padding-bottom: base(4);
   }
 
   &--is-open {

--- a/src/admin/components/elements/Drawer/index.scss
+++ b/src/admin/components/elements/Drawer/index.scss
@@ -34,9 +34,14 @@
     z-index: 1;
     overflow: auto;
     height: 100%;
+
+    @include mid-break {
+      max-height: calc(100% - #{base(4)});
+    }
   }
 
   &--is-open {
+
     .drawer__content,
     .drawer__blur-bg,
     .drawer__close {

--- a/src/admin/components/elements/ReactSelect/index.scss
+++ b/src/admin/components/elements/ReactSelect/index.scss
@@ -36,6 +36,7 @@
     border-radius: 0;
     @include shadow-lg;
     background: var(--theme-input-bg);
+    position: unset;
   }
 
   .rs__group-heading {

--- a/src/admin/components/views/collections/Edit/Default.tsx
+++ b/src/admin/components/views/collections/Edit/Default.tsx
@@ -80,6 +80,8 @@ const DefaultEditView: React.FC<Props> = (props) => {
 
   const operation = isEditing ? 'update' : 'create';
 
+  const hasSidebarFields = fields.some((field) => field?.admin?.position === 'sidebar');
+
   return (
     <React.Fragment>
       <div className={classes}>
@@ -220,32 +222,37 @@ const DefaultEditView: React.FC<Props> = (props) => {
                           </React.Fragment>
                         )}
                       </div>
-                      <div className={`${baseClass}__sidebar-fields`}>
-                        {(isEditing && preview && (collection.versions?.drafts && !collection.versions?.drafts?.autosave)) && (
-                          <PreviewButton
-                            generatePreviewURL={preview}
-                          />
-                        )}
-                        {collection.versions?.drafts && (
-                          <React.Fragment>
-                            <Status />
-                            {(collection.versions?.drafts.autosave && hasSavePermission) && (
-                              <Autosave
-                                publishedDocUpdatedAt={publishedDoc?.updatedAt || data?.createdAt}
-                                collection={collection}
-                                id={id}
+                      {(hasSidebarFields || preview || collection.versions?.drafts)
+                        && (
+                          <div className={`${baseClass}__sidebar-fields`}>
+                            {(isEditing && preview && (collection.versions?.drafts && !collection.versions?.drafts?.autosave)) && (
+                              <PreviewButton
+                                generatePreviewURL={preview}
                               />
                             )}
-                          </React.Fragment>
+                            {collection.versions?.drafts && (
+                              <React.Fragment>
+                                <Status />
+                                {(collection.versions?.drafts.autosave && hasSavePermission) && (
+                                  <Autosave
+                                    publishedDocUpdatedAt={publishedDoc?.updatedAt || data?.createdAt}
+                                    collection={collection}
+                                    id={id}
+                                  />
+                                )}
+                              </React.Fragment>
+                            )}
+                            {hasSidebarFields && (
+                              <RenderFields
+                                readOnly={!hasSavePermission}
+                                permissions={permissions.fields}
+                                filter={(field) => field?.admin?.position === 'sidebar'}
+                                fieldTypes={fieldTypes}
+                                fieldSchema={fields}
+                              />
+                            )}
+                          </div>
                         )}
-                        <RenderFields
-                          readOnly={!hasSavePermission}
-                          permissions={permissions.fields}
-                          filter={(field) => field?.admin?.position === 'sidebar'}
-                          fieldTypes={fieldTypes}
-                          fieldSchema={fields}
-                        />
-                      </div>
                       {
                         isEditing && (
                           <ul className={`${baseClass}__meta`}>

--- a/src/admin/components/views/collections/Edit/index.scss
+++ b/src/admin/components/views/collections/Edit/index.scss
@@ -75,7 +75,7 @@
     top: 0;
     z-index: var(--z-nav);
 
-    > * {
+    >* {
       position: relative;
       z-index: 1;
     }
@@ -234,6 +234,12 @@
 
     &__sidebar {
       padding-bottom: base(3.5);
+    }
+  }
+
+  @include small-break {
+    &__sidebar {
+      padding: 0 base(1);
     }
   }
 }


### PR DESCRIPTION
## Description

#2355

Select dropdown was getting obscured by the bottom `save` banner. 

This change:

- Adjusts the drawer content wrap height so it ends at the banner instead of overlapping. 
- Conditionally renders the sidebar fields to prevent empty space in drawer on mobile.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
