### PR TITLE
chore: removes duplicative code for getting parent path

### DIFF
--- a/src/admin/components/forms/Form/buildFieldSchemaMap.ts
+++ b/src/admin/components/forms/Form/buildFieldSchemaMap.ts
@@ -1,4 +1,5 @@
-import { Field } from '../fields/config/types';
+import { Field } from '../../../../fields/config/types';
+import { createNestedFieldPath } from './createNestedFieldPath';
 
 /**
  * **Returns Map with array and block field schemas**
@@ -14,40 +15,32 @@ import { Field } from '../fields/config/types';
 export const buildFieldSchemaMap = (entityFields: Field[]): Map<string, Field[]> => {
   const fieldMap = new Map<string, Field[]>();
 
-  const buildUpMap = (fields: Field[], fieldPath = '') => {
+  const buildUpMap = (fields: Field[], parentPath = '') => {
     fields.forEach((field) => {
-      let currentPath = fieldPath;
-
-      if (currentPath) {
-        if ('name' in field && field?.name) {
-          currentPath = `${currentPath}.${field.name}`;
-        }
-      } else if ('name' in field && field?.name) {
-        currentPath = field.name;
-      }
+      const path = createNestedFieldPath(parentPath, field);
 
       switch (field.type) {
         case 'blocks':
           field.blocks.forEach((block) => {
-            fieldMap.set(`${currentPath}.${block.slug}`, block.fields);
-            buildUpMap(block.fields, currentPath);
+            fieldMap.set(`${path}.${block.slug}`, block.fields);
+            buildUpMap(block.fields, path);
           });
           break;
 
         case 'array':
-          fieldMap.set(currentPath, field.fields);
-          buildUpMap(field.fields, currentPath);
+          fieldMap.set(path, field.fields);
+          buildUpMap(field.fields, path);
           break;
 
         case 'row':
         case 'collapsible':
         case 'group':
-          buildUpMap(field.fields, currentPath);
+          buildUpMap(field.fields, path);
           break;
 
         case 'tabs':
           field.tabs.forEach((tab) => {
-            let tabPath = currentPath;
+            let tabPath = path;
             if (tabPath) {
               tabPath = 'name' in tab ? `${tabPath}.${tab.name}` : tabPath;
             } else {

--- a/src/admin/components/forms/Form/index.tsx
+++ b/src/admin/components/forms/Form/index.tsx
@@ -28,7 +28,7 @@ import { useOperation } from '../../utilities/OperationProvider';
 import { WatchFormErrors } from './WatchFormErrors';
 import { splitPathByArrayFields } from '../../../../utilities/splitPathByArrayFields';
 import { setsAreEqual } from '../../../../utilities/setsAreEqual';
-import { buildFieldSchemaMap } from '../../../../utilities/buildFieldSchemaMap';
+import { buildFieldSchemaMap } from './buildFieldSchemaMap';
 import { isNumber } from '../../../../utilities/isNumber';
 
 const baseClass = 'form';


### PR DESCRIPTION
## Description

I noticed that `buildSchemaMap` was implementing the same logic from `createNestedFieldPath`. Removes duplicative code and just uses `createNestedFieldPath`.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
