### PR TITLE
chore: migrates react-router-dom to v5.1

### DIFF
--- a/src/admin/components/Routes.tsx
+++ b/src/admin/components/Routes.tsx
@@ -1,5 +1,5 @@
-import React, { lazy, Suspense, useEffect, useState } from 'react';
-import { Redirect, Route, Switch, withRouter } from 'react-router-dom';
+import React, { Fragment, lazy, Suspense, useEffect, useState } from 'react';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './utilities/Auth';
 import { useConfig } from './utilities/Config';
@@ -26,7 +26,7 @@ const ResetPassword = lazy(() => import('./views/ResetPassword'));
 const Unauthorized = lazy(() => import('./views/Unauthorized'));
 const Account = lazy(() => import('./views/Account'));
 
-const Routes = () => {
+const Routes: React.FC = () => {
   const [initialized, setInitialized] = useState(null);
   const { user, permissions, refreshCookie } = useAuth();
   const { i18n } = useTranslation();
@@ -35,6 +35,7 @@ const Routes = () => {
   const canAccessAdmin = permissions?.canAccessAdmin;
 
   const config = useConfig();
+
   const {
     admin: {
       user: userSlug,
@@ -115,7 +116,6 @@ const Routes = () => {
                     />
                   </Route>
                 ))}
-
                 <Route path={`${match.url}/login`}>
                   <Login />
                 </Route>
@@ -125,7 +125,6 @@ const Routes = () => {
                 <Route path={`${match.url}${logoutInactivityRoute}`}>
                   <Logout inactivity />
                 </Route>
-
                 {!userCollection.auth.disableLocalStrategy && (
                   <Route path={`${match.url}/forgot`}>
                     <ForgotPassword />
@@ -153,240 +152,171 @@ const Routes = () => {
                   return null;
                 })}
 
-                <Route
-                  render={() => {
-                    if (user) {
-                      if (canAccessAdmin) {
-                        return (
-                          <DefaultTemplate>
-                            <Switch>
-                              <Route
-                                path={`${match.url}/`}
-                                exact
+                <Route>
+                  {user ? (
+                    <Fragment>
+                      {canAccessAdmin && (
+                        <DefaultTemplate>
+                          <Switch>
+                            <Route
+                              path={`${match.url}/`}
+                              exact
+                            >
+                              <Dashboard />
+                            </Route>
+                            <Route path={`${match.url}/account`}>
+                              <DocumentInfoProvider
+                                collection={collections.find(({ slug }) => slug === userSlug)}
+                                id={user.id}
                               >
-                                <Dashboard />
-                              </Route>
+                                <Account />
+                              </DocumentInfoProvider>
+                            </Route>
+                            {collections
+                              .filter(({ admin: { hidden } }) => !(typeof hidden === 'function' ? hidden({ user }) : hidden))
+                              .reduce((collectionRoutes, collection) => {
+                                const routesToReturn = [
+                                  ...collectionRoutes,
+                                  <Route
+                                    key={`${collection.slug}-list`}
+                                    path={`${match.url}/collections/${collection.slug}`}
+                                    exact
+                                  >
+                                    {permissions?.collections?.[collection.slug]?.read?.permission
+                                      ? <List collection={collection} />
+                                      : <Unauthorized />}
+                                  </Route>,
+                                  <Route
+                                    key={`${collection.slug}-create`}
+                                    path={`${match.url}/collections/${collection.slug}/create`}
+                                    exact
+                                  >
+                                    {permissions?.collections?.[collection.slug]?.create?.permission ? (
+                                      <DocumentInfoProvider
+                                        collection={collection}
+                                        idFromParams
+                                      >
+                                        <Edit collection={collection} />
+                                      </DocumentInfoProvider>
+                                      ) : (
+                                        <Unauthorized />
+                                      )}
+                                  </Route>,
+                                  <Route
+                                    key={`${collection.slug}-edit`}
+                                    path={`${match.url}/collections/${collection.slug}/:id`}
+                                    exact
+                                  >
+                                    {permissions?.collections?.[collection.slug]?.read?.permission ? (
+                                      <DocumentInfoProvider
+                                        collection={collection}
+                                        idFromParams
+                                      >
+                                        <Edit
+                                          isEditing
+                                          collection={collection}
+                                        />
+                                      </DocumentInfoProvider>
+                                      ) : <Unauthorized />}
+                                  </Route>,
+                                ];
 
-                              <Route path={`${match.url}/account`}>
-                                <DocumentInfoProvider
-                                  collection={collections.find(({ slug }) => slug === userSlug)}
-                                  id={user.id}
-                                >
-                                  <Account />
-                                </DocumentInfoProvider>
-                              </Route>
-
-                              {collections
-                                .filter(({ admin: { hidden } }) => !(typeof hidden === 'function' ? hidden({ user }) : hidden))
-                                .reduce((collectionRoutes, collection) => {
-                                  const routesToReturn = [
-                                    ...collectionRoutes,
+                                if (collection.versions) {
+                                  routesToReturn.push(
                                     <Route
-                                      key={`${collection.slug}-list`}
-                                      path={`${match.url}/collections/${collection.slug}`}
+                                      key={`${collection.slug}-versions`}
+                                      path={`${match.url}/collections/${collection.slug}/:id/versions`}
                                       exact
-                                      render={(routeProps) => {
-                                        if (permissions?.collections?.[collection.slug]?.read?.permission) {
-                                          return (
-                                            <List
-                                              {...routeProps}
-                                              collection={collection}
-                                            />
-                                          );
-                                        }
+                                    >
+                                      {permissions?.collections?.[collection.slug]?.readVersions?.permission ? (
+                                        <Versions collection={collection} />
+                                        ) : <Unauthorized />}
+                                    </Route>,
+                                  );
 
-                                        return <Unauthorized />;
-                                      }}
-                                    />,
+                                  routesToReturn.push(
                                     <Route
-                                      key={`${collection.slug}-create`}
-                                      path={`${match.url}/collections/${collection.slug}/create`}
+                                      key={`${collection.slug}-view-version`}
+                                      path={`${match.url}/collections/${collection.slug}/:id/versions/:versionID`}
                                       exact
-                                      render={(routeProps) => {
-                                        if (permissions?.collections?.[collection.slug]?.create?.permission) {
-                                          return (
-                                            <DocumentInfoProvider collection={collection}>
-                                              <Edit
-                                                {...routeProps}
-                                                collection={collection}
-                                              />
-                                            </DocumentInfoProvider>
-                                          );
-                                        }
+                                    >
+                                      {permissions?.collections?.[collection.slug]?.readVersions?.permission ? (
+                                        <DocumentInfoProvider
+                                          collection={collection}
+                                          idFromParams
+                                        >
+                                          <Version collection={collection} />
+                                        </DocumentInfoProvider>
+                                        ) : <Unauthorized />}
+                                    </Route>,
+                                  );
+                                }
 
-                                        return <Unauthorized />;
-                                      }}
-                                    />,
+                                return routesToReturn;
+                              }, [])}
+                            {globals && globals
+                              .filter(({ admin: { hidden } }) => !(typeof hidden === 'function' ? hidden({ user }) : hidden))
+                              .reduce((globalRoutes, global) => {
+                                const routesToReturn = [
+                                  ...globalRoutes,
+                                  <Route
+                                    key={`${global.slug}`}
+                                    path={`${match.url}/globals/${global.slug}`}
+                                    exact
+                                  >
+                                    {permissions?.globals?.[global.slug]?.read?.permission ? (
+                                      <DocumentInfoProvider
+                                        global={global}
+                                        key={`${global.slug}-${locale}`}
+                                        idFromParams
+                                      >
+                                        <EditGlobal global={global} />
+                                      </DocumentInfoProvider>
+                                      ) : <Unauthorized />}
+                                  </Route>,
+                                ];
+
+                                if (global.versions) {
+                                  routesToReturn.push(
                                     <Route
-                                      key={`${collection.slug}-edit`}
-                                      path={`${match.url}/collections/${collection.slug}/:id`}
+                                      key={`${global.slug}-versions`}
+                                      path={`${match.url}/globals/${global.slug}/versions`}
                                       exact
-                                      render={(routeProps) => {
-                                        const { match: { params: { id } } } = routeProps;
-                                        if (permissions?.collections?.[collection.slug]?.read?.permission) {
-                                          return (
-                                            <DocumentInfoProvider
-                                              key={`${collection.slug}-edit-${id}-${locale}`}
-                                              collection={collection}
-                                              id={id}
-                                            >
-                                              <Edit
-                                                isEditing
-                                                {...routeProps}
-                                                collection={collection}
-                                              />
-                                            </DocumentInfoProvider>
-                                          );
-                                        }
+                                    >
+                                      {permissions?.globals?.[global.slug]?.readVersions?.permission
+                                        ? <Versions global={global} />
+                                        : <Unauthorized />}
+                                    </Route>,
+                                  );
 
-                                        return <Unauthorized />;
-                                      }}
-                                    />,
-                                  ];
-
-                                  if (collection.versions) {
-                                    routesToReturn.push(
-                                      <Route
-                                        key={`${collection.slug}-versions`}
-                                        path={`${match.url}/collections/${collection.slug}/:id/versions`}
-                                        exact
-                                        render={(routeProps) => {
-                                          if (permissions?.collections?.[collection.slug]?.readVersions?.permission) {
-                                            return (
-                                              <Versions
-                                                {...routeProps}
-                                                collection={collection}
-                                              />
-                                            );
-                                          }
-
-                                          return <Unauthorized />;
-                                        }}
-                                      />,
-                                    );
-
-                                    routesToReturn.push(
-                                      <Route
-                                        key={`${collection.slug}-view-version`}
-                                        path={`${match.url}/collections/${collection.slug}/:id/versions/:versionID`}
-                                        exact
-                                        render={(routeProps) => {
-                                          if (permissions?.collections?.[collection.slug]?.readVersions?.permission) {
-                                            return (
-                                              <DocumentInfoProvider
-                                                collection={collection}
-                                                id={routeProps.match.params.id}
-                                              >
-                                                <Version
-                                                  {...routeProps}
-                                                  collection={collection}
-                                                />
-                                              </DocumentInfoProvider>
-                                            );
-                                          }
-
-                                          return <Unauthorized />;
-                                        }}
-                                      />,
-                                    );
-                                  }
-
-                                  return routesToReturn;
-                                }, [])}
-
-                              {globals && globals
-                                .filter(({ admin: { hidden } }) => !(typeof hidden === 'function' ? hidden({ user }) : hidden))
-                                .reduce((globalRoutes, global) => {
-                                  const routesToReturn = [
-                                    ...globalRoutes,
+                                  routesToReturn.push(
                                     <Route
-                                      key={`${global.slug}`}
-                                      path={`${match.url}/globals/${global.slug}`}
+                                      key={`${global.slug}-view-version`}
+                                      path={`${match.url}/globals/${global.slug}/versions/:versionID`}
                                       exact
-                                      render={(routeProps) => {
-                                        if (permissions?.globals?.[global.slug]?.read?.permission) {
-                                          return (
-                                            <DocumentInfoProvider
-                                              global={global}
-                                              key={`${global.slug}-${locale}`}
-                                            >
-                                              <EditGlobal
-                                                {...routeProps}
-                                                global={global}
-                                              />
-                                            </DocumentInfoProvider>
-                                          );
-                                        }
+                                    >
+                                      {permissions?.globals?.[global.slug]?.readVersions?.permission ? (
+                                        <Version global={global} />
+                                          ) : <Unauthorized />}
+                                    </Route>,
+                                  );
+                                }
 
-                                        return <Unauthorized />;
-                                      }}
-                                    />,
-                                  ];
+                                return routesToReturn;
+                              }, [])}
 
-                                  if (global.versions) {
-                                    routesToReturn.push(
-                                      <Route
-                                        key={`${global.slug}-versions`}
-                                        path={`${match.url}/globals/${global.slug}/versions`}
-                                        exact
-                                        render={(routeProps) => {
-                                          if (permissions?.globals?.[global.slug]?.readVersions?.permission) {
-                                            return (
-                                              <Versions
-                                                {...routeProps}
-                                                global={global}
-                                              />
-                                            );
-                                          }
-
-                                          return <Unauthorized />;
-                                        }}
-                                      />,
-                                    );
-                                    routesToReturn.push(
-                                      <Route
-                                        key={`${global.slug}-view-version`}
-                                        path={`${match.url}/globals/${global.slug}/versions/:versionID`}
-                                        exact
-                                        render={(routeProps) => {
-                                          if (permissions?.globals?.[global.slug]?.readVersions?.permission) {
-                                            return (
-                                              <Version
-                                                {...routeProps}
-                                                global={global}
-                                              />
-                                            );
-                                          }
-
-                                          return <Unauthorized />;
-                                        }}
-                                      />,
-                                    );
-                                  }
-                                  return routesToReturn;
-                                }, [])}
-
-                              <Route path={`${match.url}*`}>
-                                <NotFound />
-                              </Route>
-                            </Switch>
-                          </DefaultTemplate>
-                        );
-                      }
-
-                      if (canAccessAdmin === false) {
-                        return <Unauthorized />;
-                      }
-
-                      return (
-                        // user without admin panel access
-                        <div />
-                      );
-                    }
-
-                    return <Redirect to={`${match.url}/login`} />;
-                  }}
-                />
+                            <Route path={`${match.url}*`}>
+                              <NotFound />
+                            </Route>
+                          </Switch>
+                        </DefaultTemplate>
+                      )}
+                      {canAccessAdmin === false && (
+                        <Unauthorized />
+                      )}
+                    </Fragment>
+                  ) : <Redirect to={`${match.url}/login`} />}
+                </Route>
                 <Route path={`${match.url}*`}>
                   <NotFound />
                 </Route>
@@ -402,4 +332,4 @@ const Routes = () => {
   );
 };
 
-export default withRouter(Routes);
+export default Routes;

--- a/src/admin/components/utilities/DocumentInfo/index.tsx
+++ b/src/admin/components/utilities/DocumentInfo/index.tsx
@@ -3,6 +3,7 @@ import React, {
 } from 'react';
 import qs from 'qs';
 import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
 import { useConfig } from '../Config';
 import { PaginatedDocs } from '../../../../mongoose/types';
 import { ContextType, DocumentPermissions, Props, Version } from './types';
@@ -21,8 +22,12 @@ export const DocumentInfoProvider: React.FC<Props> = ({
   children,
   global,
   collection,
-  id,
+  id: idFromProps,
+  idFromParams: getIDFromParams,
 }) => {
+  const { id: idFromParams } = useParams<{id: string}>();
+  const id = idFromProps || (getIDFromParams ? idFromParams : null);
+
   const { serverURL, routes: { api } } = useConfig();
   const { getPreference } = usePreferences();
   const { i18n } = useTranslation();

--- a/src/admin/components/utilities/DocumentInfo/types.ts
+++ b/src/admin/components/utilities/DocumentInfo/types.ts
@@ -27,5 +27,6 @@ export type Props = {
   collection?: SanitizedCollectionConfig
   global?: SanitizedGlobalConfig
   id?: string | number
+  idFromParams?: boolean
   children?: React.ReactNode
 }


### PR DESCRIPTION
## Description

Migrates to `react-router-dom` v5.1. We were already on v5 but not fully up-to-date with the API. This PR completes the update to `5.1` in preparation of `6.0` as described here: https://reactrouter.com/en/main/upgrading/v5

There is a backwards compatible package that will allow us to migrate core to v6 while allowing those with custom views and components to migrate slowly over time.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
