### PR TITLE
fix: handle invalid tokens in refresh token operation

### DIFF
--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -58,7 +58,7 @@ async function refresh(incomingArgs: Arguments): Promise<Result> {
     },
   } = args
 
-  if (typeof args.token !== 'string') throw new Forbidden(args.req.t)
+  if (typeof args.token !== 'string' || args.req.user == null) throw new Forbidden(args.req.t)
 
   const parsedURL = url.parse(args.req.url)
   const isGraphQL = parsedURL.pathname === config.routes.graphQL

--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -58,7 +58,7 @@ async function refresh(incomingArgs: Arguments): Promise<Result> {
     },
   } = args
 
-  if (typeof args.token !== 'string' || args.req.user == null) throw new Forbidden(args.req.t)
+  if (typeof args.token !== 'string' || !args.req.user) throw new Forbidden(args.req.t)
 
   const parsedURL = url.parse(args.req.url)
   const isGraphQL = parsedURL.pathname === config.routes.graphQL

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -636,6 +636,21 @@ describe('Auth', () => {
       }).then((res) => res.json())
       expect(editorMe.user.adminOnlyField).toBeUndefined()
     })
+
+    it('should not allow refreshing an invalid token', async () => {
+      const response = await fetch(`${apiUrl}/${slug}/refresh-token`, {
+        body: JSON.stringify({
+          token: 'INVALID',
+        }),
+        headers,
+        method: 'post',
+      })
+
+      const data = await response.json()
+
+      expect(response.status).toBe(403)
+      expect(data.token).toBeUndefined()
+    })
   })
 
   describe('API Key', () => {


### PR DESCRIPTION
## Description

Fixes the "refresh token" operation to correctly reject invalid tokens instead of crashing with an internal server error.
Fixes #3646 

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
