### PR TITLE
fix: updates location of error background to fill entire textarea

### DIFF
--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -22,8 +22,8 @@
   }
 
   &.error {
-    textarea {
-      background-color: var(--theme-error-200);
+    .textarea-outer {
+      background: var(--theme-error-200);
     }
   }
 


### PR DESCRIPTION
## Description

#2440 

Updates the location of where error background color gets set to fill entire textarea.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Before:
![Screen Shot 2023-04-10 at 12 21 07 PM](https://user-images.githubusercontent.com/35232443/230946457-b0415831-3f8c-4a70-9b3b-98d5514934e8.png)

After: 
![Screen Shot 2023-04-10 at 12 21 26 PM](https://user-images.githubusercontent.com/35232443/230946464-b2d2ccfb-3790-4b05-bc77-d913c8ea8fbd.png)


## Checklist:

- [x] Existing test suite passes locally with my changes
