### PR TITLE
chore: make bundlers use named exports

### DIFF
--- a/packages/bundler-vite/src/index.ts
+++ b/packages/bundler-vite/src/index.ts
@@ -5,7 +5,7 @@ import { devAdmin } from './scripts/dev'
 import { buildAdmin } from './scripts/build'
 import { serveAdmin } from './scripts/serve'
 
-export default (viteConfig?: InlineConfig): PayloadBundler => ({
+export const viteBundler: (viteConfig?: InlineConfig) => PayloadBundler = (viteConfig) => ({
   dev: async (payload) => devAdmin({ payload, viteConfig }),
   build: async (payloadConfig) => buildAdmin({ payloadConfig, viteConfig }),
   serve: async (payload) => serveAdmin({ payload }),

--- a/packages/bundler-webpack/src/index.ts
+++ b/packages/bundler-webpack/src/index.ts
@@ -4,7 +4,7 @@ import { devAdmin } from './scripts/dev'
 import { buildAdmin } from './scripts/build'
 import { serveAdmin } from './scripts/serve'
 
-export default (): PayloadBundler => ({
+export const webpackBundler: () => PayloadBundler = () => ({
   dev: async (payload) => devAdmin({ payload }),
   build: async (payloadConfig) => buildAdmin({ payloadConfig }),
   serve: async (payload) => serveAdmin({ payload }),

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -2,8 +2,8 @@ import path from 'path'
 
 import type { Config, SanitizedConfig } from '../packages/payload/src/config/types'
 
-// import viteBundler from '../packages/bundler-vite/src'
-import webpackBundler from '../packages/bundler-webpack/src'
+// import { viteBundler } from '../packages/bundler-vite/src'
+import { webpackBundler } from '../packages/bundler-webpack/src'
 import { mongooseAdapter } from '../packages/db-mongodb/src/index'
 import { postgresAdapter } from '../packages/db-postgres/src/index'
 import { buildConfig as buildPayloadConfig } from '../packages/payload/src/config/build'


### PR DESCRIPTION
Change bundlers to use named exports like our other packages.