### PR TITLE
Multi value Select draggable enhancement

### DIFF
--- a/src/admin/components/elements/ReactSelect/MultiValue/index.scss
+++ b/src/admin/components/elements/ReactSelect/MultiValue/index.scss
@@ -3,9 +3,13 @@
 .multi-value {
   &.rs__multi-value {
     padding: 0;
-    background: transparent;
+    background: var(--theme-input-bg);
     border: $style-stroke-width-s solid var(--theme-elevation-800);
     line-height: calc(#{$baseline} - #{$style-stroke-width-s * 2});
     margin: base(.25) base(.5) base(.25) 0;
+  }
+
+  &--is-dragging {
+    z-index: 2;
   }
 }

--- a/src/admin/components/elements/ReactSelect/MultiValue/index.tsx
+++ b/src/admin/components/elements/ReactSelect/MultiValue/index.tsx
@@ -26,20 +26,22 @@ export const MultiValue: React.FC<MultiValueProps<OptionType>> = (props) => {
     },
   } = props;
 
-  const classes = [
-    baseClass,
-    className,
-    !isDisabled && 'draggable',
-  ].filter(Boolean).join(' ');
-
   const {
     attributes,
     listeners,
     setNodeRef,
     transform,
+    isDragging,
   } = useDraggableSortable({
     id: value.toString(),
   });
+
+  const classes = [
+    baseClass,
+    className,
+    !isDisabled && 'draggable',
+    isDragging && `${baseClass}--is-dragging`,
+  ].filter(Boolean).join(' ');
 
   return (
     <SelectComponents.MultiValue


### PR DESCRIPTION
## Description
At the moment when dragging around selected options in a `multi value` Select field, the background is transparent and in some cases the label goes underneath other labels. 

This PR enhances this scenario by giving a default background to the labels and applying a z-index when dragging.

Before: 
![image](https://i.gyazo.com/68d47da3ee255f223924eb78965be061.gif)

After:
![image](https://i.gyazo.com/f698da38993df175bc9638f4ab56f634.gif)


- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] Existing test suite passes locally with my changes
