### PR TITLE
fix(generateTypes): mark 'id' field as required for blocks field

### DIFF
--- a/src/utilities/entityToJSONSchema.ts
+++ b/src/utilities/entityToJSONSchema.ts
@@ -295,6 +295,7 @@ function generateFieldTypes(config: SanitizedConfig, fields: Field[]): {
                       },
                     },
                     required: [
+                      'id',
                       'blockType',
                       ...blockSchema.required,
                     ],


### PR DESCRIPTION
## Description

When generating types for blocks fields, the `id` field was generated as optional (`id?: string`).
I think this is not correct behaviour, because why would a blocks field not have an `id` field? 
If I am missing something, please excuse me.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
