### PR TITLE
fix(#3289): removes HMR plugin in prod configs

### DIFF
--- a/src/bundlers/webpack/configs/base.ts
+++ b/src/bundlers/webpack/configs/base.ts
@@ -88,6 +88,5 @@ export const getBaseConfig = (payloadConfig: SanitizedConfig): Configuration => 
       template: payloadConfig.admin.indexHTML,
       filename: path.normalize('./index.html'),
     }),
-    new webpack.HotModuleReplacementPlugin(),
   ],
 });


### PR DESCRIPTION
## Description

Fixes #3289 

HMR plugin only belongs in dev config.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
