### PR TITLE
fix: fixes modal overflow caused by unused button tooltips

### DIFF
--- a/src/admin/components/elements/Button/index.tsx
+++ b/src/admin/components/elements/Button/index.tsx
@@ -28,12 +28,14 @@ const ButtonContents = ({ children, icon, tooltip, showTooltip }) => {
 
   return (
     <Fragment>
-      <Tooltip
-        className={`${baseClass}__tooltip`}
-        show={showTooltip}
-      >
-        {tooltip}
-      </Tooltip>
+      {tooltip && (
+        <Tooltip
+          className={`${baseClass}__tooltip`}
+          show={showTooltip}
+        >
+          {tooltip}
+        </Tooltip>
+      )}
       <span className={`${baseClass}__content`}>
         {children && (
           <span className={`${baseClass}__label`}>

--- a/src/admin/components/elements/DeleteDocument/index.scss
+++ b/src/admin/components/elements/DeleteDocument/index.scss
@@ -16,6 +16,12 @@
   }
 
   .btn {
-    margin-right: $baseline;
+    margin: 0;
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $baseline;
   }
 }

--- a/src/admin/components/elements/DeleteDocument/index.tsx
+++ b/src/admin/components/elements/DeleteDocument/index.tsx
@@ -109,20 +109,22 @@ const DeleteDocument: React.FC<Props> = (props) => {
                 </strong>
               </Trans>
             </p>
-            <Button
-              id="confirm-cancel"
-              buttonStyle="secondary"
-              type="button"
-              onClick={deleting ? undefined : () => toggleModal(modalSlug)}
-            >
-              {t('cancel')}
-            </Button>
-            <Button
-              onClick={deleting ? undefined : handleDelete}
-              id="confirm-delete"
-            >
-              {deleting ? t('deleting') : t('confirm')}
-            </Button>
+            <div className={`${baseClass}__actions`}>
+              <Button
+                id="confirm-cancel"
+                buttonStyle="secondary"
+                type="button"
+                onClick={deleting ? undefined : () => toggleModal(modalSlug)}
+              >
+                {t('cancel')}
+              </Button>
+              <Button
+                onClick={deleting ? undefined : handleDelete}
+                id="confirm-delete"
+              >
+                {deleting ? t('deleting') : t('confirm')}
+              </Button>
+            </div>
           </MinimalTemplate>
         </Modal>
       </React.Fragment>

--- a/src/admin/components/modals/StayLoggedIn/index.scss
+++ b/src/admin/components/modals/StayLoggedIn/index.scss
@@ -12,6 +12,12 @@
   }
 
   .btn {
-    margin-right: base(1);
+    margin: 0;
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $baseline;
   }
 }

--- a/src/admin/components/modals/StayLoggedIn/index.tsx
+++ b/src/admin/components/modals/StayLoggedIn/index.tsx
@@ -20,8 +20,8 @@ const StayLoggedInModal: React.FC<Props> = (props) => {
   const {
     routes: { admin },
     admin: {
-      logoutRoute
-    }
+      logoutRoute,
+    },
   } = config;
   const { toggleModal } = useModal();
   const { t } = useTranslation('authentication');


### PR DESCRIPTION
## Description

The `DeleteDocument` and `StayLoggedIn` modals were rendering buttons with unused tooltips. These tooltips were absolutely positioned relative to the _window_ and causing overflow for _all_ modals because these two modals in particular never leave the DOM. This meant that all modals rendered overtop these two, i.e. the `DocumentDrawer` would experience a double scroll bar.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
