### PR TITLE
chore(templates/ecommerce): bypasses next cache

### DIFF
--- a/templates/ecommerce/README.md
+++ b/templates/ecommerce/README.md
@@ -254,6 +254,11 @@ Core features:
 - Complete Stripe integration
 - Fully built paywall
 
+### Cache
+
+Although Next.js includes a robust set of caching strategies out of the box, Payload Cloud proxies and caches all files through Cloudflare using the [Official Cloud Plugin](https://github.com/payloadcms/plugin-cloud). This means that Next.js caching is not needed and is disabled by default.
+If you are hosting your app outside of Payload Cloud, you can easily reenable the Next.js caching mechanisms by removing the `no-cache` headers from all fetch requests in `./src/app/_api` and then removing all instances of `export const dynamic = 'force-dynamic'` from pages files, such as `./src/app/(pages)/[slug]/page.tsx`. For more details, see the official [Next.js Caching Docs](https://nextjs.org/docs/app/building-your-application/caching).
+
 ### Eject
 
 If you prefer another front-end framework or would like to use Payload as a standalone CMS, you can easily eject the front-end from this template. To eject, simply run `yarn eject`. This will uninstall all Next.js related dependencies and delete all files and folders related to the Next.js front-end. It also removes all custom routing from your `server.ts` file and updates your `eslintrc.js`.

--- a/templates/ecommerce/README.md
+++ b/templates/ecommerce/README.md
@@ -256,8 +256,7 @@ Core features:
 
 ### Cache
 
-Although Next.js includes a robust set of caching strategies out of the box, Payload Cloud proxies and caches all files through Cloudflare using the [Official Cloud Plugin](https://github.com/payloadcms/plugin-cloud). This means that Next.js caching is not needed and is disabled by default.
-If you are hosting your app outside of Payload Cloud, you can easily reenable the Next.js caching mechanisms by removing the `no-cache` headers from all fetch requests in `./src/app/_api` and then removing all instances of `export const dynamic = 'force-dynamic'` from pages files, such as `./src/app/(pages)/[slug]/page.tsx`. For more details, see the official [Next.js Caching Docs](https://nextjs.org/docs/app/building-your-application/caching).
+Although Next.js includes a robust set of caching strategies out of the box, Payload Cloud proxies and caches all files through Cloudflare using the [Official Cloud Plugin](https://github.com/payloadcms/plugin-cloud). This means that Next.js caching is not needed and is disabled by default. If you are hosting your app outside of Payload Cloud, you can easily reenable the Next.js caching mechanisms by removing the `no-store` directive from all fetch requests in `./src/app/_api` and then removing all instances of `export const dynamic = 'force-dynamic'` from pages files, such as `./src/app/(pages)/[slug]/page.tsx`. For more details, see the official [Next.js Caching Docs](https://nextjs.org/docs/app/building-your-application/caching).
 
 ### Eject
 

--- a/templates/ecommerce/csp.js
+++ b/templates/ecommerce/csp.js
@@ -1,0 +1,10 @@
+module.exports = `
+default-src 'self';
+script-src 'self' 'unsafe-inline' 'unsafe-eval' https://checkout.stripe.com https://js.stripe.com https://maps.googleapis.com;
+child-src 'self';
+style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+img-src 'self' https://*.stripe.com https://raw.githubusercontent.com;
+font-src 'self';
+frame-src 'self' https://checkout.stripe.com https://js.stripe.com https://hooks.stripe.com;
+connect-src 'self' https://checkout.stripe.com https://api.stripe.com https://maps.googleapis.com;
+`

--- a/templates/ecommerce/next.config.js
+++ b/templates/ecommerce/next.config.js
@@ -1,15 +1,5 @@
 /** @type {import('next').NextConfig} */
-
-const ContentSecurityPolicy = `
-  default-src 'self';
-  script-src 'self' 'unsafe-inline' 'unsafe-eval' https://checkout.stripe.com https://js.stripe.com https://maps.googleapis.com;
-  child-src 'self';
-  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
-  img-src 'self' https://*.stripe.com https://raw.githubusercontent.com;
-  font-src 'self';
-  frame-src 'self' https://checkout.stripe.com https://js.stripe.com https://hooks.stripe.com;
-  connect-src 'self' https://checkout.stripe.com https://api.stripe.com https://maps.googleapis.com;
-`
+const ContentSecurityPolicy = require('./csp')
 
 const nextConfig = {
   reactStrictMode: true,
@@ -22,6 +12,10 @@ const nextConfig = {
   async headers() {
     const headers = []
 
+    // Prevent search engines from indexing the site if it is not live
+    // This is useful for staging environments before they are ready to go live
+    // To allow robots to crawl the site, use the `NEXT_PUBLIC_IS_LIVE` env variable
+    // You may want to also use this variable to conditionally render any tracking scripts
     if (!process.env.NEXT_PUBLIC_IS_LIVE) {
       headers.push({
         headers: [
@@ -34,6 +28,9 @@ const nextConfig = {
       })
     }
 
+    // Set the `Content-Security-Policy` header as a security measure to prevent XSS attacks
+    // It works by explicitly whitelisting trusted sources of content for your website
+    // This will block all inline scripts and styles except for those that are allowed
     headers.push({
       source: '/(.*)',
       headers: [

--- a/templates/ecommerce/src/app/(pages)/[slug]/page.tsx
+++ b/templates/ecommerce/src/app/(pages)/[slug]/page.tsx
@@ -11,6 +11,14 @@ import { Blocks } from '../../_components/Blocks'
 import { Hero } from '../../_components/Hero'
 import { generateMeta } from '../../_utilities/generateMeta'
 
+// Payload Cloud caches all files through Cloudflare, so we don't need Next.js to cache them as well
+// This means that we can turn off Next.js data caching and instead rely solely on the Cloudflare CDN
+// To do this, we include the `no-cache` header on the fetch requests used to get the data for this page
+// But we also need to force Next.js to dynamically render this page on each request for preview mode to work
+// See https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic
+// If you are not using Payload Cloud then this line can be removed, see `../../../README.md#cache`
+export const dynamic = 'force-dynamic'
+
 export default async function Page({ params: { slug = 'home' } }) {
   const { isEnabled: isDraftMode } = draftMode()
 

--- a/templates/ecommerce/src/app/(pages)/cart/page.tsx
+++ b/templates/ecommerce/src/app/(pages)/cart/page.tsx
@@ -15,6 +15,10 @@ import { CartPage } from './CartPage'
 
 import classes from './index.module.scss'
 
+// Force this page to be dynamic so that Next.js does not cache it
+// See the note in '../[slug]/page.tsx' about this
+export const dynamic = 'force-dynamic'
+
 export default async function Cart() {
   let page: Page | null = null
 

--- a/templates/ecommerce/src/app/(pages)/products/[slug]/page.tsx
+++ b/templates/ecommerce/src/app/(pages)/products/[slug]/page.tsx
@@ -11,6 +11,10 @@ import { PaywallBlocks } from '../../../_components/PaywallBlocks'
 import { ProductHero } from '../../../_heros/Product'
 import { generateMeta } from '../../../_utilities/generateMeta'
 
+// Force this page to be dynamic so that Next.js does not cache it
+// See the note in '../../../[slug]/page.tsx' about this
+export const dynamic = 'force-dynamic'
+
 export default async function Product({ params: { slug } }) {
   const { isEnabled: isDraftMode } = draftMode()
 

--- a/templates/ecommerce/src/app/_api/fetchDoc.ts
+++ b/templates/ecommerce/src/app/_api/fetchDoc.ts
@@ -44,6 +44,7 @@ export const fetchDoc = async <T>(args: {
       'Content-Type': 'application/json',
       ...(token?.value && draft ? { Authorization: `JWT ${token.value}` } : {}),
     },
+    cache: 'no-store',
     next: { tags: [`${collection}_${slug}`] },
     body: JSON.stringify({
       query: queryMap[collection].query,

--- a/templates/ecommerce/src/app/_api/fetchDocs.ts
+++ b/templates/ecommerce/src/app/_api/fetchDocs.ts
@@ -40,6 +40,7 @@ export const fetchDocs = async <T>(
       'Content-Type': 'application/json',
       ...(token?.value && draft ? { Authorization: `JWT ${token.value}` } : {}),
     },
+    cache: 'no-store',
     next: { tags: [collection] },
     body: JSON.stringify({
       query: queryMap[collection].query,

--- a/templates/ecommerce/src/app/_api/fetchGlobals.ts
+++ b/templates/ecommerce/src/app/_api/fetchGlobals.ts
@@ -9,6 +9,7 @@ export async function fetchSettings(): Promise<Settings> {
     headers: {
       'Content-Type': 'application/json',
     },
+    cache: 'no-store',
     body: JSON.stringify({
       query: SETTINGS_QUERY,
     }),

--- a/templates/ecommerce/src/app/_api/fetchGlobals.ts
+++ b/templates/ecommerce/src/app/_api/fetchGlobals.ts
@@ -33,6 +33,7 @@ export async function fetchHeader(): Promise<Header> {
     headers: {
       'Content-Type': 'application/json',
     },
+    cache: 'no-store',
     body: JSON.stringify({
       query: HEADER_QUERY,
     }),

--- a/templates/ecommerce/src/app/_api/getMe.ts
+++ b/templates/ecommerce/src/app/_api/getMe.ts
@@ -21,6 +21,7 @@ export const getMe = async (args?: {
       Authorization: `JWT ${token}`,
       'Content-Type': 'application/json',
     },
+    cache: 'no-store',
     body: JSON.stringify({
       query: ME_QUERY,
     }),

--- a/templates/ecommerce/src/app/api/revalidate/route.ts
+++ b/templates/ecommerce/src/app/api/revalidate/route.ts
@@ -7,8 +7,15 @@ export async function GET(request: NextRequest): Promise<unknown> {
   const slug = request.nextUrl.searchParams.get('slug')
   const secret = request.nextUrl.searchParams.get('secret')
 
-  if (secret !== process.env.NEXT_PRIVATE_REVALIDATION_KEY) {
-    return NextResponse.json({ revalidated: false, now: Date.now() })
+  if (
+    !secret ||
+    secret !== process.env.NEXT_PRIVATE_REVALIDATION_KEY ||
+    typeof collection !== 'string' ||
+    typeof slug !== 'string'
+  ) {
+    // Do not indicate that the revalidation key is incorrect in the response
+    // This will protect this API route from being exploited
+    return new Response('Invalid request', { status: 400 })
   }
 
   if (typeof collection === 'string' && typeof slug === 'string') {

--- a/templates/ecommerce/src/payload/utilities/revalidate.ts
+++ b/templates/ecommerce/src/payload/utilities/revalidate.ts
@@ -1,7 +1,3 @@
-// ensure that the home page is revalidated at '/' instead of '/home'
-// Revalidate the page in the background, so the user doesn't have to wait
-// Notice that the function itself is not async and we are not awaiting `revalidate`
-
 import type { Payload } from 'payload'
 
 export const revalidate = async (args: {
@@ -19,11 +15,13 @@ export const revalidate = async (args: {
     if (res.ok) {
       payload.logger.info(`Revalidated page '${slug}' in collection '${collection}'`)
     } else {
-      payload.logger.error(`Error revalidating page '${slug}' in collection '${collection}'`)
+      payload.logger.error(
+        `Error revalidating page '${slug}' in collection '${collection}': ${res}`,
+      )
     }
   } catch (err: unknown) {
     payload.logger.error(
-      `Error hitting revalidate route for page '${slug}' in collection '${collection}'`,
+      `Error hitting revalidate route for page '${slug}' in collection '${collection}': ${err}`,
     )
   }
 }


### PR DESCRIPTION
## Description

When deploying the [E-Commerce Template](https://github.com/payloadcms/payload/tree/master/templates/ecommerce) to Payload Cloud, the Next.js data caching mechanisms are incompatible with our Cloudflare services. When revalidating pages with `revalidateTag`, for instance, pages would continue to serve stale content. Since this is a duplicative caching layer anyway, we can simply bypass the Next.js data cache in the following ways:

- Add the `no-store` cache directive to all fetch requests. This is so that pages never receive the `X-Nextjs-Cache: HIT` response header.
- Force pages to render dynamically. This is so that when previewing a draft page, stale content is not served to public users in the background.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Change to the [templates](../templates/) directory (does not affect core functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes