### PR TITLE
chore: optionally use sharp functionality

### DIFF
--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -1,5 +1,5 @@
 import type { UploadedFile } from 'express-fileupload'
-import type { Sharp } from 'sharp'
+import type { Sharp, SharpOptions } from 'sharp'
 
 import { fromBuffer } from 'file-type'
 import mkdirp from 'mkdirp'
@@ -98,12 +98,13 @@ export const generateFileData = async <T>({
     let fileBuffer
     let ext
     let mime: string
+    const isSharpRequired = fileSupportsResize && (resizeOptions || formatOptions || trimOptions)
 
-    const sharpOptions: sharp.SharpOptions = {}
+    const sharpOptions: SharpOptions = {}
 
     if (fileIsAnimated) sharpOptions.animated = true
 
-    if (fileSupportsResize && (resizeOptions || formatOptions || trimOptions)) {
+    if (isSharpRequired) {
       if (file.tempFilePath) {
         sharpFile = sharp(file.tempFilePath, sharpOptions).rotate() // pass rotate() to auto-rotate based on EXIF data. https://github.com/payloadcms/payload/pull/3081
       } else {
@@ -170,7 +171,7 @@ export const generateFileData = async <T>({
     fileData.filename = fsSafeName
     let fileForResize = file
 
-    if (cropData) {
+    if (isSharpRequired && cropData) {
       const { data: croppedImage, info } = await cropImage({ cropData, dimensions, file })
 
       filesToSave.push({

--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -1,4 +1,5 @@
 import type { UploadedFile } from 'express-fileupload'
+import type { OutputInfo } from 'sharp'
 
 import { fromBuffer } from 'file-type'
 import fs from 'fs'
@@ -65,7 +66,7 @@ const getSanitizedImageData = (sourceImage: string): SanitizedImageData => {
  */
 const createImageName = (
   outputImageName: string,
-  { height, width }: sharp.OutputInfo,
+  { height, width }: OutputInfo,
   extension: string,
 ) => `${outputImageName}-${width}x${height}.${extension}`
 


### PR DESCRIPTION
## Description

Related: https://github.com/payloadcms/next-payload/issues/72

Only use `sharp` when it is necessary. Nothing has changed, just opting to use sharp types via `import type` instead of from the core package.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
