### PR TITLE
fix: #2647, slate not reinitializing after row change

### DIFF
--- a/src/admin/components/forms/field-types/RichText/RichText.tsx
+++ b/src/admin/components/forms/field-types/RichText/RichText.tsx
@@ -272,7 +272,7 @@ const RichText: React.FC<Props> = (props) => {
           required={required}
         />
         <Slate
-          key={JSON.stringify(initialValue)}
+          key={JSON.stringify({ initialValue, path })}
           editor={editor}
           value={valueToRender as any[]}
           onChange={handleChange}


### PR DESCRIPTION
## Description

Fixes #2647 by ensuring the Slate `key` is based on both `initialValue` and `path`.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
