### PR TITLE
fix: autosave on localized fields, adds test

### DIFF
--- a/src/admin/components/elements/Autosave/index.tsx
+++ b/src/admin/components/elements/Autosave/index.tsx
@@ -32,6 +32,7 @@ const Autosave: React.FC<Props> = ({ collection, global, id, publishedDocUpdated
   const debouncedFields = useDebounce(fields, interval);
   const fieldRef = useRef(fields);
   const modifiedRef = useRef(modified);
+  const localeRef = useRef(locale);
 
   // Store fields in ref so the autosave func
   // can always retrieve the most to date copies
@@ -85,12 +86,12 @@ const Autosave: React.FC<Props> = ({ collection, global, id, publishedDocUpdated
         let method: string;
 
         if (collection && id) {
-          url = `${serverURL}${api}/${collection.slug}/${id}?draft=true&autosave=true&locale=${locale}`;
+          url = `${serverURL}${api}/${collection.slug}/${id}?draft=true&autosave=true&locale=${localeRef.current}`;
           method = 'PATCH';
         }
 
         if (global) {
-          url = `${serverURL}${api}/globals/${global.slug}?draft=true&autosave=true&locale=${locale}`;
+          url = `${serverURL}${api}/globals/${global.slug}?draft=true&autosave=true&locale=${localeRef.current}`;
           method = 'POST';
         }
 
@@ -125,7 +126,7 @@ const Autosave: React.FC<Props> = ({ collection, global, id, publishedDocUpdated
     };
 
     autosave();
-  }, [i18n, debouncedFields, modified, serverURL, api, collection, global, id, getVersions, locale, modifiedRef]);
+  }, [i18n, debouncedFields, modified, serverURL, api, collection, global, id, getVersions, localeRef, modifiedRef]);
 
   useEffect(() => {
     if (versions?.docs?.[0]) {

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -116,16 +116,6 @@ describe('versions', () => {
 
     test('should retain localized data during autosave', async () => {
       const autosaveURL = new AdminUrlUtil(serverURL, autosaveSlug);
-      // .fill localized and non localized fields
-      // wait however long you need for it to autosave, using the wait utility
-      // click locale selector and change locale (harvest from localize test suite)
-      // fill localized and non localized fields again
-      // wait again for autosave
-      // click locale selector and change locale back to original
-      // .fill non localized field
-      // switch locales
-      // figure out how to force a page reload
-
       const locale = 'en';
       const spanishLocale = 'es';
       const title = 'english title';
@@ -151,11 +141,6 @@ describe('versions', () => {
       await page.reload();
       await expect(page.locator('#field-title')).toHaveValue(spanishTitle);
       await expect(page.locator('#field-description')).toHaveValue(newDescription);
-
-      // await changeLocale(locale);
-      // await wait(500);
-      // await expect(page.locator('#field-title')).toHaveValue(title);
-      // await expect(page.locator('#field-description')).toHaveValue(description);
     });
   });
 

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -29,7 +29,8 @@ import { expect, test } from '@playwright/test';
 import { initPayloadE2E } from '../helpers/configHelpers';
 import { AdminUrlUtil } from '../helpers/adminUrlUtil';
 import { login } from '../helpers';
-import { draftSlug } from './shared';
+import { draftSlug, autosaveSlug } from './shared';
+import wait from '../../src/utilities/wait';
 
 const { beforeAll, describe } = test;
 
@@ -112,5 +113,55 @@ describe('versions', () => {
       await expect(page.locator('.row-1 .cell-_status')).toContainText('Draft');
       await expect(page.locator('.row-2 .cell-_status')).toContainText('Draft');
     });
+
+    test('should retain localized data during autosave', async () => {
+      const autosaveURL = new AdminUrlUtil(serverURL, autosaveSlug);
+      // .fill localized and non localized fields
+      // wait however long you need for it to autosave, using the wait utility
+      // click locale selector and change locale (harvest from localize test suite)
+      // fill localized and non localized fields again
+      // wait again for autosave
+      // click locale selector and change locale back to original
+      // .fill non localized field
+      // switch locales
+      // figure out how to force a page reload
+
+      const locale = 'en';
+      const spanishLocale = 'es';
+      const title = 'english title';
+      const spanishTitle = 'spanish title';
+      const description = 'description';
+      const newDescription = 'new description';
+
+      await page.goto(autosaveURL.create);
+      await page.locator('#field-title').fill(title);
+      await page.locator('#field-description').fill(description);
+      await wait(500);
+
+      await changeLocale(spanishLocale);
+      await page.locator('#field-title').fill(spanishTitle);
+      await wait(500);
+
+      await changeLocale(locale);
+      await page.locator('#field-description').fill(newDescription);
+      await wait(500);
+
+      await changeLocale(spanishLocale);
+      await wait(500);
+      await page.reload();
+      await expect(page.locator('#field-title')).toHaveValue(spanishTitle);
+      await expect(page.locator('#field-description')).toHaveValue(newDescription);
+
+      // await changeLocale(locale);
+      // await wait(500);
+      // await expect(page.locator('#field-title')).toHaveValue(title);
+      // await expect(page.locator('#field-description')).toHaveValue(description);
+    });
   });
+
+  async function changeLocale(newLocale: string) {
+    await page.locator('.localizer >> button').first().click();
+    await page.locator(`.localizer >> a:has-text("${newLocale}")`).click();
+    expect(page.url()).toContain(`locale=${newLocale}`);
+  }
 });


### PR DESCRIPTION
## Description

Prevents autosave running on locale change and adds e2e test.

Closes #2878 

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
