### PR TITLE
fix: defaultValue missing from Upload field schema

### DIFF
--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -287,6 +287,10 @@ export const upload = baseField.keys({
     joi.object(),
     joi.func(),
   ),
+  defaultValue: joi.alternatives().try(
+    joi.object(),
+    joi.func(),
+  ),
 });
 
 export const checkbox = baseField.keys({


### PR DESCRIPTION
## Description

#2630 

Upload field schema was missing `defaultValue`.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
