### PR TITLE
fix: adds missing dark-mode styles for version differences view 

### DIFF
--- a/src/admin/components/views/Version/RenderFieldsToDiff/fields/styles.ts
+++ b/src/admin/components/views/Version/RenderFieldsToDiff/fields/styles.ts
@@ -10,5 +10,15 @@ export const diffStyles = {
       wordRemovedBackground: 'var(--theme-error-200)',
       emptyLineBackground: 'var(--theme-elevation-50)',
     },
+    dark: {
+      diffViewerBackground: 'transparent',
+      addedBackground: 'var(--theme-success-900)',
+      addedColor: 'var(--theme-success-100)',
+      removedBackground: 'var(--theme-error-900)',
+      removedColor: 'var(--theme-error-100)',
+      wordAddedBackground: 'var(--theme-success-800)',
+      wordRemovedBackground: 'var(--theme-error-800)',
+      emptyLineBackground: 'var(--theme-elevation-50)',
+    },
   },
 };


### PR DESCRIPTION
## Description

Resolves #2811 Styles defined for the version difference view were missing dark mode, this PR adds them.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
