### PR TITLE
feat: opens upload relationship in drawer instead of upload URL

### DIFF
--- a/src/admin/components/elements/FileDetails/Meta/index.scss
+++ b/src/admin/components/elements/FileDetails/Meta/index.scss
@@ -20,4 +20,8 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  &__edit {
+    position: relative;
+  }
 }

--- a/src/admin/components/elements/FileDetails/Meta/index.tsx
+++ b/src/admin/components/elements/FileDetails/Meta/index.tsx
@@ -5,13 +5,24 @@ import formatFilesize from '../../../../../uploads/formatFilesize';
 import { Props } from './types';
 
 import './index.scss';
+import { useDocumentDrawer } from '../../DocumentDrawer';
 
 const baseClass = 'file-meta';
 
 const Meta: React.FC<Props> = (props) => {
   const {
-    filename, filesize, width, height, mimeType, staticURL, url,
+    filename, filesize, width, height, mimeType, staticURL, url, id, collection,
   } = props;
+
+  const openInDrawer = Boolean(id && collection);
+
+  const [
+    DocumentDrawer,
+    DocumentDrawerToggler,
+    { isDrawerOpen },
+  ] = useDocumentDrawer({
+    id, collectionSlug: collection,
+  });
 
   const { serverURL } = useConfig();
 
@@ -20,13 +31,22 @@ const Meta: React.FC<Props> = (props) => {
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__url`}>
-        <a
-          href={fileURL}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {filename}
-        </a>
+        {openInDrawer && <DocumentDrawer />}
+        {openInDrawer && !isDrawerOpen
+          ? (
+            <DocumentDrawerToggler>
+              {filename}
+            </DocumentDrawerToggler>
+          )
+          : (
+            <a
+              href={fileURL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {filename}
+            </a>
+          )}
         <CopyToClipboard
           value={fileURL}
           defaultMessage="Copy URL"

--- a/src/admin/components/elements/FileDetails/Meta/index.tsx
+++ b/src/admin/components/elements/FileDetails/Meta/index.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useConfig } from '../../../utilities/Config';
 import CopyToClipboard from '../../CopyToClipboard';
 import formatFilesize from '../../../../../uploads/formatFilesize';
 import { Props } from './types';
+import { useDocumentDrawer } from '../../DocumentDrawer';
+import Edit from '../../../icons/Edit';
+import Tooltip from '../../Tooltip';
 
 import './index.scss';
-import { useDocumentDrawer } from '../../DocumentDrawer';
 
 const baseClass = 'file-meta';
 
@@ -14,12 +16,12 @@ const Meta: React.FC<Props> = (props) => {
     filename, filesize, width, height, mimeType, staticURL, url, id, collection,
   } = props;
 
+  const [hovered, setHovered] = useState(false);
   const openInDrawer = Boolean(id && collection);
 
   const [
     DocumentDrawer,
     DocumentDrawerToggler,
-    { isDrawerOpen },
   ] = useDocumentDrawer({
     id, collectionSlug: collection,
   });
@@ -32,25 +34,32 @@ const Meta: React.FC<Props> = (props) => {
     <div className={baseClass}>
       <div className={`${baseClass}__url`}>
         {openInDrawer && <DocumentDrawer />}
-        {openInDrawer && !isDrawerOpen
-          ? (
-            <DocumentDrawerToggler>
-              {filename}
-            </DocumentDrawerToggler>
-          )
-          : (
-            <a
-              href={fileURL}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {filename}
-            </a>
-          )}
+        <a
+          href={fileURL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {filename}
+        </a>
         <CopyToClipboard
           value={fileURL}
           defaultMessage="Copy URL"
         />
+        {openInDrawer
+          && (
+            <DocumentDrawerToggler
+              className={`${baseClass}__edit`}
+              onMouseEnter={() => setHovered(true)}
+              onMouseLeave={() => setHovered(false)}
+            >
+              <Edit />
+              <Tooltip
+                show={hovered}
+              >
+                Edit
+              </Tooltip>
+            </DocumentDrawerToggler>
+          )}
       </div>
       <div className={`${baseClass}__size-type`}>
         {formatFilesize(filesize)}

--- a/src/admin/components/elements/FileDetails/Meta/types.ts
+++ b/src/admin/components/elements/FileDetails/Meta/types.ts
@@ -6,5 +6,7 @@ export type Props = {
   width?: number,
   height?: number,
   sizes?: unknown,
-  url?: string
+  url?: string,
+  id?: string,
+  collection?: string
 }

--- a/src/admin/components/elements/FileDetails/index.tsx
+++ b/src/admin/components/elements/FileDetails/index.tsx
@@ -39,6 +39,7 @@ const FileDetails: React.FC<Props> = (props) => {
       staticURL,
       imageSizes,
     },
+    slug: collectionSlug,
   } = collection;
 
   const {
@@ -49,6 +50,7 @@ const FileDetails: React.FC<Props> = (props) => {
     mimeType,
     sizes,
     url,
+    id,
   } = doc;
 
   const [orderedSizes, setOrderedSizes] = useState<FileSizes>(() => sortSizes(sizes, imageSizes));
@@ -78,6 +80,8 @@ const FileDetails: React.FC<Props> = (props) => {
             height={height as number}
             mimeType={mimeType as string}
             url={url as string}
+            id={id as string}
+            collection={collectionSlug as string}
           />
           {hasSizes && (
             <Button

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -1081,10 +1081,11 @@ describe('fields', () => {
       await expect(page.locator('.Toastify')).toContainText('successfully');
 
       // Assert that the media field has the png upload
-      await expect(page.locator('.field-type.upload .file-details .file-meta__url a')).toHaveAttribute('href', '/uploads/payload-1.png');
-      await expect(page.locator('.field-type.upload .file-details .file-meta__url a')).toContainText('payload-1.png');
-      await expect(page.locator('.field-type.upload .file-details img')).toHaveAttribute('src', '/uploads/payload-1.png');
-      await page.locator('#action-save').click();
+      await page.locator('.field-type.upload .file-details .file-meta__url button').first().click();
+      await expect(page.locator('[id^=doc-drawer_uploads_1_] .file-details .file-meta__url a')).toHaveAttribute('href', '/uploads/payload-1.png');
+      await expect(page.locator('[id^=doc-drawer_uploads_1_] .file-details .file-meta__url a')).toContainText('payload-1.png');
+      await expect(page.locator('[id^=doc-drawer_uploads_1_] .file-details img')).toHaveAttribute('src', '/uploads/payload-1.png');
+      await page.locator('[id^=doc-drawer_uploads_1_] #action-save').click();
       await wait(200);
       await expect(page.locator('.Toastify')).toContainText('successfully');
     });

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -1091,6 +1091,7 @@ describe('fields', () => {
     });
 
     test('should clear selected upload', async () => {
+      await page.locator('.doc-drawer__header-close').click();
       await page.locator('.field-type.upload .file-details__remove').click();
     });
 

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -1081,17 +1081,15 @@ describe('fields', () => {
       await expect(page.locator('.Toastify')).toContainText('successfully');
 
       // Assert that the media field has the png upload
-      await page.locator('.field-type.upload .file-details .file-meta__url button').first().click();
-      await expect(page.locator('[id^=doc-drawer_uploads_1_] .file-details .file-meta__url a')).toHaveAttribute('href', '/uploads/payload-1.png');
-      await expect(page.locator('[id^=doc-drawer_uploads_1_] .file-details .file-meta__url a')).toContainText('payload-1.png');
-      await expect(page.locator('[id^=doc-drawer_uploads_1_] .file-details img')).toHaveAttribute('src', '/uploads/payload-1.png');
-      await page.locator('[id^=doc-drawer_uploads_1_] #action-save').click();
+      await expect(page.locator('.field-type.upload .file-details .file-meta__url a')).toHaveAttribute('href', '/uploads/payload-1.png');
+      await expect(page.locator('.field-type.upload .file-details .file-meta__url a')).toContainText('payload-1.png');
+      await expect(page.locator('.field-type.upload .file-details img')).toHaveAttribute('src', '/uploads/payload-1.png');
+      await page.locator('#action-save').click();
       await wait(200);
       await expect(page.locator('.Toastify')).toContainText('successfully');
     });
 
     test('should clear selected upload', async () => {
-      await page.locator('.doc-drawer__header-close').click();
       await page.locator('.field-type.upload .file-details__remove').click();
     });
 


### PR DESCRIPTION
## Description

[Feature request #3042 ](https://github.com/payloadcms/payload/discussions/3042)

Utilizes the document drawer to show the upload file from an upload relationship.

Before:
<img width="908" alt="before" src="https://github.com/payloadcms/payload/assets/67977755/ccaa57cc-8e01-4fa1-be9f-dabb02ce69f6">

After:
<img width="882" alt="after" src="https://github.com/payloadcms/payload/assets/67977755/eff615f5-0577-49de-86a7-a1df902e16b0">


https://github.com/payloadcms/payload/assets/67977755/43f5aee4-f567-4fd1-a166-16dd2f3f2183

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] Existing test suite passes locally with my changes
