### PR TITLE
Fix/2428 media access mutation

### DIFF
--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -166,7 +166,6 @@ The `useDocumentInfo` hook provides lots of information about the document curre
 |---------------------------|--------------------------------------------------------------------------------------------------------------------|                                |
 | **`collection`**          | If the doc is a collection, its collection config will be returned                                                 |
 | **`global`**              | If the doc is a global, its global config will be returned                                                         |
-| **`type`**                | The type of document being edited (collection or global)                                                           |
 | **`id`**                  | If the doc is a collection, its ID will be returned                                                                |
 | **`preferencesKey`**      | The `preferences` key to use when interacting with document-level user preferences                                 |
 | **`versions`**            | Versions of the current doc                                                                                        |

--- a/src/admin/components/forms/field-types/Array/index.tsx
+++ b/src/admin/components/forms/field-types/Array/index.tsx
@@ -63,13 +63,12 @@ const ArrayFieldType: React.FC<Props> = (props) => {
 
   const CustomRowLabel = components?.RowLabel || undefined;
 
-  const { preferencesKey } = useDocumentInfo();
+  const { preferencesKey, id } = useDocumentInfo();
   const { getPreference } = usePreferences();
   const { setPreference } = usePreferences();
   const [rows, dispatchRows] = useReducer(reducer, undefined);
   const formContext = useForm();
   const { user } = useAuth();
-  const { id } = useDocumentInfo();
   const locale = useLocale();
   const operation = useOperation();
   const { t, i18n } = useTranslation('fields');

--- a/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -65,13 +65,12 @@ const BlocksField: React.FC<Props> = (props) => {
 
   const path = pathFromProps || name;
 
-  const { preferencesKey } = useDocumentInfo();
+  const { preferencesKey, id } = useDocumentInfo();
   const { getPreference } = usePreferences();
   const { setPreference } = usePreferences();
   const [rows, dispatchRows] = useReducer(reducer, undefined);
   const formContext = useForm();
   const { user } = useAuth();
-  const { id } = useDocumentInfo();
   const locale = useLocale();
   const operation = useOperation();
   const { dispatchFields, setModified } = formContext;

--- a/src/admin/components/utilities/DocumentInfo/index.tsx
+++ b/src/admin/components/utilities/DocumentInfo/index.tsx
@@ -5,7 +5,7 @@ import qs from 'qs';
 import { useTranslation } from 'react-i18next';
 import { useConfig } from '../Config';
 import { PaginatedDocs } from '../../../../mongoose/types';
-import { ContextType, DocumentPermissions, EntityType, Props, Version } from './types';
+import { ContextType, DocumentPermissions, Props, Version } from './types';
 import { TypeWithID } from '../../../../globals/config/types';
 import { TypeWithTimestamps } from '../../../../collections/config/types';
 import { Where } from '../../../../types';
@@ -14,6 +14,8 @@ import { usePreferences } from '../Preferences';
 import { useAuth } from '../Auth';
 
 const Context = createContext({} as ContextType);
+
+export const useDocumentInfo = (): ContextType => useContext(Context);
 
 export const DocumentInfoProvider: React.FC<Props> = ({
   children,
@@ -32,7 +34,7 @@ export const DocumentInfoProvider: React.FC<Props> = ({
 
   const baseURL = `${serverURL}${api}`;
   let slug: string;
-  let type: EntityType;
+  let type: 'global' | 'collection';
   let pluralType: 'globals' | 'collections';
   let preferencesKey: string;
 
@@ -233,5 +235,3 @@ export const DocumentInfoProvider: React.FC<Props> = ({
     </Context.Provider>
   );
 };
-
-export const useDocumentInfo = (): ContextType => useContext(Context);

--- a/src/admin/components/utilities/DocumentInfo/types.ts
+++ b/src/admin/components/utilities/DocumentInfo/types.ts
@@ -9,13 +9,9 @@ export type Version = TypeWithVersion<any>
 
 export type DocumentPermissions = null | GlobalPermission | CollectionPermission
 
-export type EntityType = 'global' | 'collection'
-
 export type ContextType = {
   collection?: SanitizedCollectionConfig
   global?: SanitizedGlobalConfig
-  type: EntityType
-  /** Slug of the collection or global */
   slug?: string
   id?: string | number
   preferencesKey?: string

--- a/src/admin/components/views/collections/Edit/Upload/index.tsx
+++ b/src/admin/components/views/collections/Edit/Upload/index.tsx
@@ -2,6 +2,7 @@ import React, {
   useState, useRef, useEffect, useCallback,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDocumentInfo } from '../../../../utilities/DocumentInfo';
 import useField from '../../../../forms/useField';
 import Button from '../../../../elements/Button';
 import FileDetails from '../../../../elements/FileDetails';
@@ -40,6 +41,7 @@ const Upload: React.FC<Props> = (props) => {
   const [replacingFile, setReplacingFile] = useState(false);
   const { t } = useTranslation('upload');
   const [doc, setDoc] = useState(reduceFieldsToValues(internalState || {}, true));
+  const { docPermissions } = useDocumentInfo();
 
   const {
     value,
@@ -129,6 +131,8 @@ const Upload: React.FC<Props> = (props) => {
     'field-type',
   ].filter(Boolean).join(' ');
 
+  const canRemoveUpload = docPermissions?.update?.permission && 'delete' in docPermissions && docPermissions?.delete?.permission;
+
   return (
     <div className={classes}>
       <Error
@@ -139,10 +143,10 @@ const Upload: React.FC<Props> = (props) => {
         <FileDetails
           doc={doc}
           collection={collection}
-          handleRemove={() => {
+          handleRemove={canRemoveUpload ? () => {
             setReplacingFile(true);
             setValue(null);
-          }}
+          } : undefined}
         />
       )}
       {(!doc.filename || replacingFile) && (


### PR DESCRIPTION
## Description

Fixes: #2428

As the issue describes, the "x" button on media collection file details should not be shown if a user does not have access to update/delete a media document.

Note that a user without delete access will also not be allowed to update the media file because an update operation will delete the underlying files.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
