### PR TITLE
fix: timestamp queries

### DIFF
--- a/src/admin/components/elements/ListDrawer/DrawerContent.tsx
+++ b/src/admin/components/elements/ListDrawer/DrawerContent.tsx
@@ -50,11 +50,11 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
 
   const [selectedOption, setSelectedOption] = useState<{ label: string, value: string }>(() => (selectedCollectionConfig ? { label: getTranslation(selectedCollectionConfig.labels.singular, i18n), value: selectedCollectionConfig.slug } : undefined));
 
-  const [fields, setFields] = useState<Field[]>(() => formatFields(selectedCollectionConfig, t));
+  const [fields, setFields] = useState<Field[]>(() => formatFields(selectedCollectionConfig));
 
   useEffect(() => {
-    setFields(formatFields(selectedCollectionConfig, t));
-  }, [selectedCollectionConfig, t]);
+    setFields(formatFields(selectedCollectionConfig));
+  }, [selectedCollectionConfig]);
 
   // allow external control of selected collection, same as the initial state logic above
   useEffect(() => {

--- a/src/admin/components/elements/TableColumns/index.tsx
+++ b/src/admin/components/elements/TableColumns/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useReducer, createContext, useContext, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useReducer, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SanitizedCollectionConfig } from '../../../../collections/config/types';
 import { usePreferences } from '../../utilities/Preferences';
@@ -46,7 +46,7 @@ export const TableColumnsProvider: React.FC<{
   const hasInitialized = useRef(false);
   const { getPreference, setPreference } = usePreferences();
   const { t } = useTranslation();
-  const [formattedFields] = useState<Field[]>(() => formatFields(collection, t));
+  const [formattedFields] = useState<Field[]>(() => formatFields(collection));
 
   const [tableColumns, dispatchTableColumns] = useReducer(columnReducer, {}, () => {
     const initialColumns = getInitialColumnState(formattedFields, useAsTitle, defaultColumns);
@@ -91,7 +91,7 @@ export const TableColumnsProvider: React.FC<{
               }
               return column;
             }),
-            collection: { ...collection, fields: formatFields(collection, t) },
+            collection: { ...collection, fields: formatFields(collection) },
             cellProps,
           },
         });
@@ -101,7 +101,7 @@ export const TableColumnsProvider: React.FC<{
     };
 
     sync();
-  }, [preferenceKey, setPreference, tableColumns, getPreference, useAsTitle, defaultColumns, collection, cellProps, formattedFields, t]);
+  }, [preferenceKey, setPreference, tableColumns, getPreference, useAsTitle, defaultColumns, collection, cellProps, formattedFields]);
 
   // /////////////////////////////////////
   // Set preferences on column change
@@ -131,7 +131,7 @@ export const TableColumnsProvider: React.FC<{
     dispatchTableColumns({
       type: 'set',
       payload: {
-        collection: { ...collection, fields: formatFields(collection, t) },
+        collection: { ...collection, fields: formatFields(collection) },
         columns: columns.map((column) => ({
           accessor: column,
           active: true,
@@ -140,7 +140,7 @@ export const TableColumnsProvider: React.FC<{
         cellProps,
       },
     });
-  }, [collection, t, cellProps]);
+  }, [collection, cellProps]);
 
   const moveColumn = useCallback((args: {
     fromIndex: number
@@ -153,22 +153,22 @@ export const TableColumnsProvider: React.FC<{
       payload: {
         fromIndex,
         toIndex,
-        collection: { ...collection, fields: formatFields(collection, t) },
+        collection: { ...collection, fields: formatFields(collection) },
         cellProps,
       },
     });
-  }, [collection, t, cellProps]);
+  }, [collection, cellProps]);
 
   const toggleColumn = useCallback((column: string) => {
     dispatchTableColumns({
       type: 'toggle',
       payload: {
         column,
-        collection: { ...collection, fields: formatFields(collection, t) },
+        collection: { ...collection, fields: formatFields(collection) },
         cellProps,
       },
     });
-  }, [collection, t, cellProps]);
+  }, [collection, cellProps]);
 
   return (
     <TableColumnContext.Provider

--- a/src/admin/components/views/collections/List/formatFields.tsx
+++ b/src/admin/components/views/collections/List/formatFields.tsx
@@ -23,27 +23,6 @@ const formatFields = (config: SanitizedCollectionConfig, t: TFunction): Field[] 
     },
   }]);
 
-  if (config.timestamps) {
-    fields.push(
-      {
-        name: 'createdAt',
-        label: t('general:createdAt'),
-        type: 'date',
-        admin: {
-          disableBulkEdit: true,
-        },
-      },
-      {
-        name: 'updatedAt',
-        label: t('general:updatedAt'),
-        type: 'date',
-        admin: {
-          disableBulkEdit: true,
-        },
-      },
-    );
-  }
-
   return fields;
 };
 

--- a/src/admin/components/views/collections/List/formatFields.tsx
+++ b/src/admin/components/views/collections/List/formatFields.tsx
@@ -1,9 +1,8 @@
-import { TFunction } from 'react-i18next';
 import React from 'react';
 import { SanitizedCollectionConfig } from '../../../../../collections/config/types';
 import { Field, fieldAffectsData, fieldIsPresentationalOnly } from '../../../../../fields/config/types';
 
-const formatFields = (config: SanitizedCollectionConfig, t: TFunction): Field[] => {
+const formatFields = (config: SanitizedCollectionConfig): Field[] => {
   const hasID = config.fields.findIndex((field) => fieldAffectsData(field) && field.name === 'id') > -1;
   const fields: Field[] = config.fields.reduce((formatted, field) => {
     if (!fieldIsPresentationalOnly(field) && (field.hidden === true || field?.admin?.disabled === true)) {

--- a/src/admin/components/views/collections/List/index.tsx
+++ b/src/admin/components/views/collections/List/index.tsx
@@ -1,5 +1,5 @@
 import { v4 as uuid } from 'uuid';
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import queryString from 'qs';
 import { useTranslation } from 'react-i18next';
@@ -10,7 +10,7 @@ import DefaultList from './Default';
 import RenderCustomComponent from '../../../utilities/RenderCustomComponent';
 import { useStepNav } from '../../../elements/StepNav';
 import formatFields from './formatFields';
-import { Props, ListIndexProps, ListPreferences } from './types';
+import { ListIndexProps, ListPreferences, Props } from './types';
 import { usePreferences } from '../../../utilities/Preferences';
 import { useSearchParams } from '../../../utilities/SearchParams';
 import { TableColumnsProvider } from '../../../elements/TableColumns';
@@ -46,7 +46,7 @@ const ListView: React.FC<ListIndexProps> = (props) => {
   const history = useHistory();
   const { t } = useTranslation('general');
   const [fetchURL, setFetchURL] = useState<string>('');
-  const [fields] = useState<Field[]>(() => formatFields(collection, t));
+  const [fields] = useState<Field[]>(() => formatFields(collection));
   const collectionPermissions = permissions?.collections?.[slug];
   const hasCreatePermission = collectionPermissions?.create?.permission;
   const newDocumentURL = `${admin}/collections/${slug}/create`;

--- a/src/collections/config/sanitize.ts
+++ b/src/collections/config/sanitize.ts
@@ -31,21 +31,20 @@ const sanitizeCollection = (config: Config, collection: CollectionConfig): Sanit
   });
 
   if (sanitized.timestamps !== false) {
+    // add default timestamps fields only as needed
     let hasUpdatedAt = null;
     let hasCreatedAt = null;
-    let i = 0;
-    while (hasCreatedAt === null && hasUpdatedAt === null && i < sanitized.fields.length) {
-      const field = sanitized.fields[i];
-      i += 1;
+    sanitized.fields.some((field) => {
       if (fieldAffectsData(field)) {
         if (field.name === 'updatedAt') hasUpdatedAt = true;
         if (field.name === 'createdAt') hasCreatedAt = true;
       }
-    }
-    if (!hasCreatedAt) {
+      return hasCreatedAt && hasUpdatedAt;
+    });
+    if (!hasUpdatedAt) {
       sanitized.fields.push({
-        name: 'createdAt',
-        label: translations['general:createdAt'],
+        name: 'updatedAt',
+        label: translations['general:updatedAt'],
         type: 'date',
         admin: {
           hidden: true,
@@ -53,10 +52,10 @@ const sanitizeCollection = (config: Config, collection: CollectionConfig): Sanit
         },
       });
     }
-    if (!hasUpdatedAt) {
+    if (!hasCreatedAt) {
       sanitized.fields.push({
-        name: 'updatedAt',
-        label: translations['general:updatedAt'],
+        name: 'createdAt',
+        label: translations['general:createdAt'],
         type: 'date',
         admin: {
           hidden: true,

--- a/src/collections/config/sanitize.ts
+++ b/src/collections/config/sanitize.ts
@@ -48,6 +48,7 @@ const sanitizeCollection = (config: Config, collection: CollectionConfig): Sanit
         label: translations['general:createdAt'],
         type: 'date',
         admin: {
+          hidden: true,
           disableBulkEdit: true,
         },
       });
@@ -58,6 +59,7 @@ const sanitizeCollection = (config: Config, collection: CollectionConfig): Sanit
         label: translations['general:updatedAt'],
         type: 'date',
         admin: {
+          hidden: true,
           disableBulkEdit: true,
         },
       });

--- a/src/collections/config/sanitize.ts
+++ b/src/collections/config/sanitize.ts
@@ -1,6 +1,6 @@
 import merge from 'deepmerge';
 import { isPlainObject } from 'is-plain-object';
-import { SanitizedCollectionConfig, CollectionConfig } from './types';
+import { CollectionConfig, SanitizedCollectionConfig } from './types';
 import sanitizeFields from '../../fields/config/sanitize';
 import baseAuthFields from '../../auth/baseFields/auth';
 import baseAPIKeyFields from '../../auth/baseFields/apiKey';
@@ -8,11 +8,18 @@ import baseVerificationFields from '../../auth/baseFields/verification';
 import baseAccountLockFields from '../../auth/baseFields/accountLock';
 import getBaseUploadFields from '../../uploads/getBaseFields';
 import { formatLabels } from '../../utilities/formatLabels';
-import { defaults, authDefaults } from './defaults';
+import { authDefaults, defaults } from './defaults';
 import { Config } from '../../config/types';
 import baseVersionFields from '../../versions/baseFields';
 import TimestampsRequired from '../../errors/TimestampsRequired';
 import mergeBaseFields from '../../fields/mergeBaseFields';
+import { extractTranslations } from '../../translations/extractTranslations';
+import { fieldAffectsData } from '../../fields/config/types';
+
+const translations = extractTranslations([
+  'general:createdAt',
+  'general:updatedAt',
+]);
 
 const sanitizeCollection = (config: Config, collection: CollectionConfig): SanitizedCollectionConfig => {
   // /////////////////////////////////
@@ -22,6 +29,40 @@ const sanitizeCollection = (config: Config, collection: CollectionConfig): Sanit
   const sanitized: CollectionConfig = merge(defaults, collection, {
     isMergeableObject: isPlainObject,
   });
+
+  if (sanitized.timestamps !== false) {
+    let hasUpdatedAt = null;
+    let hasCreatedAt = null;
+    let i = 0;
+    while (hasCreatedAt === null && hasUpdatedAt === null && i < sanitized.fields.length) {
+      const field = sanitized.fields[i];
+      i += 1;
+      if (fieldAffectsData(field)) {
+        if (field.name === 'updatedAt') hasUpdatedAt = true;
+        if (field.name === 'createdAt') hasCreatedAt = true;
+      }
+    }
+    if (!hasCreatedAt) {
+      sanitized.fields.push({
+        name: 'createdAt',
+        label: translations['general:createdAt'],
+        type: 'date',
+        admin: {
+          disableBulkEdit: true,
+        },
+      });
+    }
+    if (!hasUpdatedAt) {
+      sanitized.fields.push({
+        name: 'updatedAt',
+        label: translations['general:updatedAt'],
+        type: 'date',
+        admin: {
+          disableBulkEdit: true,
+        },
+      });
+    }
+  }
 
   sanitized.labels = sanitized.labels || formatLabels(sanitized.slug);
 

--- a/src/collections/graphql/init.ts
+++ b/src/collections/graphql/init.ts
@@ -1,12 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { DateTimeResolver } from 'graphql-scalars';
-import {
-  GraphQLString,
-  GraphQLObjectType,
-  GraphQLBoolean,
-  GraphQLNonNull,
-  GraphQLInt,
-} from 'graphql';
+import { GraphQLBoolean, GraphQLInt, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 
 import formatName from '../../graphql/utilities/formatName';
 import buildPaginatedListType from '../../graphql/schema/buildPaginatedListType';
@@ -33,7 +26,7 @@ import { Field, fieldAffectsData } from '../../fields/config/types';
 import buildObjectType, { ObjectTypeConfig } from '../../graphql/schema/buildObjectType';
 import buildWhereInputType from '../../graphql/schema/buildWhereInputType';
 import getDeleteResolver from './resolvers/delete';
-import { toWords, formatNames } from '../../utilities/formatLabels';
+import { formatNames, toWords } from '../../utilities/formatLabels';
 import { Collection, SanitizedCollectionConfig } from '../config/types';
 import { buildPolicyType } from '../../graphql/schema/buildPoliciesType';
 import { docAccessResolver } from './resolvers/docAccess';
@@ -45,7 +38,6 @@ function initCollectionsGraphQL(payload: Payload): void {
       config: {
         graphQL = {} as SanitizedCollectionConfig['graphQL'],
         fields,
-        timestamps,
         versions,
       },
     } = collection;
@@ -88,28 +80,6 @@ function initCollectionsGraphQL(payload: Payload): void {
       whereInputFields.push({
         name: 'id',
         type: 'text',
-      });
-    }
-
-    if (timestamps) {
-      baseFields.createdAt = {
-        type: new GraphQLNonNull(DateTimeResolver),
-      };
-
-      baseFields.updatedAt = {
-        type: new GraphQLNonNull(DateTimeResolver),
-      };
-
-      whereInputFields.push({
-        name: 'createdAt',
-        label: 'Created At',
-        type: 'date',
-      });
-
-      whereInputFields.push({
-        name: 'updatedAt',
-        label: 'Updated At',
-        type: 'date',
       });
     }
 

--- a/src/graphql/schema/withNullableType.ts
+++ b/src/graphql/schema/withNullableType.ts
@@ -4,8 +4,9 @@ import { FieldAffectingData } from '../../fields/config/types';
 const withNullableType = (field: FieldAffectingData, type: GraphQLType, forceNullable = false): GraphQLType => {
   const hasReadAccessControl = field.access && field.access.read;
   const condition = field.admin && field.admin.condition;
+  const isTimestamp = field.name === 'createdAt' || field.name === 'updatedAt';
 
-  if (!forceNullable && 'required' in field && field.required && !field.localized && !condition && !hasReadAccessControl) {
+  if (!forceNullable && 'required' in field && field.required && !field.localized && !condition && !hasReadAccessControl && !isTimestamp) {
     return new GraphQLNonNull(type);
   }
 

--- a/src/utilities/entityToJSONSchema.ts
+++ b/src/utilities/entityToJSONSchema.ts
@@ -1,7 +1,6 @@
-
 import { singular } from 'pluralize';
 import type { JSONSchema4 } from 'json-schema';
-import { fieldAffectsData, Field, Option, FieldAffectingData, tabHasName } from '../fields/config/types';
+import { Field, FieldAffectingData, fieldAffectsData, Option, tabHasName } from '../fields/config/types';
 import { SanitizedCollectionConfig } from '../collections/config/types';
 import { SanitizedGlobalConfig } from '../globals/config/types';
 import deepCopyObject from './deepCopyObject';
@@ -401,19 +400,17 @@ export function entityToJSONSchema(config: SanitizedConfig, incomingEntity: Sani
     entity.fields.unshift(idField);
   }
 
+  // mark timestamp fields required
   if ('timestamps' in entity && entity.timestamps !== false) {
-    entity.fields.push(
-      {
-        type: 'text',
-        name: 'createdAt',
-        required: true,
-      },
-      {
-        type: 'text',
-        name: 'updatedAt',
-        required: true,
-      },
-    );
+    entity.fields = entity.fields.map((field) => {
+      if (fieldAffectsData(field) && (field.name === 'createdAt' || field.name === 'updatedAt')) {
+        return {
+          ...field,
+          required: true,
+        };
+      }
+      return field;
+    });
   }
 
   if ('auth' in entity && entity.auth && !entity.auth?.disableLocalStrategy) {

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -5,94 +5,88 @@
  * and re-run `payload generate:types` to regenerate this file.
  */
 
-export interface Config {}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "global".
- */
-export interface Global {
-  id: string;
-  title?: string;
+export interface Config {
+  collections: {
+    users: User;
+    'hidden-collection': HiddenCollection;
+    posts: Post;
+    'group-one-collection-ones': GroupOneCollectionOne;
+    'group-one-collection-twos': GroupOneCollectionTwo;
+    'group-two-collection-ones': GroupTwoCollectionOne;
+    'group-two-collection-twos': GroupTwoCollectionTwo;
+  };
+  globals: {
+    'hidden-global': HiddenGlobal;
+    global: Global;
+    'group-globals-one': GroupGlobalsOne;
+    'group-globals-two': GroupGlobalsTwo;
+  };
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "group-globals-one".
- */
-export interface GroupGlobalsOne {
-  id: string;
-  title?: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "group-globals-two".
- */
-export interface GroupGlobalsTwo {
-  id: string;
-  title?: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "users".
- */
 export interface User {
   id: string;
+  createdAt: string;
+  updatedAt: string;
   email?: string;
   resetPasswordToken?: string;
   resetPasswordExpiration?: string;
   loginAttempts?: number;
   lockUntil?: string;
+  password?: string;
+}
+export interface HiddenCollection {
+  id: string;
+  title?: string;
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "posts".
- */
 export interface Post {
   id: string;
   title?: string;
   description?: string;
   number?: number;
+  richText?: {
+    [k: string]: unknown;
+  }[];
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "group-one-collection-ones".
- */
 export interface GroupOneCollectionOne {
   id: string;
   title?: string;
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "group-one-collection-twos".
- */
 export interface GroupOneCollectionTwo {
   id: string;
   title?: string;
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "group-two-collection-ones".
- */
 export interface GroupTwoCollectionOne {
   id: string;
   title?: string;
   createdAt: string;
   updatedAt: string;
 }
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "group-two-collection-twos".
- */
 export interface GroupTwoCollectionTwo {
   id: string;
   title?: string;
   createdAt: string;
   updatedAt: string;
+}
+export interface HiddenGlobal {
+  id: string;
+  title?: string;
+}
+export interface Global {
+  id: string;
+  title?: string;
+}
+export interface GroupGlobalsOne {
+  id: string;
+  title?: string;
+}
+export interface GroupGlobalsTwo {
+  id: string;
+  title?: string;
 }

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -10,6 +10,7 @@ import { defaultText } from './collections/Text';
 import { blocksFieldSeedData } from './collections/Blocks';
 import { localizedTextValue, namedTabDefaultValue, namedTabText, tabsDoc, tabsSlug } from './collections/Tabs';
 import { defaultNumber, numberDoc } from './collections/Number';
+import { dateDoc } from './collections/Date';
 
 let client;
 let serverURL;
@@ -38,6 +39,45 @@ describe('Fields', () => {
       expect(doc.text).toEqual(text);
       expect(doc.defaultFunction).toEqual(defaultText);
       expect(doc.defaultAsync).toEqual(defaultText);
+    });
+  });
+
+  describe('timestamps', () => {
+    const tenMinutesAgo = new Date(Date.now() - 1000 * 60 * 10);
+    let doc;
+    beforeAll(async () => {
+      doc = await payload.create({
+        collection: 'date-fields',
+        data: dateDoc,
+      });
+    });
+
+    it('should query updatedAt', async () => {
+      const { docs } = await payload.find({
+        collection: 'date-fields',
+        depth: 0,
+        where: {
+          updatedAt: {
+            greater_than_equal: tenMinutesAgo,
+          },
+        },
+      });
+
+      expect(docs.map(({ id }) => id)).toContain(doc.id);
+    });
+
+    it('should query createdAt', async () => {
+      const result = await payload.find({
+        collection: 'date-fields',
+        depth: 0,
+        where: {
+          createdAt: {
+            greater_than_equal: tenMinutesAgo,
+          },
+        },
+      });
+
+      expect(result.docs[0].id).toEqual(doc.id);
     });
   });
 

--- a/test/graphql-schema-gen/generated-schema.graphql
+++ b/test/graphql-schema-gen/generated-schema.graphql
@@ -19,8 +19,6 @@ type Query {
 
 type Post {
   id: String
-  createdAt: DateTime!
-  updatedAt: DateTime!
   title: String
   description: String
   number: Float
@@ -28,19 +26,21 @@ type Post {
   relationHasManyField: [Relation!]
   relationMultiRelationTo: Post_RelationMultiRelationTo_Relationship
   relationMultiRelationToHasMany: [Post_RelationMultiRelationToHasMany_Relationship!]
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+type Relation {
+  id: String
+  name: String
+  createdAt: DateTime!
+  updatedAt: DateTime!
 }
 
 """
 A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
 """
 scalar DateTime
-
-type Relation {
-  id: String
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  name: String
-}
 
 type Post_RelationMultiRelationTo_Relationship {
   relationTo: Post_RelationMultiRelationTo_RelationTo
@@ -56,9 +56,9 @@ union Post_RelationMultiRelationTo = Relation | Dummy
 
 type Dummy {
   id: String
+  name: String
   createdAt: DateTime!
   updatedAt: DateTime!
-  name: String
 }
 
 type Post_RelationMultiRelationToHasMany_Relationship {
@@ -95,9 +95,9 @@ input Post_where {
   relationHasManyField: Post_relationHasManyField_operator
   relationMultiRelationTo: Post_relationMultiRelationTo_Relation
   relationMultiRelationToHasMany: Post_relationMultiRelationToHasMany_Relation
-  id: Post_id_operator
   createdAt: Post_createdAt_operator
   updatedAt: Post_updatedAt_operator
+  id: Post_id_operator
   OR: [Post_where_or]
   AND: [Post_where_and]
 }
@@ -172,20 +172,6 @@ enum Post_relationMultiRelationToHasMany_Relation_RelationTo {
   dummy
 }
 
-input Post_id_operator {
-  equals: JSON
-  not_equals: JSON
-  in: [JSON]
-  not_in: [JSON]
-  all: [JSON]
-  exists: Boolean
-}
-
-"""
-The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSON
-
 input Post_createdAt_operator {
   equals: DateTime
   not_equals: DateTime
@@ -208,6 +194,20 @@ input Post_updatedAt_operator {
   exists: Boolean
 }
 
+input Post_id_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+
 input Post_where_or {
   title: Post_title_operator
   description: Post_description_operator
@@ -216,9 +216,9 @@ input Post_where_or {
   relationHasManyField: Post_relationHasManyField_operator
   relationMultiRelationTo: Post_relationMultiRelationTo_Relation
   relationMultiRelationToHasMany: Post_relationMultiRelationToHasMany_Relation
-  id: Post_id_operator
   createdAt: Post_createdAt_operator
   updatedAt: Post_updatedAt_operator
+  id: Post_id_operator
 }
 
 input Post_where_and {
@@ -229,9 +229,9 @@ input Post_where_and {
   relationHasManyField: Post_relationHasManyField_operator
   relationMultiRelationTo: Post_relationMultiRelationTo_Relation
   relationMultiRelationToHasMany: Post_relationMultiRelationToHasMany_Relation
-  id: Post_id_operator
   createdAt: Post_createdAt_operator
   updatedAt: Post_updatedAt_operator
+  id: Post_id_operator
 }
 
 type postsDocAccess {
@@ -250,6 +250,8 @@ type PostsDocAccessFields {
   relationHasManyField: PostsDocAccessFields_relationHasManyField
   relationMultiRelationTo: PostsDocAccessFields_relationMultiRelationTo
   relationMultiRelationToHasMany: PostsDocAccessFields_relationMultiRelationToHasMany
+  createdAt: PostsDocAccessFields_createdAt
+  updatedAt: PostsDocAccessFields_updatedAt
 }
 
 type PostsDocAccessFields_title {
@@ -413,6 +415,52 @@ type PostsDocAccessFields_relationMultiRelationToHasMany_Delete {
   permission: Boolean!
 }
 
+type PostsDocAccessFields_createdAt {
+  create: PostsDocAccessFields_createdAt_Create
+  read: PostsDocAccessFields_createdAt_Read
+  update: PostsDocAccessFields_createdAt_Update
+  delete: PostsDocAccessFields_createdAt_Delete
+}
+
+type PostsDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_updatedAt {
+  create: PostsDocAccessFields_updatedAt_Create
+  read: PostsDocAccessFields_updatedAt_Read
+  update: PostsDocAccessFields_updatedAt_Update
+  delete: PostsDocAccessFields_updatedAt_Delete
+}
+
+type PostsDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
 type PostsCreateDocAccess {
   permission: Boolean!
   where: JSONObject
@@ -454,9 +502,9 @@ type Relations {
 
 input Relation_where {
   name: Relation_name_operator
-  id: Relation_id_operator
   createdAt: Relation_createdAt_operator
   updatedAt: Relation_updatedAt_operator
+  id: Relation_id_operator
   OR: [Relation_where_or]
   AND: [Relation_where_and]
 }
@@ -469,15 +517,6 @@ input Relation_name_operator {
   in: [String]
   not_in: [String]
   all: [String]
-  exists: Boolean
-}
-
-input Relation_id_operator {
-  equals: JSON
-  not_equals: JSON
-  in: [JSON]
-  not_in: [JSON]
-  all: [JSON]
   exists: Boolean
 }
 
@@ -503,18 +542,27 @@ input Relation_updatedAt_operator {
   exists: Boolean
 }
 
+input Relation_id_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
 input Relation_where_or {
   name: Relation_name_operator
-  id: Relation_id_operator
   createdAt: Relation_createdAt_operator
   updatedAt: Relation_updatedAt_operator
+  id: Relation_id_operator
 }
 
 input Relation_where_and {
   name: Relation_name_operator
-  id: Relation_id_operator
   createdAt: Relation_createdAt_operator
   updatedAt: Relation_updatedAt_operator
+  id: Relation_id_operator
 }
 
 type relationDocAccess {
@@ -527,6 +575,8 @@ type relationDocAccess {
 
 type RelationDocAccessFields {
   name: RelationDocAccessFields_name
+  createdAt: RelationDocAccessFields_createdAt
+  updatedAt: RelationDocAccessFields_updatedAt
 }
 
 type RelationDocAccessFields_name {
@@ -549,6 +599,52 @@ type RelationDocAccessFields_name_Update {
 }
 
 type RelationDocAccessFields_name_Delete {
+  permission: Boolean!
+}
+
+type RelationDocAccessFields_createdAt {
+  create: RelationDocAccessFields_createdAt_Create
+  read: RelationDocAccessFields_createdAt_Read
+  update: RelationDocAccessFields_createdAt_Update
+  delete: RelationDocAccessFields_createdAt_Delete
+}
+
+type RelationDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type RelationDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type RelationDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type RelationDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type RelationDocAccessFields_updatedAt {
+  create: RelationDocAccessFields_updatedAt_Create
+  read: RelationDocAccessFields_updatedAt_Read
+  update: RelationDocAccessFields_updatedAt_Update
+  delete: RelationDocAccessFields_updatedAt_Delete
+}
+
+type RelationDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type RelationDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type RelationDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type RelationDocAccessFields_updatedAt_Delete {
   permission: Boolean!
 }
 
@@ -588,9 +684,9 @@ type Dummies {
 
 input Dummy_where {
   name: Dummy_name_operator
-  id: Dummy_id_operator
   createdAt: Dummy_createdAt_operator
   updatedAt: Dummy_updatedAt_operator
+  id: Dummy_id_operator
   OR: [Dummy_where_or]
   AND: [Dummy_where_and]
 }
@@ -603,15 +699,6 @@ input Dummy_name_operator {
   in: [String]
   not_in: [String]
   all: [String]
-  exists: Boolean
-}
-
-input Dummy_id_operator {
-  equals: JSON
-  not_equals: JSON
-  in: [JSON]
-  not_in: [JSON]
-  all: [JSON]
   exists: Boolean
 }
 
@@ -637,18 +724,27 @@ input Dummy_updatedAt_operator {
   exists: Boolean
 }
 
+input Dummy_id_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
 input Dummy_where_or {
   name: Dummy_name_operator
-  id: Dummy_id_operator
   createdAt: Dummy_createdAt_operator
   updatedAt: Dummy_updatedAt_operator
+  id: Dummy_id_operator
 }
 
 input Dummy_where_and {
   name: Dummy_name_operator
-  id: Dummy_id_operator
   createdAt: Dummy_createdAt_operator
   updatedAt: Dummy_updatedAt_operator
+  id: Dummy_id_operator
 }
 
 type dummyDocAccess {
@@ -661,6 +757,8 @@ type dummyDocAccess {
 
 type DummyDocAccessFields {
   name: DummyDocAccessFields_name
+  createdAt: DummyDocAccessFields_createdAt
+  updatedAt: DummyDocAccessFields_updatedAt
 }
 
 type DummyDocAccessFields_name {
@@ -683,6 +781,52 @@ type DummyDocAccessFields_name_Update {
 }
 
 type DummyDocAccessFields_name_Delete {
+  permission: Boolean!
+}
+
+type DummyDocAccessFields_createdAt {
+  create: DummyDocAccessFields_createdAt_Create
+  read: DummyDocAccessFields_createdAt_Read
+  update: DummyDocAccessFields_createdAt_Update
+  delete: DummyDocAccessFields_createdAt_Delete
+}
+
+type DummyDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type DummyDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type DummyDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type DummyDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type DummyDocAccessFields_updatedAt {
+  create: DummyDocAccessFields_updatedAt_Create
+  read: DummyDocAccessFields_updatedAt_Read
+  update: DummyDocAccessFields_updatedAt_Update
+  delete: DummyDocAccessFields_updatedAt_Delete
+}
+
+type DummyDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type DummyDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type DummyDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type DummyDocAccessFields_updatedAt_Delete {
   permission: Boolean!
 }
 
@@ -738,32 +882,12 @@ type Users {
 }
 
 input User_where {
-  email: User_email_operator
-  id: User_id_operator
   createdAt: User_createdAt_operator
   updatedAt: User_updatedAt_operator
+  email: User_email_operator
+  id: User_id_operator
   OR: [User_where_or]
   AND: [User_where_and]
-}
-
-input User_email_operator {
-  equals: EmailAddress
-  not_equals: EmailAddress
-  like: EmailAddress
-  contains: EmailAddress
-  in: [EmailAddress]
-  not_in: [EmailAddress]
-  all: [EmailAddress]
-  exists: Boolean
-}
-
-input User_id_operator {
-  equals: JSON
-  not_equals: JSON
-  in: [JSON]
-  not_in: [JSON]
-  all: [JSON]
-  exists: Boolean
 }
 
 input User_createdAt_operator {
@@ -788,18 +912,38 @@ input User_updatedAt_operator {
   exists: Boolean
 }
 
+input User_email_operator {
+  equals: EmailAddress
+  not_equals: EmailAddress
+  like: EmailAddress
+  contains: EmailAddress
+  in: [EmailAddress]
+  not_in: [EmailAddress]
+  all: [EmailAddress]
+  exists: Boolean
+}
+
+input User_id_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
 input User_where_or {
-  email: User_email_operator
-  id: User_id_operator
   createdAt: User_createdAt_operator
   updatedAt: User_updatedAt_operator
+  email: User_email_operator
+  id: User_id_operator
 }
 
 input User_where_and {
-  email: User_email_operator
-  id: User_id_operator
   createdAt: User_createdAt_operator
   updatedAt: User_updatedAt_operator
+  email: User_email_operator
+  id: User_id_operator
 }
 
 type usersDocAccess {
@@ -812,8 +956,55 @@ type usersDocAccess {
 }
 
 type UsersDocAccessFields {
+  createdAt: UsersDocAccessFields_createdAt
+  updatedAt: UsersDocAccessFields_updatedAt
   email: UsersDocAccessFields_email
-  password: UsersDocAccessFields_password
+}
+
+type UsersDocAccessFields_createdAt {
+  create: UsersDocAccessFields_createdAt_Create
+  read: UsersDocAccessFields_createdAt_Read
+  update: UsersDocAccessFields_createdAt_Update
+  delete: UsersDocAccessFields_createdAt_Delete
+}
+
+type UsersDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type UsersDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type UsersDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type UsersDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type UsersDocAccessFields_updatedAt {
+  create: UsersDocAccessFields_updatedAt_Create
+  read: UsersDocAccessFields_updatedAt_Read
+  update: UsersDocAccessFields_updatedAt_Update
+  delete: UsersDocAccessFields_updatedAt_Delete
+}
+
+type UsersDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type UsersDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type UsersDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type UsersDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
 }
 
 type UsersDocAccessFields_email {
@@ -836,29 +1027,6 @@ type UsersDocAccessFields_email_Update {
 }
 
 type UsersDocAccessFields_email_Delete {
-  permission: Boolean!
-}
-
-type UsersDocAccessFields_password {
-  create: UsersDocAccessFields_password_Create
-  read: UsersDocAccessFields_password_Read
-  update: UsersDocAccessFields_password_Update
-  delete: UsersDocAccessFields_password_Delete
-}
-
-type UsersDocAccessFields_password_Create {
-  permission: Boolean!
-}
-
-type UsersDocAccessFields_password_Read {
-  permission: Boolean!
-}
-
-type UsersDocAccessFields_password_Update {
-  permission: Boolean!
-}
-
-type UsersDocAccessFields_password_Delete {
   permission: Boolean!
 }
 
@@ -925,6 +1093,8 @@ type PostsFields {
   relationHasManyField: PostsFields_relationHasManyField
   relationMultiRelationTo: PostsFields_relationMultiRelationTo
   relationMultiRelationToHasMany: PostsFields_relationMultiRelationToHasMany
+  createdAt: PostsFields_createdAt
+  updatedAt: PostsFields_updatedAt
 }
 
 type PostsFields_title {
@@ -1088,6 +1258,52 @@ type PostsFields_relationMultiRelationToHasMany_Delete {
   permission: Boolean!
 }
 
+type PostsFields_createdAt {
+  create: PostsFields_createdAt_Create
+  read: PostsFields_createdAt_Read
+  update: PostsFields_createdAt_Update
+  delete: PostsFields_createdAt_Delete
+}
+
+type PostsFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PostsFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PostsFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PostsFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_updatedAt {
+  create: PostsFields_updatedAt_Create
+  read: PostsFields_updatedAt_Read
+  update: PostsFields_updatedAt_Update
+  delete: PostsFields_updatedAt_Delete
+}
+
+type PostsFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PostsFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PostsFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PostsFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
 type PostsCreateAccess {
   permission: Boolean!
   where: JSONObject
@@ -1118,6 +1334,8 @@ type relationAccess {
 
 type RelationFields {
   name: RelationFields_name
+  createdAt: RelationFields_createdAt
+  updatedAt: RelationFields_updatedAt
 }
 
 type RelationFields_name {
@@ -1140,6 +1358,52 @@ type RelationFields_name_Update {
 }
 
 type RelationFields_name_Delete {
+  permission: Boolean!
+}
+
+type RelationFields_createdAt {
+  create: RelationFields_createdAt_Create
+  read: RelationFields_createdAt_Read
+  update: RelationFields_createdAt_Update
+  delete: RelationFields_createdAt_Delete
+}
+
+type RelationFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type RelationFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type RelationFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type RelationFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type RelationFields_updatedAt {
+  create: RelationFields_updatedAt_Create
+  read: RelationFields_updatedAt_Read
+  update: RelationFields_updatedAt_Update
+  delete: RelationFields_updatedAt_Delete
+}
+
+type RelationFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type RelationFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type RelationFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type RelationFields_updatedAt_Delete {
   permission: Boolean!
 }
 
@@ -1173,6 +1437,8 @@ type dummyAccess {
 
 type DummyFields {
   name: DummyFields_name
+  createdAt: DummyFields_createdAt
+  updatedAt: DummyFields_updatedAt
 }
 
 type DummyFields_name {
@@ -1195,6 +1461,52 @@ type DummyFields_name_Update {
 }
 
 type DummyFields_name_Delete {
+  permission: Boolean!
+}
+
+type DummyFields_createdAt {
+  create: DummyFields_createdAt_Create
+  read: DummyFields_createdAt_Read
+  update: DummyFields_createdAt_Update
+  delete: DummyFields_createdAt_Delete
+}
+
+type DummyFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type DummyFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type DummyFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type DummyFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type DummyFields_updatedAt {
+  create: DummyFields_updatedAt_Create
+  read: DummyFields_updatedAt_Read
+  update: DummyFields_updatedAt_Update
+  delete: DummyFields_updatedAt_Delete
+}
+
+type DummyFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type DummyFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type DummyFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type DummyFields_updatedAt_Delete {
   permission: Boolean!
 }
 
@@ -1228,8 +1540,55 @@ type usersAccess {
 }
 
 type UsersFields {
+  createdAt: UsersFields_createdAt
+  updatedAt: UsersFields_updatedAt
   email: UsersFields_email
-  password: UsersFields_password
+}
+
+type UsersFields_createdAt {
+  create: UsersFields_createdAt_Create
+  read: UsersFields_createdAt_Read
+  update: UsersFields_createdAt_Update
+  delete: UsersFields_createdAt_Delete
+}
+
+type UsersFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type UsersFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type UsersFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type UsersFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type UsersFields_updatedAt {
+  create: UsersFields_updatedAt_Create
+  read: UsersFields_updatedAt_Read
+  update: UsersFields_updatedAt_Update
+  delete: UsersFields_updatedAt_Delete
+}
+
+type UsersFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type UsersFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type UsersFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type UsersFields_updatedAt_Delete {
+  permission: Boolean!
 }
 
 type UsersFields_email {
@@ -1252,29 +1611,6 @@ type UsersFields_email_Update {
 }
 
 type UsersFields_email_Delete {
-  permission: Boolean!
-}
-
-type UsersFields_password {
-  create: UsersFields_password_Create
-  read: UsersFields_password_Read
-  update: UsersFields_password_Update
-  delete: UsersFields_password_Delete
-}
-
-type UsersFields_password_Create {
-  permission: Boolean!
-}
-
-type UsersFields_password_Read {
-  permission: Boolean!
-}
-
-type UsersFields_password_Update {
-  permission: Boolean!
-}
-
-type UsersFields_password_Delete {
   permission: Boolean!
 }
 
@@ -1335,6 +1671,8 @@ input mutationPostInput {
   relationHasManyField: [String]
   relationMultiRelationTo: Post_RelationMultiRelationToRelationshipInput
   relationMultiRelationToHasMany: [Post_RelationMultiRelationToHasManyRelationshipInput]
+  createdAt: String!
+  updatedAt: String!
 }
 
 input Post_RelationMultiRelationToRelationshipInput {
@@ -1365,6 +1703,8 @@ input mutationPostUpdateInput {
   relationHasManyField: [String]
   relationMultiRelationTo: PostUpdate_RelationMultiRelationToRelationshipInput
   relationMultiRelationToHasMany: [PostUpdate_RelationMultiRelationToHasManyRelationshipInput]
+  createdAt: String
+  updatedAt: String
 }
 
 input PostUpdate_RelationMultiRelationToRelationshipInput {
@@ -1389,21 +1729,31 @@ enum PostUpdate_RelationMultiRelationToHasManyRelationshipInputRelationTo {
 
 input mutationRelationInput {
   name: String
+  createdAt: String!
+  updatedAt: String!
 }
 
 input mutationRelationUpdateInput {
   name: String
+  createdAt: String
+  updatedAt: String
 }
 
 input mutationDummyInput {
   name: String
+  createdAt: String!
+  updatedAt: String!
 }
 
 input mutationDummyUpdateInput {
   name: String
+  createdAt: String
+  updatedAt: String
 }
 
 input mutationUserInput {
+  createdAt: String!
+  updatedAt: String!
   email: String
   resetPasswordToken: String
   resetPasswordExpiration: String
@@ -1413,6 +1763,8 @@ input mutationUserInput {
 }
 
 input mutationUserUpdateInput {
+  createdAt: String
+  updatedAt: String
   email: String
   resetPasswordToken: String
   resetPasswordExpiration: String


### PR DESCRIPTION
## Description

fixes #2582
I fixed the issue by injecting createdAt and updatedAt fields during config sanitization. I was going to have to also push them in buildQuery and getEntityPolicies. Instead I eliminated redundancy where we were pushing those same fields in many places which should help avoid future bugs. 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
