### PR TITLE
fix: admin route not mounting on production serve

### DIFF
--- a/src/bundlers/webpack/scripts/serve.ts
+++ b/src/bundlers/webpack/scripts/serve.ts
@@ -9,7 +9,7 @@ const router = express.Router();
 type ServeAdminType = (options: { payload: Payload }) => Promise<PayloadHandler>;
 
 export const serveAdmin: ServeAdminType = async ({ payload }) => {
-  router.use(payload.config.routes.admin, history());
+  router.use(history());
 
   router.get('*', (req, res, next) => {
     if (req.path.substr(-1) === '/' && req.path.length > 1) {

--- a/src/express/admin.ts
+++ b/src/express/admin.ts
@@ -3,7 +3,7 @@ import { Payload } from '../payload';
 async function initAdmin(ctx: Payload): Promise<void> {
   if (!ctx.config.admin.disable) {
     if (process.env.NODE_ENV === 'production') {
-      ctx.express.use(await ctx.config.admin.bundler.serve(ctx));
+      ctx.express.use(ctx.config.routes.admin, await ctx.config.admin.bundler.serve(ctx));
     } else {
       ctx.express.use(await ctx.config.admin.bundler.dev(ctx));
     }


### PR DESCRIPTION
## Description

**Hot Fix**: Fixes issue with new bundler pattern when serving built payload. The /admin routes were not being correctly mounted when serving the production version of payload.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
