### PR TITLE
fix: hide fields with admin.hidden attribute

### DIFF
--- a/src/admin/components/elements/TableColumns/buildColumns.tsx
+++ b/src/admin/components/elements/TableColumns/buildColumns.tsx
@@ -18,8 +18,10 @@ const buildColumns = ({
   columns: Pick<Column, 'accessor' | 'active'>[],
   cellProps: Partial<CellProps>[]
 }): Column[] => {
+  const filteredFields = collection.fields.filter((field) => fieldIsPresentationalOnly(field) || !field.admin?.hidden);
+
   // sort the fields to the order of activeColumns
-  const sortedFields = flattenFields(collection.fields, true).sort((a, b) => {
+  const sortedFields = flattenFields(filteredFields, true).sort((a, b) => {
     const aIndex = columns.findIndex((column) => column.accessor === a.name);
     const bIndex = columns.findIndex((column) => column.accessor === b.name);
     if (aIndex === -1 && bIndex === -1) return 0;

--- a/src/admin/components/views/collections/List/formatFields.tsx
+++ b/src/admin/components/views/collections/List/formatFields.tsx
@@ -6,7 +6,7 @@ import { Field, fieldAffectsData, fieldIsPresentationalOnly } from '../../../../
 const formatFields = (config: SanitizedCollectionConfig, t: TFunction): Field[] => {
   const hasID = config.fields.findIndex((field) => fieldAffectsData(field) && field.name === 'id') > -1;
   const fields: Field[] = config.fields.reduce((formatted, field) => {
-    if (!fieldIsPresentationalOnly(field) && (field.hidden === true || field?.admin?.disabled === true)) {
+    if (!fieldIsPresentationalOnly(field) && (field.hidden === true || field.admin?.hidden === true || field.admin?.disabled === true)) {
       return formatted;
     }
 


### PR DESCRIPTION
## Description

Make sure fields that have `admin.hidden = true` are not shown in the Admin UI.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
