### PR TITLE
fix: renders global label as page title

### DIFF
--- a/packages/payload/src/admin/components/elements/DeleteDocument/index.tsx
+++ b/packages/payload/src/admin/components/elements/DeleteDocument/index.tsx
@@ -35,7 +35,7 @@ const DeleteDocument: React.FC<Props> = (props) => {
   const { toggleModal } = useModal()
   const history = useHistory()
   const { i18n, t } = useTranslation('general')
-  const title = useTitle(collection)
+  const title = useTitle({ collection })
   const titleToRender = titleFromProps || title
 
   const modalSlug = `delete-${id}`

--- a/packages/payload/src/admin/components/elements/DocumentHeader/index.tsx
+++ b/packages/payload/src/admin/components/elements/DocumentHeader/index.tsx
@@ -27,16 +27,14 @@ export const DocumentHeader: React.FC<{
       {customHeader && customHeader}
       {!customHeader && (
         <Fragment>
-          {collection && (
-            <RenderTitle
-              className={`${baseClass}__title`}
-              collection={collection}
-              data={data}
-              fallback={`[${t('untitled')}]`}
-              useAsTitle={collection?.admin?.useAsTitle}
-            />
-          )}
-          {global && <h1 className={`${baseClass}__title`}>{global?.slug}</h1>}
+          <RenderTitle
+            className={`${baseClass}__title`}
+            collection={collection}
+            data={data}
+            fallback={`[${t('untitled')}]`}
+            global={global}
+            useAsTitle={collection?.admin?.useAsTitle}
+          />
           <DocumentTabs
             apiURL={apiURL}
             collection={collection}

--- a/packages/payload/src/admin/components/elements/RenderTitle/index.tsx
+++ b/packages/payload/src/admin/components/elements/RenderTitle/index.tsx
@@ -15,10 +15,11 @@ const RenderTitle: React.FC<Props> = (props) => {
     data,
     element = 'h1',
     fallback = '[untitled]',
+    global,
     title: titleFromProps,
   } = props
 
-  const titleFromForm = useTitle(collection)
+  const titleFromForm = useTitle({ collection, global })
 
   let title = titleFromForm
   if (!title) title = data?.id

--- a/packages/payload/src/admin/components/views/collections/Edit/SetStepNav.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/SetStepNav.tsx
@@ -49,8 +49,7 @@ export const SetStepNav: React.FC<
     slug = globalFromProps?.slug
   }
 
-  // This only applies to collections
-  const title = useTitle(collection)
+  const title = useTitle({ collection, global })
 
   const { setStepNav } = useStepNav()
 
@@ -80,7 +79,7 @@ export const SetStepNav: React.FC<
       }
     } else if (global) {
       nav.push({
-        label: getTranslation(global.label, i18n),
+        label: title,
         url: `${admin}/globals/${slug}`,
       })
     }

--- a/packages/payload/src/admin/hooks/useTitle.tsx
+++ b/packages/payload/src/admin/hooks/useTitle.tsx
@@ -4,9 +4,11 @@ import { useTranslation } from 'react-i18next'
 
 import type { SanitizedCollectionConfig } from '../../collections/config/types'
 import type { SanitizedConfig } from '../../config/types'
+import type { SanitizedGlobalConfig } from '../../globals/config/types'
 import type { FormField } from '../components/forms/Form/types'
 
 import { getObjectDotNotation } from '../../utilities/getObjectDotNotation'
+import { getTranslation } from '../../utilities/getTranslation'
 import { useFormFields } from '../components/forms/Form/context'
 import { useConfig } from '../components/utilities/Config'
 import { formatDate } from '../utilities/formatDate'
@@ -54,19 +56,30 @@ export const formatUseAsTitle = (args: {
 
 // Keep `collection` optional so that component do need to worry about conditionally rendering hooks
 // This is so that components which take both `collection` and `global` props can use this hook
-const useTitle = (collection?: SanitizedCollectionConfig): string => {
+const useTitle = (args: {
+  collection?: SanitizedCollectionConfig
+  global?: SanitizedGlobalConfig
+}): string => {
+  const { collection, global } = args
   const { i18n } = useTranslation()
+  const config = useConfig()
+
+  let title: string = ''
 
   const field = useFormFields(([formFields]) => {
     if (!collection) return
     return formFields[collection?.admin?.useAsTitle]
   })
 
-  const config = useConfig()
+  if (collection) {
+    title = formatUseAsTitle({ collection, config, field, i18n })
+  }
 
-  if (!collection) return ''
+  if (global) {
+    title = getTranslation(global.label, i18n) || global.slug
+  }
 
-  return formatUseAsTitle({ collection, config, field, i18n })
+  return title
 }
 
 export default useTitle

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -281,6 +281,9 @@ export default buildConfigWithDefaults({
     },
     {
       slug: globalSlug,
+      label: {
+        en: 'My Global Label',
+      },
       admin: {
         group: 'Group',
       },
@@ -301,7 +304,6 @@ export default buildConfigWithDefaults({
         },
       ],
     },
-
     {
       slug: 'custom-global-views-one',
       versions: true,
@@ -354,6 +356,7 @@ export default buildConfigWithDefaults({
     },
     {
       slug: 'group-globals-one',
+      label: 'Group Globals 1',
       admin: {
         group: 'Group',
       },

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -173,6 +173,7 @@ describe('admin', () => {
       await expect(page.locator('.step-nav.app-header__step-nav')).toContainText(title)
       await page.locator('#field-title').fill('')
       await expect(page.locator('.doc-header__title.render-title')).toContainText('ID: ')
+      await expect(page.locator('.step-nav.app-header__step-nav')).toContainText('[Untitled]')
     })
 
     test('global - should render custom, localized label', async () => {

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -149,6 +149,27 @@ describe('admin', () => {
     })
   })
 
+  describe('doc titles', () => {
+    beforeAll(async () => {
+      await openNav(page)
+    })
+
+    test('global - should render custom, localized label', async () => {
+      const globalLabel = page.locator(`#nav-global-${globalSlug}`)
+      await expect(globalLabel).toContainText('My Global Label')
+    })
+
+    test('global - should render simple label strings', async () => {
+      const globalLabel = page.locator(`#nav-global-group-globals-one`)
+      await expect(globalLabel).toContainText('Group Globals 1')
+    })
+
+    test('global - should render slug in sentence case as fallback', async () => {
+      const globalLabel = page.locator(`#nav-global-group-globals-two`)
+      await expect(globalLabel).toContainText('Group Globals Two')
+    })
+  })
+
   describe('CRUD', () => {
     test('should create', async () => {
       await page.goto(url.create)

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -154,6 +154,7 @@ describe('admin', () => {
       await page.goto(url.create)
       await expect(page.locator('.doc-header__title.render-title')).toContainText('[Untitled]')
       await expect(page.locator('.step-nav.app-header__step-nav')).toContainText('Create New')
+      await saveDocAndAssert(page)
     })
 
     test('collection - should render `useAsTitle` field', async () => {
@@ -174,17 +175,17 @@ describe('admin', () => {
       await page.locator('#field-title').fill('')
       await expect(page.locator('.doc-header__title.render-title')).toContainText('ID: ')
       await expect(page.locator('.step-nav.app-header__step-nav')).toContainText('[Untitled]')
+      await saveDocAndAssert(page)
     })
 
     test('global - should render custom, localized label', async () => {
       await openNav(page)
       const label = 'My Global Label'
-      const globalLabel = page.locator(`#nav-global-${globalSlug}`)
+      const globalLabel = page.locator(`#nav-global-global`)
       await expect(globalLabel).toContainText(label)
       await globalLabel.click()
       await expect(page.locator('.doc-header__title.render-title')).toContainText(label)
-      const nav = page.locator('.step-nav.app-header__step-nav')
-      await expect(nav).toContainText(label)
+      await expect(page.locator('.step-nav.app-header__step-nav')).toContainText(label)
     })
 
     test('global - should render simple label strings', async () => {
@@ -196,6 +197,7 @@ describe('admin', () => {
       await expect(page.locator('.doc-header__title.render-title')).toContainText(label)
       const nav = page.locator('.step-nav.app-header__step-nav')
       await expect(nav).toContainText(label)
+      await saveDocAndAssert(page)
     })
 
     test('global - should render slug in sentence case as fallback', async () => {
@@ -207,6 +209,7 @@ describe('admin', () => {
       await expect(page.locator('.doc-header__title.render-title')).toContainText(label)
       const nav = page.locator('.step-nav.app-header__step-nav')
       await expect(nav).toContainText(label)
+      await saveDocAndAssert(page)
     })
   })
 

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -150,23 +150,62 @@ describe('admin', () => {
   })
 
   describe('doc titles', () => {
-    beforeAll(async () => {
-      await openNav(page)
+    test('collection - should render fallback titles when creating new', async () => {
+      await page.goto(url.create)
+      await expect(page.locator('.doc-header__title.render-title')).toContainText('[Untitled]')
+      await expect(page.locator('.step-nav.app-header__step-nav')).toContainText('Create New')
+    })
+
+    test('collection - should render `useAsTitle` field', async () => {
+      await page.goto(url.create)
+      const titleField = page.locator('#field-title')
+      await titleField.fill(title)
+      await expect(page.locator('.doc-header__title.render-title')).toContainText(title)
+      await saveDocAndAssert(page)
+      await expect(page.locator('.step-nav.app-header__step-nav')).toContainText(title)
+    })
+
+    test('collection - should render `id` as `useAsTitle` fallback', async () => {
+      await page.goto(url.create)
+      await page.locator('#field-title').fill(title)
+      await expect(page.locator('.doc-header__title.render-title')).toContainText(title)
+      await saveDocAndAssert(page)
+      await expect(page.locator('.step-nav.app-header__step-nav')).toContainText(title)
+      await page.locator('#field-title').fill('')
+      await expect(page.locator('.doc-header__title.render-title')).toContainText('ID: ')
     })
 
     test('global - should render custom, localized label', async () => {
+      await openNav(page)
+      const label = 'My Global Label'
       const globalLabel = page.locator(`#nav-global-${globalSlug}`)
-      await expect(globalLabel).toContainText('My Global Label')
+      await expect(globalLabel).toContainText(label)
+      await globalLabel.click()
+      await expect(page.locator('.doc-header__title.render-title')).toContainText(label)
+      const nav = page.locator('.step-nav.app-header__step-nav')
+      await expect(nav).toContainText(label)
     })
 
     test('global - should render simple label strings', async () => {
+      await openNav(page)
+      const label = 'Group Globals 1'
       const globalLabel = page.locator(`#nav-global-group-globals-one`)
-      await expect(globalLabel).toContainText('Group Globals 1')
+      await expect(globalLabel).toContainText(label)
+      await globalLabel.click()
+      await expect(page.locator('.doc-header__title.render-title')).toContainText(label)
+      const nav = page.locator('.step-nav.app-header__step-nav')
+      await expect(nav).toContainText(label)
     })
 
     test('global - should render slug in sentence case as fallback', async () => {
+      await openNav(page)
+      const label = 'Group Globals Two'
       const globalLabel = page.locator(`#nav-global-group-globals-two`)
-      await expect(globalLabel).toContainText('Group Globals Two')
+      await expect(globalLabel).toContainText(label)
+      await globalLabel.click()
+      await expect(page.locator('.doc-header__title.render-title')).toContainText(label)
+      const nav = page.locator('.step-nav.app-header__step-nav')
+      await expect(nav).toContainText(label)
     })
   })
 


### PR DESCRIPTION
## Description

Fixes #3524 by properly rendering global labels as the page title. Adds e2e tests to prevent regression going forward.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
