### PR TITLE
fix: document sidebar vertical overflow

### DIFF
--- a/packages/payload/src/admin/components/views/Global/Default/index.scss
+++ b/packages/payload/src/admin/components/views/Global/Default/index.scss
@@ -52,7 +52,7 @@
     position: sticky;
     top: var(--doc-controls-height);
     width: 33.33%;
-    height: 100%;
+    height: calc(100vh - var(--doc-controls-height));
   }
 
   &__sidebar {

--- a/packages/payload/src/admin/components/views/collections/Edit/Default/index.scss
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default/index.scss
@@ -56,7 +56,7 @@
     position: sticky;
     top: var(--doc-controls-height);
     width: 33.33%;
-    height: 100%;
+    height: calc(100vh - var(--doc-controls-height));
   }
 
   &__sidebar {

--- a/test/admin/collections/Posts.ts
+++ b/test/admin/collections/Posts.ts
@@ -66,6 +66,24 @@ export const Posts: CollectionConfig = {
       ],
     },
     {
+      name: 'group',
+      type: 'group',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'relationship',
+      type: 'relationship',
+      relationTo: 'posts',
+      admin: {
+        position: 'sidebar',
+      },
+    },
+    {
       name: 'sidebarField',
       type: 'text',
       admin: {


### PR DESCRIPTION
## Description

Documents with many fields in the sidebar need to potentially `overflow: scroll` independently of the main fields, and remain sticky. To make this happen, `height` is a required property. Fortunately the new Admin UI provides a CSS variable we can use to define the height of the sidebar to be the exact value. Ideally we can get this "sidebar" view built out as a template so that it can be reused across globals, the account view, and custom views.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
