### PR TITLE
Fix: correct types for express configuration, set default JSON request body size limit

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -46,7 +46,9 @@ export const defaults: Config = {
     max: 500,
   },
   express: {
-    json: {},
+    json: {
+      limit: '2mb',
+    },
     compression: {},
     middleware: [],
     preMiddleware: [],

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,4 +1,5 @@
-import { Express, NextFunction, Response } from 'express';
+import { Express, NextFunction, Response, json } from 'express';
+import type compression from 'compression';
 import { DeepRequired } from 'ts-essentials';
 import { Transporter } from 'nodemailer';
 import { Options as ExpressFileUploadOptions } from 'express-fileupload';
@@ -25,6 +26,9 @@ type Email = {
   fromAddress: string;
   logMockCredentials?: boolean;
 };
+
+type JsonOptions = Parameters<typeof json>[0];
+type CompressionOptions = Parameters<typeof compression>[0];
 
 // eslint-disable-next-line no-use-before-define
 export type Plugin = (config: Config) => Promise<Config> | Config;
@@ -415,15 +419,10 @@ export type Config = {
    * @see https://payloadcms.com/docs/configuration/express
    */
   express?: {
-    /** Control the way JSON is parsed */
-    json?: {
-      /** Defaults to 2MB  */
-      limit?: number;
-    };
+    /** Control the way JSON is parsed. Payload overrides the default express request body size `limit` of '100kb' and sets it to '2mb'. */
+    json?: JsonOptions;
     /** Control the way responses are compressed */
-    compression?: {
-      [key: string]: unknown;
-    };
+    compression?: CompressionOptions;
     /**
      * @deprecated express.middleware will be removed in a future version. Please migrate to express.postMiddleware.
      */


### PR DESCRIPTION
## Description

This PR fixes 2 issues I found when I needed to increase the express JSON request body size limit after running into 'request entity too large' errors when submitting API requests larger than 100kb during a migration script. The issues are:
1. The type for `express.json.limit` is `number | undefined` where it should be `number | string | undefined`. This means trying to set `limit: '2mb'` gives a type error even though it is supported by express. I can get around this fine by setting `limit: 2097152` but the issue should still be fixed.
2. According to both a comment in the config [types.ts](https://github.com/payloadcms/payload/blob/master/src/config/types.ts) and a section of the [documentation](https://payloadcms.com/docs/configuration/express#json) Payload uses a default of 2mb for this request body size limit, but that default is never actually set anywhere, leading to the actual default limit being express's 100kb.

I have fixed issue 1 by using TypeScript's [parameters utility type](https://www.typescriptlang.org/docs/handbook/utility-types.html#parameterstype) to extract the actual types used in configuring the express middleware. Issue 2 I fixed by adding a default in payload's defaults file. Issue 2 could alternatively be fixed with a documentation change if the 100kb limit is a preferred default.

Let me know if any of these solutions are not ideal. Thanks!


- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
