### PR TITLE
fix(richtext-*): link drawer form receiving incorrect field schema

### DIFF
--- a/packages/richtext-lexical/src/field/features/Link/drawer/index.tsx
+++ b/packages/richtext-lexical/src/field/features/Link/drawer/index.tsx
@@ -18,9 +18,10 @@ export const LinkDrawer: React.FC<Props> = ({
   initialState,
 }) => {
   const { t } = useTranslation('fields')
+
   return (
     <Drawer className={baseClass} slug={drawerSlug} title={t('editLink') ?? ''}>
-      <Form initialState={initialState} onSubmit={handleModalSubmit}>
+      <Form fields={fieldSchema} initialState={initialState} onSubmit={handleModalSubmit}>
         <RenderFields
           fieldSchema={fieldSchema}
           fieldTypes={fieldTypes}

--- a/packages/richtext-slate/src/field/elements/link/LinkDrawer/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/LinkDrawer/index.tsx
@@ -22,7 +22,7 @@ export const LinkDrawer: React.FC<Props> = ({
 
   return (
     <Drawer className={baseClass} slug={drawerSlug} title={t('editLink')}>
-      <Form initialState={initialState} onSubmit={handleModalSubmit}>
+      <Form fields={fieldSchema} initialState={initialState} onSubmit={handleModalSubmit}>
         <RenderFields
           fieldSchema={fieldSchema}
           fieldTypes={fieldTypes}


### PR DESCRIPTION
## Description

Fixes #3680 

By default, a Form takes the fields (which is mostly used for row stuff, so for Array and Blocks fields) from the current collection/document.

However, the drawer has different fields than the collection/document. This PR thus overrides this behavior by passing the link drawer's correct fields to the form with the Form's `fields` property. The form's `fields` property overrides the default behavior (which is: getting the fields from the document/collection)

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
