### PR TITLE
Feat/custom admin buttons

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -84,6 +84,7 @@ You can override components on a Collection-by-Collection basis via each Collect
 | **`elements.SaveButton`**      | Replace the default `Save` button with a custom component. Drafts must be disabled                                     |
 | **`elements.SaveDraftButton`** | Replace the default `Save Draft` button with a custom component. Drafts must be enabled and autosave must be disabled. |
 | **`elements.PublishButton`**   | Replace the default `Publish` button with a custom component. Drafts must be enabled.                                  |
+| **`elements.PreviewButton`**   | Replace the default `Preview` button with a custom component.                                                          |
 
 #### Examples
 
@@ -95,6 +96,7 @@ import {
   CustomSaveButtonProps,
   CustomSaveDraftButtonProps,
   CustomPublishButtonProps,
+  CustomPreviewButtonProps,
 } from "payload/types";
 
 export const CustomSaveButton: CustomSaveButtonProps = ({
@@ -123,6 +125,15 @@ export const CustomPublishButton: CustomPublishButtonProps = ({
 }) => {
   return <DefaultButton label={label} disabled={disabled} publish={publish} />;
 };
+
+export const CustomPreviewButton: CustomPreviewButtonProps = ({
+  DefaultButton,
+  disabled,
+  label,
+  preview,
+}) => {
+  return <DefaultButton label={label} disabled={disabled} preview={preview} />;
+};
 ```
 
 ### Globals
@@ -135,6 +146,7 @@ As with Collections, You can override components on a global-by-global basis via
 | **`elements.SaveButton`**      | Replace the default `Save` button with a custom component. Drafts must be disabled                                     |
 | **`elements.SaveDraftButton`** | Replace the default `Save Draft` button with a custom component. Drafts must be enabled and autosave must be disabled. |
 | **`elements.PublishButton`**   | Replace the default `Publish` button with a custom component. Drafts must be enabled.                                  |
+| **`elements.PreviewButton`**   | Replace the default `Preview` button with a custom component.                                                          |
 
 ### Fields
 

--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -21,22 +21,22 @@ To swap in your own React component, first, consult the list of available compon
 
 You can override a set of admin panel-wide components by providing a component to your base Payload config's `admin.components` property. The following options are available:
 
-| Path                         | Description                                                                                                                                                                                                 |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`Nav`**                    | Contains the sidebar and mobile Nav in its entirety.                                                                                                                                                        |
-| **`logout.Button`**          | A custom React component.
-| **`BeforeDashboard`**        | Array of components to inject into the built-in Dashboard, _before_ the default dashboard contents.                                                                                                         |
-| **`AfterDashboard`**         | Array of components to inject into the built-in Dashboard, _after_ the default dashboard contents. [Demo](https://github.com/payloadcms/payload/tree/master/test/admin/components/AfterDashboard/index.tsx) |
-| **`BeforeLogin`**            | Array of components to inject into the built-in Login, _before_ the default login form.                                                                                                                     |
-| **`AfterLogin`**             | Array of components to inject into the built-in Login, _after_ the default login form.                                                                                                                      |
-| **`BeforeNavLinks`**         | Array of components to inject into the built-in Nav, _before_ the links themselves.                                                                                                                         |
-| **`AfterNavLinks`**          | Array of components to inject into the built-in Nav, _after_ the links.                                                                                                                                     |
-| **`views.Account`**          | The Account view is used to show the currently logged in user's Account page.                                                                                                                               |
-| **`views.Dashboard`**        | The main landing page of the Admin panel.                                                                                                                                                                   |
-| **`graphics.Icon`**          | Used as a graphic within the `Nav` component. Often represents a condensed version of a full logo.                                                                                                          |
-| **`graphics.Logo`**          | The full logo to be used in contexts like the `Login` view.                                                                                                                                                 |
-| **`routes`**                 | Define your own routes to add to the Payload Admin UI. [More](#custom-routes)                                                                                                                               |
-| **`providers`**              | Define your own provider components that will wrap the Payload Admin UI. [More](#custom-providers)                                                                                                          |
+| Path                  | Description                                                                                                                                                                                                 |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`Nav`**             | Contains the sidebar and mobile Nav in its entirety.                                                                                                                                                        |
+| **`logout.Button`**   | A custom React component.                                                                                                                                                                                   |
+| **`BeforeDashboard`** | Array of components to inject into the built-in Dashboard, _before_ the default dashboard contents.                                                                                                         |
+| **`AfterDashboard`**  | Array of components to inject into the built-in Dashboard, _after_ the default dashboard contents. [Demo](https://github.com/payloadcms/payload/tree/master/test/admin/components/AfterDashboard/index.tsx) |
+| **`BeforeLogin`**     | Array of components to inject into the built-in Login, _before_ the default login form.                                                                                                                     |
+| **`AfterLogin`**      | Array of components to inject into the built-in Login, _after_ the default login form.                                                                                                                      |
+| **`BeforeNavLinks`**  | Array of components to inject into the built-in Nav, _before_ the links themselves.                                                                                                                         |
+| **`AfterNavLinks`**   | Array of components to inject into the built-in Nav, _after_ the links.                                                                                                                                     |
+| **`views.Account`**   | The Account view is used to show the currently logged in user's Account page.                                                                                                                               |
+| **`views.Dashboard`** | The main landing page of the Admin panel.                                                                                                                                                                   |
+| **`graphics.Icon`**   | Used as a graphic within the `Nav` component. Often represents a condensed version of a full logo.                                                                                                          |
+| **`graphics.Logo`**   | The full logo to be used in contexts like the `Login` view.                                                                                                                                                 |
+| **`routes`**          | Define your own routes to add to the Payload Admin UI. [More](#custom-routes)                                                                                                                               |
+| **`providers`**       | Define your own provider components that will wrap the Payload Admin UI. [More](#custom-providers)                                                                                                          |
 
 #### Full example:
 
@@ -77,18 +77,64 @@ _For more examples regarding how to customize components, look at the following 
 
 You can override components on a Collection-by-Collection basis via each Collection's `admin` property.
 
-| Path             | Description                                                                                      |
-| ---------------- | ------------------------------------------------------------------------------------------------ |
-| **`views.Edit`** | Used while a document within this Collection is being edited.                                    |
-| **`views.List`** | The `List` view is used to render a paginated, filterable table of Documents in this Collection. |
+| Path                           | Description                                                                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| **`views.Edit`**               | Used while a document within this Collection is being edited.                                                          |
+| **`views.List`**               | The `List` view is used to render a paginated, filterable table of Documents in this Collection.                       |
+| **`elements.SaveButton`**      | Replace the default `Save` button with a custom component. Drafts must be disabled                                     |
+| **`elements.SaveDraftButton`** | Replace the default `Save Draft` button with a custom component. Drafts must be enabled and autosave must be disabled. |
+| **`elements.PublishButton`**   | Replace the default `Publish` button with a custom component. Drafts must be enabled.                                  |
+
+#### Examples
+
+```tsx
+// Custom Buttons
+
+import * as React from "react";
+import {
+  CustomSaveButtonProps,
+  CustomSaveDraftButtonProps,
+  CustomPublishButtonProps,
+} from "payload/types";
+
+export const CustomSaveButton: CustomSaveButtonProps = ({
+  DefaultButton,
+  label,
+}) => {
+  return <DefaultButton label={label} />;
+};
+
+export const CustomSaveDraftButton: CustomSaveDraftButtonProps = ({
+  DefaultButton,
+  disabled,
+  label,
+  saveDraft,
+}) => {
+  return (
+    <DefaultButton label={label} disabled={disabled} saveDraft={saveDraft} />
+  );
+};
+
+export const CustomPublishButton: CustomPublishButtonProps = ({
+  DefaultButton,
+  disabled,
+  label,
+  publish,
+}) => {
+  return <DefaultButton label={label} disabled={disabled} publish={publish} />;
+};
+```
 
 ### Globals
 
 As with Collections, You can override components on a global-by-global basis via their `admin` property.
 
-| Path             | Description                             |
-| ---------------- | --------------------------------------- |
-| **`views.Edit`** | Used while this Global is being edited. |
+| Path                           | Description                                                                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| **`views.Edit`**               | Used while this Global is being edited.                                                                                |
+| **`elements.SaveButton`**      | Replace the default `Save` button with a custom component. Drafts must be disabled                                     |
+| **`elements.SaveDraftButton`** | Replace the default `Save Draft` button with a custom component. Drafts must be enabled and autosave must be disabled. |
+| **`elements.PublishButton`**   | Replace the default `Publish` button with a custom component. Drafts must be enabled.                                  |
 
 ### Fields
 
@@ -163,7 +209,11 @@ const CustomTextField: React.FC<Props> = ({ path }) => {
 
 <Banner type="success">
   For more information regarding the hooks that are available to you while you
-  build custom components, including the <strong>useField</strong> hook, <a href="/docs/admin/hooks" style={{ color: "black" }}>click here</a>.
+  build custom components, including the <strong>useField</strong> hook,{" "}
+  <a href="/docs/admin/hooks" style={{ color: "black" }}>
+    click here
+  </a>
+  .
 </Banner>
 
 ## Custom routes
@@ -232,19 +282,20 @@ To make use of Payload SCSS variables / mixins to use directly in your own compo
 When developing custom components you can support multiple languages to be consistent with Payload's i18n support. The best way to do this is to add your translation resources to the [i18n configuration](https://payloadcms.com/docs/configuration/i18n) and import `useTranslation` from `react-i18next` in your components.
 
 For example:
+
 ```tsx
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from "react-i18next";
 
 const CustomComponent: React.FC = () => {
   // highlight-start
-  const { t, i18n } = useTranslation('namespace1');
+  const { t, i18n } = useTranslation("namespace1");
   // highlight-end
 
   return (
     <ul>
-      <li>{ t('key', { variable: 'value' }) }</li>
-      <li>{ t('namespace2:key', { variable: 'value' }) }</li>
-      <li>{ i18n.language }</li>
+      <li>{t("key", { variable: "value" })}</li>
+      <li>{t("namespace2:key", { variable: "value" })}</li>
+      <li>{i18n.language}</li>
     </ul>
   );
 };

--- a/src/admin/components/elements/PreviewButton/index.scss
+++ b/src/admin/components/elements/PreviewButton/index.scss
@@ -1,1 +1,0 @@
-@import '../../../scss/styles.scss';

--- a/src/admin/components/elements/PreviewButton/index.tsx
+++ b/src/admin/components/elements/PreviewButton/index.tsx
@@ -7,7 +7,6 @@ import Button from '../Button';
 import { useLocale } from '../../utilities/Locale';
 import { useDocumentInfo } from '../../utilities/DocumentInfo';
 import { useConfig } from '../../utilities/Config';
-
 import RenderCustomComponent from '../../utilities/RenderCustomComponent';
 
 const baseClass = 'preview-btn';

--- a/src/admin/components/elements/PreviewButton/index.tsx
+++ b/src/admin/components/elements/PreviewButton/index.tsx
@@ -1,22 +1,46 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useRef, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
+import { GeneratePreviewURL } from '../../../../config/types';
 import { useAuth } from '../../utilities/Auth';
 import Button from '../Button';
-import { Props } from './types';
 import { useLocale } from '../../utilities/Locale';
 import { useDocumentInfo } from '../../utilities/DocumentInfo';
 import { useConfig } from '../../utilities/Config';
 
-import './index.scss';
+import RenderCustomComponent from '../../utilities/RenderCustomComponent';
 
 const baseClass = 'preview-btn';
 
-const PreviewButton: React.FC<Props> = (props) => {
-  const {
-    generatePreviewURL,
-  } = props;
+export type CustomPreviewButtonProps = React.ComponentType<DefaultPreviewButtonProps & {
+  DefaultButton: React.ComponentType<DefaultPreviewButtonProps>;
+}>
+export type DefaultPreviewButtonProps = {
+  preview: () => void;
+  disabled: boolean;
+  label: string;
+};
+const DefaultPreviewButton: React.FC<DefaultPreviewButtonProps> = ({ preview, disabled, label }) => {
+  return (
+    <Button
+      className={baseClass}
+      buttonStyle="secondary"
+      onClick={preview}
+      disabled={disabled}
+    >
+      {label}
+    </Button>
+  );
+};
 
+type Props = {
+  CustomComponent?: CustomPreviewButtonProps
+  generatePreviewURL?: GeneratePreviewURL
+}
+const PreviewButton: React.FC<Props> = ({
+  CustomComponent,
+  generatePreviewURL,
+}) => {
   const { id, collection, global } = useDocumentInfo();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -29,7 +53,7 @@ const PreviewButton: React.FC<Props> = (props) => {
   // we need to regenerate the preview URL every time the button is clicked
   // to do this we need to fetch the document data fresh from the API
   // this will ensure the latest data is used when generating the preview URL
-  const handleClick = useCallback(async () => {
+  const preview = useCallback(async () => {
     if (!generatePreviewURL || isGeneratingPreviewURL.current) return;
     isGeneratingPreviewURL.current = true;
 
@@ -54,14 +78,16 @@ const PreviewButton: React.FC<Props> = (props) => {
   }, [serverURL, api, collection, global, id, generatePreviewURL, locale, token, t]);
 
   return (
-    <Button
-      className={baseClass}
-      buttonStyle="secondary"
-      onClick={handleClick}
-      disabled={isLoading || !generatePreviewURL}
-    >
-      {isLoading ? t('general:loading') : t('preview')}
-    </Button>
+    <RenderCustomComponent
+      CustomComponent={CustomComponent}
+      DefaultComponent={DefaultPreviewButton}
+      componentProps={{
+        preview,
+        disabled: isLoading || !generatePreviewURL,
+        label: isLoading ? t('general:loading') : t('preview'),
+        DefaultButton: DefaultPreviewButton,
+      }}
+    />
   );
 };
 

--- a/src/admin/components/elements/PreviewButton/types.ts
+++ b/src/admin/components/elements/PreviewButton/types.ts
@@ -1,5 +1,0 @@
-import { GeneratePreviewURL } from '../../../../config/types';
-
-export type Props = {
-  generatePreviewURL?: GeneratePreviewURL,
-}

--- a/src/admin/components/elements/Publish/index.tsx
+++ b/src/admin/components/elements/Publish/index.tsx
@@ -1,11 +1,34 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import FormSubmit from '../../forms/Submit';
-import { Props } from './types';
 import { useDocumentInfo } from '../../utilities/DocumentInfo';
 import { useForm, useFormModified } from '../../forms/Form/context';
+import RenderCustomComponent from '../../utilities/RenderCustomComponent';
 
-const Publish: React.FC<Props> = () => {
+export type CustomPublishButtonProps = React.ComponentType<DefaultPublishButtonProps & {
+  DefaultButton: React.ComponentType<DefaultPublishButtonProps>;
+}>
+export type DefaultPublishButtonProps = {
+  publish: () => void;
+  disabled: boolean;
+  label: string;
+};
+const DefaultPublishButton: React.FC<DefaultPublishButtonProps> = ({ disabled, publish, label }) => {
+  return (
+    <FormSubmit
+      type="button"
+      onClick={publish}
+      disabled={disabled}
+    >
+      {label}
+    </FormSubmit>
+  );
+};
+
+type Props = {
+  CustomComponent?: CustomPublishButtonProps
+}
+export const Publish: React.FC<Props> = ({ CustomComponent }) => {
   const { unpublishedVersions, publishedDoc } = useDocumentInfo();
   const { submit } = useForm();
   const modified = useFormModified();
@@ -23,14 +46,15 @@ const Publish: React.FC<Props> = () => {
   }, [submit]);
 
   return (
-    <FormSubmit
-      type="button"
-      onClick={publish}
-      disabled={!canPublish}
-    >
-      {t('publishChanges')}
-    </FormSubmit>
+    <RenderCustomComponent
+      CustomComponent={CustomComponent}
+      DefaultComponent={DefaultPublishButton}
+      componentProps={{
+        publish,
+        disabled: !canPublish,
+        label: t('publishChanges'),
+        DefaultButton: DefaultPublishButton,
+      }}
+    />
   );
 };
-
-export default Publish;

--- a/src/admin/components/elements/Publish/types.ts
+++ b/src/admin/components/elements/Publish/types.ts
@@ -1,1 +1,0 @@
-export type Props = {}

--- a/src/admin/components/elements/Save/index.tsx
+++ b/src/admin/components/elements/Save/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import FormSubmit from '../../forms/Submit';
+import RenderCustomComponent from '../../utilities/RenderCustomComponent';
+
+export type CustomSaveButtonProps = React.ComponentType<DefaultSaveButtonProps & {
+  DefaultButton: React.ComponentType<DefaultSaveButtonProps>;
+}>
+type DefaultSaveButtonProps = {
+  label: string;
+};
+const DefaultSaveButton: React.FC<DefaultSaveButtonProps> = ({ label }) => {
+  return (
+    <FormSubmit buttonId="action-save">{label}</FormSubmit>
+  );
+};
+
+type Props = {
+  CustomComponent?: CustomSaveButtonProps;
+}
+export const Save: React.FC<Props> = ({ CustomComponent }) => {
+  const { t } = useTranslation('general');
+
+  return (
+    <RenderCustomComponent
+      CustomComponent={CustomComponent}
+      DefaultComponent={DefaultSaveButton}
+      componentProps={{
+        label: t('save'),
+        DefaultButton: DefaultSaveButton,
+      }}
+    />
+  );
+};

--- a/src/admin/components/elements/SaveDraft/index.tsx
+++ b/src/admin/components/elements/SaveDraft/index.tsx
@@ -5,12 +5,37 @@ import FormSubmit from '../../forms/Submit';
 import { useForm, useFormModified } from '../../forms/Form/context';
 import { useDocumentInfo } from '../../utilities/DocumentInfo';
 import { useLocale } from '../../utilities/Locale';
+import RenderCustomComponent from '../../utilities/RenderCustomComponent';
 
-import './index.scss';
 
 const baseClass = 'save-draft';
 
-const SaveDraft: React.FC = () => {
+export type CustomSaveDraftButtonProps = React.ComponentType<DefaultSaveDraftButtonProps & {
+  DefaultButton: React.ComponentType<DefaultSaveDraftButtonProps>;
+}>
+export type DefaultSaveDraftButtonProps = {
+  saveDraft: () => void;
+  disabled: boolean;
+  label: string;
+};
+const DefaultSaveDraftButton: React.FC<DefaultSaveDraftButtonProps> = ({ disabled, saveDraft, label }) => {
+  return (
+    <FormSubmit
+      className={baseClass}
+      type="button"
+      buttonStyle="secondary"
+      onClick={saveDraft}
+      disabled={disabled}
+    >
+      {label}
+    </FormSubmit>
+  );
+};
+
+type Props = {
+  CustomComponent?: CustomSaveDraftButtonProps
+}
+export const SaveDraft: React.FC<Props> = ({ CustomComponent }) => {
   const { serverURL, routes: { api } } = useConfig();
   const { submit } = useForm();
   const { collection, global, id } = useDocumentInfo();
@@ -45,16 +70,15 @@ const SaveDraft: React.FC = () => {
   }, [submit, collection, global, serverURL, api, locale, id]);
 
   return (
-    <FormSubmit
-      className={baseClass}
-      type="button"
-      buttonStyle="secondary"
-      onClick={saveDraft}
-      disabled={!canSaveDraft}
-    >
-      {t('saveDraft')}
-    </FormSubmit>
+    <RenderCustomComponent
+      CustomComponent={CustomComponent}
+      DefaultComponent={DefaultSaveDraftButton}
+      componentProps={{
+        saveDraft,
+        disabled: !canSaveDraft,
+        label: t('saveDraft'),
+        DefaultButton: DefaultSaveDraftButton,
+      }}
+    />
   );
 };
-
-export default SaveDraft;

--- a/src/admin/components/elements/types.ts
+++ b/src/admin/components/elements/types.ts
@@ -1,3 +1,4 @@
 export { CustomPublishButtonProps } from './Publish';
 export { CustomSaveButtonProps } from './Save';
 export { CustomSaveDraftButtonProps } from './SaveDraft';
+export { CustomPreviewButtonProps } from './PreviewButton';

--- a/src/admin/components/elements/types.ts
+++ b/src/admin/components/elements/types.ts
@@ -1,0 +1,3 @@
+export { CustomPublishButtonProps } from './Publish';
+export { CustomSaveButtonProps } from './Save';
+export { CustomSaveDraftButtonProps } from './SaveDraft';

--- a/src/admin/components/views/Account/Default.tsx
+++ b/src/admin/components/views/Account/Default.tsx
@@ -147,6 +147,7 @@ const DefaultAccount: React.FC<Props> = (props) => {
                       {(preview && (!collection.versions?.drafts || collection.versions?.drafts?.autosave)) && (
                         <PreviewButton
                           generatePreviewURL={preview}
+                          CustomComponent={collection?.admin?.components?.elements?.PreviewButton}
                         />
                       )}
                       {hasSavePermission && (

--- a/src/admin/components/views/Account/Default.tsx
+++ b/src/admin/components/views/Account/Default.tsx
@@ -5,7 +5,7 @@ import { useConfig } from '../../utilities/Config';
 import Eyebrow from '../../elements/Eyebrow';
 import Form from '../../forms/Form';
 import PreviewButton from '../../elements/PreviewButton';
-import FormSubmit from '../../forms/Submit';
+import { Save } from '../../elements/Save';
 import RenderFields from '../../forms/RenderFields';
 import CopyToClipboard from '../../elements/CopyToClipboard';
 import fieldTypes from '../../forms/field-types';
@@ -150,7 +150,9 @@ const DefaultAccount: React.FC<Props> = (props) => {
                         />
                       )}
                       {hasSavePermission && (
-                        <FormSubmit buttonId="action-save">{t('general:save')}</FormSubmit>
+                        <Save
+                          CustomComponent={collection?.admin?.components?.elements?.SaveButton}
+                        />
                       )}
                     </div>
                     <div className={`${baseClass}__sidebar-fields`}>

--- a/src/admin/components/views/Global/Default.tsx
+++ b/src/admin/components/views/Global/Default.tsx
@@ -106,6 +106,7 @@ const DefaultGlobalView: React.FC<Props> = (props) => {
                       {(preview && (!global.versions?.drafts || global.versions?.drafts?.autosave)) && (
                         <PreviewButton
                           generatePreviewURL={preview}
+                          CustomComponent={global?.admin?.components?.elements?.PreviewButton}
                         />
                       )}
 
@@ -136,6 +137,7 @@ const DefaultGlobalView: React.FC<Props> = (props) => {
                       {(preview && (global.versions?.drafts && !global.versions?.drafts?.autosave)) && (
                         <PreviewButton
                           generatePreviewURL={preview}
+                          CustomComponent={global?.admin?.components?.elements?.PreviewButton}
                         />
                       )}
                       {global.versions?.drafts && (

--- a/src/admin/components/views/Global/Default.tsx
+++ b/src/admin/components/views/Global/Default.tsx
@@ -4,7 +4,6 @@ import { useConfig } from '../../utilities/Config';
 import Eyebrow from '../../elements/Eyebrow';
 import Form from '../../forms/Form';
 import PreviewButton from '../../elements/PreviewButton';
-import FormSubmit from '../../forms/Submit';
 import RenderFields from '../../forms/RenderFields';
 import CopyToClipboard from '../../elements/CopyToClipboard';
 import Meta from '../../utilities/Meta';
@@ -14,8 +13,9 @@ import VersionsCount from '../../elements/VersionsCount';
 import { Props } from './types';
 import ViewDescription from '../../elements/ViewDescription';
 import { useDocumentInfo } from '../../utilities/DocumentInfo';
-import SaveDraft from '../../elements/SaveDraft';
-import Publish from '../../elements/Publish';
+import { SaveDraft } from '../../elements/SaveDraft';
+import { Publish } from '../../elements/Publish';
+import { Save } from '../../elements/Save';
 import Status from '../../elements/Status';
 import Autosave from '../../elements/Autosave';
 import { OperationContext } from '../../utilities/OperationProvider';
@@ -108,18 +108,26 @@ const DefaultGlobalView: React.FC<Props> = (props) => {
                           generatePreviewURL={preview}
                         />
                       )}
+
                       {hasSavePermission && (
                         <React.Fragment>
                           {global.versions?.drafts && (
                             <React.Fragment>
                               {!global.versions.drafts.autosave && (
-                                <SaveDraft />
+                                <SaveDraft
+                                  CustomComponent={global?.admin?.components?.elements?.SaveDraftButton}
+                                />
                               )}
-                              <Publish />
+
+                              <Publish
+                                CustomComponent={global?.admin?.components?.elements?.PublishButton}
+                              />
                             </React.Fragment>
                           )}
                           {!global.versions?.drafts && (
-                            <FormSubmit buttonId="action-save">{t('save')}</FormSubmit>
+                            <Save
+                              CustomComponent={global?.admin?.components?.elements?.SaveButton}
+                            />
                           )}
                         </React.Fragment>
                       )}

--- a/src/admin/components/views/collections/Edit/Default.tsx
+++ b/src/admin/components/views/collections/Edit/Default.tsx
@@ -216,6 +216,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                         {(isEditing && preview && (!collection.versions?.drafts || collection.versions?.drafts?.autosave)) && (
                           <PreviewButton
                             generatePreviewURL={preview}
+                            CustomComponent={collection?.admin?.components?.elements?.PreviewButton}
                           />
                         )}
 
@@ -244,6 +245,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                         {(isEditing && preview && (collection.versions?.drafts && !collection.versions?.drafts?.autosave)) && (
                           <PreviewButton
                             generatePreviewURL={preview}
+                            CustomComponent={collection?.admin?.components?.elements?.PreviewButton}
                           />
                         )}
 

--- a/src/admin/components/views/collections/Edit/Default.tsx
+++ b/src/admin/components/views/collections/Edit/Default.tsx
@@ -5,7 +5,6 @@ import { useConfig } from '../../../utilities/Config';
 import Eyebrow from '../../../elements/Eyebrow';
 import Form from '../../../forms/Form';
 import PreviewButton from '../../../elements/PreviewButton';
-import FormSubmit from '../../../forms/Submit';
 import RenderFields from '../../../forms/RenderFields';
 import CopyToClipboard from '../../../elements/CopyToClipboard';
 import DuplicateDocument from '../../../elements/DuplicateDocument';
@@ -20,8 +19,9 @@ import Upload from './Upload';
 import { Props } from './types';
 import Autosave from '../../../elements/Autosave';
 import Status from '../../../elements/Status';
-import Publish from '../../../elements/Publish';
-import SaveDraft from '../../../elements/SaveDraft';
+import { Publish } from '../../../elements/Publish';
+import { SaveDraft } from '../../../elements/SaveDraft';
+import { Save } from '../../../elements/Save';
 import { useDocumentInfo } from '../../../utilities/DocumentInfo';
 import { OperationContext } from '../../../utilities/OperationProvider';
 import { Gutter } from '../../../elements/Gutter';
@@ -109,6 +109,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                     id={data?.id}
                   />
                 )}
+
                 <div className={`${baseClass}__main`}>
                   <Meta
                     title={`${isEditing ? t('editing') : t('creating')} - ${getTranslation(collection.labels.singular, i18n)}`}
@@ -118,9 +119,11 @@ const DefaultEditView: React.FC<Props> = (props) => {
                   {!disableEyebrow && (
                     <Eyebrow />
                   )}
+
                   {(!(collection.versions?.drafts && collection.versions?.drafts?.autosave) && !disableLeaveWithoutSaving) && (
                     <LeaveWithoutSaving />
                   )}
+
                   <Gutter className={`${baseClass}__edit`}>
                     <header className={`${baseClass}__header`}>
                       {customHeader && customHeader}
@@ -135,6 +138,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                         </h1>
                       )}
                     </header>
+
                     {auth && (
                       <Auth
                         useAPIKey={auth.useAPIKey}
@@ -145,6 +149,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                         operation={operation}
                       />
                     )}
+
                     {upload && (
                       <Upload
                         data={data}
@@ -152,6 +157,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                         internalState={internalState}
                       />
                     )}
+
                     <RenderFields
                       readOnly={!hasSavePermission}
                       permissions={permissions.fields}
@@ -176,6 +182,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                                   {t('createNew')}
                                 </Link>
                               </li>
+
                               {!disableDuplicate && isEditing && (
                                 <li>
                                   <DuplicateDocument
@@ -187,6 +194,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                               )}
                             </React.Fragment>
                           )}
+
                           {permissions?.delete?.permission && (
                             <li>
                               <DeleteDocument
@@ -198,6 +206,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                           )}
                         </ul>
                       )}
+
                       <div
                         className={[
                           `${baseClass}__document-actions`,
@@ -209,28 +218,35 @@ const DefaultEditView: React.FC<Props> = (props) => {
                             generatePreviewURL={preview}
                           />
                         )}
+
                         {hasSavePermission && (
                           <React.Fragment>
-                            {collection.versions?.drafts && (
+                            {collection.versions?.drafts ? (
                               <React.Fragment>
                                 {!collection.versions.drafts.autosave && (
-                                  <SaveDraft />
+                                  <SaveDraft CustomComponent={collection?.admin?.components?.elements?.SaveDraftButton} />
                                 )}
-                                <Publish />
+
+                                <Publish
+                                  CustomComponent={collection?.admin?.components?.elements?.PublishButton}
+                                />
                               </React.Fragment>
-                            )}
-                            {!collection.versions?.drafts && (
-                              <FormSubmit buttonId="action-save">{t('save')}</FormSubmit>
+                            ) : (
+                              <Save
+                                CustomComponent={collection?.admin?.components?.elements?.SaveButton}
+                              />
                             )}
                           </React.Fragment>
                         )}
                       </div>
+
                       <div className={`${baseClass}__sidebar-fields`}>
                         {(isEditing && preview && (collection.versions?.drafts && !collection.versions?.drafts?.autosave)) && (
                           <PreviewButton
                             generatePreviewURL={preview}
                           />
                         )}
+
                         {collection.versions?.drafts && (
                           <React.Fragment>
                             <Status />
@@ -243,6 +259,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                             )}
                           </React.Fragment>
                         )}
+
                         <RenderFields
                           readOnly={!hasSavePermission}
                           permissions={permissions.fields}
@@ -251,6 +268,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                           fieldSchema={fields}
                         />
                       </div>
+
                       {
                         isEditing && (
                           <ul className={`${baseClass}__meta`}>
@@ -270,6 +288,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                                 </a>
                               </li>
                             )}
+
                             {versions && (
                               <li>
                                 <div className={`${baseClass}__label`}>{t('version:versions')}</div>
@@ -279,6 +298,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
                                 />
                               </li>
                             )}
+
                             {timestamps && (
                               <React.Fragment>
                                 {updatedAt && (

--- a/src/collections/config/schema.ts
+++ b/src/collections/config/schema.ts
@@ -62,6 +62,11 @@ const collectionSchema = joi.object().keys({
         List: componentSchema,
         Edit: componentSchema,
       }),
+      elements: joi.object({
+        SaveButton: componentSchema,
+        PublishButton: componentSchema,
+        SaveDraftButton: componentSchema,
+      }),
     }),
     pagination: joi.object({
       defaultLimit: joi.number(),

--- a/src/collections/config/schema.ts
+++ b/src/collections/config/schema.ts
@@ -66,6 +66,7 @@ const collectionSchema = joi.object().keys({
         SaveButton: componentSchema,
         PublishButton: componentSchema,
         SaveDraftButton: componentSchema,
+        PreviewButton: componentSchema,
       }),
     }),
     pagination: joi.object({

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -11,6 +11,9 @@ import { Auth, IncomingAuthType, User } from '../../auth/types';
 import { IncomingUploadType, Upload } from '../../uploads/types';
 import { IncomingCollectionVersions, SanitizedCollectionVersions } from '../../versions/types';
 import { BuildQueryArgs } from '../../mongoose/buildQuery';
+import { CustomSaveButtonProps } from '../../admin/components/elements/Save';
+import { CustomSaveDraftButtonProps } from '../../admin/components/elements/SaveDraft';
+import { CustomPublishButtonProps } from '../../admin/components/elements/Publish';
 
 type Register<T = any> = (doc: T, password: string) => T;
 
@@ -193,6 +196,24 @@ export type CollectionAdminOptions = {
    * Custom admin components
    */
   components?: {
+    elements?: {
+      /**
+       * Replaces the "Save" button
+       * + drafts must be disabled
+       */
+      SaveButton?: CustomSaveButtonProps
+      /**
+       * Replaces the "Publish" button
+       * + drafts must be enabled
+       */
+      PublishButton?: CustomPublishButtonProps
+      /**
+       * Replaces the "Save Draft" button
+       * + drafts must be enabled
+       * + autosave must be disabled
+       */
+      SaveDraftButton?: CustomSaveDraftButtonProps
+    },
     views?: {
       Edit?: React.ComponentType<any>
       List?: React.ComponentType<any>
@@ -312,7 +333,7 @@ export type CollectionConfig = {
   custom?: Record<string, any>;
 };
 
-export interface SanitizedCollectionConfig extends Omit<DeepRequired<CollectionConfig>, 'auth' | 'upload' | 'fields' | 'versions'| 'endpoints'> {
+export interface SanitizedCollectionConfig extends Omit<DeepRequired<CollectionConfig>, 'auth' | 'upload' | 'fields' | 'versions' | 'endpoints'> {
   auth: Auth;
   upload: Upload;
   fields: Field[];

--- a/src/collections/config/types.ts
+++ b/src/collections/config/types.ts
@@ -11,9 +11,7 @@ import { Auth, IncomingAuthType, User } from '../../auth/types';
 import { IncomingUploadType, Upload } from '../../uploads/types';
 import { IncomingCollectionVersions, SanitizedCollectionVersions } from '../../versions/types';
 import { BuildQueryArgs } from '../../mongoose/buildQuery';
-import { CustomSaveButtonProps } from '../../admin/components/elements/Save';
-import { CustomSaveDraftButtonProps } from '../../admin/components/elements/SaveDraft';
-import { CustomPublishButtonProps } from '../../admin/components/elements/Publish';
+import { CustomPreviewButtonProps, CustomPublishButtonProps, CustomSaveButtonProps, CustomSaveDraftButtonProps } from '../../admin/components/elements/types';
 
 type Register<T = any> = (doc: T, password: string) => T;
 
@@ -213,6 +211,10 @@ export type CollectionAdminOptions = {
        * + autosave must be disabled
        */
       SaveDraftButton?: CustomSaveDraftButtonProps
+      /**
+       * Replaces the "Preview" button
+       */
+      PreviewButton?: CustomPreviewButtonProps
     },
     views?: {
       Edit?: React.ComponentType<any>

--- a/src/globals/config/schema.ts
+++ b/src/globals/config/schema.ts
@@ -30,6 +30,7 @@ const globalSchema = joi.object().keys({
         SaveButton: componentSchema,
         PublishButton: componentSchema,
         SaveDraftButton: componentSchema,
+        PreviewButton: componentSchema,
       }),
     }),
     preview: joi.func(),

--- a/src/globals/config/schema.ts
+++ b/src/globals/config/schema.ts
@@ -26,6 +26,11 @@ const globalSchema = joi.object().keys({
       views: joi.object({
         Edit: componentSchema,
       }),
+      elements: joi.object({
+        SaveButton: componentSchema,
+        PublishButton: componentSchema,
+        SaveDraftButton: componentSchema,
+      }),
     }),
     preview: joi.func(),
   }),

--- a/src/globals/config/types.ts
+++ b/src/globals/config/types.ts
@@ -7,9 +7,7 @@ import { PayloadRequest } from '../../express/types';
 import { Access, Endpoint, EntityDescription, GeneratePreviewURL } from '../../config/types';
 import { Field } from '../../fields/config/types';
 import { IncomingGlobalVersions, SanitizedGlobalVersions } from '../../versions/types';
-import { CustomSaveButtonProps } from '../../admin/components/elements/Save';
-import { CustomSaveDraftButtonProps } from '../../admin/components/elements/SaveDraft';
-import { CustomPublishButtonProps } from '../../admin/components/elements/Publish';
+import { CustomSaveButtonProps, CustomSaveDraftButtonProps, CustomPublishButtonProps, CustomPreviewButtonProps } from '../../admin/components/elements/types';
 
 export type TypeWithID = {
   id: string | number
@@ -90,6 +88,10 @@ export type GlobalAdminOptions = {
        * + autosave must be disabled
        */
       SaveDraftButton?: CustomSaveDraftButtonProps
+      /**
+       * Replaces the "Preview" button
+       */
+      PreviewButton?: CustomPreviewButtonProps
     },
   };
   /**

--- a/src/globals/config/types.ts
+++ b/src/globals/config/types.ts
@@ -7,6 +7,9 @@ import { PayloadRequest } from '../../express/types';
 import { Access, Endpoint, EntityDescription, GeneratePreviewURL } from '../../config/types';
 import { Field } from '../../fields/config/types';
 import { IncomingGlobalVersions, SanitizedGlobalVersions } from '../../versions/types';
+import { CustomSaveButtonProps } from '../../admin/components/elements/Save';
+import { CustomSaveDraftButtonProps } from '../../admin/components/elements/SaveDraft';
+import { CustomPublishButtonProps } from '../../admin/components/elements/Publish';
 
 export type TypeWithID = {
   id: string | number
@@ -70,6 +73,24 @@ export type GlobalAdminOptions = {
     views?: {
       Edit?: React.ComponentType<any>
     }
+    elements?: {
+      /**
+       * Replaces the "Save" button
+       * + drafts must be disabled
+       */
+      SaveButton?: CustomSaveButtonProps
+      /**
+       * Replaces the "Publish" button
+       * + drafts must be enabled
+       */
+      PublishButton?: CustomPublishButtonProps
+      /**
+       * Replaces the "Save Draft" button
+       * + drafts must be enabled
+       * + autosave must be disabled
+       */
+      SaveDraftButton?: CustomSaveDraftButtonProps
+    },
   };
   /**
    * Function to generate custom preview URL

--- a/test/versions/collections/Drafts.ts
+++ b/test/versions/collections/Drafts.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig } from '../../../src/collections/config/types';
-import { CustomSaveButton } from '../elements/CustomSaveButton';
+import { CustomPublishButton } from '../elements/CustomSaveButton';
 import { draftSlug } from '../shared';
 
 const DraftPosts: CollectionConfig = {
@@ -10,7 +10,7 @@ const DraftPosts: CollectionConfig = {
     preview: () => 'https://payloadcms.com',
     components: {
       elements: {
-        PublishButton: CustomSaveButton,
+        PublishButton: CustomPublishButton,
       },
     },
   },

--- a/test/versions/collections/Drafts.ts
+++ b/test/versions/collections/Drafts.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from '../../../src/collections/config/types';
+import { CustomSaveButton } from '../elements/CustomSaveButton';
 import { draftSlug } from '../shared';
 
 const DraftPosts: CollectionConfig = {
@@ -7,6 +8,11 @@ const DraftPosts: CollectionConfig = {
     useAsTitle: 'title',
     defaultColumns: ['title', 'description', 'createdAt', '_status'],
     preview: () => 'https://payloadcms.com',
+    components: {
+      elements: {
+        PublishButton: CustomSaveButton,
+      },
+    },
   },
   versions: {
     maxPerDoc: 35,

--- a/test/versions/elements/CustomSaveButton/index.module.scss
+++ b/test/versions/elements/CustomSaveButton/index.module.scss
@@ -1,0 +1,16 @@
+.customButton {
+  :global(.btn) {
+    background-color: var(--theme-success-500);
+    color: var(--theme-success-900);
+
+    &:hover {
+      background-color: var(--theme-success-550) !important;
+      color: var(--theme-success-900) !important;
+    }
+
+    &:disabled {
+      background-color: var(--theme-success-750);
+      color: var(--theme-success-500);
+    }
+  }
+}

--- a/test/versions/elements/CustomSaveButton/index.tsx
+++ b/test/versions/elements/CustomSaveButton/index.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { CustomPublishButtonProps } from '../../../../src/admin/components/elements/Publish';
+
+import classes from './index.module.scss';
+
+export const CustomSaveButton: CustomPublishButtonProps = ({ DefaultButton, ...rest }) => {
+  return (
+    <div className={classes.customButton}>
+      <DefaultButton {...rest} />
+    </div>
+  );
+};

--- a/test/versions/elements/CustomSaveButton/index.tsx
+++ b/test/versions/elements/CustomSaveButton/index.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { CustomPublishButtonProps } from '../../../../src/admin/components/elements/Publish';
+import { CustomPublishButtonProps } from '../../../../src/admin/components/elements/types';
+
+// In your projects, you can import as follows:
+// import { CustomPublishButtonProps } from 'payload/types';
 
 import classes from './index.module.scss';
 

--- a/test/versions/elements/CustomSaveButton/index.tsx
+++ b/test/versions/elements/CustomSaveButton/index.tsx
@@ -3,7 +3,7 @@ import { CustomPublishButtonProps } from '../../../../src/admin/components/eleme
 
 import classes from './index.module.scss';
 
-export const CustomSaveButton: CustomPublishButtonProps = ({ DefaultButton, ...rest }) => {
+export const CustomPublishButton: CustomPublishButtonProps = ({ DefaultButton, ...rest }) => {
   return (
     <div className={classes.customButton}>
       <DefaultButton {...rest} />

--- a/types.d.ts
+++ b/types.d.ts
@@ -62,3 +62,13 @@ export {
   UIField,
   Validate,
 } from './dist/fields/config/types';
+
+export {
+  RowLabel,
+} from './dist/admin/components/forms/RowLabel/types';
+
+export {
+  CustomSaveButtonProps,
+  CustomSaveDraftButtonProps,
+  CustomPublishButtonProps,
+} from './dist/admin/components/elements/types';


### PR DESCRIPTION
## Description

Related to: #1324 

Lays the groundwork for allowing different elements within the admin panel to be replaced with custom components. In this PR, the Save/SaveDraft/Publish/Preview buttons can all be replaced with custom react components.

### Example config
```ts
// collection/global config file

const Config = {
  admin: {
    components: {
      elements: {
        /**
         Custom "Save" button
           - drafts must be disabled
         */
        SaveButton: CustomSaveButton,
        /**
         Custom "Save Draft" button
           - drafts must be enabled
           - autosave must be disabled
         */
        SaveDraftButton: CustomSaveDraftButton,
        /**
         Custom "Publish" button
           - drafts must be enabled
         */
        PublishButton: CustomPublishButton,
        /**
         Custom "Preview" button
         */
        PreviewButton: CustomPreviewButton,
      },
    },
  }
}
```

### Example component

Note that this component uses the DefaultButton from props just to show the abstraction. But it could render anything and use the props passed to create a custom button and omit the usage of DefaultButton.
```tsx
import * as React from 'react';
import { CustomPublishButtonProps } from 'payload/types';

export const CustomPublishButton: CustomPublishButtonProps = ({ DefaultButton, disabled, label, publish }) => {
  return (
    <DefaultButton
      label={label}
      publish={publish}
      disabled={disabled}
    />
  );
};
```
- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
