### PR TITLE
chore: updates ui field docs to show admin.components.Field is required

### DIFF
--- a/docs/fields/ui.mdx
+++ b/docs/fields/ui.mdx
@@ -26,13 +26,13 @@ With this field, you can also inject custom `Cell` components that appear as add
 
 ### Config
 
-| Option                       | Description                                                                                                            |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **`name`** \*                | A unique identifier for this field.                                                                                    |
-| **`label`**                  | Human-readable label for this UI field.                                                                                |
-| **`admin.components.Field`** | React component to be rendered for this field within the Edit view. [More](/docs/admin/components/#field-component)    |
-| **`admin.components.Cell`**  | React component to be rendered as a Cell within collection List views. [More](/docs/admin/components/#field-component) |
-| **`custom`**                 | Extension point for adding custom data (e.g. for plugins)                                                              |
+| Option                          | Description                                                                                                            |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **`name`** \*                   | A unique identifier for this field.                                                                                    |
+| **`label`**                     | Human-readable label for this UI field.                                                                                |
+| **`admin.components.Field`** \* | React component to be rendered for this field within the Edit view. [More](/docs/admin/components/#field-component)    |
+| **`admin.components.Cell`**     | React component to be rendered as a Cell within collection List views. [More](/docs/admin/components/#field-component) |
+| **`custom`**                    | Extension point for adding custom data (e.g. for plugins)                                                              |
 
 _\* An asterisk denotes that a property is required._
 


### PR DESCRIPTION
## Description

UI field documentation [here](https://payloadcms.com/docs/fields/ui) shows `admin.components.Field` as `not required` but it is a `required` field.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
