### PR TITLE
fix(#3263): store array and block fields actual value instead of length

### DIFF
--- a/src/admin/components/elements/ArrayAction/index.tsx
+++ b/src/admin/components/elements/ArrayAction/index.tsx
@@ -63,7 +63,7 @@ export const ArrayAction: React.FC<Props> = ({
                   className={`${baseClass}__action ${baseClass}__add`}
                   type="button"
                   onClick={() => {
-                    addRow(index + 1);
+                    addRow(index);
                     close();
                   }}
                 >

--- a/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
+++ b/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
@@ -128,8 +128,8 @@ export const addFieldStatePromise = async ({
           fieldState.value = null;
           fieldState.initialValue = null;
         } else {
-          fieldState.value = arrayValue.length;
-          fieldState.initialValue = arrayValue.length;
+          fieldState.value = arrayValue;
+          fieldState.initialValue = arrayValue;
 
           if (arrayValue.length > 0) {
             fieldState.disableFormData = true;
@@ -210,8 +210,8 @@ export const addFieldStatePromise = async ({
           fieldState.value = null;
           fieldState.initialValue = null;
         } else {
-          fieldState.value = blocksValue.length;
-          fieldState.initialValue = blocksValue.length;
+          fieldState.value = blocksValue;
+          fieldState.initialValue = blocksValue;
 
           if (blocksValue.length > 0) {
             fieldState.disableFormData = true;

--- a/src/admin/components/forms/Form/fieldReducer.ts
+++ b/src/admin/components/forms/Form/fieldReducer.ts
@@ -100,7 +100,7 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
         ...remainingFields,
         [path]: {
           ...state[path],
-          value: rows.length,
+          value: rows,
           disableFormData: rows.length > 0,
           rows: rowsMetadata,
         },
@@ -144,7 +144,7 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
         ...flattenRows(path, rows),
         [path]: {
           ...state[path],
-          value: rows.length,
+          value: rows,
           disableFormData: true,
           rows: rowsMetadata,
         },
@@ -182,7 +182,7 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
         ...flattenRows(path, rows),
         [path]: {
           ...state[path],
-          value: rows.length,
+          value: rows,
           disableFormData: true,
           rows: rowsMetadata,
         },
@@ -213,7 +213,7 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
         ...remainingFields,
         [path]: {
           ...state[path],
-          value: rows.length,
+          value: rows,
           disableFormData: true,
           rows: rowsMetadata,
         },

--- a/src/admin/components/forms/Form/fieldReducer.ts
+++ b/src/admin/components/forms/Form/fieldReducer.ts
@@ -115,7 +115,7 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
 
       const rowsMetadata = [...state[path]?.rows || []];
       rowsMetadata.splice(
-        rowIndex + 1,
+        rowIndex,
         0,
         // new row
         {
@@ -137,7 +137,7 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
       const { remainingFields, rows } = separateRows(path, state);
 
       // actual form state (value saved in db)
-      rows.splice(rowIndex + 1, 0, subFieldState);
+      rows.splice(rowIndex, 0, subFieldState);
 
       const newState: Fields = {
         ...remainingFields,

--- a/src/admin/components/forms/Form/index.tsx
+++ b/src/admin/components/forms/Form/index.tsx
@@ -429,7 +429,7 @@ const Form: React.FC<Props> = (props) => {
 
     if (fieldConfig) {
       const subFieldState = await buildStateFromSchema({ fieldSchema: fieldConfig, data, preferences, operation, id, user, locale, t });
-      dispatchFields({ type: 'ADD_ROW', rowIndex: rowIndex - 1, path, blockType: data?.blockType, subFieldState });
+      dispatchFields({ type: 'ADD_ROW', rowIndex, path, blockType: data?.blockType, subFieldState });
     }
   }, [dispatchFields, getDocPreferences, id, user, operation, locale, t, getRowConfigByPath]);
 
@@ -446,7 +446,7 @@ const Form: React.FC<Props> = (props) => {
 
     if (fieldConfig) {
       const subFieldState = await buildStateFromSchema({ fieldSchema: fieldConfig, data, preferences, operation, id, user, locale, t });
-      dispatchFields({ type: 'REPLACE_ROW', rowIndex: rowIndex - 1, path, blockType: data?.blockType, subFieldState });
+      dispatchFields({ type: 'REPLACE_ROW', rowIndex, path, blockType: data?.blockType, subFieldState });
     }
   }, [dispatchFields, getDocPreferences, id, user, operation, locale, t, getRowConfigByPath]);
 

--- a/src/admin/components/forms/field-types/Array/index.tsx
+++ b/src/admin/components/forms/field-types/Array/index.tsx
@@ -92,7 +92,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
     value,
     rows = [],
     valid,
-  } = useField<number>({
+  } = useField<[]>({
     path,
     validate: memoizedValidate,
     condition,
@@ -269,7 +269,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
             buttonStyle="icon-label"
             iconStyle="with-border"
             iconPosition="left"
-            onClick={() => addRow(value as number)}
+            onClick={() => addRow(value?.length || 0)}
           >
             {t('addLabel', { label: getTranslation(labels.singular, i18n) })}
           </Button>

--- a/src/admin/components/forms/field-types/Array/index.tsx
+++ b/src/admin/components/forms/field-types/Array/index.tsx
@@ -104,7 +104,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
     setModified(true);
 
     setTimeout(() => {
-      scrollToID(`${path}-row-${rowIndex + 1}`);
+      scrollToID(`${path}-row-${rowIndex}`);
     }, 0);
   }, [addFieldRow, path, setModified]);
 

--- a/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -90,7 +90,7 @@ const BlocksField: React.FC<Props> = (props) => {
     value,
     rows = [],
     valid,
-  } = useField<number>({
+  } = useField<[]>({
     path,
     validate: memoizedValidate,
     condition,
@@ -290,7 +290,7 @@ const BlocksField: React.FC<Props> = (props) => {
             drawerSlug={drawerSlug}
             blocks={blocks}
             addRow={addRow}
-            addRowIndex={value}
+            addRowIndex={value?.length || 0}
             labels={labels}
           />
         </Fragment>

--- a/src/fields/hooks/beforeChange/promise.ts
+++ b/src/fields/hooks/beforeChange/promise.ts
@@ -85,13 +85,8 @@ export const promise = async ({
 
     // Validate
     if (!skipValidationFromHere && field.validate) {
-      let valueToValidate = siblingData[field.name];
+      const valueToValidate = siblingData[field.name];
       let jsonError;
-
-      if (['array', 'blocks'].includes(field.type)) {
-        const rows = siblingData[field.name];
-        valueToValidate = Array.isArray(rows) ? rows.length : 0;
-      }
 
 
       if (field.type === 'json' && typeof siblingData[field.name] === 'string') {

--- a/src/fields/validations.ts
+++ b/src/fields/validations.ts
@@ -365,7 +365,7 @@ export const relationship: Validate<unknown, unknown, RelationshipField> = async
 };
 
 export const array: Validate<unknown, unknown, ArrayField> = (value, { t, minRows, maxRows, required }) => {
-  const arrayLength = Array.isArray(value) ? value.length : (value || 0);
+  const arrayLength = Array.isArray(value) ? value.length : 0;
 
   if (minRows && arrayLength < minRows) {
     return t('validation:requiresAtLeast', { count: minRows, label: t('rows') });
@@ -410,15 +410,17 @@ export const radio: Validate<unknown, unknown, RadioField> = (value, { t, option
 };
 
 export const blocks: Validate<unknown, unknown, BlockField> = (value, { t, maxRows, minRows, required }) => {
-  if (minRows && value < minRows) {
+  const arrayLength = Array.isArray(value) ? value.length : 0;
+
+  if (minRows && arrayLength < minRows) {
     return t('validation:requiresAtLeast', { count: minRows, label: t('rows') });
   }
 
-  if (maxRows && value > maxRows) {
+  if (maxRows && arrayLength > maxRows) {
     return t('validation:requiresNoMoreThan', { count: maxRows, label: t('rows') });
   }
 
-  if (!value && required) {
+  if (!arrayLength && required) {
     return t('validation:requiresAtLeast', { count: 1, label: t('row') });
   }
 

--- a/src/fields/validations.ts
+++ b/src/fields/validations.ts
@@ -365,15 +365,17 @@ export const relationship: Validate<unknown, unknown, RelationshipField> = async
 };
 
 export const array: Validate<unknown, unknown, ArrayField> = (value, { t, minRows, maxRows, required }) => {
-  if (minRows && value < minRows) {
+  const arrayLength = Array.isArray(value) ? value.length : (value || 0);
+
+  if (minRows && arrayLength < minRows) {
     return t('validation:requiresAtLeast', { count: minRows, label: t('rows') });
   }
 
-  if (maxRows && value > maxRows) {
+  if (maxRows && arrayLength > maxRows) {
     return t('validation:requiresNoMoreThan', { count: maxRows, label: t('rows') });
   }
 
-  if (!value && required) {
+  if (!arrayLength && required) {
     return t('validation:requiresAtLeast', { count: 1, label: t('row') });
   }
 

--- a/test/fields/collections/Array/components/AddCustomBlocks/index.tsx
+++ b/test/fields/collections/Array/components/AddCustomBlocks/index.tsx
@@ -8,9 +8,9 @@ const baseClass = 'custom-blocks-field-management';
 
 export const AddCustomBlocks: React.FC = () => {
   const { addFieldRow, replaceFieldRow } = useForm();
-  const { value } = useField({ path: 'customBlocks' });
+  const { value } = useField<[]>({ path: 'customBlocks' });
 
-  const nextIndex = typeof value === 'number' ? value + 1 : 0;
+  const nextIndex = Array.isArray(value) ? value.length : 0;
 
   return (
     <div className={baseClass}>

--- a/test/fields/collections/Array/components/AddCustomBlocks/index.tsx
+++ b/test/fields/collections/Array/components/AddCustomBlocks/index.tsx
@@ -40,7 +40,7 @@ export const AddCustomBlocks: React.FC = () => {
         >
           Replace Block
           {' '}
-          {nextIndex - 1}
+          {nextIndex}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Description

Fixes #3263 

Before `value` on array and block fields were storing the length of the row inside form state. This replaces that with the _actual_ value of the array. Read more in the [related issue](#3263).

I think this change makes sense and the reasoning is sound. We could put this behind a flag since it has the potential to affect existing applications - however I see the argument that it is a "bug" also.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
