### PR TITLE
fix: sticky doc sidebar

### DIFF
--- a/packages/payload/src/admin/components/views/Global/Default/index.scss
+++ b/packages/payload/src/admin/components/views/Global/Default/index.scss
@@ -49,8 +49,9 @@
 
   &__sidebar-wrap {
     position: sticky;
-    top: 0;
+    top: var(--doc-controls-height);
     width: 33.33%;
+    height: 100%;
   }
 
   &__sidebar {

--- a/packages/payload/src/admin/components/views/collections/Edit/Default/index.scss
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default/index.scss
@@ -53,8 +53,9 @@
 
   &__sidebar-wrap {
     position: sticky;
-    top: 0;
+    top: var(--doc-controls-height);
     width: 33.33%;
+    height: 100%;
   }
 
   &__sidebar {


### PR DESCRIPTION
## Description

The doc sidebar was not sticking. Now it is.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes