### PR TITLE
fix: adjusts swc loader to only exclude non ts/tsx files - #2888

### DIFF
--- a/src/webpack/getBaseConfig.ts
+++ b/src/webpack/getBaseConfig.ts
@@ -19,7 +19,7 @@ export default (config: SanitizedConfig): Configuration => ({
     rules: [
       {
         test: /\.(t|j)sx?$/,
-        exclude: /node_modules/,
+        exclude: /\/node_modules\/(?!.+\.tsx?$).*$/,
         use: [
           {
             loader: require.resolve('swc-loader'),


### PR DESCRIPTION
## Description

Fixes #2888 

Ensures SWC loader sill runs against ts/tsx files in the node_modules folder.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
