### PR TITLE
fix: simplifies logic for DatePicker display formatting

### DIFF
--- a/src/admin/components/elements/DatePicker/DatePicker.tsx
+++ b/src/admin/components/elements/DatePicker/DatePicker.tsx
@@ -16,8 +16,8 @@ const DateTime: React.FC<Props> = (props) => {
   const {
     value,
     onChange,
-    displayFormat,
-    pickerAppearance = "dayOnly",
+    displayFormat: customDisplayFormat,
+    pickerAppearance = 'default',
     minDate,
     maxDate,
     monthsToShow = 1,
@@ -39,20 +39,21 @@ const DateTime: React.FC<Props> = (props) => {
     console.warn(`Could not find DatePicker locale for ${locale}`);
   }
 
-  let dateTimeFormat = displayFormat;
+  let dateFormat = customDisplayFormat;
 
-  if (dateTimeFormat === undefined && pickerAppearance) {
-    if (pickerAppearance === 'dayAndTime') dateTimeFormat = 'MMM d, yyy h:mm a';
-    else if (pickerAppearance === 'timeOnly') dateTimeFormat = 'h:mm a';
-    else if (pickerAppearance === 'dayOnly') dateTimeFormat = 'dd';
-    else if (pickerAppearance === 'monthOnly') dateTimeFormat = 'MMMM';
-    else dateTimeFormat = 'MMM d, yyy';
+  if (!customDisplayFormat) {
+    // when no displayFormat is provided, determine format based on the picker appearance
+    if (pickerAppearance === 'default') dateFormat = 'MM/dd/yyyy';
+    else if (pickerAppearance === 'dayAndTime') dateFormat = 'MMM d, yyy h:mm a';
+    else if (pickerAppearance === 'timeOnly') dateFormat = 'h:mm a';
+    else if (pickerAppearance === 'dayOnly') dateFormat = 'MMM dd';
+    else if (pickerAppearance === 'monthOnly') dateFormat = 'MMMM';
   }
 
   const dateTimePickerProps = {
     minDate,
     maxDate,
-    dateFormat: dateTimeFormat,
+    dateFormat,
     monthsShown: Math.min(2, monthsToShow),
     showTimeSelect: pickerAppearance === 'dayAndTime' || pickerAppearance === 'timeOnly',
     minTime,

--- a/src/admin/components/elements/DatePicker/types.ts
+++ b/src/admin/components/elements/DatePicker/types.ts
@@ -1,6 +1,6 @@
 type SharedProps = {
   displayFormat?: string
-  pickerAppearance?: 'dayAndTime' | 'timeOnly' | 'dayOnly' | 'monthOnly'
+  pickerAppearance?: 'default' | 'dayAndTime' | 'timeOnly' | 'dayOnly' | 'monthOnly'
 }
 
 type TimePickerProps = {
@@ -22,6 +22,9 @@ type MonthPickerProps = {
 }
 
 export type ConditionalDateProps =
+  | SharedProps & {
+    pickerAppearance?: 'default'
+  }
   | SharedProps & DayPickerProps & TimePickerProps & {
     pickerAppearance?: 'dayAndTime'
   }


### PR DESCRIPTION
## Description

Fixes issue where date was defaulting to only displaying the day number.

Regression from https://github.com/payloadcms/payload/pull/2347.

#### Before:
![CleanShot 2023-08-14 at 10 56 02](https://github.com/payloadcms/payload/assets/30633324/642c40a8-14da-4794-a9a5-b384785aa275)

#### After:
![CleanShot 2023-08-14 at 10 55 11](https://github.com/payloadcms/payload/assets/30633324/fd0fd654-df6a-4fad-999e-b32b2b24afdc)

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
