### PR TITLE
fix: columns and filters pill colors are now less obnoxious and in line with their role

### DIFF
--- a/src/admin/components/elements/ListControls/index.tsx
+++ b/src/admin/components/elements/ListControls/index.tsx
@@ -89,7 +89,7 @@ const ListControls: React.FC<Props> = (props) => {
             )}
             {enableColumns && (
               <Pill
-                pillStyle="dark"
+                pillStyle="light"
                 className={`${baseClass}__toggle-columns ${visibleDrawer === 'columns' ? `${baseClass}__buttons-active` : ''}`}
                 onClick={() => setVisibleDrawer(visibleDrawer !== 'columns' ? 'columns' : undefined)}
                 icon={<Chevron />}
@@ -98,7 +98,7 @@ const ListControls: React.FC<Props> = (props) => {
               </Pill>
             )}
             <Pill
-              pillStyle="dark"
+              pillStyle="light"
               className={`${baseClass}__toggle-where ${visibleDrawer === 'where' ? `${baseClass}__buttons-active` : ''}`}
               onClick={() => setVisibleDrawer(visibleDrawer !== 'where' ? 'where' : undefined)}
               icon={<Chevron />}


### PR DESCRIPTION
## Description

Following up on [this Discord thread](https://discord.com/channels/967097582721572934/1103912281861009488/1103912288731287602).

The "columns" and "filters" pills on the collection's list pages currently have a their style set to `dark`, which makes them stand out a lot, and place them at the same level of importance than the "Publish" button (`btn--style-primary`) and higher than the "Create new" button or the docs themselves.

I'm proposing switching them to `light`, which would bring them in line with the "Create new" pill on that page.

---

### Before:
![image](https://user-images.githubusercontent.com/1763338/236940235-55caafa3-fb77-4273-bd67-95a0eaffc152.png)
![image](https://user-images.githubusercontent.com/1763338/236940259-1e5c11b9-0761-4b18-a8be-eb07703a0726.png)
![image](https://user-images.githubusercontent.com/1763338/236940451-2315ef81-b18d-4948-9a20-b22e78c23bb5.png) ![image](https://user-images.githubusercontent.com/1763338/236940589-ecd933a4-997e-4115-b243-8de19e8b10cb.png)

---

### After:
![image](https://user-images.githubusercontent.com/1763338/236940742-f4b7c843-b8d6-4fa8-843f-7de99752a0e0.png)
![image](https://user-images.githubusercontent.com/1763338/236940753-7c1d551f-4421-4db6-81aa-4efdfd9ac7f5.png)
![image](https://user-images.githubusercontent.com/1763338/236940805-fec8e443-4a37-48f0-a962-9f79d103bd1a.png) ![image](https://user-images.githubusercontent.com/1763338/236940866-0121ffb5-63e4-4522-aef1-a1de99190377.png)

---

- [ ] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
