### PR TITLE
chore(examples/form-builder): improves form input accessibility

### DIFF
--- a/examples/form-builder/nextjs/components/Blocks/Form/Country/index.tsx
+++ b/examples/form-builder/nextjs/components/Blocks/Form/Country/index.tsx
@@ -17,7 +17,7 @@ export const Country: React.FC<CountryField & {
   return (
     <Width width={width}>
       <div className={classes.select}>
-        <label htmlFor="name" className={classes.label}>
+        <label htmlFor={name} className={classes.label}>
           {label}
         </label>
         <Controller
@@ -33,6 +33,7 @@ export const Country: React.FC<CountryField & {
               onChange={(val) => onChange(val.value)}
               className={classes.reactSelect}
               classNamePrefix="rs"
+              inputId={name}
             />
           )}
         />

--- a/examples/form-builder/nextjs/components/Blocks/Form/Email/index.tsx
+++ b/examples/form-builder/nextjs/components/Blocks/Form/Email/index.tsx
@@ -15,13 +15,14 @@ export const Email: React.FC<EmailField & {
   return (
     <Width width={width}>
       <div className={classes.wrap}>
-        <label htmlFor="name" className={classes.label}>
+        <label htmlFor={name} className={classes.label}>
           {label}
         </label>
         <input
           type="text"
           placeholder="Email"
           className={classes.input}
+          id={name}
           {...register(name, { required: requiredFromProps, pattern: /^\S+@\S+$/i })}
         />
         {requiredFromProps && errors[name] && <Error />}

--- a/examples/form-builder/nextjs/components/Blocks/Form/Number/index.tsx
+++ b/examples/form-builder/nextjs/components/Blocks/Form/Number/index.tsx
@@ -15,12 +15,13 @@ export const Number: React.FC<TextField & {
   return (
     <Width width={width}>
       <div className={classes.wrap}>
-        <label htmlFor="name" className={classes.label}>
+        <label htmlFor={name} className={classes.label}>
           {label}
         </label>
         <input
           type="number"
           className={classes.input}
+          id={name}
           {...register(name, { required: requiredFromProps })}
         />
         {requiredFromProps && errors[name] && <Error />}

--- a/examples/form-builder/nextjs/components/Blocks/Form/Select/index.tsx
+++ b/examples/form-builder/nextjs/components/Blocks/Form/Select/index.tsx
@@ -16,7 +16,7 @@ export const Select: React.FC<SelectField & {
   return (
     <Width width={width}>
       <div className={classes.select}>
-        <label htmlFor="name" className={classes.label}>
+        <label htmlFor={name} className={classes.label}>
           {label}
         </label>
         <Controller
@@ -32,6 +32,7 @@ export const Select: React.FC<SelectField & {
               onChange={(val) => onChange(val.value)}
               className={classes.reactSelect}
               classNamePrefix="rs"
+              inputId={name}
             />
           )}
         />

--- a/examples/form-builder/nextjs/components/Blocks/Form/State/index.tsx
+++ b/examples/form-builder/nextjs/components/Blocks/Form/State/index.tsx
@@ -18,7 +18,7 @@ export const State: React.FC<StateField & {
   return (
     <Width width={width}>
       <div className={classes.select}>
-        <label htmlFor="name" className={classes.label}>
+        <label htmlFor={name} className={classes.label}>
           {label}
         </label>
         <Controller
@@ -34,6 +34,7 @@ export const State: React.FC<StateField & {
               onChange={(val) => onChange(val.value)}
               className={classes.reactSelect}
               classNamePrefix="rs"
+              inputId={name}
             />
           )}
         />

--- a/examples/form-builder/nextjs/components/Blocks/Form/Text/index.tsx
+++ b/examples/form-builder/nextjs/components/Blocks/Form/Text/index.tsx
@@ -16,12 +16,13 @@ export const Text: React.FC<TextField & {
   return (
     <Width width={width}>
       <div className={classes.wrap}>
-        <label htmlFor="name" className={classes.label}>
+        <label htmlFor={name} className={classes.label}>
           {label}
         </label>
         <input
           type="text"
           className={classes.input}
+          id={name}
           {...register(name, { required: requiredFromProps })}
         />
         {requiredFromProps && errors[name] && <Error />}

--- a/examples/form-builder/nextjs/components/Blocks/Form/Textarea/index.tsx
+++ b/examples/form-builder/nextjs/components/Blocks/Form/Textarea/index.tsx
@@ -16,12 +16,13 @@ export const Textarea: React.FC<TextField & {
   return (
     <Width width={width}>
       <div className={classes.wrap}>
-        <label htmlFor="name" className={classes.label}>
+        <label htmlFor={name} className={classes.label}>
           {label}
         </label>
         <textarea
           rows={rows}
           className={classes.textarea}
+          id={name}
           {...register(name, { required: requiredFromProps })}
         />
         {requiredFromProps && errors[name] && <Error />}


### PR DESCRIPTION
## Description

Small fix to associate labels with form elements in the form builder example, by using `name` as the `htmlFor` of the labels, and using `name` as the `id` of the form elements.

This will allow users to click on the label to focus the form element, as well as ensuring screen readers refer to the correct label.

- [x] I have read and understand the CONTRIBUTING.md document in this repository

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
