### PR TITLE
fix: adds custom property to ui field in joi validation

### DIFF
--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -469,6 +469,7 @@ export const ui = joi.object().keys({
       Field: componentSchema,
     }).default({}),
   }).default(),
+  custom: joi.object().pattern(joi.string(), joi.any()),
 });
 
 const fieldSchema = joi.alternatives()


### PR DESCRIPTION
## Description

Fixes #2834 

Adds `custom` property to joi validation for `ui` field type. It was already correct in the field types.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
