### PR TITLE
chore: adds tests for react hooks, updates to add at index instead of after

### DIFF
--- a/src/admin/components/elements/ArrayAction/index.tsx
+++ b/src/admin/components/elements/ArrayAction/index.tsx
@@ -63,10 +63,10 @@ export const ArrayAction: React.FC<Props> = ({
                   className={`${baseClass}__action ${baseClass}__add`}
                   type="button"
                   onClick={() => {
-                    addRow(index);
+                    addRow(index + 1);
                     close();
                   }}
-                  >
+                >
                   <Plus />
                   {t('addBelow')}
                 </button>
@@ -77,7 +77,7 @@ export const ArrayAction: React.FC<Props> = ({
                     duplicateRow(index);
                     close();
                   }}
-                  >
+                >
                   <Copy />
                   {t('duplicate')}
                 </button>

--- a/src/admin/components/forms/Form/fieldReducer.ts
+++ b/src/admin/components/forms/Form/fieldReducer.ts
@@ -111,9 +111,7 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
     }
 
     case 'ADD_ROW': {
-      const { rowIndex: rowIndexArg, path, subFieldState, blockType } = action;
-      const defaultRowIndex = state[path]?.rows?.length ? state[path].rows.length - 1 : 0;
-      const rowIndex = Math.max(0, Math.min(rowIndexArg ?? defaultRowIndex, state[path]?.rows?.length - 1 || 0));
+      const { rowIndex, path, subFieldState, blockType } = action;
 
       const rowsMetadata = [...state[path]?.rows || []];
       rowsMetadata.splice(

--- a/src/admin/components/forms/Form/index.tsx
+++ b/src/admin/components/forms/Form/index.tsx
@@ -426,7 +426,7 @@ const Form: React.FC<Props> = (props) => {
 
     if (fieldConfig) {
       const subFieldState = await buildStateFromSchema({ fieldSchema: fieldConfig, data, preferences, operation, id, user, locale, t });
-      dispatchFields({ type: 'ADD_ROW', rowIndex, path, blockType: data?.blockType, subFieldState });
+      dispatchFields({ type: 'ADD_ROW', rowIndex: rowIndex - 1, path, blockType: data?.blockType, subFieldState });
     }
   }, [dispatchFields, getDocPreferences, id, user, operation, locale, t, getRowConfigByPath]);
 
@@ -443,7 +443,7 @@ const Form: React.FC<Props> = (props) => {
 
     if (fieldConfig) {
       const subFieldState = await buildStateFromSchema({ fieldSchema: fieldConfig, data, preferences, operation, id, user, locale, t });
-      dispatchFields({ type: 'REPLACE_ROW', rowIndex, path, blockType: data?.blockType, subFieldState });
+      dispatchFields({ type: 'REPLACE_ROW', rowIndex: rowIndex - 1, path, blockType: data?.blockType, subFieldState });
     }
   }, [dispatchFields, getDocPreferences, id, user, operation, locale, t, getRowConfigByPath]);
 

--- a/src/admin/components/forms/Form/types.ts
+++ b/src/admin/components/forms/Form/types.ts
@@ -182,7 +182,7 @@ export type Context = {
   reset: Reset
   replaceState: (state: Fields) => void
   buildRowErrors: () => void
-  addFieldRow: ({ path, rowIndex, data }: { path: string, rowIndex?: number, data?: Data }) => Promise<void>
+  addFieldRow: ({ path, rowIndex, data }: { path: string, rowIndex: number, data?: Data }) => Promise<void>
   removeFieldRow: ({ path, rowIndex }: { path: string, rowIndex: number }) => Promise<void>
   replaceFieldRow: ({ path, rowIndex, data }: { path: string, rowIndex: number, data?: Data }) => Promise<void>
 }

--- a/src/admin/components/forms/field-types/Blocks/BlocksDrawer/index.tsx
+++ b/src/admin/components/forms/field-types/Blocks/BlocksDrawer/index.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { useModal } from '@faceless-ui/modal';
 import { useTranslation } from 'react-i18next';
+import type { i18n } from 'i18next';
 import BlockSearch from './BlockSearch';
 import { Props } from './types';
 import { Drawer } from '../../../../elements/Drawer';
 import { getTranslation } from '../../../../../../utilities/getTranslation';
 import { ThumbnailCard } from '../../../../elements/ThumbnailCard';
 import DefaultBlockImage from '../../../../graphics/DefaultBlockImage';
-import { i18n } from 'i18next';
 import { Block } from '../../../../../../fields/config/types';
 
 import './index.scss';

--- a/src/admin/components/forms/field-types/Blocks/RowActions.tsx
+++ b/src/admin/components/forms/field-types/Blocks/RowActions.tsx
@@ -1,5 +1,5 @@
-import { useModal } from '@faceless-ui/modal';
 import React from 'react';
+import { useModal } from '@faceless-ui/modal';
 import { Block, Labels } from '../../../../../fields/config/types';
 import { ArrayAction } from '../../../elements/ArrayAction';
 import { useDrawerSlug } from '../../../elements/Drawer/useDrawerSlug';
@@ -33,14 +33,16 @@ export const RowActions: React.FC<{
   const { openModal, closeModal } = useModal();
   const drawerSlug = useDrawerSlug('blocks-drawer');
 
+  const [indexToAdd, setIndexToAdd] = React.useState<number | null>(null);
+
   return (
     <React.Fragment>
       <BlocksDrawer
         drawerSlug={drawerSlug}
         blocks={blocks}
-        addRow={(index, rowBlockType) => {
+        addRow={(_, rowBlockType) => {
           if (typeof addRow === 'function') {
-            addRow(index, rowBlockType);
+            addRow(indexToAdd, rowBlockType);
           }
           closeModal(drawerSlug);
         }}
@@ -49,7 +51,8 @@ export const RowActions: React.FC<{
       />
       <ArrayAction
         rowCount={rowCount}
-        addRow={() => {
+        addRow={(index) => {
+          setIndexToAdd(index);
           openModal(drawerSlug);
         }}
         duplicateRow={() => duplicateRow(rowIndex, blockType)}

--- a/src/admin/scss/app.scss
+++ b/src/admin/scss/app.scss
@@ -4,6 +4,10 @@
 @import './colors.scss';
 
 :root {
+  --base-px: 25;
+  --base-body-size: 13;
+  --base: calc((var(--base-px) / var(--base-body-size)) * 1rem);
+
   --breakpoint-xs-width : #{$breakpoint-xs-width};
   --breakpoint-s-width : #{$breakpoint-s-width};
   --breakpoint-m-width : #{$breakpoint-m-width};

--- a/src/admin/scss/colors.scss
+++ b/src/admin/scss/colors.scss
@@ -81,6 +81,8 @@
   --color-error-900: rgb(51, 22, 24);
   --color-error-950: rgb(25, 11, 12);
 
+  --theme-border-color: var(--theme-elevation-150);
+
   --theme-success-50: var(--color-success-50);
   --theme-success-100: var(--color-success-100);
   --theme-success-150: var(--color-success-150);
@@ -165,6 +167,8 @@
 }
 
 html[data-theme=dark] {
+  --theme-border-color: var(--theme-elevation-150);
+
   --theme-elevation-0: var(--color-base-900);
   --theme-elevation-50: var(--color-base-850);
   --theme-elevation-100: var(--color-base-800);

--- a/test/fields/collections/Array/components/AddCustomBlocks/index.scss
+++ b/test/fields/collections/Array/components/AddCustomBlocks/index.scss
@@ -1,0 +1,44 @@
+@mixin btn-reset {
+  border: 0;
+  background: none;
+  box-shadow: none;
+  border-radius: 0;
+  padding: 0;
+  color: currentColor;
+  cursor: pointer;
+}
+
+#field-customBlocks {
+  margin-bottom: var(--base);
+
+  .blocks-field__drawer-toggler {
+    display: none;
+  }
+}
+
+.custom-blocks-field-management {
+  &__blocks-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: calc(var(--base) * 2);
+  }
+
+  &__block-button {
+    @include btn-reset;
+
+    border: 1px solid var(--theme-border-color);
+    width: 100%;
+    padding: 25px 10px;
+
+    &:hover {
+      border-color: var(--theme-elevation-400);
+    }
+  }
+
+  &__replace-block-button {
+    margin-top: calc(var(--base) * 1.5);
+    color: var(--theme-bg);
+    background: var(--theme-text);
+  }
+}
+

--- a/test/fields/collections/Array/components/AddCustomBlocks/index.tsx
+++ b/test/fields/collections/Array/components/AddCustomBlocks/index.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { useForm } from '../../../../../../src/admin/components/forms/Form/context';
+import useField from '../../../../../../src/admin/components/forms/useField';
+
+import './index.scss';
+
+const baseClass = 'custom-blocks-field-management';
+
+export const AddCustomBlocks: React.FC = () => {
+  const { addFieldRow, replaceFieldRow } = useForm();
+  const { value } = useField({ path: 'customBlocks' });
+
+  const nextIndex = typeof value === 'number' ? value + 1 : 0;
+
+  return (
+    <div className={baseClass}>
+      <div className={`${baseClass}__blocks-grid`}>
+        <button
+          className={`${baseClass}__block-button`}
+          type="button"
+          onClick={() => addFieldRow({ path: 'customBlocks', data: { block1Title: 'Block 1: Prefilled Title', blockType: 'block-1' }, rowIndex: nextIndex })}
+        >
+          Add Block 1
+        </button>
+
+        <button
+          className={`${baseClass}__block-button`}
+          type="button"
+          onClick={() => addFieldRow({ path: 'customBlocks', data: { block2Title: 'Block 2: Prefilled Title', blockType: 'block-2' }, rowIndex: nextIndex })}
+        >
+          Add Block 2
+        </button>
+      </div>
+
+      <div>
+        <button
+          className={`${baseClass}__block-button ${baseClass}__replace-block-button`}
+          type="button"
+          onClick={() => replaceFieldRow({ path: 'customBlocks', data: { block1Title: 'REPLACED BLOCK', blockType: 'block-1' }, rowIndex: nextIndex - 1 })}
+        >
+          Replace Block
+          {' '}
+          {nextIndex - 1}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -120,42 +120,37 @@ const ArrayFields: CollectionConfig = {
       },
     },
     {
-      type: 'row',
-      fields: [
+      name: 'customBlocks',
+      type: 'blocks',
+      blocks: [
         {
-          name: 'customBlocks',
-          type: 'blocks',
-          blocks: [
+          slug: 'block-1',
+          fields: [
             {
-              slug: 'block-1',
-              fields: [
-                {
-                  name: 'block1Title',
-                  type: 'text',
-                },
-              ],
-            },
-            {
-              slug: 'block-2',
-              fields: [
-                {
-                  name: 'block2Title',
-                  type: 'text',
-                },
-              ],
+              name: 'block1Title',
+              type: 'text',
             },
           ],
         },
         {
-          type: 'ui',
-          name: 'ui',
-          admin: {
-            components: {
-              Field: AddCustomBlocks,
+          slug: 'block-2',
+          fields: [
+            {
+              name: 'block2Title',
+              type: 'text',
             },
-          },
+          ],
         },
       ],
+    },
+    {
+      type: 'ui',
+      name: 'ui',
+      admin: {
+        components: {
+          Field: AddCustomBlocks,
+        },
+      },
     },
   ],
 };

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig } from '../../../../src/collections/config/types';
 import { ArrayRowLabel } from './LabelComponent';
+import { AddCustomBlocks } from './components/AddCustomBlocks';
 
 export const arrayDefaultValue = [
   { text: 'row one' },
@@ -117,6 +118,44 @@ const ArrayFields: CollectionConfig = {
           RowLabel: ArrayRowLabel,
         },
       },
+    },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'customBlocks',
+          type: 'blocks',
+          blocks: [
+            {
+              slug: 'block-1',
+              fields: [
+                {
+                  name: 'block1Title',
+                  type: 'text',
+                },
+              ],
+            },
+            {
+              slug: 'block-2',
+              fields: [
+                {
+                  name: 'block2Title',
+                  type: 'text',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'ui',
+          name: 'ui',
+          admin: {
+            components: {
+              Field: AddCustomBlocks,
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -396,14 +396,13 @@ describe('fields', () => {
   describe('array', () => {
     let url: AdminUrlUtil;
     beforeAll(() => {
-      url = new AdminUrlUtil(serverURL, arrayFieldsSlug);
+      url = new AdminUrlUtil(serverURL, 'array-fields');
     });
 
     test('should be readOnly', async () => {
       await page.goto(url.create);
       const field = page.locator('#field-readOnly__0__text');
-      await expect(field)
-        .toBeDisabled();
+      await expect(field).toBeDisabled();
     });
 
     test('should have defaultValue', async () => {
@@ -514,6 +513,21 @@ describe('fields', () => {
         });
 
         expect(directChildDivCount).toBe(2);
+      });
+    });
+
+    describe('row react hooks', () => {
+      test('should add 2 new block rows', async () => {
+        await page.goto(url.create);
+
+        await page.locator('.custom-blocks-field-management').getByRole('button', { name: 'Add Block 1' }).click();
+        expect(await page.locator('#field-customBlocks input[name="customBlocks.0.block1Title"]').inputValue()).toEqual('Block 1: Prefilled Title');
+
+        await page.locator('.custom-blocks-field-management').getByRole('button', { name: 'Add Block 2' }).click();
+        expect(await page.locator('#field-customBlocks input[name="customBlocks.1.block2Title"]').inputValue()).toEqual('Block 2: Prefilled Title');
+
+        await page.locator('.custom-blocks-field-management').getByRole('button', { name: 'Replace Block 2' }).click();
+        expect(await page.locator('#field-customBlocks input[name="customBlocks.1.block1Title"]').inputValue()).toEqual('REPLACED BLOCK');
       });
     });
   });


### PR DESCRIPTION
## Description

Fixes the newly added react hooks `addFieldRow` and `replaceFieldRow` insert position. They should insert _at_ the `rowIndex` passed in, currently they are inserted after the passed `rowIndex`.

I also added a custom component to showcase how these functions work, I left the example in the `Arrays` test folder because this approach can be used with arrays or blocks:

![CleanShot 2023-08-08 at 14 08 03](https://github.com/payloadcms/payload/assets/30633324/c853c37e-22d3-428b-a12f-c1434d58495a)


- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
