### PR TITLE
docs: add missing admin.group property in configuration/globals

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -67,7 +67,7 @@ You can customize the way that the Admin panel behaves on a collection-by-collec
 
 | Option                       | Description                                                                                                                                                                                           |
 |------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `group`                      | Text used as a label for grouping collection links together in the navigation.                                                                                                                        |
+| `group`                      | Text used as a label for grouping collection and global links together in the navigation.                                                                                                             |
 | `hidden`                     | Set to true or a function, called with the current user, returning true to exclude this collection from navigation and admin routing.                                                                 |
 | `hooks`                      | Admin-specific hooks for this collection. [More](#admin-hooks)                                                                                                                                        |
 | `useAsTitle`                 | Specify a top-level field to use for a document title throughout the Admin panel. If no field is defined, the ID of the document is used as the title.                                                |

--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -67,6 +67,7 @@ You can customize the way that the Admin panel behaves on a Global-by-Global bas
 
 | Option       | Description                                                                                                                       |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `group`      | Text used as a label for grouping collection and global links together in the navigation.                                                    |
 | `hidden`     | Set to true or a function, called with the current user, returning true to exclude this global from navigation and admin routing. |
 | `components` | Swap in your own React components to be used within this Global. [More](/docs/admin/components#globals)                           |
 | `preview`    | Function to generate a preview URL within the Admin panel for this global that can point to your app. [More](#preview).           |


### PR DESCRIPTION
## Description

The docs for the global configuration was missing the admin.group property.
I also clarified the description a bit to make it clear that you can group both collections and globals together.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
