### PR TITLE
fix: lexical pass config property instead of payload to the field.val…

### DIFF
--- a/packages/richtext-lexical/src/field/features/Blocks/validate.ts
+++ b/packages/richtext-lexical/src/field/features/Blocks/validate.ts
@@ -41,7 +41,7 @@ export const blockValidationHOC = (
         const fieldValue = 'name' in field ? node.fields.data[field.name] : null
         const validationResult = await field.validate(fieldValue, {
           id: validation.options.id,
-          config: payloadConfig,
+          payload: payloadConfig,
           data: fieldValue,
           operation: validation.options.operation,
           siblingData: validation.options.siblingData,


### PR DESCRIPTION
## Description

Using Payload Richtext Lexical with a Block having a Relationship Field generates the following error:

### Reproduction

https://github.com/GeorgeHulpoi/payload-lexical-issues

1. Create a Toy
2. Create a Page with QuoteBlock in Content and then choose the created Toy.
3. Press Save

### Error
```
[16:07:34] ERROR (payload): TypeError: Cannot read properties of undefined (reading 'collections')
    at filter (C:\payload-test\node_modules\payload\src\fields\validations.ts:377:31)
    at Array.filter (<anonymous>)
    at defaultValidate (C:\payload-test\node_modules\payload\src\fields\validations.ts:357:41)
    at Object.validate (C:\payload-test\node_modules\payload\src\fields\config\sanitize.ts:108:46)
    at validation (C:\payload-test\node_modules\@payloadcms\richtext-lexical\src\field\features\Blocks\validate.ts:42:46)
    at validateNodes (C:\payload-test\node_modules\@payloadcms\richtext-lexical\src\validate\validateNodes.ts:30:40)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Object.richTextValidate [as validate] (C:\payload-test\node_modules\@payloadcms\richtext-lexical\src\validate\index.ts:35:14)
    at richText (C:\payload-test\node_modules\payload\src\fields\validations.ts:223:10)
    at promise (C:\payload-test\node_modules\payload\src\fields\hooks\beforeChange\promise.ts:106:32)
```

### Debuging

After I followed the stack error, it seemed like the lexical was trying to validate the field with the wrong properties (https://github.com/payloadcms/payload/blob/890af8be053847640c6e0c19e7b2ee326df894da/packages/richtext-lexical/src/field/features/Blocks/validate.ts#L44C1-L44C33). 

```ts
        const validationResult = await field.validate(fieldValue, {
          id: validation.options.id,
          config: payloadConfig,
          data: fieldValue,
          operation: validation.options.operation,
          siblingData: validation.options.siblingData,
          t: validation.options.t,
          user: validation.options.user,
        })
```

But the validation function expects `payload` instead of `config` (https://github.com/payloadcms/payload/blob/890af8be053847640c6e0c19e7b2ee326df894da/packages/payload/src/fields/validations.ts#L377):

```ts
      const idField = payload.collections[collection]?.config?.fields?.find(
        (field) => fieldAffectsData(field) && field.name === 'id',
      )
```

The solution is to change `config` to `payload`. After the change, the tests are passing.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
