### PR TITLE
Fix: correct out of order dark-mode color variables

### DIFF
--- a/src/admin/scss/colors.scss
+++ b/src/admin/scss/colors.scss
@@ -177,8 +177,9 @@ html[data-theme=dark] {
   --theme-elevation-250: var(--color-base-650);
   --theme-elevation-300: var(--color-base-600);
   --theme-elevation-350: var(--color-base-550);
-  --theme-elevation-400: var(--color-base-450);
-  --theme-elevation-450: var(--color-base-400);
+  --theme-elevation-400: var(--color-base-500);
+  --theme-elevation-450: var(--color-base-450);
+  --theme-elevation-500: var(--color-base-400);
   --theme-elevation-550: var(--color-base-350);
   --theme-elevation-600: var(--color-base-300);
   --theme-elevation-650: var(--color-base-250);


### PR DESCRIPTION
## Description

The `theme-elevation` color variables for dark mode are out of order, skipping `base-500` at `elevation-400`, and leaving `elevation-500` undefined (falls back to `base-500` when it should be `base-400` since dark-mode starts at `base-900` instead of `base-1000`).

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
