### PR TITLE
Chore: adds warning message for empty server URLs

### DIFF
--- a/src/config/sanitize.ts
+++ b/src/config/sanitize.ts
@@ -54,12 +54,10 @@ export const sanitizeConfig = (incomingConfig: Config): SanitizedConfig => {
     config.serverURL = '';
   }
 
-  if (config.serverURL === '') {
-    getLogger().warn('No serverURL provided in config, defaulted to \'\'. If this was intended, ignore this message.');
-  }
-
   if (config.serverURL !== '') {
     config.csrf.push(config.serverURL);
+  } else {
+    getLogger().warn('No serverURL provided in config, defaulted to \'\'. If this was intended, ignore this message.');
   }
 
   return config as SanitizedConfig;

--- a/src/config/sanitize.ts
+++ b/src/config/sanitize.ts
@@ -8,6 +8,7 @@ import sanitizeGlobals from '../globals/config/sanitize';
 import checkDuplicateCollections from '../utilities/checkDuplicateCollections';
 import { defaults } from './defaults';
 import getDefaultBundler from '../bundlers/webpack/bundler';
+import getLogger from '../utilities/logger';
 
 const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig> => {
   const sanitizedConfig = { ...configToSanitize };
@@ -51,6 +52,10 @@ export const sanitizeConfig = (incomingConfig: Config): SanitizedConfig => {
 
   if (typeof config.serverURL === 'undefined') {
     config.serverURL = '';
+  }
+
+  if (config.serverURL === '') {
+    getLogger().warn('No serverURL provided in config, defaulted to \'\'. If this was intended, ignore this message.');
   }
 
   if (config.serverURL !== '') {


### PR DESCRIPTION
## Description

Adding extra logging to notify a user when the serverUrl has been left blank. This takes into consideration the following Pull Request - https://github.com/payloadcms/payload/pull/437

When a user does not add a serverUrl, the app starts up as normal, however the admin panel and API are not reachable. Because it is not always immediatly obvious as to why, this PR adds a warning message to the console informing the user than the serverURL is an empty string. This message displays in the terminal during start up.

`No serverURL provided in config, defaulted to ''. If this was intended, ignore this message.`

Other than showing this warning message, no other changes have been made.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
