### PR TITLE
fix(richtext-lexical): blocks: missing properties passed into validation calls

### DIFF
--- a/packages/payload/src/fields/validations.spec.ts
+++ b/packages/payload/src/fields/validations.spec.ts
@@ -193,20 +193,25 @@ describe('Field Validations', () => {
   })
 
   describe('relationship', () => {
+    const relationCollection = {
+      fields: [
+        {
+          name: 'id',
+          type: 'text',
+        },
+      ],
+      slug: 'relation',
+    }
+
     const relationshipOptions = {
       ...options,
+      config: {
+        collections: [relationCollection],
+      },
       payload: {
         collections: {
           relation: {
-            config: {
-              fields: [
-                {
-                  name: 'id',
-                  type: 'text',
-                },
-              ],
-              slug: 'relation',
-            },
+            config: relationCollection,
           },
         },
       },

--- a/packages/richtext-lexical/src/field/features/Blocks/validate.ts
+++ b/packages/richtext-lexical/src/field/features/Blocks/validate.ts
@@ -40,10 +40,12 @@ export const blockValidationHOC = (
       if ('validate' in field && typeof field.validate === 'function' && field.validate) {
         const fieldValue = 'name' in field ? node.fields.data[field.name] : null
         const validationResult = await field.validate(fieldValue, {
+          ...field,
           id: validation.options.id,
           config: payloadConfig,
           data: fieldValue,
           operation: validation.options.operation,
+          payload: validation.options.payload,
           siblingData: validation.options.siblingData,
           t: validation.options.t,
           user: validation.options.user,

--- a/test/fields/collections/RichText/blocks.ts
+++ b/test/fields/collections/RichText/blocks.ts
@@ -30,6 +30,18 @@ export const UploadAndRichTextBlock: Block = {
   slug: 'uploadAndRichText',
 }
 
+export const RelationshipBlock: Block = {
+  fields: [
+    {
+      name: 'rel',
+      type: 'relationship',
+      relationTo: 'uploads',
+      required: true,
+    },
+  ],
+  slug: 'relationshipBlock',
+}
+
 export const SelectFieldBlock: Block = {
   fields: [
     {

--- a/test/fields/collections/RichText/index.ts
+++ b/test/fields/collections/RichText/index.ts
@@ -8,7 +8,7 @@ import {
   lexicalEditor,
 } from '../../../../packages/richtext-lexical/src'
 import { slateEditor } from '../../../../packages/richtext-slate/src'
-import { SelectFieldBlock, TextBlock, UploadAndRichTextBlock } from './blocks'
+import { RelationshipBlock, SelectFieldBlock, TextBlock, UploadAndRichTextBlock } from './blocks'
 import { generateLexicalRichText } from './generateLexicalRichText'
 import { generateSlateRichText } from './generateSlateRichText'
 
@@ -63,7 +63,7 @@ const RichTextFields: CollectionConfig = {
             },
           }),
           BlocksFeature({
-            blocks: [TextBlock, UploadAndRichTextBlock, SelectFieldBlock],
+            blocks: [TextBlock, UploadAndRichTextBlock, SelectFieldBlock, RelationshipBlock],
           }),
         ],
       }),


### PR DESCRIPTION
## Description

Fixes an issue where relationships inside of blocks in the lexical editor will not validate correctly.

This also makes sure to use config.collections over payload.collections for existing validation functions, as config.collections is likely to exist on the admin panel, while the `payload` object might not.

- [ ] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
