### PR TITLE
fix: shows updatedAt date when selecting a version to compare

### DIFF
--- a/src/admin/components/views/Version/Compare/index.tsx
+++ b/src/admin/components/views/Version/Compare/index.tsx
@@ -76,7 +76,7 @@ const CompareVersion: React.FC<Props> = (props) => {
         setOptions((existingOptions) => [
           ...existingOptions,
           ...data.docs.map((doc) => ({
-            label: formatDate(doc.createdAt, dateFormat, i18n?.language),
+            label: formatDate(doc.updatedAt, dateFormat, i18n?.language),
             value: doc.id,
           })),
         ]);


### PR DESCRIPTION
## Description

Resolves #2915. Replaces `createdAt` value with `updatedAt` value when selecting a version to compare from the dropdown menu.

<img width="962" alt="Screenshot 2023-06-28 at 10 51 50 AM" src="https://github.com/payloadcms/payload/assets/89618855/e1af1a0f-a2a5-4b87-9198-a4dd4f6808da">

___
- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
