### PR TITLE
fix: add new relationship drawer onSave handling

### DIFF
--- a/src/admin/components/elements/DocumentDrawer/types.ts
+++ b/src/admin/components/elements/DocumentDrawer/types.ts
@@ -1,14 +1,10 @@
 import React, { HTMLAttributes } from 'react';
-import { SanitizedCollectionConfig } from '../../../../collections/config/types';
+import { Props as EditViewProps } from '../../views/collections/Edit/types';
 
 export type DocumentDrawerProps = {
   collectionSlug: string
   id?: string
-  onSave?: (json: {
-    doc: Record<string, any>
-    message: string
-    collectionConfig: SanitizedCollectionConfig
-  }) => void
+  onSave?: EditViewProps['onSave']
   customHeader?: React.ReactNode
   drawerSlug?: string
 }

--- a/src/admin/components/forms/field-types/Relationship/AddNew/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/AddNew/index.tsx
@@ -11,6 +11,7 @@ import { getTranslation } from '../../../../../../utilities/getTranslation';
 import Tooltip from '../../../../elements/Tooltip';
 import { useDocumentDrawer } from '../../../../elements/DocumentDrawer';
 import { useConfig } from '../../../../utilities/Config';
+import { Props as EditViewProps } from '../../../../views/collections/Edit/types';
 
 import './index.scss';
 
@@ -36,7 +37,7 @@ export const AddNewRelation: React.FC<Props> = ({ path, hasMany, relationTo, val
     collectionSlug: collectionConfig?.slug,
   });
 
-  const onSave = useCallback((json) => {
+  const onSave: EditViewProps['onSave'] = useCallback((json) => {
     const newValue = Array.isArray(relationTo) ? {
       relationTo: collectionConfig.slug,
       value: json.doc.id,

--- a/src/admin/components/forms/field-types/Relationship/AddNew/types.ts
+++ b/src/admin/components/forms/field-types/Relationship/AddNew/types.ts
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Action } from '../types';
+import { Action, OptionGroup, Value } from '../types';
 
 export type Props = {
   hasMany: boolean
   relationTo: string | string[]
   path: string
-  value: unknown
+  value: Value | Value[]
+  options: OptionGroup[]
   setValue: (value: unknown) => void
   dispatchOptions: React.Dispatch<Action>
 }

--- a/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -450,7 +450,7 @@ const Relationship: React.FC<Props> = (props) => {
           />
           {!readOnly && allowCreate && (
             <AddNewRelation
-              {...{ path: pathOrName, hasMany, relationTo, value, setValue, dispatchOptions }}
+              {...{ path: pathOrName, hasMany, relationTo, value, setValue, dispatchOptions, options }}
             />
           )}
         </div>

--- a/src/admin/components/views/collections/Edit/Default.tsx
+++ b/src/admin/components/views/collections/Edit/Default.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useConfig } from '../../../utilities/Config';
@@ -43,7 +43,7 @@ const DefaultEditView: React.FC<Props> = (props) => {
     collection,
     isEditing,
     data,
-    onSave,
+    onSave: onSaveFromProps,
     permissions,
     isLoading,
     internalState,
@@ -77,6 +77,15 @@ const DefaultEditView: React.FC<Props> = (props) => {
     baseClass,
     isEditing && `${baseClass}--is-editing`,
   ].filter(Boolean).join(' ');
+
+  const onSave = useCallback((json) => {
+    if (typeof onSaveFromProps === 'function') {
+      onSaveFromProps({
+        ...json,
+        operation: id ? 'update' : 'create',
+      });
+    }
+  }, [id, onSaveFromProps]);
 
   const operation = isEditing ? 'update' : 'create';
 

--- a/src/admin/components/views/collections/Edit/types.ts
+++ b/src/admin/components/views/collections/Edit/types.ts
@@ -11,7 +11,12 @@ export type IndexProps = {
 
 export type Props = IndexProps & {
   data: Document
-  onSave?: () => void
+  onSave?: (json: Record<string, unknown> & {
+    doc: Record<string, any>
+    message: string
+    collectionConfig: SanitizedCollectionConfig
+    operation: 'create' | 'update',
+  }) => void
   id?: string
   permissions: CollectionPermission
   isLoading: boolean

--- a/test/fields-relationship/collectionSlugs.ts
+++ b/test/fields-relationship/collectionSlugs.ts
@@ -1,4 +1,3 @@
-
 export const slug = 'fields-relationship';
 
 export const relationOneSlug = 'relation-one';

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -277,6 +277,33 @@ describe('fields - relationship', () => {
     await expect(documentDrawer).toBeVisible();
   });
 
+  test('should open document drawer and append newly created docs onto the parent field', async () => {
+    await page.goto(url.edit(docWithExistingRelations.id));
+
+    const field = page.locator('#field-relationshipHasMany');
+
+    // open the document drawer
+    const addNewButton = await field.locator('button.relationship-add-new__add-button.doc-drawer__toggler');
+    await addNewButton.click();
+    const documentDrawer = await page.locator('[id^=doc-drawer_relation-one_1_]');
+    await expect(documentDrawer).toBeVisible();
+
+    // fill in the field and save the document, keep the drawer open for further testing
+    const drawerField = await documentDrawer.locator('#field-name');
+    await drawerField.fill('Newly created document');
+    const saveButton = await documentDrawer.locator('#action-save');
+    await saveButton.click();
+    await expect(page.locator('.Toastify')).toContainText('successfully');
+
+    // count the number of values in the field to ensure only one was added
+    await expect(await page.locator('#field-relationshipHasMany .value-container .rs__multi-value')).toHaveCount(1);
+
+    // save the same document again to ensure the relationship field doesn't receive duplicative values
+    await saveButton.click();
+    await expect(page.locator('.Toastify')).toContainText('successfully');
+    await expect(await page.locator('#field-relationshipHasMany .value-container .rs__multi-value')).toHaveCount(1);
+  });
+
   describe('existing relationships', () => {
     test('should highlight existing relationship', async () => {
       await page.goto(url.edit(docWithExistingRelations.id));
@@ -365,7 +392,6 @@ describe('fields - relationship', () => {
 
   describe('externally update field', () => {
     beforeAll(async () => {
-      url = new AdminUrlUtil(serverURL, relationUpdatedExternallySlug);
       await page.goto(url.create);
     });
 

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -390,24 +390,21 @@ describe('fields - relationship', () => {
     });
   });
 
-  describe('externally update field', () => {
+  describe('externally update relationship field', () => {
     beforeAll(async () => {
-      await page.goto(url.create);
+      const externalRelationURL = new AdminUrlUtil(serverURL, relationUpdatedExternallySlug);
+      await page.goto(externalRelationURL.create);
     });
 
     test('has many, one collection', async () => {
-      await page.goto(url.create);
-
       await page.locator('#field-relationHasMany + .pre-populate-field-ui button').click();
       await wait(300);
-
       await expect(page.locator('#field-relationHasMany .rs__value-container > .rs__multi-value')).toHaveCount(15);
     });
 
     test('has many, many collections', async () => {
       await page.locator('#field-relationToManyHasMany + .pre-populate-field-ui button').click();
       await wait(300);
-
       await expect(page.locator('#field-relationToManyHasMany .rs__value-container > .rs__multi-value')).toHaveCount(15);
     });
   });


### PR DESCRIPTION
## Description

Resolves #2688 by only adding _newly_ created relationships to the parent field. Does so by first checking the operation of the event, then also checking for an existing value.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
