### PR TITLE
fix: increase line height for global title

### DIFF
--- a/src/admin/components/views/Global/index.scss
+++ b/src/admin/components/views/Global/index.scss
@@ -20,6 +20,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       margin: 0;
+      line-height: 1.25;
     }
 
     margin-bottom: base(1);


### PR DESCRIPTION
## Description

#2431 

Increases title line height in Global view to save space for diacritics.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

Before
<img width="744" alt="Screen Shot 2023-04-10 at 2 40 52 PM" src="https://user-images.githubusercontent.com/67977755/230913051-4e46df30-1f7b-4bbd-9cff-ea33eb05c447.png">

After
<img width="747" alt="Screen Shot 2023-04-10 at 2 41 04 PM" src="https://user-images.githubusercontent.com/67977755/230913046-d2b23c78-9d24-4433-9f3c-a492d8516d2f.png">


