### PR TITLE
feat(live-preview): exports ready function

### DIFF
--- a/packages/live-preview/src/index.ts
+++ b/packages/live-preview/src/index.ts
@@ -1,4 +1,5 @@
 export { handleMessage } from './handleMessage'
 export { mergeData } from './mergeData'
+export { ready } from './ready'
 export { subscribe } from './subscribe'
 export { unsubscribe } from './unsubscribe'

--- a/packages/live-preview/src/ready.ts
+++ b/packages/live-preview/src/ready.ts
@@ -1,0 +1,15 @@
+export const ready = (args: { serverURL: string }): void => {
+  const { serverURL } = args
+
+  if (typeof window !== 'undefined') {
+    // This subscription may have been from either an iframe `src` or `window.open()`
+    // i.e. `window?.opener` || `window?.parent`
+    window?.opener?.postMessage(
+      JSON.stringify({
+        popupReady: true,
+        type: 'payload-live-preview',
+      }),
+      serverURL,
+    )
+  }
+}

--- a/packages/live-preview/src/subscribe.ts
+++ b/packages/live-preview/src/subscribe.ts
@@ -15,17 +15,6 @@ export const subscribe = <T>(args: {
 
   if (typeof window !== 'undefined') {
     window.addEventListener('message', onMessage)
-
-    // This subscription may have been from either an iframe `src` or `window.open()`
-    // i.e. `window?.opener` || `window?.parent`
-
-    window?.opener?.postMessage(
-      JSON.stringify({
-        popupReady: true,
-        type: 'payload-live-preview',
-      }),
-      serverURL,
-    )
   }
 
   return onMessage


### PR DESCRIPTION
## Description

Exports the `ready` function for reuse.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works