### PR TITLE
fix: cutoff tooltips in relationship field

### DIFF
--- a/src/admin/components/elements/ReactSelect/ValueContainer/index.scss
+++ b/src/admin/components/elements/ReactSelect/ValueContainer/index.scss
@@ -2,6 +2,7 @@
 
 .value-container {
   flex-grow: 1;
+  min-width: 0;
 
   .rs__value-container {
     padding: base(.25) 0;

--- a/src/admin/components/forms/field-types/Relationship/index.scss
+++ b/src/admin/components/forms/field-types/Relationship/index.scss
@@ -11,7 +11,8 @@
     width: 100%;
 
     div.react-select {
-      flex-grow: 1;
+      width: 100%;
+      min-width: 0;
     }
   }
 

--- a/src/admin/components/forms/field-types/Relationship/select-components/SingleValue/index.scss
+++ b/src/admin/components/forms/field-types/Relationship/select-components/SingleValue/index.scss
@@ -2,6 +2,11 @@
 
 
 .relationship--single-value {
+  &.rs__single-value {
+    overflow: visible;
+    min-width: 0;
+  }
+
   &__label-text {
     max-width: unset;
     display: flex;


### PR DESCRIPTION
## Description

Tooltips within the relationship field were being cutoff by the `overflow: hidden` property. This only affected singular relationships, fields with `hasMany: true` were fine. This was tricky because the label in relationship field needs to ellipse its text without growing full-width by default or having a max-width. Here's a before and after: 

Before:
![Screenshot 2023-06-20 at 4 12 10 PM](https://github.com/payloadcms/payload/assets/15735305/d6940e66-e2c1-4e82-903f-d12e4a6d40a6)

After:
![Screenshot 2023-06-20 at 5 13 13 PM](https://github.com/payloadcms/payload/assets/15735305/7e1ba17a-5604-4e0e-a6c0-415d827fc1c0)
![Screenshot 2023-06-20 at 5 13 23 PM](https://github.com/payloadcms/payload/assets/15735305/66b1b4d4-954d-4f3f-8e2c-eb1f63fcc796)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes