### PR TITLE
chore(templates/ecommerce): correctly sets next images domain

### DIFF
--- a/templates/ecommerce/next.config.js
+++ b/templates/ecommerce/next.config.js
@@ -18,14 +18,6 @@ const nextConfig = {
     domains: ['localhost', process.env.NEXT_PUBLIC_SERVER_URL]
       .filter(Boolean)
       .map(url => url.replace(/https?:\/\//, '')),
-    // remotePatterns: [
-    //   {
-    //     protocol: 'https',
-    //     hostname: 'localhost',
-    //     port: '3000',
-    //     pathname: '/media/**',
-    //   },
-    // ],
   },
   async headers() {
     const headers = []

--- a/templates/ecommerce/next.config.js
+++ b/templates/ecommerce/next.config.js
@@ -15,7 +15,9 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: ['localhost', process.env.NEXT_PUBLIC_SERVER_URL].filter(Boolean),
+    domains: ['localhost', process.env.NEXT_PUBLIC_SERVER_URL]
+      .filter(Boolean)
+      .map(url => url.replace(/https?:\/\//, '')),
     // remotePatterns: [
     //   {
     //     protocol: 'https',

--- a/templates/ecommerce/package.json
+++ b/templates/ecommerce/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint --fix --ext .ts,.tsx src"
   },
   "dependencies": {
-    "@payloadcms/plugin-cloud": "latest",
+    "@payloadcms/plugin-cloud": "^2.0.0",
     "@payloadcms/plugin-nested-docs": "^1.0.4",
     "@payloadcms/plugin-seo": "^1.0.10",
     "@payloadcms/plugin-stripe": "^0.0.13",

--- a/templates/ecommerce/package.json
+++ b/templates/ecommerce/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint --fix --ext .ts,.tsx src"
   },
   "dependencies": {
-    "@payloadcms/plugin-cloud": "^2.0.0",
+    "@payloadcms/plugin-cloud": "latest",
     "@payloadcms/plugin-nested-docs": "^1.0.4",
     "@payloadcms/plugin-seo": "^1.0.10",
     "@payloadcms/plugin-stripe": "^0.0.13",

--- a/templates/ecommerce/src/payload/components/BeforeDashboard/index.tsx
+++ b/templates/ecommerce/src/payload/components/BeforeDashboard/index.tsx
@@ -45,7 +45,7 @@ const BeforeDashboard: React.FC = () => {
         </li>
         <li>
           <Link to="/admin/collections/products">Link each of your products</Link>
-          {' to Stripe by selecting the corresponding product using the using the dropdown under '}
+          {' to Stripe by selecting the corresponding product using the dropdown under '}
           <i>Product Details</i>.
         </li>
         <li>

--- a/templates/ecommerce/src/payload/seed/index.ts
+++ b/templates/ecommerce/src/payload/seed/index.ts
@@ -22,13 +22,19 @@ const globals = ['header', 'settings', 'footer']
 export const seed = async (payload: Payload): Promise<void> => {
   payload.logger.info('Seeding database...')
 
-  // remove the media directory
+  // we need to clear the media directory before seeding
+  // as well as the collections and globals
+  // this is because while `yarn seed` drops the database
+  // the custom `/api/seed` endpoint does not
+
+  payload.logger.info(`— Clearing media...`)
+
   const mediaDir = path.resolve(__dirname, '../../media')
   if (fs.existsSync(mediaDir)) {
     fs.rmdirSync(mediaDir, { recursive: true })
   }
 
-  payload.logger.info(`✓ cleared media`)
+  payload.logger.info(`— Clearing collections and globals...`)
 
   // clear the database
   await Promise.all([
@@ -46,7 +52,7 @@ export const seed = async (payload: Payload): Promise<void> => {
     ), // eslint-disable-line function-paren-newline
   ])
 
-  payload.logger.info(`✓ cleared collections and globals`)
+  payload.logger.info(`— Seeding media...`)
 
   const [image1Doc, image2Doc, image3Doc] = await Promise.all([
     payload.create({
@@ -66,7 +72,7 @@ export const seed = async (payload: Payload): Promise<void> => {
     }),
   ])
 
-  payload.logger.info(`✓ seeded images`)
+  payload.logger.info(`— Seeding categories...`)
 
   const [apparelCategory, ebooksCategory, coursesCategory] = await Promise.all([
     payload.create({
@@ -89,7 +95,7 @@ export const seed = async (payload: Payload): Promise<void> => {
     }),
   ])
 
-  payload.logger.info(`✓ seeded categories`)
+  payload.logger.info(`— Seeding products...`)
 
   Promise.all([
     payload.create({
@@ -121,14 +127,14 @@ export const seed = async (payload: Payload): Promise<void> => {
     }),
   ])
 
-  payload.logger.info(`✓ seeded products`)
+  payload.logger.info(`— Seeding products page...`)
 
   const { id: productsPageID } = await payload.create({
     collection: 'pages',
     data: productsPage,
   })
 
-  payload.logger.info(`✓ seeded products page`)
+  payload.logger.info(`— Seeding home page...`)
 
   await payload.create({
     collection: 'pages',
@@ -140,14 +146,14 @@ export const seed = async (payload: Payload): Promise<void> => {
     ),
   })
 
-  payload.logger.info(`✓ seeded home page`)
+  payload.logger.info(`— Seeding cart page...`)
 
   await payload.create({
     collection: 'pages',
     data: JSON.parse(JSON.stringify(cartPage).replace(/{{PRODUCTS_PAGE_ID}}/g, productsPageID)),
   })
 
-  payload.logger.info(`✓ seeded cart page`)
+  payload.logger.info(`— Seeding settings...`)
 
   await payload.updateGlobal({
     slug: 'settings',
@@ -156,7 +162,7 @@ export const seed = async (payload: Payload): Promise<void> => {
     },
   })
 
-  payload.logger.info(`✓ seeded settings`)
+  payload.logger.info(`— Seeding header...`)
 
   await payload.updateGlobal({
     slug: 'header',
@@ -176,7 +182,5 @@ export const seed = async (payload: Payload): Promise<void> => {
     },
   })
 
-  payload.logger.info(`✓ seeded header`)
-
-  payload.logger.info('Successfully seeded database')
+  payload.logger.info('Seeded database successfully!')
 }

--- a/templates/ecommerce/src/server.default.ts
+++ b/templates/ecommerce/src/server.default.ts
@@ -35,6 +35,7 @@ const start = async (): Promise<void> => {
   if (process.env.PAYLOAD_SEED === 'true') {
     payload.logger.info('---- SEEDING DATABASE ----')
     await seed(payload)
+    process.exit()
   }
 
   app.listen(PORT, async () => {

--- a/templates/ecommerce/src/server.default.ts
+++ b/templates/ecommerce/src/server.default.ts
@@ -33,7 +33,6 @@ const start = async (): Promise<void> => {
   })
 
   if (process.env.PAYLOAD_SEED === 'true') {
-    payload.logger.info('---- SEEDING DATABASE ----')
     await seed(payload)
     process.exit()
   }

--- a/templates/ecommerce/src/server.ts
+++ b/templates/ecommerce/src/server.ts
@@ -26,8 +26,8 @@ const start = async (): Promise<void> => {
   })
 
   if (process.env.PAYLOAD_SEED === 'true') {
-    payload.logger.info('---- SEEDING DATABASE ----')
     await seed(payload)
+    process.exit()
   }
 
   if (process.env.NEXT_BUILD) {

--- a/templates/ecommerce/yarn.lock
+++ b/templates/ecommerce/yarn.lock
@@ -1406,17 +1406,17 @@
   resolved "https://registry.yarnpkg.com/@payloadcms/eslint-config/-/eslint-config-0.0.1.tgz#4324702ddef6c773b3f3033795a13e6b50c95a92"
   integrity sha512-Il59+0C4E/bI6uM2hont3I+oABWkJZbfbItubje5SGMrXkymUq8jT/UZRk0eCt918bB7gihxDXx8guFnR/aNIw==
 
-"@payloadcms/plugin-cloud@^2.0.0":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@payloadcms/plugin-cloud/-/plugin-cloud-2.1.1.tgz#87643864a0dc50feb6831cca5323607e0fbf32d9"
-  integrity sha512-/sjqbU6H/AvDQ03PTmuwrJgwZUU1mfARkRjCvPbgkB7Pyo0iVy4wZNlPdnarqlZ/RR83T/Uwl/U1jl3YoQsBpw==
+"@payloadcms/plugin-cloud@latest":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@payloadcms/plugin-cloud/-/plugin-cloud-2.2.1.tgz#765a800dfe5b5e0126a1c878df47855bdbcf060a"
+  integrity sha512-jOflGHygn6rarLt/GPdRzB8ob2FRJ2fUGqhbXoEqHcOeudbJGUY+cyYTQ8gxJMpSlSBZ4yY5ITHMECrGknUJCg==
   dependencies:
     "@aws-sdk/client-cognito-identity" "^3.289.0"
     "@aws-sdk/client-s3" "^3.142.0"
     "@aws-sdk/credential-providers" "^3.289.0"
     "@aws-sdk/lib-storage" "^3.267.0"
     amazon-cognito-identity-js "^6.1.2"
-    resend "^0.15.3"
+    resend "^0.17.2"
 
 "@payloadcms/plugin-nested-docs@^1.0.4":
   version "1.0.6"
@@ -7468,13 +7468,14 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-resend@^0.15.3:
-  version "0.15.4"
-  resolved "https://registry.yarnpkg.com/resend/-/resend-0.15.4.tgz#4f4a67a01c15fd94aba4c79d7d7a59b10a6a9a96"
-  integrity sha512-QgQ1sMQ8CGtG5yWhPHUITsMmKxohoUiRo+s+8WpBbVhX3cJo87slUbDji2tqNgKz6Tza7fgd+cWNNQSYSeJDsA==
+resend@^0.17.2:
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/resend/-/resend-0.17.2.tgz#52ab40cff8e998c2ca621eb298da38b4ab1e3eb3"
+  integrity sha512-lakm76u4MiIDeMF1s2tCmjtksOhwZOs4WcAXkA7aUTvl+63/h+0h6Q6WnkB8RGtj6GakUhQuUkiZshfXgtIrGw==
   dependencies:
     "@react-email/render" "0.0.7"
     axios "1.4.0"
+    type-fest "3.13.0"
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -8337,6 +8338,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-fest@3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.13.0.tgz#b088347ae73779a750c461694b264340c4c8c0d7"
+  integrity sha512-Gur3yQGM9qiLNs0KPP7LPgeRbio2QTt4xXouobMCarR0/wyW3F+F/+OWwshg3NG0Adon7uQfSZBpB46NfhoF1A==
 
 type-fest@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
## Description

Correctly sets `images.domains` in `next.config.ts` of the [E-commerce Template](https://github.com/payloadcms/payload/tree/master/templates/ecommerce). This was previsouly using the `NEXT_PUBLIC_SERVER_URL` which incorrectly includes the domain protocol, i.e. `https://`. This meant that production instances of this template were failing in the Next.js image server because it expects only the root domain itself. This PR also does some other minor housekeeping to this template.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Change to the [templates](../templates/) directory (does not affect core functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes