### PR TITLE
fix: query localized fields without localization configured

### DIFF
--- a/src/mongoose/buildQuery.ts
+++ b/src/mongoose/buildQuery.ts
@@ -449,7 +449,7 @@ export class ParamParser {
             // Skip the next iteration, because it's a locale
             i += 1;
             currentPath = `${currentPath}.${nextSegment}`;
-          } else if ('localized' in matchedField && matchedField.localized) {
+          } else if (this.localizationConfig && 'localized' in matchedField && matchedField.localized) {
             currentPath = `${currentPath}.${this.req.locale}`;
           }
 

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -75,6 +75,12 @@ export default buildConfig({
           name: 'number',
           type: 'number',
         },
+        {
+          name: 'fakeLocalization',
+          type: 'text',
+          // field is localized even though the config localization is not on
+          localized: true,
+        },
         // Relationship
         {
           name: 'relationField',

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -469,6 +469,24 @@ describe('collections-rest', () => {
       });
     });
 
+    describe('Edge cases', () => {
+      it('should query a localized field without localization configured', async () => {
+        const test = 'test';
+        await createPost({ fakeLocalization: test });
+
+        const { status, result } = await client.find({
+          query: {
+            fakeLocalization: {
+              equals: test,
+            },
+          },
+        });
+
+        expect(status).toEqual(200);
+        expect(result.docs).toHaveLength(1);
+      });
+    });
+
     describe('Operators', () => {
       it('equals', async () => {
         const valueToQuery = 'valueToQuery';

--- a/test/collections-rest/payload-types.ts
+++ b/test/collections-rest/payload-types.ts
@@ -23,6 +23,7 @@ export interface Post {
   title?: string;
   description?: string;
   number?: number;
+  fakeLocalization?: string;
   relationField?: string | Relation;
   relationHasManyField?: string[] | Relation[];
   relationMultiRelationTo?:
@@ -55,6 +56,7 @@ export interface Post {
             relationTo: 'dummy';
           }
       )[];
+  restrictedField?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -66,6 +68,7 @@ export interface Relation {
 }
 export interface Dummy {
   id: string;
+  title?: string;
   name?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Description

Since Payload v1.7.0 a field that has `localization: true` cannot be queried when the config localization was not set.

https://discord.com/channels/967097582721572934/1098401199268564992/1098401199268564992

This change restores the previous behavior and adds a test case.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
