### PR TITLE
chore: properly scopes selector in bulk update e2e test

### DIFF
--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -330,10 +330,12 @@ describe('admin', () => {
       await page.locator('input#select-all').check()
       await page.locator('.edit-many__toggle').click()
       await page.locator('.field-select .rs__control').click()
-      const options = page.locator('.rs__option')
-      const titleOption = options.locator('text=Title')
 
-      await expect(titleOption).toHaveText('Title')
+      const titleOption = page.locator('.rs__option', {
+        hasText: exactText('Title'),
+      })
+
+      await expect(titleOption).toBeVisible()
 
       await titleOption.click()
       const titleInput = page.locator('#field-title')


### PR DESCRIPTION
## Description

Fixes the admin e2e test by properly scoping the element selector. It was previously resolving to two elements. Now it uses the `exactText` regex to ensure that options with similar titles are never located.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
