### PR TITLE
fix: prevent sharp toFormat settings fallthrough by using clone

### DIFF
--- a/src/uploads/imageResizer.ts
+++ b/src/uploads/imageResizer.ts
@@ -56,7 +56,7 @@ export default async function resizeAndSave({
   const sizesToSave: FileToSave[] = [];
   const sizeData = {};
 
-  const sharpInstance = sharp(file.tempFilePath || file.data);
+  const sharpBase = sharp(file.tempFilePath || file.data);
 
   const promises = imageSizes
     .map(async (desiredSize) => {
@@ -71,7 +71,7 @@ export default async function resizeAndSave({
         };
         return;
       }
-      let resized = sharpInstance.resize(desiredSize);
+      let resized = sharpBase.clone().resize(desiredSize);
 
       if (desiredSize.formatOptions) {
         resized = resized.toFormat(desiredSize.formatOptions.format, desiredSize.formatOptions.options);


### PR DESCRIPTION
## Description

Fixes #2526 

We were sharing a common sharp instance and setting `toFormat` options on it. This was being shared between all resizing operations.

With this change, the sharp instances are now isolated between sizes by taking advantage of sharp's [clone](https://sharp.pixelplumbing.com/api-constructor#clone) function.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
