### PR TITLE
fix: correct casing on graphql type

### DIFF
--- a/src/express/types.ts
+++ b/src/express/types.ts
@@ -27,7 +27,7 @@ export declare type PayloadRequest<U = any> = Request & {
    * */
   collection?: Collection;
   /** What triggered this request */
-  payloadAPI: 'REST' | 'local' | 'graphQL';
+  payloadAPI?: 'REST' | 'local' | 'GraphQL';
   /** Uploaded files */
   files?: {
     /**


### PR DESCRIPTION
## Description

#2624 

`payloadAPI` type `graphQL` is inaccurate, should be `GraphQL`.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
