### PR TITLE
chore: cleans up custom collection and global view routing

### DIFF
--- a/packages/payload/src/collections/config/schema.ts
+++ b/packages/payload/src/collections/config/schema.ts
@@ -38,14 +38,13 @@ const collectionSchema = joi.object().keys({
         Edit: joi.alternatives().try(
           componentSchema,
           joi.object({
+            API: joi.alternatives().try(componentSchema, customViewSchema),
             Default: joi.alternatives().try(componentSchema, customViewSchema),
+            LivePreview: joi.alternatives().try(componentSchema, customViewSchema),
+            Version: joi.alternatives().try(componentSchema, customViewSchema),
             Versions: joi.alternatives().try(componentSchema, customViewSchema),
-            // Version
-            // Preview
             // Relationships
             // References
-            // API
-            // :path
           }),
         ),
         List: componentSchema,

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -213,6 +213,7 @@ export type CollectionAdminOptions = {
       Edit?:
         | {
             [key: string]: EditView
+            API?: EditView
             /**
              * Replace or modify individual nested routes, or add new ones:
              * + `Default` - `/admin/collections/:collection/:id`
@@ -225,13 +226,12 @@ export type CollectionAdminOptions = {
              * + `:path` - `/admin/collections/:collection/:id/:path`
              */
             Default?: EditView
+            LivePreview?: EditView
+            Version?: EditView
             Versions?: EditView
             // TODO: uncomment these as they are built
-            // API?: EditView
-            // LivePreview?: EditView
             // References?: EditView
             // Relationships?: EditView
-            // Version: EditView
           }
         | EditViewComponent
       List?: React.ComponentType<ListProps>

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -249,7 +249,11 @@ export type EditViewConfig = {
   path: string
 }
 
-export type EditViewComponent = React.ComponentType<CollectionEditViewProps | GlobalEditViewProps>
+export type EditViewComponent = React.ComponentType<{
+  collection?: SanitizedCollectionConfig
+  global?: SanitizedGlobalConfig
+  user: User | null | undefined
+}>
 
 export type EditView = EditViewComponent | EditViewConfig
 

--- a/packages/payload/src/globals/config/schema.ts
+++ b/packages/payload/src/globals/config/schema.ts
@@ -27,14 +27,13 @@ const globalSchema = joi
           Edit: joi.alternatives().try(
             componentSchema,
             joi.object({
+              API: joi.alternatives().try(componentSchema, customViewSchema),
               Default: joi.alternatives().try(componentSchema, customViewSchema),
+              Preview: joi.alternatives().try(componentSchema, customViewSchema),
+              Version: joi.alternatives().try(componentSchema, customViewSchema),
               Versions: joi.alternatives().try(componentSchema, customViewSchema),
-              // Version
-              // Preview
               // Relationships
               // References
-              // API
-              // :path
             }),
           ),
         }),

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -80,6 +80,7 @@ export type GlobalAdminOptions = {
       Edit?:
         | {
             [name: string]: EditView
+            API?: EditView
             /**
              * Replace or modify individual nested routes, or add new ones:
              * + `Default` - `/admin/globals/:slug`
@@ -92,13 +93,12 @@ export type GlobalAdminOptions = {
              * + `:path` - `/admin/globals/:id/:path`
              */
             Default?: EditView
+            LivePreview?: EditView
+            Version?: EditView
             Versions?: EditView
             // TODO: uncomment these as they are built
-            // API?: EditView
-            // LivePreview?: EditView
             // References?: EditView
             // Relationships?: EditView
-            // Version?: EditView
           }
         | EditViewComponent
     }


### PR DESCRIPTION
Cleans up custom collection and global view routing by properly typing the `collectionCustomRoutes` and `globalCustomRoutes` functions and `EditViewComponent` type, and returning proper values.