### PR TITLE
fix: adjusts activation constraint of draggable nodes

### DIFF
--- a/src/admin/components/elements/DraggableSortable/index.tsx
+++ b/src/admin/components/elements/DraggableSortable/index.tsx
@@ -30,8 +30,7 @@ const DraggableSortable: React.FC<Props> = (props) => {
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
-        delay: 100,
-        tolerance: 5,
+        distance: 5,
       },
     }),
     useSensor(KeyboardSensor, {


### PR DESCRIPTION
## Description

Fixes a bug where pills with select fields not being easily clearable. This was especially evident on relationships with multi-value. The problem was with the events provided by `dnd-kit`, which were overriding click events _if you're mouse was moving when the event took place_. Fortunately that package supplies an API to constrain the activation of the drag event.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes