### PR TITLE
fix: drawer closes when pressing backspace

### DIFF
--- a/src/admin/components/elements/ReactSelect/index.tsx
+++ b/src/admin/components/elements/ReactSelect/index.tsx
@@ -33,6 +33,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     isLoading,
     onMenuOpen,
     components,
+    selectProps,
   } = props;
 
   const classes = [
@@ -47,6 +48,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
       placeholder={getTranslation(placeholder, i18n)}
       captureMenuScroll
       {...props}
+      customProps={selectProps}
       value={value}
       onChange={onChange}
       isDisabled={disabled}

--- a/src/admin/components/elements/ReactSelect/types.ts
+++ b/src/admin/components/elements/ReactSelect/types.ts
@@ -65,4 +65,5 @@ export type Props = {
     [key: string]: React.FC<any>
   }
   selectProps?: CustomSelectProps
+  backspaceRemovesValue?: boolean
 }

--- a/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -375,6 +375,7 @@ const Relationship: React.FC<Props> = (props) => {
       {!errorLoading && (
         <div className={`${baseClass}__wrap`}>
           <ReactSelect
+            backspaceRemovesValue={!drawerIsOpen}
             disabled={readOnly || formProcessing}
             onInputChange={(newSearch) => handleInputChange(newSearch, value)}
             onChange={!readOnly ? (selected) => {

--- a/src/admin/components/forms/field-types/Relationship/select-components/SingleValue/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/select-components/SingleValue/index.tsx
@@ -18,9 +18,11 @@ export const SingleValue: React.FC<SingleValueProps<Option>> = (props) => {
       label,
     },
     children,
-    customProps: {
-      setDrawerIsOpen,
-      onSave,
+    selectProps: {
+      customProps: {
+        setDrawerIsOpen,
+        onSave,
+      } = {},
     } = {},
   } = props;
 
@@ -35,7 +37,9 @@ export const SingleValue: React.FC<SingleValueProps<Option>> = (props) => {
   });
 
   useEffect(() => {
-    if (typeof setDrawerIsOpen === 'function') setDrawerIsOpen(isDrawerOpen);
+    if (typeof setDrawerIsOpen === 'function') {
+      setDrawerIsOpen(isDrawerOpen);
+    }
   }, [isDrawerOpen, setDrawerIsOpen]);
 
   return (


### PR DESCRIPTION
## Description

Fixes #2840 (drawer closes when pressing backspace if the drawer is opened from a react-select, e.g. through relationships)

This also fixes props not being passed down to custom react-select components. Thus, this might fix a bunch of other issues. Who knows. Now it works.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
