### PR TITLE
feat: add rich-text blockquote toggle, change quote node type to blockquote

### DIFF
--- a/docs/fields/rich-text.mdx
+++ b/docs/fields/rich-text.mdx
@@ -55,6 +55,7 @@ The default `elements` available in Payload are:
 - `h4`
 - `h5`
 - `h6`
+- `blockquote`
 - `link`
 - `ol`
 - `ul`
@@ -154,6 +155,7 @@ const ExampleCollection: CollectionConfig = {
           'h3',
           'h4',
           'link',
+          'blockquote',
           {
             name: 'cta',
             Button: CustomCallToActionButton,

--- a/docs/fields/rich-text.mdx
+++ b/docs/fields/rich-text.mdx
@@ -271,7 +271,7 @@ const serialize = (children) => children.map((node, i) => {
           {serialize(node.children)}
         </h6>
       );
-    case 'quote':
+    case 'blockquote':
       return (
         <blockquote key={i}>
           {serialize(node.children)}

--- a/examples/auth/nextjs/components/RichText/serialize.tsx
+++ b/examples/auth/nextjs/components/RichText/serialize.tsx
@@ -69,7 +69,7 @@ const serialize = (children: Children): React.ReactElement[] =>
         return <h5 key={i}>{serialize(node.children)}</h5>
       case 'h6':
         return <h6 key={i}>{serialize(node.children)}</h6>
-      case 'quote':
+      case 'blockquote':
         return <blockquote key={i}>{serialize(node.children)}</blockquote>
       case 'ul':
         return <ul key={i}>{serialize(node.children)}</ul>

--- a/examples/form-builder/nextjs/components/RichText/serialize.tsx
+++ b/examples/form-builder/nextjs/components/RichText/serialize.tsx
@@ -114,7 +114,7 @@ const serialize = (children: Children): React.ReactElement[] => children.map((no
           {serialize(node.children)}
         </h6>
       );
-    case 'quote':
+    case 'blockquote':
       return (
         <blockquote key={i}>
           {serialize(node.children)}

--- a/examples/preview/nextjs/components/RichText/serialize.tsx
+++ b/examples/preview/nextjs/components/RichText/serialize.tsx
@@ -69,7 +69,7 @@ const serialize = (children: Children): React.ReactElement[] =>
         return <h5 key={i}>{serialize(node.children)}</h5>
       case 'h6':
         return <h6 key={i}>{serialize(node.children)}</h6>
-      case 'quote':
+      case 'blockquote':
         return <blockquote key={i}>{serialize(node.children)}</blockquote>
       case 'ul':
         return <ul key={i}>{serialize(node.children)}</ul>

--- a/examples/redirects/nextjs/components/RichText/serialize.tsx
+++ b/examples/redirects/nextjs/components/RichText/serialize.tsx
@@ -67,7 +67,7 @@ const serialize = (children: Children): React.ReactElement[] =>
         return <h5 key={i}>{serialize(node.children)}</h5>
       case 'h6':
         return <h6 key={i}>{serialize(node.children)}</h6>
-      case 'quote':
+      case 'blockquote':
         return <blockquote key={i}>{serialize(node.children)}</blockquote>
       case 'ul':
         return <ul key={i}>{serialize(node.children)}</ul>

--- a/src/admin/components/forms/field-types/RichText/elements/blockquote/index.scss
+++ b/src/admin/components/forms/field-types/RichText/elements/blockquote/index.scss
@@ -1,0 +1,9 @@
+@import '../../../../../../scss/styles.scss';
+
+.rich-text-blockquote {
+  &[data-slate-node=element] {
+    margin: base(.625) 0;
+    padding-left: base(0.625);
+    border-left: 1px solid var(--theme-elevation-200);
+  }
+}

--- a/src/admin/components/forms/field-types/RichText/elements/blockquote/index.tsx
+++ b/src/admin/components/forms/field-types/RichText/elements/blockquote/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import ElementButton from '../Button';
+import BlockquoteIcon from '../../../../../icons/Blockquote';
+
+import './index.scss';
+
+const Blockquote = ({ attributes, children }) => (
+  <blockquote
+    className="rich-text-blockquote"
+    {...attributes}
+  >
+    {children}
+  </blockquote>
+);
+
+const blockquote = {
+  Button: () => (
+    <ElementButton format="blockquote">
+      <BlockquoteIcon />
+    </ElementButton>
+  ),
+  Element: Blockquote,
+};
+
+export default blockquote;

--- a/src/admin/components/forms/field-types/RichText/elements/index.tsx
+++ b/src/admin/components/forms/field-types/RichText/elements/index.tsx
@@ -5,6 +5,7 @@ import h4 from './h4';
 import h5 from './h5';
 import h6 from './h6';
 import link from './link';
+import blockquote from './blockquote';
 import ol from './ol';
 import ul from './ul';
 import li from './li';
@@ -20,6 +21,7 @@ const elements = {
   h5,
   h6,
   link,
+  blockquote,
   ol,
   ul,
   li,

--- a/src/admin/components/views/Version/RenderFieldsToDiff/fields/Text/richTextToHTML.ts
+++ b/src/admin/components/views/Version/RenderFieldsToDiff/fields/Text/richTextToHTML.ts
@@ -70,6 +70,10 @@ export const richTextToHTML = (content: unknown): string => {
             nodeHTML = `<h6>${richTextToHTML(node.children)}</h6>`;
             break;
 
+          case 'blockquote':
+            nodeHTML = `<blockquote>${richTextToHTML(node.children)}</blockquote>`;
+            break;
+
           case 'ul':
             nodeHTML = `<ul>${richTextToHTML(node.children)}</ul>`;
             break;


### PR DESCRIPTION
## Description

The `blockquote` element inside the rich text editor did not display a functioning toggle. This PR adds the missing blockquote toggle. I have also renamed the node type in various examples and in the docs to be more explicit. I am unsure whether this may cause a breaking change for people relying on this so I left it checked just to be sure.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
