### PR TITLE
chore(examples): updates draft preview next app example to use revalidateTag

### DIFF
--- a/examples/draft-preview/next-app/README.md
+++ b/examples/draft-preview/next-app/README.md
@@ -1,6 +1,6 @@
 # Payload Draft Preview Example Front-End
 
-This is a [Next.js](https://nextjs.org) app using the [App Router](https://nextjs.org/docs/app). It was made explicitly for Payload's [Draft Preview Example](https://github.com/payloadcms/payload/tree/master/examples/draft-preview).
+This is a [Next.js](https://nextjs.org) app using the [App Router](https://nextjs.org/docs/app). It was made explicitly for Payload's [Draft Preview Example](https://github.com/payloadcms/payload/tree/master/examples/draft-preview/payload).
 
 > This example uses the App Router, the latest API of Next.js. If your app is using the legacy [Pages Router](https://nextjs.org/docs/pages), check out the official [Pages Router Example](https://github.com/payloadcms/payload/tree/master/examples/draft-preview/next-pages).
 

--- a/examples/draft-preview/next-app/app/_api/fetchPage.ts
+++ b/examples/draft-preview/next-app/app/_api/fetchPage.ts
@@ -20,6 +20,11 @@ export const fetchPage = async (
       draft && payloadToken ? '&draft=true' : ''
     }`,
     {
+      method: 'GET',
+      // this is the key we'll use to on-demand revalidate pages that use this data
+      // we do this by calling `revalidateTag()` using the same key
+      // see `app/api/revalidate.ts` for more info
+      next: { tags: [`pages_${slug}`] },
       ...(draft && payloadToken
         ? {
             headers: {

--- a/examples/draft-preview/next-app/app/api/revalidate/route.ts
+++ b/examples/draft-preview/next-app/app/api/revalidate/route.ts
@@ -1,23 +1,32 @@
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
+// this endpoint will revalidate a page by tag or path
+// this is to achieve on-demand revalidation of pages that use this data
+// send either `collection` and `slug` or `revalidatePath` as query params
 export async function GET(request: NextRequest): Promise<unknown> {
-  const path = request.nextUrl.searchParams.get('revalidatePath')
+  const collection = request.nextUrl.searchParams.get('collection')
+  const slug = request.nextUrl.searchParams.get('slug')
+  const path = request.nextUrl.searchParams.get('path')
   const secret = request.nextUrl.searchParams.get('secret')
 
   if (secret !== process.env.NEXT_PRIVATE_REVALIDATION_KEY) {
     return NextResponse.json({ revalidated: false, now: Date.now() })
   }
 
+  if (typeof collection === 'string' && typeof slug === 'string') {
+    revalidateTag(`${collection}_${slug}`)
+    return NextResponse.json({ revalidated: true, now: Date.now() })
+  }
+
+  // there is a known limitation with `revalidatePath` where it will not revalidate exact paths of dynamic routes
+  // instead, Next.js expects us to revalidate entire directories, i.e. `revalidatePath('/[slug]')` instead of `/example-page`
+  // for this reason, it is preferred to use `revalidateTag` instead of `revalidatePath`
+  // - https://github.com/vercel/next.js/issues/49387
+  // - https://github.com/vercel/next.js/issues/49778#issuecomment-1547028830
   if (typeof path === 'string') {
-    // there is a known bug with `revalidatePath` where it will not revalidate exact paths of dynamic routes
-    // instead, Next.js expects us to revalidate entire directories, i.e. `/[slug]` instead of `/example-page`
-    // for now we'll make this change but with expectation that it will be fixed so we can use `revalidatePath('/example-page')`
-    // - https://github.com/vercel/next.js/issues/49387
-    // - https://github.com/vercel/next.js/issues/49778#issuecomment-1547028830
-    // revalidatePath(path)
-    revalidatePath('/[slug]')
+    revalidatePath(path)
     return NextResponse.json({ revalidated: true, now: Date.now() })
   }
 

--- a/examples/draft-preview/next-pages/README.md
+++ b/examples/draft-preview/next-pages/README.md
@@ -1,6 +1,6 @@
 # Payload Draft Preview Example Front-End
 
-This is a [Next.js](https://nextjs.org) app using the [Pages Router](https://nextjs.org/docs/pages). It was made explicitly for Payload's [Draft Preview Example](https://github.com/payloadcms/payload/tree/master/examples/draft-preview).
+This is a [Next.js](https://nextjs.org) app using the [Pages Router](https://nextjs.org/docs/pages). It was made explicitly for Payload's [Draft Preview Example](https://github.com/payloadcms/payload/tree/master/examples/draft-preview/payload).
 
 > This example uses the Pages Router, the legacy API of Next.js. If your app is using the latest [App Router](https://nextjs.org/docs/app), check out the official [App Router Example](https://github.com/payloadcms/payload/tree/master/examples/draft-preview/next-app).
 

--- a/examples/draft-preview/next-pages/src/pages/api/revalidate.ts
+++ b/examples/draft-preview/next-pages/src/pages/api/revalidate.ts
@@ -6,9 +6,9 @@ const revalidate = async (req: NextApiRequest, res: NextApiResponse): Promise<vo
     return res.status(401).json({ message: 'Invalid token' })
   }
 
-  if (typeof req.query.revalidatePath === 'string') {
+  if (typeof req.query.path === 'string') {
     try {
-      await res.revalidate(req.query.revalidatePath)
+      await res.revalidate(req.query.path)
       return res.json({ revalidated: true })
     } catch (err: unknown) {
       // If there was an error, Next.js will continue

--- a/examples/draft-preview/payload/README.md
+++ b/examples/draft-preview/payload/README.md
@@ -1,6 +1,6 @@
 # Payload Draft Preview Example
 
-The [Payload Draft Preview Example](https://github.com/payloadcms/payload/tree/master/examples/draft-preview) demonstrates how to implement draft preview in [Payload](https://github.com/payloadcms/payload) using [Versions](https://payloadcms.com/docs/versions/overview) and [Drafts](https://payloadcms.com/docs/versions/drafts). Draft preview allows you to see content on your front-end before it is published. There are various fully working front-ends made explicitly for this example, including:
+The [Payload Draft Preview Example](https://github.com/payloadcms/payload/tree/master/examples/draft-preview/payload) demonstrates how to implement draft preview in [Payload](https://github.com/payloadcms/payload) using [Versions](https://payloadcms.com/docs/versions/overview) and [Drafts](https://payloadcms.com/docs/versions/drafts). Draft preview allows you to see content on your front-end before it is published. There are various fully working front-ends made explicitly for this example, including:
 
 - [Next.js App Router](../next-app)
 - [Next.js Pages Router](../next-pages)

--- a/examples/draft-preview/payload/src/collections/Pages/hooks/revalidatePage.ts
+++ b/examples/draft-preview/payload/src/collections/Pages/hooks/revalidatePage.ts
@@ -7,9 +7,11 @@ export const formatAppURL = ({ doc }): string => {
   return pathname
 }
 
-// Revalidate the page in the background, so the user doesn't have to wait
-// Notice that the hook itself is not async and we are not awaiting `revalidate`
-// Only revalidate existing docs that are published
+// revalidate the page in the background, so the user doesn't have to wait
+// notice that the hook itself is not async and we are not awaiting `revalidate`
+// only revalidate existing docs that are published (not drafts)
+// send `revalidatePath`, `collection`, and `slug` to the frontend to use in its revalidate route
+// frameworks may have different ways of doing this, but the idea is the same
 export const revalidatePage: AfterChangeHook = ({ doc, req, operation }) => {
   if (operation === 'update' && doc._status === 'published') {
     const url = formatAppURL({ doc })
@@ -17,7 +19,7 @@ export const revalidatePage: AfterChangeHook = ({ doc, req, operation }) => {
     const revalidate = async (): Promise<void> => {
       try {
         const res = await fetch(
-          `${process.env.PAYLOAD_PUBLIC_SITE_URL}/api/revalidate?secret=${process.env.REVALIDATION_KEY}&revalidatePath=${url}`,
+          `${process.env.PAYLOAD_PUBLIC_SITE_URL}/api/revalidate?secret=${process.env.REVALIDATION_KEY}&collection=pages&slug=${doc?.slug}&path=${url}`,
         )
 
         if (res.ok) {

--- a/examples/draft-preview/payload/src/collections/Pages/index.ts
+++ b/examples/draft-preview/payload/src/collections/Pages/index.ts
@@ -16,7 +16,7 @@ export const Pages: CollectionConfig = {
         formatAppURL({
           doc,
         }),
-      )}&secret=${process.env.PAYLOAD_PUBLIC_DRAFT_SECRET}`
+      )}&collection=pages&slug=${doc.slug}&secret=${process.env.PAYLOAD_PUBLIC_DRAFT_SECRET}`
     },
   },
   versions: {

--- a/examples/draft-preview/payload/src/seed/pageDraft.ts
+++ b/examples/draft-preview/payload/src/seed/pageDraft.ts
@@ -1,6 +1,7 @@
 import type { Page } from '../payload-types'
 
 export const examplePageDraft: Partial<Page> = {
+  title: 'Example Page (Draft)',
   richText: [
     {
       children: [


### PR DESCRIPTION
## Description

Updates the Draft Preview Next.js App Router example to use `revalidateTag` for on-demand revalidation instead of `revalidatePath`. This is a much more granular way of regenerating static pages using this router because it points to individual fetch requests as opposed to entire routes.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Change to the [examples](../examples/) directory (does not affect core functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes