### PR TITLE
fix: properly threads custom react-select props through relationship field

### DIFF
--- a/src/admin/components/elements/ReactSelect/index.tsx
+++ b/src/admin/components/elements/ReactSelect/index.tsx
@@ -18,7 +18,6 @@ import type { Option } from './types';
 
 import './index.scss';
 
-
 const createOption = (label: string) => ({
   label,
   value: label,
@@ -60,6 +59,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
         isLoading={isLoading}
         placeholder={getTranslation(placeholder, i18n)}
         captureMenuScroll
+        customProps={selectProps}
         {...props}
         value={value}
         onChange={onChange}
@@ -120,7 +120,6 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
       placeholder={getTranslation(placeholder, i18n)}
       captureMenuScroll
       {...props}
-      customProps={selectProps}
       value={value}
       onChange={onChange}
       isDisabled={disabled}

--- a/src/admin/components/elements/ReactSelect/types.ts
+++ b/src/admin/components/elements/ReactSelect/types.ts
@@ -70,6 +70,10 @@ export type Props = {
   components?: {
     [key: string]: React.FC<any>
   }
+  customProps?: CustomSelectProps
+  /**
+  * @deprecated Since version 1.0. Will be deleted in version 2.0. Use customProps instead.
+  */
   selectProps?: CustomSelectProps
   backspaceRemovesValue?: boolean
 }

--- a/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -439,7 +439,7 @@ const Relationship: React.FC<Props> = (props) => {
               SingleValue,
               MultiValueLabel,
             }}
-            selectProps={{
+            customProps={{
               disableMouseDown: drawerIsOpen,
               disableKeyDown: drawerIsOpen,
               setDrawerIsOpen,

--- a/src/admin/components/forms/field-types/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/select-components/MultiValueLabel/index.tsx
@@ -21,7 +21,7 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
       customProps: {
         setDrawerIsOpen,
         draggableProps,
-        onSave,
+        // onSave,
       } = {},
     } = {},
   } = props;
@@ -70,7 +70,7 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
             </Tooltip>
             <Edit />
           </DocumentDrawerToggler>
-          <DocumentDrawer onSave={onSave} />
+          <DocumentDrawer onSave={/* onSave */null} />
         </Fragment>
       )}
     </div>

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -924,9 +924,11 @@ describe('fields', () => {
 
       // Now open the drawer again to edit the `text` field _using the keyboard_
       // Mimic real user behavior by typing into the field with spaces and backspaces
+      // Explicitly use both `down` and `type` to cover edge cases
       await page.locator('#field-relationshipHasMany button.relationship--multi-value-label__drawer-toggler').click();
       await page.locator('[id^=doc-drawer_text-fields_1_] #field-text').click();
-      await page.keyboard.type('123');
+      await page.keyboard.down('1');
+      await page.keyboard.type('23');
       await expect(await page.locator('[id^=doc-drawer_text-fields_1_] #field-text')).toHaveValue(`${value}123`);
       await page.keyboard.type('4567');
       await page.keyboard.press('Backspace');

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -911,7 +911,6 @@ describe('fields', () => {
       await page.locator('#action-save').click();
       await expect(page.locator('.Toastify')).toContainText('successfully');
 
-
       // Create a new doc for the `relationshipHasMany` field
       await page.locator('#field-relationshipHasMany button.relationship-add-new__add-button').click();
       const textField2 = page.locator('[id^=doc-drawer_text-fields_1_] #field-text');
@@ -924,12 +923,15 @@ describe('fields', () => {
       await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click();
 
       // Now open the drawer again to edit the `text` field _using the keyboard_
+      // Mimic real user behavior by typing into the field with spaces and backspaces
       await page.locator('#field-relationshipHasMany button.relationship--multi-value-label__drawer-toggler').click();
-      const textField3 = page.locator('[id^=doc-drawer_text-fields_1_] #field-text');
-      await textField3.click();
-      await page.keyboard.down('1');
-      await page.keyboard.down('2');
-      await page.keyboard.down('3');
+      await page.locator('[id^=doc-drawer_text-fields_1_] #field-text').click();
+      await page.keyboard.type('123');
+      await expect(await page.locator('[id^=doc-drawer_text-fields_1_] #field-text')).toHaveValue(`${value}123`);
+      await page.keyboard.type('4567');
+      await page.keyboard.press('Backspace');
+      await expect(await page.locator('[id^=doc-drawer_text-fields_1_] #field-text')).toHaveValue(`${value}123456`);
+
       // save drawer
       await page.locator('[id^=doc-drawer_text-fields_1_] #action-save').click();
       await expect(page.locator('.Toastify')).toContainText('successfully');
@@ -939,8 +941,9 @@ describe('fields', () => {
       await page.locator('#action-save').click();
       await expect(page.locator('.Toastify')).toContainText('successfully');
       await page.reload();
+
       // check if the value is saved
-      await expect(page.locator('#field-relationshipHasMany .relationship--multi-value-label__text')).toContainText(`${value}123`);
+      await expect(page.locator('#field-relationshipHasMany .relationship--multi-value-label__text')).toHaveText(`${value}123456`);
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #2815, #2945, and #2840 by properly threading custom `react-select` props through the relationship field. This prevents the underlying field from reacting to keyboard events while the drawer is open.
- Adjusts the test to include a backspace keyboard event which would be caught by these custom props
- Adds the `@deprecated` flag to the `selectProps` prop so that those who are actively using this component in their project do not experience any breaking changes as a result of us migrating from react-select v3 to v5 here: https://github.com/payloadcms/payload/pull/2656. Use `customProps` instead.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
