### PR TITLE
fix: originalDoc being mutated in beforeChange field hooks

### DIFF
--- a/src/fields/hooks/beforeChange/cloneDataFromOriginalDoc.ts
+++ b/src/fields/hooks/beforeChange/cloneDataFromOriginalDoc.ts
@@ -1,0 +1,13 @@
+export const cloneDataFromOriginalDoc = (originalDocData: unknown): unknown => {
+  if (Array.isArray(originalDocData)) {
+    return originalDocData.map((row) => ({
+      ...row,
+    }));
+  }
+
+  if (typeof originalDocData === 'object' && originalDocData !== null) {
+    return { ...originalDocData };
+  }
+
+  return originalDocData;
+};

--- a/src/fields/hooks/beforeChange/promise.ts
+++ b/src/fields/hooks/beforeChange/promise.ts
@@ -6,6 +6,7 @@ import { PayloadRequest } from '../../../express/types';
 import getValueWithDefault from '../../getDefaultValue';
 import { traverseFields } from './traverseFields';
 import { getExistingRowDoc } from './getExistingRowDoc';
+import { cloneDataFromOriginalDoc } from './cloneDataFromOriginalDoc';
 
 type Args = {
   data: Record<string, unknown>
@@ -60,9 +61,9 @@ export const promise = async ({
       // If no incoming data, but existing document data is found, merge it in
       if (typeof siblingDoc[field.name] !== 'undefined') {
         if (field.localized && typeof siblingDocWithLocales[field.name] === 'object' && siblingDocWithLocales[field.name] !== null) {
-          siblingData[field.name] = siblingDocWithLocales[field.name][req.locale];
+          siblingData[field.name] = cloneDataFromOriginalDoc(siblingDocWithLocales[field.name][req.locale]);
         } else {
-          siblingData[field.name] = siblingDoc[field.name];
+          siblingData[field.name] = cloneDataFromOriginalDoc(siblingDoc[field.name]);
         }
 
         // Otherwise compute default value


### PR DESCRIPTION
## Description

Fields within arrays and blocks on `originalDoc` were being mutated by `beforeChange` hooks. This fixes that.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
