### PR TITLE
chore: allows super-admins to view as tenant in multi-tenant example

### DIFF
--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -53,6 +53,8 @@ This applies to each collection in the following ways:
 - `tenants`: Only super-admins and tenant-admins can read, create, update, or delete tenants. See [Tenants](#tenants) for more details.
 - `pages`: Everyone can access pages, but only super-admins and tenant-admins can create, update, or delete them.
 
+When a user logs in, a `lastLoggedInTenant` field is saved to their profile. This is done by reading the value of `req.headers.host`, querying for a tenant with a matching `domain`, and verifying that the user is a member of that tenant. This field is then used to automatically assign the tenant to any documents that the user creates, such as pages. Super-admins can also use this field to browse the admin panel as a specific tenant.
+
 > If you have versions and drafts enabled on your pages, you will need to add additional read access control condition to check the user's tenants that prevents them from accessing draft documents of other tenants.
 
 For more details on how to extend this functionality, see the [Payload Access Control](https://payloadcms.com/docs/access-control/overview#access-control) docs.

--- a/examples/multi-tenant/src/collections/Pages/access/lastLoggedInTenant.ts
+++ b/examples/multi-tenant/src/collections/Pages/access/lastLoggedInTenant.ts
@@ -1,6 +1,4 @@
 import type { Access } from 'payload/types'
 
-import { checkUserRoles } from '../../utilities/checkUserRoles'
-
 export const lastLoggedInTenant: Access = ({ req: { user }, data }) =>
-  checkUserRoles(['super-admin'], user) || user?.lastLoggedInTenant?.id === data?.id
+  user?.lastLoggedInTenant?.id === data?.id

--- a/examples/multi-tenant/src/collections/Pages/access/tenants.ts
+++ b/examples/multi-tenant/src/collections/Pages/access/tenants.ts
@@ -3,9 +3,9 @@ import type { Access } from 'payload/types'
 import { isSuperAdmin } from '../../utilities/isSuperAdmin'
 
 export const tenants: Access = ({ req: { user }, data }) =>
-  isSuperAdmin(user) ||
   // individual documents
-  (data?.tenant?.id && user?.lastLoggedInTenant?.id === data.tenant.id) || {
+  (data?.tenant?.id && user?.lastLoggedInTenant?.id === data.tenant.id) ||
+  (!user?.lastLoggedInTenant?.id && isSuperAdmin(user)) || {
     // list of documents
     tenant: {
       equals: user?.lastLoggedInTenant?.id,

--- a/examples/multi-tenant/src/collections/Tenants/access/tenantAdmins.ts
+++ b/examples/multi-tenant/src/collections/Tenants/access/tenantAdmins.ts
@@ -1,10 +1,10 @@
 import type { Access } from 'payload/config'
 
-import { checkUserRoles } from '../../utilities/checkUserRoles'
+import { isSuperAdmin } from '../../utilities/isSuperAdmin'
 
 // the user must be an admin of the tenant being accessed
 export const tenantAdmins: Access = ({ req: { user } }) => {
-  if (checkUserRoles(['super-admin'], user)) {
+  if (isSuperAdmin(user)) {
     return true
   }
 

--- a/examples/multi-tenant/src/collections/Users/access/adminsAndSelf.ts
+++ b/examples/multi-tenant/src/collections/Users/access/adminsAndSelf.ts
@@ -5,7 +5,10 @@ import { isSuperAdmin } from '../../utilities/isSuperAdmin'
 
 export const adminsAndSelf: Access<any, User> = async ({ req: { user } }) => {
   if (user) {
-    if (isSuperAdmin(user)) {
+    const isSuper = isSuperAdmin(user)
+
+    // allow super-admins through only if they have not scoped their user via `lastLoggedInTenant`
+    if (isSuper && !user?.lastLoggedInTenant) {
       return true
     }
 
@@ -17,20 +20,34 @@ export const adminsAndSelf: Access<any, User> = async ({ req: { user } }) => {
             equals: user.id,
           },
         },
-        {
-          'tenants.tenant': {
-            in:
-              user?.tenants
-                ?.map(({ tenant, roles }) =>
-                  roles.includes('admin')
-                    ? typeof tenant === 'string'
-                      ? tenant
-                      : tenant.id
-                    : null,
-                ) // eslint-disable-line function-paren-newline
-                .filter(Boolean) || [],
-          },
-        },
+        ...(isSuper
+          ? [
+              {
+                'tenants.tenant': {
+                  in: [
+                    typeof user?.lastLoggedInTenant === 'string'
+                      ? user?.lastLoggedInTenant
+                      : user?.lastLoggedInTenant?.id,
+                  ].filter(Boolean),
+                },
+              },
+            ]
+          : [
+              {
+                'tenants.tenant': {
+                  in:
+                    user?.tenants
+                      ?.map(({ tenant, roles }) =>
+                        roles.includes('admin')
+                          ? typeof tenant === 'string'
+                            ? tenant
+                            : tenant.id
+                          : null,
+                      ) // eslint-disable-line function-paren-newline
+                      .filter(Boolean) || [],
+                },
+              },
+            ]),
       ],
     }
   }

--- a/examples/multi-tenant/src/collections/Users/hooks/recordLastLoggedInTenant.ts
+++ b/examples/multi-tenant/src/collections/Users/hooks/recordLastLoggedInTenant.ts
@@ -1,30 +1,26 @@
 import type { AfterLoginHook } from 'payload/dist/collections/config/types'
 
-import { isSuperAdmin } from '../../utilities/isSuperAdmin'
-
 export const recordLastLoggedInTenant: AfterLoginHook = async ({ req, user }) => {
   try {
-    if (!isSuperAdmin(user)) {
-      const relatedOrg = await req.payload.find({
-        collection: 'tenants',
-        where: {
-          'domains.domain': {
-            in: [req.headers.host],
-          },
+    const relatedOrg = await req.payload.find({
+      collection: 'tenants',
+      where: {
+        'domains.domain': {
+          in: [req.headers.host],
         },
-        depth: 0,
-        limit: 1,
-      })
+      },
+      depth: 0,
+      limit: 1,
+    })
 
-      if (relatedOrg.docs.length > 0) {
-        await req.payload.update({
-          id: user.id,
-          collection: 'users',
-          data: {
-            lastLoggedInTenant: relatedOrg.docs[0].id,
-          },
-        })
-      }
+    if (relatedOrg.docs.length > 0) {
+      await req.payload.update({
+        id: user.id,
+        collection: 'users',
+        data: {
+          lastLoggedInTenant: relatedOrg.docs[0].id,
+        },
+      })
     }
   } catch (err: unknown) {
     req.payload.logger.error(`Error recording last logged in tenant for user ${user.id}: ${err}`)

--- a/examples/multi-tenant/src/collections/Users/index.ts
+++ b/examples/multi-tenant/src/collections/Users/index.ts
@@ -97,7 +97,10 @@ export const Users: CollectionConfig = {
       access: {
         create: () => false,
         read: tenantAdmins,
-        update: () => false,
+        update: superAdminFieldAccess,
+      },
+      admin: {
+        position: 'sidebar',
       },
     },
   ],

--- a/examples/multi-tenant/src/collections/utilities/isSuperAdmin.ts
+++ b/examples/multi-tenant/src/collections/utilities/isSuperAdmin.ts
@@ -2,7 +2,4 @@ import type { User } from 'payload/generated-types'
 
 import { checkUserRoles } from './checkUserRoles'
 
-export const isSuperAdmin = (user: User): boolean => {
-  if (user?.email === 'dev@payloadcms.com') return true // for the seed script, remove this in production
-  return checkUserRoles(['super-admin'], user)
-}
+export const isSuperAdmin = (user: User): boolean => checkUserRoles(['super-admin'], user)


### PR DESCRIPTION
## Description

Allows super-admins to view as tenant in the multi-tenant example by allowing them to set `lastLoggedInTenant` and adjusting access control accordingly.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
