### PR TITLE
chore: stubs out example RTE element in test/fields folder

### DIFF
--- a/src/admin/components/forms/field-types/RichText/elements/injectVoid.ts
+++ b/src/admin/components/forms/field-types/RichText/elements/injectVoid.ts
@@ -8,7 +8,7 @@ export const injectVoidElement = (editor: Editor, element: Element): void => {
 
   if (lastSelectedElementIsEmpty) {
     // If previous node is void
-    if (Editor.isVoid(editor, previous?.[0])) {
+    if (previous?.[0] && Editor.isVoid(editor, previous[0])) {
       // Insert a blank element between void nodes
       // so user can place cursor between void nodes
       Transforms.insertNodes(editor, { children: [{ text: '' }] });

--- a/test/fields/collections/RichText/CustomElements/Markdown/Button.tsx
+++ b/test/fields/collections/RichText/CustomElements/Markdown/Button.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { ReactEditor, useSlate } from 'slate-react';
+import RichTextButton from '../../../../../../src/admin/components/forms/field-types/RichText/elements/Button';
+import { injectVoidElement } from '../../../../../../src/admin/components/forms/field-types/RichText/elements/injectVoid';
+
+import { elementIdentifier } from '.';
+
+const insertMarkdown = (editor) => {
+  const markdownElement = {
+    type: elementIdentifier,
+    children: [
+      { text: ' ' },
+    ],
+  };
+
+  injectVoidElement(editor, markdownElement);
+
+  ReactEditor.focus(editor);
+};
+
+const Icon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="100%"
+      viewBox="0 0 208 128"
+      style={{
+        width: 'auto',
+      }}
+      stroke="currentColor"
+    >
+      <rect
+        width="198"
+        height="118"
+        x="5"
+        y="5"
+        ry="10"
+        strokeWidth="10"
+        fill="none"
+      />
+      <path
+        d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39zm125 0l-30-33h20V30h20v35h20z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};
+
+export const Button: React.FC = () => {
+  const editor = useSlate();
+
+  const onClick = () => {
+    insertMarkdown(editor);
+  };
+
+  return (
+    <RichTextButton
+      onClick={onClick}
+      format={elementIdentifier}
+    >
+      <Icon />
+    </RichTextButton>
+  );
+};

--- a/test/fields/collections/RichText/CustomElements/Markdown/Element.tsx
+++ b/test/fields/collections/RichText/CustomElements/Markdown/Element.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { Transforms } from 'slate';
+import { ReactEditor, useSlateStatic } from 'slate-react';
+import { elementIdentifier } from '.';
+import { Field } from '../../../../../../src/fields/config/types';
+
+const valueKey = 'markdownValue';
+
+type ElementProps = {
+  attributes: React.HTMLAttributes<HTMLDivElement>
+  children: React.ReactNode
+  element: any
+  fieldProps: Field
+}
+export const Element: React.FC<ElementProps> = (props) => {
+  const {
+    attributes,
+    children,
+    element,
+  } = props;
+
+  const currentState = element?.[valueKey] || '';
+  const editor = useSlateStatic();
+
+  const updateNode = React.useCallback((newValue) => {
+    if (currentState !== newValue) {
+      const elementPath = ReactEditor.findPath(editor, element);
+
+      Transforms.setNodes(editor,
+        {
+          type: elementIdentifier,
+          [valueKey]: newValue,
+          children: [
+            { text: ' ' },
+          ],
+        },
+        { at: elementPath });
+    }
+  }, [editor, element, currentState]);
+
+  const removeNode = React.useCallback(() => {
+    const elementPath = ReactEditor.findPath(editor, element);
+
+    Transforms.removeNodes(
+      editor,
+      { at: elementPath },
+    );
+  }, [editor, element]);
+
+  return (
+    <div
+      {...attributes}
+      contentEditable={false}
+    >
+      <div>
+        <button
+          type="button"
+          onClick={removeNode}
+        >
+          remove
+        </button>
+
+        <textarea
+          className={classes.textArea}
+          onChange={(e) => updateNode(e.target.value)}
+          value={currentState}
+          style={{
+            width: '100%',
+            height: '20vh',
+            resize: 'vertical',
+          }}
+        />
+      </div>
+
+      {children}
+    </div>
+  );
+};

--- a/test/fields/collections/RichText/CustomElements/Markdown/index.tsx
+++ b/test/fields/collections/RichText/CustomElements/Markdown/index.tsx
@@ -1,0 +1,14 @@
+import { Element } from './Element';
+import { Button } from './Button';
+import { withMarkdown } from './plugin';
+
+export const elementIdentifier = 'markdown';
+
+export const markdownElement = {
+  name: elementIdentifier,
+  Button,
+  Element,
+  plugins: [
+    withMarkdown,
+  ],
+};

--- a/test/fields/collections/RichText/CustomElements/Markdown/plugin.tsx
+++ b/test/fields/collections/RichText/CustomElements/Markdown/plugin.tsx
@@ -1,0 +1,9 @@
+import { elementIdentifier } from '.';
+
+export const withMarkdown = (editor) => {
+  const { isVoid } = editor;
+
+  editor.isVoid = (element) => (element.type === elementIdentifier ? true : isVoid(element));
+
+  return editor;
+};

--- a/test/fields/collections/RichText/index.ts
+++ b/test/fields/collections/RichText/index.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from '../../../../src/collections/config/types';
+import { markdownElement } from './CustomElements/Markdown';
 import { loremIpsum } from './loremIpsum';
 
 const RichTextFields: CollectionConfig = {
@@ -142,6 +143,15 @@ const RichTextFields: CollectionConfig = {
             },
           },
         },
+      },
+    },
+    {
+      name: 'richTextWithCustomElement',
+      type: 'richText',
+      admin: {
+        elements: [
+          markdownElement,
+        ],
       },
     },
   ],


### PR DESCRIPTION
## Description

Fixes a bug where inserting an element on an empty first line would break the editor.

Adds simple custom element in tests/fields/RichText.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
