### PR TITLE
fix: aligns depth behaviour between local api and admin panel

### DIFF
--- a/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
+++ b/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
@@ -245,7 +245,8 @@ export const addFieldStatePromise = async ({
         break;
       }
 
-      case 'relationship': {
+      case 'relationship':
+      case 'upload': {
         const relationshipValue = valueWithDefault && typeof valueWithDefault === 'object' && 'id' in valueWithDefault ? valueWithDefault.id : valueWithDefault;
         fieldState.value = relationshipValue;
         fieldState.initialValue = relationshipValue;

--- a/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
+++ b/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
@@ -245,6 +245,16 @@ export const addFieldStatePromise = async ({
         break;
       }
 
+      case 'relationship': {
+        const relationshipValue = valueWithDefault && typeof valueWithDefault === 'object' && 'id' in valueWithDefault ? valueWithDefault.id : valueWithDefault;
+        fieldState.value = relationshipValue;
+        fieldState.initialValue = relationshipValue;
+
+        state[`${path}${field.name}`] = fieldState;
+
+        break;
+      }
+
       default: {
         fieldState.value = valueWithDefault;
         fieldState.initialValue = valueWithDefault;

--- a/src/admin/components/views/Global/index.tsx
+++ b/src/admin/components/views/Global/index.tsx
@@ -96,7 +96,7 @@ const GlobalView: React.FC<IndexProps> = (props) => {
         global,
         onSave,
         apiURL: `${serverURL}${api}/globals/${slug}?locale=${locale}${global.versions?.drafts ? '&draft=true' : ''}`,
-        action: `${serverURL}${api}/globals/${slug}?locale=${locale}&depth=0&fallback-locale=null`,
+        action: `${serverURL}${api}/globals/${slug}?locale=${locale}&fallback-locale=null`,
         updatedAt: updatedAt || dataToRender?.updatedAt,
       }}
     />

--- a/src/admin/components/views/collections/Edit/index.tsx
+++ b/src/admin/components/views/collections/Edit/index.tsx
@@ -110,7 +110,7 @@ const EditView: React.FC<IndexProps> = (props) => {
   }
 
   const apiURL = `${serverURL}${api}/${slug}/${id}?locale=${locale}${collection.versions.drafts ? '&draft=true' : ''}`;
-  const action = `${serverURL}${api}/${slug}${isEditing ? `/${id}` : ''}?locale=${locale}&depth=0&fallback-locale=null`;
+  const action = `${serverURL}${api}/${slug}${isEditing ? `/${id}` : ''}?locale=${locale}&fallback-locale=null`;
   const hasSavePermission = (isEditing && docPermissions?.update?.permission) || (!isEditing && (docPermissions as CollectionPermission)?.create?.permission);
   const isLoading = !internalState || !docPermissions || isLoadingData;
 

--- a/test/hooks/collections/ContextHooks/index.ts
+++ b/test/hooks/collections/ContextHooks/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-param-reassign */
-import payload from '../../../../src';
 import { CollectionConfig } from '../../../../src/collections/config/types';
 import type { PayloadRequest } from '../../../../src/types';
 
@@ -41,11 +40,11 @@ const ContextHooks: CollectionConfig = {
       }
       return data;
     }],
-    afterChange: [async ({ context, doc }) => {
+    afterChange: [async ({ context, doc, req }) => {
       if (context.triggerAfterChange === false) { // Make sure we don't trigger afterChange again and again in an infinite loop
         return;
       }
-      await payload.update({
+      await req.payload.update({
         collection: contextHooksSlug,
         id: doc.id,
         data: {

--- a/test/hooks/collections/Users/index.ts
+++ b/test/hooks/collections/Users/index.ts
@@ -1,4 +1,4 @@
-import { Payload } from '../../../../src/payload';
+import type { Payload } from '../../../../src/payload';
 import { BeforeLoginHook, CollectionConfig } from '../../../../src/collections/config/types';
 import { AuthenticationError } from '../../../../src/errors';
 import { devUser, regularUser } from '../../../credentials';


### PR DESCRIPTION
## Description

Fixes #3248 
Fixes #3246 

- Removes depth param from admin panel `<form>` action urls.
- Sets relationship fields to the id when data is set from a fetch made with depth > 0

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
