### PR TITLE
fix: ensures fields within blocks respect field level access control

### DIFF
--- a/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -273,7 +273,7 @@ const BlocksField: React.FC<Props> = (props) => {
                         className={`${baseClass}__fields`}
                         readOnly={readOnly}
                         fieldTypes={fieldTypes}
-                        permissions={permissions?.fields}
+                        permissions={permissions?.blocks?.[blockType]?.fields}
                         fieldSchema={blockToRender.fields.map((field) => ({
                           ...field,
                           path: createNestedFieldPath(`${path}.${i}`, field),

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -20,7 +20,14 @@ export type FieldPermissions = {
     permission: boolean
   }
   fields?: {
-    [field: string]: FieldPermissions
+    [fieldName: string]: FieldPermissions
+  }
+  blocks?: {
+    [blockSlug: string]: {
+      fields: {
+        [fieldName: string]: FieldPermissions
+      }
+    }
   }
 }
 
@@ -31,7 +38,7 @@ export type CollectionPermission = {
   delete: Permission
   readVersions?: Permission
   fields: {
-    [field: string]: FieldPermissions
+    [fieldName: string]: FieldPermissions
   }
 }
 
@@ -40,7 +47,7 @@ export type GlobalPermission = {
   update: Permission
   readVersions?: Permission
   fields: {
-    [field: string]: FieldPermissions
+    [fieldName: string]: FieldPermissions
   }
 }
 


### PR DESCRIPTION
## Description

Fixes #2724

Fields inside blocks were not respecting access control. This extends the policy structure from the doc access endpoint to return field level access control scoped to block types.

Extended response shape from `/api/${doc-slug}/access/${doc-id}` looks like:
```json
{
  "fields": {
    "layoutBlocks": {
      "blocks": { // <-- new key to store block fields
        "textBlock": { // <-- blocks are scoped via slug
          "fields": {
            "textField": {
              "read": {
                "permission": true
              },
              "delete": {
                "permission": true
              },
              "create": {
                "permission": false
              },
              "update": {
                "permission": false
              }
            }
          }
        }
      }
      // ... field level permissions
    }
  }
}
```

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
