### PR TITLE
fix: unable to clear relationships or open relationship drawer on mobile

### DIFF
--- a/src/admin/components/forms/field-types/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/select-components/MultiValueLabel/index.tsx
@@ -54,6 +54,8 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
           <DocumentDrawerToggler
             className={`${baseClass}__drawer-toggler`}
             aria-label={`Edit ${label}`}
+            onTouchEnd={(e) => e.stopPropagation()} // prevents react-select dropdown from opening
+            onMouseDown={(e) => e.stopPropagation()} // prevents react-select dropdown from opening
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
             onClick={() => setShowTooltip(false)}

--- a/src/admin/components/forms/field-types/Relationship/select-components/SingleValue/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/select-components/SingleValue/index.tsx
@@ -53,6 +53,7 @@ export const SingleValue: React.FC<SingleValueProps<Option>> = (props) => {
               <DocumentDrawerToggler
                 className={`${baseClass}__drawer-toggler`}
                 aria-label={t('editLabel', { label })}
+                onTouchEnd={(e) => e.stopPropagation()} // prevents react-select dropdown from opening
                 onMouseDown={(e) => e.stopPropagation()} // prevents react-select dropdown from opening
                 onMouseEnter={() => setShowTooltip(true)}
                 onMouseLeave={() => setShowTooltip(false)}


### PR DESCRIPTION
Closes both #2691 #2692 by preventing the react-select dropdown from opening on mobile devices when clearing relationships or attempting to open the relationship drawer.

## Description

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
