### PR TITLE
bugfix/feature: Allow users to manipulate images without needing to resize them

### DIFF
--- a/src/uploads/imageResizer.ts
+++ b/src/uploads/imageResizer.ts
@@ -71,12 +71,7 @@ export default async function resizeAndSave({
         };
         return;
       }
-
-      let resized = sharpBase.clone();
-
-      if (!desiredSize.keepSize) {
-        resized = resized.resize(desiredSize);
-      }
+      let resized = sharpBase.clone().resize(desiredSize);
 
       if (desiredSize.formatOptions) {
         resized = resized.toFormat(desiredSize.formatOptions.format, desiredSize.formatOptions.options);
@@ -134,5 +129,5 @@ function createImageName(
 function needsResize(desiredSize: ImageSize, dimensions: Dimensions): boolean {
   return (typeof desiredSize.width === 'number' && desiredSize.width <= dimensions.width)
     || (typeof desiredSize.height === 'number' && desiredSize.height <= dimensions.height)
-    || (typeof desiredSize.keepSize === 'boolean' && desiredSize.keepSize === true);
+    || (!desiredSize.height && !desiredSize.width);
 }

--- a/src/uploads/imageResizer.ts
+++ b/src/uploads/imageResizer.ts
@@ -71,7 +71,12 @@ export default async function resizeAndSave({
         };
         return;
       }
-      let resized = sharpBase.clone().resize(desiredSize);
+
+      let resized = sharpBase.clone();
+
+      if (!desiredSize.keepSize) {
+        resized = resized.resize(desiredSize);
+      }
 
       if (desiredSize.formatOptions) {
         resized = resized.toFormat(desiredSize.formatOptions.format, desiredSize.formatOptions.options);
@@ -128,5 +133,6 @@ function createImageName(
 
 function needsResize(desiredSize: ImageSize, dimensions: Dimensions): boolean {
   return (typeof desiredSize.width === 'number' && desiredSize.width <= dimensions.width)
-    || (typeof desiredSize.height === 'number' && desiredSize.height <= dimensions.height);
+    || (typeof desiredSize.height === 'number' && desiredSize.height <= dimensions.height)
+    || (typeof desiredSize.keepSize === 'boolean' && desiredSize.keepSize === true);
 }

--- a/src/uploads/types.ts
+++ b/src/uploads/types.ts
@@ -49,6 +49,7 @@ export type ImageUploadTrimOptions = Parameters<Sharp['trim']>[0]
 
 export type ImageSize = ResizeOptions & {
   name: string
+  keepSize?: boolean
   formatOptions?: ImageUploadFormatOptions
   trimOptions?: ImageUploadTrimOptions
   /**

--- a/src/uploads/types.ts
+++ b/src/uploads/types.ts
@@ -49,7 +49,6 @@ export type ImageUploadTrimOptions = Parameters<Sharp['trim']>[0]
 
 export type ImageSize = ResizeOptions & {
   name: string
-  keepSize?: boolean
   formatOptions?: ImageUploadFormatOptions
   trimOptions?: ImageUploadTrimOptions
   /**

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -115,6 +115,17 @@ export default buildConfig({
             formatOptions: { format: 'jpg', options: { quality: 90 } },
           },
           {
+            name: 'maintainedImageSize',
+            width: undefined,
+            height: undefined,
+          },
+          {
+            name: 'maintainedImageSizeWithNewFormat',
+            width: undefined,
+            height: undefined,
+            formatOptions: { format: 'jpg', options: { quality: 90 } },
+          },
+          {
             name: 'tablet',
             width: 640,
             height: 480,

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -99,13 +99,20 @@ describe('uploads', () => {
     const differentFormatFromMainImageMeta = page.locator('.file-details__sizes .file-meta').nth(1);
     await expect(differentFormatFromMainImageMeta).toContainText('image/jpeg');
 
-    const tabletMeta = page.locator('.file-details__sizes .file-meta').nth(2);
+    const maintainedImageSizeMeta = page.locator('.file-details__sizes .file-meta').nth(2);
+    await expect(maintainedImageSizeMeta).toContainText('1600x1600');
+
+    const maintainedImageSizeWithNewFormatMeta = page.locator('.file-details__sizes .file-meta').nth(3);
+    await expect(maintainedImageSizeWithNewFormatMeta).toContainText('image/jpeg');
+    await expect(maintainedImageSizeWithNewFormatMeta).toContainText('1600x1600');
+
+    const tabletMeta = page.locator('.file-details__sizes .file-meta').nth(4);
     await expect(tabletMeta).toContainText('640x480');
 
-    const mobileMeta = page.locator('.file-details__sizes .file-meta').nth(3);
+    const mobileMeta = page.locator('.file-details__sizes .file-meta').nth(5);
     await expect(mobileMeta).toContainText('320x240');
 
-    const iconMeta = page.locator('.file-details__sizes .file-meta').nth(4);
+    const iconMeta = page.locator('.file-details__sizes .file-meta').nth(6);
     await expect(iconMeta).toContainText('16x16');
   });
 

--- a/test/uploads/payload-types.ts
+++ b/test/uploads/payload-types.ts
@@ -45,6 +45,22 @@ export interface Media {
       filesize?: number;
       filename?: string;
     };
+    maintainedImageSize: {
+      url?: string;
+      width?: number;
+      height?: number;
+      mimeType?: string;
+      filesize?: number;
+      filename?: string;
+    };
+    maintainedImageSizeWithNewFormat: {
+      url?: string;
+      width?: number;
+      height?: number;
+      mimeType?: string;
+      filesize?: number;
+      filename?: string;
+    };
     tablet: {
       url?: string;
       width?: number;


### PR DESCRIPTION
## Description

Right now, Payload's image "transformation" feature is limited to images that requires resizing. 

This is a simple fix/feature that allows us to "reuse" the original size of an uploaded media. This way, users can use Sharp's features like changing formatOptions and trimOptions without needing to give a new size to the images.

It also allows users to keep an original copy of the image for certain use cases.

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
