### PR TITLE
docs: fix global hooks intro anchor links

### DIFF
--- a/docs/hooks/globals.mdx
+++ b/docs/hooks/globals.mdx
@@ -8,11 +8,11 @@ keywords: hooks, globals, config, configuration, documentation, Content Manageme
 
 Globals feature the ability to define the following hooks:
 
-- [beforeValidate](#beforeValidate)
-- [beforeChange](#beforeChange)
-- [afterChange](#afterChange)
-- [beforeRead](#beforeRead)
-- [afterRead](#afterRead)
+- [beforeValidate](#beforevalidate)
+- [beforeChange](#beforechange)
+- [afterChange](#afterchange)
+- [beforeRead](#beforeread)
+- [afterRead](#afterread)
 
 ## Config
 


### PR DESCRIPTION
## Description

Intro anchor links on the [Global Hooks page](https://payloadcms.com/docs/hooks/globals) were written in lowerCamelCase instead of the lowercase used for the titles ids, resulting in non-working links.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
