### PR TITLE
Add a fix and new collection in the graphql-schema-gen test

### DIFF
--- a/src/graphql/schema/buildMutationInputType.ts
+++ b/src/graphql/schema/buildMutationInputType.ts
@@ -200,7 +200,7 @@ function buildMutationInputType(payload: Payload, name: string, fields: Field[],
           if (requiresAtLeastOneField) type = new GraphQLNonNull(type);
 
           return {
-            ...inputObjectTypeConfig,
+            ...acc,
             [tab.name]: { type },
           };
         }

--- a/test/graphql-schema-gen/config.ts
+++ b/test/graphql-schema-gen/config.ts
@@ -141,5 +141,48 @@ export default buildConfigWithDefaults({
         },
       ],
     },
+    {
+      slug: 'collection3',
+      fields: [
+        {
+          type: 'tabs',
+          tabs: [
+            {
+              label: 'Tab 1',
+              fields: [
+                {
+                  name: 'descriptiontab1',
+                  type: 'textarea',
+                },
+              ],
+            },
+            {
+              label: 'Tab 2',
+              name: 'tab2',
+              fields: [
+                {
+                  type: 'select',
+                  name: 'selecttab2',
+                  options: [
+                    { value: 'option1', label: 'Option 1' },
+                    { value: 'option2', label: 'Option 2' },
+                  ],
+                },
+              ],
+            },
+            {
+              label: 'Tab3',
+              name: 'tab3',
+              fields: [
+                {
+                  name: 'acheckbox',
+                  type: 'checkbox',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## Description

Closes https://github.com/payloadcms/payload/issues/3195

Fixes a bug where the `data` input in a mutation type with tabs is missing previous tabs if the last tab in the array is named

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
