### PR TITLE
chore: improve checkboxes

### DIFF
--- a/src/admin/components/forms/field-types/Checkbox/Input.tsx
+++ b/src/admin/components/forms/field-types/Checkbox/Input.tsx
@@ -50,7 +50,6 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = (props) => {
           name={name}
           aria-label={ariaLabel}
           checked={Boolean(checked)}
-          readOnly
           onInput={onToggle}
         />
         <span className={`${baseClass}__icon ${!partialChecked ? 'check' : 'partial'}`}>

--- a/src/admin/components/forms/field-types/Checkbox/Input.tsx
+++ b/src/admin/components/forms/field-types/Checkbox/Input.tsx
@@ -50,6 +50,7 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = (props) => {
           name={name}
           aria-label={ariaLabel}
           checked={Boolean(checked)}
+          disabled={readOnly}
           onInput={onToggle}
         />
         <span className={`${baseClass}__icon ${!partialChecked ? 'check' : 'partial'}`}>

--- a/src/admin/components/forms/field-types/Checkbox/index.scss
+++ b/src/admin/components/forms/field-types/Checkbox/index.scss
@@ -25,7 +25,7 @@
     padding-left: base(.5);
   }
   
-  &:hover {
+  &:hover:not(&--read-only) {
     cursor: pointer;
 
     svg {

--- a/src/admin/components/forms/field-types/Checkbox/index.scss
+++ b/src/admin/components/forms/field-types/Checkbox/index.scss
@@ -26,7 +26,7 @@
   }
   
  
-  &:not(:disabled):not(&--read-only){
+  &:not(:disabled):not(&--read-only) {
     &:active,
     &:focus-within,
     &:focus {
@@ -59,8 +59,9 @@
     width: $baseline;
     height: $baseline;
 
-    & input[type="checkbox"] {
+    &input[type="checkbox"] {
       position: absolute;
+      // Without the extra 4px, there is an uncheckable area due to the border of the parent element
       width: calc(100% + 4px);
       height: calc(100% + 4px);
       padding: 0;

--- a/src/admin/components/forms/field-types/Checkbox/index.scss
+++ b/src/admin/components/forms/field-types/Checkbox/index.scss
@@ -60,10 +60,13 @@
     height: $baseline;
 
     & input[type="checkbox"] {
-      width: 100%;
-      height: 100%;
+      position: absolute;
+      width: calc(100% + 4px);
+      height: calc(100% + 4px);
       padding: 0;
       margin: 0;
+      margin-left: -2px;
+      margin-top: -2px;
       opacity: 0;
       border-radius: 0;
       z-index: 1;

--- a/src/admin/components/forms/field-types/Checkbox/index.scss
+++ b/src/admin/components/forms/field-types/Checkbox/index.scss
@@ -25,13 +25,30 @@
     padding-left: base(.5);
   }
   
-  &:hover:not(&--read-only) {
-    cursor: pointer;
+ 
+  &:not(:disabled):not(&--read-only){
+    &:active,
+    &:focus-within,
+    &:focus {
+      .custom-checkbox__input {
+        @include inputShadowActive;
 
-    svg {
-      opacity: 0.2;
+        border-color: var(--theme-elevation-400);
+        outline: 0;
+      }
     }
   }
+  
+  &:not(:disabled):not(&--read-only):not(&--checked) {
+    &:hover {
+      cursor: pointer;
+
+      svg {
+        opacity: 0.2;
+      }
+    }
+  }
+
 
   &__input {
     @include formInput;

--- a/src/admin/components/forms/field-types/Checkbox/index.scss
+++ b/src/admin/components/forms/field-types/Checkbox/index.scss
@@ -30,11 +30,11 @@
     &:active,
     &:focus-within,
     &:focus {
-      .custom-checkbox__input {
+      .custom-checkbox__input, & input[type="checkbox"] {
         @include inputShadowActive;
 
-        border-color: var(--theme-elevation-400);
         outline: 0;
+        box-shadow: 0 0 3px 3px var(--theme-success-400)!important;
       }
     }
   }
@@ -59,7 +59,7 @@
     width: $baseline;
     height: $baseline;
 
-    &input[type="checkbox"] {
+    & input[type="checkbox"] {
       position: absolute;
       // Without the extra 4px, there is an uncheckable area due to the border of the parent element
       width: calc(100% + 4px);
@@ -72,10 +72,6 @@
       border-radius: 0;
       z-index: 1;
       cursor: pointer;
-    }
-
-    &:focus-within {
-      box-shadow: 0 0 3px 3px var(--theme-success-400);
     }
   }
 

--- a/src/admin/components/forms/field-types/Checkbox/index.scss
+++ b/src/admin/components/forms/field-types/Checkbox/index.scss
@@ -24,38 +24,6 @@
     padding-bottom: 0;
     padding-left: base(.5);
   }
-  
- 
-  &:not(:disabled):not(&--read-only) {
-    &:active,
-    &:focus-within,
-    &:focus {
-      .custom-checkbox__input, & input[type="checkbox"] {
-        @include inputShadowActive;
-
-        outline: 0;
-        box-shadow: 0 0 3px 3px var(--theme-success-400)!important;
-        border: 1px solid var(--theme-elevation-150);
-      }
-    }
-
-    &:hover {
-      .custom-checkbox__input, & input[type="checkbox"] {
-        border-color: var(--theme-elevation-250);
-      }
-    }
-  }
-  
-  &:not(:disabled):not(&--read-only):not(&--checked) {
-    &:hover {
-      cursor: pointer;
-
-      svg {
-        opacity: 0.2;
-      }
-    }
-  }
-
 
   &__input {
     @include formInput;
@@ -87,6 +55,37 @@
 
     svg {
       opacity: 0;
+    }
+  }
+  
+ 
+  &:not(&--read-only) {
+    &:active,
+    &:focus-within,
+    &:focus {
+      .custom-checkbox__input, & input[type="checkbox"] {
+        @include inputShadowActive;
+
+        outline: 0;
+        box-shadow: 0 0 3px 3px var(--theme-success-400)!important;
+        border: 1px solid var(--theme-elevation-150);
+      }
+    }
+
+    &:hover {
+      .custom-checkbox__input, & input[type="checkbox"] {
+        border-color: var(--theme-elevation-250);
+      }
+    }
+  }
+  
+  &:not(&--read-only):not(&--checked) {
+    &:hover {
+      cursor: pointer;
+
+      svg {
+        opacity: 0.2;
+      }
     }
   }
 

--- a/src/admin/components/forms/field-types/Checkbox/index.scss
+++ b/src/admin/components/forms/field-types/Checkbox/index.scss
@@ -35,6 +35,13 @@
 
         outline: 0;
         box-shadow: 0 0 3px 3px var(--theme-success-400)!important;
+        border: 1px solid var(--theme-elevation-150);
+      }
+    }
+
+    &:hover {
+      .custom-checkbox__input, & input[type="checkbox"] {
+        border-color: var(--theme-elevation-250);
       }
     }
   }

--- a/src/admin/components/forms/field-types/Checkbox/index.tsx
+++ b/src/admin/components/forms/field-types/Checkbox/index.tsx
@@ -88,6 +88,7 @@ const Checkbox: React.FC<Props> = (props) => {
         label={getTranslation(label || name, i18n)}
         name={path}
         checked={Boolean(value)}
+        readOnly={readOnly}
       />
       <FieldDescription
         value={value}


### PR DESCRIPTION
## Description

## Before

https://github.com/payloadcms/payload/assets/70709113/a1fa9bfd-e8dc-48fc-b7a4-148c23bd22eb

## After

https://github.com/payloadcms/payload/assets/70709113/6b96c912-3bd0-4248-b3ee-dcf98b032323

It
- Brings back the green shimmer
- Adds proper styling for when a checkbox is readonly / disabled. Readonly checkboxes also aren't keyboard-navigatable anymore. It addresses https://discord.com/channels/967097582721572934/1102950643259424828/1141311563719000064
- Fixes the issue where there is a small area outside the checkbox which is un-clickable (due to the parent's border)


This adds back the missing readonly checkbox styles, and includes other improvements.

- [X] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
