### PR TITLE
Fix/doc drawer access

### DIFF
--- a/src/admin/components/elements/DocumentDrawer/DrawerContent.tsx
+++ b/src/admin/components/elements/DocumentDrawer/DrawerContent.tsx
@@ -23,7 +23,6 @@ import { CollectionPermission } from '../../../../auth';
 
 const Content: React.FC<DocumentDrawerProps> = ({
   collectionSlug,
-  id,
   drawerSlug,
   customHeader,
   onSave,
@@ -37,12 +36,14 @@ const Content: React.FC<DocumentDrawerProps> = ({
   const hasInitializedState = useRef(false);
   const [isOpen, setIsOpen] = useState(false);
   const [collectionConfig] = useRelatedCollections(collectionSlug);
-  const { docPermissions } = useDocumentInfo();
+  const { docPermissions, id } = useDocumentInfo();
 
   const [fields, setFields] = useState(() => formatFields(collectionConfig, true));
 
+  // no need to an additional requests when creating new documents
+  const initialID = useRef(id);
   const [{ data, isLoading: isLoadingDocument, isError }] = usePayloadAPI(
-    (id ? `${serverURL}${api}/${collectionSlug}/${id}` : null),
+    (initialID.current ? `${serverURL}${api}/${collectionSlug}/${initialID.current}` : null),
     { initialParams: { 'fallback-locale': 'null', depth: 0, draft: 'true' } },
   );
 
@@ -51,7 +52,7 @@ const Content: React.FC<DocumentDrawerProps> = ({
   }, [collectionSlug, collectionConfig]);
 
   useEffect(() => {
-    if (isLoadingDocument) {
+    if (isLoadingDocument || hasInitializedState.current) {
       return;
     }
 
@@ -127,7 +128,7 @@ const Content: React.FC<DocumentDrawerProps> = ({
               </Button>
             </div>
             {id && (
-              <IDLabel id={id} />
+              <IDLabel id={id.toString()} />
             )}
           </div>
         ),
@@ -163,7 +164,6 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = (props) => {
     >
       <Content
         {...props}
-        id={id}
         onSave={onSave}
       />
     </DocumentInfoProvider>

--- a/src/admin/components/elements/DocumentDrawer/DrawerContent.tsx
+++ b/src/admin/components/elements/DocumentDrawer/DrawerContent.tsx
@@ -12,20 +12,21 @@ import Button from '../Button';
 import { useConfig } from '../../utilities/Config';
 import { useLocale } from '../../utilities/Locale';
 import { useAuth } from '../../utilities/Auth';
-import { DocumentInfoProvider } from '../../utilities/DocumentInfo';
+import { DocumentInfoProvider, useDocumentInfo } from '../../utilities/DocumentInfo';
 import RenderCustomComponent from '../../utilities/RenderCustomComponent';
 import usePayloadAPI from '../../../hooks/usePayloadAPI';
 import formatFields from '../../views/collections/Edit/formatFields';
 import { useRelatedCollections } from '../../forms/field-types/Relationship/AddNew/useRelatedCollections';
 import IDLabel from '../IDLabel';
 import { baseClass } from '.';
+import { CollectionPermission } from '../../../../auth';
 
-export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
+const Content: React.FC<DocumentDrawerProps> = ({
   collectionSlug,
   id,
   drawerSlug,
-  onSave: onSaveFromProps,
   customHeader,
+  onSave,
 }) => {
   const { serverURL, routes: { api } } = useConfig();
   const { toggleModal, modalState, closeModal } = useModal();
@@ -36,17 +37,18 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   const hasInitializedState = useRef(false);
   const [isOpen, setIsOpen] = useState(false);
   const [collectionConfig] = useRelatedCollections(collectionSlug);
+  const { docPermissions } = useDocumentInfo();
 
   const [fields, setFields] = useState(() => formatFields(collectionConfig, true));
-
-  useEffect(() => {
-    setFields(formatFields(collectionConfig, true));
-  }, [collectionSlug, collectionConfig]);
 
   const [{ data, isLoading: isLoadingDocument, isError }] = usePayloadAPI(
     (id ? `${serverURL}${api}/${collectionSlug}/${id}` : null),
     { initialParams: { 'fallback-locale': 'null', depth: 0, draft: 'true' } },
   );
+
+  useEffect(() => {
+    setFields(formatFields(collectionConfig, true));
+  }, [collectionSlug, collectionConfig]);
 
   useEffect(() => {
     if (isLoadingDocument) {
@@ -81,62 +83,88 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
     }
   }, [isError, t, isOpen, data, drawerSlug, closeModal, isLoadingDocument]);
 
+  if (isError) return null;
+
+  const isEditing = Boolean(id);
+  const apiURL = id ? `${serverURL}${api}/${collectionSlug}/${id}` : null;
+  const action = `${serverURL}${api}/${collectionSlug}${id ? `/${id}` : ''}?locale=${locale}&depth=0&fallback-locale=null`;
+  const hasSavePermission = (isEditing && docPermissions?.update?.permission) || (!isEditing && (docPermissions as CollectionPermission)?.create?.permission);
+  const isLoading = !internalState || !docPermissions || isLoadingDocument;
+
+  return (
+    <RenderCustomComponent
+      DefaultComponent={DefaultEdit}
+      CustomComponent={collectionConfig.admin?.components?.views?.Edit}
+      componentProps={{
+        isLoading,
+        data,
+        id,
+        collection: collectionConfig,
+        permissions: permissions.collections[collectionConfig.slug],
+        isEditing,
+        apiURL,
+        onSave,
+        internalState,
+        hasSavePermission,
+        action,
+        disableEyebrow: true,
+        disableActions: true,
+        me: true,
+        disableLeaveWithoutSaving: true,
+        customHeader: (
+          <div className={`${baseClass}__header`}>
+            <div className={`${baseClass}__header-content`}>
+              <h2 className={`${baseClass}__header-text`}>
+                {!customHeader ? t(!id ? 'fields:addNewLabel' : 'general:editLabel', { label: getTranslation(collectionConfig.labels.singular, i18n) }) : customHeader}
+              </h2>
+              <Button
+                buttonStyle="none"
+                className={`${baseClass}__header-close`}
+                onClick={() => toggleModal(drawerSlug)}
+                aria-label={t('general:close')}
+              >
+                <X />
+              </Button>
+            </div>
+            {id && (
+              <IDLabel id={id} />
+            )}
+          </div>
+        ),
+      }}
+    />
+  );
+};
+
+// First provide the document context using `DocumentInfoProvider`
+// this is so we can utilize the `useDocumentInfo` hook in the `Content` component
+// this drawer is used for both creating and editing documents
+// this means that the `id` may be unknown until the document is created
+export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = (props) => {
+  const { collectionSlug, id: idFromProps, onSave: onSaveFromProps } = props;
+  const [collectionConfig] = useRelatedCollections(collectionSlug);
+  const [id, setId] = useState<string | null>(idFromProps);
+
   const onSave = useCallback<DocumentDrawerProps['onSave']>((args) => {
+    setId(args.doc.id);
+
     if (typeof onSaveFromProps === 'function') {
       onSaveFromProps({
         ...args,
         collectionConfig,
       });
     }
-  }, [collectionConfig, onSaveFromProps]);
-
-  if (isError) return null;
+  }, [onSaveFromProps, collectionConfig]);
 
   return (
     <DocumentInfoProvider
       collection={collectionConfig}
       id={id}
     >
-      <RenderCustomComponent
-        DefaultComponent={DefaultEdit}
-        CustomComponent={collectionConfig.admin?.components?.views?.Edit}
-        componentProps={{
-          isLoading: !internalState,
-          data,
-          id,
-          collection: collectionConfig,
-          permissions: permissions.collections[collectionConfig.slug],
-          isEditing: Boolean(id),
-          apiURL: id ? `${serverURL}${api}/${collectionSlug}/${id}` : null,
-          onSave,
-          internalState,
-          hasSavePermission: true,
-          action: `${serverURL}${api}/${collectionSlug}${id ? `/${id}` : ''}?locale=${locale}&depth=0&fallback-locale=null`,
-          disableEyebrow: true,
-          disableActions: true,
-          me: true,
-          disableLeaveWithoutSaving: true,
-          customHeader: (
-            <div className={`${baseClass}__header`}>
-              <div className={`${baseClass}__header-content`}>
-                <h2 className={`${baseClass}__header-text`}>
-                  {!customHeader ? t(!id ? 'fields:addNewLabel' : 'general:editLabel', { label: getTranslation(collectionConfig.labels.singular, i18n) }) : customHeader}
-                </h2>
-                <Button
-                  buttonStyle="none"
-                  className={`${baseClass}__header-close`}
-                  onClick={() => toggleModal(drawerSlug)}
-                  aria-label={t('general:close')}
-                >
-                  <X />
-                </Button>
-              </div>
-              {id && (
-                <IDLabel id={id} />
-              )}
-            </div>
-          ),
-        }}
+      <Content
+        {...props}
+        id={id}
+        onSave={onSave}
       />
     </DocumentInfoProvider>
   );

--- a/src/admin/components/utilities/Auth/index.tsx
+++ b/src/admin/components/utilities/Auth/index.tsx
@@ -92,7 +92,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const json: Permissions = await request.json();
       setPermissions(json);
     } else {
-      throw new Error("Fetching permissions failed with status code " + request.status);
+      throw new Error(`Fetching permissions failed with status code ${request.status}`);
     }
   }, [serverURL, api, i18n]);
 
@@ -135,7 +135,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (id) {
       refreshPermissions();
     }
-  }, [i18n, id, api, serverURL]);
+  }, [i18n, id, api, serverURL, refreshPermissions]);
 
   useEffect(() => {
     let reminder: ReturnType<typeof setTimeout>;

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -1,11 +1,13 @@
 import { devUser } from '../credentials';
 import { buildConfig } from '../buildConfig';
 import { FieldAccess } from '../../src/fields/config/types';
-import { SiblingDatum } from './payload-types';
 import { firstArrayText, secondArrayText } from './shared';
 
 export const slug = 'posts';
+export const unrestrictedSlug = 'unrestricted';
 export const readOnlySlug = 'read-only-collection';
+
+export const userRestrictedSlug = 'user-restricted';
 export const restrictedSlug = 'restricted';
 export const restrictedVersionsSlug = 'restricted-versions';
 export const siblingDataSlug = 'sibling-data';
@@ -111,6 +113,21 @@ export default buildConfig({
       ],
     },
     {
+      slug: unrestrictedSlug,
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+        },
+        {
+          name: 'userRestrictedDocs',
+          type: 'relationship',
+          relationTo: userRestrictedSlug,
+          hasMany: true,
+        },
+      ],
+    },
+    {
       slug: restrictedSlug,
       fields: [
         {
@@ -137,6 +154,28 @@ export default buildConfig({
         create: () => false,
         read: () => true,
         update: () => false,
+        delete: () => false,
+      },
+    },
+    {
+      slug: userRestrictedSlug,
+      admin: {
+        useAsTitle: 'name',
+      },
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+        },
+      ],
+      access: {
+        create: () => true,
+        read: () => true,
+        update: ({ req }) => ({
+          name: {
+            equals: req.user?.email,
+          },
+        }),
         delete: () => false,
       },
     },
@@ -314,7 +353,7 @@ export default buildConfig({
       },
     });
 
-    await payload.create<SiblingDatum>({
+    await payload.create({
       collection: siblingDataSlug,
       data: {
         array: [


### PR DESCRIPTION
## Description

Fixes #2545 by tying user permissions into the `DocumentDrawer` component for proper access control. Previously, this component hard-coded `hasSavePermission: true` but now reads from `docPermissions` as expected.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
