### PR TITLE
chore: label is only required when no name is set

### DIFF
--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -227,7 +227,7 @@ const tab = baseField.keys({
   label: joi.alternatives().try(
     joi.string(),
     joi.object().pattern(joi.string(), [joi.string()]),
-  ).required(),
+  ).when('name', { not: joi.exist(), then: joi.required() }),
   fields: joi.array().items(joi.link('#field')).required(),
   description: joi.alternatives().try(
     joi.string(),


### PR DESCRIPTION
## Description

Aligns joi schema validation with TS types for the `tab` fields.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
