### PR TITLE
chore: add alternative vscode launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "command": "yarn run dev _community",
+      "name": "Run Dev Community",
+      "request": "launch",
+      "type": "node-terminal",
+      "cwd": "${workspaceFolder}"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Launch Program",


### PR DESCRIPTION
I like this one more, as it runs both in the node terminal, as well as the normal terminal. The other one also omits a lot of logs. I also feel like this will be used more often, e.g. by community members wanting to create reproductions