### PR TITLE
Fix `setPreference()` return type

### DIFF
--- a/src/admin/components/utilities/Preferences/index.tsx
+++ b/src/admin/components/utilities/Preferences/index.tsx
@@ -7,7 +7,7 @@ import { requests } from '../../../api';
 
 type PreferencesContext = {
   getPreference: <T = any>(key: string) => T | Promise<T>;
-  setPreference: <T = any>(key: string, value: T) => void;
+  setPreference: <T = any>(key: string, value: T) => Promise<void>;
 }
 
 const Context = createContext({} as PreferencesContext);


### PR DESCRIPTION
## Description

Fixes the return type from `void` to `Promise<void>` to avoid a warning when you try to `await setPreference(...)`:

> 'await' has no effect on the type of this expression. ts(80007)

![image](https://github.com/payloadcms/payload/assets/5570098/5b1b6d8c-8885-429e-ba39-d7b38c10c94d)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
- [x] I believe this is a minor change that requires none of the above