### PR TITLE
Allow custom mongourl during tests

### DIFF
--- a/src/mongoose/connect.ts
+++ b/src/mongoose/connect.ts
@@ -43,7 +43,7 @@ const connectInMemory = async (
 };
 
 const _connect = async (logger: pino.Logger, urlToConnectTo: string|false, options: InitOptions['mongoOptions']): Promise<void> => {
-  if (!urlToConnectTo) {
+  if (!urlToConnectTo || typeof urlToConnectTo !== 'string') {
     throw new Error('Error: missing MongoDB connection URL.');
   }
   const connectionOptions: ConnectOptions & { useFacet: undefined } = {

--- a/src/mongoose/connect.ts
+++ b/src/mongoose/connect.ts
@@ -5,55 +5,66 @@ import pino from 'pino';
 import { InitOptions } from '../config/types';
 import { connection } from './testCredentials';
 
-const connectMongoose = async (
-  url: string,
+const connect = async (
+  urlToConnectTo: string|false,
   options: InitOptions['mongoOptions'],
   logger: pino.Logger,
-): Promise<void | any> => {
-  let urlToConnect = url;
-  let successfulConnectionMessage = 'Connected to Mongo server successfully!';
+): Promise<void> => {
+  await _connect(logger, urlToConnectTo, options);
+  logger.info('Connected to Mongo server successfully!');
+};
 
+const connectInMemory = async (
+  options: InitOptions['mongoOptions'],
+  logger: pino.Logger,
+): Promise<any> => {
+  const getPort = require('get-port');
+  const port = await getPort();
+
+  const { MongoMemoryServer } = require('mongodb-memory-server');
+  const mongoMemoryServer = await MongoMemoryServer.create({
+    instance: {
+      dbName: connection.name,
+      port,
+    },
+  });
+
+  await _connect(
+    logger,
+    mongoMemoryServer.getUri(),
+    {
+      ...options,
+      dbName: 'payloadmemory',
+    },
+  );
+  logger.info('Connected to in-memory Mongo server successfully!');
+
+  return mongoMemoryServer;
+};
+
+const _connect = async (logger: pino.Logger, urlToConnectTo: string|false, options: InitOptions['mongoOptions']): Promise<void> => {
+  if (!urlToConnectTo) {
+    throw new Error('Error: missing MongoDB connection URL.');
+  }
   const connectionOptions: ConnectOptions & { useFacet: undefined } = {
     autoIndex: true,
     ...options,
     useFacet: undefined,
   };
-
-  let mongoMemoryServer;
-
-  if (process.env.NODE_ENV === 'test') {
-    connectionOptions.dbName = 'payloadmemory';
-    const { MongoMemoryServer } = require('mongodb-memory-server');
-    const getPort = require('get-port');
-
-    const port = await getPort();
-    mongoMemoryServer = await MongoMemoryServer.create({
-      instance: {
-        dbName: connection.name,
-        port,
-      },
-    });
-
-    urlToConnect = mongoMemoryServer.getUri();
-    successfulConnectionMessage = 'Connected to in-memory Mongo server successfully!';
-  }
+  mongoose.set('strictQuery', false);
 
   try {
-    await mongoose.connect(urlToConnect, connectionOptions);
+    await mongoose.connect(urlToConnectTo, connectionOptions);
 
     if (process.env.PAYLOAD_DROP_DATABASE === 'true') {
       logger.info('---- DROPPING DATABASE ----');
       await mongoose.connection.dropDatabase();
       logger.info('---- DROPPED DATABASE ----');
     }
-
-    logger.info(successfulConnectionMessage);
   } catch (err) {
     logger.error(`Error: cannot connect to MongoDB. Details: ${err.message}`, err);
     process.exit(1);
   }
-
-  return mongoMemoryServer;
 };
 
-export default connectMongoose;
+export default { connect, connectInMemory };


### PR DESCRIPTION
## Description

As discussed on Discord, it is currently not possible to provide a custom MongoDB URL during tests because it is automatically overridden with the address of an in memory database. At the same time, `payload.init` throws an error when the URL was _not_ supplied.  

IMHO the ideal behavior would be:
If `mongoURL` is supplied, use it regardless of `NODE_ENV` value.
If `NODE_ENV === "test"` and `mongoURL` is missing, connect to in-memory database and do not complain about missing value.
If `NODE_ENV !== "test"` and `mongoURL` is missing, throw an error about missing value.

However, simply changing the behavior will probably break some people's test environments, as it was previously not necessary to have a _working_ `mongoURL` during tests. If we simply started connecting to `mongoURL` now just because it is set to something it might have unforeseen consequences. At best the tests just won't run but at worst they'll modify a database they shouldn't connect to.

This is why we rely on an additional environment variable `PAYLOAD_USE_MONGO_URL_FOR_TESTS` to decide what to do and issue a warning explaining the behavior and how to avoid the warning.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
