### PR TITLE
chore: statically renders live preview toolbar

### DIFF
--- a/packages/payload/src/admin/components/views/LivePreview/Device/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Device/index.tsx
@@ -23,7 +23,7 @@ export const DeviceContainer: React.FC<{
       const scaledWidth = size.width / zoom
       const difference = scaledWidth - size.width
       x = `${difference / 2}px`
-      margin = 'auto'
+      margin = '0 auto'
     }
   }
 

--- a/packages/payload/src/admin/components/views/LivePreview/DeviceContainer/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/DeviceContainer/index.tsx
@@ -25,7 +25,7 @@ export const DeviceContainer: React.FC<{
       const scaledWidth = size.width / zoom
       const difference = scaledWidth - size.width
       x = `${difference / 2}px`
-      margin = 'auto'
+      margin = '0 auto'
     }
   }
 

--- a/packages/payload/src/admin/components/views/LivePreview/Preview/index.scss
+++ b/packages/payload/src/admin/components/views/LivePreview/Preview/index.scss
@@ -9,17 +9,29 @@
   height: calc(100vh - var(--doc-controls-height));
   overflow: hidden;
 
-  &--has-breakpoint {
-    padding: var(--base);
+  &__wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: flex-start;
+  }
 
+  &__main {
+    flex-grow: 1;
+    height: 100%;
+    width: 100%;
+  }
+
+  &--has-breakpoint {
     .live-preview-iframe {
       border: 1px solid var(--theme-elevation-100);
     }
-  }
 
-  &__wrapper {
-    height: 100%;
-    width: 100%;
+    .live-preview-window {
+      &__main {
+        padding: var(--base);
+      }
+    }
   }
 
   @include mid-break {

--- a/packages/payload/src/admin/components/views/LivePreview/Preview/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Preview/index.tsx
@@ -13,7 +13,6 @@ import { useLivePreviewContext } from '../Context/context'
 import { DeviceContainer } from '../Device'
 import { IFrame } from '../IFrame'
 import { LivePreviewToolbar } from '../Toolbar'
-import { ToolbarArea } from '../ToolbarArea'
 import './index.scss'
 
 const baseClass = 'live-preview-window'
@@ -100,14 +99,14 @@ const Preview: React.FC<
           .filter(Boolean)
           .join(' ')}
       >
-        <ToolbarArea>
-          <div className={`${baseClass}__wrapper`}>
+        <div className={`${baseClass}__wrapper`}>
+          <LivePreviewToolbar {...props} iframeRef={iframeRef} url={url} />
+          <div className={`${baseClass}__main`}>
             <DeviceContainer>
               <IFrame ref={iframeRef} setIframeHasLoaded={setIframeHasLoaded} url={url} />
             </DeviceContainer>
           </div>
-          <LivePreviewToolbar {...props} iframeRef={iframeRef} url={url} />
-        </ToolbarArea>
+        </div>
       </div>
     )
   }

--- a/packages/payload/src/admin/components/views/LivePreview/Toolbar/Controls/index.scss
+++ b/packages/payload/src/admin/components/views/LivePreview/Toolbar/Controls/index.scss
@@ -1,0 +1,54 @@
+@import '../../../../../scss/styles.scss';
+
+.live-preview-toolbar-controls {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--base) / 3);
+
+  &__breakpoint {
+    border: none;
+    background: transparent;
+    height: var(--base);
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  &__device-size {
+    display: flex;
+    align-items: center;
+  }
+
+  &__size {
+    width: 50px;
+    height: var(--base);
+    display: flex;
+    align-items: center;
+    border: 1px solid var(--theme-elevation-200);
+    background: var(--theme-elevation-100);
+    border-radius: 2px;
+    font-size: small;
+  }
+
+  &__zoom {
+    width: 55px;
+    border: none;
+    background: transparent;
+    height: var(--base);
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  &__external {
+    flex-shrink: 0;
+    display: flex;
+    width: var(--base);
+    height: var(--base);
+    align-items: center;
+    justify-content: center;
+    padding: 6px 0;
+  }
+}

--- a/packages/payload/src/admin/components/views/LivePreview/Toolbar/Controls/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Toolbar/Controls/index.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+import type { LivePreviewToolbarProps } from '..'
+
+import { X } from '../../../..'
+import { ExternalLinkIcon } from '../../../../graphics/ExternalLink'
+import { useLivePreviewContext } from '../../Context/context'
+import { PreviewFrameSizeInput } from '../SizeInput'
+import './index.scss'
+
+const baseClass = 'live-preview-toolbar-controls'
+
+export const ToolbarControls: React.FC<LivePreviewToolbarProps> = (props) => {
+  const { breakpoint, breakpoints, setBreakpoint, setZoom, zoom } = useLivePreviewContext()
+
+  const {
+    popupState: { openPopupWindow },
+    url,
+  } = props
+
+  return (
+    <div className={baseClass}>
+      {breakpoints?.length > 0 && (
+        <select
+          className={`${baseClass}__breakpoint`}
+          onChange={(e) => setBreakpoint(e.target.value)}
+          value={breakpoint}
+        >
+          {breakpoints.map((bp) => (
+            <option key={bp.name} value={bp.name}>
+              {bp.label}
+            </option>
+          ))}
+          {breakpoint === 'custom' && (
+            // Dynamically add this option so that it only appears when the width and height inputs are explicitly changed
+            // TODO: Translate this string
+            <option value="custom">Custom</option>
+          )}
+        </select>
+      )}
+      <div className={`${baseClass}__device-size`}>
+        <PreviewFrameSizeInput axis="x" />
+        <span className={`${baseClass}__size-divider`}>
+          <X />
+        </span>
+        <PreviewFrameSizeInput axis="y" />
+      </div>
+      <select
+        className={`${baseClass}__zoom`}
+        onChange={(e) => setZoom(Number(e.target.value) / 100)}
+        value={zoom * 100}
+      >
+        <option value={50}>50%</option>
+        <option value={75}>75%</option>
+        <option value={100}>100%</option>
+        <option value={125}>125%</option>
+        <option value={150}>150%</option>
+        <option value={200}>200%</option>
+      </select>
+      <a className={`${baseClass}__external`} href={url} onClick={openPopupWindow} type="button">
+        <ExternalLinkIcon />
+      </a>
+    </div>
+  )
+}

--- a/packages/payload/src/admin/components/views/LivePreview/Toolbar/index.scss
+++ b/packages/payload/src/admin/components/views/LivePreview/Toolbar/index.scss
@@ -3,13 +3,26 @@
 .live-preview-toolbar {
   display: flex;
   background-color: var(--theme-bg);
-  border: 1px solid var(--theme-elevation-200);
-  border-radius: 1px;
   color: var(--theme-text);
-  position: absolute;
-  top: 0;
-  left: 0;
-  margin: 0;
+  height: calc(var(--base) * 1.75);
+  align-items: center;
+  flex-shrink: 0;
+
+  &--static {
+    position: relative;
+    width: 100%;
+    justify-content: center;
+    border-bottom: 1px solid var(--theme-elevation-100);
+  }
+
+  &--draggable {
+    @include shadow-lg;
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin: 0;
+    border-radius: 4px;
+  }
 
   &__drag-handle {
     background: transparent;
@@ -24,59 +37,5 @@
     &:active {
       cursor: grabbing;
     }
-  }
-
-  &__controls {
-    padding: 6px 6px 6px 0;
-    display: flex;
-    align-items: center;
-    gap: calc(var(--base) / 3);
-  }
-
-  &__breakpoint {
-    border: none;
-    background: transparent;
-    height: var(--base);
-
-    &:focus {
-      outline: none;
-    }
-  }
-
-  &__device-size {
-    display: flex;
-    align-items: center;
-  }
-
-  &__size {
-    width: 50px;
-    height: var(--base);
-    display: flex;
-    align-items: center;
-    border: 1px solid var(--theme-elevation-200);
-    background: var(--theme-elevation-100);
-    border-radius: 2px;
-    font-size: small;
-  }
-
-  &__zoom {
-    width: 55px;
-    border: none;
-    background: transparent;
-    height: var(--base);
-
-    &:focus {
-      outline: none;
-    }
-  }
-
-  &__external {
-    flex-shrink: 0;
-    display: flex;
-    width: var(--base);
-    height: var(--base);
-    align-items: center;
-    justify-content: center;
-    padding: 6px 0;
   }
 }

--- a/packages/payload/src/admin/components/views/LivePreview/Toolbar/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Toolbar/index.tsx
@@ -3,27 +3,19 @@ import React from 'react'
 
 import type { ToolbarProviderProps } from '../Context'
 
-import { X } from '../../..'
-import { ExternalLinkIcon } from '../../../graphics/ExternalLink'
 import DragHandle from '../../../icons/Drag'
 import { useLivePreviewContext } from '../Context/context'
-import { PreviewFrameSizeInput } from './SizeInput'
+import { ToolbarControls } from './Controls'
 import './index.scss'
 
 const baseClass = 'live-preview-toolbar'
 
-export const LivePreviewToolbar: React.FC<
-  Omit<ToolbarProviderProps, 'children'> & {
-    iframeRef: React.RefObject<HTMLIFrameElement>
-  }
-> = (props) => {
-  const {
-    popupState: { openPopupWindow },
-    url,
-  } = props
+export type LivePreviewToolbarProps = Omit<ToolbarProviderProps, 'children'> & {
+  iframeRef: React.RefObject<HTMLIFrameElement>
+}
 
-  const { breakpoint, breakpoints, setBreakpoint, setZoom, toolbarPosition, zoom } =
-    useLivePreviewContext()
+const DraggableToolbar: React.FC<LivePreviewToolbarProps> = (props) => {
+  const { toolbarPosition } = useLivePreviewContext()
 
   const { attributes, listeners, setNodeRef, transform } = useDraggable({
     id: 'live-preview-toolbar',
@@ -31,7 +23,7 @@ export const LivePreviewToolbar: React.FC<
 
   return (
     <div
-      className={baseClass}
+      className={[baseClass, `${baseClass}--draggable`].join(' ')}
       style={{
         left: `${toolbarPosition.x}px`,
         top: `${toolbarPosition.y}px`,
@@ -53,48 +45,29 @@ export const LivePreviewToolbar: React.FC<
       >
         <DragHandle />
       </button>
-      <div className={`${baseClass}__controls`}>
-        {breakpoints?.length > 0 && (
-          <select
-            className={`${baseClass}__breakpoint`}
-            onChange={(e) => setBreakpoint(e.target.value)}
-            value={breakpoint}
-          >
-            {breakpoints.map((bp) => (
-              <option key={bp.name} value={bp.name}>
-                {bp.label}
-              </option>
-            ))}
-            {breakpoint === 'custom' && (
-              // Dynamically add this option so that it only appears when the width and height inputs are explicitly changed
-              // TODO: Translate this string
-              <option value="custom">Custom</option>
-            )}
-          </select>
-        )}
-        <div className={`${baseClass}__device-size`}>
-          <PreviewFrameSizeInput axis="x" />
-          <span className={`${baseClass}__size-divider`}>
-            <X />
-          </span>
-          <PreviewFrameSizeInput axis="y" />
-        </div>
-        <select
-          className={`${baseClass}__zoom`}
-          onChange={(e) => setZoom(Number(e.target.value) / 100)}
-          value={zoom * 100}
-        >
-          <option value={50}>50%</option>
-          <option value={75}>75%</option>
-          <option value={100}>100%</option>
-          <option value={125}>125%</option>
-          <option value={150}>150%</option>
-          <option value={200}>200%</option>
-        </select>
-        <a className={`${baseClass}__external`} href={url} onClick={openPopupWindow} type="button">
-          <ExternalLinkIcon />
-        </a>
-      </div>
+      <ToolbarControls {...props} />
     </div>
   )
+}
+
+const StaticToolbar: React.FC<LivePreviewToolbarProps> = (props) => {
+  return (
+    <div className={[baseClass, `${baseClass}--static`].join(' ')}>
+      <ToolbarControls {...props} />
+    </div>
+  )
+}
+
+export const LivePreviewToolbar: React.FC<
+  LivePreviewToolbarProps & {
+    draggable?: boolean
+  }
+> = (props) => {
+  const { draggable } = props
+
+  if (draggable) {
+    return <DraggableToolbar {...props} />
+  }
+
+  return <StaticToolbar {...props} />
 }


### PR DESCRIPTION
Removes the ability to freely drag the live preview toolbar around the window. This is because regardless of where it is placed, overlapping the site _anywhere_ doesn't provide the best UX.