### PR TITLE
chore: improves error messaging for not found collections

### DIFF
--- a/src/auth/operations/local/forgotPassword.ts
+++ b/src/auth/operations/local/forgotPassword.ts
@@ -31,7 +31,7 @@ async function localForgotPassword<T extends keyof GeneratedTypes['collections']
   const collection = payload.collections[collectionSlug];
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Forgot Password Operation.`);
   }
 
   req.payloadAPI = req.payloadAPI || 'local';

--- a/src/auth/operations/local/login.ts
+++ b/src/auth/operations/local/login.ts
@@ -41,7 +41,7 @@ async function localLogin<TSlug extends keyof GeneratedTypes['collections']>(
   const collection = payload.collections[collectionSlug];
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Login Operation.`);
   }
 
   req.payloadAPI = req.payloadAPI || 'local';

--- a/src/auth/operations/local/resetPassword.ts
+++ b/src/auth/operations/local/resetPassword.ts
@@ -30,7 +30,7 @@ async function localResetPassword<T extends keyof GeneratedTypes['collections']>
   const collection = payload.collections[collectionSlug];
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Reset Password Operation.`);
   }
 
   req.payload = payload;

--- a/src/auth/operations/local/unlock.ts
+++ b/src/auth/operations/local/unlock.ts
@@ -29,7 +29,7 @@ async function localUnlock<T extends keyof GeneratedTypes['collections']>(
   const collection = payload.collections[collectionSlug];
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Unlock Operation.`);
   }
 
   req.payload = payload;

--- a/src/auth/operations/local/verifyEmail.ts
+++ b/src/auth/operations/local/verifyEmail.ts
@@ -20,7 +20,7 @@ async function localVerifyEmail<T extends keyof GeneratedTypes['collections']>(
   const collection = payload.collections[collectionSlug];
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Verify Email Operation.`);
   }
 
   return verifyEmail({

--- a/src/collections/operations/local/create.ts
+++ b/src/collections/operations/local/create.ts
@@ -53,7 +53,7 @@ export default async function createLocal<TSlug extends keyof GeneratedTypes['co
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Create Operation.`);
   }
 
   req.payloadAPI = req.payloadAPI || 'local';

--- a/src/collections/operations/local/delete.ts
+++ b/src/collections/operations/local/delete.ts
@@ -52,7 +52,7 @@ async function deleteLocal<TSlug extends keyof GeneratedTypes['collections']>(pa
 
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Delete Operation.`);
   }
 
   const req = {

--- a/src/collections/operations/local/find.ts
+++ b/src/collections/operations/local/find.ts
@@ -54,7 +54,7 @@ export default async function findLocal<T extends keyof GeneratedTypes['collecti
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Find Operation.`);
   }
 
   req.payloadAPI = req.payloadAPI || 'local';

--- a/src/collections/operations/local/findByID.ts
+++ b/src/collections/operations/local/findByID.ts
@@ -45,7 +45,7 @@ export default async function findByIDLocal<T extends keyof GeneratedTypes['coll
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Find By ID Operation.`);
   }
 
   req.payloadAPI = req.payloadAPI || 'local';

--- a/src/collections/operations/local/findVersionByID.ts
+++ b/src/collections/operations/local/findVersionByID.ts
@@ -41,7 +41,7 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Find Version By ID Operation.`);
   }
 
   req.payloadAPI = req.payloadAPI || 'local';

--- a/src/collections/operations/local/findVersions.ts
+++ b/src/collections/operations/local/findVersions.ts
@@ -45,7 +45,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Find Versions Operation.`);
   }
 
   const i18n = i18nInit(payload.config.i18n);

--- a/src/collections/operations/local/restoreVersion.ts
+++ b/src/collections/operations/local/restoreVersion.ts
@@ -36,7 +36,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   const collection = payload.collections[collectionSlug];
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Restore Version Operation.`);
   }
 
   const i18n = i18nInit(payload.config.i18n);

--- a/src/collections/operations/local/update.ts
+++ b/src/collections/operations/local/update.ts
@@ -65,7 +65,7 @@ async function updateLocal<TSlug extends keyof GeneratedTypes['collections']>(pa
   const collection = payload.collections[collectionSlug];
 
   if (!collection) {
-    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found.`);
+    throw new APIError(`The collection with slug ${String(collectionSlug)} can't be found. Update Operation.`);
   }
 
   const i18n = i18nInit(payload.config.i18n);


### PR DESCRIPTION
## Description

Improves error messaging for collections when they are not found within operations. This is helpful for example when you are seeding a user in `onInit` and logging them in but the collection does not exist.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
