### PR TITLE
fix: checks whether staticURL is relative or absolute path

### DIFF
--- a/src/admin/hooks/useThumbnail.ts
+++ b/src/admin/hooks/useThumbnail.ts
@@ -21,6 +21,11 @@ const useThumbnail = (collection: SanitizedCollectionConfig, doc: Record<string,
   } = doc;
 
   const { serverURL } = useConfig();
+  let pathURL = `${serverURL}${staticURL || ''}`;
+
+  if (absoluteURLPattern.test(staticURL)) {
+    pathURL = staticURL;
+  }
 
   if (typeof adminThumbnail === 'function') {
     const thumbnailURL = adminThumbnail({ doc });
@@ -31,7 +36,7 @@ const useThumbnail = (collection: SanitizedCollectionConfig, doc: Record<string,
       return thumbnailURL;
     }
 
-    return `${serverURL}${thumbnailURL}`;
+    return `${pathURL}/${thumbnailURL}`;
   }
 
   if (isImage(mimeType as string)) {
@@ -44,10 +49,10 @@ const useThumbnail = (collection: SanitizedCollectionConfig, doc: Record<string,
     }
 
     if (sizes?.[adminThumbnail]?.filename) {
-      return `${serverURL}${staticURL}/${sizes[adminThumbnail].filename}`;
+      return `${pathURL}/${sizes[adminThumbnail].filename}`;
     }
 
-    return `${serverURL}${staticURL}/${filename}`;
+    return `${pathURL}/${filename}`;
   }
 
   return false;


### PR DESCRIPTION
## Description

Fixes #3097 - staticURL was getting appended to the serverURL even when it is an absolute path.

- [X] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
