### PR TITLE
chore(templates): fix website template unused ts-expect-error

### DIFF
--- a/templates/website/src/app/_components/Media/index.tsx
+++ b/templates/website/src/app/_components/Media/index.tsx
@@ -11,7 +11,6 @@ export const Media: React.FC<Props> = props => {
   const Tag = (htmlElement as any) || Fragment
 
   return (
-    // ts-expect-error
     <Tag
       {...(htmlElement !== null
         ? {
@@ -19,13 +18,7 @@ export const Media: React.FC<Props> = props => {
           }
         : {})}
     >
-      {isVideo ? (
-        // @ts-expect-error
-        <Video {...props} />
-      ) : (
-        // @ts-expect-error
-        <Image {...props} /> // eslint-disable-line
-      )}
+      {isVideo ? <Video {...props} /> : <Image {...props} />}
     </Tag>
   )
 }

--- a/templates/website/tsconfig.json
+++ b/templates/website/tsconfig.json
@@ -22,7 +22,10 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "paths": {
+      "react": ["./node_modules/@types/react"],
+    }
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
## Description

Patch website template `yarn build` fails due to Unused @ts-expect-error directive error.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
