### PR TITLE
feat: adds x-payload-admin header

### DIFF
--- a/src/admin/components/Routes.tsx
+++ b/src/admin/components/Routes.tsx
@@ -60,6 +60,7 @@ const Routes: React.FC = () => {
       requests.get(`${routes.api}/${slug}/init`, {
         headers: {
           'Accept-Language': i18n.language,
+          'x-payload-admin': 'true',
         },
       }).then((res) => res.json().then((data) => {
         if (data && 'initialized' in data) {

--- a/src/admin/components/elements/Autosave/index.tsx
+++ b/src/admin/components/elements/Autosave/index.tsx
@@ -51,6 +51,7 @@ const Autosave: React.FC<Props> = ({ collection, global, id, publishedDocUpdated
       headers: {
         'Content-Type': 'application/json',
         'Accept-Language': i18n.language,
+        'x-payload-admin': 'true',
       },
       body: JSON.stringify({}),
     });
@@ -109,6 +110,7 @@ const Autosave: React.FC<Props> = ({ collection, global, id, publishedDocUpdated
                 headers: {
                   'Content-Type': 'application/json',
                   'Accept-Language': i18n.language,
+                  'x-payload-admin': 'true',
                 },
                 body: JSON.stringify(body),
               });

--- a/src/admin/components/elements/DeleteDocument/index.tsx
+++ b/src/admin/components/elements/DeleteDocument/index.tsx
@@ -52,6 +52,7 @@ const DeleteDocument: React.FC<Props> = (props) => {
       headers: {
         'Content-Type': 'application/json',
         'Accept-Language': i18n.language,
+        'x-payload-admin': 'true',
       },
     }).then(async (res) => {
       try {

--- a/src/admin/components/elements/DeleteMany/index.tsx
+++ b/src/admin/components/elements/DeleteMany/index.tsx
@@ -49,6 +49,7 @@ const DeleteMany: React.FC<Props> = (props) => {
       headers: {
         'Content-Type': 'application/json',
         'Accept-Language': i18n.language,
+        'x-payload-admin': 'true',
       },
     }).then(async (res) => {
       try {

--- a/src/admin/components/elements/DuplicateDocument/index.tsx
+++ b/src/admin/components/elements/DuplicateDocument/index.tsx
@@ -43,6 +43,7 @@ const Duplicate: React.FC<Props> = ({ slug, collection, id }) => {
         },
         headers: {
           'Accept-Language': i18n.language,
+          'x-payload-admin': 'true',
         },
       });
       let data = await response.json();
@@ -61,6 +62,7 @@ const Duplicate: React.FC<Props> = ({ slug, collection, id }) => {
         headers: {
           'Content-Type': 'application/json',
           'Accept-Language': i18n.language,
+          'x-payload-admin': 'true',
         },
         body: JSON.stringify(data),
       });
@@ -88,6 +90,7 @@ const Duplicate: React.FC<Props> = ({ slug, collection, id }) => {
               },
               headers: {
                 'Accept-Language': i18n.language,
+                'x-payload-admin': 'true',
               },
             });
             let localizedDoc = await res.json();
@@ -103,6 +106,7 @@ const Duplicate: React.FC<Props> = ({ slug, collection, id }) => {
               headers: {
                 'Content-Type': 'application/json',
                 'Accept-Language': i18n.language,
+                'x-payload-admin': 'true',
               },
               body: JSON.stringify(localizedDoc),
             });
@@ -118,6 +122,7 @@ const Duplicate: React.FC<Props> = ({ slug, collection, id }) => {
         await requests.delete(`${serverURL}${api}/${slug}/${id}`, {
           headers: {
             'Accept-Language': i18n.language,
+            'x-payload-admin': 'true',
           },
         });
       }

--- a/src/admin/components/elements/PublishMany/index.tsx
+++ b/src/admin/components/elements/PublishMany/index.tsx
@@ -53,6 +53,7 @@ const PublishMany: React.FC<Props> = (props) => {
       headers: {
         'Content-Type': 'application/json',
         'Accept-Language': i18n.language,
+        'x-payload-admin': 'true',
       },
     }).then(async (res) => {
       try {

--- a/src/admin/components/elements/Status/index.tsx
+++ b/src/admin/components/elements/Status/index.tsx
@@ -78,6 +78,7 @@ const Status: React.FC = () => {
       headers: {
         'Content-Type': 'application/json',
         'Accept-Language': i18n.language,
+        'x-payload-admin': 'true',
       },
       body: JSON.stringify(body),
     });

--- a/src/admin/components/elements/UnpublishMany/index.tsx
+++ b/src/admin/components/elements/UnpublishMany/index.tsx
@@ -53,6 +53,7 @@ const UnpublishMany: React.FC<Props> = (props) => {
       headers: {
         'Content-Type': 'application/json',
         'Accept-Language': i18n.language,
+        'x-payload-admin': 'true',
       },
     }).then(async (res) => {
       try {

--- a/src/admin/components/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/src/admin/components/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -66,6 +66,7 @@ const RelationshipField: React.FC<Props> = (props) => {
             credentials: 'include',
             headers: {
               'Accept-Language': i18n.language,
+              'x-payload-admin': 'true',
             },
           });
 
@@ -163,6 +164,7 @@ const RelationshipField: React.FC<Props> = (props) => {
         credentials: 'include',
         headers: {
           'Accept-Language': i18n.language,
+          'x-payload-admin': 'true',
         },
       });
 

--- a/src/admin/components/forms/Form/index.tsx
+++ b/src/admin/components/forms/Form/index.tsx
@@ -231,6 +231,7 @@ const Form: React.FC<Props> = (props) => {
         body: formData,
         headers: {
           'Accept-Language': i18n.language,
+          'x-payload-admin': 'true',
         },
       });
 

--- a/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -180,6 +180,7 @@ const Relationship: React.FC<Props> = (props) => {
                 credentials: 'include',
                 headers: {
                   'Accept-Language': i18n.language,
+                  'x-payload-admin': 'true',
                 },
               },
             );
@@ -294,6 +295,7 @@ const Relationship: React.FC<Props> = (props) => {
             credentials: 'include',
             headers: {
               'Accept-Language': i18n.language,
+              'x-payload-admin': 'true',
             },
           });
 

--- a/src/admin/components/forms/field-types/Upload/Input.tsx
+++ b/src/admin/components/forms/field-types/Upload/Input.tsx
@@ -105,6 +105,7 @@ const UploadInput: React.FC<UploadInputProps> = (props) => {
           credentials: 'include',
           headers: {
             'Accept-Language': i18n.language,
+            'x-payload-admin': 'true',
           },
         });
         if (response.ok) {

--- a/src/admin/components/utilities/Auth/index.tsx
+++ b/src/admin/components/utilities/Auth/index.tsx
@@ -81,6 +81,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           const request = await requests.post(`${serverURL}${api}/${userSlug}/refresh-token`, {
             headers: {
               'Accept-Language': i18n.language,
+              'x-payload-admin': 'true',
             },
           });
 
@@ -104,6 +105,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const request = await requests.post(`${serverURL}${api}/${userSlug}/refresh-token`, {
         headers: {
           'Accept-Language': i18n.language,
+          'x-payload-admin': 'true',
         },
       });
 
@@ -136,6 +138,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const request = await requests.get(`${serverURL}${api}/access`, {
         headers: {
           'Accept-Language': i18n.language,
+          'x-payload-admin': 'true',
         },
       });
 
@@ -155,6 +158,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const request = await requests.get(`${serverURL}${api}/${userSlug}/me`, {
         headers: {
           'Accept-Language': i18n.language,
+          'x-payload-admin': 'true',
         },
       });
 
@@ -177,6 +181,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             headers: {
               'Accept-Language': i18n.language,
               'Content-Type': 'application/json',
+              'x-payload-admin': 'true',
             },
           });
           if (autoLoginResult.status === 200) {

--- a/src/admin/components/utilities/DocumentInfo/index.tsx
+++ b/src/admin/components/utilities/DocumentInfo/index.tsx
@@ -134,6 +134,7 @@ export const DocumentInfoProvider: React.FC<Props> = ({
           credentials: 'include',
           headers: {
             'Accept-Language': i18n.language,
+            'x-payload-admin': 'true',
           },
         }).then((res) => res.json());
 
@@ -147,6 +148,7 @@ export const DocumentInfoProvider: React.FC<Props> = ({
           credentials: 'include',
           headers: {
             'Accept-Language': i18n.language,
+            'x-payload-admin': 'true',
           },
         }).then((res) => res.json());
 
@@ -171,6 +173,7 @@ export const DocumentInfoProvider: React.FC<Props> = ({
             credentials: 'include',
             headers: {
               'Accept-Language': i18n.language,
+              'x-payload-admin': 'true',
             },
           });
 
@@ -199,6 +202,7 @@ export const DocumentInfoProvider: React.FC<Props> = ({
         credentials: 'include',
         headers: {
           'Accept-Language': i18n.language,
+          'x-payload-admin': 'true',
         },
       });
       const json = await res.json();

--- a/src/admin/components/utilities/Preferences/index.tsx
+++ b/src/admin/components/utilities/Preferences/index.tsx
@@ -43,6 +43,7 @@ export const PreferencesProvider: React.FC<{children?: React.ReactNode}> = ({ ch
         const request = await requests.get(`${serverURL}${api}/_preferences/${key}`, {
           headers: {
             'Accept-Language': i18n.language,
+            'x-payload-admin': 'true',
           },
         });
         let value = null;

--- a/src/admin/components/views/Verify/index.tsx
+++ b/src/admin/components/views/Verify/index.tsx
@@ -32,6 +32,7 @@ const Verify: React.FC<{ collection: SanitizedCollectionConfig }> = ({ collectio
         credentials: 'include',
         headers: {
           'Accept-Language': i18n.language,
+          'x-payload-admin': 'true',
         },
       });
       setVerifyResult(result);

--- a/src/admin/components/views/Version/Compare/index.tsx
+++ b/src/admin/components/views/Version/Compare/index.tsx
@@ -67,6 +67,7 @@ const CompareVersion: React.FC<Props> = (props) => {
       credentials: 'include',
       headers: {
         'Accept-Language': i18n.language,
+        'x-payload-admin': 'true',
       },
     });
 

--- a/src/admin/components/views/Version/Restore/index.tsx
+++ b/src/admin/components/views/Version/Restore/index.tsx
@@ -43,6 +43,7 @@ const Restore: React.FC<Props> = ({ collection, global, className, versionID, or
     const res = await requests.post(fetchURL, {
       headers: {
         'Accept-Language': i18n.language,
+        'x-payload-admin': 'true',
       },
     });
 

--- a/src/admin/components/views/collections/Edit/Auth/index.tsx
+++ b/src/admin/components/views/collections/Edit/Auth/index.tsx
@@ -47,6 +47,7 @@ const Auth: React.FC<Props> = (props) => {
       headers: {
         'Content-Type': 'application/json',
         'Accept-Language': i18n.language,
+        'x-payload-admin': 'true',
       },
       body: JSON.stringify({
         email,

--- a/src/admin/components/views/collections/List/RelationshipProvider/index.tsx
+++ b/src/admin/components/views/collections/List/RelationshipProvider/index.tsx
@@ -64,6 +64,7 @@ export const RelationshipProvider: React.FC<{ children?: React.ReactNode }> = ({
           credentials: 'include',
           headers: {
             'Accept-Language': i18n.language,
+            'x-payload-admin': 'true',
           },
         });
 

--- a/src/admin/hooks/usePayloadAPI.tsx
+++ b/src/admin/hooks/usePayloadAPI.tsx
@@ -54,6 +54,7 @@ const usePayloadAPI: UsePayloadAPI = (url, options = {}) => {
           signal: abortController.signal,
           headers: {
             'Accept-Language': i18n.language,
+            'x-payload-admin': 'true',
           },
         });
 


### PR DESCRIPTION
## Description

This PR adds `x-payload-admin` header to all requests from the admin panel.

The motivation for this is so that fields can be conditionally serialized to a different JSON structure, without affecting the data passed to forms in the admin UI. Currently, if data is serialized in an `afterRead` field hook, the admin panel will not function properly for those fields.

For example, consider a `Nav` global, which uses a reusable set of `Links` fields, enabling an array of `Page` relationships to be configured. Requesting the global with `depth=1` expensively returns the entire page, when all that is required is a subset of fields for building the links. 

By implementing a conditional `afterRead` field hook, which checks the `x-payload-admin` header, this problem can be solved. The following solution was in fact [hallucinated by the ai-help Discord bot](https://discord.com/channels/967097582721572934/1126111493570691135/1149280925759328316) and may be a short-term band-aid solution for those waiting on select functionality (https://github.com/payloadcms/payload/pull/1288) to be delivered.

```ts
[
  //...
  {
    name: 'page',
    type: 'relationship',
    relationTo: 'pages',
    maxDepth: 0,
    hooks: {
      afterRead: [
        async ({ value, req }) => {
          // If request is made by admin panel, return the value as-is
          if (req.headers?.['x-payload-admin']) {
            return value
          }

          // Otherwise, return only the required fields
          if (value?.value) {
            const entity = await req.payload.findByID({
              collection: value.relationTo,
              id: value.value
            })

            return {
              relationTo: value.relationTo,
              value: {
                id: entity.id,
                path: entity.path,
                locale: req.locale,
                title: entity.title,
                _status: entity._status
              }
            }
          }

          return value
        }
      ]
    }
  }
]
``` 

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation