### PR TITLE
fix: Sanitize serverUrl before sanitizing collections

### DIFF
--- a/src/config/sanitize.ts
+++ b/src/config/sanitize.ts
@@ -39,6 +39,9 @@ export const sanitizeConfig = (incomingConfig: Config): SanitizedConfig => {
   const configWithDefaults: Config = merge(defaults, incomingConfig, {
     isMergeableObject: isPlainObject,
   });
+  if (typeof configWithDefaults.serverURL === 'undefined') {
+    configWithDefaults.serverURL = '';
+  }
 
   const config: Partial<SanitizedConfig> = sanitizeAdminConfig(configWithDefaults);
   config.collections = config.collections.map((collection) => sanitizeCollection(configWithDefaults, collection));

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -22,6 +22,7 @@ export const adminThumbnailSlug = 'admin-thumbnail';
 const mockModulePath = path.resolve(__dirname, './mocks/mockFSModule.js');
 
 export default buildConfigWithDefaults({
+  serverURL: undefined,
   admin: {
     webpack: (config) => ({
       ...config,

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -57,6 +57,7 @@ describe('Collections - Uploads', () => {
         expect(sizes).toHaveProperty('tablet');
         expect(sizes).toHaveProperty('mobile');
         expect(sizes).toHaveProperty('icon');
+        expect(doc.url).not.toContain('undefined');
       });
 
       it('creates from form data given an svg', async () => {


### PR DESCRIPTION
Resolve #3237

## Description

See #3237

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update: upload.staticURL is actually optional

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
