### PR TITLE
chore(templates/website): adds seeded users to readme

### DIFF
--- a/templates/website/README.md
+++ b/templates/website/README.md
@@ -227,9 +227,15 @@ That's it! The Docker instance will help you get up and running quickly while al
 
 To seed the database with a few pages, posts, and projects you can run `yarn seed`. This template also comes with a `GET /api/seed` endpoint you can use to seed the database from the admin panel.
 
-On boot, a seed script is included to create 2 users:
-1. email `demo-author@payloadcms.com`, password `password`, the role `admin`.
-2. email `demo-user@payloadcms.com`, password `password`, the role `user`
+The seed script will also create two users for demonstration purposes only:
+1. Demo Author
+    - Email: `demo-author@payloadcms.com`
+    - Password: `password`
+    - Role: `admin`
+2. Demo User
+    - Email: `demo-user@payloadcms.com`
+    - Password: `password`
+    - Role: `user`
 
 > NOTICE: seeding the database is destructive because it drops your current database to populate a fresh one from the seed template. Only run this command if you are starting a new project or can afford to lose your current data.
 

--- a/templates/website/README.md
+++ b/templates/website/README.md
@@ -227,6 +227,10 @@ That's it! The Docker instance will help you get up and running quickly while al
 
 To seed the database with a few pages, posts, and projects you can run `yarn seed`. This template also comes with a `GET /api/seed` endpoint you can use to seed the database from the admin panel.
 
+On boot, a seed script is included to create 2 users:
+1. email `demo-author@payloadcms.com`, password `password`, the role `admin`.
+2. email `demo-user@payloadcms.com`, password `password`, the role `user`
+
 > NOTICE: seeding the database is destructive because it drops your current database to populate a fresh one from the seed template. Only run this command if you are starting a new project or can afford to lose your current data.
 
 ## Production


### PR DESCRIPTION
### Update website template README.md with appropriate Seed Accounts and Matching Passwords 

## Description
All other references to seed accounts and passwords were in the Auth example: 

[Auth Example](https://github.com/payloadcms/payload/edit/master/examples/auth/payload/README.md
)

However, the valid username and password is slightly different for the template website page. This information would be very helpful in the README of each template installation as I could not find this info easily within the Payload Docs.

Additional note: the e-commerce site seed data may need to be updated as well.

- [ X ] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ X ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist: N / A

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
