### PR TITLE
Fix typo on graphql-schema.mdx

### DIFF
--- a/docs/graphql/graphql-schema.mdx
+++ b/docs/graphql/graphql-schema.mdx
@@ -8,7 +8,7 @@ keywords: headless cms, typescript, documentation, Content Management System, cm
 
 When working with GraphQL it is useful to have the schema for development of other projects that need to call on your GraphQL endpoint. In Payload the schema is controlled by your collections and globals and is made available to the developer or third parties, it is not necessary for developers using Payload to write schema types manually.
 
-### Schema generatation script
+### Schema generation script
 
 Run the following command in a Payload project to generate your project's GraphQL schema from Payload:
 


### PR DESCRIPTION
## Description

Fixed misspelling typo of `generatation` to `generation`

- [X] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)

## Checklist:

- [X] I have made corresponding changes to the documentation
