### PR TITLE
fix: anchor Button component respect margins

### DIFF
--- a/src/admin/components/elements/Button/index.scss
+++ b/src/admin/components/elements/Button/index.scss
@@ -1,5 +1,9 @@
 @import '../../../scss/styles.scss';
 
+a.btn {
+  display: inline-block;
+}
+
 .btn {
   background: transparent;
   line-height: base(1);


### PR DESCRIPTION
## Description

When using <Button> with `el="anchor"` the margins are not respected and require extra CSS to get the intended spacing around it. This change adds `display: inline-block` correct it.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
