### PR TITLE
docs: removes auto-formatting from rich-text.mdx

### DIFF
--- a/docs/fields/rich-text.mdx
+++ b/docs/fields/rich-text.mdx
@@ -7,9 +7,7 @@ keywords: rich text, fields, config, configuration, documentation, Content Manag
 ---
 
 <Banner>
-  The Rich Text field is a powerful way to allow editors to write dynamic
-  content. The content is saved as JSON in the database and can be converted
-  into any format, including HTML, that you need.
+  The Rich Text field is a powerful way to allow editors to write dynamic content. The content is saved as JSON in the database and can be converted into any format, including HTML, that you need.
 </Banner>
 
 <LightDarkImage 
@@ -22,13 +20,7 @@ keywords: rich text, fields, config, configuration, documentation, Content Manag
 The Admin component is built on the powerful [`slatejs`](https://docs.slatejs.org/) editor and is meant to be as extensible and customizable as possible.
 
 <Banner type="success">
-  <strong>
-    Consistent with Payload's goal of making you learn as little of Payload as
-    possible, customizing and using the Rich Text Editor does not involve
-    learning how to develop for a <em>Payload</em> rich text editor.
-  </strong> Instead, you can invest your time and effort into learning Slate, an
-  open-source tool that will allow you to apply your learnings elsewhere as
-  well.
+  <strong>Consistent with Payload's goal of making you learn as little of Payload as possible, customizing and using the Rich Text Editor does not involve learning how to develop for a <em>Payload</em> rich text editor.</strong> Instead, you can invest your time and effort into learning Slate, an open-source tool that will allow you to apply your learnings elsewhere as well.
 </Banner>
 
 ### Config
@@ -124,13 +116,7 @@ The built-in `relationship` element is a powerful way to reference other Documen
 Similar to the `relationship` element, the `upload` element is a user-friendly way to reference [Upload-enabled collections](/docs/upload/overview) with a UI specifically designed for media / image-based uploads.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
-  Collections are automatically allowed to be selected within the Rich Text
-  relationship and upload elements by default. If you want to disable a
-  collection from being able to be referenced in Rich Text fields, set the
-  collection admin options of <strong>enableRichTextLink</strong> and{" "}
-  <strong>enableRichTextRelationship</strong> to false.
+  <strong>Tip:</strong><br />Collections are automatically allowed to be selected within the Rich Text relationship and upload elements by default. If you want to disable a collection from being able to be referenced in Rich Text fields, set the collection admin options of <strong>enableRichTextLink</strong> and <strong>enableRichTextRelationship</strong> to false.
 </Banner>
 
 Relationship and Upload elements are populated dynamically into your Rich Text field' content. Within the REST and Local APIs, any present RichText `relationship` or `upload` elements will respect the `depth` option that you pass, and will be populated accordingly. In GraphQL, each `richText` field accepts an argument of `depth` for you to utilize.
@@ -306,10 +292,7 @@ const serialize = (children) =>
 ```
 
 <Banner>
-  <strong>Note:</strong>
-  <br />
-  The above example is for how to render to JSX, although for plain HTML the
-  pattern is similar. Just remove the JSX and return HTML strings instead!
+  <strong>Note:</strong><br />The above example is for how to render to JSX, although for plain HTML the pattern is similar. Just remove the JSX and return HTML strings instead!
 </Banner>
 
 ### Built-in SlateJS Plugins


### PR DESCRIPTION
## Description

The closing tag of all inline HTML elements within MDX files must be on the same line as its opener, otherwise it throws an error during compilation. The `strong` tag [here](https://github.com/payloadcms/payload/compare/docs/rich-text-auto-format?expand=1#diff-b3177f16b01085dd79947cb80a25c9f7c5f10cc053473b9407d7de5a7439eb46R23) was the culprit this time. Our auto-formatting is notorious for improperly formatting doc files.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
