### PR TITLE
fix: conditional fields perf bug - #2886

### DIFF
--- a/src/admin/components/forms/Form/fieldReducer.ts
+++ b/src/admin/components/forms/Form/fieldReducer.ts
@@ -49,7 +49,7 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
           // Besides those who still fail their own conditions
 
           if (passesCondition && field.condition) {
-            passesCondition = field.condition(reduceFieldsToValues(state), getSiblingData(state, path), { user });
+            passesCondition = field.condition(reduceFieldsToValues(state, true), getSiblingData(state, path), { user });
           }
 
           return {

--- a/src/admin/components/forms/withCondition/WatchCondition.tsx
+++ b/src/admin/components/forms/withCondition/WatchCondition.tsx
@@ -10,12 +10,14 @@ type Props = {
   path?: string
   name: string
   condition: Condition
+  setShowField: (isVisible: boolean) => void
 }
 
 export const WatchCondition: React.FC<Props> = ({
   path: pathFromProps,
   name,
   condition,
+  setShowField,
 }) => {
   const path = typeof pathFromProps === 'string' ? pathFromProps : name;
 
@@ -30,21 +32,26 @@ export const WatchCondition: React.FC<Props> = ({
   data.id = id;
 
   const hasCondition = Boolean(condition);
-  const currentlyPassesCondition = hasCondition ? condition(data, siblingData, { user }) : true;
+  const isPassingCondition = hasCondition ? condition(data, siblingData, { user }) : true;
   const field = fields[path];
-  const existingConditionPasses = field?.passesCondition;
+
+  const wasPassingCondition = field?.passesCondition;
 
   useEffect(() => {
     if (hasCondition) {
-      if (!existingConditionPasses && currentlyPassesCondition) {
+      if (isPassingCondition && !wasPassingCondition) {
         dispatchFields({ type: 'MODIFY_CONDITION', path, result: true, user });
       }
 
-      if (!currentlyPassesCondition && (existingConditionPasses || typeof existingConditionPasses === 'undefined')) {
+      if (!isPassingCondition && (wasPassingCondition || typeof wasPassingCondition === 'undefined')) {
         dispatchFields({ type: 'MODIFY_CONDITION', path, result: false, user });
       }
     }
-  }, [currentlyPassesCondition, existingConditionPasses, dispatchFields, path, hasCondition, user, fields]);
+  }, [isPassingCondition, wasPassingCondition, dispatchFields, path, hasCondition, user, setShowField]);
+
+  useEffect(() => {
+    setShowField(isPassingCondition);
+  }, [setShowField, isPassingCondition]);
 
   return null;
 };

--- a/src/admin/components/forms/withCondition/index.tsx
+++ b/src/admin/components/forms/withCondition/index.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import { FieldBase } from '../../../../fields/config/types';
 import { WatchCondition } from './WatchCondition';
-import { useFormFields } from '../Form/context';
 
 const withCondition = <P extends Record<string, unknown>>(Field: React.ComponentType<P>): React.FC<P> => {
   const CheckForCondition: React.FC<P> = (props) => {
@@ -31,15 +30,16 @@ const withCondition = <P extends Record<string, unknown>>(Field: React.Component
       path?: string
     };
 
-    const passesCondition = useFormFields(([fields]) => fields[path]?.passesCondition);
+    const [showField, setShowField] = React.useState(false);
 
-    if (passesCondition) {
+    if (showField) {
       return (
         <React.Fragment>
           <WatchCondition
             path={path}
             name={name}
             condition={condition}
+            setShowField={setShowField}
           />
           <Field {...props} />
         </React.Fragment>
@@ -51,6 +51,7 @@ const withCondition = <P extends Record<string, unknown>>(Field: React.Component
         path={path}
         name={name}
         condition={condition}
+        setShowField={setShowField}
       />
     );
   };

--- a/test/fields/collections/ConditionalLogic/index.ts
+++ b/test/fields/collections/ConditionalLogic/index.ts
@@ -37,7 +37,7 @@ const ConditionalLogic: CollectionConfig = {
       type: 'group',
       fields: [
         {
-          name: 'toggleSiblingField',
+          name: 'enableParentGroupFields',
           type: 'checkbox',
           defaultValue: false,
         },
@@ -45,11 +45,53 @@ const ConditionalLogic: CollectionConfig = {
           name: 'siblingField',
           type: 'text',
           admin: {
-            description: 'This conditional field ensures it can rely on nested fields inside `data` i.e. `data.parentGroup.toggleSiblingField`.',
-            condition: ({ parentGroup }) => parentGroup?.toggleSiblingField,
+            description: 'Ensures we can rely on nested fields within `data`.',
+            condition: ({ parentGroup }) => Boolean(parentGroup?.enableParentGroupFields),
           },
         },
       ],
+    },
+    {
+      name: 'reliesOnParentGroup',
+      type: 'text',
+      admin: {
+        description: 'Ensures we can rely on nested fields within `siblingsData`.',
+        condition: (_, { parentGroup }) => Boolean(parentGroup?.enableParentGroupFields),
+      },
+    },
+    {
+      name: 'groupSelection',
+      type: 'select',
+      options: [
+        'group1',
+        'group2',
+      ],
+    },
+    {
+      name: 'group1',
+      type: 'group',
+      fields: [
+        {
+          name: 'group1Field',
+          type: 'text',
+        },
+      ],
+      admin: {
+        condition: ({ groupSelection }) => groupSelection === 'group1',
+      },
+    },
+    {
+      name: 'group2',
+      type: 'group',
+      fields: [
+        {
+          name: 'group2Field',
+          type: 'text',
+        },
+      ],
+      admin: {
+        condition: ({ groupSelection }) => groupSelection === 'group2',
+      },
     },
   ],
 };

--- a/test/fields/collections/ConditionalLogic/index.ts
+++ b/test/fields/collections/ConditionalLogic/index.ts
@@ -32,6 +32,25 @@ const ConditionalLogic: CollectionConfig = {
         },
       },
     },
+    {
+      name: 'parentGroup',
+      type: 'group',
+      fields: [
+        {
+          name: 'toggleSiblingField',
+          type: 'checkbox',
+          defaultValue: false,
+        },
+        {
+          name: 'siblingField',
+          type: 'text',
+          admin: {
+            description: 'This conditional field ensures it can rely on nested fields inside `data` i.e. `data.parentGroup.toggleSiblingField`.',
+            condition: ({ parentGroup }) => parentGroup?.toggleSiblingField,
+          },
+        },
+      ],
+    },
   ],
 };
 

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -1039,10 +1039,24 @@ describe('fields', () => {
       await expect(fieldToToggle).toBeVisible();
     });
 
-    test('should show conditionl field based on user data', async () => {
+    test('should show conditional field based on user data', async () => {
       await page.goto(url.create);
       const userConditional = page.locator('input#field-userConditional');
       await expect(userConditional).toBeVisible();
+    });
+
+    test('should allow conditional fields to rely on unflattened form data', async () => {
+      await page.goto(url.create);
+
+      const parentGroupFields = page.locator('div#field-parentGroup > .group-field__wrap > .render-fields');
+      await expect(parentGroupFields).toHaveCount(1);
+
+      const toggleSiblingFieldWithinParentGroup = page.locator('label[for=field-parentGroup__toggleSiblingField]');
+      await toggleSiblingFieldWithinParentGroup.click();
+
+      const toggledField = page.locator('input#field-parentGroup__siblingField');
+
+      await expect(toggledField).toBeVisible();
     });
   });
 });

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -1045,18 +1045,28 @@ describe('fields', () => {
       await expect(userConditional).toBeVisible();
     });
 
-    test('should allow conditional fields to rely on unflattened form data', async () => {
+    test('should show conditional field based on fields nested within data', async () => {
       await page.goto(url.create);
 
       const parentGroupFields = page.locator('div#field-parentGroup > .group-field__wrap > .render-fields');
       await expect(parentGroupFields).toHaveCount(1);
 
-      const toggleSiblingFieldWithinParentGroup = page.locator('label[for=field-parentGroup__toggleSiblingField]');
-      await toggleSiblingFieldWithinParentGroup.click();
+      const toggle = page.locator('label[for=field-parentGroup__enableParentGroupFields]');
+      await toggle.click();
 
       const toggledField = page.locator('input#field-parentGroup__siblingField');
 
       await expect(toggledField).toBeVisible();
+    });
+
+    test('should show conditional field based on fields nested within siblingData', async () => {
+      await page.goto(url.create);
+
+      const toggle = page.locator('label[for=field-parentGroup__enableParentGroupFields]');
+      await toggle.click();
+
+      const fieldRelyingOnSiblingData = page.locator('input#field-reliesOnParentGroup');
+      await expect(fieldRelyingOnSiblingData).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes #2886

PR #2856 introduced a bug where conditional fields inside group/tab were causing infinite re-renders and not working correctly for group & tab fields.

In that PR we were attempting to use form state to see if fields have the flag `passesCondition` on them. We were accessing them via `fields[path]` but fields such as group/tab do not have form state so they always returned false and the field never rendered.

This PR proposes a different option where we pass a setter/callback function down to `<WatchCondition/>` and that component will set the internal state on the `<WithCondition/>` component when it dispatches to form state.

This also fixes a bug where conditions were being called incorrectly inside the fieldReducers `'MODIFY_CONDITION'` action. It was passing flattened state but should have been passing the full unflattened object.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
