### PR TITLE
fix: form-builder buildInitialFormState example

### DIFF
--- a/examples/form-builder/nextjs/components/Blocks/Form/buildInitialFormState.tsx
+++ b/examples/form-builder/nextjs/components/Blocks/Form/buildInitialFormState.tsx
@@ -1,41 +1,41 @@
-import { FormFieldBlock } from "payload-plugin-form-builder/dist/types"
+import { FormFieldBlock } from 'payload-plugin-form-builder/dist/types'
 
 export const buildInitialFormState = (fields: FormFieldBlock[]) => {
   return fields.reduce((initialSchema, field) => {
     if (field.blockType === 'checkbox') {
       return {
         ...initialSchema,
-        [field.blockName]: false,
+        [field.name]: false,
       }
     }
     if (field.blockType === 'country') {
       return {
         ...initialSchema,
-        [field.blockName]: '',
+        [field.name]: '',
       }
     }
     if (field.blockType === 'email') {
       return {
         ...initialSchema,
-        [field.blockName]: '',
+        [field.name]: '',
       }
     }
     if (field.blockType === 'text') {
       return {
         ...initialSchema,
-        [field.blockName]: '',
+        [field.name]: '',
       }
     }
     if (field.blockType === 'select') {
       return {
         ...initialSchema,
-        [field.blockName]: '',
+        [field.name]: '',
       }
     }
     if (field.blockType === 'state') {
       return {
         ...initialSchema,
-        [field.blockName]: '',
+        [field.name]: '',
       }
     }
   }, {})


### PR DESCRIPTION
## Description

Use `field.name` in the `buildInitialFormState` under form-builder example
Closes https://github.com/payloadcms/payload/issues/3133

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Change to the [examples](../examples/) directory (does not affect core functionality)
