### PR TITLE
fix: doc title not rendering in breadcrumbs

### DIFF
--- a/packages/payload/src/admin/components/views/collections/Edit/SetStepNav.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/SetStepNav.tsx
@@ -29,9 +29,6 @@ export const SetStepNav: React.FC<
   let isEditing = false
   let id: string | undefined
 
-  // This only applies to collections
-  const title = useTitle(collection)
-
   if ('collection' in props) {
     const {
       id: idFromProps,
@@ -51,6 +48,9 @@ export const SetStepNav: React.FC<
     global = globalFromProps
     slug = globalFromProps?.slug
   }
+
+  // This only applies to collections
+  const title = useTitle(collection)
 
   const { setStepNav } = useStepNav()
 


### PR DESCRIPTION
## Description

Fixes the issue where useAsTitle was not generating the document title correctly and breadcrumbs displayed [untitled] instead.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
