### PR TITLE
fix: swaps variables in logger.error

### DIFF
--- a/src/email/sendEmail.ts
+++ b/src/email/sendEmail.ts
@@ -8,8 +8,8 @@ export default async function sendEmail(message: SendMailOptions): Promise<unkno
     result = await email.transport.sendMail(message);
   } catch (err) {
     this.logger.error(
-      `Failed to send mail to ${message.to}, subject: ${message.subject}`,
       err,
+      `Failed to send mail to ${message.to}, subject: ${message.subject}`,
     );
     return err;
   }


### PR DESCRIPTION
## Description

Swaps variables in `logger.error` within `sendEmail`. Pino [docs](https://github.com/pinojs/pino/blob/master/docs/api.md#error) show messages need to be the second argument. 

Brought up in Discord [here](https://discord.com/channels/967097582721572934/1106463699314692106/1106463699314692106)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
