### PR TITLE
chore(test): adds test to ensure relationship returns over 10 docs

### DIFF
--- a/test/relationships/config.ts
+++ b/test/relationships/config.ts
@@ -190,6 +190,12 @@ export default buildConfigWithDefaults({
           name: 'name',
           type: 'text',
         },
+        {
+          name: 'movies',
+          type: 'relationship',
+          relationTo: 'movies',
+          hasMany: true,
+        },
       ],
     },
   ],

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -345,6 +345,65 @@ describe('Relationships', () => {
         expect(query.docs).toHaveLength(1);
       });
     });
+    describe('Multiple Docs', () => {
+      const movieList = [
+        'Pulp Fiction',
+        'Reservoir Dogs',
+        'Once Upon a Time in Hollywood',
+        'Shrek',
+        'Shrek 2',
+        'Shrek 3',
+        'Scream',
+        'The Matrix',
+        'The Matrix Reloaded',
+        'The Matrix Revolutions',
+        'The Matrix Resurrections',
+        'The Haunting',
+        'The Haunting of Hill House',
+        'The Haunting of Bly Manor',
+        'Insidious',
+      ];
+
+      beforeAll(async () => {
+        let movieDocs: any[] = [];
+        movieDocs = await Promise.all(movieList.map((movie) => {
+          return payload.create({
+            collection: 'movies',
+            data: {
+              name: movie,
+            },
+          });
+        }));
+      });
+
+      it('should return more than 10 docs in relationship', async () => {
+        const allMovies = await payload.find({
+          collection: 'movies',
+          limit: 20,
+        });
+
+        const movieIDs = allMovies.docs.map((doc) => doc.id);
+
+        await payload.create({
+          collection: 'directors',
+          data: {
+            name: 'Quentin Tarantino',
+            movies: movieIDs,
+          },
+        });
+
+        const director = await payload.find({
+          collection: 'directors',
+          where: {
+            name: {
+              equals: 'Quentin Tarantino',
+            },
+          },
+        });
+
+        expect(director.docs[0].movies.length).toBeGreaterThan(10);
+      });
+    });
   });
 });
 

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -1,5 +1,5 @@
-import mongoose from 'mongoose';
 import { randomBytes } from 'crypto';
+import mongoose from 'mongoose';
 import { initPayloadTest } from '../helpers/configHelpers';
 import config, { customIdSlug, chainedRelSlug, defaultAccessRelSlug, slug, relationSlug, customIdNumberSlug } from './config';
 import payload from '../../src';
@@ -365,8 +365,7 @@ describe('Relationships', () => {
       ];
 
       beforeAll(async () => {
-        let movieDocs: any[] = [];
-        movieDocs = await Promise.all(movieList.map((movie) => {
+        await Promise.all(movieList.map((movie) => {
           return payload.create({
             collection: 'movies',
             data: {

--- a/test/relationships/payload-types.ts
+++ b/test/relationships/payload-types.ts
@@ -85,6 +85,7 @@ export interface Movie {
 export interface Director {
   id: string;
   name?: string;
+  movies?: Array<string | Movie>;
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Description

Related issue #2885

Adds test to ensure relationship fields are returning more than 10 docs.

- [X] I have read and understand the CONTRIBUTING.md document in this repository

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works