### PR TITLE
fix: adjusts code field joi schema to allow editorOptions

### DIFF
--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -135,6 +135,7 @@ export const code = baseField.keys({
   ),
   admin: baseAdminFields.keys({
     language: joi.string(),
+    editorOptions: joi.object().unknown(), // Editor['options'] @monaco-editor/react
   }),
 });
 


### PR DESCRIPTION
## Description

Fixes #2729

Adjusts code field joi schema to allow for editorOptions to be set in the field config.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
