### PR TITLE
chore(live-preview): removes react dependencies

### DIFF
--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",
-    "@types/node": "20.5.7",
     "payload": "workspace:*"
   },
   "exports": {

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -16,13 +16,9 @@
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
     "prepublishOnly": "pnpm clean && pnpm build"
   },
-  "dependencies": {
-    "react": "18.2.0"
-  },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",
     "@types/node": "20.5.7",
-    "@types/react": "18.2.15",
     "payload": "workspace:*"
   },
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,10 +429,6 @@ importers:
         version: 1.15.0(eslint@8.48.0)
 
   packages/live-preview:
-    dependencies:
-      react:
-        specifier: 18.2.0
-        version: 18.2.0
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*
@@ -440,9 +436,6 @@ importers:
       '@types/node':
         specifier: 20.5.7
         version: 20.5.7
-      '@types/react':
-        specifier: 18.2.15
-        version: 18.2.15
       payload:
         specifier: workspace:*
         version: link:../payload

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,9 +433,6 @@ importers:
       '@payloadcms/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config-payload
-      '@types/node':
-        specifier: 20.5.7
-        version: 20.5.7
       payload:
         specifier: workspace:*
         version: link:../payload


### PR DESCRIPTION
## Description

Closes #3528 by removing the `react` dependency and the `@types/react` dev dependency from the `@payloadcms/live-preview` package.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
