### PR TITLE
fix: make incrementName match multiple digits

### DIFF
--- a/src/uploads/getSafeFilename.ts
+++ b/src/uploads/getSafeFilename.ts
@@ -7,7 +7,7 @@ const incrementName = (name: string) => {
   const extension = name.split('.').pop();
   const baseFilename = sanitize(name.substring(0, name.lastIndexOf('.')) || name);
   let incrementedName = baseFilename;
-  const regex = /(.*)-(\d)$/;
+  const regex = /(.*)-(\d+)$/;
   const found = baseFilename.match(regex);
   if (found === null) {
     incrementedName += '-1';


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

When you upload a file with name `file-1.png` and such a file already exists, Payload automatically changes the name to `file-2.png`. However, if the number consists of multiple digits, like `file-10.png`, Payload would create `file-10-1.png` instead, rather than the expected `file-11.png`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Not currently completed any of those below because I don't have enough time right now. Let me know if the change is critical enough to require those.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
- [x] I *have* tested in my project, though. I made the change directly in `node_modules` and it worked as expected