### PR TITLE
Fix/admin thumbnail base64

### DIFF
--- a/src/admin/hooks/useThumbnail.ts
+++ b/src/admin/hooks/useThumbnail.ts
@@ -1,6 +1,7 @@
 import { useConfig } from '../components/utilities/Config';
 import { SanitizedCollectionConfig } from '../../collections/config/types';
 import isImage from '../../uploads/isImage';
+import isBase64Image from '../../uploads/isBase64Image';
 
 const absoluteURLPattern = new RegExp('^(?:[a-z]+:)?//', 'i');
 
@@ -29,7 +30,7 @@ const useThumbnail = (collection: SanitizedCollectionConfig, doc: Record<string,
     if (typeof adminThumbnail === 'function') {
       const thumbnailURL = adminThumbnail({ doc });
 
-      if (absoluteURLPattern.test(thumbnailURL)) {
+      if (absoluteURLPattern.test(thumbnailURL) || isBase64Image(thumbnailURL)) {
         return thumbnailURL;
       }
 

--- a/src/admin/hooks/useThumbnail.ts
+++ b/src/admin/hooks/useThumbnail.ts
@@ -1,9 +1,9 @@
 import { useConfig } from '../components/utilities/Config';
 import { SanitizedCollectionConfig } from '../../collections/config/types';
 import isImage from '../../uploads/isImage';
-import isBase64Image from '../../uploads/isBase64Image';
 
 const absoluteURLPattern = new RegExp('^(?:[a-z]+:)?//', 'i');
+const base64Pattern = new RegExp(/^data:image\/[a-z]+;base64,/);
 
 const useThumbnail = (collection: SanitizedCollectionConfig, doc: Record<string, unknown>): string | false => {
   const {
@@ -30,7 +30,7 @@ const useThumbnail = (collection: SanitizedCollectionConfig, doc: Record<string,
     if (typeof adminThumbnail === 'function') {
       const thumbnailURL = adminThumbnail({ doc });
 
-      if (absoluteURLPattern.test(thumbnailURL) || isBase64Image(thumbnailURL)) {
+      if (absoluteURLPattern.test(thumbnailURL) || base64Pattern.test(thumbnailURL)) {
         return thumbnailURL;
       }
 

--- a/src/uploads/isBase64Image.ts
+++ b/src/uploads/isBase64Image.ts
@@ -1,0 +1,4 @@
+export default function isBase64Image(image: string): boolean {
+  // Check if the image starts with the base64 prefix
+  return /^data:image\/[a-z]+;base64,/.test(image);
+}

--- a/src/uploads/isBase64Image.ts
+++ b/src/uploads/isBase64Image.ts
@@ -1,4 +1,0 @@
-export default function isBase64Image(image: string): boolean {
-  // Check if the image starts with the base64 prefix
-  return /^data:image\/[a-z]+;base64,/.test(image);
-}


### PR DESCRIPTION
## Description

Correctly returns thumbnail URL in `adminThumbnail` if returned image is of `base64`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
