### PR TITLE
chore: properly separates server / client exports

### DIFF
--- a/packages/payload/src/exports/components/forms.ts
+++ b/packages/payload/src/exports/components/forms.ts
@@ -18,16 +18,18 @@ export {
    */
   useWatchForm,
 } from '../../admin/components/forms/Form/context'
+
 export { createNestedFieldPath } from '../../admin/components/forms/Form/createNestedFieldPath'
-
 export { default as getSiblingData } from '../../admin/components/forms/Form/getSiblingData'
+
 export { default as reduceFieldsToValues } from '../../admin/components/forms/Form/reduceFieldsToValues'
-
 export { default as Label } from '../../admin/components/forms/Label'
-export { default as RenderFields } from '../../admin/components/forms/RenderFields'
 
+export { default as RenderFields } from '../../admin/components/forms/RenderFields'
 export { default as Submit } from '../../admin/components/forms/Submit'
+
 export { default as FormSubmit } from '../../admin/components/forms/Submit'
+export { fieldTypes } from '../../admin/components/forms/field-types'
 export { default as Checkbox } from '../../admin/components/forms/field-types/Checkbox'
 
 export { default as Collapsible } from '../../admin/components/forms/field-types/Collapsible'

--- a/packages/payload/src/exports/config.ts
+++ b/packages/payload/src/exports/config.ts
@@ -1,7 +1,7 @@
 export { buildConfig } from '../config/build'
 export * from '../config/types'
 
-export { type FieldTypes, fieldTypes } from '../admin/components/forms/field-types'
+export { type FieldTypes } from '../admin/components/forms/field-types'
 export { defaults } from '../config/defaults'
 export { sanitizeConfig } from '../config/sanitize'
 export { baseBlockFields } from '../fields/baseFields/baseBlockFields'

--- a/packages/payload/src/exports/utilities.ts
+++ b/packages/payload/src/exports/utilities.ts
@@ -1,10 +1,11 @@
+export { withMergedProps } from '../admin/components/utilities/WithMergedProps'
 export { extractTranslations } from '../translations/extractTranslations'
-export { i18nInit } from '../translations/init'
 
+export { i18nInit } from '../translations/init'
 export { combineMerge } from '../utilities/combineMerge'
 export { configToJSONSchema, entityToJSONSchema } from '../utilities/configToJSONSchema'
-export { createArrayFromCommaDelineated } from '../utilities/createArrayFromCommaDelineated'
 
+export { createArrayFromCommaDelineated } from '../utilities/createArrayFromCommaDelineated'
 export { deepCopyObject } from '../utilities/deepCopyObject'
 export { deepMerge } from '../utilities/deepMerge'
 export { default as flattenTopLevelFields } from '../utilities/flattenTopLevelFields'

--- a/packages/richtext-lexical/src/field/features/Blocks/component/BlockContent.tsx
+++ b/packages/richtext-lexical/src/field/features/Blocks/component/BlockContent.tsx
@@ -8,7 +8,7 @@ import { SectionTitle } from 'payload/components/fields/Blocks'
 import { RenderFields, createNestedFieldPath, useFormSubmitted } from 'payload/components/forms'
 import { useDocumentInfo } from 'payload/components/utilities'
 import { getTranslation } from 'payload/utilities'
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { FieldProps } from '../../../../types'

--- a/packages/richtext-lexical/src/field/features/Link/drawer/index.tsx
+++ b/packages/richtext-lexical/src/field/features/Link/drawer/index.tsx
@@ -2,7 +2,7 @@ import { Drawer } from 'payload/components/elements'
 import { Form } from 'payload/components/forms'
 import { RenderFields } from 'payload/components/forms'
 import { FormSubmit } from 'payload/components/forms'
-import { fieldTypes } from 'payload/config'
+import { fieldTypes } from 'payload/components/forms'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/packages/richtext-lexical/src/field/features/Link/index.tsx
+++ b/packages/richtext-lexical/src/field/features/Link/index.tsx
@@ -5,7 +5,7 @@ import type { Field } from 'payload/types'
 import LexicalClickableLinkPlugin from '@lexical/react/LexicalClickableLinkPlugin'
 import { $findMatchingParent } from '@lexical/utils'
 import { $getSelection, $isRangeSelection } from 'lexical'
-import { withMergedProps } from 'payload/components/utilities'
+import { withMergedProps } from 'payload/utilities'
 
 import type { FeatureProvider } from '../types'
 import type { LinkFields } from './nodes/LinkNode'

--- a/packages/richtext-lexical/src/field/features/Upload/component/ExtraFieldsDrawer/index.tsx
+++ b/packages/richtext-lexical/src/field/features/Upload/component/ExtraFieldsDrawer/index.tsx
@@ -4,7 +4,7 @@ import { useModal } from '@faceless-ui/modal'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { $getNodeByKey } from 'lexical'
 import { Drawer } from 'payload/components/elements'
-import { Form, FormSubmit, RenderFields } from 'payload/components/forms'
+import { Form, FormSubmit, RenderFields, fieldTypes } from 'payload/components/forms'
 import {
   buildStateFromSchema,
   useAuth,
@@ -12,7 +12,7 @@ import {
   useDocumentInfo,
   useLocale,
 } from 'payload/components/utilities'
-import { fieldTypes, sanitizeFields } from 'payload/config'
+import { sanitizeFields } from 'payload/config'
 import { deepCopyObject, getTranslation } from 'payload/utilities'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -2,7 +2,7 @@ import type { SerializedEditorState } from 'lexical'
 import type { EditorConfig as LexicalEditorConfig } from 'lexical/LexicalEditor'
 import type { RichTextAdapter } from 'payload/types'
 
-import { withMergedProps } from 'payload/components/utilities'
+import { withMergedProps } from 'payload/utilities'
 
 import type { FeatureProvider } from './field/features/types'
 import type { EditorConfig, SanitizedEditorConfig } from './field/lexical/config/types'

--- a/packages/richtext-slate/src/field/elements/link/LinkDrawer/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/LinkDrawer/index.tsx
@@ -1,8 +1,8 @@
 import { Drawer } from 'payload/components/elements'
 import { Form, FormSubmit, RenderFields } from 'payload/components/forms'
+import { fieldTypes } from 'payload/components/forms'
 import { useHotkey } from 'payload/components/hooks'
 import { useEditDepth } from 'payload/components/utilities'
-import { fieldTypes } from 'payload/config'
 import React, { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/packages/richtext-slate/src/field/elements/upload/Element/UploadDrawer/index.tsx
+++ b/packages/richtext-slate/src/field/elements/upload/Element/UploadDrawer/index.tsx
@@ -2,7 +2,7 @@ import type { SanitizedCollectionConfig } from 'payload/types'
 
 import { useModal } from '@faceless-ui/modal'
 import { Drawer } from 'payload/components/elements'
-import { Form, FormSubmit, RenderFields } from 'payload/components/forms'
+import { Form, FormSubmit, RenderFields, fieldTypes } from 'payload/components/forms'
 import {
   buildStateFromSchema,
   useAuth,
@@ -10,7 +10,7 @@ import {
   useDocumentInfo,
   useLocale,
 } from 'payload/components/utilities'
-import { fieldTypes, sanitizeFields } from 'payload/config'
+import { sanitizeFields } from 'payload/config'
 import { deepCopyObject, getTranslation } from 'payload/utilities'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/packages/richtext-slate/src/index.ts
+++ b/packages/richtext-slate/src/index.ts
@@ -1,6 +1,6 @@
 import type { RichTextAdapter } from 'payload/types'
 
-import { withMergedProps } from 'payload/components/utilities'
+import { withMergedProps } from 'payload/utilities'
 
 import type { AdapterArguments } from './types'
 


### PR DESCRIPTION
## Description

Moves `fieldTypes` from `payload/config` to `payload/components/forms` and `withMergedProps` from `payload/components/utilities` to `payload/utilities`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
