### PR TITLE
fix: unique webpack chunk names on each build (#3289)

### DIFF
--- a/src/bundlers/webpack/configs/base.ts
+++ b/src/bundlers/webpack/configs/base.ts
@@ -88,6 +88,5 @@ export const getBaseConfig = (payloadConfig: SanitizedConfig): Configuration => 
       template: payloadConfig.admin.indexHTML,
       filename: path.normalize('./index.html'),
     }),
-    new webpack.HotModuleReplacementPlugin(),
   ],
 });


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation

---

This simply removes the hot reload plugin from the base config, as it's already present in the dev config:

https://github.com/payloadcms/payload/blob/5e1bed3177ee915ee04a1e77005d81538d90f9fd/src/bundlers/webpack/configs/dev.ts#L34-L37

By removing the hot reload plugin from the base config, it is essentially removed from the prod config, meaning that the hot reload module no longer appears in production builds and doesn't lead to different chunk hashes every time (#3289).