### PR TITLE
fix: mobile loading overlay width #2866

### DIFF
--- a/src/admin/scss/app.scss
+++ b/src/admin/scss/app.scss
@@ -34,7 +34,7 @@
 
   @include mid-break {
     --gutter-h: #{base(2)};
-    --nav-width: 0;
+    --nav-width: 0px;
   }
 
   @include small-break {


### PR DESCRIPTION
## Description

Resolves #2866 which was caused by using the `--nav-width` css variable inside a `calc()` function when it's value was `0`. CSS is not capable of concatenating variables in this way, so this fix adds the `px` unit when it gets first defined.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
