### PR TITLE
chore: uses discord vanity urls

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -22,7 +22,7 @@ If you're an incredibly awesome person and want to help us make Payload even bet
 
 ### Before Starting
 
-To help us work on new features, you can create a new feature request post in [GitHub Discussion](https://github.com/payloadcms/payload/discussions) or discuss it in our [Discord](https://discord.com/invite/r6sCXqVk3v). New functionality often has large implications across the entire Payload repo, so it is best to discuss the architecture and approach before starting work on a pull request.
+To help us work on new features, you can create a new feature request post in [GitHub Discussion](https://github.com/payloadcms/payload/discussions) or discuss it in our [Discord](https://discord.com/invite/payload). New functionality often has large implications across the entire Payload repo, so it is best to discuss the architecture and approach before starting work on a pull request.
 
 ### Code
 

--- a/examples/auth/cms/README.md
+++ b/examples/auth/cms/README.md
@@ -63,5 +63,5 @@ The easiest way to deploy your project is to use [Payload Cloud](https://payload
 
 ## Questions
 
-If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/r6sCXqVk3v) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).
+If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/payload) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).
 

--- a/examples/email/README.md
+++ b/examples/email/README.md
@@ -60,4 +60,4 @@ For more information on integrating email, check out these resources:
 
 ## Questions
 
-If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/r6sCXqVk3v) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).
+If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/payload) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).

--- a/examples/form-builder/cms/README.md
+++ b/examples/form-builder/cms/README.md
@@ -44,5 +44,5 @@ The easiest way to deploy your project is to use [Payload Cloud](https://payload
 
 ## Questions
 
-If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/r6sCXqVk3v) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).
+If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/payload) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).
 

--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -129,4 +129,4 @@ The easiest way to deploy your project is to use [Payload Cloud](https://payload
 
 ## Questions
 
-If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/r6sCXqVk3v) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).
+If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/payload) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).

--- a/examples/preview/cms/README.md
+++ b/examples/preview/cms/README.md
@@ -67,4 +67,4 @@ The easiest way to deploy your project is to use [Payload Cloud](https://payload
 
 ## Questions
 
-If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/r6sCXqVk3v) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).
+If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/payload) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).

--- a/examples/redirects/cms/README.md
+++ b/examples/redirects/cms/README.md
@@ -48,4 +48,4 @@ The easiest way to deploy your project is to use [Payload Cloud](https://payload
 
 ## Questions
 
-If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/r6sCXqVk3v) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).
+If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/payload) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).

--- a/examples/virtual-fields/README.md
+++ b/examples/virtual-fields/README.md
@@ -77,4 +77,4 @@ The easiest way to deploy your project is to use [Payload Cloud](https://payload
 
 ## Questions
 
-If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/r6sCXqVk3v) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).
+If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/payload) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).

--- a/examples/whitelabel/README.md
+++ b/examples/whitelabel/README.md
@@ -52,4 +52,4 @@ The easiest way to deploy your project is to use [Payload Cloud](https://payload
 
 ## Questions
 
-If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/r6sCXqVk3v) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).
+If you have any issues or questions, reach out to us on [Discord](https://discord.com/invite/payload) or start a [GitHub discussion](https://github.com/payloadcms/payload/discussions).


### PR DESCRIPTION
## Description

Replaces instances of the Payload Discord server URL with the human-friendly version.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
