### PR TITLE
feat: set JWT token field name with saveToJWT

### DIFF
--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -83,7 +83,7 @@ Once enabled, each document that is created within the Collection can be thought
 
 Successfully logging in returns a `JWT` (JSON web token) which is how a user will identify themselves to Payload. By providing this JWT via either an HTTP-only cookie or an `Authorization` header, Payload will automatically identify the user and add its user JWT data to the Express `req`, which is available throughout Payload including within access control, hooks, and more.
 
-You can specify what data gets encoded to the JWT by setting `saveToJWT` to true in your auth collection fields. If you wish to use a different key other than the field `name`, you can provide it to `saveToJWT` as a string.
+You can specify what data gets encoded to the JWT token by setting `saveToJWT` to true in your auth collection fields. If you wish to use a different key other than the field `name`, you can provide it to `saveToJWT` as a string.
 
 <Banner type="success">
   <strong>Tip:</strong><br/>

--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -83,9 +83,11 @@ Once enabled, each document that is created within the Collection can be thought
 
 Successfully logging in returns a `JWT` (JSON web token) which is how a user will identify themselves to Payload. By providing this JWT via either an HTTP-only cookie or an `Authorization` header, Payload will automatically identify the user and add its user JWT data to the Express `req`, which is available throughout Payload including within access control, hooks, and more.
 
+You can specify what data gets encoded to the JWT by setting `saveToJWT` to true in your auth collection fields. If you wish to use a different key other than the field `name`, you can provide it to `saveToJWT` as a string.
+
 <Banner type="success">
   <strong>Tip:</strong><br/>
-  You can access the logged in user from access control functions and hooks via the Express <strong>req</strong>. The logged in user is automatically added as the <strong>user</strong> property.
+  You can access the logged-in user from access control functions and hooks via the Express <strong>req</strong>. The logged-in user is automatically added as the <strong>user</strong> property.
 </Banner>
 
 ### HTTP-only cookies

--- a/src/auth/operations/getFieldsToSign.ts
+++ b/src/auth/operations/getFieldsToSign.ts
@@ -18,16 +18,17 @@ export const getFieldsToSign = (args: {
       ...signedFields,
     };
 
+    // get subfields from non-named fields like rows
     if (!fieldAffectsData(field) && fieldHasSubFields(field)) {
       field.fields.forEach((subField) => {
         if (fieldAffectsData(subField) && subField.saveToJWT) {
-          result[subField.name] = user[subField.name];
+          result[typeof subField.saveToJWT === 'string' ? subField.saveToJWT : subField.name] = user[subField.name];
         }
       });
     }
 
     if (fieldAffectsData(field) && field.saveToJWT) {
-      result[field.name] = user[field.name];
+      result[typeof field.saveToJWT === 'string' ? field.saveToJWT : field.name] = user[field.name];
     }
 
     return result;

--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -33,7 +33,10 @@ export const baseField = joi.object().keys({
     joi.valid(false),
   ),
   required: joi.boolean().default(false),
-  saveToJWT: joi.boolean().default(false),
+  saveToJWT: joi.alternatives().try(
+    joi.boolean(),
+    joi.string(),
+  ).default(false),
   unique: joi.boolean().default(false),
   localized: joi.boolean().default(false),
   index: joi.boolean().default(false),

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 import { CSSProperties } from 'react';
 import { Editor } from 'slate';
-import type { TFunction, i18n as Ii18n } from 'i18next';
+import type { i18n as Ii18n, TFunction } from 'i18next';
 import type { EditorProps } from '@monaco-editor/react';
 import { Operation, Where } from '../../types';
 import { SanitizedConfig } from '../../config/types';
@@ -108,7 +108,7 @@ export interface FieldBase {
   index?: boolean;
   defaultValue?: any;
   hidden?: boolean;
-  saveToJWT?: boolean
+  saveToJWT?: string | boolean;
   localized?: boolean;
   validate?: Validate;
   hooks?: {

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -39,6 +39,12 @@ export default buildConfigWithDefaults({
           hasMany: true,
         },
         {
+          name: 'namedSaveToJWT',
+          type: 'text',
+          defaultValue: 'namedSaveToJWT',
+          saveToJWT: 'named',
+        },
+        {
           name: 'custom',
           label: 'Custom',
           type: 'text',

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -6,6 +6,10 @@ import { AuthDebug } from './AuthDebug';
 
 export const slug = 'users';
 
+export const namedSaveToJWTValue = 'namedSaveToJWT value';
+
+export const saveToJWTKey = 'x-custom-jwt-property-name';
+
 export default buildConfigWithDefaults({
   admin: {
     user: 'users',
@@ -41,8 +45,8 @@ export default buildConfigWithDefaults({
         {
           name: 'namedSaveToJWT',
           type: 'text',
-          defaultValue: 'namedSaveToJWT',
-          saveToJWT: 'named',
+          defaultValue: namedSaveToJWTValue,
+          saveToJWT: saveToJWTKey,
         },
         {
           name: 'custom',

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -2,7 +2,7 @@ import mongoose from 'mongoose';
 import jwtDecode from 'jwt-decode';
 import payload from '../../src';
 import { initPayloadTest } from '../helpers/configHelpers';
-import { slug } from './config';
+import { namedSaveToJWTValue, saveToJWTKey, slug } from './config';
 import { devUser } from '../credentials';
 import type { User } from '../../src/auth';
 
@@ -107,7 +107,7 @@ describe('Auth', () => {
           email: jwtEmail,
           collection,
           roles,
-          named,
+          [saveToJWTKey]: customJWTPropertyKey,
           iat,
           exp,
         } = jwtDecode<User>(token);
@@ -115,7 +115,8 @@ describe('Auth', () => {
         expect(jwtEmail).toBeDefined();
         expect(collection).toEqual('users');
         expect(Array.isArray(roles)).toBeTruthy();
-        expect(named).toEqual('namedSaveToJWT');
+        // 'x-custom-jwt-property-name': 'namedSaveToJWT value'
+        expect(customJWTPropertyKey).toEqual(namedSaveToJWTValue);
         expect(iat).toBeDefined();
         expect(exp).toBeDefined();
       });

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import jwtDecode from 'jwt-decode';
 import payload from '../../src';
 import { initPayloadTest } from '../helpers/configHelpers';
 import { slug } from './config';
@@ -101,6 +102,23 @@ describe('Auth', () => {
         expect(data.user.email).toBeDefined();
       });
 
+      it('should have fields saved to JWT', async () => {
+        const {
+          email: jwtEmail,
+          collection,
+          roles,
+          named,
+          iat,
+          exp,
+        } = jwtDecode<User>(token);
+
+        expect(jwtEmail).toBeDefined();
+        expect(collection).toEqual('users');
+        expect(Array.isArray(roles)).toBeTruthy();
+        expect(named).toEqual('namedSaveToJWT');
+        expect(iat).toBeDefined();
+        expect(exp).toBeDefined();
+      });
 
       it('should allow authentication with an API key with useAPIKey', async () => {
         const apiKey = '0123456789ABCDEFGH';


### PR DESCRIPTION
## Description

When using API key authentication with 3rd party systems it can sometimes be necessary to have control over the attribute names in the JWT token.

This change widens the type of `saveToJWT` to be a string that can set the name of the attribute in the JWT token instead of using the field `name`.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
