### PR TITLE
feat: allow extra attribute for fields

### DIFF
--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -52,6 +52,7 @@ export const baseField = joi.object().keys({
       afterRead: joi.array().items(joi.func()).default([]),
     }).default(),
   admin: baseAdminFields.default(),
+  extra: joi.any(),
 }).default();
 
 export const idField = baseField.keys({

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -121,6 +121,7 @@ export interface FieldBase {
     read?: FieldAccess;
     update?: FieldAccess;
   };
+  extra?: unknown;
 }
 
 export type NumberField = FieldBase & {

--- a/test/_community/collections/Posts/index.ts
+++ b/test/_community/collections/Posts/index.ts
@@ -8,9 +8,6 @@ export const PostsCollection: CollectionConfig = {
     {
       name: 'text',
       type: 'text',
-      extra: {
-        test: true,
-      },
     },
   ],
 };

--- a/test/_community/collections/Posts/index.ts
+++ b/test/_community/collections/Posts/index.ts
@@ -8,6 +8,9 @@ export const PostsCollection: CollectionConfig = {
     {
       name: 'text',
       type: 'text',
+      extra: {
+        test: true,
+      },
     },
   ],
 };


### PR DESCRIPTION
## Description

This allows you to add "extra:" as an attribute to any fields. Example:
![WebStorm 2023-04-04 at 21 59 11@2x](https://user-images.githubusercontent.com/70709113/229906397-107bbf40-54de-431f-869f-67f3feee795b.jpg)

## Why this is useful

Copied from discord: https://discord.com/channels/967097582721572934/1092895968623591444

The goal is to be able to read extra information information through a plugin.

E.g. something like:
```ts
{
            name: 'textArea',
            type: 'textarea',
            extraInfo: {
              someKey: "val"
            }
},
```

So I can do stuff like:
Find all fields of a **CollectionConfig** which have value XX for key XY

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
