### PR TITLE
fix: totalDocs is always 1 when using payload.find({ pagination: false })

### DIFF
--- a/src/collections/operations/find.ts
+++ b/src/collections/operations/find.ts
@@ -134,7 +134,6 @@ async function find<T extends TypeWithID & Record<string, unknown>>(
     leanWithId: true,
     useEstimatedCount,
     pagination: usePagination,
-    useCustomCountFn: pagination ? undefined : () => Promise.resolve(1),
     options: {
       // limit must also be set here, it's ignored when pagination is false
       limit: limitToUse,

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -62,6 +62,22 @@ describe('collections-rest', () => {
       expect(result.docs[0].id).toEqual(post1.id);
     });
 
+    it('should find with pagination false', async () => {
+      const post1 = await createPost();
+      const post2 = await createPost();
+
+      const { docs, totalDocs } = await payload.find({
+        collection: slug,
+        pagination: false,
+      });
+
+      const expectedDocs = [post1, post2];
+      expect(docs).toHaveLength(expectedDocs.length);
+      expect(docs).toEqual(expect.arrayContaining(expectedDocs));
+
+      expect(totalDocs).toEqual(2);
+    });
+
     it('should update existing', async () => {
       const {
         id,


### PR DESCRIPTION
## Description

If you do `payload.find({ pagination: false })` then it will not return paginated results.  This is great.  But for some reason, it will always have `totalDocs: 1` in the result.  When using `true` instead or when using the REST API where you cannot set this, the correct count for `totalDocs` is returned.

I traced it to this line:
https://github.com/payloadcms/payload/blob/91dba7be881d3cd4079e242db9aba8594fcfe279/src/collections/operations/find.ts#L137
I cannot think of a reason to use a custom count function, so I just removed the entire line.

The PR comes with a test that fails without the fix.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation -> not relevant
