### PR TITLE
fix: typing of sendEmail function

### DIFF
--- a/src/payload.ts
+++ b/src/payload.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import mongoose from 'mongoose';
 import { Config as GeneratedTypes } from 'payload/generated-types';
 import { OperationArgs, Request as graphQLRequest } from 'graphql-http/lib/handler';
+import { SendMailOptions } from 'nodemailer';
 import { BulkOperationResult, Collection, CollectionModel } from './collections/config/types';
 import { EmailOptions, InitOptions, SanitizedConfig } from './config/types';
 import { TypeWithVersion } from './versions/types';
@@ -17,7 +18,7 @@ import { ErrorHandler } from './express/middleware/errorHandler';
 import localOperations from './collections/operations/local';
 import localGlobalOperations from './globals/operations/local';
 import { decrypt, encrypt } from './auth/crypto';
-import { BuildEmailResult, Message } from './email/types';
+import { BuildEmailResult } from './email/types';
 import { Preferences } from './preferences/types';
 
 import { Options as CreateOptions } from './collections/operations/local/create';
@@ -88,7 +89,7 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
 
   email: BuildEmailResult;
 
-  sendEmail: (message: Message) => Promise<unknown>;
+  sendEmail: (message: SendMailOptions) => Promise<unknown>;
 
   secret: string;
 


### PR DESCRIPTION
## Description

[`payload.sendEmail`](https://github.com/payloadcms/payload/blob/6125b66286e5315725ca0ae365c81a04c1c1a54c/src/payload.ts#L91) uses the old message typing, while the [`sendEmail`](https://github.com/payloadcms/payload/blob/6125b66286e5315725ca0ae365c81a04c1c1a54c/src/email/sendEmail.ts#L3) function itself uses the typing from the nodemailer package (as stated in [the documentation](https://github.com/payloadcms/payload/blob/6125b66286e5315725ca0ae365c81a04c1c1a54c/docs/email/overview.mdx?plain=1#L123)). This PR fixes the problem.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
