### PR TITLE
Configuration extension point

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -27,8 +27,9 @@ It's often best practice to write your Collections in separate files and then im
 | **`endpoints`**    | Add custom routes to the REST API. [More](/docs/rest-api/overview#custom-endpoints)                                                                                                                                      |
 | **`graphQL`**      | An object with `singularName` and `pluralName` strings used in schema generation. Auto-generated from slug if not defined.                                                                                               |
 | **`typescript`**   | An object with property `interface` as the text used in schema generation. Auto-generated from slug if not defined.                                                                                                      |
-| **`defaultSort`**  | Pass a top-level field to sort by default in the collection List view. Prefix the name of the field with a minus symbol ("-") to sort in descending order.                                                                |
-| **`pagination`**   | Set pagination-specific options for this collection. [More](#pagination) |
+| **`defaultSort`**  | Pass a top-level field to sort by default in the collection List view. Prefix the name of the field with a minus symbol ("-") to sort in descending order.                                                               |
+| **`pagination`**   | Set pagination-specific options for this collection. [More](#pagination)                                                                                                                                                 |
+| **`custom`**       | Extension point for adding custom data (e.g. for plugins)                                                                                                                                                                |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -25,6 +25,7 @@ As with Collection configs, it's often best practice to write your Globals in se
 | **`endpoints`**    | Add custom routes to the REST API. [More](/docs/rest-api/overview#custom-endpoints)                                                                                                                                  |
 | **`graphQL.name`** | Text used in schema generation. Auto-generated from slug if not defined.                                                                                                                                             |
 | **`typescript`**   | An object with property `interface` as the text used in schema generation. Auto-generated from slug if not defined.                                                                                                  |
+| **`custom`**       | Extension point for adding custom data (e.g. for plugins)                                                                                                                                                            |
 
 _\* An asterisk denotes that a property is required._
 

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -43,6 +43,7 @@ Payload is a _config-based_, code-first CMS and application framework. The Paylo
 | `hooks`               | Tap into Payload-wide hooks. [More](/docs/hooks/overview)                                                                                                                     |
 | `plugins`             | An array of Payload plugins. [More](/docs/plugins/overview)                                                                                                                   |
 | `endpoints`           | An array of custom API endpoints added to the Payload router. [More](/docs/rest-api/overview#custom-endpoints)                                                                |
+| `custom`              | Extension point for adding custom data (e.g. for plugins)                                                                                                                     |
 
 #### Simple example
 

--- a/docs/fields/array.mdx
+++ b/docs/fields/array.mdx
@@ -35,7 +35,8 @@ keywords: array, fields, config, configuration, documentation, Content Managemen
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. If enabled, a separate, localized set of all data within this Array will be kept, so there is no need to specify each nested field as `localized`. |
 | **`required`**       | Require this field to have a value.                                                                                                                                                                                                                                               |
 | **`labels`**         | Customize the row labels appearing in the Admin dashboard.                                                                                                                                                                                                                        |
-| **`admin`**        | Admin-specific configuration. See below for [more detail](#admin-config).                                                                                                                                                                                                         |
+| **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config).                                                                                                                                                                                                         |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins)                                                                                                                                                                                                                         |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -37,6 +37,7 @@ keywords: blocks, fields, config, configuration, documentation, Content Manageme
 | **`unique`**            | Enforce that each entry in the Collection has a unique value for this field.                                                                                                                                                                                                       |
 | **`labels`**            | Customize the block row labels appearing in the Admin dashboard.                                                                                                                                                                                                                   |
 | **`admin`**             | Admin-specific configuration. See below for [more detail](#admin-config).                                                                                                                                                                                                          |
+| **`custom`**            | Extension point for adding custom data (e.g. for plugins)                                                                                                                                                                                                                          |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/checkbox.mdx
+++ b/docs/fields/checkbox.mdx
@@ -26,6 +26,7 @@ keywords: checkbox, fields, config, configuration, documentation, Content Manage
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. |
 | **`required`**       | Require this field to have a value. |
 | **`admin`**          | Admin-specific configuration. See the [default field admin config](/docs/fields/overview#admin-config) for more details. |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/code.mdx
+++ b/docs/fields/code.mdx
@@ -32,6 +32,7 @@ This field uses the `monaco-react` editor syntax highlighting.
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. |
 | **`required`**       | Require this field to have a value. |
 | **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 _\* An asterisk denotes that a property is required._
 

--- a/docs/fields/collapsible.mdx
+++ b/docs/fields/collapsible.mdx
@@ -17,6 +17,7 @@ keywords: row, fields, config, configuration, documentation, Content Management 
 | **`label`** *  | A label to render within the header of the collapsible component. This can be a string, function or react component. Function/components receive `({ data, path })` as args. |
 | **`fields`** * | Array of field types to nest within this Collapsible.                     |
 | **`admin`**    | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**   | Extension point for adding custom data (e.g. for plugins)                 |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -29,6 +29,7 @@ This field uses [`react-datepicker`](https://www.npmjs.com/package/react-datepic
 | **`localized`**    | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config.                                                                     |
 | **`required`**     | Require this field to have a value.                                                                                                                                                                 |
 | **`admin`**        | Admin-specific configuration. See below for [more detail](#admin-config).                                                                                                                           |
+| **`custom`**       | Extension point for adding custom data (e.g. for plugins)                                                                                                                                           |
 
 _\* An asterisk denotes that a property is required._
 

--- a/docs/fields/email.mdx
+++ b/docs/fields/email.mdx
@@ -27,6 +27,7 @@ keywords: email, fields, config, configuration, documentation, Content Managemen
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. |
 | **`required`**       | Require this field to have a value. |
 | **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/group.mdx
+++ b/docs/fields/group.mdx
@@ -25,6 +25,7 @@ keywords: group, fields, config, configuration, documentation, Content Managemen
 | **`defaultValue`**   | Provide an object of data to be used for this field's default value. [More](/docs/fields/overview#default-values) |
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. If enabled, a separate, localized set of all data within this Group will be kept, so there is no need to specify each nested field as `localized`. |
 | **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/json.mdx
+++ b/docs/fields/json.mdx
@@ -30,6 +30,7 @@ This field uses the `monaco-react` editor syntax highlighting.
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. |
 | **`required`**       | Require this field to have a value. |
 | **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 _\* An asterisk denotes that a property is required._
 

--- a/docs/fields/number.mdx
+++ b/docs/fields/number.mdx
@@ -29,6 +29,7 @@ keywords: number, fields, config, configuration, documentation, Content Manageme
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. |
 | **`required`**       | Require this field to have a value. |
 | **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/point.mdx
+++ b/docs/fields/point.mdx
@@ -30,6 +30,7 @@ The data structure in the database matches the GeoJSON structure to represent po
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. |
 | **`required`**       | Require this field to have a value. |
 | **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/radio.mdx
+++ b/docs/fields/radio.mdx
@@ -27,6 +27,7 @@ keywords: radio, fields, config, configuration, documentation, Content Managemen
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. |
 | **`required`**       | Require this field to have a value. |
 | **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/relationship.mdx
+++ b/docs/fields/relationship.mdx
@@ -26,7 +26,7 @@ keywords: relationship, fields, config, configuration, documentation, Content Ma
 | **`filterOptions`** | A query to filter which options appear in the UI and validate against. [More](#filtering-relationship-options).                                                                                     |
 | **`hasMany`**       | Boolean when, if set to `true`, allows this field to have many relations instead of only one.                                                                                                       |
 | **`min`**           | A number for the fewest allowed items during validation when a value is present. Used with `hasMany`.                                                                                               |
-| **`max`**           | A number for the most allowed items during validation when a value is present. Used with `hasMany`.                                                                                        |
+| **`max`**           | A number for the most allowed items during validation when a value is present. Used with `hasMany`.                                                                                                 |
 | **`maxDepth`**      | Sets a number limit on iterations of related documents to populate when queried. [Depth](/docs/getting-started/concepts#depth)                                                                      |
 | **`label`**         | Text used as a field label in the Admin panel or an object with keys for each language.                                                                                                             |
 | **`unique`**        | Enforce that each entry in the Collection has a unique value for this field.                                                                                                                        |
@@ -40,6 +40,7 @@ keywords: relationship, fields, config, configuration, documentation, Content Ma
 | **`localized`**     | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config.                                                                     |
 | **`required`**      | Require this field to have a value.                                                                                                                                                                 |
 | **`admin`**         | Admin-specific configuration. See the [default field admin config](/docs/fields/overview#admin-config) for more details.                                                                            |
+| **`custom`**        | Extension point for adding custom data (e.g. for plugins)                                                                                                                                           |
 
 _\* An asterisk denotes that a property is required._
 

--- a/docs/fields/rich-text.mdx
+++ b/docs/fields/rich-text.mdx
@@ -31,6 +31,7 @@ The Admin component is built on the powerful [`slatejs`](https://docs.slatejs.or
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. |
 | **`required`**       | Require this field to have a value. |
 | **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/row.mdx
+++ b/docs/fields/row.mdx
@@ -16,6 +16,7 @@ keywords: row, fields, config, configuration, documentation, Content Management 
 | ---------------- | ----------- |
 | **`fields`** *       | Array of field types to nest within this Row. |
 | **`admin`**          | Admin-specific configuration excluding `description`, `readOnly`, and `hidden`. See the [default field admin config](/docs/fields/overview#admin-config) for more details. |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/select.mdx
+++ b/docs/fields/select.mdx
@@ -30,6 +30,7 @@ keywords: select, multi-select, fields, config, configuration, documentation, Co
 | **`localized`**    | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config.                                                                     |
 | **`required`**     | Require this field to have a value.                                                                                                                                                                 |
 | **`admin`**        | Admin-specific configuration. See the [default field admin config](/docs/fields/overview#admin-config) for more details.                                                                            |
+| **`custom`**       | Extension point for adding custom data (e.g. for plugins)                                                                                                                                           |
 
 _\* An asterisk denotes that a property is required._
 

--- a/docs/fields/tabs.mdx
+++ b/docs/fields/tabs.mdx
@@ -19,6 +19,7 @@ keywords: tabs, fields, config, configuration, documentation, Content Management
 | ---------------- | ----------- |
 | **`tabs`** *     | Array of tabs to render within this Tabs field. |
 | **`admin`**      | Admin-specific configuration. See the [default field admin config](/docs/fields/overview#admin-config) for more details. |
+| **`custom`**     | Extension point for adding custom data (e.g. for plugins) |
 
 #### Tab-specific Config
 

--- a/docs/fields/text.mdx
+++ b/docs/fields/text.mdx
@@ -29,6 +29,7 @@ keywords: text, fields, config, configuration, documentation, Content Management
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. |
 | **`required`**       | Require this field to have a value. |
 | **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/textarea.mdx
+++ b/docs/fields/textarea.mdx
@@ -29,6 +29,7 @@ keywords: textarea, fields, config, configuration, documentation, Content Manage
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config. |
 | **`required`**       | Require this field to have a value. |
 | **`admin`**          | Admin-specific configuration. See below for [more detail](#admin-config). |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/ui.mdx
+++ b/docs/fields/ui.mdx
@@ -29,6 +29,7 @@ With this field, you can also inject custom `Cell` components that appear as add
 | **`label`**                  | Human-readable label for this UI field.                                                                           |
 | **`admin.components.Field`** | React component to be rendered for this field within the Edit view. [More](/docs/admin/components/#field-component)    |
 | **`admin.components.Cell`**  | React component to be rendered as a Cell within collection List views. [More](/docs/admin/components/#field-component) |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/fields/upload.mdx
+++ b/docs/fields/upload.mdx
@@ -41,6 +41,7 @@ keywords: upload, images media, fields, config, configuration, documentation, Co
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config.                                                                     |
 | **`required`**       | Require this field to have a value.                                                                                                                                                                 |
 | **`admin`**          | Admin-specific configuration. See the [default field admin config](/docs/fields/overview#admin-config) for more details.                                                                            |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
 
 *\* An asterisk denotes that a property is required.*
 

--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -91,6 +91,7 @@ Each endpoint object needs to have:
 | **`method`**   | The lowercase HTTP verb to use: 'get', 'head', 'post', 'put', 'delete', 'connect' or 'options' |
 | **`handler`**  | A function or array of functions to be called with **req**, **res** and **next** arguments. [Express](https://expressjs.com/en/guide/routing.html#route-handlers) |
 | **`root`**     | When `true`, defines the endpoint on the root Express app, bypassing Payload handlers and the `routes.api` subpath. Note: this only applies to top-level endpoints of your Payload config, endpoints defined on `collections` or `globals` cannot be root. |
+| **`custom`**   | Extension point for adding custom data (e.g. for plugins) |
 
 Example:
 

--- a/src/collections/config/defaults.ts
+++ b/src/collections/config/defaults.ts
@@ -39,6 +39,7 @@ export const defaults = {
   auth: false,
   upload: false,
   versions: false,
+  custom: {},
 };
 
 export const authDefaults = {

--- a/src/collections/config/schema.ts
+++ b/src/collections/config/schema.ts
@@ -187,6 +187,7 @@ const collectionSchema = joi.object().keys({
     }),
     joi.boolean(),
   ),
+  custom: joi.object().pattern(joi.string(), joi.any()),
 });
 
 export default collectionSchema;

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -304,6 +304,8 @@ export type CollectionConfig = {
    * @default true
    */
   timestamps?: boolean
+  /** Extension  point to add your custom data. */
+  custom?: Record<string, any>;
 };
 
 export interface SanitizedCollectionConfig extends Omit<DeepRequired<CollectionConfig>, 'auth' | 'upload' | 'fields' | 'versions'> {

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -308,11 +308,12 @@ export type CollectionConfig = {
   custom?: Record<string, any>;
 };
 
-export interface SanitizedCollectionConfig extends Omit<DeepRequired<CollectionConfig>, 'auth' | 'upload' | 'fields' | 'versions'> {
+export interface SanitizedCollectionConfig extends Omit<DeepRequired<CollectionConfig>, 'auth' | 'upload' | 'fields' | 'versions'| 'endpoints'> {
   auth: Auth;
   upload: Upload;
   fields: Field[];
-  versions: SanitizedCollectionVersions
+  versions: SanitizedCollectionVersions;
+  endpoints: Omit<Endpoint, 'root'>[];
 }
 
 export type Collection = {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -55,4 +55,5 @@ export const defaults: Config = {
   hooks: {},
   localization: false,
   telemetry: true,
+  custom: {},
 };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -13,6 +13,7 @@ export const endpointsSchema = joi.array().items(joi.object({
     joi.array().items(joi.func()),
     joi.func(),
   ),
+  custom: joi.object().pattern(joi.string(), joi.any()),
 }));
 
 export default joi.object({
@@ -162,4 +163,5 @@ export default joi.object({
   ),
   onInit: joi.func(),
   debug: joi.boolean(),
+  custom: joi.object().pattern(joi.string(), joi.any()),
 });

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -535,10 +535,11 @@ export type Config = {
 
 export type SanitizedConfig = Omit<
   DeepRequired<Config>,
-  'collections' | 'globals'
+  'collections' | 'globals' | 'endpoint'
 > & {
   collections: SanitizedCollectionConfig[];
   globals: SanitizedGlobalConfig[];
+  endpoints: Endpoint[];
   paths: {
     configDir: string
     config: string

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -189,6 +189,8 @@ export type Endpoint = {
    * @default false
    */
   root?: boolean;
+  /** Extension  point to add your custom data. */
+  custom?: Record<string, any>;
 };
 
 export type AdminView = React.ComponentType<{
@@ -527,6 +529,8 @@ export type Config = {
   telemetry?: boolean;
   /** A function that is called immediately following startup that receives the Payload instance as its only argument. */
   onInit?: (payload: Payload) => Promise<void> | void;
+  /** Extension  point to add your custom data. */
+  custom?: Record<string, any>;
 };
 
 export type SanitizedConfig = Omit<

--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -52,6 +52,7 @@ export const baseField = joi.object().keys({
       afterRead: joi.array().items(joi.func()).default([]),
     }).default(),
   admin: baseAdminFields.default(),
+  custom: joi.object().pattern(joi.string(), joi.any()),
 }).default();
 
 export const idField = baseField.keys({

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -121,6 +121,8 @@ export interface FieldBase {
     read?: FieldAccess;
     update?: FieldAccess;
   };
+  /** Extension  point to add your custom data. */
+  custom?: Record<string, any>;
 }
 
 export type NumberField = FieldBase & {
@@ -241,6 +243,8 @@ export type UIField = {
     }
   }
   type: 'ui';
+  /** Extension  point to add your custom data. */
+  custom?: Record<string, any>;
 }
 
 export type UploadField = FieldBase & {

--- a/src/globals/config/sanitize.ts
+++ b/src/globals/config/sanitize.ts
@@ -51,6 +51,8 @@ const sanitizeGlobals = (collections: CollectionConfig[], globals: GlobalConfig[
       }
     }
 
+    if (!sanitizedGlobal.custom) sanitizedGlobal.custom = {};
+
     // /////////////////////////////////
     // Sanitize fields
     // /////////////////////////////////

--- a/src/globals/config/schema.ts
+++ b/src/globals/config/schema.ts
@@ -66,6 +66,7 @@ const globalSchema = joi.object().keys({
     }),
     joi.boolean(),
   ),
+  custom: joi.object().pattern(joi.string(), joi.any()),
 }).unknown();
 
 export default globalSchema;

--- a/src/globals/config/types.ts
+++ b/src/globals/config/types.ts
@@ -109,6 +109,8 @@ export type GlobalConfig = {
   }
   fields: Field[];
   admin?: GlobalAdminOptions
+  /** Extension  point to add your custom data. */
+  custom?: Record<string, any>;
 }
 
 export interface SanitizedGlobalConfig extends Omit<DeepRequired<GlobalConfig>, 'fields' | 'versions'> {

--- a/src/globals/config/types.ts
+++ b/src/globals/config/types.ts
@@ -113,8 +113,9 @@ export type GlobalConfig = {
   custom?: Record<string, any>;
 }
 
-export interface SanitizedGlobalConfig extends Omit<DeepRequired<GlobalConfig>, 'fields' | 'versions'> {
+export interface SanitizedGlobalConfig extends Omit<DeepRequired<GlobalConfig>, 'fields' | 'versions' | 'endpoints'> {
   fields: Field[]
+  endpoints: Omit<Endpoint, 'root'>[],
   versions: SanitizedGlobalVersions
 }
 

--- a/test/config/config.ts
+++ b/test/config/config.ts
@@ -1,0 +1,65 @@
+import { buildConfig } from '../buildConfig';
+import { openAccess } from '../helpers/configHelpers';
+import { Config } from '../../src/config/types';
+
+const config: Config = {
+  collections: [
+    {
+      slug: 'pages',
+      access: openAccess,
+      endpoints: [
+        {
+          path: '/hello',
+          method: 'get',
+          handler: (_, res): void => {
+            res.json({ message: 'hi' });
+          },
+          custom: { examples: [{ type: 'response', value: { message: 'hi' } }] },
+        },
+      ],
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          custom: { description: 'The title of this page' },
+        },
+      ],
+      custom: { externalLink: 'https://foo.bar' },
+    },
+  ],
+  globals: [
+    {
+      slug: 'my-global',
+      endpoints: [{
+        path: '/greet',
+        method: 'get',
+        handler: (req, res): void => {
+          const { name } = req.query;
+          res.json({ message: `Hi ${name}!` });
+        },
+        custom: { params: [{ in: 'query', name: 'name', type: 'string' }] },
+      }],
+      fields: [{
+        name: 'title',
+        type: 'text',
+        custom: { description: 'The title of my global' },
+      },
+      ],
+      custom: { foo: 'bar' },
+    },
+  ],
+  endpoints: [
+    {
+      path: '/config',
+      method: 'get',
+      root: true,
+      handler: (req, res): void => {
+        res.json(req.payload.config);
+      },
+      custom: { description: 'Get the sanitized payload config' },
+    },
+  ],
+  custom: { name: 'Customer portal' },
+};
+
+export default buildConfig(config);

--- a/test/config/int.spec.ts
+++ b/test/config/int.spec.ts
@@ -1,0 +1,66 @@
+import { initPayloadTest } from '../helpers/configHelpers';
+import payload from '../../src';
+
+require('isomorphic-fetch');
+
+describe('Config', () => {
+  beforeAll(async () => {
+    await initPayloadTest({ __dirname, init: { local: true } });
+  });
+
+  describe('payload config', () => {
+    it('allows a custom field at the config root', () => {
+      const { config } = payload;
+      expect(config.custom).toEqual({ name: 'Customer portal' });
+    });
+
+    it('allows a custom field in the root endpoints', () => {
+      const [endpoint] = payload.config.endpoints;
+
+      expect(endpoint.custom).toEqual({ description: 'Get the sanitized payload config' });
+    });
+  });
+
+  describe('collection config', () => {
+    it('allows a custom field in collections', () => {
+      const [collection] = payload.config.collections;
+      expect(collection.custom).toEqual({ externalLink: 'https://foo.bar' });
+    });
+
+    it('allows a custom field in collection endpoints', () => {
+      const [collection] = payload.config.collections;
+      const [endpoint] = collection.endpoints;
+
+      expect(endpoint.custom).toEqual({ examples: [{ type: 'response', value: { message: 'hi' } }] });
+    });
+
+    it('allows a custom field in collection fields', () => {
+      const [collection] = payload.config.collections;
+      const [field] = collection.fields;
+
+      expect(field.custom).toEqual({ description: 'The title of this page' });
+    });
+  });
+
+
+  describe('global config', () => {
+    it('allows a custom field in globals', () => {
+      const [global] = payload.config.globals;
+      expect(global.custom).toEqual({ foo: 'bar' });
+    });
+
+    it('allows a custom field in global endpoints', () => {
+      const [global] = payload.config.globals;
+      const [endpoint] = global.endpoints;
+
+      expect(endpoint.custom).toEqual({ params: [{ in: 'query', name: 'name', type: 'string' }] });
+    });
+
+    it('allows a custom field in global fields', () => {
+      const [global] = payload.config.globals;
+      const [field] = global.fields;
+
+      expect(field.custom).toEqual({ description: 'The title of my global' });
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR adds a field called `custom` as extension point on several places in the config, like discussed here: GH-2369
The `custom` field, which has type `Record<string, any>` is added at the following locations:
- payload (root) config
- collections
- globals
- fields
- endpoints
I've decided to call the field `custom`, because I thought naming it `plugins` might be confusing, since there's already a field with that name in the config, which has a totally different purpose and also the usage of this new field is not restricted to plugins only. Of course I'm open to any other naming suggestions.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
