### PR TITLE
chore: better parity for initing admin routes between dev and build

### DIFF
--- a/src/bundlers/webpack/configs/dev.ts
+++ b/src/bundlers/webpack/configs/dev.ts
@@ -19,12 +19,12 @@ export const getDevConfig = (payloadConfig: SanitizedConfig): Configuration => {
     entry: {
       ...baseConfig.entry,
       main: [
-        require.resolve('webpack-hot-middleware/client'),
+        `webpack-hot-middleware/client?path=${payloadConfig.routes.admin}/__webpack_hmr`,
         ...(baseConfig.entry.main as string[]),
       ],
     },
     output: {
-      publicPath: payloadConfig.routes.admin,
+      publicPath: `${payloadConfig.routes.admin}/`,
       path: '/',
       filename: '[name].js',
     },

--- a/src/bundlers/webpack/scripts/dev.ts
+++ b/src/bundlers/webpack/scripts/dev.ts
@@ -11,14 +11,14 @@ const router = express.Router();
 
 type DevAdminType = (options: { payload: Payload }) => Promise<PayloadHandler>;
 export const devAdmin: DevAdminType = async ({ payload }) => {
-  payload.express.use(payload.config.routes.admin, history());
+  router.use(history());
 
   try {
     const webpackConfig = getDevConfig(payload.config);
     const compiler = webpack(webpackConfig);
 
     router.use(webpackDevMiddleware(compiler, {
-      publicPath: webpackConfig.output.publicPath as string,
+      publicPath: '/',
     }));
 
     router.use(webpackHotMiddleware(compiler));

--- a/src/express/admin.ts
+++ b/src/express/admin.ts
@@ -5,7 +5,7 @@ async function initAdmin(ctx: Payload): Promise<void> {
     if (process.env.NODE_ENV === 'production') {
       ctx.express.use(ctx.config.routes.admin, await ctx.config.admin.bundler.serve(ctx));
     } else {
-      ctx.express.use(await ctx.config.admin.bundler.dev(ctx));
+      ctx.express.use(ctx.config.routes.admin, await ctx.config.admin.bundler.dev(ctx));
     }
   }
 }


### PR DESCRIPTION
## Description

Adds more parity between the webpack `dev` script and the `build` scripts.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
