### PR TITLE
fix: updates admin e2e test for stepnav change

### DIFF
--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -167,14 +167,15 @@ describe('admin', () => {
     })
 
     test('collection - should render `id` as `useAsTitle` fallback', async () => {
-      await page.goto(url.create)
+      const { id } = await createPost()
+      await page.goto(url.edit(id))
       await page.locator('#field-title').fill(title)
       await expect(page.locator('.doc-header__title.render-title')).toContainText(title)
       await saveDocAndAssert(page)
       await expect(page.locator('.step-nav.app-header__step-nav')).toContainText(title)
       await page.locator('#field-title').fill('')
       await expect(page.locator('.doc-header__title.render-title')).toContainText('ID: ')
-      await expect(page.locator('.step-nav.app-header__step-nav')).toContainText('[Untitled]')
+      await expect(page.locator('.step-nav.app-header__step-nav')).toContainText(id)
       await saveDocAndAssert(page)
     })
 


### PR DESCRIPTION
## Description

Fixes failing e2e test for: **_collection - should render `id` as `useAsTitle` fallback_**

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Chore (non-breaking change which does not add functionality)