### PR TITLE
docs: clarify docs around direction transaction access

### DIFF
--- a/docs/database/transactions.mdx
+++ b/docs/database/transactions.mdx
@@ -60,10 +60,44 @@ const afterChange: CollectionAfterChangeHook = async ({ req }) => {
 
 ### Direct Transaction Access
 
-When writing your own scripts or custom endpoints, you may wish to have direct control over transactions. This is useful for interacting with your database outside of Payload's local API.
+When writing your own scripts or custom endpoints, you may wish to have direct control over transactions. This is useful for interacting with your database in something like a background job, outside the normal request-response flow.
 
 The following functions can be used for managing transactions:
 
-`payload.db.beginTransaction` - Starts a new session and returns a transaction ID for use in other Payload Local API calls.
-`payload.db.commitTransaction` - Takes the identifier for the transaction, finalizes any changes.
+`payload.db.beginTransaction` - Starts a new session and returns a transaction ID for use in other Payload Local API calls. Note that if your database does not support transactions, this will return `null`.\
+`payload.db.commitTransaction` - Takes the identifier for the transaction, finalizes any changes.\
 `payload.db.rollbackTransaction` - Takes the identifier for the transaction, discards any changes.
+
+You can then use the transaction ID with Payload's local API by passing it inside the `PayloadRequest` object.
+
+Here is an example for a "background job" function, which utilizes the direct transaction API to make sure it either succeeds completely or gets rolled back in case of an error.
+
+```ts
+async function allOrNothingJob() {
+    const req = {} as PayloadRequest;
+    req.transactionID = await payload.db.beginTransaction();
+    try {
+      await payload.create({
+        req, // use our manual transaction
+        collection: 'my-slug',
+        data: {
+          some: 'data'
+        }
+      });
+
+      await payload.create({
+        req, // use our manual transaction
+        collection: 'something-else',
+        data: {
+          some: 'data'
+        }
+      });
+      console.log('Everything done.');
+      if (req.transactionID) await payload.db.commitTransaction(req.transactionID);
+    } catch (e) {
+      console.error('Oh no, something went wrong!');
+      if (req.transactionID) await payload.db.rollbackTransaction(req.transactionID);
+    }
+
+}
+```


### PR DESCRIPTION
## Description

Improves the documentation around how to use the direct transaction management (`DatabaseAdapter#beginTransaction`, etc.).
I have added an example function for how to use the methods in an "all or nothing" background job and shown how to pass the transactionID inside `PayloadRequest`.

Prior discussion: https://github.com/payloadcms/payload/discussions/3525

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] This change requires a documentation update

## Checklist:

- [X] I have made corresponding changes to the documentation
