### PR TITLE
fix: flattens relationships in the update operation for globals #2766

### DIFF
--- a/src/globals/operations/update.ts
+++ b/src/globals/operations/update.ts
@@ -94,7 +94,7 @@ async function update<TSlug extends keyof GeneratedTypes['globals']>(
   }
 
   const originalDoc = await afterRead({
-    depth,
+    depth: 0,
     doc: globalJSON,
     entityConfig: globalConfig,
     req,


### PR DESCRIPTION
## Description

Fixes #2766 by flattening relationships within the update operation for globals. This is how collections currently behave, where `originalDoc` is queried with `depth: 0`. This resolves misleading validation errors that were throwing on required, non-localized relationship fields when updating with `?locale=`. Validation functions were not able to properly resolve because the data was not properly shaped.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
