### PR TITLE
fix: incorrect graphql type generation

### DIFF
--- a/src/graphql/schema/withOperators.ts
+++ b/src/graphql/schema/withOperators.ts
@@ -2,7 +2,7 @@ import { GraphQLBoolean, GraphQLInputObjectType, GraphQLString, GraphQLList, Gra
 import type { GraphQLType } from 'graphql';
 import { GraphQLJSON } from 'graphql-type-json';
 import { DateTimeResolver, EmailAddressResolver } from 'graphql-scalars';
-import { FieldAffectingData, NumberField, RadioField, RelationshipField, SelectField, optionIsObject } from '../../fields/config/types';
+import { FieldAffectingData, RadioField, SelectField, optionIsObject } from '../../fields/config/types';
 import combineParentName from '../utilities/combineParentName';
 import formatName from '../utilities/formatName';
 import operators from './operators';
@@ -27,10 +27,7 @@ type DefaultsType = {
 
 const defaults: DefaultsType = {
   number: {
-    type: (field: NumberField): GraphQLType => {
-      const type = field?.name === 'id' ? GraphQLInt : GraphQLFloat;
-      return field?.hasMany === true ? new GraphQLList(type) : type;
-    },
+    type: GraphQLInt,
     operators: [...operators.equality, ...operators.comparison],
   },
   text: {
@@ -89,9 +86,7 @@ const defaults: DefaultsType = {
     operators: [...operators.equality, ...operators.comparison, ...operators.geo],
   },
   relationship: {
-    type: (field: RelationshipField): GraphQLType => {
-      return field?.hasMany === true ? new GraphQLList(GraphQLString) : GraphQLString;
-    },
+    type: GraphQLString,
     operators: [...operators.equality, ...operators.contains],
   },
   upload: {


### PR DESCRIPTION
## Description

Fixes issue described [on discord](https://discord.com/channels/967097582721572934/1121757896267550801).

Types were being incorrectly generated. The `contains` operators are already wrapped in a GraphQLList outside of the defaults. Other operators such as `equals`, does not need to be inside a List. Passing a string or an array both result in the same outcome.

I do think this file could be further improved in the future and create union types for things like this.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
