### PR TITLE
fix: narrower check for document info when rendering API views

### DIFF
--- a/packages/payload/src/admin/components/views/collections/Edit/SetStepNav.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/SetStepNav.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import type { SanitizedCollectionConfig } from '../../../../../collections/config/types'
 import type { SanitizedGlobalConfig } from '../../../../../exports/types'
 import type { StepNavItem } from '../../../elements/StepNav/types'
+import type { ContextType as DocumentInfo } from '../../../utilities/DocumentInfo/types'
 
 import { getTranslation } from '../../../../../utilities/getTranslation'
 import useTitle from '../../../../hooks/useTitle'
@@ -11,14 +12,7 @@ import { useStepNav } from '../../../elements/StepNav'
 import { useConfig } from '../../../utilities/Config'
 
 export const SetStepNav: React.FC<
-  | {
-      collection: SanitizedCollectionConfig
-      id: number | string
-      isEditing: boolean
-    }
-  | {
-      global: SanitizedGlobalConfig
-    }
+  Pick<DocumentInfo, 'id' | 'collection' | 'global'> & { isEditing?: boolean }
 > = (props) => {
   let collection: SanitizedCollectionConfig | undefined
   let global: SanitizedGlobalConfig | undefined
@@ -29,7 +23,7 @@ export const SetStepNav: React.FC<
   let isEditing = false
   let id: number | string | undefined
 
-  if ('collection' in props) {
+  if (props.collection) {
     const {
       id: idFromProps,
       collection: collectionFromProps,
@@ -43,7 +37,7 @@ export const SetStepNav: React.FC<
     id = idFromProps
   }
 
-  if ('global' in props) {
+  if (props.global) {
     const { global: globalFromProps } = props
     global = globalFromProps
     slug = globalFromProps?.slug

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -352,6 +352,16 @@ describe('admin', () => {
     })
   })
 
+  describe('API view', () => {
+    // Basic test to ensure the front-end renders for globals.
+    test('renders for globals', async () => {
+      await page.goto(url.global(globalSlug, 'api'))
+
+      // Major page element chosen arbitrarily to signal a successful page load.
+      await expect(page.locator('.query-inspector__results-wrapper')).toBeAttached()
+    })
+  })
+
   describe('list view', () => {
     const tableRowLocator = 'table > tbody > tr'
 

--- a/test/helpers/adminUrlUtil.ts
+++ b/test/helpers/adminUrlUtil.ts
@@ -22,7 +22,8 @@ export class AdminUrlUtil {
     return `${this.list}/${id}`
   }
 
-  global(slug: string): string {
-    return `${this.admin}/globals/${slug}`
+  global(slug: string, view?: 'api'): string {
+    const viewSegment = view ? `/${view}` : ''
+    return `${this.admin}/globals/${slug}${viewSegment}`
   }
 }


### PR DESCRIPTION
## Description

Couldn't get the new API view to render for a global model -- there's crash in React code for the SetStepNav component.

The types are subtly allowing for an error, because both `global` and `collection` are passed as props here: https://github.com/payloadcms/payload/blob/68f55c4064f70d9b93a2ce0c8e4d25682250d55b/packages/payload/src/admin/components/views/API/index.tsx#L223

Thus, `'foo' in bar` checks are always true though the values are undefined.  I added a failing test as well.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
