### PR TITLE
fix: read-only styles for textArea and richtext

### DIFF
--- a/src/admin/components/forms/field-types/RichText/index.scss
+++ b/src/admin/components/forms/field-types/RichText/index.scss
@@ -102,7 +102,7 @@
 
   &--read-only {
     .rich-text__editor {
-      background: var(--theme-elevation-200);
+      background-color: var(--theme-elevation-200);
       color: var(--theme-elevation-450);
       padding: base(.5);
 

--- a/src/admin/components/forms/field-types/RichText/index.scss
+++ b/src/admin/components/forms/field-types/RichText/index.scss
@@ -102,7 +102,7 @@
 
   &--read-only {
     .rich-text__editor {
-      background-color: var(--theme-elevation-200);
+      background: var(--theme-elevation-200);
       color: var(--theme-elevation-450);
       padding: base(.5);
 

--- a/src/admin/components/forms/field-types/RichText/index.scss
+++ b/src/admin/components/forms/field-types/RichText/index.scss
@@ -102,7 +102,8 @@
 
   &--read-only {
     .rich-text__editor {
-      background-color: var(--theme-elevation-150);
+      background: var(--theme-elevation-200);
+      color: var(--theme-elevation-450);
       padding: base(.5);
 
       .popup button {
@@ -122,7 +123,7 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background-color: var(--theme-elevation-150);
+        background-color: var(--theme-elevation-200);
         opacity: .85;
         z-index: 2;
         backdrop-filter: unset;

--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -32,6 +32,10 @@
     .textarea-outer {
       background: var(--theme-elevation-200);
       color: var(--theme-elevation-450);
+      &:hover {
+        border-color: var(--theme-elevation-150);
+        @include shadow-sm;
+      }
     }
   }
 

--- a/src/admin/components/forms/field-types/Textarea/index.scss
+++ b/src/admin/components/forms/field-types/Textarea/index.scss
@@ -28,6 +28,13 @@
     }
   }
 
+  &.read-only {
+    .textarea-outer {
+      background: var(--theme-elevation-200);
+      color: var(--theme-elevation-450);
+    }
+  }
+
   // This element takes exactly the same dimensions as the clone
   .textarea-inner {
     display: block;


### PR DESCRIPTION
## Description

This
1. Makes sure that textArea is grayed out if it's read-only (currently, it's not)
2. Makes sure that richText uses `--theme-elevation-200 `instead of `--theme-elevation-150` if it's read-only, to be more consistent with the text and textArea fields. Additionally, I gave it a `color: var(--theme-elevation-450);` as text and textArea are using that too.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
