### PR TITLE
fix: injectVoidNode unable to inject on first line

### DIFF
--- a/src/admin/components/forms/field-types/RichText/elements/injectVoid.ts
+++ b/src/admin/components/forms/field-types/RichText/elements/injectVoid.ts
@@ -8,7 +8,12 @@ export const injectVoidElement = (editor: Editor, element: Element): void => {
 
   if (lastSelectedElementIsEmpty) {
     // If previous node is void
-    if (Editor.isVoid(editor, previous?.[0])) {
+    if (!previous) {
+      // If first element, insert a blank element above
+      // so user can place cursor above the inserted node
+      Transforms.insertNodes(editor, { children: [{ text: '' }] });
+      Transforms.setNodes(editor, element);
+    } else if (Editor.isVoid(editor, previous[0])) {
       // Insert a blank element between void nodes
       // so user can place cursor between void nodes
       Transforms.insertNodes(editor, { children: [{ text: '' }] });


### PR DESCRIPTION
## Description

`injectVoidElement` would not allow insertion on the first line of the RTE.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
