### PR TITLE
chore: refactor query validation outside of mongoose

### DIFF
--- a/src/auth/getExecuteStaticAccess.ts
+++ b/src/auth/getExecuteStaticAccess.ts
@@ -1,4 +1,4 @@
-import { Response, NextFunction } from 'express';
+import { NextFunction, Response } from 'express';
 import { Where } from '../types';
 import executeAccess from './executeAccess';
 import { Forbidden } from '../errors';
@@ -44,7 +44,6 @@ const getExecuteStaticAccess = ({ config, Model }) => async (req: PayloadRequest
         const query = await Model.buildQuery({
           where: queryToBuild,
           req,
-          overrideAccess: true,
         });
 
         const doc = await Model.findOne(query);

--- a/src/collections/operations/delete.ts
+++ b/src/collections/operations/delete.ts
@@ -10,6 +10,7 @@ import { Where } from '../../types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { deleteCollectionVersions } from '../../versions/deleteCollectionVersions';
 import { deleteAssociatedFiles } from '../../uploads/deleteAssociatedFiles';
+import { validateQueryPaths } from '../../utilities/validateQueryPaths';
 
 export type Arguments = {
   depth?: number
@@ -75,6 +76,11 @@ async function deleteOperation<TSlug extends keyof GeneratedTypes['collections']
   let accessResult: AccessResult;
 
   if (!overrideAccess) {
+    await validateQueryPaths({
+      collectionConfig,
+      where,
+      req,
+    });
     accessResult = await executeAccess({ req }, collectionConfig.access.delete);
   }
 
@@ -82,7 +88,6 @@ async function deleteOperation<TSlug extends keyof GeneratedTypes['collections']
     where,
     access: accessResult,
     req,
-    overrideAccess,
   });
 
   // /////////////////////////////////////

--- a/src/collections/operations/delete.ts
+++ b/src/collections/operations/delete.ts
@@ -10,7 +10,7 @@ import { Where } from '../../types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { deleteCollectionVersions } from '../../versions/deleteCollectionVersions';
 import { deleteAssociatedFiles } from '../../uploads/deleteAssociatedFiles';
-import { validateQueryPaths } from '../../utilities/validateQueryPaths';
+import { validateQueryPaths } from '../../utilities/queryValidation/validateQueryPaths';
 
 export type Arguments = {
   depth?: number

--- a/src/collections/operations/delete.ts
+++ b/src/collections/operations/delete.ts
@@ -76,13 +76,15 @@ async function deleteOperation<TSlug extends keyof GeneratedTypes['collections']
   let accessResult: AccessResult;
 
   if (!overrideAccess) {
-    await validateQueryPaths({
-      collectionConfig,
-      where,
-      req,
-    });
     accessResult = await executeAccess({ req }, collectionConfig.access.delete);
   }
+
+  await validateQueryPaths({
+    collectionConfig,
+    where,
+    req,
+    overrideAccess,
+  });
 
   const query = await Model.buildQuery({
     where,

--- a/src/collections/operations/deleteByID.ts
+++ b/src/collections/operations/deleteByID.ts
@@ -1,10 +1,10 @@
 import { Config as GeneratedTypes } from 'payload/generated-types';
 import { PayloadRequest } from '../../express/types';
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields';
-import { NotFound, Forbidden } from '../../errors';
+import { Forbidden, NotFound } from '../../errors';
 import executeAccess from '../../auth/executeAccess';
 import { BeforeOperationHook, Collection } from '../config/types';
-import { Document, Where } from '../../types';
+import { Document } from '../../types';
 import { hasWhereAccessResult } from '../../auth/types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { deleteCollectionVersions } from '../../versions/deleteCollectionVersions';
@@ -87,7 +87,6 @@ async function deleteByID<TSlug extends keyof GeneratedTypes['collections']>(inc
       },
     },
     access: accessResults,
-    overrideAccess,
   });
 
   const docToDelete = await Model.findOne(query);

--- a/src/collections/operations/find.ts
+++ b/src/collections/operations/find.ts
@@ -9,6 +9,7 @@ import { buildSortParam } from '../../mongoose/buildSortParam';
 import { AccessResult } from '../../config/types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { queryDrafts } from '../../versions/drafts/queryDrafts';
+import { validateQueryPaths } from '../../utilities/validateQueryPaths';
 
 export type Arguments = {
   collection: Collection
@@ -81,6 +82,11 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
   let accessResult: AccessResult;
 
   if (!overrideAccess) {
+    await validateQueryPaths({
+      collectionConfig,
+      where,
+      req,
+    });
     accessResult = await executeAccess({ req, disableErrors }, collectionConfig.access.read);
 
     // If errors are disabled, and access returns false, return empty results
@@ -103,7 +109,6 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
   const query = await Model.buildQuery({
     req,
     where,
-    overrideAccess,
     access: accessResult,
   });
 

--- a/src/collections/operations/find.ts
+++ b/src/collections/operations/find.ts
@@ -9,7 +9,7 @@ import { buildSortParam } from '../../mongoose/buildSortParam';
 import { AccessResult } from '../../config/types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { queryDrafts } from '../../versions/drafts/queryDrafts';
-import { validateQueryPaths } from '../../utilities/validateQueryPaths';
+import { validateQueryPaths } from '../../utilities/queryValidation/validateQueryPaths';
 
 export type Arguments = {
   collection: Collection

--- a/src/collections/operations/find.ts
+++ b/src/collections/operations/find.ts
@@ -82,11 +82,6 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
   let accessResult: AccessResult;
 
   if (!overrideAccess) {
-    await validateQueryPaths({
-      collectionConfig,
-      where,
-      req,
-    });
     accessResult = await executeAccess({ req, disableErrors }, collectionConfig.access.read);
 
     // If errors are disabled, and access returns false, return empty results
@@ -105,6 +100,14 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
       };
     }
   }
+
+  await validateQueryPaths({
+    collectionConfig,
+    where,
+    req,
+    overrideAccess,
+  });
+
 
   const query = await Model.buildQuery({
     req,

--- a/src/collections/operations/findByID.ts
+++ b/src/collections/operations/findByID.ts
@@ -74,7 +74,6 @@ async function findByID<T extends TypeWithID>(
     },
     access: accessResult,
     req,
-    overrideAccess,
   });
 
   // /////////////////////////////////////

--- a/src/collections/operations/findVersionByID.ts
+++ b/src/collections/operations/findVersionByID.ts
@@ -62,7 +62,6 @@ async function findVersionByID<T extends TypeWithVersion<T> = any>(args: Argumen
     },
     access: accessResults,
     req,
-    overrideAccess,
   });
 
   // /////////////////////////////////////

--- a/src/collections/operations/findVersions.ts
+++ b/src/collections/operations/findVersions.ts
@@ -9,7 +9,7 @@ import { PaginatedDocs } from '../../mongoose/types';
 import { TypeWithVersion } from '../../versions/types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { buildVersionCollectionFields } from '../../versions/buildCollectionFields';
-import { validateQueryPaths } from '../../utilities/validateQueryPaths';
+import { validateQueryPaths } from '../../utilities/queryValidation/validateQueryPaths';
 
 export type Arguments = {
   collection: Collection

--- a/src/collections/operations/findVersions.ts
+++ b/src/collections/operations/findVersions.ts
@@ -58,17 +58,19 @@ async function findVersions<T extends TypeWithVersion<T>>(
   }
 
   let accessResults;
-  const versionFields = buildVersionCollectionFields(collectionConfig);
-
   if (!overrideAccess) {
-    await validateQueryPaths({
-      collectionConfig,
-      versionFields,
-      where,
-      req,
-    });
     accessResults = await executeAccess({ req }, collectionConfig.access.readVersions);
   }
+
+  const versionFields = buildVersionCollectionFields(collectionConfig);
+
+  await validateQueryPaths({
+    collectionConfig,
+    versionFields,
+    where,
+    req,
+    overrideAccess,
+  });
 
   const query = await VersionsModel.buildQuery({
     where,

--- a/src/collections/operations/restoreVersion.ts
+++ b/src/collections/operations/restoreVersion.ts
@@ -79,7 +79,6 @@ async function restoreVersion<T extends TypeWithID = any>(args: Arguments): Prom
     },
     access: accessResults,
     req,
-    overrideAccess,
   });
 
   const doc = await Model.findOne(query);

--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -18,6 +18,7 @@ import { AccessResult } from '../../config/types';
 import { queryDrafts } from '../../versions/drafts/queryDrafts';
 import { deleteAssociatedFiles } from '../../uploads/deleteAssociatedFiles';
 import { unlinkTempFiles } from '../../uploads/unlinkTempFiles';
+import { validateQueryPaths } from '../../utilities/validateQueryPaths';
 
 export type Arguments<T extends { [field: string | number | symbol]: unknown }> = {
   collection: Collection
@@ -86,6 +87,11 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
   let accessResult: AccessResult;
 
   if (!overrideAccess) {
+    await validateQueryPaths({
+      collectionConfig,
+      where,
+      req,
+    });
     accessResult = await executeAccess({ req }, collectionConfig.access.update);
   }
 
@@ -93,7 +99,6 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
     where,
     access: accessResult,
     req,
-    overrideAccess,
   });
 
   // /////////////////////////////////////

--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -18,7 +18,7 @@ import { AccessResult } from '../../config/types';
 import { queryDrafts } from '../../versions/drafts/queryDrafts';
 import { deleteAssociatedFiles } from '../../uploads/deleteAssociatedFiles';
 import { unlinkTempFiles } from '../../uploads/unlinkTempFiles';
-import { validateQueryPaths } from '../../utilities/validateQueryPaths';
+import { validateQueryPaths } from '../../utilities/queryValidation/validateQueryPaths';
 
 export type Arguments<T extends { [field: string | number | symbol]: unknown }> = {
   collection: Collection

--- a/src/collections/operations/update.ts
+++ b/src/collections/operations/update.ts
@@ -85,15 +85,16 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
   // /////////////////////////////////////
 
   let accessResult: AccessResult;
-
   if (!overrideAccess) {
-    await validateQueryPaths({
-      collectionConfig,
-      where,
-      req,
-    });
     accessResult = await executeAccess({ req }, collectionConfig.access.update);
   }
+
+  await validateQueryPaths({
+    collectionConfig,
+    where,
+    req,
+    overrideAccess,
+  });
 
   const query = await Model.buildQuery({
     where,

--- a/src/collections/operations/updateByID.ts
+++ b/src/collections/operations/updateByID.ts
@@ -5,7 +5,7 @@ import { Document } from '../../types';
 import { Collection } from '../config/types';
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields';
 import executeAccess from '../../auth/executeAccess';
-import { NotFound, Forbidden, APIError, ValidationError } from '../../errors';
+import { APIError, Forbidden, NotFound, ValidationError } from '../../errors';
 import { PayloadRequest } from '../../express/types';
 import { hasWhereAccessResult } from '../../auth/types';
 import { saveVersion } from '../../versions/saveVersion';
@@ -105,7 +105,6 @@ async function updateByID<TSlug extends keyof GeneratedTypes['collections']>(
     },
     access: accessResults,
     req,
-    overrideAccess,
   });
 
   const doc = await getLatestCollectionVersion({

--- a/src/globals/operations/findVersionByID.ts
+++ b/src/globals/operations/findVersionByID.ts
@@ -55,7 +55,6 @@ async function findVersionByID<T extends TypeWithVersion<T> = any>(args: Argumen
     },
     access: accessResults,
     req,
-    overrideAccess,
     globalSlug: globalConfig.slug,
   });
 

--- a/src/globals/operations/findVersions.ts
+++ b/src/globals/operations/findVersions.ts
@@ -9,6 +9,7 @@ import { SanitizedGlobalConfig } from '../config/types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { buildVersionGlobalFields } from '../../versions/buildGlobalFields';
 import { TypeWithVersion } from '../../versions/types';
+import { validateQueryPaths } from '../../utilities/validateQueryPaths';
 
 export type Arguments = {
   globalConfig: SanitizedGlobalConfig
@@ -41,6 +42,7 @@ async function findVersions<T extends TypeWithVersion<T>>(
   } = args;
 
   const VersionsModel = payload.versions[globalConfig.slug];
+  const versionFields = buildVersionGlobalFields(globalConfig);
 
   // /////////////////////////////////////
   // Access
@@ -55,11 +57,19 @@ async function findVersions<T extends TypeWithVersion<T>>(
 
   const accessResults = !overrideAccess ? await executeAccess({ req }, globalConfig.access.readVersions) : true;
 
+  if (!overrideAccess) {
+    await validateQueryPaths({
+      globalConfig,
+      versionFields,
+      where,
+      req,
+    });
+  }
+
   const query = await VersionsModel.buildQuery({
     where,
     access: accessResults,
     req,
-    overrideAccess,
     globalSlug: globalConfig.slug,
   });
 
@@ -69,7 +79,7 @@ async function findVersions<T extends TypeWithVersion<T>>(
 
   const [sortProperty, sortOrder] = buildSortParam({
     sort: args.sort || '-updatedAt',
-    fields: buildVersionGlobalFields(globalConfig),
+    fields: versionFields,
     timestamps: true,
     config: payload.config,
     locale,

--- a/src/globals/operations/findVersions.ts
+++ b/src/globals/operations/findVersions.ts
@@ -57,14 +57,13 @@ async function findVersions<T extends TypeWithVersion<T>>(
 
   const accessResults = !overrideAccess ? await executeAccess({ req }, globalConfig.access.readVersions) : true;
 
-  if (!overrideAccess) {
-    await validateQueryPaths({
-      globalConfig,
-      versionFields,
-      where,
-      req,
-    });
-  }
+  await validateQueryPaths({
+    globalConfig,
+    versionFields,
+    where,
+    req,
+    overrideAccess,
+  });
 
   const query = await VersionsModel.buildQuery({
     where,

--- a/src/globals/operations/findVersions.ts
+++ b/src/globals/operations/findVersions.ts
@@ -9,7 +9,7 @@ import { SanitizedGlobalConfig } from '../config/types';
 import { afterRead } from '../../fields/hooks/afterRead';
 import { buildVersionGlobalFields } from '../../versions/buildGlobalFields';
 import { TypeWithVersion } from '../../versions/types';
-import { validateQueryPaths } from '../../utilities/validateQueryPaths';
+import { validateQueryPaths } from '../../utilities/queryValidation/validateQueryPaths';
 
 export type Arguments = {
   globalConfig: SanitizedGlobalConfig

--- a/src/mongoose/buildAndOrConditions.ts
+++ b/src/mongoose/buildAndOrConditions.ts
@@ -1,0 +1,49 @@
+import { PayloadRequest, Where } from '../types';
+import { parsePathOrRelation } from './parsePathOrRelation';
+import { EntityPolicies } from './buildQuery';
+import { Field } from '../fields/config/types';
+
+export async function buildAndOrConditions({
+  where,
+  overrideAccess,
+  collectionSlug,
+  errors,
+  globalSlug,
+  policies,
+  req,
+  fields,
+}: {
+  where: Where[],
+  overrideAccess: boolean,
+  collectionSlug?: string,
+  errors: {path: string}[],
+  globalSlug?: string,
+  policies: EntityPolicies,
+  req: PayloadRequest,
+  fields: Field[],
+}): Promise<Record<string, unknown>[]> {
+  const completedConditions = [];
+  // Loop over all AND / OR operations and add them to the AND / OR query param
+  // Operations should come through as an array
+  // eslint-disable-next-line no-restricted-syntax
+  for (const condition of where) {
+  // If the operation is properly formatted as an object
+    if (typeof condition === 'object') {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await parsePathOrRelation({
+        where: condition,
+        overrideAccess,
+        collectionSlug,
+        errors,
+        globalSlug,
+        policies,
+        req,
+        fields,
+      });
+      if (Object.keys(result).length > 0) {
+        completedConditions.push(result);
+      }
+    }
+  }
+  return completedConditions;
+}

--- a/src/mongoose/buildAndOrConditions.ts
+++ b/src/mongoose/buildAndOrConditions.ts
@@ -1,24 +1,17 @@
 import { PayloadRequest, Where } from '../types';
 import { parsePathOrRelation } from './parsePathOrRelation';
-import { EntityPolicies } from './buildQuery';
 import { Field } from '../fields/config/types';
 
 export async function buildAndOrConditions({
   where,
-  overrideAccess,
   collectionSlug,
-  errors,
   globalSlug,
-  policies,
   req,
   fields,
 }: {
   where: Where[],
-  overrideAccess: boolean,
   collectionSlug?: string,
-  errors: {path: string}[],
   globalSlug?: string,
-  policies: EntityPolicies,
   req: PayloadRequest,
   fields: Field[],
 }): Promise<Record<string, unknown>[]> {
@@ -32,11 +25,8 @@ export async function buildAndOrConditions({
       // eslint-disable-next-line no-await-in-loop
       const result = await parsePathOrRelation({
         where: condition,
-        overrideAccess,
         collectionSlug,
-        errors,
         globalSlug,
-        policies,
         req,
         fields,
       });

--- a/src/mongoose/buildQuery.ts
+++ b/src/mongoose/buildQuery.ts
@@ -1,14 +1,8 @@
-/* eslint-disable no-continue */
-/* eslint-disable no-await-in-loop */
-/* eslint-disable no-restricted-syntax */
-import deepmerge from 'deepmerge';
-import { FilterQuery } from 'mongoose';
-import { combineMerge } from '../utilities/combineMerge';
 import { PayloadRequest, Where } from '../types';
 import { Field, FieldAffectingData, TabAsField, UIField } from '../fields/config/types';
 import { CollectionPermission, FieldPermissions, GlobalPermission } from '../auth';
 import QueryError from '../errors/QueryError';
-import { buildSearchParam } from './buildSearchParams';
+import { parsePathOrRelation } from './parsePathOrRelation';
 
 export const validOperators = ['like', 'contains', 'in', 'all', 'not_in', 'greater_than_equal', 'greater_than', 'less_than_equal', 'less_than', 'not_equals', 'equals', 'exists', 'near'];
 
@@ -110,7 +104,16 @@ export class ParamParser {
   // Entry point to the ParamParser class
 
   async parse(): Promise<Record<string, unknown>> {
-    const query = await this.parsePathOrRelation(this.where, this.overrideAccess);
+    const query = await parsePathOrRelation({
+      collectionSlug: this.collectionSlug,
+      errors: this.errors,
+      fields: this.fields,
+      globalSlug: this.globalSlug,
+      policies: this.policies,
+      req: this.req,
+      where: this.where,
+      overrideAccess: this.overrideAccess,
+    });
 
     const result = {
       $and: [],
@@ -119,79 +122,20 @@ export class ParamParser {
     if (query) result.$and.push(query);
 
     if (typeof this.access === 'object') {
-      const accessQuery = await this.parsePathOrRelation(this.access, true);
+      const accessQuery = await parsePathOrRelation({
+        where: this.access,
+        overrideAccess: true,
+        collectionSlug: this.collectionSlug,
+        errors: this.errors,
+        fields: this.fields,
+        globalSlug: this.globalSlug,
+        policies: this.policies,
+        req: this.req,
+      });
       if (accessQuery) result.$and.push(accessQuery);
     }
 
     return result;
-  }
-
-  async parsePathOrRelation(object: Where, overrideAccess: boolean): Promise<Record<string, unknown>> {
-    let result = {} as FilterQuery<any>;
-
-    if (typeof object === 'object') {
-      // We need to determine if the whereKey is an AND, OR, or a schema path
-      for (const relationOrPath of Object.keys(object)) {
-        const condition = object[relationOrPath];
-        if (relationOrPath.toLowerCase() === 'and' && Array.isArray(condition)) {
-          const builtAndConditions = await this.buildAndOrConditions(condition, overrideAccess);
-          if (builtAndConditions.length > 0) result.$and = builtAndConditions;
-        } else if (relationOrPath.toLowerCase() === 'or' && Array.isArray(condition)) {
-          const builtOrConditions = await this.buildAndOrConditions(condition, overrideAccess);
-          if (builtOrConditions.length > 0) result.$or = builtOrConditions;
-        } else {
-          // It's a path - and there can be multiple comparisons on a single path.
-          // For example - title like 'test' and title not equal to 'tester'
-          // So we need to loop on keys again here to handle each operator independently
-          const pathOperators = object[relationOrPath];
-          if (typeof pathOperators === 'object') {
-            for (const operator of Object.keys(pathOperators)) {
-              if (validOperators.includes(operator)) {
-                const searchParam = await buildSearchParam({
-                  collectionSlug: this.collectionSlug,
-                  errors: this.errors,
-                  globalSlug: this.globalSlug,
-                  policies: this.policies,
-                  req: this.req,
-                  fields: this.fields,
-                  incomingPath: relationOrPath,
-                  val: pathOperators[operator],
-                  operator,
-                  overrideAccess,
-                });
-
-                if (searchParam?.value && searchParam?.path) {
-                  result = {
-                    ...result,
-                    [searchParam.path]: searchParam.value,
-                  };
-                } else if (typeof searchParam?.value === 'object') {
-                  result = deepmerge(result, searchParam.value, { arrayMerge: combineMerge });
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    return result;
-  }
-
-  async buildAndOrConditions(conditions: Where[], overrideAccess: boolean): Promise<Record<string, unknown>[]> {
-    const completedConditions = [];
-    // Loop over all AND / OR operations and add them to the AND / OR query param
-    // Operations should come through as an array
-    for (const condition of conditions) {
-      // If the operation is properly formatted as an object
-      if (typeof condition === 'object') {
-        const result = await this.parsePathOrRelation(condition, overrideAccess);
-        if (Object.keys(result).length > 0) {
-          completedConditions.push(result);
-        }
-      }
-    }
-    return completedConditions;
   }
 }
 

--- a/src/mongoose/buildQuery.ts
+++ b/src/mongoose/buildQuery.ts
@@ -4,19 +4,21 @@
 import deepmerge from 'deepmerge';
 import { FilterQuery } from 'mongoose';
 import { combineMerge } from '../utilities/combineMerge';
-import { operatorMap } from './operatorMap';
-import { sanitizeQueryValue } from './sanitizeQueryValue';
 import { PayloadRequest, Where } from '../types';
-import { Field, FieldAffectingData, fieldAffectsData, TabAsField, UIField } from '../fields/config/types';
+import { Field, FieldAffectingData, TabAsField, UIField } from '../fields/config/types';
 import { CollectionPermission, FieldPermissions, GlobalPermission } from '../auth';
 import QueryError from '../errors/QueryError';
-import { getLocalizedPaths } from './getLocalizedPaths';
+import { buildSearchParam } from './buildSearchParams';
 
-const validOperators = ['like', 'contains', 'in', 'all', 'not_in', 'greater_than_equal', 'greater_than', 'less_than_equal', 'less_than', 'not_equals', 'equals', 'exists', 'near'];
+export const validOperators = ['like', 'contains', 'in', 'all', 'not_in', 'greater_than_equal', 'greater_than', 'less_than_equal', 'less_than', 'not_equals', 'equals', 'exists', 'near'];
 
-const subQueryOptions = {
-  limit: 50,
-  lean: true,
+export type EntityPolicies = {
+  collections?: {
+    [collectionSlug: string]: CollectionPermission;
+  };
+  globals?: {
+    [globalSlug: string]: GlobalPermission;
+  };
 };
 
 export type PathToQuery = {
@@ -28,11 +30,6 @@ export type PathToQuery = {
   fieldPolicies?: {
     [field: string]: FieldPermissions
   }
-}
-
-type SearchParam = {
-  path?: string,
-  value: unknown,
 }
 
 type ParamParserArgs = {
@@ -150,7 +147,12 @@ export class ParamParser {
           if (typeof pathOperators === 'object') {
             for (const operator of Object.keys(pathOperators)) {
               if (validOperators.includes(operator)) {
-                const searchParam = await this.buildSearchParam({
+                const searchParam = await buildSearchParam({
+                  collectionSlug: this.collectionSlug,
+                  errors: this.errors,
+                  globalSlug: this.globalSlug,
+                  policies: this.policies,
+                  req: this.req,
                   fields: this.fields,
                   incomingPath: relationOrPath,
                   val: pathOperators[operator],
@@ -190,158 +192,6 @@ export class ParamParser {
       }
     }
     return completedConditions;
-  }
-
-  // Convert the Payload key / value / operator into a MongoDB query
-  async buildSearchParam({
-    fields,
-    incomingPath,
-    val,
-    operator,
-    overrideAccess,
-  }: {
-    fields: Field[],
-    incomingPath: string,
-    val: unknown,
-    operator: string
-    overrideAccess: boolean
-  }): Promise<SearchParam> {
-    // Replace GraphQL nested field double underscore formatting
-    let sanitizedPath = incomingPath.replace(/__/gi, '.');
-    if (sanitizedPath === 'id') sanitizedPath = '_id';
-
-    let paths: PathToQuery[] = [];
-
-    let hasCustomID = false;
-
-    if (sanitizedPath === '_id') {
-      const customIDfield = this.req.payload.collections[this.collectionSlug]?.config.fields.find((field) => fieldAffectsData(field) && field.name === 'id');
-
-      let idFieldType: 'text' | 'number' = 'text';
-
-      if (customIDfield) {
-        if (customIDfield?.type === 'text' || customIDfield?.type === 'number') {
-          idFieldType = customIDfield.type;
-        }
-
-        hasCustomID = true;
-      }
-
-      paths.push({
-        path: '_id',
-        field: {
-          name: 'id',
-          type: idFieldType,
-        },
-        complete: true,
-        collectionSlug: this.collectionSlug,
-      });
-    } else {
-      paths = await getLocalizedPaths({
-        errors: this.errors,
-        policies: this.policies,
-        req: this.req,
-        collectionSlug: this.collectionSlug,
-        globalSlug: this.globalSlug,
-        fields,
-        incomingPath: sanitizedPath,
-        overrideAccess,
-      });
-    }
-
-    const [{ path, field }] = paths;
-
-    if (path) {
-      const formattedValue = sanitizeQueryValue({
-        field,
-        path,
-        operator,
-        val,
-        hasCustomID,
-      });
-
-      // If there are multiple collections to search through,
-      // Recursively build up a list of query constraints
-      if (paths.length > 1) {
-        // Remove top collection and reverse array
-        // to work backwards from top
-        const pathsToQuery = paths.slice(1).reverse();
-
-        const initialRelationshipQuery = {
-          value: {},
-        } as SearchParam;
-
-        const relationshipQuery = await pathsToQuery.reduce(async (priorQuery, { path: subPath, collectionSlug }, i) => {
-          const priorQueryResult = await priorQuery;
-
-          const SubModel = this.req.payload.collections[collectionSlug].Model;
-
-          // On the "deepest" collection,
-          // Search on the value passed through the query
-          if (i === 0) {
-            const subQuery = await SubModel.buildQuery({
-              where: {
-                [subPath]: {
-                  [operator]: val,
-                },
-              },
-              req: this.req,
-              overrideAccess,
-            });
-
-            const result = await SubModel.find(subQuery, subQueryOptions);
-
-            const $in = result.map((doc) => doc._id.toString());
-
-            if (pathsToQuery.length === 1) return { path, value: { $in } };
-
-            const nextSubPath = pathsToQuery[i + 1].path;
-
-            return {
-              value: { [nextSubPath]: { $in } },
-            };
-          }
-
-          const subQuery = priorQueryResult.value;
-          const result = await SubModel.find(subQuery, subQueryOptions);
-
-          const $in = result.map((doc) => doc._id.toString());
-
-          // If it is the last recursion
-          // then pass through the search param
-          if (i + 1 === pathsToQuery.length) {
-            return { path, value: { $in } };
-          }
-
-          return {
-            value: {
-              _id: { $in },
-            },
-          };
-        }, Promise.resolve(initialRelationshipQuery));
-
-        return relationshipQuery;
-      }
-
-      if (operator && validOperators.includes(operator)) {
-        const operatorKey = operatorMap[operator];
-
-        // Some operators like 'near' need to define a full query
-        // so if there is no operator key, just return the value
-        if (!operatorKey) {
-          return {
-            path,
-            value: formattedValue,
-          };
-        }
-
-        return {
-          path,
-          value: { [operatorKey]: formattedValue },
-        };
-      }
-    }
-    return undefined;
   }
 }
 

--- a/src/mongoose/buildQuery.ts
+++ b/src/mongoose/buildQuery.ts
@@ -1,8 +1,7 @@
 import { PayloadRequest, Where } from '../types';
 import { Field, FieldAffectingData, TabAsField, UIField } from '../fields/config/types';
-import { CollectionPermission, FieldPermissions, GlobalPermission } from '../auth';
+import { CollectionPermission, GlobalPermission } from '../auth';
 import QueryError from '../errors/QueryError';
-import { getLocalizedPaths } from './getLocalizedPaths';
 import { parseParams } from './parseParams';
 
 export const validOperators = ['like', 'contains', 'in', 'all', 'not_in', 'greater_than_equal', 'greater_than', 'less_than_equal', 'less_than', 'not_equals', 'equals', 'exists', 'near'];
@@ -19,12 +18,11 @@ export type EntityPolicies = {
 export type PathToQuery = {
   complete: boolean
   collectionSlug?: string
+  globalSlug?: string
   path: string
   field: Field | TabAsField
   fields?: (FieldAffectingData | UIField | TabAsField)[]
-  fieldPolicies?: {
-    [field: string]: FieldPermissions
-  }
+  invalid?: boolean
 }
 
 type GetBuildQueryPluginArgs = {
@@ -35,7 +33,6 @@ type GetBuildQueryPluginArgs = {
 export type BuildQueryArgs = {
   req: PayloadRequest
   where: Where
-  overrideAccess: boolean
   access?: Where | boolean
   globalSlug?: string
 }
@@ -48,7 +45,7 @@ const getBuildQueryPlugin = ({
 }: GetBuildQueryPluginArgs = {}) => {
   return function buildQueryPlugin(schema) {
     const modifiedSchema = schema;
-    async function buildQuery({ req, where, overrideAccess = false, access, globalSlug }: BuildQueryArgs): Promise<Record<string, unknown>> {
+    async function buildQuery({ req, where, access, globalSlug }: BuildQueryArgs): Promise<Record<string, unknown>> {
       let fields = versionsFields;
       if (!fields) {
         if (globalSlug) {
@@ -62,18 +59,12 @@ const getBuildQueryPlugin = ({
       }
       const errors = [];
       const result = await parseParams({
-        policies: {
-          collections: {},
-          globals: {},
-        },
         collectionSlug,
         access,
-        errors,
         fields,
         globalSlug,
         req,
         where,
-        overrideAccess,
       });
 
       if (errors.length > 0) {

--- a/src/mongoose/buildQuery.ts
+++ b/src/mongoose/buildQuery.ts
@@ -2,6 +2,7 @@ import { PayloadRequest, Where } from '../types';
 import { Field, FieldAffectingData, TabAsField, UIField } from '../fields/config/types';
 import { CollectionPermission, FieldPermissions, GlobalPermission } from '../auth';
 import QueryError from '../errors/QueryError';
+import { getLocalizedPaths } from './getLocalizedPaths';
 import { parseParams } from './parseParams';
 
 export const validOperators = ['like', 'contains', 'in', 'all', 'not_in', 'greater_than_equal', 'greater_than', 'less_than_equal', 'less_than', 'not_equals', 'equals', 'exists', 'near'];

--- a/src/mongoose/buildQuery.ts
+++ b/src/mongoose/buildQuery.ts
@@ -1,29 +1,7 @@
 import { PayloadRequest, Where } from '../types';
-import { Field, FieldAffectingData, TabAsField, UIField } from '../fields/config/types';
-import { CollectionPermission, GlobalPermission } from '../auth';
+import { Field } from '../fields/config/types';
 import QueryError from '../errors/QueryError';
 import { parseParams } from './parseParams';
-
-export const validOperators = ['like', 'contains', 'in', 'all', 'not_in', 'greater_than_equal', 'greater_than', 'less_than_equal', 'less_than', 'not_equals', 'equals', 'exists', 'near'];
-
-export type EntityPolicies = {
-  collections?: {
-    [collectionSlug: string]: CollectionPermission;
-  };
-  globals?: {
-    [globalSlug: string]: GlobalPermission;
-  };
-};
-
-export type PathToQuery = {
-  complete: boolean
-  collectionSlug?: string
-  globalSlug?: string
-  path: string
-  field: Field | TabAsField
-  fields?: (FieldAffectingData | UIField | TabAsField)[]
-  invalid?: boolean
-}
 
 type GetBuildQueryPluginArgs = {
   collectionSlug?: string

--- a/src/mongoose/buildSearchParams.ts
+++ b/src/mongoose/buildSearchParams.ts
@@ -1,5 +1,5 @@
 import { Field, fieldAffectsData } from '../fields/config/types';
-import { EntityPolicies, PathToQuery, validOperators } from './buildQuery';
+import { PathToQuery, validOperators } from './buildQuery';
 import { operatorMap } from './operatorMap';
 import { getLocalizedPaths } from './getLocalizedPaths';
 import { sanitizeQueryValue } from './sanitizeQueryValue';
@@ -23,23 +23,17 @@ export async function buildSearchParam({
   incomingPath,
   val,
   operator,
-  overrideAccess,
   collectionSlug,
   globalSlug,
   req,
-  errors,
-  policies,
 }: {
   fields: Field[],
   incomingPath: string,
   val: unknown,
   operator: string
-  overrideAccess: boolean
   collectionSlug?: string,
   globalSlug?: string,
   req: PayloadRequest,
-  errors: {path: string}[],
-  policies: EntityPolicies,
 }): Promise<SearchParam> {
   // Replace GraphQL nested field double underscore formatting
   let sanitizedPath = incomingPath.replace(/__/gi, '.');
@@ -73,14 +67,11 @@ export async function buildSearchParam({
     });
   } else {
     paths = await getLocalizedPaths({
-      errors,
-      policies,
       req,
       collectionSlug,
       globalSlug,
       fields,
       incomingPath: sanitizedPath,
-      overrideAccess,
     });
   }
 
@@ -128,7 +119,6 @@ export async function buildSearchParam({
               },
             },
             req,
-            overrideAccess,
           });
 
           const result = await SubModel.find(subQuery, subQueryOptions);

--- a/src/mongoose/buildSearchParams.ts
+++ b/src/mongoose/buildSearchParams.ts
@@ -1,0 +1,195 @@
+import { Field, fieldAffectsData } from '../fields/config/types';
+import { EntityPolicies, PathToQuery, validOperators } from './buildQuery';
+import { operatorMap } from './operatorMap';
+import { getLocalizedPaths } from './getLocalizedPaths';
+import { sanitizeQueryValue } from './sanitizeQueryValue';
+import { PayloadRequest } from '../express/types';
+
+type SearchParam = {
+  path?: string,
+  value: unknown,
+}
+
+const subQueryOptions = {
+  limit: 50,
+  lean: true,
+};
+
+/**
+ * Convert the Payload key / value / operator into a MongoDB query
+ */
+export async function buildSearchParam({
+  fields,
+  incomingPath,
+  val,
+  operator,
+  overrideAccess,
+  collectionSlug,
+  globalSlug,
+  req,
+  errors,
+  policies,
+}: {
+  fields: Field[],
+  incomingPath: string,
+  val: unknown,
+  operator: string
+  overrideAccess: boolean
+  collectionSlug?: string,
+  globalSlug?: string,
+  req: PayloadRequest,
+  errors: {path: string}[],
+  policies: EntityPolicies,
+}): Promise<SearchParam> {
+  // Replace GraphQL nested field double underscore formatting
+  let sanitizedPath = incomingPath.replace(/__/gi, '.');
+  if (sanitizedPath === 'id') sanitizedPath = '_id';
+
+  let paths: PathToQuery[] = [];
+
+  let hasCustomID = false;
+
+  if (sanitizedPath === '_id') {
+    const customIDfield = req.payload.collections[collectionSlug]?.config.fields.find((field) => fieldAffectsData(field) && field.name === 'id');
+
+    let idFieldType: 'text' | 'number' = 'text';
+
+    if (customIDfield) {
+      if (customIDfield?.type === 'text' || customIDfield?.type === 'number') {
+        idFieldType = customIDfield.type;
+      }
+
+      hasCustomID = true;
+    }
+
+    paths.push({
+      path: '_id',
+      field: {
+        name: 'id',
+        type: idFieldType,
+      },
+      complete: true,
+      collectionSlug,
+    });
+  } else {
+    paths = await getLocalizedPaths({
+      errors,
+      policies,
+      req,
+      collectionSlug,
+      globalSlug,
+      fields,
+      incomingPath: sanitizedPath,
+      overrideAccess,
+    });
+  }
+
+  const [{
+    path,
+    field,
+  }] = paths;
+
+  if (path) {
+    const formattedValue = sanitizeQueryValue({
+      field,
+      path,
+      operator,
+      val,
+      hasCustomID,
+    });
+
+    // If there are multiple collections to search through,
+    // Recursively build up a list of query constraints
+    if (paths.length > 1) {
+      // Remove top collection and reverse array
+      // to work backwards from top
+      const pathsToQuery = paths.slice(1)
+        .reverse();
+
+      const initialRelationshipQuery = {
+        value: {},
+      } as SearchParam;
+
+      const relationshipQuery = await pathsToQuery.reduce(async (priorQuery, {
+        path: subPath,
+        collectionSlug: slug,
+      }, i) => {
+        const priorQueryResult = await priorQuery;
+
+        const SubModel = req.payload.collections[slug].Model;
+
+        // On the "deepest" collection,
+        // Search on the value passed through the query
+        if (i === 0) {
+          const subQuery = await SubModel.buildQuery({
+            where: {
+              [subPath]: {
+                [operator]: val,
+              },
+            },
+            req,
+            overrideAccess,
+          });
+
+          const result = await SubModel.find(subQuery, subQueryOptions);
+
+          const $in = result.map((doc) => doc._id.toString());
+
+          if (pathsToQuery.length === 1) {
+            return {
+              path,
+              value: { $in },
+            };
+          }
+
+          const nextSubPath = pathsToQuery[i + 1].path;
+
+          return {
+            value: { [nextSubPath]: { $in } },
+          };
+        }
+
+        const subQuery = priorQueryResult.value;
+        const result = await SubModel.find(subQuery, subQueryOptions);
+
+        const $in = result.map((doc) => doc._id.toString());
+
+        // If it is the last recursion
+        // then pass through the search param
+        if (i + 1 === pathsToQuery.length) {
+          return {
+            path,
+            value: { $in },
+          };
+        }
+
+        return {
+          value: {
+            _id: { $in },
+          },
+        };
+      }, Promise.resolve(initialRelationshipQuery));
+
+      return relationshipQuery;
+    }
+
+    if (operator && validOperators.includes(operator)) {
+      const operatorKey = operatorMap[operator];
+
+      // Some operators like 'near' need to define a full query
+      // so if there is no operator key, just return the value
+      if (!operatorKey) {
+        return {
+          path,
+          value: formattedValue,
+        };
+      }
+
+      return {
+        path,
+        value: { [operatorKey]: formattedValue },
+      };
+    }
+  }
+  return undefined;
+}

--- a/src/mongoose/buildSearchParams.ts
+++ b/src/mongoose/buildSearchParams.ts
@@ -1,9 +1,9 @@
 import { Field, fieldAffectsData } from '../fields/config/types';
-import { PathToQuery, validOperators } from './buildQuery';
 import { operatorMap } from './operatorMap';
 import { getLocalizedPaths } from './getLocalizedPaths';
 import { sanitizeQueryValue } from './sanitizeQueryValue';
 import { PayloadRequest } from '../express/types';
+import { PathToQuery, validOperators } from '../utilities/queryValidation/types';
 
 type SearchParam = {
   path?: string,

--- a/src/mongoose/getLocalizedPaths.ts
+++ b/src/mongoose/getLocalizedPaths.ts
@@ -1,18 +1,9 @@
 import { Field, fieldAffectsData } from '../fields/config/types';
 import flattenFields from '../utilities/flattenTopLevelFields';
 import { getEntityPolicies } from '../utilities/getEntityPolicies';
-import { PathToQuery } from './buildQuery';
+import { EntityPolicies, PathToQuery } from './buildQuery';
 import { PayloadRequest } from '../express/types';
-import { CollectionPermission, GlobalPermission } from '../auth';
 
-type EntityPolicies = {
-  collections?: {
-    [collectionSlug: string]: CollectionPermission;
-  };
-  globals?: {
-    [globalSlug: string]: GlobalPermission;
-  };
-};
 export async function getLocalizedPaths({
   req,
   policies,
@@ -30,7 +21,7 @@ export async function getLocalizedPaths({
   fields: Field[]
   incomingPath: string
   overrideAccess: boolean
-  errors
+  errors: {path: string}[]
 }): Promise<PathToQuery[]> {
   const pathSegments = incomingPath.split('.');
   const localizationConfig = req.payload.config.localization;

--- a/src/mongoose/getLocalizedPaths.ts
+++ b/src/mongoose/getLocalizedPaths.ts
@@ -1,0 +1,216 @@
+import { Field, fieldAffectsData } from '../fields/config/types';
+import flattenFields from '../utilities/flattenTopLevelFields';
+import { getEntityPolicies } from '../utilities/getEntityPolicies';
+import { PathToQuery } from './buildQuery';
+import { PayloadRequest } from '../express/types';
+import { CollectionPermission, GlobalPermission } from '../auth';
+
+type EntityPolicies = {
+  collections?: {
+    [collectionSlug: string]: CollectionPermission;
+  };
+  globals?: {
+    [globalSlug: string]: GlobalPermission;
+  };
+};
+export async function getLocalizedPaths({
+  req,
+  policies,
+  collectionSlug,
+  globalSlug,
+  fields,
+  incomingPath,
+  overrideAccess,
+  errors,
+}: {
+  req: PayloadRequest
+  policies: EntityPolicies
+  collectionSlug?: string
+  globalSlug?: string
+  fields: Field[]
+  incomingPath: string
+  overrideAccess: boolean
+  errors
+}): Promise<PathToQuery[]> {
+  const pathSegments = incomingPath.split('.');
+  const localizationConfig = req.payload.config.localization;
+
+  let paths: PathToQuery[] = [
+    {
+      path: '',
+      complete: false,
+      field: undefined,
+      fields: flattenFields(fields, false),
+      fieldPolicies: undefined,
+      collectionSlug,
+    },
+  ];
+
+  if (!overrideAccess) {
+    if (collectionSlug) {
+      const collection = { ...req.payload.collections[collectionSlug].config };
+      collection.fields = fields;
+
+      if (!policies.collections[collectionSlug]) {
+        const policy = await getEntityPolicies({
+          req,
+          entity: collection,
+          operations: ['read'],
+          type: 'collection',
+        });
+
+        // eslint-disable-next-line no-param-reassign
+        policies.collections[collectionSlug] = policy;
+      }
+
+      paths[0].fieldPolicies = policies.collections[collectionSlug].fields;
+
+      if (['salt', 'hash'].includes(incomingPath) && collection.auth && !collection.auth?.disableLocalStrategy) {
+        errors.push({ path: incomingPath });
+        return [];
+      }
+    }
+
+    if (globalSlug) {
+      if (!policies.globals[globalSlug]) {
+        const global = { ...req.payload.globals.config.find(({ slug }) => slug === globalSlug) };
+        global.fields = fields;
+
+        const policy = await getEntityPolicies({
+          req,
+          entity: global,
+          operations: ['read'],
+          type: 'global',
+        });
+
+        // eslint-disable-next-line no-param-reassign
+        policies.globals[globalSlug] = policy;
+      }
+
+      paths[0].fieldPolicies = policies.globals[globalSlug].fields;
+    }
+  }
+
+  for (let i = 0; i < pathSegments.length; i += 1) {
+    const segment = pathSegments[i];
+
+    const lastIncompletePath = paths.find(({ complete }) => !complete);
+
+    if (lastIncompletePath) {
+      const { path } = lastIncompletePath;
+      let currentPath = path ? `${path}.${segment}` : segment;
+
+      const matchedField = lastIncompletePath.fields.find((field) => fieldAffectsData(field) && field.name === segment);
+      lastIncompletePath.field = matchedField;
+
+      if (currentPath === 'globalType' && globalSlug) {
+        lastIncompletePath.path = currentPath;
+        lastIncompletePath.complete = true;
+        lastIncompletePath.field = {
+          name: 'globalType',
+          type: 'text',
+        };
+
+        return paths;
+      }
+
+      if (matchedField) {
+        if (!overrideAccess) {
+          const fieldAccess = lastIncompletePath.fieldPolicies[matchedField.name].read.permission;
+
+          if (!fieldAccess || ('hidden' in matchedField && matchedField.hidden)) {
+            errors.push({ path: currentPath });
+            return paths;
+          }
+        }
+
+        const nextSegment = pathSegments[i + 1];
+        const nextSegmentIsLocale = localizationConfig && localizationConfig.locales.includes(nextSegment);
+
+        if (nextSegmentIsLocale) {
+        // Skip the next iteration, because it's a locale
+          i += 1;
+          currentPath = `${currentPath}.${nextSegment}`;
+        } else if (localizationConfig && 'localized' in matchedField && matchedField.localized) {
+          currentPath = `${currentPath}.${req.locale}`;
+        }
+
+        switch (matchedField.type) {
+          case 'blocks':
+          case 'richText':
+          case 'json': {
+            const upcomingSegments = pathSegments.slice(i + 1).join('.');
+            lastIncompletePath.complete = true;
+            lastIncompletePath.path = upcomingSegments ? `${currentPath}.${upcomingSegments}` : currentPath;
+            return paths;
+          }
+
+          case 'relationship':
+          case 'upload': {
+          // If this is a polymorphic relation,
+          // We only support querying directly (no nested querying)
+            if (typeof matchedField.relationTo !== 'string') {
+              const lastSegmentIsValid = ['value', 'relationTo'].includes(pathSegments[pathSegments.length - 1]);
+
+              if (lastSegmentIsValid) {
+                lastIncompletePath.complete = true;
+                lastIncompletePath.path = pathSegments.join('.');
+              } else {
+                errors.push({ path: currentPath });
+                return paths;
+              }
+            } else {
+              lastIncompletePath.complete = true;
+              lastIncompletePath.path = currentPath;
+
+              const nestedPathToQuery = pathSegments.slice(nextSegmentIsLocale ? i + 2 : i + 1).join('.');
+
+              if (nestedPathToQuery) {
+                const relatedCollection = req.payload.collections[matchedField.relationTo as string].config;
+
+                // eslint-disable-next-line no-await-in-loop
+                const remainingPaths = await getLocalizedPaths({
+                  errors,
+                  req,
+                  policies,
+                  globalSlug,
+                  collectionSlug: relatedCollection.slug,
+                  fields: relatedCollection.fields,
+                  incomingPath: nestedPathToQuery,
+                  overrideAccess,
+                });
+
+                paths = [
+                  ...paths,
+                  ...remainingPaths,
+                ];
+              }
+
+              return paths;
+            }
+
+            break;
+          }
+
+          default: {
+            if ('fields' in lastIncompletePath.field) {
+              lastIncompletePath.fields = flattenFields(lastIncompletePath.field.fields, false);
+            }
+
+            if (!overrideAccess && 'fields' in lastIncompletePath.fieldPolicies[lastIncompletePath.field.name]) {
+              lastIncompletePath.fieldPolicies = lastIncompletePath.fieldPolicies[lastIncompletePath.field.name].fields;
+            }
+
+            if (i + 1 === pathSegments.length) lastIncompletePath.complete = true;
+            lastIncompletePath.path = currentPath;
+          }
+        }
+      } else {
+        errors.push({ path: currentPath });
+        return paths;
+      }
+    }
+  }
+
+  return paths;
+}

--- a/src/mongoose/getLocalizedPaths.ts
+++ b/src/mongoose/getLocalizedPaths.ts
@@ -1,7 +1,7 @@
 import { Field, fieldAffectsData } from '../fields/config/types';
 import flattenFields from '../utilities/flattenTopLevelFields';
-import { PathToQuery } from './buildQuery';
 import { PayloadRequest } from '../express/types';
+import { PathToQuery } from '../utilities/queryValidation/types';
 
 export async function getLocalizedPaths({
   req,

--- a/src/mongoose/getLocalizedPaths.ts
+++ b/src/mongoose/getLocalizedPaths.ts
@@ -9,12 +9,14 @@ export async function getLocalizedPaths({
   globalSlug,
   fields,
   incomingPath,
+  overrideAccess = false,
 }: {
   req: PayloadRequest
   collectionSlug?: string
   globalSlug?: string
   fields: Field[]
   incomingPath: string
+  overrideAccess?: boolean,
 }): Promise<PathToQuery[]> {
   const pathSegments = incomingPath.split('.');
   const localizationConfig = req.payload.config.localization;
@@ -55,9 +57,8 @@ export async function getLocalizedPaths({
       }
 
       if (matchedField) {
-        if ('hidden' in matchedField && matchedField.hidden) {
+        if ('hidden' in matchedField && matchedField.hidden && !overrideAccess) {
           lastIncompletePath.invalid = true;
-          // return paths;
         }
 
         const nextSegment = pathSegments[i + 1];

--- a/src/mongoose/parseParams.ts
+++ b/src/mongoose/parseParams.ts
@@ -1,0 +1,59 @@
+import { parsePathOrRelation } from './parsePathOrRelation';
+import { PayloadRequest, Where } from '../types';
+import { EntityPolicies } from './buildQuery';
+import { Field } from '../fields/config/types';
+
+export async function parseParams({
+  collectionSlug,
+  access,
+  errors,
+  fields,
+  globalSlug,
+  policies,
+  req,
+  where,
+  overrideAccess,
+}: {
+  where: Where,
+  access: Where | boolean,
+  overrideAccess: boolean,
+  collectionSlug?: string,
+  errors: {path: string}[],
+  globalSlug?: string,
+  policies: EntityPolicies,
+  req: PayloadRequest,
+  fields: Field[],
+}): Promise<Record<string, unknown>> {
+  const query = await parsePathOrRelation({
+    collectionSlug,
+    errors,
+    fields,
+    globalSlug,
+    policies,
+    req,
+    where,
+    overrideAccess,
+  });
+
+  const result = {
+    $and: [],
+  };
+
+  if (query) result.$and.push(query);
+
+  if (typeof access === 'object') {
+    const accessQuery = await parsePathOrRelation({
+      where: access,
+      overrideAccess: true,
+      collectionSlug,
+      errors,
+      fields,
+      globalSlug,
+      policies,
+      req,
+    });
+    if (accessQuery) result.$and.push(accessQuery);
+  }
+
+  return result;
+}

--- a/src/mongoose/parseParams.ts
+++ b/src/mongoose/parseParams.ts
@@ -1,38 +1,28 @@
 import { parsePathOrRelation } from './parsePathOrRelation';
 import { PayloadRequest, Where } from '../types';
-import { EntityPolicies } from './buildQuery';
 import { Field } from '../fields/config/types';
 
 export async function parseParams({
   collectionSlug,
   access,
-  errors,
   fields,
   globalSlug,
-  policies,
   req,
   where,
-  overrideAccess,
 }: {
   where: Where,
   access: Where | boolean,
-  overrideAccess: boolean,
   collectionSlug?: string,
-  errors: {path: string}[],
   globalSlug?: string,
-  policies: EntityPolicies,
   req: PayloadRequest,
   fields: Field[],
 }): Promise<Record<string, unknown>> {
   const query = await parsePathOrRelation({
     collectionSlug,
-    errors,
     fields,
     globalSlug,
-    policies,
     req,
     where,
-    overrideAccess,
   });
 
   const result = {
@@ -44,12 +34,9 @@ export async function parseParams({
   if (typeof access === 'object') {
     const accessQuery = await parsePathOrRelation({
       where: access,
-      overrideAccess: true,
       collectionSlug,
-      errors,
       fields,
       globalSlug,
-      policies,
       req,
     });
     if (accessQuery) result.$and.push(accessQuery);

--- a/src/mongoose/parsePathOrRelation.ts
+++ b/src/mongoose/parsePathOrRelation.ts
@@ -5,26 +5,21 @@ import deepmerge from 'deepmerge';
 import { PayloadRequest, Where } from '../types';
 import { buildSearchParam } from './buildSearchParams';
 import { combineMerge } from '../utilities/combineMerge';
-import { EntityPolicies, validOperators } from './buildQuery';
+import { validOperators } from './buildQuery';
 import { buildAndOrConditions } from './buildAndOrConditions';
 import { Field } from '../fields/config/types';
 
+
 export async function parsePathOrRelation({
   where,
-  overrideAccess,
   collectionSlug,
-  errors,
   globalSlug,
-  policies,
   req,
   fields,
 }: {
   where: Where,
-  overrideAccess: boolean,
   collectionSlug?: string,
-  errors: {path: string}[],
   globalSlug?: string,
-  policies: EntityPolicies,
   req: PayloadRequest,
   fields: Field[],
 }): Promise<Record<string, unknown>> {
@@ -43,13 +38,10 @@ export async function parsePathOrRelation({
       if (Array.isArray(condition)) {
         const builtConditions = await buildAndOrConditions({
           collectionSlug,
-          errors,
           fields,
           globalSlug,
-          policies,
           req,
           where: condition,
-          overrideAccess,
         });
         if (builtConditions.length > 0) result[conditionOperator] = builtConditions;
       } else {
@@ -62,15 +54,12 @@ export async function parsePathOrRelation({
             if (validOperators.includes(operator)) {
               const searchParam = await buildSearchParam({
                 collectionSlug,
-                errors,
                 globalSlug,
-                policies,
                 req,
                 fields,
                 incomingPath: relationOrPath,
                 val: pathOperators[operator],
                 operator,
-                overrideAccess,
               });
 
               if (searchParam?.value && searchParam?.path) {

--- a/src/mongoose/parsePathOrRelation.ts
+++ b/src/mongoose/parsePathOrRelation.ts
@@ -34,8 +34,14 @@ export async function parsePathOrRelation({
   // We need to determine if the whereKey is an AND, OR, or a schema path
     for (const relationOrPath of Object.keys(where)) {
       const condition = where[relationOrPath];
-      if (relationOrPath.toLowerCase() === 'and' && Array.isArray(condition)) {
-        const builtAndConditions = await buildAndOrConditions({
+      let conditionOperator: '$and' | '$or';
+      if (relationOrPath.toLowerCase() === 'and') {
+        conditionOperator = '$and';
+      } else if (relationOrPath.toLowerCase() === 'or') {
+        conditionOperator = '$or';
+      }
+      if (Array.isArray(condition)) {
+        const builtConditions = await buildAndOrConditions({
           collectionSlug,
           errors,
           fields,
@@ -45,19 +51,7 @@ export async function parsePathOrRelation({
           where: condition,
           overrideAccess,
         });
-        if (builtAndConditions.length > 0) result.$and = builtAndConditions;
-      } else if (relationOrPath.toLowerCase() === 'or' && Array.isArray(condition)) {
-        const builtOrConditions = await buildAndOrConditions({
-          collectionSlug,
-          errors,
-          fields,
-          globalSlug,
-          policies,
-          req,
-          where: condition,
-          overrideAccess,
-        });
-        if (builtOrConditions.length > 0) result.$or = builtOrConditions;
+        if (builtConditions.length > 0) result[conditionOperator] = builtConditions;
       } else {
       // It's a path - and there can be multiple comparisons on a single path.
       // For example - title like 'test' and title not equal to 'tester'

--- a/src/mongoose/parsePathOrRelation.ts
+++ b/src/mongoose/parsePathOrRelation.ts
@@ -1,0 +1,98 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-await-in-loop */
+import { FilterQuery } from 'mongoose';
+import deepmerge from 'deepmerge';
+import { PayloadRequest, Where } from '../types';
+import { buildSearchParam } from './buildSearchParams';
+import { combineMerge } from '../utilities/combineMerge';
+import { EntityPolicies, validOperators } from './buildQuery';
+import { buildAndOrConditions } from './buildAndOrConditions';
+import { Field } from '../fields/config/types';
+
+export async function parsePathOrRelation({
+  where,
+  overrideAccess,
+  collectionSlug,
+  errors,
+  globalSlug,
+  policies,
+  req,
+  fields,
+}: {
+  where: Where,
+  overrideAccess: boolean,
+  collectionSlug?: string,
+  errors: {path: string}[],
+  globalSlug?: string,
+  policies: EntityPolicies,
+  req: PayloadRequest,
+  fields: Field[],
+}): Promise<Record<string, unknown>> {
+  let result = {} as FilterQuery<any>;
+
+  if (typeof where === 'object') {
+  // We need to determine if the whereKey is an AND, OR, or a schema path
+    for (const relationOrPath of Object.keys(where)) {
+      const condition = where[relationOrPath];
+      if (relationOrPath.toLowerCase() === 'and' && Array.isArray(condition)) {
+        const builtAndConditions = await buildAndOrConditions({
+          collectionSlug,
+          errors,
+          fields,
+          globalSlug,
+          policies,
+          req,
+          where: condition,
+          overrideAccess,
+        });
+        if (builtAndConditions.length > 0) result.$and = builtAndConditions;
+      } else if (relationOrPath.toLowerCase() === 'or' && Array.isArray(condition)) {
+        const builtOrConditions = await buildAndOrConditions({
+          collectionSlug,
+          errors,
+          fields,
+          globalSlug,
+          policies,
+          req,
+          where: condition,
+          overrideAccess,
+        });
+        if (builtOrConditions.length > 0) result.$or = builtOrConditions;
+      } else {
+      // It's a path - and there can be multiple comparisons on a single path.
+      // For example - title like 'test' and title not equal to 'tester'
+      // So we need to loop on keys again here to handle each operator independently
+        const pathOperators = where[relationOrPath];
+        if (typeof pathOperators === 'object') {
+          for (const operator of Object.keys(pathOperators)) {
+            if (validOperators.includes(operator)) {
+              const searchParam = await buildSearchParam({
+                collectionSlug,
+                errors,
+                globalSlug,
+                policies,
+                req,
+                fields,
+                incomingPath: relationOrPath,
+                val: pathOperators[operator],
+                operator,
+                overrideAccess,
+              });
+
+              if (searchParam?.value && searchParam?.path) {
+                result = {
+                  ...result,
+                  [searchParam.path]: searchParam.value,
+                };
+              } else if (typeof searchParam?.value === 'object') {
+                result = deepmerge(result, searchParam.value, { arrayMerge: combineMerge });
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/mongoose/parsePathOrRelation.ts
+++ b/src/mongoose/parsePathOrRelation.ts
@@ -5,9 +5,9 @@ import deepmerge from 'deepmerge';
 import { PayloadRequest, Where } from '../types';
 import { buildSearchParam } from './buildSearchParams';
 import { combineMerge } from '../utilities/combineMerge';
-import { validOperators } from './buildQuery';
 import { buildAndOrConditions } from './buildAndOrConditions';
 import { Field } from '../fields/config/types';
+import { validOperators } from '../utilities/queryValidation/types';
 
 
 export async function parsePathOrRelation({

--- a/src/utilities/flattenWhereConstraints.ts
+++ b/src/utilities/flattenWhereConstraints.ts
@@ -1,4 +1,4 @@
-import { WhereField, Where } from '../types';
+import { Where, WhereField } from '../types';
 
 // Take a where query and flatten it to all top-level operators
 const flattenWhereConstraints = (query: Where): WhereField[] => Object.entries(query).reduce((flattenedConstraints, [key, val]) => {

--- a/src/utilities/queryValidation/types.ts
+++ b/src/utilities/queryValidation/types.ts
@@ -1,0 +1,23 @@
+import { CollectionPermission, GlobalPermission } from '../../auth';
+import { Field, FieldAffectingData, TabAsField, UIField } from '../../fields/config/types';
+
+export const validOperators = ['like', 'contains', 'in', 'all', 'not_in', 'greater_than_equal', 'greater_than', 'less_than_equal', 'less_than', 'not_equals', 'equals', 'exists', 'near'];
+
+export type EntityPolicies = {
+  collections?: {
+    [collectionSlug: string]: CollectionPermission;
+  };
+  globals?: {
+    [globalSlug: string]: GlobalPermission;
+  };
+};
+
+export type PathToQuery = {
+  complete: boolean
+  collectionSlug?: string
+  globalSlug?: string
+  path: string
+  field: Field | TabAsField
+  fields?: (FieldAffectingData | UIField | TabAsField)[]
+  invalid?: boolean
+}

--- a/src/utilities/queryValidation/validateQueryPaths.ts
+++ b/src/utilities/queryValidation/validateQueryPaths.ts
@@ -1,14 +1,14 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable no-await-in-loop */
-import { PayloadRequest, Where, WhereField } from '../types';
-import { EntityPolicies, validOperators } from '../mongoose/buildQuery';
-import QueryError from '../errors/QueryError';
-import { SanitizedCollectionConfig } from '../collections/config/types';
-import { SanitizedGlobalConfig } from '../globals/config/types';
-import flattenFields from './flattenTopLevelFields';
-import { Field, FieldAffectingData } from '../fields/config/types';
+import { PayloadRequest, Where, WhereField } from '../../types';
+import QueryError from '../../errors/QueryError';
+import { SanitizedCollectionConfig } from '../../collections/config/types';
+import { SanitizedGlobalConfig } from '../../globals/config/types';
+import flattenFields from '../flattenTopLevelFields';
+import { Field, FieldAffectingData } from '../../fields/config/types';
 import { validateSearchParam } from './validateSearchParams';
-import deepCopyObject from './deepCopyObject';
+import deepCopyObject from '../deepCopyObject';
+import { EntityPolicies, validOperators } from './types';
 
 const flattenWhere = (query: Where): WhereField[] => Object.entries(query).reduce((flattenedConstraints, [key, val]) => {
   if ((key === 'and' || key === 'or') && Array.isArray(val)) {

--- a/src/utilities/queryValidation/validateSearchParams.ts
+++ b/src/utilities/queryValidation/validateSearchParams.ts
@@ -1,11 +1,11 @@
-import { Field, fieldAffectsData } from '../fields/config/types';
-import { PayloadRequest } from '../express/types';
-import { getLocalizedPaths } from '../mongoose/getLocalizedPaths';
-import { EntityPolicies, PathToQuery } from '../mongoose/buildQuery';
-import { getEntityPolicies } from './getEntityPolicies';
-import { SanitizedCollectionConfig } from '../collections/config/types';
-import { SanitizedGlobalConfig } from '../globals/config/types';
+import { Field, fieldAffectsData } from '../../fields/config/types';
+import { PayloadRequest } from '../../express/types';
+import { getLocalizedPaths } from '../../mongoose/getLocalizedPaths';
+import { getEntityPolicies } from '../getEntityPolicies';
+import { SanitizedCollectionConfig } from '../../collections/config/types';
+import { SanitizedGlobalConfig } from '../../globals/config/types';
 import { validateQueryPaths } from './validateQueryPaths';
+import { EntityPolicies, PathToQuery } from './types';
 
 type Args = {
   fields: Field[]

--- a/src/utilities/validateQueryPaths.ts
+++ b/src/utilities/validateQueryPaths.ts
@@ -1,0 +1,82 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-await-in-loop */
+import { PayloadRequest, Where, WhereField } from '../types';
+import { EntityPolicies, validOperators } from '../mongoose/buildQuery';
+import QueryError from '../errors/QueryError';
+import { SanitizedCollectionConfig } from '../collections/config/types';
+import { SanitizedGlobalConfig } from '../globals/config/types';
+import flattenFields from './flattenTopLevelFields';
+import { Field, FieldAffectingData } from '../fields/config/types';
+import { validateSearchParam } from './validateSearchParams';
+
+const flattenWhere = (query: Where): WhereField[] => Object.entries(query).reduce((flattenedConstraints, [key, val]) => {
+  if ((key === 'and' || key === 'or') && Array.isArray(val)) {
+    return [
+      ...flattenedConstraints,
+      ...val.map((subVal) => flattenWhere(subVal)),
+    ];
+  }
+
+  return [
+    ...flattenedConstraints,
+    { [key]: val },
+  ];
+}, []);
+
+type Args = {
+  where: Where
+  errors?: {path: string}[]
+  policies?: EntityPolicies
+  req: PayloadRequest
+  versionFields?: Field[]
+} & ({
+  collectionConfig: SanitizedCollectionConfig
+  globalConfig?: never | undefined
+} | {
+  globalConfig: SanitizedGlobalConfig
+  collectionConfig?: never | undefined
+})
+export async function validateQueryPaths({
+  where,
+  collectionConfig,
+  globalConfig,
+  errors = [],
+  policies = {
+    collections: {},
+    globals: {},
+  },
+  versionFields,
+  req,
+}: Args): Promise<void> {
+  const fields = flattenFields(versionFields || (globalConfig || collectionConfig).fields) as FieldAffectingData[];
+  if (typeof where === 'object') {
+    // const flattenedWhere = flattenWhere(where);
+    const whereFields = flattenWhere(where);
+    // We need to determine if the whereKey is an AND, OR, or a schema path
+    const promises = [];
+    whereFields.map(async (constraint) => {
+      Object.keys(constraint).map(async (path) => {
+        Object.entries(constraint[path]).map(async ([operator, val]) => {
+          if (validOperators.includes(operator)) {
+            promises.push(validateSearchParam({
+              collectionConfig,
+              globalConfig,
+              fields: (fields as Field[]),
+              versionFields,
+              errors,
+              policies,
+              req,
+              path,
+              val,
+              operator,
+            }));
+          }
+        });
+      });
+    });
+    await Promise.all(promises);
+    if (errors.length > 0) {
+      throw new QueryError(errors);
+    }
+  }
+}

--- a/src/utilities/validateQueryPaths.ts
+++ b/src/utilities/validateQueryPaths.ts
@@ -30,6 +30,7 @@ type Args = {
   policies?: EntityPolicies
   req: PayloadRequest
   versionFields?: Field[]
+  overrideAccess: boolean
 } & ({
   collectionConfig: SanitizedCollectionConfig
   globalConfig?: never | undefined
@@ -48,6 +49,7 @@ export async function validateQueryPaths({
   },
   versionFields,
   req,
+  overrideAccess,
 }: Args): Promise<void> {
   const fields = flattenFields(versionFields || (globalConfig || collectionConfig).fields) as FieldAffectingData[];
   if (typeof where === 'object') {
@@ -70,6 +72,7 @@ export async function validateQueryPaths({
               path,
               val,
               operator,
+              overrideAccess,
             }));
           }
         });

--- a/src/utilities/validateQueryPaths.ts
+++ b/src/utilities/validateQueryPaths.ts
@@ -8,6 +8,7 @@ import { SanitizedGlobalConfig } from '../globals/config/types';
 import flattenFields from './flattenTopLevelFields';
 import { Field, FieldAffectingData } from '../fields/config/types';
 import { validateSearchParam } from './validateSearchParams';
+import deepCopyObject from './deepCopyObject';
 
 const flattenWhere = (query: Where): WhereField[] => Object.entries(query).reduce((flattenedConstraints, [key, val]) => {
   if ((key === 'and' || key === 'or') && Array.isArray(val)) {
@@ -59,8 +60,8 @@ export async function validateQueryPaths({
         Object.entries(constraint[path]).map(async ([operator, val]) => {
           if (validOperators.includes(operator)) {
             promises.push(validateSearchParam({
-              collectionConfig,
-              globalConfig,
+              collectionConfig: deepCopyObject(collectionConfig),
+              globalConfig: deepCopyObject(globalConfig),
               fields: (fields as Field[]),
               versionFields,
               errors,

--- a/src/utilities/validateSearchParams.ts
+++ b/src/utilities/validateSearchParams.ts
@@ -68,6 +68,7 @@ export async function validateSearchParam({
       globalSlug: globalConfig?.slug,
       fields,
       incomingPath: sanitizedPath,
+      overrideAccess,
     });
   }
 

--- a/src/utilities/validateSearchParams.ts
+++ b/src/utilities/validateSearchParams.ts
@@ -39,7 +39,12 @@ export async function validateSearchParam({
   overrideAccess,
 }: Args): Promise<void> {
   // Replace GraphQL nested field double underscore formatting
-  const sanitizedPath = incomingPath.replace(/__/gi, '.');
+  let sanitizedPath;
+  if (incomingPath === '_id') {
+    sanitizedPath = 'id';
+  } else {
+    sanitizedPath = incomingPath.replace(/__/gi, '.');
+  }
   let paths: PathToQuery[] = [];
   const { slug } = (collectionConfig || globalConfig);
 

--- a/src/utilities/validateSearchParams.ts
+++ b/src/utilities/validateSearchParams.ts
@@ -95,6 +95,9 @@ export async function validateSearchParam({
       if (path.endsWith(req.locale)) {
         fieldPath = path.slice(0, -(req.locale.length + 1));
       }
+      if (field.type === 'relationship' && Array.isArray(field.relationTo)) {
+        fieldPath = fieldPath.replace('.value', '');
+      }
       if (versionFields) {
         if (fieldPath === 'parent' || fieldPath === 'version') {
           fieldAccess = true;

--- a/src/utilities/validateSearchParams.ts
+++ b/src/utilities/validateSearchParams.ts
@@ -1,0 +1,138 @@
+import { Field, fieldAffectsData } from '../fields/config/types';
+import { PayloadRequest } from '../express/types';
+import { getLocalizedPaths } from '../mongoose/getLocalizedPaths';
+import { EntityPolicies, PathToQuery } from '../mongoose/buildQuery';
+import { getEntityPolicies } from './getEntityPolicies';
+import { SanitizedCollectionConfig } from '../collections/config/types';
+import { SanitizedGlobalConfig } from '../globals/config/types';
+import { validateQueryPaths } from './validateQueryPaths';
+
+type Args = {
+  fields: Field[],
+  path: string,
+  val: unknown,
+  operator: string
+  req: PayloadRequest,
+  errors: {path: string}[],
+  policies: EntityPolicies,
+  collectionConfig?: SanitizedCollectionConfig
+  globalConfig?: SanitizedGlobalConfig
+  versionFields?: Field[],
+}
+
+
+/**
+ * Convert the Payload key / value / operator into a MongoDB query
+ */
+export async function validateSearchParam({
+  fields,
+  path: incomingPath,
+  versionFields,
+  val,
+  operator,
+  collectionConfig,
+  globalConfig,
+  errors,
+  req,
+  policies,
+}: Args): Promise<void> {
+  // Replace GraphQL nested field double underscore formatting
+  const sanitizedPath = incomingPath.replace(/__/gi, '.');
+  let paths: PathToQuery[] = [];
+  const { slug } = (collectionConfig || globalConfig);
+
+  if (globalConfig && !policies.globals[slug]) {
+    // eslint-disable-next-line no-param-reassign
+    globalConfig.fields = fields;
+
+    // eslint-disable-next-line no-param-reassign
+    policies.globals[slug] = await getEntityPolicies({
+      req,
+      entity: globalConfig,
+      operations: ['read'],
+      type: 'global',
+    });
+  }
+
+  if (sanitizedPath !== 'id') {
+    paths = await getLocalizedPaths({
+      req,
+      collectionSlug: collectionConfig?.slug,
+      globalSlug: globalConfig?.slug,
+      fields,
+      incomingPath: sanitizedPath,
+    });
+  }
+
+  const promises = paths.map(async ({ path, field, invalid, collectionSlug }, i) => {
+    if (invalid) {
+      errors.push({ path });
+      return;
+    }
+
+    if (fieldAffectsData(field)) {
+      if (collectionSlug) {
+        if (!policies.collections[collectionSlug]) {
+          // eslint-disable-next-line no-param-reassign
+          policies.collections[collectionSlug] = await getEntityPolicies({
+            req,
+            entity: req.payload.collections[collectionSlug].config,
+            operations: ['read'],
+            type: 'collection',
+          });
+        }
+
+        if (['salt', 'hash'].includes(incomingPath) && collectionConfig.auth && !collectionConfig.auth?.disableLocalStrategy) {
+          errors.push({ path: incomingPath });
+        }
+      }
+      let fieldAccess;
+      if (versionFields) {
+        if (path === 'parent' || path === 'version') {
+          fieldAccess = true;
+        } else if (globalConfig) {
+          fieldAccess = path.startsWith('version.') ? policies.globals[globalConfig.slug].fields.version.fields[field.name].read.permission : policies.globals[globalConfig.slug].fields[field.name].read.permission;
+        } else if (collectionConfig) {
+          fieldAccess = policies.collections[collectionSlug].fields[field.name].read.permission;
+        }
+      } else if (globalConfig) {
+        fieldAccess = policies.globals[globalConfig.slug].fields[field.name].read.permission;
+      } else {
+        fieldAccess = policies.collections[collectionSlug].fields[field.name].read.permission;
+      }
+      if (!fieldAccess) {
+        errors.push({ path });
+      }
+    }
+
+    if (i > 1) {
+      // Remove top collection and reverse array
+      // to work backwards from top
+      const pathsToQuery = paths.slice(1)
+        .reverse();
+
+      pathsToQuery.forEach(({
+        path: subPath,
+        collectionSlug: pathCollectionSlug,
+      }, pathToQueryIndex) => {
+        // On the "deepest" collection,
+        // validate query of the relationship
+        if (pathToQueryIndex === 0) {
+          validateQueryPaths({
+            collectionConfig: req.payload.collections[pathCollectionSlug].config,
+            globalConfig: undefined,
+            where: {
+              [subPath]: {
+                [operator]: val,
+              },
+            },
+            errors,
+            policies,
+            req,
+          });
+        }
+      });
+    }
+  });
+  await Promise.all(promises);
+}

--- a/src/versions/drafts/queryDrafts.ts
+++ b/src/versions/drafts/queryDrafts.ts
@@ -6,6 +6,7 @@ import { PaginatedDocs } from '../../mongoose/types';
 import { Collection, CollectionModel, TypeWithID } from '../../collections/config/types';
 import { hasWhereAccessResult } from '../../auth';
 import { appendVersionToQueryKey } from './appendVersionToQueryKey';
+import { validateQueryPaths } from '../../utilities/validateQueryPaths';
 
 type AggregateVersion<T> = {
   _id: string
@@ -43,11 +44,18 @@ export const queryDrafts = async <T extends TypeWithID>({
     versionAccessResult = appendVersionToQueryKey(accessResult);
   }
 
+  if (!overrideAccess) {
+    await validateQueryPaths({
+      collectionConfig: collection.config,
+      where,
+      req,
+    });
+  }
+
   const versionQuery = await VersionModel.buildQuery({
     where,
     access: versionAccessResult,
     req,
-    overrideAccess,
   });
 
   const aggregate = VersionModel.aggregate<AggregateVersion<T>>([

--- a/src/versions/drafts/queryDrafts.ts
+++ b/src/versions/drafts/queryDrafts.ts
@@ -6,7 +6,7 @@ import { PaginatedDocs } from '../../mongoose/types';
 import { Collection, CollectionModel, TypeWithID } from '../../collections/config/types';
 import { hasWhereAccessResult } from '../../auth';
 import { appendVersionToQueryKey } from './appendVersionToQueryKey';
-import { validateQueryPaths } from '../../utilities/validateQueryPaths';
+import { validateQueryPaths } from '../../utilities/queryValidation/validateQueryPaths';
 import { buildVersionCollectionFields } from '../buildCollectionFields';
 
 type AggregateVersion<T> = {

--- a/src/versions/drafts/queryDrafts.ts
+++ b/src/versions/drafts/queryDrafts.ts
@@ -7,6 +7,7 @@ import { Collection, CollectionModel, TypeWithID } from '../../collections/confi
 import { hasWhereAccessResult } from '../../auth';
 import { appendVersionToQueryKey } from './appendVersionToQueryKey';
 import { validateQueryPaths } from '../../utilities/validateQueryPaths';
+import { buildVersionCollectionFields } from '../buildCollectionFields';
 
 type AggregateVersion<T> = {
   _id: string
@@ -49,6 +50,7 @@ export const queryDrafts = async <T extends TypeWithID>({
     where,
     req,
     overrideAccess,
+    versionFields: buildVersionCollectionFields(collection.config),
   });
 
   const versionQuery = await VersionModel.buildQuery({

--- a/src/versions/drafts/queryDrafts.ts
+++ b/src/versions/drafts/queryDrafts.ts
@@ -44,13 +44,12 @@ export const queryDrafts = async <T extends TypeWithID>({
     versionAccessResult = appendVersionToQueryKey(accessResult);
   }
 
-  if (!overrideAccess) {
-    await validateQueryPaths({
-      collectionConfig: collection.config,
-      where,
-      req,
-    });
-  }
+  await validateQueryPaths({
+    collectionConfig: collection.config,
+    where,
+    req,
+    overrideAccess,
+  });
 
   const versionQuery = await VersionModel.buildQuery({
     where,

--- a/src/versions/drafts/replaceWithDraftIfAvailable.ts
+++ b/src/versions/drafts/replaceWithDraftIfAvailable.ts
@@ -23,7 +23,6 @@ const replaceWithDraftIfAvailable = async <T extends TypeWithID>({
   entityType,
   doc,
   req,
-  overrideAccess,
   accessResult,
 }: Arguments<T>): Promise<T> => {
   const VersionModel = payload.versions[entity.slug] as CollectionModel;
@@ -64,7 +63,6 @@ const replaceWithDraftIfAvailable = async <T extends TypeWithID>({
     where: queryToBuild,
     access: versionAccessResult,
     req,
-    overrideAccess,
     globalSlug: entityType === 'global' ? entity.slug : undefined,
   });
 


### PR DESCRIPTION
## Description

Refactors query validation out from mongoose buildQuery so that it has no reliance on the database adapter being used.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Chore

## Checklist:

- [x] Existing test suite passes locally with my changes
