### PR TITLE
docs: adds decrypt jwt example and references

### DIFF
--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -250,6 +250,8 @@ const Greeting: React.FC = () => {
 };
 ```
 
+To decrypt and verify a user's token checkout this [example](/docs/authentication/overview#decrypt-the-user-token).
+
 ### useConfig
 
 Used to easily fetch the full Payload config.

--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -83,6 +83,45 @@ Successfully logging in returns a `JWT` (JSON web token) which is how a user wil
   You can access the logged in user from access control functions and hooks via the Express <strong>req</strong>. The logged in user is automatically added as the <strong>user</strong> property.
 </Banner>
 
+## Decrypt the user token
+
+The user token is generated from the secret key provided in your `payload.config.ts` and encrypted using SHA-256.
+
+Here is a sample function that can be used to decrypt and verify the token:
+
+```ts
+  const decryptAndVerify = (
+    req: express.Request,
+    res: express.Response,
+  ): string | false => {
+    if (req.cookies['payload-token']) {
+      const hash = crypto
+        .createHash('sha256')
+        .update(process.env.PAYLOAD_SECRET)
+        .digest('hex')
+        .slice(0, 32);
+
+      try {
+        const decoded = jwt.verify(req.cookies['payload-token'], hash, {
+          algorithms: ['HS256'],
+        });
+
+        if (!decoded) return false;
+
+        const { repid } = decoded as jwtResponse;
+
+        return repid;
+      } catch (err) {
+        console.log('Invalid token request.', err);
+        return false;
+      }
+    } else {
+      console.log('Missing token in request.');
+      return false;
+    }
+  };
+```
+
 ### HTTP-only cookies
 
 Payload `login`, `logout`, and `refresh` operations make use of HTTP-only cookies for authentication purposes. HTTP-only cookies are a highly secure method of storing identifiable data on a user's device so that Payload can automatically recognize a returning user until their cookie expires. They are totally protected from common XSS attacks and cannot be read at all via JavaScript in the browser.

--- a/docs/hooks/overview.mdx
+++ b/docs/hooks/overview.mdx
@@ -18,6 +18,7 @@ Example uses:
 - Send a copy of uploaded files to Amazon S3 or similar
 - Automatically add `lastModifiedBy` data to a document to track who changed what over time
 - Encrypt a field's data when it's saved and decrypt it when it's read
+- Decrypt and verify a user's [JWT token](/docs/authentication/overview#decrypt-the-user-token)
 - Send emails when `ContactSubmission`s are created from a public website
 - Integrate with a payment provider like Stripe to automatically process payments when an `Order` is created
 - Securely recalculate order prices on the backend to ensure that the total price for `Order`s that users submit is accurate and valid


### PR DESCRIPTION
## Description

#2441 

Adds example to decrypt and verify the user token, adds links to the example in hooks and admin hooks.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Documentation update

## Checklist:

- [X] I have made corresponding changes to the documentation
