### PR TITLE
fix: ensure breadcrumbs docs are of type int for postgres

### DIFF
--- a/packages/plugin-nested-docs/src/index.ts
+++ b/packages/plugin-nested-docs/src/index.ts
@@ -9,41 +9,51 @@ import populateBreadcrumbs from './utilities/populateBreadcrumbs'
 
 const nestedDocs =
   (pluginConfig: PluginConfig): Plugin =>
-  (config) => ({
-    ...config,
-    collections: (config.collections || []).map((collection) => {
-      if (pluginConfig.collections.indexOf(collection.slug) > -1) {
-        const fields = [...(collection?.fields || [])]
-
-        if (!pluginConfig.parentFieldSlug) {
-          fields.push(createParentField(collection.slug))
-        }
-
-        if (!pluginConfig.breadcrumbsFieldSlug) {
-          fields.push(createBreadcrumbsField(collection.slug))
-        }
-
-        return {
-          ...collection,
-          hooks: {
-            ...(collection.hooks || {}),
-            beforeChange: [
-              async ({ req, data, originalDoc }) =>
-                populateBreadcrumbs(req, pluginConfig, collection, data, originalDoc),
-              ...(collection?.hooks?.beforeChange || []),
-            ],
-            afterChange: [
-              resaveChildren(pluginConfig, collection),
-              resaveSelfAfterCreate(collection),
-              ...(collection?.hooks?.afterChange || []),
-            ],
-          },
-          fields,
-        }
+  (config) => {
+    // @TODO: This is a hack to get the database adapter
+    if (!pluginConfig?.dbType) {
+      let databaseAdapter: PluginConfig['dbType'] = 'mongoose'
+      if (config.db.toString().match('postgres')) {
+        databaseAdapter = 'postgres'
       }
+      pluginConfig.dbType = databaseAdapter
+    }
+    return {
+      ...config,
+      collections: (config.collections || []).map((collection) => {
+        if (pluginConfig.collections.indexOf(collection.slug) > -1) {
+          const fields = [...(collection?.fields || [])]
 
-      return collection
-    }),
-  })
+          if (!pluginConfig.parentFieldSlug) {
+            fields.push(createParentField(collection.slug))
+          }
+
+          if (!pluginConfig.breadcrumbsFieldSlug) {
+            fields.push(createBreadcrumbsField(collection.slug))
+          }
+
+          return {
+            ...collection,
+            hooks: {
+              ...(collection.hooks || {}),
+              beforeChange: [
+                async ({ req, data, originalDoc }) =>
+                  populateBreadcrumbs(req, pluginConfig, collection, data, originalDoc),
+                ...(collection?.hooks?.beforeChange || []),
+              ],
+              afterChange: [
+                resaveChildren(pluginConfig, collection),
+                resaveSelfAfterCreate(collection),
+                ...(collection?.hooks?.afterChange || []),
+              ],
+            },
+            fields,
+          }
+        }
+
+        return collection
+      }),
+    }
+  }
 
 export default nestedDocs

--- a/packages/plugin-nested-docs/src/types.ts
+++ b/packages/plugin-nested-docs/src/types.ts
@@ -1,7 +1,7 @@
 export interface Breadcrumb {
   url?: string
   label: string
-  doc: string
+  doc: string | number
 }
 
 export type GenerateURL = (
@@ -20,4 +20,5 @@ export interface PluginConfig {
   generateLabel?: GenerateLabel
   parentFieldSlug?: string
   breadcrumbsFieldSlug?: string
+  dbType?: 'mongoose' | 'postgres'
 }

--- a/packages/plugin-nested-docs/src/utilities/formatBreadcrumb.ts
+++ b/packages/plugin-nested-docs/src/utilities/formatBreadcrumb.ts
@@ -23,10 +23,13 @@ const formatBreadcrumb = (
     label = lastDoc[useAsTitle] as string
   }
 
+  const docId =
+    pluginConfig.dbType === 'mongoose' ? (lastDoc.id as string) : parseInt(lastDoc.id as string)
+
   return {
     label,
     url,
-    doc: lastDoc.id as string,
+    doc: docId,
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes

## Description

I've identified an issue in the Nested Docs plugin (v1.0.8) regarding the handling of the doc property on breadcrumbs across different database adapters.

MongoDB naturally handles this as a string, aligning with the plugin's expectations. However, with PostgreSQL, it's processed as an int, leading to a validation error when saving breadcrumbs.

To resolve this, I've implemented I did `config.db.toString().match('postgres')` which for sure isn't pretty at all, probably should be an easier way and more robust way of checking this. I then added this information to the plugin's config, ensuring both MongoDB and PostgreSQL operate smoothly. 

While changing IDs to strings in documents for Postgres might also solve the problem, I believe that approach would introduce a breaking change.

