### PR TITLE
Fix credentials not in allowed headers

### DIFF
--- a/src/express/middleware/corsHeaders.ts
+++ b/src/express/middleware/corsHeaders.ts
@@ -4,15 +4,20 @@ import { SanitizedConfig } from '../../config/types';
 export default (config: SanitizedConfig) => (
   (req: Request, res: Response, next: NextFunction) => {
     if (config.cors) {
+      let headers = ['Origin', 'X-Requested-With', 'Content-Type', 'Accept', 'Authorization', 'Content-Encoding', 'x-apollo-tracing'];
+
       res.header('Access-Control-Allow-Methods', 'PUT, PATCH, POST, GET, DELETE, OPTIONS');
-      res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization, Content-Encoding, x-apollo-tracing');
+      
 
       if (config.cors === '*') {
         res.setHeader('Access-Control-Allow-Origin', '*');
       } else if (Array.isArray(config.cors) && config.cors.indexOf(req.headers.origin) > -1) {
         res.header('Access-Control-Allow-Credentials', 'true');
         res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
+        headers.push("credentials");
       }
+
+      res.header('Access-Control-Allow-Headers', headers.join(","));
     }
 
     next();


### PR DESCRIPTION
## Description

Fix credentials not being included in allowed headers if cors origin is set

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

