### PR TITLE
docs: fixes misc links

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -85,14 +85,15 @@ You can override components on a Collection-by-Collection basis via each Collect
 | **`edit.SaveDraftButton`** | Replace the default `Save Draft` button with a custom component. Drafts must be enabled and autosave must be disabled. |
 | **`edit.PublishButton`**   | Replace the default `Publish` button with a custom component. Drafts must be enabled.                                  |
 | **`edit.PreviewButton`**   | Replace the default `Preview` button with a custom component.                                                          |
-| **`BeforeList`**   | Array of components to inject _before_ the built-in List view
-                                                         |
-| **`BeforeListTable`**   | Array of components to inject _before_ the built-in List view's table
-                                                         |
-| **`AfterListTable`**   | Array of components to inject _after_ the built-in List view's table
-                                                         |
-| **`AfterList`**   | Array of components to inject _after_ the built-in List view
-                                                         |
+| **`BeforeList`**           | Array of components to inject _before_ the built-in List view                                                          |
+|  |
+| **`BeforeListTable`**      | Array of components to inject _before_ the built-in List view's table                                                  |
+|  |
+| **`AfterListTable`**       | Array of components to inject _after_ the built-in List view's table                                                   |
+|  |
+| **`AfterList`**            | Array of components to inject _after_ the built-in List view                                                           |
+|  |
+
 #### Examples
 
 ```tsx
@@ -146,6 +147,7 @@ export const CustomPreviewButton: CustomPreviewButtonProps = ({
 ##### Custom Collection List View Example
 
 Collection.ts
+
 ```tsx
 import { MyListComponent } from './MyListComponent';
 export const MyCollection: CollectionConfig = {
@@ -164,12 +166,16 @@ export const MyCollection: CollectionConfig = {
 ```
 
 MyListComponent.tsx
+
 ```tsx
-import React from 'react';
-import {List, type Props} from 'payload/components/views/List' // Payload's default List view component and its props
+import React from "react";
+import { List, type Props } from "payload/components/views/List"; // Payload's default List view component and its props
 export const MyListComponent: React.FC<Props> = (props) => (
   <div>
-    <p>Some text before the default list view component. If you just want to do that, you can also use the admin.components.list.BeforeList hook</p>
+    <p>
+      Some text before the default list view component. If you just want to do
+      that, you can also use the admin.components.list.BeforeList hook
+    </p>
     <List {...props} />
   </div>
 );
@@ -260,11 +266,8 @@ const CustomTextField: React.FC<Props> = ({ path }) => {
 
 <Banner type="success">
   For more information regarding the hooks that are available to you while you
-  build custom components, including the <strong>useField</strong> hook,{" "}
-  <a href="/docs/admin/hooks" style={{ color: "black" }}>
-    click here
-  </a>
-  .
+  build custom components, including the <strong>useField</strong> hook, [click
+  here](/docs/admin/hooks).
 </Banner>
 
 ## Custom routes

--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -25,7 +25,7 @@ _Screenshot of the Admin panel while editing a document from an example `AllFiel
 All options for the Admin panel are defined in your base Payload config file.
 
 | Option                | Description                                                                                                                                                                                                                                                  |
-| --------------------- | -------------------------------------------------------------------------------------------------- |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- |
 | `user`                | The `slug` of a Collection that you want be used to log in to the Admin dashboard. [More](/docs/admin/overview#the-admin-user-collection)                                                                                                                    |
 | `buildPath`           | Specify an absolute path for where to store the built Admin panel bundle used in production. Defaults to `path.resolve(process.cwd(), 'build')`.                                                                                                             |
 | `meta`                | Base meta data to use for the Admin panel. Included properties are `titleSuffix`, `ogImage`, and `favicon`.                                                                                                                                                  |
@@ -45,8 +45,8 @@ All options for the Admin panel are defined in your base Payload config file.
 <Banner type="warning">
   <strong>Important:</strong>
   <br />
-  The Payload Admin panel can only be used by one Collection that supports{" "}
-  <a href="/docs/authentication/overview">Authentication</a>.
+  The Payload Admin panel can only be used by one Collection that supports
+  [Authentication](/docs/authentication/overview).
 </Banner>
 
 To specify which Collection to use to log in to the Admin panel, pass the `admin` options a `user` key equal to the slug of the Collection that you'd like to use.

--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -11,44 +11,49 @@ Not only does Payload support managing localized content, it also has internatio
 While Payload's built-in features come translated, you may want to also translate parts of your project's configuration too. This is possible in places like collections and globals labels and groups, field labels, descriptions and input placeholder text. The admin UI will display all the correct translations you provide based on the user's language.
 
 Here is an example of a simple collection supporting both English and Spanish editors:
+
 ```ts
-import { CollectionConfig } from 'payload/types';
+import { CollectionConfig } from "payload/types";
 
 export const Articles: CollectionConfig = {
-  slug: 'articles',
+  slug: "articles",
   labels: {
     singular: {
-      en: 'Article', es: 'Artículo',
+      en: "Article",
+      es: "Artículo",
     },
     plural: {
-      en: 'Articles', es: 'Artículos',
+      en: "Articles",
+      es: "Artículos",
     },
   },
   admin: {
-    group: { en: 'Content', es: 'Contenido' },
+    group: { en: "Content", es: "Contenido" },
   },
   fields: [
     {
-      name: 'title',
-      type: 'text',
+      name: "title",
+      type: "text",
       label: {
-        en: 'Title', es: 'Título',
+        en: "Title",
+        es: "Título",
       },
       admin: {
-        placeholder: { en: 'Enter title', es: 'Introduce el título' }
-      }
+        placeholder: { en: "Enter title", es: "Introduce el título" },
+      },
     },
     {
-      name: 'type',
-      type: 'radio',
-      options: [{
-        value: 'news',
-        label: { en: 'News', es: 'Noticias' },
-      }, // etc...
+      name: "type",
+      type: "radio",
+      options: [
+        {
+          value: "news",
+          label: { en: "News", es: "Noticias" },
+        }, // etc...
       ],
     },
   ],
-}
+};
 ```
 
 ### Admin UI
@@ -57,8 +62,10 @@ The Payload admin panel reads the language settings of a user's browser and disp
 After a user logs in, they can change their language selection in the `/account` view.
 
 <Banner>
-  <strong>Note:</strong><br/>
-  If there is a language that Payload does not yet support, we accept code <a href="https://github.com/payloadcms/payload/blob/master/contributing.md">contributions</a>.
+  <strong>Note:</strong>
+  <br />
+  If there is a language that Payload does not yet support, we accept code
+  [contributions](https://github.com/payloadcms/payload/blob/master/contributing.md).
 </Banner>
 
 ### Node Express
@@ -76,21 +83,22 @@ In your Payload config, you can add translations and customize the settings in `
 **Example Payload config extending i18n:**
 
 ```ts
-import { buildConfig } from 'payload/config'
+import { buildConfig } from "payload/config";
 
 export default buildConfig({
   //...
   i18n: {
-    fallbackLng: 'en', // default
+    fallbackLng: "en", // default
     debug: false, // default
     resources: {
       en: {
-        custom: { // namespace can be anything you want
-          key1: 'Translation with {{variable}}', // translation
+        custom: {
+          // namespace can be anything you want
+          key1: "Translation with {{variable}}", // translation
         },
         // override existing translation keys
         general: {
-          dashboard: 'Home',
+          dashboard: "Home",
         },
       },
     },

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -122,9 +122,8 @@ project-name
   <br />
   If you use an environment variable to configure any properties that are
   required for the Admin panel to function (ex. serverURL or any routes), you
-  need to make sure that your Admin panel code can access it.{" "}
-  <a href="/docs/admin/webpack#admin-environment-vars">Click here</a> for more
-  info.
+  need to make sure that your Admin panel code can access it. [Click
+  here](/docs/admin/webpack#admin-environment-vars) for more info.
 </Banner>
 
 ### Customizing & overriding the config location

--- a/docs/email/overview.mdx
+++ b/docs/email/overview.mdx
@@ -25,21 +25,22 @@ in the `email` property object of your payload init call. Payload will make use 
 
 The following options are configurable in the `email` property object as part of the options object when calling payload.init().
 
-| Option                       | Description  |
-| ---------------------------- | -------------|
-| **`fromName`** *             | The name part of the From field that will be seen on the delivered email |
-| **`fromAddress`** *          | The email address part of the From field that will be used when delivering email |
-| **`transport`**              | The NodeMailer transport object for when you want to do it yourself, not needed when transportOptions is set |
-| **`transportOptions`**       | An object that configures the transporter that Payload will create. For all the available options see the [NodeMailer documentation](https://nodemailer.com/smtp/) or see the examples below |
-| **`logMockCredentials`**          | If set to true and no transport/transportOptions, ethereal credentials will be logged to console on startup |
+| Option                   | Description                                                                                                                                                                                  |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`fromName`** \*        | The name part of the From field that will be seen on the delivered email                                                                                                                     |
+| **`fromAddress`** \*     | The email address part of the From field that will be used when delivering email                                                                                                             |
+| **`transport`**          | The NodeMailer transport object for when you want to do it yourself, not needed when transportOptions is set                                                                                 |
+| **`transportOptions`**   | An object that configures the transporter that Payload will create. For all the available options see the [NodeMailer documentation](https://nodemailer.com/smtp/) or see the examples below |
+| **`logMockCredentials`** | If set to true and no transport/transportOptions, ethereal credentials will be logged to console on startup                                                                                  |
 
-*\* An asterisk denotes that a property is required.*
+_\* An asterisk denotes that a property is required._
 
 ### Use SMTP
 
 Simple Mail Transfer Protocol, also known as SMTP can be passed in using the `transportOptions` object on the `email` options.
 
 **Example email part using SMTP:**
+
 ```ts
 payload.init({
   email: {
@@ -47,24 +48,26 @@ payload.init({
       host: process.env.SMTP_HOST,
       auth: {
         user: process.env.SMTP_USER,
-        pass: process.env.SMTP_PASS
+        pass: process.env.SMTP_PASS,
       },
       port: 587,
       secure: true, // use TLS
       tls: {
         // do not fail on invalid certs
-        rejectUnauthorized: false
-        }
+        rejectUnauthorized: false,
       },
-    fromName: 'hello',
-    fromAddress: 'hello@example.com'
-  }
+    },
+    fromName: "hello",
+    fromAddress: "hello@example.com",
+  },
   // ...
-})
+});
 ```
 
 <Banner type="warning">
-  It is best practice to avoid saving credentials or API keys directly in your code, use <a href="/docs/configuration/overview#using-environment-variables-in-your-config">environment variables</a>.
+  It is best practice to avoid saving credentials or API keys directly in your
+  code, use [environment
+  variables](/docs/configuration/overview#using-environment-variables-in-your-config).
 </Banner>
 
 ### Use an email service
@@ -72,57 +75,62 @@ payload.init({
 Many third party mail providers are available and offer benefits beyond basic SMTP. As an example your payload init could look this if you wanted to use SendGrid.com though the same approach would work for any other [NodeMailer transports](https://nodemailer.com/transports/) shown here or provided by another third party.
 
 ```ts
-import payload from 'payload'
-import nodemailerSendgrid from 'nodemailer-sendgrid'
+import payload from "payload";
+import nodemailerSendgrid from "nodemailer-sendgrid";
 
 const sendGridAPIKey = process.env.SENDGRID_API_KEY;
 
 payload.init({
-  ...sendGridAPIKey ? {
-    email: {
-      transportOptions: nodemailerSendgrid({
-        apiKey: sendGridAPIKey,
-      }),
-      fromName: 'Admin',
-      fromAddress: 'admin@example.com',
-    },
-  } : {},
+  ...(sendGridAPIKey
+    ? {
+        email: {
+          transportOptions: nodemailerSendgrid({
+            apiKey: sendGridAPIKey,
+          }),
+          fromName: "Admin",
+          fromAddress: "admin@example.com",
+        },
+      }
+    : {}),
 });
 ```
 
 ### Use a custom NodeMailer transport
+
 To take full control of the mail transport you may wish to use `nodemailer.createTransport()` on your server and provide it to Payload init.
 
 ```ts
-import payload from 'payload'
-import nodemailer from 'nodemailer'
+import payload from "payload";
+import nodemailer from "nodemailer";
 
-const payload = require('payload');
-const nodemailer = require('nodemailer');
+const payload = require("payload");
+const nodemailer = require("nodemailer");
 
 const transport = await nodemailer.createTransport({
   host: process.env.SMTP_HOST,
   port: 587,
   auth: {
     user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASS
+    pass: process.env.SMTP_PASS,
   },
 });
 
 payload.init({
   email: {
-    fromName: 'Admin',
-    fromAddress: 'admin@example.com',
-    transport
+    fromName: "Admin",
+    fromAddress: "admin@example.com",
+    transport,
   },
   // ...
 });
 ```
 
 ### Sending Mail
+
 With a working transport you can call it anywhere you have access to payload by calling `payload.sendEmail(message)`. The `message` will contain the `to`, `subject` and `email` or `text` for the email being sent. To see all available message configuration options see [NodeMailer](https://nodemailer.com/message).
 
 ### Mock transport
+
 By default, Payload uses a mock implementation that only sends mail to the [ethereal](https://ethereal.email) capture service that will never reach a user's inbox. While in development you may wish to make use of the captured messages which is why the payload output during server output helpfully logs this out on the server console.
 
 To see ethereal credentials, add `logMockCredentials: true` to the email options. This will cause them to be logged to console on startup.
@@ -130,8 +138,8 @@ To see ethereal credentials, add `logMockCredentials: true` to the email options
 ```ts
 payload.init({
   email: {
-    fromName: 'Admin',
-    fromAddress: 'admin@example.com',
+    fromName: "Admin",
+    fromAddress: "admin@example.com",
     logMockCredentials: true, // Optional
   },
   // ...
@@ -139,6 +147,7 @@ payload.init({
 ```
 
 **Console output when starting payload with a mock email instance and logMockCredentials: true**
+
 ```
 [06:37:21] INFO  (payload): Starting Payload...
 [06:37:22] INFO  (payload): Payload Demo Initialized
@@ -153,7 +162,8 @@ payload.init({
 The mock email handler is used when payload is started with neither `transport` or `transportOptions` to know how to deliver email.
 
 <Banner type="warning">
-  The randomly generated email account username and password will be different each time the Payload server starts.
+  The randomly generated email account username and password will be different
+  each time the Payload server starts.
 </Banner>
 
 ### Using multiple mail providers

--- a/docs/fields/relationship.mdx
+++ b/docs/fields/relationship.mdx
@@ -25,8 +25,8 @@ keywords: relationship, fields, config, configuration, documentation, Content Ma
 | **`relationTo`** \* | Provide one or many collection `slug`s to be able to assign relationships to.                                                                                                                       |
 | **`filterOptions`** | A query to filter which options appear in the UI and validate against. [More](#filtering-relationship-options).                                                                                     |
 | **`hasMany`**       | Boolean when, if set to `true`, allows this field to have many relations instead of only one.                                                                                                       |
-| **`minRows`**           | A number for the fewest allowed items during validation when a value is present. Used with `hasMany`.                                                                                               |
-| **`maxRows`**           | A number for the most allowed items during validation when a value is present. Used with `hasMany`.                                                                                                 |
+| **`minRows`**       | A number for the fewest allowed items during validation when a value is present. Used with `hasMany`.                                                                                               |
+| **`maxRows`**       | A number for the most allowed items during validation when a value is present. Used with `hasMany`.                                                                                                 |
 | **`maxDepth`**      | Sets a number limit on iterations of related documents to populate when queried. [Depth](/docs/getting-started/concepts#depth)                                                                      |
 | **`label`**         | Text used as a field label in the Admin panel or an object with keys for each language.                                                                                                             |
 | **`unique`**        | Enforce that each entry in the Collection has a unique value for this field.                                                                                                                        |
@@ -47,8 +47,8 @@ _\* An asterisk denotes that a property is required._
 <Banner type="success">
   <strong>Tip:</strong>
   <br />
-  The <a href="/docs/getting-started/concepts#depth">Depth</a> parameter can be
-  used to automatically populate related documents that are returned by the API.
+  The [Depth](/docs/getting-started/concepts#depth) parameter can be used to
+  automatically populate related documents that are returned by the API.
 </Banner>
 
 ### Admin config

--- a/docs/fields/upload.mdx
+++ b/docs/fields/upload.mdx
@@ -6,13 +6,18 @@ desc: Upload fields will allow a file to be uploaded, only from a collection sup
 keywords: upload, images media, fields, config, configuration, documentation, Content Management System, cms, headless, javascript, node, react, express
 ---
 
-<Banner >
-  The Upload field allows for the selection of a Document from a collection supporting Uploads, and formats the selection as a thumbnail in the Admin panel.
+<Banner>
+  The Upload field allows for the selection of a Document from a collection
+  supporting Uploads, and formats the selection as a thumbnail in the Admin
+  panel.
 </Banner>
 
 <Banner type="warning">
-  <strong>Important:</strong><br/>
-  To use this field, you need to have a Collection configured to allow Uploads. For more information, <a href="/docs/upload/overview">click here</a> to read about how to enable Uploads on a collection by collection basis.
+  <strong>Important:</strong>
+  <br />
+  To use this field, you need to have a Collection configured to allow Uploads.
+  For more information, [click here](/docs/upload/overview) to read about how to
+  enable Uploads on a collection by collection basis.
 </Banner>
 
 **Example uses:**
@@ -23,10 +28,10 @@ keywords: upload, images media, fields, config, configuration, documentation, Co
 
 ### Config
 
-| Option           | Description                                                                                                                                                                                         |
-| ---------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **`name`** *         | To be used as the property name when stored and retrieved from the database. [More](/docs/fields/overview#field-names)                                                                              |
-| **`*relationTo`** *  | Provide a single collection `slug` to allow this field to accept a relation to. <strong>Note: the related collection must be configured to support Uploads.</strong>                                |
+| Option               | Description                                                                                                                                                                                         |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`name`** \*        | To be used as the property name when stored and retrieved from the database. [More](/docs/fields/overview#field-names)                                                                              |
+| **`*relationTo`** \* | Provide a single collection `slug` to allow this field to accept a relation to. <strong>Note: the related collection must be configured to support Uploads.</strong>                                |
 | **`filterOptions`**  | A query to filter which options appear in the UI and validate against. [More](#filtering-upload-options).                                                                                           |
 | **`maxDepth`**       | Sets a number limit on iterations of related documents to populate when queried. [Depth](/docs/getting-started/concepts#depth)                                                                      |
 | **`label`**          | Text used as a field label in the Admin panel or an object with keys for each language.                                                                                                             |
@@ -41,28 +46,28 @@ keywords: upload, images media, fields, config, configuration, documentation, Co
 | **`localized`**      | Enable localization for this field. Requires [localization to be enabled](/docs/configuration/localization) in the Base config.                                                                     |
 | **`required`**       | Require this field to have a value.                                                                                                                                                                 |
 | **`admin`**          | Admin-specific configuration. See the [default field admin config](/docs/fields/overview#admin-config) for more details.                                                                            |
-| **`custom`**         | Extension point for adding custom data (e.g. for plugins) |
+| **`custom`**         | Extension point for adding custom data (e.g. for plugins)                                                                                                                                           |
 
-*\* An asterisk denotes that a property is required.*
+_\* An asterisk denotes that a property is required._
 
 ### Example
 
 `collections/ExampleCollection.ts`
+
 ```ts
-import { CollectionConfig } from 'payload/types';
+import { CollectionConfig } from "payload/types";
 
 export const ExampleCollection: CollectionConfig = {
-  slug: 'example-collection',
+  slug: "example-collection",
   fields: [
     {
-      name: 'backgroundImage', // required
-      type: 'upload', // required
-      relationTo: 'media', // required
+      name: "backgroundImage", // required
+      type: "upload", // required
+      relationTo: "media", // required
       required: true,
-    }
-  ]
-}
-
+    },
+  ],
+};
 ```
 
 ### Filtering upload options
@@ -71,23 +76,23 @@ Options can be dynamically limited by supplying a [query constraint](/docs/queri
 
 The `filterOptions` property can either be a `Where` query directly, or a function that returns one. When using a function, it will be called with an argument object with the following properties:
 
-| Property      | Description  |
-| ------------- | -------------|
-| `relationTo`       | The `relationTo` to filter against (as defined on the field) |
-| `data`             | An object of the full collection or global document currently being edited |
-| `siblingData`      | An object of the document data limited to fields within the same parent to the field |
-| `id`               | The value of the collection `id`, will be `undefined` on create request |
-| `user`             | The currently authenticated user object |
+| Property      | Description                                                                          |
+| ------------- | ------------------------------------------------------------------------------------ |
+| `relationTo`  | The `relationTo` to filter against (as defined on the field)                         |
+| `data`        | An object of the full collection or global document currently being edited           |
+| `siblingData` | An object of the document data limited to fields within the same parent to the field |
+| `id`          | The value of the collection `id`, will be `undefined` on create request              |
+| `user`        | The currently authenticated user object                                              |
 
 **Example:**
 
 ```ts
 const uploadField = {
-  name: 'image',
-  type: 'upload',
-  relationTo: 'media',
+  name: "image",
+  type: "upload",
+  relationTo: "media",
   filterOptions: {
-    mimeType: { contains: 'image' },
+    mimeType: { contains: "image" },
   },
 };
 ```
@@ -95,6 +100,11 @@ const uploadField = {
 You can learn more about writing queries [here](/docs/queries/overview).
 
 <Banner type="warning">
-  <strong>Note:</strong><br/>
-  When an upload field has both <strong>filterOptions</strong> and a custom <strong>validate</strong> function, the api will not validate <strong>filterOptions</strong> unless you call the default upload field validation function imported from <strong>payload/fields/validations</strong> in your validate function.
+  <strong>Note:</strong>
+  <br />
+  When an upload field has both <strong>filterOptions</strong> and a custom{" "}
+  <strong>validate</strong> function, the api will not validate{" "}
+  <strong>filterOptions</strong> unless you call the default upload field
+  validation function imported from <strong>payload/fields/validations</strong>{" "}
+  in your validate function.
 </Banner>

--- a/docs/graphql/overview.mdx
+++ b/docs/graphql/overview.mdx
@@ -118,11 +118,9 @@ You can even log in using the `login[collection-singular-label-here]` mutation t
   <strong>Tip:</strong>
   <br />
   To see more regarding how the above queries and mutations are used, visit your
-  GraphQL playground (by default at{" "}
-  <a href="http://localhost:3000/api/graphql-playground">
-    (http://localhost:3000/api/graphql-playground
-  </a>
-  ) while your server is running. There, you can use the "Schema" and "Docs"
+  GraphQL playground (by default at
+  [http://localhost:3000/api/graphql-playground](http://localhost:3000/api/graphql-playground))
+  while your server is running. There, you can use the "Schema" and "Docs"
   buttons on the right to see a ton of detail about how GraphQL operates within
   Payload.
 </Banner>

--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -7,7 +7,9 @@ keywords: deployment, production, config, configuration, documentation, Content 
 ---
 
 <Banner type="success">
-  So you've developed a Payload app, it's fully tested, and running great locally. Now it's time to launch. <strong>Awesome! Great work!</strong> Now, what's next?
+  So you've developed a Payload app, it's fully tested, and running great
+  locally. Now it's time to launch. <strong>Awesome! Great work!</strong> Now,
+  what's next?
 </Banner>
 
 There are many ways to deploy Payload to a production environment. When evaluating how you will deploy Payload, you need to consider these main aspects:
@@ -35,7 +37,13 @@ When you initialize Payload, you provide it with a `secret` property. This prope
 Because _**you**_ are in complete control of who can do what with your data, you should double and triple-check that you wield that power responsibly before deploying to Production.
 
 <Banner type="error">
-  <strong>By default, all Access Control functions require that a user is successfully logged in to Payload to create, read, update, or delete data.</strong> But, if you allow public user registration, for example, you will want to make sure that your access control functions are more strict - permitting <strong>only appropriate users</strong> to perform appropriate actions.
+  <strong>
+    By default, all Access Control functions require that a user is successfully
+    logged in to Payload to create, read, update, or delete data.
+  </strong>{" "}
+  But, if you allow public user registration, for example, you will want to make
+  sure that your access control functions are more strict - permitting{" "}
+  <strong>only appropriate users</strong> to perform appropriate actions.
 </Banner>
 
 ##### Building the Admin panel
@@ -43,6 +51,7 @@ Because _**you**_ are in complete control of who can do what with your data, you
 Before running in Production, you need to have built a production-ready copy of the Payload Admin panel. To do this, Payload provides the `build` NPM script. You can use it by adding a `script` to your `package.json` file like this:
 
 `package.json`:
+
 ```json
 {
   "name": "project-name-here",
@@ -51,7 +60,8 @@ Before running in Production, you need to have built a production-ready copy of 
   },
   "dependencies": {
     // your dependencies
-  },
+  }
+}
 ```
 
 Then, to build Payload, you would run `npm run build` in your project folder. A production-ready Admin bundle will be created in the `build` directory.
@@ -83,14 +93,19 @@ Alternatively, you can rely on a third-party MongoDB host such as [MongoDB Atlas
 <Banner type="warning">
   <strong>Note:</strong>
   <br />
-  If versions are enabled and a collection has many documents you may need a minimum of an m10 mongoDB atlas cluster if you reach a sorting `exceeded memory limit` error to view a collection list in the admin UI. The limitations of the m2 and m5 tier clusters are here:
-  <a href="https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/?_ga=2.176267877.1329169847.1677683154-860992573.1647438381#operational-limitations">Atlas M0 (Free Cluster), M2, and M5 Limitations</a>
+  If versions are enabled and a collection has many documents you may need a
+  minimum of an m10 mongoDB atlas cluster if you reach a sorting `exceeded
+  memory limit` error to view a collection list in the admin UI. The limitations
+  of the m2 and m5 tier clusters are here: [Atlas M0 (Free Cluster), M2, and M5
+  Limitations](https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/?_ga=2.176267877.1329169847.1677683154-860992573.1647438381#operational-limitations).
 </Banner>
 
 ##### DocumentDB
+
 When using AWS DocumentDB, you will need to configure connection options for authentication in the `mongoOptions` passed to `payload.init`. You also need to set `mongoOptions.useFacet` to `false` to disable use of the unsupported `$facet` aggregation.
 
 ##### CosmosDB
+
 When using Azure Cosmos DB, an index is needed for any field you may want to sort on. To add the sort index for all fields that may be sorted in the admin UI use the <a href="/docs/configuration/overview">indexSortableFields</a> configuration option.
 
 ## File storage
@@ -116,15 +131,18 @@ Alternatively, persistent filesystems will never delete your files and can be tr
 - Many other more traditional web hosts
 
 <Banner type="error">
-  <strong>Warning:</strong><br/>
-  If you rely on Payload's <strong>Upload</strong> functionality, make sure you either use a host with a persistent filesystem or have an integration with a third-party file host like Amazon S3.
+  <strong>Warning:</strong>
+  <br />
+  If you rely on Payload's <strong>Upload</strong> functionality, make sure you
+  either use a host with a persistent filesystem or have an integration with a
+  third-party file host like Amazon S3.
 </Banner>
 
 ##### Using ephemeral filesystem providers like Heroku
 
 If you don't use Payload's `upload` functionality, you can go ahead and use Heroku or similar platform easily. Everything will work exactly as you want it to.
 
-But, if you do, and you still want to use an ephemeral filesystem provider, you can write a hook-based solution to *copy* the files your users upload to a more permanent storage solution like Amazon S3 or DigitalOcean Spaces.
+But, if you do, and you still want to use an ephemeral filesystem provider, you can write a hook-based solution to _copy_ the files your users upload to a more permanent storage solution like Amazon S3 or DigitalOcean Spaces.
 
 **To automatically send uploaded files to S3 or similar, you could:**
 
@@ -182,10 +200,9 @@ CMD ["node", "dist/server.js"]
 Here is an example of a docker-compose.yml file that can be used for development
 
 ```yml
-version: '3'
+version: "3"
 
 services:
-
   payload:
     image: node:18-alpine
     ports:

--- a/docs/queries/overview.mdx
+++ b/docs/queries/overview.mdx
@@ -9,7 +9,13 @@ keywords: query, documents, overview, documentation, Content Management System, 
 Payload provides an extremely granular querying language through all APIs. Each API takes the same syntax and fully supports all options.
 
 <Banner>
-  <strong>Here, "querying" relates to filtering or searching through documents within a Collection.</strong> You can build queries to pass to Find operations as well as to <a href="/docs/access-control/overview">restrict which documents certain users can access</a> via access control functions.
+  <strong>
+    Here, "querying" relates to filtering or searching through documents within
+    a Collection.
+  </strong>{" "}
+  You can build queries to pass to Find operations as well as to [restrict which
+  documents certain users can access](/docs/access-control/overview) via access
+  control functions.
 </Banner>
 
 ### Simple queries
@@ -67,8 +73,10 @@ The above example demonstrates a simple query but you can get much more complex.
 | `near`               | For distance related to a [point field](/docs/fields/point) comma separated as `<longitude>, <latitude>, <maxDistance in meters (nullable)>, <minDistance in meters (nullable)>`. |
 
 <Banner type="success">
-  <strong>Tip</strong>:<br/>
-  If you know your users will be querying on certain fields a lot, you can add <strong>index: true</strong> to a field's config which will speed up searches using that field immensely.
+  <strong>Tip</strong>:<br />
+  If you know your users will be querying on certain fields a lot, you can add <strong>
+    index: true
+  </strong> to a field's config which will speed up searches using that field immensely.
 </Banner>
 
 ### And / Or Logic


### PR DESCRIPTION
## Description

Fixes misc misformated links throughout the docs. Uses Markdown link syntax instead of anchor tags where applicable. Here's a few examples:

Before: 

![Screenshot 2023-07-05 at 11 56 03 AM](https://github.com/payloadcms/payload/assets/15735305/55952e90-16f2-4c47-a28f-e6d90b5ef277)

After:

![Screenshot 2023-07-05 at 11 44 05 AM](https://github.com/payloadcms/payload/assets/15735305/116621c9-463a-496c-b3db-c3443844128b)

Before:
 
![Screenshot 2023-07-05 at 11 45 35 AM](https://github.com/payloadcms/payload/assets/15735305/9f570a44-04cb-4a55-92b3-aad338ba09cf)

After:

![Screenshot 2023-07-05 at 11 46 24 AM](https://github.com/payloadcms/payload/assets/15735305/89b6f38c-b49d-44ca-9baa-cba6023c139a)

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change