### PR TITLE
fix: sets required on array or block type when minRows is greater than 0

### DIFF
--- a/src/utilities/configToJSONSchema.ts
+++ b/src/utilities/configToJSONSchema.ts
@@ -10,6 +10,8 @@ import { SanitizedConfig } from '../config/types';
 const propertyIsRequired = (field: Field) => {
   if (fieldAffectsData(field) && (('required' in field && field.required === true))) return true;
 
+  if ((field.type === 'array' || field.type === 'blocks') && field.minRows && field.minRows > 0) return true;
+
   if ('fields' in field && field.type !== 'array') {
     if (field.admin?.condition || field.access?.read) return false;
     return field.fields.find((subField) => propertyIsRequired(subField));


### PR DESCRIPTION
## Description

Closes #3198

Makes array or block type required if min rows is greater than 0.

- [X] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
