### PR TITLE
fix: ensures valid value is always passed to value prop, e.g. reset t…

### DIFF
--- a/src/admin/components/views/Version/Compare/index.tsx
+++ b/src/admin/components/views/Version/Compare/index.tsx
@@ -108,6 +108,7 @@ const CompareVersion: React.FC<Props> = (props) => {
       </div>
       {!errorLoading && (
         <ReactSelect
+          isClearable={false}
           isSearchable={false}
           placeholder={t('selectVersionToCompare')}
           onChange={onChange}

--- a/src/admin/components/views/Version/Version.tsx
+++ b/src/admin/components/views/Version/Version.tsx
@@ -201,7 +201,7 @@ const VersionView: React.FC<Props> = ({ collection, global }) => {
               baseURL={compareBaseURL}
               parentID={parentID}
               value={compareValue}
-              onChange={(selectedOption) => setCompareValue(selectedOption || mostRecentVersionOption)}
+              onChange={setCompareValue}
             />
             {localization && (
               <SelectLocales

--- a/src/admin/components/views/Version/Version.tsx
+++ b/src/admin/components/views/Version/Version.tsx
@@ -201,7 +201,7 @@ const VersionView: React.FC<Props> = ({ collection, global }) => {
               baseURL={compareBaseURL}
               parentID={parentID}
               value={compareValue}
-              onChange={setCompareValue}
+              onChange={(selectedOption) => setCompareValue(selectedOption || mostRecentVersionOption)}
             />
             {localization && (
               <SelectLocales


### PR DESCRIPTION
…o default value

## Description

Handles null case of compare version select by reseting to the default value.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
