### PR TITLE
Reload configuration without restarting the process

### DIFF
--- a/src/express/admin.ts
+++ b/src/express/admin.ts
@@ -7,27 +7,35 @@ import { Payload } from '../payload';
 const router = express.Router();
 
 function initAdmin(ctx: Payload): void {
-  if (!ctx.config.admin.disable) {
-    router.use(history());
+  if (ctx.config.admin.disable) return;
 
-    if (process.env.NODE_ENV === 'production') {
-      router.get('*', (req, res, next) => {
-        if (req.path.substr(-1) === '/' && req.path.length > 1) {
-          const query = req.url.slice(req.path.length);
-          res.redirect(301, req.path.slice(0, -1) + query);
-        } else {
-          next();
-        }
-      });
+  // TODO: consider restarting webpack dev server if config changes
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  if (ctx.webpackHasStarted) return;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  ctx.webpackHasStarted = true;
 
-      router.use(compression(ctx.config.express.compression));
-      router.use(express.static(ctx.config.admin.buildPath, { redirect: false }));
+  router.use(history());
 
-      ctx.express.use(ctx.config.routes.admin, router);
-    } else {
-      ctx.express.use(ctx.config.routes.admin, history());
-      ctx.express.use(initWebpack(ctx.config));
-    }
+  if (process.env.NODE_ENV === 'production') {
+    router.get('*', (req, res, next) => {
+      if (req.path.substr(-1) === '/' && req.path.length > 1) {
+        const query = req.url.slice(req.path.length);
+        res.redirect(301, req.path.slice(0, -1) + query);
+      } else {
+        next();
+      }
+    });
+
+    router.use(compression(ctx.config.express.compression));
+    router.use(express.static(ctx.config.admin.buildPath, { redirect: false }));
+
+    ctx.express.use(ctx.config.routes.admin, router);
+  } else {
+    ctx.express.use(ctx.config.routes.admin, history());
+    ctx.express.use(initWebpack(ctx.config));
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,15 @@
-import { Config as GeneratedTypes } from 'payload/generated-types';
-import { InitOptions } from './config/types';
-import { initHTTP } from './initHTTP';
-import { Payload as LocalPayload, BasePayload } from './payload';
-
-export { getPayload } from './payload';
+import { InitOptions } from 'payload/config';
+import { BasePayload as Payload, Payload as LocalPayload } from './payload';
 
 require('isomorphic-fetch');
 
-export class Payload extends BasePayload<GeneratedTypes> {
-  async init(options: InitOptions): Promise<LocalPayload> {
-    const payload = await initHTTP(options);
-    Object.assign(this, payload);
-
-    if (!options.local) {
-      if (typeof options.onInit === 'function') await options.onInit(this);
-      if (typeof this.config.onInit === 'function') await this.config.onInit(this);
-    }
-
-    return payload;
-  }
-}
+export { Payload };
 
 const payload = new Payload();
+
+export const getPayload = (options: InitOptions): Promise<LocalPayload> =>
+  // eslint-disable-next-line implicit-arrow-linebreak
+  payload.init(options);
 
 export default payload;
 module.exports = payload;

--- a/src/initHTTP.ts
+++ b/src/initHTTP.ts
@@ -18,11 +18,10 @@ import errorHandler from './express/middleware/errorHandler';
 import { PayloadRequest } from './express/types';
 import { getDataLoader } from './collections/dataloader';
 import mountEndpoints from './express/mountEndpoints';
-import { getPayload, Payload } from './payload';
+import { Payload } from './payload';
 
-export const initHTTP = async (options: InitOptions): Promise<Payload> => {
+export const initHTTP = async (payload: Payload, options: InitOptions): Promise<Payload> => {
   if (typeof options.local === 'undefined') options.local = false;
-  const payload = await getPayload(options);
 
   if (!options.local) {
     payload.router = express.Router();

--- a/src/mongoose/connect.ts
+++ b/src/mongoose/connect.ts
@@ -56,4 +56,12 @@ const connectMongoose = async (
   return mongoMemoryServer;
 };
 
+export const disconnectMongoose = async (mongoMemoryServer: unknown): Promise<void> => {
+  if (typeof mongoMemoryServer === 'object' && 'stop' in mongoMemoryServer && typeof mongoMemoryServer.stop === 'function') {
+    await mongoMemoryServer.stop();
+  }
+
+  await mongoose.disconnect();
+};
+
 export default connectMongoose;


### PR DESCRIPTION
## Description

This is a step towards a better DX: by livereloading the configuration through both Webpack and backend, developers don't have to wait for nodemon or remember to restart their server.

This PR does not break anything, but it doesn't work perfectly right now: many of the express routes are added instead of replaced on every reload. My proposal would be to combine all middleware in 1 `Express.Router()` and replace that one by mutating `express._router.stack`.

Consider reviewing the commits in this PR separately. (the simplify commit 898916d1722485d0ee620578b5831fc82493e4d4 is not that interesting)

Here is how I tested it:

```ts
payload
  .init({
    secret: process.env.PAYLOAD_SECRET!,
    mongoURL: process.env.MONGO_URL!,
    express: app,
  })
  .then(() => {
    const imported = Object.keys(require.cache).filter((s) => !s.includes('node_modules'))
    chokidar.watch(imported).on('change', (path) => {
      console.log('changed', path)
      payload.init({
        secret: process.env.PAYLOAD_SECRET!,
        mongoURL: process.env.MONGO_URL!,
        express: app,
      })
    })
  })
app.listen(port)
```

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change


- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
