### PR TITLE
chore: add explorer file nesting for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.ts": "$(capture).js, $(capture).d.ts.map, $(capture).*.ts, $(capture)_*.js, $(capture)_*.ts",
+    "*.tsx": "$(capture).ts, $(capture).*.tsx, $(capture)_*.ts, $(capture)_*.tsx",
+    "*.js": "$(capture).js.map, $(capture).*.js, $(capture)_*.js",
+    "*.jsx": "$(capture).js, $(capture).*.jsx, $(capture)_*.js, $(capture)_*.jsx",
+    // Config
+    ".env": "*.env, .env.*, .envrc, env.d.ts",
+    ".gitignore": ".gitattributes, .gitmodules, .gitmessage, .mailmap, .git-blame*",
+    "package.json": ".editorconfig, .eslint*, .github*, .huskyrc*,.lintstagedrc*, .markdownlint*, .node-version, .nodemon*, .npm*, .nvmrc, .prettier*, .releaserc*, .release-it*.json, .tool-versions, .yarnrc*, nodemon*, package-lock.json, pm2.*, prettier*, yarn*",
+    "readme*": "authors, backers*, changelog*, citation*, code_of_conduct*, codeowners, contributing*, contributors, copying, credits, governance.md, history.md, license*, maintainers, readme*, security.md, sponsors*, ISSUE_GUIDE.md, github-stars.md",
+    // Testing
+    "jest.config.js": "jest.*config.js",
+    "playwright.config.ts": "playwright.*config.ts",
+    // Collapse top-level pointer js files
+    "*.d.ts": "$(capture).js",
+  },
+}


### PR DESCRIPTION
## Description

The number of config files at the top-level have slowly been increasing in number. This is a quality of life configuration to collapse many of them under a "parent". 

Before:

![CleanShot 2023-05-12 at 08 58 42](https://github.com/payloadcms/payload/assets/65888/004fc783-30ca-4af2-bd0b-7dcced2f8f8e)


After: 

![CleanShot 2023-05-12 at 08 59 29](https://github.com/payloadcms/payload/assets/65888/b7161be4-19a8-4cdd-8186-0f99fc92d605)


