### PR TITLE
chore: export formatListDrawerSlug

### DIFF
--- a/src/admin/components/elements/ListDrawer/index.tsx
+++ b/src/admin/components/elements/ListDrawer/index.tsx
@@ -10,7 +10,7 @@ import './index.scss';
 
 export const baseClass = 'list-drawer';
 
-const formatListDrawerSlug = ({
+export const formatListDrawerSlug = ({
   depth,
   uuid,
 }: {


### PR DESCRIPTION
## Description

I'd like to use this method in my plugin. Since `formatDrawerSlug` is already exported & used in my project, why not export `formatListDrawerSlug` as well?

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
