### PR TITLE
feat: Optionally allows passing logger instance when calling payload.init

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -26,6 +26,7 @@ import type { PayloadRequest } from '../express/types'
 import type { GlobalConfig, SanitizedGlobalConfig } from '../globals/config/types'
 import type { Payload } from '../payload'
 import type { Where } from '../types'
+import type { PayloadLogger } from '../utilities/logger'
 
 type Prettify<T> = {
   [K in keyof T]: T[K]
@@ -151,6 +152,11 @@ export type InitOptions = {
    * See Pino Docs for options: https://getpino.io/#/docs/api?id=options
    */
   loggerOptions?: LoggerOptions
+  /**
+   * A previously instantiated logger instance. Must conform to the PayloadLogger interface which uses Pino
+   * This allows you to bring your own logger instance and let payload use it
+   */
+  logger?: PayloadLogger
 
   /**
    * A function that is called immediately following startup that receives the Payload instance as it's only argument.

--- a/packages/payload/src/payload.ts
+++ b/packages/payload/src/payload.ts
@@ -312,7 +312,8 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
    */
   // @ts-expect-error // TODO: TypeScript hallucinating again. fix later
   async init(options: InitOptions): Promise<Payload> {
-    this.logger = Logger('payload', options.loggerOptions, options.loggerDestination)
+    this.logger =
+      options.logger ?? Logger('payload', options.loggerOptions, options.loggerDestination)
 
     if (!options.secret) {
       throw new Error('Error: missing secret key. A secret key is needed to secure Payload.')


### PR DESCRIPTION
## Description

This PR allows passing of a pino logger instance to payload and using the `getLogger` function from `utilities`. However, if a logger instance is not provided in `InitOptions`, payload fallbacks to the current behavior.

Logging is an essential part of our application and is used in a lot of places, especially in places that could throw an error or fail unexpectedly. Currently, the logger instance is highly coupled to payload which of course can be circumvented either by initializing payload first and using the returned logger or creating a separate logger instance outside of payload.

However, in some situations initializing payload first is not ideal as puts a lot of middleware in the stack which you might not want to go first. To give a better example, [overload-protection](https://github.com/davidmarkclements/overload-protection) is a middleware that returns 503 when the server is overloaded. Ideally, it wants to be at the top of the middleware to prevent other middleware from running first since the server is already overloaded. Also, it needs a logger instance so you can log into your logging service.

This creates an issue where you need the logger instance before registering the overload middleware but also don't want to call `payload.init()` first since it will put all its middleware ahead of `overload-protection`.

There are 2 possible options I have found in order to circumvent this.

- First, use `payload.config`'s `preMiddleware` hook and put `overload-protection` there. However, this resulted in webpack errors which were hard to debug.
- Second, create a separate logger instance, pass it to `overload-protection` then initialize payload after. This works but is wasteful since we now have 2 logger instances

The solution I found, and what I'm currently doing in my dev setup with the help of `patch-package` is to just create the logger instance, pass it to `overload-protection`, then finally initialize payload and pass logger to it. That being said, it's probably possible to solve this using the `preMiddleware` hook but debugging webpack errors is really not fun. This seems like a more simple solution that also improves payload's flexibility.

Other advantages of these changes:
- Ability to support other types of loggers and swap implementation as long as those loggers follow payload's logger interface
- Better migration story for teams with existing codebases

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
