### PR TITLE
docs: Add image showcases of fields: point, checkbox, code, collapsible, email, group, json, number, radio

### DIFF
--- a/docs/fields/checkbox.mdx
+++ b/docs/fields/checkbox.mdx
@@ -12,7 +12,6 @@ keywords: checkbox, fields, config, configuration, documentation, Content Manage
 
 ![Checkbox field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228344152-d48b0a2b-0789-426f-b1ac-359c76afe2ca.jpg)
 
-
 ### Config
 
 | Option           | Description |

--- a/docs/fields/checkbox.mdx
+++ b/docs/fields/checkbox.mdx
@@ -10,6 +10,9 @@ keywords: checkbox, fields, config, configuration, documentation, Content Manage
   The Checkbox field type saves a boolean in the database.
 </Banner>
 
+![Checkbox field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228344152-d48b0a2b-0789-426f-b1ac-359c76afe2ca.jpg)
+
+
 ### Config
 
 | Option           | Description |

--- a/docs/fields/code.mdx
+++ b/docs/fields/code.mdx
@@ -15,7 +15,6 @@ This field uses the `monaco-react` editor syntax highlighting.
 
 ![Code field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228344650-d672d5bb-872d-4354-9169-5862f2bbd3f1.jpg)
 
-
 ### Config
 
 | Option           | Description |

--- a/docs/fields/code.mdx
+++ b/docs/fields/code.mdx
@@ -13,6 +13,9 @@ keywords: code, fields, config, configuration, documentation, Content Management
 
 This field uses the `monaco-react` editor syntax highlighting.
 
+![Code field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228344650-d672d5bb-872d-4354-9169-5862f2bbd3f1.jpg)
+
+
 ### Config
 
 | Option           | Description |

--- a/docs/fields/collapsible.mdx
+++ b/docs/fields/collapsible.mdx
@@ -10,6 +10,9 @@ keywords: row, fields, config, configuration, documentation, Content Management 
   The Collapsible field is presentational-only and only affects the Admin panel. By using it, you can place fields within a nice layout component that can be collapsed / expanded.
 </Banner>
 
+![Collapsible field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228345163-02b0c9b5-e152-4e40-887c-39698ba9f62e.gif)
+
+
 ### Config
 
 | Option         | Description                                                               |

--- a/docs/fields/collapsible.mdx
+++ b/docs/fields/collapsible.mdx
@@ -10,8 +10,7 @@ keywords: row, fields, config, configuration, documentation, Content Management 
   The Collapsible field is presentational-only and only affects the Admin panel. By using it, you can place fields within a nice layout component that can be collapsed / expanded.
 </Banner>
 
-![Collapsible field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228345163-02b0c9b5-e152-4e40-887c-39698ba9f62e.gif)
-
+![Collapsible field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228345471-925bb08a-7415-491a-838c-b2f5d19b679a.gif)
 
 ### Config
 

--- a/docs/fields/email.mdx
+++ b/docs/fields/email.mdx
@@ -10,6 +10,8 @@ keywords: email, fields, config, configuration, documentation, Content Managemen
   The Email field enforces that the value provided is a valid email address.
 </Banner>
 
+![Email field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228346248-00090635-5ec1-4c5e-aeb3-9784044b4218.jpg)
+
 ### Config
 
 | Option           | Description |

--- a/docs/fields/group.mdx
+++ b/docs/fields/group.mdx
@@ -10,6 +10,8 @@ keywords: group, fields, config, configuration, documentation, Content Managemen
   The Group field allows fields to be nested under a common property name. It also groups fields together visually in the Admin panel.
 </Banner>
 
+![Group field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228346627-d4e87eaa-bcc9-40e5-89c8-faea14fd4eb3.jpg)
+
 ### Config
 
 | Option           | Description |

--- a/docs/fields/json.mdx
+++ b/docs/fields/json.mdx
@@ -13,6 +13,8 @@ keywords: json, fields, config, configuration, documentation, Content Management
 
 This field uses the `monaco-react` editor syntax highlighting.
 
+![JSON field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228347143-4b031d06-0aa2-45bf-bbfd-b716e2d83743.jpg)
+
 ### Config
 
 | Option           | Description |

--- a/docs/fields/number.mdx
+++ b/docs/fields/number.mdx
@@ -10,6 +10,8 @@ keywords: number, fields, config, configuration, documentation, Content Manageme
   The Number field stores and validates numeric entry and supports additional numerical validation and formatting features.
 </Banner>
 
+![Number field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228347443-eed6ed0c-9b0d-4aca-9fe9-eba8008cbd5b.jpg)
+
 ### Config
 
 | Option           | Description |

--- a/docs/fields/point.mdx
+++ b/docs/fields/point.mdx
@@ -50,6 +50,8 @@ const ExampleCollection: CollectionConfig = {
   ]
 };
 ```
+![Point field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228343287-d873bbbb-36c6-477f-af35-0982b3ee84c9.jpg)
+
 
 ### Querying
 

--- a/docs/fields/point.mdx
+++ b/docs/fields/point.mdx
@@ -13,6 +13,8 @@ keywords: point, geolocation, geospatial, geojson, 2dsphere, config, configurati
 
 The data structure in the database matches the GeoJSON structure to represent point. The Payload APIs simplifies the object data to only the [longitude, latitude] location.
 
+![Point field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228343287-d873bbbb-36c6-477f-af35-0982b3ee84c9.jpg)
+
 ### Config
 
 | Option           | Description |
@@ -50,8 +52,6 @@ const ExampleCollection: CollectionConfig = {
   ]
 };
 ```
-![Point field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228343287-d873bbbb-36c6-477f-af35-0982b3ee84c9.jpg)
-
 
 ### Querying
 

--- a/docs/fields/radio.mdx
+++ b/docs/fields/radio.mdx
@@ -10,6 +10,8 @@ keywords: radio, fields, config, configuration, documentation, Content Managemen
   The Radio Group field type allows for the selection of one value from a predefined set of possible values and presents a radio group-style set of inputs to the Admin panel.
 </Banner>
 
+![Radio field in Payload admin panel](https://user-images.githubusercontent.com/70709113/228347659-a91acb83-5711-47ab-a50a-3a12bdf6e2fa.jpg)
+
 ### Config
 
 | Option           | Description |


### PR DESCRIPTION
I, personally, really would like to see what the fields showcased in the docs look like before using them, just like it's done with the Arrays and Blocks field. This covers some more fields, where an example preview is shown.

[images.zip](https://github.com/payloadcms/payload/files/11093513/images.zip)