### PR TITLE
fix(db-postgres): update password error

### DIFF
--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -243,8 +243,8 @@ async function updateByID<TSlug extends keyof GeneratedTypes['collections']>(
       const { hash, salt } = await generatePasswordSaltHash({ password })
       dataToUpdate.salt = salt
       dataToUpdate.hash = hash
+      delete dataToUpdate.password
       delete data.password
-      delete result.password
     }
 
     // /////////////////////////////////////


### PR DESCRIPTION
## Description

Allows a password to be changed when using postgres without erroring.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
