### PR TITLE
fix: safely check for tempFilePath when updating media document

### DIFF
--- a/src/uploads/unlinkTempFiles.ts
+++ b/src/uploads/unlinkTempFiles.ts
@@ -25,7 +25,7 @@ export const unlinkTempFiles: (args: Args) => Promise<void> = async ({
     const fileArray = Array.isArray(files) ? files : [files];
     await mapAsync(fileArray, async ({ file }) => {
       // Still need this check because this will not be populated if using local API
-      if (file.tempFilePath) {
+      if (file?.tempFilePath) {
         await unlinkFile(file.tempFilePath);
       }
     });


### PR DESCRIPTION
## Description

If `useTempFiles` is enabled, and a media record is being updated without providing the file, the check was not being safely done and throwing an error during update.

This fix checks the value safely.

```
13:45:51] ERROR (payload): TypeError: Cannot read properties of undefined (reading 'tempFilePath')
```

[A user in Discord](https://discord.com/channels/967097582721572934/1120349686629404792) was also getting a similar error when using `plugin-cloud`.


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

