### PR TITLE
fix: API tab breadcrumbs and results indentation

### DIFF
--- a/packages/payload/src/admin/components/views/API/index.scss
+++ b/packages/payload/src/admin/components/views/API/index.scss
@@ -7,6 +7,10 @@
   gap: calc(var(--base) * 2);
   align-items: flex-start;
 
+  ul {
+    padding-left: calc(var(--base) * 1);
+  }
+
   &--fullscreen {
     padding-left: 0;
     .query-inspector__configuration {
@@ -171,6 +175,10 @@
         color: var(--string-color);
       }
     }
+  }
+
+  &__row-line--nested {
+    margin-left: 25px;
   }
 
   &__bracket {

--- a/packages/payload/src/admin/components/views/API/index.tsx
+++ b/packages/payload/src/admin/components/views/API/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import type { EditViewProps } from '../types'
+
 import { Chevron } from '../..'
 import { requests } from '../../../api'
 import CopyToClipboard from '../../elements/CopyToClipboard'
@@ -11,6 +13,7 @@ import { MinimizeMaximize } from '../../icons/MinimizeMaximize'
 import { useConfig } from '../../utilities/Config'
 import { useDocumentInfo } from '../../utilities/DocumentInfo'
 import { useLocale } from '../../utilities/Locale'
+import { SetStepNav } from '../collections/Edit/SetStepNav'
 import './index.scss'
 
 const chars = {
@@ -156,7 +159,8 @@ function createURL(url: string) {
   }
 }
 
-export const API = ({ apiURL }) => {
+export const API: React.FC<EditViewProps> = (props) => {
+  const { apiURL } = props
   const { i18n } = useTranslation()
   const {
     localization,
@@ -201,8 +205,15 @@ export const API = ({ apiURL }) => {
 
   const classes = [baseClass, fullscreen && `${baseClass}--fullscreen`].filter(Boolean).join(' ')
 
+  let isEditing: boolean
+
+  if ('collection' in props) {
+    isEditing = props?.isEditing
+  }
+
   return (
     <Gutter className={classes} right={false}>
+      <SetStepNav collection={collection} global={global} id={id} isEditing={isEditing} />
       <div className={`${baseClass}__configuration`}>
         <div className={`${baseClass}__api-url`}>
           <span className={`${baseClass}__label`}>

--- a/packages/payload/src/admin/components/views/API/index.tsx
+++ b/packages/payload/src/admin/components/views/API/index.tsx
@@ -122,12 +122,19 @@ const RecursivelyRenderObjectData = ({
             }
 
             if (type === 'date' || type === 'string' || type === 'null' || type === 'number') {
+              const parentHasKey = Boolean(parentType === 'object' && key)
+
+              const rowClasses = [
+                `${baseClass}__row-line`,
+                `${baseClass}__value-type--${type}`,
+                `${baseClass}__row-line--${objectKey ? 'nested' : 'top'}`,
+              ]
+                .filter(Boolean)
+                .join(' ')
+
               return (
-                <li
-                  className={`${baseClass}__row-line ${baseClass}__value-type--${type}`}
-                  key={`${key}-${keyIndex}`}
-                >
-                  {parentType === 'object' ? <span>{`"${key}": `}</span> : null}
+                <li className={rowClasses} key={`${key}-${keyIndex}`}>
+                  {parentHasKey ? <span>{`"${key}": `}</span> : null}
 
                   {type === 'string' ? (
                     <span className={`${baseClass}__value`}>{`"${value}"`}</span>

--- a/packages/payload/src/admin/components/views/collections/Edit/SetStepNav.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/SetStepNav.tsx
@@ -13,7 +13,7 @@ import { useConfig } from '../../../utilities/Config'
 export const SetStepNav: React.FC<
   | {
       collection: SanitizedCollectionConfig
-      id: string
+      id: number | string
       isEditing: boolean
     }
   | {
@@ -27,7 +27,7 @@ export const SetStepNav: React.FC<
   let pluralLabel: SanitizedCollectionConfig['labels']['plural']
   let slug: string
   let isEditing = false
-  let id: string | undefined
+  let id: number | string | undefined
 
   if ('collection' in props) {
     const {
@@ -70,7 +70,7 @@ export const SetStepNav: React.FC<
 
       if (isEditing) {
         nav.push({
-          label: useAsTitle && useAsTitle !== 'id' ? title || `[${t('untitled')}]` : id,
+          label: useAsTitle && useAsTitle !== 'id' ? title || `[${t('untitled')}]` : `${id}`,
         })
       } else {
         nav.push({


### PR DESCRIPTION
## Description

Add breadcrumbs to API view when page is reloaded. Fixes indentation in results view.

- [x] I have read and understand the [CONTRIBUTING.md](../CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
