### PR TITLE
Rich Text toolbar not rendered if leaves and elements are empty 

### DIFF
--- a/src/admin/components/forms/field-types/RichText/RichText.tsx
+++ b/src/admin/components/forms/field-types/RichText/RichText.tsx
@@ -322,56 +322,58 @@ const RichText: React.FC<Props> = (props) => {
           onChange={handleChange}
         >
           <div className={`${baseClass}__wrapper`}>
-            <div
-              className={[
-                `${baseClass}__toolbar`,
-                drawerIsOpen && `${baseClass}__drawerIsOpen`,
-              ].filter(Boolean).join(' ')}
-              ref={toolbarRef}
-            >
-              <div className={`${baseClass}__toolbar-wrap`}>
-                {elements.map((element, i) => {
-                  let elementName: string;
-                  if (typeof element === 'object' && element?.name) elementName = element.name;
-                  if (typeof element === 'string') elementName = element;
+            {elements.length + leaves.length > 0 && (
+              <div
+                className={[
+                  `${baseClass}__toolbar`,
+                  drawerIsOpen && `${baseClass}__drawerIsOpen`,
+                ].filter(Boolean).join(' ')}
+                ref={toolbarRef}
+              >
+                <div className={`${baseClass}__toolbar-wrap`}>
+                  {elements.map((element, i) => {
+                    let elementName: string;
+                    if (typeof element === 'object' && element?.name) elementName = element.name;
+                    if (typeof element === 'string') elementName = element;
 
-                  const elementType = enabledElements[elementName];
-                  const Button = elementType?.Button;
+                    const elementType = enabledElements[elementName];
+                    const Button = elementType?.Button;
 
-                  if (Button) {
-                    return (
-                      <Button
-                        fieldProps={props}
-                        key={i}
-                        path={path}
-                      />
-                    );
-                  }
+                    if (Button) {
+                      return (
+                        <Button
+                          fieldProps={props}
+                          key={i}
+                          path={path}
+                        />
+                      );
+                    }
 
-                  return null;
-                })}
-                {leaves.map((leaf, i) => {
-                  let leafName: string;
-                  if (typeof leaf === 'object' && leaf?.name) leafName = leaf.name;
-                  if (typeof leaf === 'string') leafName = leaf;
+                    return null;
+                  })}
+                  {leaves.map((leaf, i) => {
+                    let leafName: string;
+                    if (typeof leaf === 'object' && leaf?.name) leafName = leaf.name;
+                    if (typeof leaf === 'string') leafName = leaf;
 
-                  const leafType = enabledLeaves[leafName];
-                  const Button = leafType?.Button;
+                    const leafType = enabledLeaves[leafName];
+                    const Button = leafType?.Button;
 
-                  if (Button) {
-                    return (
-                      <Button
-                        fieldProps={props}
-                        key={i}
-                        path={path}
-                      />
-                    );
-                  }
+                    if (Button) {
+                      return (
+                        <Button
+                          fieldProps={props}
+                          key={i}
+                          path={path}
+                        />
+                      );
+                    }
 
-                  return null;
-                })}
+                    return null;
+                  })}
+                </div>
               </div>
-            </div>
+            )}
             <div
               className={`${baseClass}__editor`}
               ref={editorRef}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

When a RichText editor is rendered with `leaves: []` and `elements: []`, the toolbar is currently rendered as a small strip below the label (see image below). This does not really look good.

<img width="531" alt="image" src="https://github.com/payloadcms/payload/assets/6343155/1ec99f8c-94d2-488a-8ae8-2a03f0c3dcb9">

The suggestion is to not render the toolbar if both `leaves` and `elements` are empty, as seen in the following image:

<img width="923" alt="Screenshot 2023-08-25 at 09 55 20" src="https://github.com/payloadcms/payload/assets/6343155/543e06f6-622c-455f-9e26-43d9670ddf68">


- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
