### PR TITLE
fix: 2.0 hotkey's pressed keys are not unset when window is not focused 

### DIFF
--- a/packages/payload/src/admin/hooks/useHotkey.tsx
+++ b/packages/payload/src/admin/hooks/useHotkey.tsx
@@ -95,7 +95,7 @@ const useHotkey = (
       // Check for Mac and iPad
       const hasCmd = window.navigator.userAgent.includes('Mac OS X')
       const pressedWithoutModifier = [...pressedKeys.keys()].filter(
-        (key) => !['meta', 'ctrl', 'alt', 'shift'].includes(key),
+        (key) => !['alt', 'ctrl', 'meta', 'shift'].includes(key),
       )
 
       // Check whether arrays contain the same values (regardless of number of occurrences)

--- a/packages/payload/src/admin/hooks/useHotkey.tsx
+++ b/packages/payload/src/admin/hooks/useHotkey.tsx
@@ -4,6 +4,9 @@ import { useCallback, useEffect } from 'react'
 
 import { setsAreEqual } from '../utilities/setsAreEqual'
 
+// Required to be outside of hook, else debounce would be necessary
+// and then one could not prevent the default behaviour.
+
 // It maps the pressed keys with the time they were pressed, in order to implement a maximum time
 // for the user to press the next key in the sequence
 

--- a/packages/payload/src/admin/hooks/useHotkey.tsx
+++ b/packages/payload/src/admin/hooks/useHotkey.tsx
@@ -4,9 +4,13 @@ import { useCallback, useEffect } from 'react'
 
 import { setsAreEqual } from '../utilities/setsAreEqual'
 
-// Required to be outside of hook, else debounce would be necessary
-// and then one could not prevent the default behaviour.
-const pressedKeys = new Set<string>([])
+// It maps the pressed keys with the time they were pressed, in order to implement a maximum time
+// for the user to press the next key in the sequence
+
+// This is necessary to prevent a bug where the keyup event, which unsets the key as pressed
+// is not fired when the window is not focused.
+// When the user then comes back to the window, the key is still registered as pressed, even though it's not.
+const pressedKeys = new Map<string, number>([])
 
 const map = {
   altleft: 'alt',
@@ -34,10 +38,12 @@ const pushToKeys = (code: string) => {
   // There is a weird bug with macos that if the keys are not cleared they remain in the
   // pressed keys set.
   if (key === 'meta') {
-    pressedKeys.forEach((pressedKey) => pressedKey !== 'meta' && pressedKeys.delete(pressedKey))
+    pressedKeys.forEach(
+      (time, pressedKey) => pressedKey !== 'meta' && pressedKeys.delete(pressedKey),
+    )
   }
 
-  pressedKeys.add(key)
+  pressedKeys.set(key, Date.now())
 }
 
 const removeFromKeys = (code: string) => {
@@ -76,12 +82,20 @@ const useHotkey = (
         // Autofill events, or other synthetic events, can be ignored
         return
       }
+
+      // Filter out pressed keys which have been pressed > 3 seconds ago
+      pressedKeys.forEach((time, key) => {
+        if (Date.now() - time > 3000) {
+          pressedKeys.delete(key)
+        }
+      })
+
       if (e.code) pushToKeys(e.code)
 
       // Check for Mac and iPad
       const hasCmd = window.navigator.userAgent.includes('Mac OS X')
-      const pressedWithoutModifier = [...pressedKeys].filter(
-        (key) => !['alt', 'ctrl', 'meta', 'shift'].includes(key),
+      const pressedWithoutModifier = [...pressedKeys.keys()].filter(
+        (key) => !['meta', 'ctrl', 'alt', 'shift'].includes(key),
       )
 
       // Check whether arrays contain the same values (regardless of number of occurrences)


### PR DESCRIPTION
## Description

See https://github.com/payloadcms/payload/pull/3400

- [ ] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
