### PR TITLE
Fix: argument order

### DIFF
--- a/src/versions/saveVersion.ts
+++ b/src/versions/saveVersion.ts
@@ -101,12 +101,12 @@ export const saveVersion = async ({
 
   if (max > 0) {
     await enforceMaxVersions({
-      id,
       payload,
-      Model: VersionModel,
-      slug: entityConfig.slug,
-      entityType,
+      VersionModel,
       max,
+      entityConfig.slug,
+      entityType,
+      id,
     });
   }
 


### PR DESCRIPTION
The `enforceMaxVersions` takes arguments in the following order:

```js
{
      payload,
      Model,
      max,
      slug,
      entityType,
      id,
}
```

but it is being called with this order instead:

```js
{
      id,
      payload,
      Model: VersionModel,
      slug: entityConfig.slug,
      entityType,
      max,
}
```