### PR TITLE
Fix context propagation for find operations

### DIFF
--- a/src/collections/operations/local/find.ts
+++ b/src/collections/operations/local/find.ts
@@ -55,7 +55,7 @@ export default async function findLocal<T extends keyof GeneratedTypes['collecti
     req = {} as PayloadRequest,
     context,
   } = options;
-  setRequestContext(options.req, context);
+  setRequestContext(req, context);
 
   const collection = payload.collections[collectionSlug];
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;

--- a/src/collections/operations/local/findByID.ts
+++ b/src/collections/operations/local/findByID.ts
@@ -46,7 +46,7 @@ export default async function findByIDLocal<T extends keyof GeneratedTypes['coll
     draft = false,
     context,
   } = options;
-  setRequestContext(options.req, context);
+  setRequestContext(req, context);
 
   const collection = payload.collections[collectionSlug];
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;

--- a/src/collections/operations/local/findVersionByID.ts
+++ b/src/collections/operations/local/findVersionByID.ts
@@ -43,7 +43,7 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
     req = {} as PayloadRequest,
     context,
   } = options;
-  setRequestContext(options.req, context);
+  setRequestContext(req, context);
 
   const collection = payload.collections[collectionSlug];
   const defaultLocale = payload?.config?.localization ? payload?.config?.localization?.defaultLocale : null;

--- a/test/hooks/collections/ContextHooks/index.ts
+++ b/test/hooks/collections/ContextHooks/index.ts
@@ -55,6 +55,14 @@ const ContextHooks: CollectionConfig = {
         },
       });
     }],
+    afterRead: [
+      async ({ context, doc }) => {
+        if (context?.secretFindValue) {
+          doc.value = context.secretFindValue;
+        }
+        return doc;
+      }
+    ]
   },
   fields: [
     {

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -247,6 +247,24 @@ describe('Hooks', () => {
       expect(retrievedDoc.value).toEqual('data from local API');
     });
 
+    it('should pass context from local findByID API to hooks', async () => {
+      const document = await payload.create({
+        collection: contextHooksSlug,
+        data: {
+          value: 'originalvalue',
+        },
+      });
+
+      const retrievedDoc = await payload.findByID({
+        collection: contextHooksSlug,
+        id: document.id,
+        context: {
+          secretFindValue: 'data from local API',
+        },
+      });
+
+      expect(retrievedDoc.value).toEqual('data from local API');
+    });
     it('should pass context from rest API to hooks', async () => {
       const params = new URLSearchParams({
         context_secretValue: 'data from rest API',


### PR DESCRIPTION
## Description

Pass the correct variable to setRequestContext for find operations, so the context passed in via find options is not discarded.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation _(no doc changes necessary - features now work as documented)_
