### PR TITLE
feat: Allow full URL in staticURL

### DIFF
--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -42,7 +42,7 @@ Every Payload Collection can opt-in to supporting Uploads by specifying the `upl
 
 | Option                    | Description                                                                                                                                     |
 | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`staticURL`** \*        | The base URL path to use to access your uploads. Example: `/media`                                                                              |
+| **`staticURL`** \*        | The URL path to use to access your uploads. Relative path like `/media` will be served by payload. Full path like `https://example.com/media` needs to be served by another web server. |
 | **`staticDir`** \*        | The folder directory to use to store media in. Can be either an absolute path or relative to the directory that contains your config.           |
 | **`imageSizes`**          | If specified, image uploads will be automatically resized in accordance to these image sizes. [More](#image-sizes)                              |
 | **`formatOptions`**       | An object with `format` and `options` that are used with the Sharp image library to format the upload file. [More](https://sharp.pixelplumbing.com/api-output#toformat) |

--- a/src/express/static.ts
+++ b/src/express/static.ts
@@ -10,7 +10,7 @@ function initStatic(ctx: Payload): void {
   Object.entries(ctx.collections).forEach(([_, collection]) => {
     const { config } = collection;
 
-    if (config.upload) {
+    if (config.upload && config.upload.staticURL.startsWith('/')) {
       const router = express.Router();
 
       router.use(corsHeaders(ctx.config));

--- a/src/uploads/getBaseFields.ts
+++ b/src/uploads/getBaseFields.ts
@@ -85,7 +85,10 @@ const getBaseUploadFields = ({ config, collection }: Options): Field[] => {
         afterRead: [
           ({ data }) => {
             if (data?.filename) {
-              return `${config.serverURL}${uploadOptions.staticURL}/${data.filename}`;
+              if (uploadOptions.staticURL.startsWith('/')) {
+                return `${config.serverURL}${uploadOptions.staticURL}/${data.filename}`;
+              }
+              return `${uploadOptions.staticURL}/${data.filename}`;
             }
 
             return undefined;
@@ -129,7 +132,10 @@ const getBaseUploadFields = ({ config, collection }: Options): Field[] => {
                     const sizeFilename = data?.sizes?.[size.name]?.filename;
 
                     if (sizeFilename) {
-                      return `${config.serverURL}${uploadOptions.staticURL}/${sizeFilename}`;
+                      if (uploadOptions.staticURL.startsWith('/')) {
+                        return `${config.serverURL}${uploadOptions.staticURL}/${sizeFilename}`;
+                      }
+                      return `${uploadOptions.staticURL}/${sizeFilename}`;
                     }
 
                     return undefined;

--- a/test/uploads/.gitignore
+++ b/test/uploads/.gitignore
@@ -1,1 +1,2 @@
-media
+/media
+/media-gif

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -143,6 +143,15 @@ export default buildConfig({
       },
       fields: [],
     },
+    {
+      slug: 'externally-served-media',
+      upload: {
+        // Either use another web server like `npx serve -l 4000` (http://localhost:4000) or use the static server from the previous collection to serve the media folder (http://localhost:3000/media)
+        staticURL: 'http://localhost:3000/media',
+        staticDir: './media',
+      },
+      fields: [],
+    },
     Uploads1,
     Uploads2,
   ],


### PR DESCRIPTION
## Description

Allow [`staticURL`](https://payloadcms.com/docs/upload/overview#enabling-uploads) to be a full URL instead of a portion of the path.

Currently, the staticURL property isn't really a full URL but just a portion of the path. When provided, the file URL will be created by concatenation : `${config.serverURL}${uploadOptions.staticURL}/${data.filename}`.

Providing a full URL is useful if you:
- want to serve your assets through something else than payload (which allows downtime of the back office for static sites)
- don't want your assets to have the same domain name as the back office

While looking at the code, I found some potential issues:
- Shouldn't we avoid serving the asset folder with a static server if the assets are not saved on the machine (`disableLocalStorage: true`) ?
- I don't know express well enough, but couldn't there be an issue if two uploads collections uses the same folder? If it's the case, I believe payload currently starts two express routers.

---

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
