### PR TITLE
feat: relationship field custom option label

### DIFF
--- a/src/admin/components/forms/field-types/Relationship/AddNew/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/AddNew/index.tsx
@@ -25,6 +25,7 @@ export const AddNewRelation: React.FC<Props> = ({
   value,
   setValue,
   dispatchOptions,
+  getOptionLabel,
 }) => {
   const relatedCollections = useRelatedCollections(relationTo);
   const { permissions } = useAuth();
@@ -70,6 +71,7 @@ export const AddNewRelation: React.FC<Props> = ({
           sort: true,
           i18n,
           config,
+          getOptionLabel,
         });
 
 
@@ -82,7 +84,7 @@ export const AddNewRelation: React.FC<Props> = ({
 
       setSelectedCollection(undefined);
     }
-  }, [relationTo, collectionConfig, dispatchOptions, i18n, hasMany, setValue, value, config]);
+  }, [relationTo, collectionConfig, dispatchOptions, i18n, hasMany, setValue, value, config, getOptionLabel]);
 
   const onPopopToggle = useCallback((state) => {
     setPopupOpen(state);
@@ -158,7 +160,7 @@ export const AddNewRelation: React.FC<Props> = ({
                 >
                   <Plus />
                 </Button>
-            )}
+              )}
               render={({ close: closePopup }) => (
                 <ul className={`${baseClass}__relations`}>
                   {relatedCollections.map((relatedCollection) => {

--- a/src/admin/components/forms/field-types/Relationship/AddNew/types.ts
+++ b/src/admin/components/forms/field-types/Relationship/AddNew/types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Action, OptionGroup, Value } from '../types';
+import { GetOptionLabel } from '../../../../../../fields/config/types';
 
 export type Props = {
   hasMany: boolean
@@ -9,4 +10,5 @@ export type Props = {
   options: OptionGroup[]
   setValue: (value: unknown) => void
   dispatchOptions: React.Dispatch<Action>
+  getOptionLabel: GetOptionLabel
 }

--- a/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -51,6 +51,7 @@ const Relationship: React.FC<Props> = (props) => {
       condition,
       isSortable = true,
       allowCreate = true,
+      getOptionLabel,
     } = {},
   } = props;
 
@@ -207,6 +208,7 @@ const Relationship: React.FC<Props> = (props) => {
                   sort,
                   i18n,
                   config,
+                  getOptionLabel,
                 });
               }
             } else if (response.status === 403) {
@@ -219,6 +221,7 @@ const Relationship: React.FC<Props> = (props) => {
                 ids: relationMap[relation],
                 i18n,
                 config,
+                getOptionLabel,
               });
             } else {
               setErrorLoading(t('error:unspecific'));
@@ -244,6 +247,7 @@ const Relationship: React.FC<Props> = (props) => {
       i18n,
       config,
       t,
+      getOptionLabel,
     ],
   );
 
@@ -313,6 +317,7 @@ const Relationship: React.FC<Props> = (props) => {
             ids: idsToLoad,
             i18n,
             config,
+            getOptionLabel,
           });
         }
       }
@@ -330,6 +335,7 @@ const Relationship: React.FC<Props> = (props) => {
     relationTo,
     locale,
     config,
+    getOptionLabel,
   ]);
 
   // Determine if we should switch to word boundary search
@@ -358,8 +364,15 @@ const Relationship: React.FC<Props> = (props) => {
   }, [relationTo, filterOptionsResult, locale]);
 
   const onSave = useCallback<DocumentDrawerProps['onSave']>((args) => {
-    dispatchOptions({ type: 'UPDATE', doc: args.doc, collection: args.collectionConfig, i18n, config });
-  }, [i18n, config]);
+    dispatchOptions({
+      type: 'UPDATE',
+      doc: args.doc,
+      collection: args.collectionConfig,
+      i18n,
+      config,
+      getOptionLabel,
+    });
+  }, [i18n, config, getOptionLabel]);
 
   const filterOption = useCallback((item: Option, searchFilter: string) => {
     if (!searchFilter) {
@@ -481,7 +494,7 @@ const Relationship: React.FC<Props> = (props) => {
           />
           {!readOnly && allowCreate && (
             <AddNewRelation
-              {...{ path: pathOrName, hasMany, relationTo, value, setValue, dispatchOptions, options }}
+              {...{ path: pathOrName, hasMany, relationTo, value, setValue, dispatchOptions, options, getOptionLabel }}
             />
           )}
         </div>

--- a/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
+++ b/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
@@ -31,11 +31,14 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
     }
 
     case 'UPDATE': {
-      const { collection, doc, i18n, config } = action;
+      const { collection, doc, i18n, config, getOptionLabel } = action;
       const relation = collection.slug;
       const newOptions = [...state];
 
-      const docTitle = formatUseAsTitle({
+      const docTitle = getOptionLabel ? getOptionLabel({
+        doc,
+        relationTo: relation,
+      }) : formatUseAsTitle({
         doc,
         collection,
         i18n,
@@ -54,7 +57,7 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
     }
 
     case 'ADD': {
-      const { collection, docs, sort, ids = [], i18n, config } = action;
+      const { collection, docs, sort, ids = [], i18n, config, getOptionLabel } = action;
       const relation = collection.slug;
       const loadedIDs = reduceToIDs(state);
       const newOptions = [...state];
@@ -64,7 +67,10 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
         if (loadedIDs.indexOf(doc.id) === -1) {
           loadedIDs.push(doc.id);
 
-          const docTitle = formatUseAsTitle({
+          const docTitle = getOptionLabel ? getOptionLabel({
+            doc,
+            relationTo: relation,
+          }) : formatUseAsTitle({
             doc,
             collection,
             i18n,

--- a/src/admin/components/forms/field-types/Relationship/types.ts
+++ b/src/admin/components/forms/field-types/Relationship/types.ts
@@ -1,6 +1,6 @@
 import i18n from 'i18next';
 import { SanitizedCollectionConfig } from '../../../../../collections/config/types';
-import { RelationshipField } from '../../../../../fields/config/types';
+import { GetOptionLabel, RelationshipField } from '../../../../../fields/config/types';
 import { Where } from '../../../../../types';
 import { SanitizedConfig } from '../../../../../config/types';
 
@@ -37,6 +37,7 @@ type UPDATE = {
   collection: SanitizedCollectionConfig
   i18n: typeof i18n
   config: SanitizedConfig
+  getOptionLabel?: GetOptionLabel
 }
 
 type ADD = {
@@ -47,6 +48,7 @@ type ADD = {
   ids?: (string | number)[]
   i18n: typeof i18n
   config: SanitizedConfig
+  getOptionLabel?: GetOptionLabel
 }
 
 export type Action = CLEAR | ADD | UPDATE

--- a/src/fields/config/schema.ts
+++ b/src/fields/config/schema.ts
@@ -347,6 +347,7 @@ export const relationship = baseField.keys({
   admin: baseAdminFields.keys({
     isSortable: joi.boolean().default(false),
     allowCreate: joi.boolean().default(true),
+    getOptionLabel: joi.func(),
   }),
   min: joi.number()
     .when('hasMany', { is: joi.not(true), then: joi.forbidden() })

--- a/src/fields/config/types.ts
+++ b/src/fields/config/types.ts
@@ -325,6 +325,13 @@ export type SelectField = FieldBase & {
   }
 }
 
+export type GetOptionLabelProps<T = any> = {
+  doc: T,
+  relationTo: string,
+}
+
+export type GetOptionLabel<T = any> = (options: GetOptionLabelProps<T>) => string;
+
 export type RelationshipField = FieldBase & {
   type: 'relationship';
   relationTo: string | string[];
@@ -334,6 +341,7 @@ export type RelationshipField = FieldBase & {
   admin?: Admin & {
     isSortable?: boolean;
     allowCreate?: boolean;
+    getOptionLabel?: GetOptionLabel;
   },
 } & ({
   hasMany: true

--- a/test/fields-relationship/collectionSlugs.ts
+++ b/test/fields-relationship/collectionSlugs.ts
@@ -5,5 +5,6 @@ export const relationTwoSlug = 'relation-two';
 export const relationRestrictedSlug = 'relation-restricted';
 export const relationWithTitleSlug = 'relation-with-title';
 export const relationUpdatedExternallySlug = 'relation-updated-externally';
+export const relationWithCustomLabelSlug = 'relation-custom-label';
 export const collection1Slug = 'collection-1';
 export const collection2Slug = 'collection-2';

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -10,9 +10,10 @@ import type {
   RelationOne,
   RelationRestricted,
   RelationTwo,
+  RelationWithCustomLabel,
   RelationWithTitle,
 } from './config';
-import { relationOneSlug, relationRestrictedSlug, relationTwoSlug, relationUpdatedExternallySlug, relationWithTitleSlug, slug } from './collectionSlugs';
+import { relationOneSlug, relationRestrictedSlug, relationTwoSlug, relationUpdatedExternallySlug, relationWithCustomLabelSlug, relationWithTitleSlug, slug } from './collectionSlugs';
 import wait from '../../src/utilities/wait';
 
 const { beforeAll, beforeEach, describe } = test;
@@ -27,6 +28,7 @@ describe('fields - relationship', () => {
   let docWithExistingRelations: CollectionWithRelationships;
   let restrictedRelation: RelationRestricted;
   let relationWithTitle: RelationWithTitle;
+  let relationWithCustomLabel: RelationWithCustomLabel;
   let serverURL: string;
 
   beforeAll(async ({ browser }) => {
@@ -94,6 +96,14 @@ describe('fields - relationship', () => {
       },
     });
 
+    relationWithCustomLabel = await payload.create({
+      collection: relationWithCustomLabelSlug,
+      data: {
+        name: 'Cake',
+        country: 'USA',
+      },
+    });
+
     // Add restricted doc as relation
     docWithExistingRelations = await payload.create({
       collection: slug,
@@ -103,6 +113,7 @@ describe('fields - relationship', () => {
         relationshipRestricted: restrictedRelation.id,
         relationshipWithTitle: relationWithTitle.id,
         relationshipReadOnly: relationOneDoc.id,
+        relationshipWithCustomLabel: relationWithCustomLabel.id,
       },
     });
   });
@@ -379,6 +390,14 @@ describe('fields - relationship', () => {
       const options = field.locator('.rs__option');
 
       await expect(options).toHaveCount(2);
+    });
+
+    test('should show custom option label with getOptionLabel on relation', async () => {
+      await page.goto(url.edit(docWithExistingRelations.id));
+      const field = page.locator('#field-relationshipWithCustomLabel');
+      const value = field.locator('.relationship--single-value__text');
+
+      await expect(value).toHaveText(`${relationWithCustomLabel.country} - ${relationWithCustomLabel.name} - ${relationWithCustomLabelSlug}`);
     });
 
     test('should show id on relation in list view', async () => {


### PR DESCRIPTION
## Description

Related to discussion #3216 
Adds getOptionLabel function property to admin options for relationship field, e2e test included.
My first "real" PR :)

### Usage: 
```ts
{ 
  getOptionLabel: ({ doc, relationTo }: GetOptionLabelProps<RelationWithCustomLabel>) => {
    return `${doc.country} - ${doc.name} - ${relationTo}`;
  },
}
```

![image](https://github.com/payloadcms/payload/assets/64744993/c22e8fff-10c7-4454-aef2-27dbc88bc102)

![image](https://github.com/payloadcms/payload/assets/64744993/33cd9f37-fe64-4680-8a2a-807cea663d4a)



- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
