### PR TITLE
fix: drawer fields are read-only if opened from a hasMany relationship

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "webpack-hot-middleware": "^2.25.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.35.1",
+    "@playwright/test": "^1.33.0",
     "@release-it/conventional-changelog": "^5.1.1",
     "@swc/jest": "^0.2.24",
     "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "webpack-hot-middleware": "^2.25.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.32.3",
+    "@playwright/test": "^1.35.1",
     "@release-it/conventional-changelog": "^5.1.1",
     "@swc/jest": "^0.2.24",
     "@testing-library/jest-dom": "^5.16.5",
@@ -262,7 +262,7 @@
     "eslint-plugin-jest-dom": "^4.0.3",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-playwright": "^0.11.2",
+    "eslint-plugin-playwright": "^0.12.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "form-data": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "webpack-hot-middleware": "^2.25.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.33.0",
+    "@playwright/test": "1.33.0",
     "@release-it/conventional-changelog": "^5.1.1",
     "@swc/jest": "^0.2.24",
     "@testing-library/jest-dom": "^5.16.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
-  // Look for test files in the "tests" directory, relative to this configuration file
+  // Look for test files in the "test" directory, relative to this configuration file
   testDir: 'test',
   testMatch: '*e2e.spec.ts',
   workers: 999,

--- a/src/admin/components/elements/ReactSelect/MultiValue/index.tsx
+++ b/src/admin/components/elements/ReactSelect/MultiValue/index.tsx
@@ -51,7 +51,6 @@ export const MultiValue: React.FC<MultiValueProps<OptionType>> = (props) => {
         onMouseDown: (e) => {
           if (!disableMouseDown) {
             // we need to prevent the dropdown from opening when clicking on the drag handle, but not when a modal is open (i.e. the 'Relationship' field component)
-            e.preventDefault();
             e.stopPropagation();
           }
         },

--- a/src/admin/components/elements/ReactSelect/MultiValue/index.tsx
+++ b/src/admin/components/elements/ReactSelect/MultiValue/index.tsx
@@ -51,6 +51,7 @@ export const MultiValue: React.FC<MultiValueProps<OptionType>> = (props) => {
         onMouseDown: (e) => {
           if (!disableMouseDown) {
             // we need to prevent the dropdown from opening when clicking on the drag handle, but not when a modal is open (i.e. the 'Relationship' field component)
+            e.preventDefault();
             e.stopPropagation();
           }
         },

--- a/test/fields/collections/Relationship/index.ts
+++ b/test/fields/collections/Relationship/index.ts
@@ -53,6 +53,12 @@ const RelationshipFields: CollectionConfig = {
       hasMany: true,
       max: 2,
     },
+    {
+      name: 'relationshipHasMany',
+      type: 'relationship',
+      relationTo: 'text-fields',
+      hasMany: true,
+    },
   ],
 };
 

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -838,6 +838,70 @@ describe('fields', () => {
       await page.locator('.rs__option:has-text("Seeded text document")').click();
       await saveDocAndAssert(page);
     });
+
+
+    // Related issue: https://github.com/payloadcms/payload/issues/2815
+    test("should create hasMany relationship, open the drawer and modify a relation document's field", async () => {
+      await page.goto(url.create);
+
+      // First fill out the relationship field, as it's required
+      {
+        const button = page.locator('#relationship-add-new .relationship-add-new__add-button');
+        await button.click();
+        await page.locator('#field-relationship .relationship-add-new__relation-button--text-fields').click();
+
+        const textField = page.locator('#field-text');
+        const textValue = 'hello';
+
+        await textField.fill(textValue);
+
+        await page.locator('[id^=doc-drawer_text-fields_1_] #action-save').click();
+        await expect(page.locator('.Toastify')).toContainText('successfully');
+        await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click();
+        await page.locator('#action-save').click();
+        await expect(page.locator('.Toastify')).toContainText('successfully');
+      }
+
+      // Now the relationshipHasMany field
+      {
+        const button = page.locator('#relationshipHasMany-add-new').getByRole('button', { name: 'Add new Text Field' });
+        await button.click();
+
+        const textField = page.getByLabel('Text*');
+        const textValue = 'hello';
+
+        await textField.fill(textValue);
+
+        await page.locator('[id^=doc-drawer_text-fields_1_] #action-save').click();
+        await expect(page.locator('.Toastify')).toContainText('successfully');
+        await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click();
+        await page.locator('#action-save').click();
+        await expect(page.locator('.Toastify')).toContainText('successfully');
+      }
+
+      await page.reload();
+
+      // Now edit it
+      const textValue2 = '123';
+      {
+        const hasManyField = await page.locator('#field-relationshipHasMany > .relationship__wrap > .react-select-container > .react-select > .rs__control');
+        const editButton = await hasManyField.getByText('Edit Edit');
+        await editButton.click();
+        const textField2 = page.getByLabel('Text*');
+        await textField2.click();
+        await page.keyboard.down('1');
+        await page.keyboard.down('2');
+        await page.keyboard.down('3');
+        await page.locator('[id^=doc-drawer_text-fields_1_] #action-save').click();
+        await expect(page.locator('.Toastify')).toContainText('successfully');
+        await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click();
+        await page.locator('#action-save').click();
+        await expect(page.locator('.Toastify')).toContainText('successfully');
+      }
+
+      await page.reload();
+      await expect(page.locator('#field-relationshipHasMany .relationship--multi-value-label__text')).toContainText(textValue2);
+    });
   });
 
   describe('upload', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,13 +1855,13 @@
   dependencies:
     "@octokit/openapi-types" "^17.1.2"
 
-"@playwright/test@^1.32.3":
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.33.0.tgz#669ef859efb81b143dfc624eef99d1dd92a81b67"
-  integrity sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==
+"@playwright/test@^1.35.1":
+  version "1.35.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.35.1.tgz#a596b61e15b980716696f149cc7a2002f003580c"
+  integrity sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.33.0"
+    playwright-core "1.35.1"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -5413,10 +5413,10 @@ eslint-plugin-node@^11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
-eslint-plugin-playwright@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-playwright/-/eslint-plugin-playwright-0.11.2.tgz#876057d4ab19d00b44bf004e27d5ace2c8bffada"
-  integrity sha512-uRLRLk7uTzc8NE6t4wBU8dijQwHvC66R/h7xwdM779jsJjMUtSmeaB8ayRkkpfwi+UU5BEfwvDANwmE+ccMVDw==
+eslint-plugin-playwright@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-playwright/-/eslint-plugin-playwright-0.12.0.tgz#0c728e07c217b5ea48acef46c52eefba9cf8ebd3"
+  integrity sha512-KXuzQjVzca5irMT/7rvzJKsVDGbQr43oQPc8i+SLEBqmfrTxlwMwRqfv9vtZqh4hpU0jmrnA/EOfwtls+5QC1w==
 
 eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
@@ -9245,10 +9245,10 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-playwright-core@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.33.0.tgz#269efe29a927cd6d144d05f3c2d2f72bd72447a1"
-  integrity sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==
+playwright-core@1.35.1:
+  version "1.35.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.35.1.tgz#52c1e6ffaa6a8c29de1a5bdf8cce0ce290ffb81d"
+  integrity sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==
 
 pluralize@^8.0.0:
   version "8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,13 +1855,13 @@
   dependencies:
     "@octokit/openapi-types" "^17.1.2"
 
-"@playwright/test@^1.33.0":
-  version "1.35.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.35.1.tgz#a596b61e15b980716696f149cc7a2002f003580c"
-  integrity sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==
+"@playwright/test@1.33.0":
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.33.0.tgz#669ef859efb81b143dfc624eef99d1dd92a81b67"
+  integrity sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.35.1"
+    playwright-core "1.33.0"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -9245,10 +9245,10 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-playwright-core@1.35.1:
-  version "1.35.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.35.1.tgz#52c1e6ffaa6a8c29de1a5bdf8cce0ce290ffb81d"
-  integrity sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==
+playwright-core@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.33.0.tgz#269efe29a927cd6d144d05f3c2d2f72bd72447a1"
+  integrity sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==
 
 pluralize@^8.0.0:
   version "8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,7 +1855,7 @@
   dependencies:
     "@octokit/openapi-types" "^17.1.2"
 
-"@playwright/test@^1.35.1":
+"@playwright/test@^1.33.0":
   version "1.35.1"
   resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.35.1.tgz#a596b61e15b980716696f149cc7a2002f003580c"
   integrity sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==


### PR DESCRIPTION
## Description

Goal: Fixing #2815

The issue is this line: https://github.com/AlessioGr/payload/blob/fix-readonly-field-drawer/src/admin/components/elements/ReactSelect/MultiValue/index.tsx/#L54

Removing it fixes this issue. But I gotta have to find out what consequences that would have.

## Todo-list:

- [X] Add failing test
- [ ] Fix the actual issue 

## ...

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
