### PR TITLE
fix: sidebar field permissions

### DIFF
--- a/packages/payload/src/admin/components/forms/RenderFields/types.ts
+++ b/packages/payload/src/admin/components/forms/RenderFields/types.ts
@@ -8,7 +8,7 @@ export type Props = {
   fieldTypes: FieldTypes
   forceRender?: boolean
   margins?: 'small' | false
-  permissions:
+  permissions?:
     | {
         [field: string]: FieldPermissions
       }
@@ -16,11 +16,13 @@ export type Props = {
   readOnly?: boolean
 } & (
   | {
+      // Fields to be filtered by the component
       fieldSchema: FieldWithPath[]
       filter?: (field: Field) => boolean
       indexPath?: string
     }
   | {
+      // Pre-filtered fields to be simply rendered
       fields: ReducedField[]
     }
 )

--- a/packages/payload/src/admin/components/forms/RenderFields/types.ts
+++ b/packages/payload/src/admin/components/forms/RenderFields/types.ts
@@ -6,19 +6,19 @@ import type { ReducedField } from './filterFields'
 export type Props = {
   className?: string
   fieldTypes: FieldTypes
-  margins?: 'small' | false
   forceRender?: boolean
+  margins?: 'small' | false
+  permissions:
+    | {
+        [field: string]: FieldPermissions
+      }
+    | FieldPermissions
+  readOnly?: boolean
 } & (
   | {
       fieldSchema: FieldWithPath[]
       filter?: (field: Field) => boolean
       indexPath?: string
-      permissions?:
-        | {
-            [field: string]: FieldPermissions
-          }
-        | FieldPermissions
-      readOnly?: boolean
     }
   | {
       fields: ReducedField[]

--- a/packages/payload/src/admin/components/views/Global/Default/index.tsx
+++ b/packages/payload/src/admin/components/views/Global/Default/index.tsx
@@ -90,9 +90,8 @@ export const DefaultGlobalEdit: React.FC<GlobalEditViewProps> = (props) => {
               <div className={`${baseClass}__sidebar-sticky-wrap`}>
                 <div className={`${baseClass}__sidebar-fields`}>
                   <RenderFields
-                    fieldSchema={fields}
                     fieldTypes={fieldTypes}
-                    filter={(field) => field.admin.position === 'sidebar'}
+                    fields={sidebarFields}
                     permissions={permissions.fields}
                     readOnly={!hasSavePermission}
                   />

--- a/packages/payload/src/admin/components/views/collections/Edit/Default/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default/index.tsx
@@ -115,7 +115,14 @@ export const DefaultCollectionEdit: React.FC<CollectionEditViewProps> = (props) 
             <div className={`${baseClass}__sidebar`}>
               <div className={`${baseClass}__sidebar-sticky-wrap`}>
                 <div className={`${baseClass}__sidebar-fields`}>
-                  <RenderFields fieldTypes={fieldTypes} fields={sidebarFields} />
+                  <RenderFields
+                    className={`${baseClass}__fields`}
+                    fieldSchema={fields}
+                    fieldTypes={fieldTypes}
+                    filter={(field) => field?.admin?.position === 'sidebar'}
+                    permissions={permissions.fields}
+                    readOnly={!hasSavePermission}
+                  />
                 </div>
               </div>
             </div>

--- a/packages/payload/src/admin/components/views/collections/Edit/Default/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default/index.tsx
@@ -116,10 +116,8 @@ export const DefaultCollectionEdit: React.FC<CollectionEditViewProps> = (props) 
               <div className={`${baseClass}__sidebar-sticky-wrap`}>
                 <div className={`${baseClass}__sidebar-fields`}>
                   <RenderFields
-                    className={`${baseClass}__fields`}
-                    fieldSchema={fields}
                     fieldTypes={fieldTypes}
-                    filter={(field) => field?.admin?.position === 'sidebar'}
+                    fields={sidebarFields}
                     permissions={permissions.fields}
                     readOnly={!hasSavePermission}
                   />


### PR DESCRIPTION
## Description

Closes #3579 - fields in the sidebar with `update: () => false` were not displaying as read only.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
