### PR TITLE
fix: slow like queries with lots of records

### DIFF
--- a/src/mongoose/buildQuery.ts
+++ b/src/mongoose/buildQuery.ts
@@ -372,6 +372,23 @@ export class ParamParser {
           }
         }
 
+        if (operator === 'like' && typeof formattedValue === 'string') {
+          const words = formattedValue.split(' ');
+
+          const result = {
+            value: {
+              $and: words.map((word) => ({
+                [path]: {
+                  $regex: word.replace(/[\\^$*+?\\.()|[\]{}]/g, '\\$&'),
+                  $options: 'i',
+                },
+              })),
+            },
+          };
+
+          return result;
+        }
+
         // Some operators like 'near' need to define a full query
         // so if there is no operator key, just return the value
         if (!operatorKey) {

--- a/src/mongoose/sanitizeQueryValue.ts
+++ b/src/mongoose/sanitizeQueryValue.ts
@@ -1,6 +1,5 @@
 import mongoose from 'mongoose';
 import { createArrayFromCommaDelineated } from './createArrayFromCommaDelineated';
-import wordBoundariesRegex from '../utilities/wordBoundariesRegex';
 import { Field, TabAsField } from '../fields/config/types';
 
 type SanitizeQueryValueArgs = {
@@ -106,11 +105,6 @@ export const sanitizeQueryValue = ({ field, path, operator, val, hasCustomID }: 
   if (path !== '_id' || (path === '_id' && hasCustomID && field.type === 'text')) {
     if (operator === 'contains') {
       formattedValue = { $regex: formattedValue, $options: 'i' };
-    }
-
-    if (operator === 'like' && typeof formattedValue === 'string') {
-      const $regex = wordBoundariesRegex(formattedValue);
-      formattedValue = { $regex };
     }
   }
 

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -648,6 +648,22 @@ describe('collections-rest', () => {
         expect(result.totalDocs).toEqual(1);
       });
 
+      it('like - cyrillic characters in multiple words', async () => {
+        const post1 = await createPost({ title: 'привет, это тест полезной нагрузки' });
+
+        const { status, result } = await client.find<Post>({
+          query: {
+            title: {
+              like: 'привет нагрузки',
+            },
+          },
+        });
+
+        expect(status).toEqual(200);
+        expect(result.docs).toEqual([post1]);
+        expect(result.totalDocs).toEqual(1);
+      });
+
       it('like - partial word match', async () => {
         const post = await createPost({ title: 'separate words should partially match' });
 


### PR DESCRIPTION
## Description

Fixes slow queries with 10s of thousands of docs caused by inefficient `like` regex.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
