### PR TITLE
fix: incorrect image rotation after being processed by sharp

### DIFF
--- a/src/uploads/generateFileData.ts
+++ b/src/uploads/generateFileData.ts
@@ -87,9 +87,9 @@ export const generateFileData = async <T>({
 
     if (fileSupportsResize && (resizeOptions || formatOptions || trimOptions)) {
       if (file.tempFilePath) {
-        sharpFile = sharp(file.tempFilePath, sharpOptions);
+        sharpFile = sharp(file.tempFilePath, sharpOptions).rotate();
       } else {
-        sharpFile = sharp(file.data, sharpOptions);
+        sharpFile = sharp(file.data, sharpOptions).rotate();
       }
 
       if (resizeOptions) {

--- a/src/uploads/generateFileData.ts
+++ b/src/uploads/generateFileData.ts
@@ -87,9 +87,9 @@ export const generateFileData = async <T>({
 
     if (fileSupportsResize && (resizeOptions || formatOptions || trimOptions)) {
       if (file.tempFilePath) {
-        sharpFile = sharp(file.tempFilePath, sharpOptions).rotate();
+        sharpFile = sharp(file.tempFilePath, sharpOptions).rotate(); // pass rotate() to auto-rotate based on EXIF data. https://github.com/payloadcms/payload/pull/3081
       } else {
-        sharpFile = sharp(file.data, sharpOptions).rotate();
+        sharpFile = sharp(file.data, sharpOptions).rotate(); // pass rotate() to auto-rotate based on EXIF data. https://github.com/payloadcms/payload/pull/3081
       }
 
       if (resizeOptions) {

--- a/src/uploads/imageResizer.ts
+++ b/src/uploads/imageResizer.ts
@@ -56,7 +56,7 @@ export default async function resizeAndSave({
   const sizesToSave: FileToSave[] = [];
   const sizeData = {};
 
-  const sharpBase = sharp(file.tempFilePath || file.data).rotate();
+  const sharpBase = sharp(file.tempFilePath || file.data).rotate(); // pass rotate() to auto-rotate based on EXIF data. https://github.com/payloadcms/payload/pull/3081
 
   const promises = imageSizes
     .map(async (desiredSize) => {

--- a/src/uploads/imageResizer.ts
+++ b/src/uploads/imageResizer.ts
@@ -56,7 +56,7 @@ export default async function resizeAndSave({
   const sizesToSave: FileToSave[] = [];
   const sizeData = {};
 
-  const sharpBase = sharp(file.tempFilePath || file.data);
+  const sharpBase = sharp(file.tempFilePath || file.data).rotate();
 
   const promises = imageSizes
     .map(async (desiredSize) => {


### PR DESCRIPTION
## Description

This is a quick and simple fix that solves a problem with some images being rotated when uploaded and processed by sharp. Fixes #3080 

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)  

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
