### PR TITLE
chore(templates): change user collection to default access

### DIFF
--- a/templates/blank/src/collections/Users.ts
+++ b/templates/blank/src/collections/Users.ts
@@ -6,9 +6,6 @@ const Users: CollectionConfig = {
   admin: {
     useAsTitle: 'email',
   },
-  access: {
-    read: () => true,
-  },
   fields: [
     // Email added by default
     // Add more fields as needed


### PR DESCRIPTION
## Description

Change blank template's user collection access to use the default instead of `read: () => true`. This is a safer default for most templates.
