### PR TITLE
feat: support email configuration in payload config

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -99,6 +99,7 @@ export default joi.object({
       }),
     webpack: joi.func(),
   }),
+  email: joi.object(),
   i18n: joi.object(),
   defaultDepth: joi.number()
     .min(0)

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -346,6 +346,14 @@ export type Config = {
    * @see https://payloadcms.com/docs/configuration/globals#global-configs
    */
   globals?: GlobalConfig[];
+
+  /**
+   * Email configuration options. This value is overridden by `email` in Payload.init if passed.
+   *
+   * @see https://payloadcms.com/docs/email/overview
+   */
+  email?: EmailOptions;
+
   /**
    * Control the behaviour of the admin internationalisation.
    *

--- a/src/email/build.ts
+++ b/src/email/build.ts
@@ -17,8 +17,8 @@ async function handleTransport(transport: Transporter, email: EmailTransport, lo
   return { ...email, transport };
 }
 
-const ensureConfigHasFrom = (emailConfig) => {
-  if (!emailConfig.fromName || !emailConfig.fromAddress) {
+const ensureConfigHasFrom = (emailConfig: EmailOptions) => {
+  if (!emailConfig?.fromName || !emailConfig?.fromAddress) {
     throw new InvalidConfiguration('Email fromName and fromAddress must be configured when transport is configured');
   }
 };
@@ -28,19 +28,23 @@ const handleMockAccount = async (emailConfig: EmailOptions, logger: Logger) => {
   try {
     mockAccount = await mockHandler(emailConfig);
     const { account: { web, user, pass } } = mockAccount;
-    if (emailConfig.logMockCredentials) {
+    if (emailConfig?.logMockCredentials) {
       logger.info('E-mail configured with mock configuration');
       logger.info(`Log into mock email provider at ${web}`);
       logger.info(`Mock email account username: ${user}`);
       logger.info(`Mock email account password: ${pass}`);
     }
   } catch (err) {
-    logger.error('There was a problem setting up the mock email handler', err);
+    logger.error({ msg: 'There was a problem setting up the mock email handler', err });
   }
   return mockAccount;
 };
 
-export default async function buildEmail(emailConfig: EmailOptions, logger: Logger): BuildEmailResult {
+export default async function buildEmail(emailConfig: EmailOptions | undefined, logger: Logger): BuildEmailResult {
+  if (!emailConfig) {
+    return handleMockAccount(emailConfig, logger);
+  }
+
   if (hasTransport(emailConfig) && emailConfig.transport) {
     ensureConfigHasFrom(emailConfig);
     const email = { ...emailConfig };

--- a/src/email/defaults.ts
+++ b/src/email/defaults.ts
@@ -1,0 +1,6 @@
+import { EmailOptions } from '../config/types';
+
+export const defaults: EmailOptions = {
+  fromName: 'Payload CMS',
+  fromAddress: 'info@payloadcms.com',
+};

--- a/src/email/mockHandler.ts
+++ b/src/email/mockHandler.ts
@@ -2,6 +2,8 @@ import nodemailer from 'nodemailer';
 import { EmailOptions } from '../config/types';
 import { MockEmailHandler } from './types';
 
+import { defaults as emailDefaults } from './defaults';
+
 const mockEmailHandler = async (emailConfig: EmailOptions): Promise<MockEmailHandler> => {
   const testAccount = await nodemailer.createTestAccount();
 
@@ -10,8 +12,8 @@ const mockEmailHandler = async (emailConfig: EmailOptions): Promise<MockEmailHan
     host: 'smtp.ethereal.email',
     port: 587,
     secure: false,
-    fromName: emailConfig?.fromName || 'Payload CMS',
-    fromAddress: emailConfig?.fromAddress || 'info@payloadcms.com',
+    fromName: emailConfig?.fromName || emailDefaults.fromName,
+    fromAddress: emailConfig?.fromAddress || emailDefaults.fromAddress,
     auth: {
       user: testAccount.user,
       pass: testAccount.pass,

--- a/src/email/mockHandler.ts
+++ b/src/email/mockHandler.ts
@@ -10,8 +10,8 @@ const mockEmailHandler = async (emailConfig: EmailOptions): Promise<MockEmailHan
     host: 'smtp.ethereal.email',
     port: 587,
     secure: false,
-    fromName: emailConfig.fromName || 'Payload CMS',
-    fromAddress: emailConfig.fromAddress || 'info@payloadcms.com',
+    fromName: emailConfig?.fromName || 'Payload CMS',
+    fromAddress: emailConfig?.fromAddress || 'info@payloadcms.com',
     auth: {
       user: testAccount.user,
       pass: testAccount.pass,

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -61,6 +61,8 @@ import Logger from './utilities/logger';
 import PreferencesModel from './preferences/model';
 import findConfig from './config/find';
 
+import { defaults as emailDefaults } from './email/defaults';
+
 /**
  * @description Payload
  */
@@ -188,7 +190,8 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
     }
 
     // Configure email service
-    this.emailOptions = options.email ? { ...(options.email) } : this.config.email;
+    const emailOptions = options.email ? { ...(options.email) } : this.config.email;
+    this.emailOptions = emailOptions ?? emailDefaults;
     this.email = buildEmail(this.emailOptions, this.logger);
     this.sendEmail = sendEmail.bind(this);
 

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -161,7 +161,6 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
       throw new Error('Error: missing MongoDB connection URL.');
     }
 
-    this.emailOptions = { ...(options.email) };
     this.secret = crypto
       .createHash('sha256')
       .update(options.secret)
@@ -189,6 +188,7 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
     }
 
     // Configure email service
+    this.emailOptions = options.email ? { ...(options.email) } : this.config.email;
     this.email = buildEmail(this.emailOptions, this.logger);
     this.sendEmail = sendEmail.bind(this);
 

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -191,6 +191,10 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
 
     // Configure email service
     const emailOptions = options.email ? { ...(options.email) } : this.config.email;
+    if (options.email && this.config.email) {
+      this.logger.warn('Email options provided in both init options and config. Using init options.');
+    }
+
     this.emailOptions = emailOptions ?? emailDefaults;
     this.email = buildEmail(this.emailOptions, this.logger);
     this.sendEmail = sendEmail.bind(this);

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -307,6 +307,8 @@ describe('Auth', () => {
         },
       });
 
+      const body = await response.json();
+
       // expect(mailSpy).toHaveBeenCalled();
 
       expect(response.status).toBe(200);

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -307,8 +307,6 @@ describe('Auth', () => {
         },
       });
 
-      const body = await response.json();
-
       // expect(mailSpy).toHaveBeenCalled();
 
       expect(response.status).toBe(200);


### PR DESCRIPTION
## Description

Support email configuration directly in the payload config. Any email configuration being passed into `payload.init` will take precedence to avoid this becoming a breaking change.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
