### PR TITLE
fix: properly import SwcMinifyWebpackPlugin

### DIFF
--- a/src/webpack/getProdConfig.ts
+++ b/src/webpack/getProdConfig.ts
@@ -1,12 +1,9 @@
 import MiniCSSExtractPlugin from 'mini-css-extract-plugin';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
-import path from 'path';
 import { Configuration, WebpackPluginInstance } from 'webpack';
+import { SwcMinifyWebpackPlugin } from 'swc-minify-webpack-plugin';
 import { SanitizedConfig } from '../config/types';
 import getBaseConfig from './getBaseConfig';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, @typescript-eslint/no-var-requires
-const SwcMinifyWebpackPlugin = require('swc-minify-webpack-plugin');
 
 export default (payloadConfig: SanitizedConfig): Configuration => {
   const baseConfig = getBaseConfig(payloadConfig) as any;


### PR DESCRIPTION
## Description

Properly import SwcMinifyWebpackPlugin after bumping to latest

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
