### PR TITLE
Fix #1517 even more

### DIFF
--- a/src/admin/components/forms/field-types/Blocks/index.scss
+++ b/src/admin/components/forms/field-types/Blocks/index.scss
@@ -77,10 +77,6 @@
   .section-title {
     min-width: 0;
     flex-grow: 1;
-    align-self: center;
-    &__input {
-      transform: translateY(-50%);
-    }
   }
 
   &__row {

--- a/src/admin/components/forms/field-types/Blocks/index.scss
+++ b/src/admin/components/forms/field-types/Blocks/index.scss
@@ -58,6 +58,7 @@
 
   &__block-header {
     display: inline-flex;
+    width: 100%;
     max-width: 100%;
     overflow: hidden;
     gap: base(.375);
@@ -75,6 +76,11 @@
 
   .section-title {
     min-width: 0;
+    flex-grow: 1;
+    align-self: center;
+    &__input {
+      transform: translateY(-50%);
+    }
   }
 
   &__row {


### PR DESCRIPTION
## Description

Fixes width and vertical alignment of the `blockName` input element as per https://github.com/payloadcms/payload/issues/1517#issuecomment-1693452854

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
