### PR TITLE
chore: refines main nav

### DIFF
--- a/packages/payload/src/admin/components/elements/Hamburger/index.scss
+++ b/packages/payload/src/admin/components/elements/Hamburger/index.scss
@@ -6,15 +6,21 @@
   cursor: pointer;
   background-color: transparent;
   outline: none;
-  position: absolute;
+  position: relative;
 
-  --hamburger-padding: 5px;
+  --hamburger-padding: 8px;
   --hamburger-size: 9px;
   --hamburger-line-gap: 3px;
+
   padding: var(--hamburger-padding);
-  border: 1px solid var(--theme-elevation-350);
+  border: 1px solid var(--theme-elevation-150);
   color: var(--theme-text);
   border-radius: 3px;
+
+  &:hover {
+    border: 1px solid var(--theme-elevation-500);
+    background-color: var(--theme-elevation-100);
+  }
 
   &:focus {
     outline: none;

--- a/packages/payload/src/admin/components/elements/Header/index.scss
+++ b/packages/payload/src/admin/components/elements/Header/index.scss
@@ -92,6 +92,12 @@
       right: base(2);
     }
 
+    &--nav-open {
+      .app-header__localizer {
+        display: none;
+      }
+    }
+
     &__mobile-nav-toggler {
       display: flex;
       align-items: center;

--- a/packages/payload/src/admin/components/elements/Header/index.tsx
+++ b/packages/payload/src/admin/components/elements/Header/index.tsx
@@ -8,6 +8,7 @@ import { Hamburger } from '../Hamburger'
 import Localizer from '../Localizer'
 import { LocalizerLabel } from '../Localizer/LocalizerLabel'
 import { NavToggler } from '../Nav/NavToggler'
+import { useNav } from '../Nav/context'
 import StepNav from '../StepNav'
 import './index.scss'
 
@@ -21,8 +22,10 @@ export const AppHeader: React.FC = (props) => {
     routes: { admin: adminRoute },
   } = useConfig()
 
+  const { navOpen } = useNav()
+
   return (
-    <header className={[baseClass].filter(Boolean).join(' ')}>
+    <header className={[baseClass, navOpen && `${baseClass}--nav-open`].filter(Boolean).join(' ')}>
       <div className={`${baseClass}__bg`} />
       <div className={`${baseClass}__content`}>
         <div className={`${baseClass}__wrapper`}>

--- a/packages/payload/src/admin/components/elements/Nav/NavToggler/index.scss
+++ b/packages/payload/src/admin/components/elements/Nav/NavToggler/index.scss
@@ -6,11 +6,5 @@
   padding: 0;
   margin: 0;
   border: 0;
-  height: var(--app-header-height);
-  width: var(--gutter-h);
   cursor: pointer;
-
-  @include small-break {
-    width: calc(var(--gutter-h) * 2);
-  }
 }

--- a/packages/payload/src/admin/components/elements/Nav/index.scss
+++ b/packages/payload/src/admin/components/elements/Nav/index.scss
@@ -41,7 +41,7 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    padding: var(--app-header-height) base(1.5) base(2) base(1.25);
+    padding: var(--app-header-height) base(1) base(2) base(1);
     overflow-y: auto;
 
     // remove the scrollbar here to prevent layout shift as nav groups are toggled
@@ -128,12 +128,7 @@
 
   @include mid-break {
     &__scroll {
-      padding: var(--app-header-height) base(0.75) base(2) base(0.75);
-    }
-
-    nav a {
-      font-size: base(0.875);
-      line-height: base(1.5);
+      padding: var(--app-header-height) base(0.5) base(2);
     }
   }
 
@@ -141,9 +136,12 @@
     &__scroll {
       padding: var(--app-header-height) var(--gutter-h) base(2);
     }
-  }
 
-  @include extra-small-break {
+    nav a {
+      font-size: base(0.875);
+      line-height: base(1.5);
+    }
+
     &--nav-open {
       transition: none;
     }

--- a/packages/payload/src/admin/components/graphics/Account/Default/index.scss
+++ b/packages/payload/src/admin/components/graphics/Account/Default/index.scss
@@ -48,6 +48,12 @@
       .graphic-account {
         &__bg {
           fill: var(--theme-elevation-300);
+          stroke: var(--theme-elevation-600);
+        }
+
+        &__head,
+        &__body {
+          fill: var(--theme-elevation-600);
         }
       }
     }

--- a/packages/payload/src/admin/components/graphics/Account/Default/index.scss
+++ b/packages/payload/src/admin/components/graphics/Account/Default/index.scss
@@ -1,17 +1,23 @@
 .graphic-account {
+  vector-effect: non-scaling-stroke;
+  overflow: visible;
+
   &__bg {
-    fill: var(--theme-elevation-100);
+    fill: var(--theme-elevation-50);
+    stroke: var(--theme-elevation-200);
+    stroke-width: 1px;
   }
 
   &__head,
   &__body {
-    fill: var(--theme-elevation-300);
+    fill: var(--theme-elevation-200);
   }
 
   &--active {
     .graphic-account {
       &__bg {
         fill: var(--theme-elevation-500);
+        stroke: var(--theme-text);
       }
 
       &__head,
@@ -25,6 +31,7 @@
     .graphic-account {
       &__bg {
         fill: var(--theme-elevation-200);
+        stroke: var(--theme-elevation-600);
       }
 
       &__head,

--- a/packages/payload/src/admin/components/templates/Default/index.scss
+++ b/packages/payload/src/admin/components/templates/Default/index.scss
@@ -21,7 +21,7 @@
     }
   }
 
-  &__nav-toggler {
+  &__nav-toggler-wrapper {
     position: fixed;
     z-index: var(--z-modal);
     top: 0;
@@ -40,111 +40,30 @@
     position: relative;
   }
 
-  &__nav-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    opacity: 0;
-    background: var(--theme-overlay);
-    padding: 0;
-    border: 0;
-    z-index: var(--z-modal);
-    cursor: pointer;
-    pointer-events: none;
-    display: none;
-  }
-
-  // on large break, push the document off the screen
-  // show an overlay to prevent clicking on the document
-  @include large-break {
-    width: calc(100% + var(--nav-width));
-    transform: translate3d(0, 0, 0);
-
-    &__wrap {
-      transform: translate3d(calc(var(--nav-width) * -1), 0, 0);
-    }
-
-    &__nav-overlay {
-      display: block;
-    }
-
-    &--nav-open {
-      transform: translate3d(0, 0, 0);
-
-      .template-default {
-        &__wrap {
-          pointer-events: none;
-          transform: translate3d(0, 0, 0);
-          transition: transform var(--nav-trans-time) linear;
-        }
-
-        &__nav-overlay {
-          opacity: 1;
-          pointer-events: auto;
-        }
-      }
-    }
-
-    &__nav-toggler {
-      .hamburger {
-        left: calc(var(--base) * 1.25);
-      }
-    }
-  }
-
   @include mid-break {
-    &__nav-toggler {
+    &__nav-toggler-wrapper {
       .hamburger {
-        left: calc(var(--base) * 0.75);
+        left: unset;
       }
     }
   }
 
   @include small-break {
-    &__nav-toggler {
-      .hamburger {
-        left: calc(var(--base) * 0.5);
-      }
-      &.nav-toggler--is-open .hamburger {
-        display: flex;
-        display: inline;
-      }
-    }
-  }
-
-  @include small-break {
-    &__nav-toggler {
-      width: unset;
-      justify-content: unset;
-
-      .hamburger {
-        opacity: none;
-      }
-    }
-
-    &__nav-toggler.nav-toggler--is-open .hamburger {
-      display: flex;
-      display: inline;
-    }
-  }
-
-  @include extra-small-break {
     &--nav-open {
       transition: none;
     }
 
-    &__nav-toggler.nav-toggler--is-open .hamburger {
-      display: none;
+    &__nav-toggler-wrapper {
+      width: unset;
+      justify-content: unset;
+
+      .hamburger {
+        display: none;
+      }
     }
 
     .template-default {
       &__wrap {
-        transition: none;
-      }
-
-      &__nav-overlay {
         transition: none;
       }
     }

--- a/packages/payload/src/admin/components/templates/Default/index.tsx
+++ b/packages/payload/src/admin/components/templates/Default/index.tsx
@@ -44,17 +44,13 @@ const Default: React.FC<Props> = ({ children, className }) => {
         <div className={`${baseClass}__wrap`}>
           <AppHeader />
           {children}
-          <button
-            aria-label={t('close')}
-            className={`${baseClass}__nav-overlay`}
-            onClick={() => setNavOpen(!navOpen)}
-            type="button"
-          />
         </div>
       </div>
-      <NavToggler className={`${baseClass}__nav-toggler`} id="nav-toggler">
-        <Hamburger closeIcon="collapse" isActive={navOpen} />
-      </NavToggler>
+      <div className={`${baseClass}__nav-toggler-wrapper`} id="nav-toggler">
+        <NavToggler className={`${baseClass}__nav-toggler`}>
+          <Hamburger closeIcon="collapse" isActive={navOpen} />
+        </NavToggler>
+      </div>
     </Fragment>
   )
 }

--- a/packages/payload/src/admin/components/views/Global/Default/index.scss
+++ b/packages/payload/src/admin/components/views/Global/Default/index.scss
@@ -3,13 +3,10 @@
 .global-default-edit {
   width: 100%;
   display: flex;
+  --doc-sidebar-width: 325px;
 
   &--has-sidebar {
     .global-default-edit {
-      &__main {
-        width: 66.66%;
-      }
-
       &__edit {
         [dir='ltr'] & {
           top: 0;
@@ -40,6 +37,7 @@
     display: flex;
     flex-direction: column;
     min-height: 100%;
+    flex-grow: 1;
   }
 
   &__edit {
@@ -48,11 +46,16 @@
     flex-grow: 1;
   }
 
+  &__auth {
+    margin-bottom: var(--base);
+  }
+
   &__sidebar-wrap {
     position: sticky;
     top: var(--doc-controls-height);
     width: 33.33%;
     height: calc(100vh - var(--doc-controls-height));
+    min-width: var(--doc-sidebar-width);
   }
 
   &__sidebar {
@@ -71,22 +74,14 @@
     display: flex;
     flex-direction: column;
     gap: var(--base);
-    padding: calc(var(--base) * 1.5) var(--gutter-h) var(--spacing-view-bottom)
-      calc(var(--base) * 2);
+    padding-top: calc(var(--base) * 1.5);
+    padding-left: calc(var(--base) * 2);
+    padding-right: var(--gutter-h);
+    padding-bottom: var(--spacing-view-bottom);
   }
 
   &__label {
     color: var(--theme-elevation-400);
-  }
-
-  @include large-break {
-    &--no-sidebar {
-      .global-default-edit {
-        &__main {
-          width: 100%;
-        }
-      }
-    }
   }
 
   @include mid-break {
@@ -130,6 +125,7 @@
       height: initial;
       border-left: 0;
       margin-top: calc(var(--base) / 2);
+      width: var(--doc-sidebar-width);
     }
 
     &__form {
@@ -158,6 +154,11 @@
   }
 
   @include small-break {
+    &__sidebar-wrap {
+      min-width: initial;
+      width: 100%;
+    }
+
     &__edit {
       padding-top: calc(var(--base) / 2);
     }

--- a/packages/payload/src/admin/components/views/collections/Edit/Default/index.scss
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default/index.scss
@@ -3,13 +3,10 @@
 .collection-default-edit {
   width: 100%;
   display: flex;
+  --doc-sidebar-width: 500px;
 
   &--has-sidebar {
     .collection-default-edit {
-      &__main {
-        width: 66.66%;
-      }
-
       &__edit {
         [dir='ltr'] & {
           top: 0;
@@ -40,6 +37,7 @@
     display: flex;
     flex-direction: column;
     min-height: 100%;
+    flex-grow: 1;
   }
 
   &__edit {
@@ -55,8 +53,9 @@
   &__sidebar-wrap {
     position: sticky;
     top: var(--doc-controls-height);
-    width: 33.33%;
     height: calc(100vh - var(--doc-controls-height));
+    width: var(--doc-sidebar-width);
+    flex-shrink: 0;
   }
 
   &__sidebar {
@@ -83,6 +82,10 @@
 
   &__label {
     color: var(--theme-elevation-400);
+  }
+
+  @include large-break {
+    --doc-sidebar-width: 350px;
   }
 
   @include mid-break {
@@ -154,6 +157,10 @@
   }
 
   @include small-break {
+    &__sidebar-wrap {
+      min-width: initial;
+    }
+
     &__edit {
       padding-top: calc(var(--base) / 2);
     }

--- a/packages/payload/src/admin/scss/app.scss
+++ b/packages/payload/src/admin/scss/app.scss
@@ -40,23 +40,18 @@
   --spacing-view-bottom: var(--gutter-h);
   --app-header-height: calc(var(--base) * 3);
   --doc-controls-height: calc(var(--base) * 3);
-  --nav-width: 300px;
+  --nav-width: 275px;
   --nav-trans-time: 150ms;
 
   @include mid-break {
     --gutter-h: #{base(2)};
     --app-header-height: calc(var(--base) * 2);
     --doc-controls-height: calc(var(--base) * 2.5);
-    // set to xs-breakpoint to achieve a seamless transition to full screen
-    --nav-width: var(--breakpoint-xs-width);
   }
 
   @include small-break {
     --gutter-h: #{base(0.5)};
     --spacing-view-bottom: calc(var(--base) * 2);
-  }
-
-  @include extra-small-break {
     --nav-width: 100vw;
   }
 }


### PR DESCRIPTION
## Description

Refines main navigation within the Admin, here are some of the highlights:

- Removes "shifting" admin when toggling the nav on mid-sized screens, carries desktop behavior down to mobile
- Prevents layout shift in the document sidebar when toggling the main nav
- Better aligns the nav content with the hamburger icon
- Prevents the hamburger icon from shifting when the window is resized
- Increase the size of the hamburger icon and adds hover style
- Adjusts the hitbox of the hamburger icon so it doesn't collide with the the "home" breadcrumb
- Refines the account icon with a subtle border

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
