### PR TITLE
Fix: greater than equal filter not working

### DIFF
--- a/src/admin/components/elements/WhereBuilder/field-types.tsx
+++ b/src/admin/components/elements/WhereBuilder/field-types.tsx
@@ -41,7 +41,7 @@ const numeric = [
   },
   {
     label: 'isGreaterThanOrEqualTo',
-    value: 'greater_than_equals',
+    value: 'greater_than_equal',
   },
 ];
 

--- a/test/fields/config.ts
+++ b/test/fields/config.ts
@@ -137,6 +137,8 @@ export default buildConfigWithDefaults({
     await payload.create({ collection: 'rich-text-fields', data: richTextBulletsDoc });
     await payload.create({ collection: 'rich-text-fields', data: richTextDocWithRelationship });
 
+    await payload.create({ collection: 'number-fields', data: { number: 2 } });
+    await payload.create({ collection: 'number-fields', data: { number: 3 } });
     await payload.create({ collection: 'number-fields', data: numberDoc });
 
     const blocksDocWithRichText = { ...blocksDoc };

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -80,33 +80,12 @@ describe('fields', () => {
         .toHaveText(String(numberDoc.number));
     });
 
-    test('should create', async () => {
-      const input = 5;
-
-      await page.goto(url.create);
-      const field = page.locator('#field-number');
-      await field.fill(String(input));
-      await saveDocAndAssert(page);
-      await expect(await field.inputValue()).toEqual(String(input));
-    });
-
-    test('should create hasMany', async () => {
-      const input = 5;
-
-      await page.goto(url.create);
-      const field = page.locator('.field-hasMany');
-      await field.click();
-      await page.keyboard.type(String(input));
-      await page.keyboard.press('Enter');
-      await saveDocAndAssert(page);
-      await expect(field.locator('.rs__value-container')).toContainText(String(input));
-    });
 
     test('should filter Number fields in the collection view - greaterThanOrEqual', async () => {
       await page.goto(url.list);
 
-      // should have 5 entries
-      await expect(page.locator('table >> tbody >> tr')).toHaveCount(5);
+      // should have 3 entries
+      await expect(page.locator('table >> tbody >> tr')).toHaveCount(3);
 
       // open the filter options
       await page.locator('.list-controls__toggle-where').click();
@@ -134,8 +113,30 @@ describe('fields', () => {
       await expect(valueField).toHaveValue('3');
       await wait(300);
 
-      // should have 3 entries after filtering
-      await expect(page.locator('table >> tbody >> tr')).toHaveCount(3);
+      // should have 2 entries after filtering
+      await expect(page.locator('table >> tbody >> tr')).toHaveCount(2);
+    });
+
+    test('should create', async () => {
+      const input = 5;
+
+      await page.goto(url.create);
+      const field = page.locator('#field-number');
+      await field.fill(String(input));
+      await saveDocAndAssert(page);
+      await expect(await field.inputValue()).toEqual(String(input));
+    });
+
+    test('should create hasMany', async () => {
+      const input = 5;
+
+      await page.goto(url.create);
+      const field = page.locator('.field-hasMany');
+      await field.click();
+      await page.keyboard.type(String(input));
+      await page.keyboard.press('Enter');
+      await saveDocAndAssert(page);
+      await expect(field.locator('.rs__value-container')).toContainText(String(input));
     });
   });
 

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -101,6 +101,42 @@ describe('fields', () => {
       await saveDocAndAssert(page);
       await expect(field.locator('.rs__value-container')).toContainText(String(input));
     });
+
+    test('should filter Number fields in the collection view - greaterThanOrEqual', async () => {
+      await page.goto(url.list);
+
+      // should have 3 entries
+      await expect(page.locator('table >> tbody >> tr')).toHaveCount(3);
+
+      // open the filter options
+      await page.locator('.list-controls__toggle-where').click();
+      await expect(page.locator('.list-controls__where.rah-static--height-auto')).toBeVisible();
+      await page.locator('.where-builder__add-first-filter').click();
+
+      const initialField = page.locator('.condition__field');
+      const operatorField = page.locator('.condition__operator');
+      const valueField = page.locator('.condition__value >> input');
+
+      // select Number field to filter on
+      await initialField.click();
+      const initialFieldOptions = initialField.locator('.rs__option');
+      await initialFieldOptions.locator('text=number').first().click();
+      expect(initialField.locator('.rs__single-value')).toContainText('Number');
+
+      // select >= operator
+      await operatorField.click();
+      const operatorOptions = operatorField.locator('.rs__option');
+      await operatorOptions.last().click();
+      expect(operatorField.locator('.rs__single-value')).toContainText('is greater than or equal to');
+
+      // enter value of 3
+      await valueField.fill('3');
+      await expect(valueField).toHaveValue('3');
+      await wait(300);
+
+      // should have 2 entries after filtering
+      await expect(page.locator('table >> tbody >> tr')).toHaveCount(2);
+    });
   });
 
   describe('json', () => {

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -105,8 +105,8 @@ describe('fields', () => {
     test('should filter Number fields in the collection view - greaterThanOrEqual', async () => {
       await page.goto(url.list);
 
-      // should have 3 entries
-      await expect(page.locator('table >> tbody >> tr')).toHaveCount(3);
+      // should have 5 entries
+      await expect(page.locator('table >> tbody >> tr')).toHaveCount(5);
 
       // open the filter options
       await page.locator('.list-controls__toggle-where').click();
@@ -134,8 +134,8 @@ describe('fields', () => {
       await expect(valueField).toHaveValue('3');
       await wait(300);
 
-      // should have 2 entries after filtering
-      await expect(page.locator('table >> tbody >> tr')).toHaveCount(2);
+      // should have 3 entries after filtering
+      await expect(page.locator('table >> tbody >> tr')).toHaveCount(3);
     });
   });
 


### PR DESCRIPTION
## Description

Closes #3305 

WhereBuilder value for `isGreaterOrEqualTo` was incorrect and causing the filter to not work.

- [X] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
