### PR TITLE
fix: row field width

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Row/index.scss
+++ b/packages/payload/src/admin/components/forms/field-types/Row/index.scss
@@ -14,10 +14,17 @@
   }
 
   @include mid-break {
-    flex-direction: column;
+    display: block;
+    margin-left: 0;
+    margin-right: 0;
+    width: 100%;
 
     > * {
+      margin-left: 0;
+      margin-right: 0;
       width: 100% !important;
+      padding-left: 0;
+      padding-right: 0;
     }
   }
 }

--- a/packages/payload/src/admin/components/forms/field-types/Row/index.scss
+++ b/packages/payload/src/admin/components/forms/field-types/Row/index.scss
@@ -3,11 +3,14 @@
 .field-type.row {
   display: flex;
   flex-wrap: wrap;
-  width: 100%;
-  gap: var(--base);
+  width: calc(100% + var(--base));
+  margin-left: calc(var(--base) * -0.5);
+  margin-right: calc(var(--base) * -0.5);
 
   > * {
     flex-grow: 1;
+    padding-left: calc(var(--base) * 0.5);
+    padding-right: calc(var(--base) * 0.5);
   }
 
   @include mid-break {

--- a/test/fields/collections/Row/index.ts
+++ b/test/fields/collections/Row/index.ts
@@ -26,6 +26,27 @@ const RowFields: CollectionConfig = {
         },
       ],
     },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'field_with_width_a',
+          label: 'Field with 50% width',
+          type: 'text',
+          admin: {
+            width: '50%',
+          },
+        },
+        {
+          name: 'field_with_width_b',
+          label: 'Field with 50% width',
+          type: 'text',
+          admin: {
+            width: '50%',
+          },
+        },
+      ],
+    },
   ],
 }
 

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -79,42 +79,43 @@ describe('fields', () => {
       await expect(textCell).toHaveText(String(numberDoc.number))
     })
 
-
     test('should filter Number fields in the collection view - greaterThanOrEqual', async () => {
-      await page.goto(url.list);
+      await page.goto(url.list)
 
       // should have 3 entries
-      await expect(page.locator('table >> tbody >> tr')).toHaveCount(3);
+      await expect(page.locator('table >> tbody >> tr')).toHaveCount(3)
 
       // open the filter options
-      await page.locator('.list-controls__toggle-where').click();
-      await expect(page.locator('.list-controls__where.rah-static--height-auto')).toBeVisible();
-      await page.locator('.where-builder__add-first-filter').click();
+      await page.locator('.list-controls__toggle-where').click()
+      await expect(page.locator('.list-controls__where.rah-static--height-auto')).toBeVisible()
+      await page.locator('.where-builder__add-first-filter').click()
 
-      const initialField = page.locator('.condition__field');
-      const operatorField = page.locator('.condition__operator');
-      const valueField = page.locator('.condition__value >> input');
+      const initialField = page.locator('.condition__field')
+      const operatorField = page.locator('.condition__operator')
+      const valueField = page.locator('.condition__value >> input')
 
       // select Number field to filter on
-      await initialField.click();
-      const initialFieldOptions = initialField.locator('.rs__option');
-      await initialFieldOptions.locator('text=number').first().click();
-      expect(initialField.locator('.rs__single-value')).toContainText('Number');
+      await initialField.click()
+      const initialFieldOptions = initialField.locator('.rs__option')
+      await initialFieldOptions.locator('text=number').first().click()
+      await expect(initialField.locator('.rs__single-value')).toContainText('Number')
 
       // select >= operator
-      await operatorField.click();
-      const operatorOptions = operatorField.locator('.rs__option');
-      await operatorOptions.last().click();
-      expect(operatorField.locator('.rs__single-value')).toContainText('is greater than or equal to');
+      await operatorField.click()
+      const operatorOptions = operatorField.locator('.rs__option')
+      await operatorOptions.last().click()
+      await expect(operatorField.locator('.rs__single-value')).toContainText(
+        'is greater than or equal to',
+      )
 
       // enter value of 3
-      await valueField.fill('3');
-      await expect(valueField).toHaveValue('3');
-      await wait(300);
+      await valueField.fill('3')
+      await expect(valueField).toHaveValue('3')
+      await wait(300)
 
       // should have 2 entries after filtering
-      await expect(page.locator('table >> tbody >> tr')).toHaveCount(2);
-    });
+      await expect(page.locator('table >> tbody >> tr')).toHaveCount(2)
+    })
 
     test('should create', async () => {
       const input = 5
@@ -1429,6 +1430,19 @@ describe('fields', () => {
       const idHeadings = page.locator('th#heading-id')
       await expect(idHeadings).toBeVisible()
       await expect(idHeadings).toHaveCount(1)
+    })
+
+    test('should render row fields inline', async () => {
+      await page.goto(url.create)
+      const fieldA = page.locator('input#field-field_with_width_a')
+      await expect(fieldA).toBeVisible()
+      const fieldB = page.locator('input#field-field_with_width_b')
+      await expect(fieldB).toBeVisible()
+      const fieldABox = await fieldA.boundingBox()
+      const fieldBBox = await fieldB.boundingBox()
+      // give it some wiggle room of like 2px to account for differences in rendering
+      const difference = Math.abs(fieldABox.width - fieldBBox.width)
+      expect(difference).toBeLessThanOrEqual(2)
     })
   })
 


### PR DESCRIPTION
## Description

Closes #3527 by removing CSS `gap` from the row field, and using negative margins with padding.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes