### PR TITLE
fix: excess padding on textarea

### DIFF
--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -3,7 +3,8 @@
 .field-type.textarea {
   position: relative;
   margin-bottom: $baseline;
-  padding-bottom: base(2.5);
+  display: flex;
+  flex-direction: column;
 
   .textarea-outer {
     @include formInput();

--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -15,7 +15,7 @@
 
     // Scrollbar for giant content
     max-height: calc(100vh - $top-header-offset - calc(#{base(5)}));
-    overflow: auto;
+    overflow: hidden;
 
     @include mid-break {
       max-height: 60vh;


### PR DESCRIPTION
## Description

Previously we added padding to the `textarea` to prevent this overlap happening:
<img width="1049" alt="Screen Shot 2023-04-13 at 10 27 14 AM" src="https://user-images.githubusercontent.com/67977755/231716940-f3372de0-524a-4d3b-a13b-75b62316bb45.png">

However it is causing excess space below the `textarea` field in other places:
<img width="1060" alt="Screen Shot 2023-04-13 at 10 26 38 AM" src="https://user-images.githubusercontent.com/67977755/231717124-c54a546b-59a0-4f9e-82f6-254fcb477a1c.png">

So I have removed the padding, and added `display:flex` to the `textarea` wrap which now looks like this: 
<img width="1056" alt="Screen Shot 2023-04-13 at 10 26 06 AM" src="https://user-images.githubusercontent.com/67977755/231717308-b1a55d63-aa3b-4a46-8c2d-ac93c812b46e.png">

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
