### PR TITLE
chore(templates): fixes orders access control in ecommerce template

### DIFF
--- a/templates/ecommerce/src/payload/access/adminsOrLoggedIn.ts
+++ b/templates/ecommerce/src/payload/access/adminsOrLoggedIn.ts
@@ -1,0 +1,12 @@
+import type { Access, AccessArgs } from 'payload/config'
+
+import { checkRole } from '../collections/Users/checkRole'
+import type { User } from '../payload-types'
+
+export const adminsOrLoggedIn: Access = ({ req }: AccessArgs<User>) => {
+  if (checkRole(['admin'], req.user)) {
+    return true
+  }
+
+  return !!req.user
+}

--- a/templates/ecommerce/src/payload/collections/Orders/index.ts
+++ b/templates/ecommerce/src/payload/collections/Orders/index.ts
@@ -20,7 +20,7 @@ export const Orders: CollectionConfig = {
   },
   access: {
     read: adminsOrOrderedBy,
-    update: adminsOrOrderedBy,
+    update: admins,
     create: adminsOrLoggedIn,
     delete: admins,
   },

--- a/templates/ecommerce/src/payload/collections/Orders/index.ts
+++ b/templates/ecommerce/src/payload/collections/Orders/index.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from 'payload/types'
 
 import { admins } from '../../access/admins'
-import { checkRole } from '../Users/checkRole'
+import { adminsOrLoggedIn } from '../../access/adminsOrLoggedIn'
 import { adminsOrOrderedBy } from './access/adminsOrOrderedBy'
 import { clearUserCart } from './hooks/clearUserCart'
 import { populateOrderedBy } from './hooks/populateOrderedBy'
@@ -20,8 +20,8 @@ export const Orders: CollectionConfig = {
   },
   access: {
     read: adminsOrOrderedBy,
-    update: admins,
-    create: admins,
+    update: adminsOrOrderedBy,
+    create: adminsOrLoggedIn,
     delete: admins,
   },
   fields: [
@@ -37,9 +37,6 @@ export const Orders: CollectionConfig = {
       name: 'stripePaymentIntentID',
       label: 'Stripe Payment Intent ID',
       type: 'text',
-      access: {
-        read: ({ req: { user } }) => checkRole(['admin'], user),
-      },
       admin: {
         position: 'sidebar',
         components: {


### PR DESCRIPTION
## Description

Fixes `orders` access control in the e-commerce template where non-admins could not create orders and customers could not read `stripePaymentIntentID`.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Change to the [templates](../templates/) directory (does not affect core functionality)