### PR TITLE
feat: automatically redirect a user back to their originally requested URL after login

### DIFF
--- a/src/admin/components/Routes.tsx
+++ b/src/admin/components/Routes.tsx
@@ -315,7 +315,7 @@ const Routes: React.FC = () => {
                         <Unauthorized />
                       )}
                     </Fragment>
-                  ) : <Redirect to={`${match.url}/login`} />}
+                  ) : <Redirect to={`${match.url}/login?originalUrl=${encodeURIComponent(window.location.pathname)}`} />}
                 </Route>
                 <Route path={`${match.url}*`}>
                   <NotFound />

--- a/src/admin/components/Routes.tsx
+++ b/src/admin/components/Routes.tsx
@@ -315,7 +315,7 @@ const Routes: React.FC = () => {
                         <Unauthorized />
                       )}
                     </Fragment>
-                  ) : <Redirect to={`${match.url}/login?originalUrl=${encodeURIComponent(window.location.pathname)}`} />}
+                  ) : <Redirect to={`${match.url}/login?redirect=${encodeURIComponent(window.location.pathname)}`} />}
                 </Route>
                 <Route path={`${match.url}*`}>
                   <NotFound />

--- a/src/admin/components/utilities/Auth/index.tsx
+++ b/src/admin/components/utilities/Auth/index.tsx
@@ -61,7 +61,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           setUser(json.user);
         } else {
           setUser(null);
-          push(`${admin}${logoutInactivityRoute}`);
+          push(`${admin}${logoutInactivityRoute}?originalUrl=${encodeURIComponent(window.location.pathname)}`);
         }
       }, 1000);
     }
@@ -159,7 +159,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (remainingTime > 0) {
       forceLogOut = setTimeout(() => {
         setUser(null);
-        push(`${admin}${logoutInactivityRoute}`);
+        push(`${admin}${logoutInactivityRoute}?originalUrl=${encodeURIComponent(window.location.pathname)}`);
         closeAllModals();
       }, Math.min(remainingTime * 1000, maxTimeoutTime));
     }

--- a/src/admin/components/utilities/Auth/index.tsx
+++ b/src/admin/components/utilities/Auth/index.tsx
@@ -61,7 +61,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           setUser(json.user);
         } else {
           setUser(null);
-          push(`${admin}${logoutInactivityRoute}?originalUrl=${encodeURIComponent(window.location.pathname)}`);
+          push(`${admin}${logoutInactivityRoute}?redirect=${encodeURIComponent(window.location.pathname)}`);
         }
       }, 1000);
     }
@@ -159,7 +159,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (remainingTime > 0) {
       forceLogOut = setTimeout(() => {
         setUser(null);
-        push(`${admin}${logoutInactivityRoute}?originalUrl=${encodeURIComponent(window.location.pathname)}`);
+        push(`${admin}${logoutInactivityRoute}?redirect=${encodeURIComponent(window.location.pathname)}`);
         closeAllModals();
       }, Math.min(remainingTime * 1000, maxTimeoutTime));
     }

--- a/src/admin/components/views/Login/index.tsx
+++ b/src/admin/components/views/Login/index.tsx
@@ -41,16 +41,16 @@ const Login: React.FC = () => {
 
   const collection = collections.find(({ slug }) => slug === userSlug);
 
-  // Fetch 'originalUrl' from the query string which denotes the URL the user originally tried to visit. This is set in the Routes.tsx file when a user tries to access a protected route and is redirected to the login screen.
+  // Fetch 'redirect' from the query string which denotes the URL the user originally tried to visit. This is set in the Routes.tsx file when a user tries to access a protected route and is redirected to the login screen.
   const query = new URLSearchParams(useLocation().search);
-  const originalUrl = query.get('originalUrl');
+  const redirect = query.get('redirect');
 
 
   const onSuccess = (data) => {
     if (data.token) {
       setToken(data.token);
 
-      history.push(originalUrl || admin);
+      history.push(redirect || admin);
     }
   };
 

--- a/src/admin/components/views/Login/index.tsx
+++ b/src/admin/components/views/Login/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import { Trans, useTranslation } from 'react-i18next';
 import { useConfig } from '../../utilities/Config';
 import { useAuth } from '../../utilities/Auth';
@@ -41,10 +41,16 @@ const Login: React.FC = () => {
 
   const collection = collections.find(({ slug }) => slug === userSlug);
 
+  // Fetch 'originalUrl' from the query string which denotes the URL the user originally tried to visit. This is set in the Routes.tsx file when a user tries to access a protected route and is redirected to the login screen.
+  const query = new URLSearchParams(useLocation().search);
+  const originalUrl = query.get('originalUrl');
+
+
   const onSuccess = (data) => {
     if (data.token) {
       setToken(data.token);
-      history.push(admin);
+
+      history.push(originalUrl || admin);
     }
   };
 

--- a/src/admin/components/views/Logout/index.tsx
+++ b/src/admin/components/views/Logout/index.tsx
@@ -18,9 +18,9 @@ const Logout: React.FC<{inactivity?: boolean}> = (props) => {
   const { routes: { admin } } = useConfig();
   const { t } = useTranslation('authentication');
 
-  // Fetch 'originalUrl' from the query string which denotes the URL the user originally tried to visit. This is set in the Routes.tsx file when a user tries to access a protected route and is redirected to the login screen.
+  // Fetch 'redirect' from the query string which denotes the URL the user originally tried to visit. This is set in the Routes.tsx file when a user tries to access a protected route and is redirected to the login screen.
   const query = new URLSearchParams(useLocation().search);
-  const originalUrl = query.get('originalUrl');
+  const redirect = query.get('redirect');
 
   useEffect(() => {
     logOut();
@@ -44,7 +44,7 @@ const Logout: React.FC<{inactivity?: boolean}> = (props) => {
         <Button
           el="anchor"
           buttonStyle="secondary"
-          url={`${admin}/login${originalUrl && originalUrl.length > 0 ? `?originalUrl=${encodeURIComponent(originalUrl)}` : ''}`}
+          url={`${admin}/login${redirect && redirect.length > 0 ? `?redirect=${encodeURIComponent(redirect)}` : ''}`}
         >
           {t('logBackIn')}
         </Button>

--- a/src/admin/components/views/Logout/index.tsx
+++ b/src/admin/components/views/Logout/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 import { useConfig } from '../../utilities/Config';
 import { useAuth } from '../../utilities/Auth';
 import Minimal from '../../templates/Minimal';
@@ -16,6 +17,10 @@ const Logout: React.FC<{inactivity?: boolean}> = (props) => {
   const { logOut } = useAuth();
   const { routes: { admin } } = useConfig();
   const { t } = useTranslation('authentication');
+
+  // Fetch 'originalUrl' from the query string which denotes the URL the user originally tried to visit. This is set in the Routes.tsx file when a user tries to access a protected route and is redirected to the login screen.
+  const query = new URLSearchParams(useLocation().search);
+  const originalUrl = query.get('originalUrl');
 
   useEffect(() => {
     logOut();
@@ -39,7 +44,7 @@ const Logout: React.FC<{inactivity?: boolean}> = (props) => {
         <Button
           el="anchor"
           buttonStyle="secondary"
-          url={`${admin}/login`}
+          url={`${admin}/login${originalUrl && originalUrl.length > 0 ? `?originalUrl=${encodeURIComponent(originalUrl)}` : ''}`}
         >
           {t('logBackIn')}
         </Button>


### PR DESCRIPTION
automatically redirect a user back to their originally requested URL if they try and access the admin panel, are not logged in, and get redirected to login screen

## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
