### PR TITLE
fix: properly awaits email send to catch potential failures #2444

### DIFF
--- a/src/email/sendEmail.ts
+++ b/src/email/sendEmail.ts
@@ -2,9 +2,10 @@ import { SendMailOptions } from 'nodemailer';
 
 export default async function sendEmail(message: SendMailOptions): Promise<unknown> {
   let result;
+
   try {
     const email = await this.email;
-    result = email.transport.sendMail(message);
+    result = await email.transport.sendMail(message);
   } catch (err) {
     this.logger.error(
       `Failed to send mail to ${message.to}, subject: ${message.subject}`,
@@ -12,5 +13,6 @@ export default async function sendEmail(message: SendMailOptions): Promise<unkno
     );
     return err;
   }
+
   return result;
 }

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -34,6 +34,29 @@ export const customIdSlug = 'custom-id';
 export const customIdNumberSlug = 'custom-id-number';
 
 export default buildConfig({
+  endpoints: [
+    {
+      path: '/send-test-email',
+      method: 'get',
+      handler: async (req, res) => {
+        await req.payload.sendEmail({
+          from: 'dev@payloadcms.com',
+          to: devUser.email,
+          subject: 'Test Email',
+          html: 'This is a test email.',
+          // to recreate a failing email transport, add the following credentials
+          // to the `email` property of `payload.init()` in `../dev.ts`
+          // the app should fail to send the email, but the error should be handled without crashing the app
+          // transportOptions: {
+          //   host: 'smtp.ethereal.email',
+          //   port: 587,
+          // },
+        });
+
+        res.status(200).send('Email sent');
+      },
+    },
+  ],
   collections: [
     {
       slug,


### PR DESCRIPTION
## Description

Resolves #2444 by awaiting `email.transport.sendMail` and catching potential failures.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
