### PR TITLE
fix: proper height data for animated gifs

### DIFF
--- a/src/uploads/generateFileData.ts
+++ b/src/uploads/generateFileData.ts
@@ -108,10 +108,13 @@ export const generateFileData = async <T>({
     }
 
     if (sharpFile) {
+      const metadata = await sharpFile.metadata();
       fileBuffer = await sharpFile.toBuffer({ resolveWithObject: true });
-      ({ mime, ext } = await fromBuffer(fileBuffer.data));
+      ({ mime, ext } = await fromBuffer(fileBuffer.data)); // This is getting an incorrect gif height back.
       fileData.width = fileBuffer.info.width;
-      fileData.height = fileBuffer.info.height;
+
+      // Animated GIFs aggregate the height from every frame, so we need to use divide by number of pages
+      fileData.height = sharpOptions.animated ? (fileBuffer.info.height / metadata.pages) : fileBuffer.info.height;
       fileData.filesize = fileBuffer.data.length;
     } else {
       mime = file.mimetype;

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -54,11 +54,42 @@ export default buildConfig({
       ],
     },
     {
+      slug: 'gif-resize',
+      upload: {
+        staticURL: '/media-gif',
+        staticDir: './media-gif',
+        mimeTypes: ['image/gif'],
+        resizeOptions: {
+          position: 'center',
+          width: 200,
+          height: 200,
+        },
+        formatOptions: {
+          format: 'gif',
+        },
+        imageSizes: [
+          {
+            name: 'small',
+            width: 100,
+            height: 100,
+            formatOptions: { format: 'gif', options: { quality: 90 } },
+          },
+          {
+            name: 'large',
+            width: 1000,
+            height: 1000,
+            formatOptions: { format: 'gif', options: { quality: 90 } },
+          },
+        ],
+      },
+      fields: [],
+    },
+    {
       slug: mediaSlug,
       upload: {
         staticURL: '/media',
         staticDir: './media',
-        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/svg+xml', 'audio/mpeg'],
+        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif', 'image/svg+xml', 'audio/mpeg'],
         resizeOptions: {
           width: 1280,
           height: 720,


### PR DESCRIPTION
## Description

Fixes #2439 

When reading from buffer, animated gifs aggregate the image height for each frame. The number of frames in an animated image is now taken into account when calculating the image data.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
