### PR TITLE
fix: corrects hasMany relationships within addFieldStatePromise

### DIFF
--- a/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
+++ b/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
@@ -252,7 +252,7 @@ export const addFieldStatePromise = async ({
               return relationship.id;
             }
             return relationship;
-          }) : [];
+          }) : undefined;
 
           fieldState.value = relationshipValue;
           fieldState.initialValue = relationshipValue;
@@ -265,6 +265,7 @@ export const addFieldStatePromise = async ({
 
           state[`${path}${field.name}`] = fieldState;
         }
+
         break;
       }
 

--- a/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
+++ b/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
@@ -245,7 +245,29 @@ export const addFieldStatePromise = async ({
         break;
       }
 
-      case 'relationship':
+      case 'relationship': {
+        if (field.hasMany) {
+          const relationshipValue = Array.isArray(valueWithDefault) ? valueWithDefault.map((relationship) => {
+            if (typeof relationship === 'object' && relationship !== null) {
+              return relationship.id;
+            }
+            return relationship;
+          }) : [];
+
+          fieldState.value = relationshipValue;
+          fieldState.initialValue = relationshipValue;
+
+          state[`${path}${field.name}`] = fieldState;
+        } else {
+          const relationshipValue = valueWithDefault && typeof valueWithDefault === 'object' && 'id' in valueWithDefault ? valueWithDefault.id : valueWithDefault;
+          fieldState.value = relationshipValue;
+          fieldState.initialValue = relationshipValue;
+
+          state[`${path}${field.name}`] = fieldState;
+        }
+        break;
+      }
+
       case 'upload': {
         const relationshipValue = valueWithDefault && typeof valueWithDefault === 'object' && 'id' in valueWithDefault ? valueWithDefault.id : valueWithDefault;
         fieldState.value = relationshipValue;


### PR DESCRIPTION
## Description

Fixes issue (mentioned [here](https://github.com/payloadcms/payload/pull/3276#issuecomment-1712363048)) where hasMany relationship fields when saved are clearing the fields.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
