### PR TITLE
fix: appends versions key to incoming where query

### DIFF
--- a/src/versions/drafts/queryDrafts.ts
+++ b/src/versions/drafts/queryDrafts.ts
@@ -124,8 +124,8 @@ const queryDraftsV2 = async <T extends TypeWithID>({
   where,
 }: Args): Promise<PaginatedDocs<T>> => {
   const VersionModel = payload.versions[collection.config.slug] as CollectionModel;
-
-  const combinedQuery = combineQueries({ latest: { equals: true } }, where);
+  const queryWithPrefix = appendVersionToQueryKey(where || {});
+  const combinedQuery = combineQueries({ latest: { equals: true } }, queryWithPrefix);
 
   const versionsQuery = await VersionModel.buildQuery({
     where: combinedQuery,


### PR DESCRIPTION
## Description

Fixes issue where filters do not function correctly when using new `database.queryDrafts_2_0` feature flag.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
