### PR TITLE
fix: textarea field overlap in UI

### DIFF
--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -3,6 +3,7 @@
 .field-type.textarea {
   position: relative;
   margin-bottom: $baseline;
+  padding-bottom: base(2.5);
 
   .textarea-outer {
     @include formInput();
@@ -81,5 +82,9 @@
   .textarea-clone::after {
     content: attr(data-after);
     opacity: 0.5;
+  }
+
+  @include mid-break {
+    padding: 0;
   }
 }


### PR DESCRIPTION
## Description

#2374 

Textarea field overlapping in the UI on desktop (not an issue on mobile).

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes

Before:
![Screen Shot 2023-03-27 at 10 08 08 AM](https://user-images.githubusercontent.com/67977755/227896917-c0272290-39b5-4aa8-befd-f789171cc4ae.png)


After:
![Screen Shot 2023-03-27 at 10 08 38 AM](https://user-images.githubusercontent.com/67977755/227896952-728ddc01-54dd-403c-9384-e167b491c2a9.png)

