### PR TITLE
fix: correctly sets index of row when index not passed

### DIFF
--- a/packages/payload/src/admin/components/forms/Form/fieldReducer.ts
+++ b/packages/payload/src/admin/components/forms/Form/fieldReducer.ts
@@ -137,7 +137,7 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
     case 'ADD_ROW': {
       const { blockType, path, rowIndex: rowIndexFromArgs, subFieldState } = action
       const rowIndex =
-        typeof rowIndexFromArgs === 'number' ? rowIndexFromArgs : state[path]?.rows?.length - 1 || 0
+        typeof rowIndexFromArgs === 'number' ? rowIndexFromArgs : state[path]?.rows?.length || 0
 
       const rowsMetadata = [...(state[path]?.rows || [])]
       rowsMetadata.splice(

--- a/packages/payload/src/admin/components/forms/Form/fieldReducer.ts
+++ b/packages/payload/src/admin/components/forms/Form/fieldReducer.ts
@@ -137,7 +137,7 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
     case 'ADD_ROW': {
       const { blockType, path, rowIndex: rowIndexFromArgs, subFieldState } = action
       const rowIndex =
-        typeof rowIndexFromArgs === 'number' ? rowIndexFromArgs : state[path]?.rows?.length || 0
+        typeof rowIndexFromArgs === 'number' ? rowIndexFromArgs : state[path]?.rows?.length - 1 || 0
 
       const rowsMetadata = [...(state[path]?.rows || [])]
       rowsMetadata.splice(

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -297,7 +297,7 @@ const BlocksField: React.FC<Props> = (props) => {
           </DrawerToggler>
           <BlocksDrawer
             addRow={addRow}
-            addRowIndex={typeof value === 'number' ? value - 1 : 0}
+            addRowIndex={rows?.length || 0}
             blocks={blocks}
             drawerSlug={drawerSlug}
             labels={labels}

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -297,7 +297,7 @@ const BlocksField: React.FC<Props> = (props) => {
           </DrawerToggler>
           <BlocksDrawer
             addRow={addRow}
-            addRowIndex={value || 0}
+            addRowIndex={typeof value === 'number' ? value - 1 : 0}
             blocks={blocks}
             drawerSlug={drawerSlug}
             labels={labels}


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/3618

Auto index on add was using the current array `length` instead of `length - 1`

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
