### PR TITLE
fix: correctly passes block path inside buildFieldSchemaMap

### DIFF
--- a/src/utilities/buildFieldSchemaMap.ts
+++ b/src/utilities/buildFieldSchemaMap.ts
@@ -29,8 +29,9 @@ export const buildFieldSchemaMap = (entityFields: Field[]): Map<string, Field[]>
       switch (field.type) {
         case 'blocks':
           field.blocks.forEach((block) => {
-            fieldMap.set(`${currentPath}.${block.slug}`, block.fields);
-            buildUpMap(block.fields, currentPath);
+            const blockPath = `${currentPath}.${block.slug}`;
+            fieldMap.set(blockPath, block.fields);
+            buildUpMap(block.fields, blockPath);
           });
           break;
 


### PR DESCRIPTION
## Description

Fixes issue where buildFieldSchemaMap was not passing the correct field path when looping over blocks. This caused an issue when block slugs had the same naming as inner fields.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
