### PR TITLE
fix: addds workaround for slate isBlock function issue

### DIFF
--- a/src/admin/components/forms/field-types/RichText/elements/getCommonBlock.tsx
+++ b/src/admin/components/forms/field-types/RichText/elements/getCommonBlock.tsx
@@ -1,5 +1,6 @@
 import { Editor, Node, NodeEntry, NodeMatch } from 'slate';
 import { ElementNode } from '../types';
+import { isBlockElement } from './isBlockElement';
 
 export const getCommonBlock = (editor: Editor, match?: NodeMatch<Node>): NodeEntry<Node> => {
   const range = Editor.unhangRange(editor, editor.selection, { voids: true });
@@ -12,12 +13,13 @@ export const getCommonBlock = (editor: Editor, match?: NodeMatch<Node>): NodeEnt
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  if (Editor.isBlock(editor, common) || Editor.isEditor(common)) {
+  if (isBlockElement(editor, common) || Editor.isEditor(common)) {
     return [common, path];
   }
 
+
   return Editor.above(editor, {
     at: path,
-    match: match || ((n: ElementNode) => Editor.isBlock(editor, n) || Editor.isEditor(n)),
+    match: match || ((n: ElementNode) => isBlockElement(editor, n) || Editor.isEditor(n)),
   });
 };

--- a/src/admin/components/forms/field-types/RichText/elements/indent/index.tsx
+++ b/src/admin/components/forms/field-types/RichText/elements/indent/index.tsx
@@ -9,6 +9,7 @@ import listTypes from '../listTypes';
 import { getCommonBlock } from '../getCommonBlock';
 import { unwrapList } from '../unwrapList';
 import { ElementNode } from '../../types';
+import { isBlockElement } from '../isBlockElement';
 
 const indentType = 'indent';
 
@@ -33,7 +34,7 @@ const indent = {
 
           const matchedParentList = Editor.above(editor, {
             at: listPath,
-            match: (n: ElementNode) => !Editor.isEditor(n) && Editor.isBlock(editor, n),
+            match: (n: ElementNode) => !Editor.isEditor(n) && isBlockElement(editor, n),
           });
 
           if (matchedParentList) {

--- a/src/admin/components/forms/field-types/RichText/elements/injectVoid.ts
+++ b/src/admin/components/forms/field-types/RichText/elements/injectVoid.ts
@@ -8,7 +8,7 @@ export const injectVoidElement = (editor: Editor, element: Element): void => {
 
   if (lastSelectedElementIsEmpty) {
     // If previous node is void
-    if (Editor.isVoid(editor, previous?.[0])) {
+    if (previous?.[0] && Editor.isVoid(editor, previous[0])) {
       // Insert a blank element between void nodes
       // so user can place cursor between void nodes
       Transforms.insertNodes(editor, { children: [{ text: '' }] });

--- a/src/admin/components/forms/field-types/RichText/elements/isBlockElement.ts
+++ b/src/admin/components/forms/field-types/RichText/elements/isBlockElement.ts
@@ -1,0 +1,26 @@
+import { Editor, Element } from 'slate';
+
+/**
+ * Returns true, if the provided node is an Element (optionally of a specific type)
+ */
+const isElement = (node: any, specificType?: string | string[]): node is Element => {
+  if (Editor.isEditor(node) || !Element.isElement(node)) {
+    return false;
+  }
+  if (undefined === specificType) {
+    return true;
+  }
+  if (typeof specificType === 'string') {
+    return node.type === specificType;
+  }
+  return specificType.includes(node.type);
+};
+
+/**
+ * Returns true, if the provided node is a Block Element.
+ * Note: Using Editor.isBlock() is not sufficient, as since slate 0.90 it returns `true` for Text nodes and the editor as well.
+ *
+ * Related Issue: https://github.com/ianstormtaylor/slate/issues/5287
+ */
+
+export const isBlockElement = (editor: Editor, node: any): node is Element => Editor.isBlock(editor, node as any) && isElement(node);


### PR DESCRIPTION
## Description

Fixes #2579 

Unable to create lists when toggling the ol/ul buttons.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
