### PR TITLE
fix(live-preview-react): prevents duplicative ready message in strict mode

### DIFF
--- a/packages/live-preview-react/src/index.ts
+++ b/packages/live-preview-react/src/index.ts
@@ -1,5 +1,5 @@
-import { subscribe, unsubscribe } from '@payloadcms/live-preview'
-import { useCallback, useEffect, useState } from 'react'
+import { ready, subscribe, unsubscribe } from '@payloadcms/live-preview'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 // To prevent the flicker of missing data on initial load,
 // you can pass in the initial page data from the server
@@ -17,6 +17,7 @@ export const useLivePreview = <T extends any>(props: {
   const { depth = 0, initialData, serverURL } = props
   const [data, setData] = useState<T>(initialData)
   const [isLoading, setIsLoading] = useState<boolean>(true)
+  const hasSentReadyMessage = useRef<boolean>(false)
 
   const onChange = useCallback((mergedData) => {
     setData(mergedData)
@@ -30,6 +31,14 @@ export const useLivePreview = <T extends any>(props: {
       initialData,
       serverURL,
     })
+
+    if (!hasSentReadyMessage.current) {
+      hasSentReadyMessage.current = true
+
+      ready({
+        serverURL,
+      })
+    }
 
     return () => {
       unsubscribe(subscription)


### PR DESCRIPTION
## Description

In [React Strict Mode](https://react.dev/reference/react/StrictMode), components immediately unmount and remount which fires cleanup effects (in development mode only). For the `useLivePreview` hook, what this means is that components would "subscribe", "unsubscribe", then "resubscribe" again. This is all expected. But what this meant for external popup windows is that upon "resubscription", a duplicative post message was being sent up to the parent window, **which when cross-origin, throws an error and blocks further communication between the windows**.

The `iframe` element is _not_ given these same security restrictions. These have always worked, despite a duplicative `ready` message being sent. This change only effects previews within an external window.

I _was_ going to simply [prevent a duplicative subscription](https://github.com/payloadcms/payload/pull/3584)...but this is not the proper React way. We _need_ to allow Strict Mode to unmount the component, and unsubscribe from the event listeners it has attached. BUT we _don't_ want it to call back to the parent window more than once.

To do this, [the `ready` function has been exported](https://github.com/payloadcms/payload/pull/3600) from the `@payloadcms/live-preview` package so that we can handle it explicitly. This needs to happen once, _after_ the initial subscription has been made.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
