### PR TITLE
feat:export additional graphql types

### DIFF
--- a/docs/graphql/extending.mdx
+++ b/docs/graphql/extending.mdx
@@ -77,10 +77,10 @@ Your function will receive four arguments you can make use of:
 Example
 
 ```ts
-async (_, args, context, info) => { }
+async (obj, args, context, info) => { }
 ```
 
-**`_`**
+**`obj`** The previous object. Not very often used and usually discarded.
 
 
 **`args`**

--- a/docs/graphql/extending.mdx
+++ b/docs/graphql/extending.mdx
@@ -67,3 +67,89 @@ export default buildConfig({
   }
 })
 ```
+
+### Resolver function
+
+In your resolver, make sure you set `depth: 0` if you're returning data directly from the local API so that GraphQL can correctly resolve queries to nested values such as relationship data.
+
+Your function will receive four arguments you can make use of:
+
+Example
+
+```ts
+async (_, args, context, info) => { }
+```
+
+**`_`**
+
+
+**`args`**
+
+The available arguments from your query or mutation will be available to you here, these must be configured via the custom operation first.
+
+**`context`**
+
+An object containing the `req` and `res` objects that will provide you with the `payload`, `user` instances and more, like any other Payload API handler.
+
+**`info`**
+
+Contextual information about the currently running GraphQL operation. You can get schema information from this as well as contextual information about where this resolver function is being run.
+
+### Types
+
+We've exposed a few types and utilities to help you extend the API further. Payload uses the GraphQL.js package for which you can view the full list of available types in the [official documentation](https://graphql.org/graphql-js/type/).
+
+**`GraphQL`**
+
+You can directly import the GraphQL package used by Payload, most useful for typing. For queries, mutations and handlers make sure you use the `GraphQL` and `payload` instances provided via arguments.
+
+**`buildPaginatedListType`**
+
+This is a utility function that allows you to build a new GraphQL type for a paginated result similar to the Payload's generated schema.
+It takes in two arguments, the first for the name of this new schema type and the second for the GraphQL type to be used in the docs parameter.
+
+Example
+
+```ts
+export const getMyPosts = (GraphQL, payload) => {
+  return {
+    args: {},
+    resolve: Resolver,
+    // The name of your new type has to be unique
+    type: buildPaginatedListType('AuthorPosts', payload.collections['posts'].graphQL?.type),
+  }
+}
+```
+
+**`payload.collections.slug.graphQL`**
+
+If you want to extend more of the provided API then the `graphQL` object on your collection slug will contain additional types to help you re-use code for types, mutations and queries.
+
+```ts
+graphQL?: {
+  type: GraphQLObjectType
+  paginatedType: GraphQLObjectType
+  JWT: GraphQLObjectType
+  versionType: GraphQLObjectType
+  whereInputType: GraphQLInputObjectType
+  mutationInputType: GraphQLNonNull<any>
+  updateMutationInputType: GraphQLNonNull<any>
+}
+```
+
+### Best practices
+
+There are a few ways to structure your code, we recommend using a dedicated `graphql` directory so you can keep all of your logic in one place. You have total freedom of how you want to structure this but a common pattern is to group functions by type and with their resolver.
+
+Example
+
+```
+src/graphql
+---- queries/
+     index.ts
+    -- myCustomQuery/
+       index.ts
+       resolver.ts
+
+---- mutations/
+```

--- a/graphql.d.ts
+++ b/graphql.d.ts
@@ -1,2 +1,2 @@
-export { default as buildPaginatedListType } from "./dist/graphql/schema/buildPaginatedListType";
-export {default as GraphQL} from 'graphql';
+export { default as buildPaginatedListType } from './dist/graphql/schema/buildPaginatedListType';
+export { default as GraphQL } from 'graphql';

--- a/graphql.d.ts
+++ b/graphql.d.ts
@@ -1,0 +1,2 @@
+export { default as buildPaginatedListType } from "./dist/graphql/schema/buildPaginatedListType";
+export {default as GraphQL} from 'graphql';

--- a/graphql.js
+++ b/graphql.js
@@ -1,4 +1,4 @@
 exports.buildPaginatedListType =
-  require("./dist/graphql/schema/buildPaginatedListType").default;
+  require('./dist/graphql/schema/buildPaginatedListType').default;
 
-exports.GraphQL = require("graphql");
+exports.GraphQL = require('graphql');

--- a/graphql.js
+++ b/graphql.js
@@ -1,0 +1,4 @@
+exports.buildPaginatedListType =
+  require("./dist/graphql/schema/buildPaginatedListType").default;
+
+exports.GraphQL = require("graphql");

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -325,6 +325,7 @@ export type Collection = {
   config: SanitizedCollectionConfig;
   graphQL?: {
     type: GraphQLObjectType
+    paginatedType: GraphQLObjectType
     JWT: GraphQLObjectType
     versionType: GraphQLObjectType
     whereInputType: GraphQLInputObjectType

--- a/src/collections/graphql/init.ts
+++ b/src/collections/graphql/init.ts
@@ -95,10 +95,15 @@ function initCollectionsGraphQL(payload: Payload): void {
       forceNullable: forceNullableObjectType,
     });
 
+    collection.graphQL.paginatedType = buildPaginatedListType(
+      pluralName,
+      collection.graphQL.type
+    );
+
     collection.graphQL.whereInputType = buildWhereInputType(
       singularName,
       whereInputFields,
-      singularName,
+      singularName
     );
 
     if (config.auth && !config.auth.disableLocalStrategy) {

--- a/src/collections/graphql/init.ts
+++ b/src/collections/graphql/init.ts
@@ -103,7 +103,7 @@ function initCollectionsGraphQL(payload: Payload): void {
     collection.graphQL.whereInputType = buildWhereInputType(
       singularName,
       whereInputFields,
-      singularName
+      singularName,
     );
 
     if (config.auth && !config.auth.disableLocalStrategy) {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -49,11 +49,6 @@ export type EmailTransportOptions = Email & {
   transportOptions: SMTPConnection.Options;
 };
 
-export type GraphQLExtension = (
-  graphQL: typeof GraphQL,
-  payload: Payload
-) => Record<string, unknown>;
-
 export type EmailOptions = EmailTransport | EmailTransportOptions | Email;
 
 /**
@@ -75,6 +70,11 @@ export function hasTransportOptions(
 ): emailConfig is EmailTransportOptions {
   return (emailConfig as EmailTransportOptions).transportOptions !== undefined;
 }
+
+export type GraphQLExtension = (
+  graphQL: typeof GraphQL,
+  payload: Payload
+) => Record<string, unknown>;
 
 export type InitOptions = {
   /** Express app for Payload to use */
@@ -261,7 +261,7 @@ export type Config = {
       favicon?: string;
     };
     /** Specify an absolute path for where to store the built Admin panel bundle used in production. */
-    buildPath?: string;
+    buildPath?: string
     /** If set to true, the entire Admin panel will be disabled. */
     disable?: boolean;
     /** Replace the entirety of the index.html file used by the Admin panel. Reference the base index.html file to ensure your replacement has the appropriate HTML elements. */
@@ -271,7 +271,7 @@ export type Config = {
     /** Global date format that will be used for all dates in the Admin panel. Any valid date-fns format pattern can be used. */
     dateFormat?: string;
     /** Set account profile picture. Options: gravatar, default or a custom React component. */
-    avatar?: "default" | "gravatar" | React.ComponentType<any>;
+    avatar?: 'default' | 'gravatar' | React.ComponentType<any>;
     /** The route for the logout page. */
     logoutRoute?: string;
     /** The route the user will be redirected to after being inactive for too long. */
@@ -299,8 +299,8 @@ export type Config = {
        */
       afterDashboard?: React.ComponentType<any>[];
       /**
-       * Add custom components before the email/password field
-       */
+      * Add custom components before the email/password field
+      */
       beforeLogin?: React.ComponentType<any>[];
       /**
        * Add custom components after the email/password field
@@ -391,7 +391,7 @@ export type Config = {
   /** A whitelist array of URLs to allow Payload cookies to be accepted from as a form of CSRF protection. */
   csrf?: string[];
   /** Either a whitelist array of URLS to allow CORS requests from, or a wildcard string ('*') to accept incoming requests from any domain. */
-  cors?: string[] | "*";
+  cors?: string[] | '*';
   /** Control the routing structure that Payload binds itself to. */
   routes?: {
     /** Defaults to /api  */
@@ -464,7 +464,7 @@ export type Config = {
    *   window: 15 * 60 * 100, // 1.5 minutes,
    *   max: 500,
    * }
-   */
+  */
   rateLimit?: {
     window?: number;
     max?: number;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -49,6 +49,11 @@ export type EmailTransportOptions = Email & {
   transportOptions: SMTPConnection.Options;
 };
 
+export type GraphQLExtension = (
+  graphQL: typeof GraphQL,
+  payload: Payload
+) => Record<string, unknown>;
+
 export type EmailOptions = EmailTransport | EmailTransportOptions | Email;
 
 /**
@@ -256,7 +261,7 @@ export type Config = {
       favicon?: string;
     };
     /** Specify an absolute path for where to store the built Admin panel bundle used in production. */
-    buildPath?: string
+    buildPath?: string;
     /** If set to true, the entire Admin panel will be disabled. */
     disable?: boolean;
     /** Replace the entirety of the index.html file used by the Admin panel. Reference the base index.html file to ensure your replacement has the appropriate HTML elements. */
@@ -266,7 +271,7 @@ export type Config = {
     /** Global date format that will be used for all dates in the Admin panel. Any valid date-fns format pattern can be used. */
     dateFormat?: string;
     /** Set account profile picture. Options: gravatar, default or a custom React component. */
-    avatar?: 'default' | 'gravatar' | React.ComponentType<any>;
+    avatar?: "default" | "gravatar" | React.ComponentType<any>;
     /** The route for the logout page. */
     logoutRoute?: string;
     /** The route the user will be redirected to after being inactive for too long. */
@@ -294,8 +299,8 @@ export type Config = {
        */
       afterDashboard?: React.ComponentType<any>[];
       /**
-      * Add custom components before the email/password field
-      */
+       * Add custom components before the email/password field
+       */
       beforeLogin?: React.ComponentType<any>[];
       /**
        * Add custom components after the email/password field
@@ -386,7 +391,7 @@ export type Config = {
   /** A whitelist array of URLs to allow Payload cookies to be accepted from as a form of CSRF protection. */
   csrf?: string[];
   /** Either a whitelist array of URLS to allow CORS requests from, or a wildcard string ('*') to accept incoming requests from any domain. */
-  cors?: string[] | '*';
+  cors?: string[] | "*";
   /** Control the routing structure that Payload binds itself to. */
   routes?: {
     /** Defaults to /api  */
@@ -459,7 +464,7 @@ export type Config = {
    *   window: 15 * 60 * 100, // 1.5 minutes,
    *   max: 500,
    * }
-  */
+   */
   rateLimit?: {
     window?: number;
     max?: number;
@@ -489,19 +494,13 @@ export type Config = {
      *
      * @see https://payloadcms.com/docs/access-control/overview
      */
-    mutations?: (
-      graphQL: typeof GraphQL,
-      payload: Payload
-    ) => Record<string, unknown>;
+    mutations?: GraphQLExtension;
     /**
-    * Function that returns an object containing keys to custom GraphQL queries
-    *
-    * @see https://payloadcms.com/docs/access-control/overview
-    */
-    queries?: (
-      graphQL: typeof GraphQL,
-      payload: Payload
-    ) => Record<string, unknown>;
+     * Function that returns an object containing keys to custom GraphQL queries
+     *
+     * @see https://payloadcms.com/docs/access-control/overview
+     */
+    queries?: GraphQLExtension;
     maxComplexity?: number;
     disablePlaygroundInProduction?: boolean;
     disable?: boolean;


### PR DESCRIPTION
## Description

Closes https://github.com/payloadcms/payload/issues/2557 , I will update the documentation around GraphQL after this PR in case there are any further changes needed in this code.

This PR exports:
- buildPaginatedListType
- the internally used GraphQL library and type to make sure there's no conflicts (happy to revert on this one but I thought it might make the DX easier)
- the mutations and queries type into a re-usable type `GraphQLExtension` in the config

And it attaches the created `buildPaginatedType` from collections to the available types for re-use on `payload.collections.graphQL.`

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (will come in a PR after this one)

