### PR TITLE
fix(live-preview): posts message to proper window

### DIFF
--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -7,11 +7,10 @@ export const handleMessage = async <T>(args: {
   serverURL: string
 }): Promise<T> => {
   const { depth, event, initialData, serverURL } = args
-
   if (event.origin === serverURL && event.data) {
     const eventData = JSON.parse(event?.data)
 
-    if (eventData.type === 'livePreview') {
+    if (eventData.type === 'payload-live-preview') {
       const mergedData = await mergeData<T>({
         depth,
         fieldSchema: eventData.fieldSchemaJSON,

--- a/packages/live-preview/src/subscribe.ts
+++ b/packages/live-preview/src/subscribe.ts
@@ -15,8 +15,18 @@ export const subscribe = <T>(args: {
     }
 
     window.addEventListener('message', handleMessageCallback)
-    window.parent.postMessage('ready', serverURL)
 
-    return handleMessageCallback
+    // This subscription may have been from either an iframe `src` or `window.open()`
+    // i.e. `window?.opener` || `window?.parent`
+
+    window?.opener?.postMessage(
+      JSON.stringify({
+        popupReady: true,
+        type: 'payload-live-preview',
+      }),
+      serverURL,
+    )
   }
+
+  return null
 }

--- a/packages/live-preview/src/subscribe.ts
+++ b/packages/live-preview/src/subscribe.ts
@@ -8,13 +8,13 @@ export const subscribe = <T>(args: {
 }): ((event: MessageEvent) => void) => {
   const { callback, depth, initialData, serverURL } = args
 
-  if (typeof window !== 'undefined') {
-    const handleMessageCallback = async (event: MessageEvent) => {
-      const mergedData = await handleMessage({ depth, event, initialData, serverURL })
-      callback(mergedData)
-    }
+  const onMessage = async (event: MessageEvent) => {
+    const mergedData = await handleMessage({ depth, event, initialData, serverURL })
+    callback(mergedData)
+  }
 
-    window.addEventListener('message', handleMessageCallback)
+  if (typeof window !== 'undefined') {
+    window.addEventListener('message', onMessage)
 
     // This subscription may have been from either an iframe `src` or `window.open()`
     // i.e. `window?.opener` || `window?.parent`
@@ -28,5 +28,5 @@ export const subscribe = <T>(args: {
     )
   }
 
-  return null
+  return onMessage
 }


### PR DESCRIPTION
## Description

The Admin panel was not receiving Live Preview `message` events from external windows because it was posting message to `window.parent` instead of `window.opener`, which appears to be compatible for both iframes and popup windows.

Renames the live preview event key from `livePreview` to `payload-live-preview`. This is technically breaking if you have already started building your own framework integrations outside of what Payload provides. In the future we will export this key for reuse.

Renames the `handleMessageCallback` to `onMessage` and defines it earlier to ensure a consistent return value.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
