### PR TITLE
feat: adds support for custom json schema

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-use-before-define */
 import type { EditorProps } from '@monaco-editor/react'
 import type { TFunction } from 'i18next'
+import type { JSONSchema4 } from 'json-schema';
 import type { CSSProperties } from 'react'
 
 import monacoeditor from 'monaco-editor' // IMPORTANT - DO NOT REMOVE: This is required for pnpm's default isolated mode to work - even though the import is not used. This is due to a typescript bug: https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189. (tsbugisolatedmode)
@@ -326,9 +327,11 @@ type JSONAdmin = Admin & {
   editorOptions?: EditorProps['options']
 }
 
+export type JSONFieldSchema = JSONSchema4|((field: Field, interfaceNameDefinitions: Map<string, JSONSchema4>) => JSONSchema4)
 export type JSONField = Omit<FieldBase, 'admin'> & {
-  admin?: JSONAdmin
-  type: 'json'
+  admin?: JSONAdmin,
+  jsonSchema?: JSONFieldSchema,
+  type: 'json',
 }
 
 export type SelectField = FieldBase & {

--- a/packages/payload/src/fields/validations.spec.ts
+++ b/packages/payload/src/fields/validations.spec.ts
@@ -1,6 +1,6 @@
 import type { ValidateOptions } from './config/types'
 
-import { number, password, point, relationship, select, text, textarea } from './validations'
+import {json, number, password, point, relationship, select, text, textarea} from './validations';
 
 const t = jest.fn((string) => string)
 
@@ -462,6 +462,53 @@ describe('Field Validations', () => {
       const val = [1.25, 2.5, 3.5]
       const result = number(val, { ...numberOptions, hasMany: true, maxRows: 2 })
       expect(result).toBe('validation:greaterThanMax')
+    })
+  })
+  describe('json', () => {
+    const jsonOptions = {
+      ...options,
+      name: 'test',
+      type: 'json',
+    }
+    it('should accept required any', () => {
+      const value = JSON.stringify({});
+      const result = json(value, {...jsonOptions, required: true});
+
+      expect(result).toBe(true);
+    })
+    it('should validate required', () => {
+      const value = '';
+      const result = json(value, {...jsonOptions, required: true});
+
+      expect(result).toBe('validation:required');
+    })
+    it('should validate against json schema', () => {
+      const value = JSON.stringify({});
+      const result = json(value, {...jsonOptions, jsonSchema: {
+        type: 'object',
+        properties: {
+          someKey: {
+            type: "string"
+          }
+        },
+        required: ['someKey']
+      }});
+
+      expect(result).toBe('validation:invalidInput');
+    })
+    it('should accept schema valid json', () => {
+      const value = JSON.stringify({someKey: 'some value'});
+      const result = json(value, {...jsonOptions, jsonSchema: {
+        type: 'object',
+        properties: {
+          someKey: {
+            type: "string"
+          }
+        },
+        required: ['someKey']
+      }});
+
+      expect(result).toBe(true);
     })
   })
 })

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -170,8 +170,8 @@ export const code: Validate<unknown, unknown, CodeField> = (value: string, { req
 }
 
 export const json: Validate<unknown, unknown, JSONField & { jsonError?: string }> = (
-  value: string,
-  { jsonError, required, t },
+  value: string, // is this typing correct?
+  { jsonError, required, t, jsonSchema },
 ) => {
   if (required && !value) {
     return t('validation:required')
@@ -179,6 +179,12 @@ export const json: Validate<unknown, unknown, JSONField & { jsonError?: string }
 
   if (jsonError !== undefined) {
     return t('validation:invalidInput')
+  }
+
+  if (jsonSchema && value) {
+    if (false) { // what lib?
+      return t('validation:invalidInput');
+    }
   }
 
   return true

--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -55,6 +55,143 @@ describe('configToJSONSchema', () => {
       required: ['id'],
       title: 'Test',
       type: 'object',
-    })
-  })
-})
+    });
+  });
+
+
+  it('should build default schema for json fields', () => {
+    const config: Config = {
+      collections: [
+        {
+          slug: 'test',
+          fields: [
+            {
+              name: 'someJsonField',
+              type: 'json',
+            },
+          ],
+          timestamps: false,
+        },
+      ],
+    };
+
+    const sanitizedConfig = sanitizeConfig(config);
+    const schema = configToJSONSchema(sanitizedConfig);
+    expect(schema?.definitions?.test).toStrictEqual({
+      title: 'Test',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: {
+          type: 'string',
+        },
+        someJsonField: {
+          oneOf: [
+            {type: 'object'},
+            {type: 'array'},
+            {type: 'string'},
+            {type: 'number'},
+            {type: 'boolean'},
+            {type: 'null'},
+          ],
+        },
+      },
+      required: ['id'],
+    });
+  });
+
+  it('should build custom static schema for json fields', () => {
+    const config: Config = {
+      collections: [
+        {
+          slug: 'test',
+          fields: [
+            {
+              name: 'someJsonField',
+              type: 'json',
+              jsonSchema: {
+                type: 'object',
+                properties: {
+                  someField: {type: 'string'}
+                },
+                required: ['someField'],
+              }
+            },
+          ],
+          timestamps: false,
+        },
+      ],
+    };
+
+    const sanitizedConfig = sanitizeConfig(config);
+    const schema = configToJSONSchema(sanitizedConfig);
+    expect(schema?.definitions?.test).toStrictEqual({
+      title: 'Test',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: {
+          type: 'string',
+        },
+        someJsonField: {
+          type: 'object',
+          properties: {
+            someField: {type: 'string'}
+          },
+          required: ['someField'],
+        },
+      },
+      required: ['id'],
+    });
+  });
+
+  it('should build custom dynamic schema for json fields', () => {
+    const config: Config = {
+      collections: [
+        {
+          slug: 'test',
+          fields: [
+            {
+              name: 'someJsonField',
+              type: 'json',
+              jsonSchema: (field, interfaceNameDefinitions) => {
+                interfaceNameDefinitions.set('MyCustomType', {
+                  type: 'object',
+                  properties: {
+                    someField: {type: 'string'},
+                  },
+                  required: ['someField'],
+                })
+
+                return {$ref: '#/definitions/MyCustomType'};
+              },
+            },
+          ],
+          timestamps: false,
+        },
+      ],
+    };
+
+    const sanitizedConfig = sanitizeConfig(config);
+    const schema = configToJSONSchema(sanitizedConfig);
+    expect(schema?.definitions?.test).toStrictEqual({
+      title: 'Test',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: {
+          type: 'string',
+        },
+        someJsonField: {$ref: '#/definitions/MyCustomType'},
+      },
+      required: ['id'],
+    });
+    expect(schema?.definitions?.MyCustomType).toStrictEqual({
+      type: 'object',
+      properties: {
+        someField: {type: 'string'},
+      },
+      required: ['someField'],
+    });
+  });
+});

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -104,16 +104,23 @@ function fieldsToJSONSchema(
           }
 
           case 'json': {
-            // https://www.rfc-editor.org/rfc/rfc7159#section-3
-            fieldSchema = {
-              oneOf: [
-                { type: 'object' },
-                { type: 'array' },
-                { type: 'string' },
-                { type: 'number' },
-                { type: 'boolean' },
-                { type: 'null' },
-              ],
+            // Allow to define a custom schema for json structures
+            if (field.jsonSchema) {
+              fieldSchema = typeof field.jsonSchema === 'function'
+                ? field.jsonSchema(field, interfaceNameDefinitions)
+                : field.jsonSchema;
+            } else {
+              // https://www.rfc-editor.org/rfc/rfc7159#section-3
+              fieldSchema = {
+                oneOf: [
+                  { type: 'object' },
+                  { type: 'array' },
+                  { type: 'string' },
+                  { type: 'number' },
+                  { type: 'boolean' },
+                  { type: 'null' },
+                ],
+              };
             }
             break
           }


### PR DESCRIPTION
## Description

When users add custom Fields, the field type `json` will most likely fit their needs. Unfortunately a user cannot define a structure for this type, yet.

This feature proposal allows users to optionally define a JSON-Schema for this field type. As far as I can see, it should produce types for the TypeScript generation as well.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
