### PR TITLE
feat: allows filterOptions to return null

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -67,6 +67,7 @@ export type FilterOptionsProps<T = any> = {
 export type FilterOptions<T = any> =
   | ((options: FilterOptionsProps<T>) => Promise<Where> | Where)
   | Where
+  | null
 
 type Admin = {
   className?: string

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -258,14 +258,18 @@ const validateFilterOptions: Validate = async (
         })
 
         if (valueIDs.length > 0) {
+          const findWhere = {
+            and: [{ id: { in: valueIDs } }, optionFilter],
+          }
+
+          if (optionFilter) findWhere.and.push(optionFilter)
+
           const result = await payload.find({
             collection,
             depth: 0,
             limit: 0,
             pagination: false,
-            where: {
-              and: [{ id: { in: valueIDs } }, optionFilter],
-            },
+            where: findWhere,
           })
 
           options[collection] = result.docs.map((doc) => doc.id)


### PR DESCRIPTION
## Description

Allows filterOptions to return null as a "bail out".

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

