### PR TITLE
chore: prevent save submission when pressing enter

### DIFF
--- a/src/admin/components/elements/Save/index.tsx
+++ b/src/admin/components/elements/Save/index.tsx
@@ -2,16 +2,24 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import FormSubmit from '../../forms/Submit';
 import RenderCustomComponent from '../../utilities/RenderCustomComponent';
+import { useForm } from '../../forms/Form/context';
 
 export type CustomSaveButtonProps = React.ComponentType<DefaultSaveButtonProps & {
   DefaultButton: React.ComponentType<DefaultSaveButtonProps>;
 }>
 type DefaultSaveButtonProps = {
   label: string;
+  save: () => void;
 };
-const DefaultSaveButton: React.FC<DefaultSaveButtonProps> = ({ label }) => {
+const DefaultSaveButton: React.FC<DefaultSaveButtonProps> = ({ label, save }) => {
   return (
-    <FormSubmit buttonId="action-save">{label}</FormSubmit>
+    <FormSubmit
+      type="button"
+      buttonId="action-save"
+      onClick={save}
+    >
+      {label}
+    </FormSubmit>
   );
 };
 
@@ -20,12 +28,14 @@ type Props = {
 }
 export const Save: React.FC<Props> = ({ CustomComponent }) => {
   const { t } = useTranslation('general');
+  const { submit } = useForm();
 
   return (
     <RenderCustomComponent
       CustomComponent={CustomComponent}
       DefaultComponent={DefaultSaveButton}
       componentProps={{
+        save: submit,
         label: t('save'),
         DefaultButton: DefaultSaveButton,
       }}


### PR DESCRIPTION
## Description

When pressing enter inside any input, the page would save. This prevents that and aligns it with our publish & draft buttons.

The only time where this can still happen is when there is only 1 input within the form and the enter key is pressed when focused. This is a default browser behavior and not something that we can change.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
