### PR TITLE
fix: default rateLimit window changed from 1.5 to 15 minutes

### DIFF
--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -43,7 +43,7 @@ export const defaults: Omit<Config, 'db' | 'editor'> = {
   maxDepth: 10,
   rateLimit: {
     max: 500,
-    window: 15 * 60 * 100, // 15min default,
+    window: 15 * 60 * 1000, // 15min default,
   },
   routes: {
     admin: '/admin',

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -14,7 +14,6 @@ import type { Configuration } from 'webpack'
 import type { DocumentTab } from '../admin/components/elements/DocumentHeader/Tabs/types'
 import type { RichTextAdapter } from '../admin/components/forms/field-types/RichText/types'
 import type { ContextType } from '../admin/components/utilities/DocumentInfo/types'
-import type { CollectionEditViewProps, GlobalEditViewProps } from '../admin/components/views/types'
 import type { User } from '../auth/types'
 import type { PayloadBundler } from '../bundlers/types'
 import type {
@@ -43,10 +42,10 @@ export type Plugin = (config: Config) => Config | Promise<Config>
 
 export type LivePreviewConfig = {
   /**
-    Device breakpoints to use for the `iframe` of the Live Preview window.
-    Options are displayed in the Live Preview toolbar.
-    The `responsive` breakpoint is included by default.
-  */
+   Device breakpoints to use for the `iframe` of the Live Preview window.
+   Options are displayed in the Live Preview toolbar.
+   The `responsive` breakpoint is included by default.
+   */
   breakpoints?: {
     height: number | string
     label: string
@@ -54,11 +53,11 @@ export type LivePreviewConfig = {
     width: number | string
   }[]
   /**
-    The URL of the frontend application. This will be rendered within an `iframe` as its `src`.
-    Payload will send a `window.postMessage()` to this URL with the document data in real-time.
-    The frontend application is responsible for receiving the message and updating the UI accordingly.
-    Use the `useLivePreview` hook to get started in React applications.
-  */
+   The URL of the frontend application. This will be rendered within an `iframe` as its `src`.
+   Payload will send a `window.postMessage()` to this URL with the document data in real-time.
+   The frontend application is responsible for receiving the message and updating the UI accordingly.
+   Use the `useLivePreview` hook to get started in React applications.
+   */
   url?:
     | ((args: { data: Record<string, any>; documentInfo: ContextType; locale: Locale }) => string)
     | string
@@ -637,7 +636,7 @@ export type Config = {
    *
    * @default
    * {
-   *   window: 15 * 60 * 100, // 1.5 minutes,
+   *   window: 15 * 60 * 1000, // 15 minutes,
    *   max: 500,
    * }
    */

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -36,7 +36,7 @@ export function buildConfigWithDefaults(testConfig?: Partial<Config>): Promise<S
     editor: slateEditor({}),
     rateLimit: {
       max: 9999999999,
-      window: 15 * 60 * 100, // 15min default,
+      window: 15 * 60 * 1000, // 15min default,
     },
     telemetry: false,
     ...testConfig,


### PR DESCRIPTION
## Description

Fixes the default rate limit window to be 15 minutes instead of 1.5 minutes.

BREAKING CHANGES: the default rate limit window was improperly set to 1.5 minutes instead of 15 minutes. This is now changed to match the docs.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Existing test suite passes locally with my changes

