### PR TITLE
fix: Row groups in tabs alignment

### DIFF
--- a/src/admin/components/forms/field-types/Group/index.scss
+++ b/src/admin/components/forms/field-types/Group/index.scss
@@ -35,6 +35,10 @@
     border-bottom: 0;
   }
 
+  &--within-tab {
+    align-self: baseline;
+  }
+
   &--within-tab:first-child {
     margin-top: 0;
     border-top: 0;

--- a/src/admin/components/forms/field-types/Group/index.scss
+++ b/src/admin/components/forms/field-types/Group/index.scss
@@ -35,10 +35,6 @@
     border-bottom: 0;
   }
 
-  &--within-tab {
-    align-self: baseline;
-  }
-
   &--within-tab:first-child {
     margin-top: 0;
     border-top: 0;
@@ -94,4 +90,8 @@
 
 .group-field--within-row+.group-field--within-row {
   margin-top: 0;
+}
+
+.group-field--within-tab+.group-field--within-row {
+  padding-top: 0;
 }

--- a/test/fields/collections/Group/index.ts
+++ b/test/fields/collections/Group/index.ts
@@ -110,6 +110,61 @@ const GroupFields: CollectionConfig = {
         },
       ],
     },
+
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          name: 'groups',
+          label: 'Groups in tabs',
+          fields: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'groupInRow',
+                  type: 'group',
+                  fields: [
+                    {
+                      name: 'field',
+                      type: 'text',
+                    },
+                    {
+                      name: 'secondField',
+                      type: 'text',
+                    },
+                    {
+                      name: 'thirdField',
+                      type: 'text',
+                    },
+                  ],
+                },
+                {
+                  name: 'secondGroupInRow',
+                  type: 'group',
+                  fields: [
+                    {
+                      name: 'field',
+                      type: 'text',
+                    },
+                    {
+                      name: 'nestedGroup',
+                      type: 'group',
+                      fields: [
+                        {
+                          name: 'nestedField',
+                          type: 'text',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
## Description
At the moment, when using groups and rows within a tab, the rows become unaligned.

Before:
![Screenshot 2023-05-01 at 11 11 27](https://user-images.githubusercontent.com/6953846/235433304-17d042b7-22f0-4d0e-9cd3-5ed0126a225e.png)

After:
![Screenshot 2023-05-01 at 11 11 50](https://user-images.githubusercontent.com/6953846/235433336-ac5f9afd-3ebf-475f-aa38-d757b0af1999.png)

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
