### PR TITLE
fix: webp upload formatting

### DIFF
--- a/src/uploads/generateFileData.ts
+++ b/src/uploads/generateFileData.ts
@@ -115,10 +115,13 @@ export const generateFileData = async <T>({
       fileBuffer = await sharpFile.toBuffer({ resolveWithObject: true });
       ({ mime, ext } = await fromBuffer(fileBuffer.data)); // This is getting an incorrect gif height back.
       fileData.width = fileBuffer.info.width;
+      fileData.filesize = fileBuffer.info.size;
 
-      // Animated GIFs aggregate the height from every frame, so we need to use divide by number of pages
-      fileData.height = sharpOptions.animated ? (fileBuffer.info.height / metadata.pages) : fileBuffer.info.height;
-      fileData.filesize = fileBuffer.data.length;
+      // Animated GIFs + WebP aggregate the height from every frame, so we need to use divide by number of pages
+      if (metadata.pages) {
+        fileData.height = fileBuffer.info.height / metadata.pages;
+        fileData.filesize = fileBuffer.data.length;
+      }
     } else {
       mime = file.mimetype;
       fileData.filesize = file.size;


### PR DESCRIPTION
## Description

#2604 

We are assuming `.webp` files are always animated and formatting the file height as if it were a `GIF` - this should only be done when the `.webp` file is actually animated and has multiple frames.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
