### PR TITLE
fix: Autosave shows 'last saved' in minutes only

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -317,7 +317,7 @@
     "currentDocumentStatus": "Current {{docStatus}} document",
     "draft": "Draft",
     "draftSavedSuccessfully": "Draft saved successfully.",
-    "lastSavedAgo": "Last saved {{distance, relativetime(minutes)}}",
+    "lastSavedAgo": "Last saved {{distance}} ago",
     "noFurtherVersionsFound": "No further versions found",
     "noRowsFound": "No {{label}} found",
     "preview": "Preview",


### PR DESCRIPTION
## Description

See #3314 

Note: "lastSavedAgo" should be updated for each translation to read as the English version to include the 'ago' in 'Last saved {distance} ago' It appears to work without but I am unsure of the translations.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
