### PR TITLE
fix: rich text link element not validating on create

### DIFF
--- a/src/admin/components/forms/field-types/RichText/elements/link/LinkDrawer/baseFields.ts
+++ b/src/admin/components/forms/field-types/RichText/elements/link/LinkDrawer/baseFields.ts
@@ -46,9 +46,7 @@ export const getBaseFields = (config: Config): Field[] => [
     type: 'text',
     required: true,
     admin: {
-      condition: ({ linkType, url }) => {
-        return (typeof linkType === 'undefined' && url) || linkType === 'custom';
-      },
+      condition: ({ linkType }) => linkType !== 'internal',
     },
   },
   {

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -496,7 +496,8 @@ describe('fields', () => {
         await wait(200);
         await editLinkModal.locator('button[type="submit"]').click();
         const errorField = await page.locator('[id^=drawer_1_rich-text-link-] .render-fields > :nth-child(3)');
-        await expect(errorField).toHaveClass('error');
+        const hasErrorClass = await errorField.evaluate(el => el.classList.contains('error'));
+        expect(hasErrorClass).toBe(true);
       });
 
       test('should create new url custom link', async () => {

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -479,6 +479,26 @@ describe('fields', () => {
     }
 
     describe('toolbar', () => {
+      test('should run url validation', async () => {
+        await navigateToRichTextFields();
+
+        // Open link drawer
+        await page.locator('.rich-text__toolbar button:not([disabled]) .link').first().click();
+
+        // find the drawer
+        const editLinkModal = await page.locator('[id^=drawer_1_rich-text-link-]');
+        await expect(editLinkModal).toBeVisible();
+
+        // Fill values and click Confirm
+        await editLinkModal.locator('#field-text').fill('link text');
+        await editLinkModal.locator('label[for="field-linkType-custom"]').click();
+        await editLinkModal.locator('#field-url').fill('');
+        await wait(200);
+        await editLinkModal.locator('button[type="submit"]').click();
+        const errorField = await page.locator('[id^=drawer_1_rich-text-link-] .render-fields > :nth-child(3)');
+        await expect(errorField).toHaveClass('error');
+      });
+
       test('should create new url custom link', async () => {
         await navigateToRichTextFields();
 


### PR DESCRIPTION
## Description

Fixes: #2985

Adjusts the logic for the URL field condition within the custom link element on the RTE.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
