### PR TITLE
Improve UI/UX of the BlocksDrawer

### DIFF
--- a/src/admin/components/elements/ThumbnailCard/index.tsx
+++ b/src/admin/components/elements/ThumbnailCard/index.tsx
@@ -44,6 +44,7 @@ export const ThumbnailCard: React.FC<Props> = (props) => {
 
   return (
     <div
+      title={title}
       className={classes}
       onClick={typeof onClick === 'function' ? onClick : undefined}
       onKeyDown={typeof onKeyDown === 'function' ? onKeyDown : undefined}

--- a/src/admin/components/forms/field-types/Blocks/BlocksDrawer/index.scss
+++ b/src/admin/components/forms/field-types/Blocks/BlocksDrawer/index.scss
@@ -17,7 +17,7 @@
 
   &__block {
     margin: base(0.5);
-    width: calc(12.5% - #{base(1)});
+    width: calc((100% / 6) - #{base(1)});
   }
 
   &__default-image {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

This PR closes #2343 by making that the `BlocksDrawer` renders 6 columns on larger screens instead of 8, which makes them wider. It also adds the `title` attribute to the `ThumbnailCard` so that even if a long title gets cut off, if the user hovers on it they get a native tooltip with the full title.

![Screenshot 2023-03-18 at 10 14 03 p m](https://user-images.githubusercontent.com/47041342/226153282-ff531b62-3bd2-43d3-bf1f-707922449c0b.png)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
