### PR TITLE
fix: resolve process/browser package in webpack config

### DIFF
--- a/src/webpack/getBaseConfig.ts
+++ b/src/webpack/getBaseConfig.ts
@@ -62,7 +62,7 @@ export default (config: SanitizedConfig): Configuration => ({
   },
   plugins: [
     new webpack.ProvidePlugin(
-      { process: 'process/browser' },
+      { process: require.resolve('process/browser') },
     ),
     new webpack.DefinePlugin(
       Object.entries(process.env).reduce(


### PR DESCRIPTION
## Description

I'm trying to use Payload via pnpm, but the ProvidePlugin in webpack wants to add an import for `process/browser`.  That package specifier isn't reachable from consumers of Payload unless it's installed directly.

It's akin to the "phantom dependency" problem that pnpm and some variants of yarn are trying to resolve.  The Payload package itself installs `process` internally, but pnpm doesn't make it available to my code unless I install it myself.  When webpack injects a reference to it, we get a build error like this:

> ERROR in ./src/payload.config.ts 6:15-22
> Module not found: Error: Can't resolve 'process/browser' in '/Users/wesleydimiceli/build/payload-repro/src'
>
> ERROR in ./src/payload.config.ts
> Cannot read properties of undefined (reading 'module')
>
> webpack compiled with 2 errors

You can do an easy repro like this:

```bash
$ npx create-payload-app
$ cd payload

# Wipe node_modules because we want to use pnpm's directory structure
$ rm -rf node_modules

# Consume yarn.lock into pnpm-lock.yaml
$ pnpm import

$ pnpm install

# Add a reference to process somewhere in the code (e.g. with OSX sed)
$ sed -i'' -e "s/'http:\/\/localhost:3000'/process.env.SERVER_URL/" src/payload.config.ts

# Build now fails on missing package
$ pnpm build
```

Wrapping the package name in `require.resolve()` should output an absolute path to the package wherever it's found on disk -- relative to the webpack config module as opposed to my own `src/` directory.  Because that config module resides in payload's internal code, the `process` package path should be resolvable from there and can be injected as normal.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
