### PR TITLE
docs(bundlers): Fixed wrong packages names for payload bundlers

### DIFF
--- a/docs/admin/bundlers.mdx
+++ b/docs/admin/bundlers.mdx
@@ -12,13 +12,13 @@ Payload has two official bundlers, the [Webpack Bundler](/docs/admin/webpack) an
 Webpack (recommended):
 
 ```text
-yarn add @payloadcms/webpack-bundler
+yarn add @payloadcms/bundler-webpack
 ```
 
 Vite (beta):
 
 ```text
-yarn add @payloadcms/vite-bundler
+yarn add @payloadcms/bundler-vite
 ```
 
 ##### Configure the bundler


### PR DESCRIPTION
## Description
The name of the packages describing the bundlers were erroneous : 

- "webpack-bundler" instead of "bundler-webpack"
- "vite-bundler" instead of "bundler-vite"

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
