### PR TITLE
fix(richtext-lexical): Blocks Field: Sub-forms being re-rendered unnecessarily

### DIFF
--- a/packages/payload/src/admin/components/forms/RenderFields/index.tsx
+++ b/packages/payload/src/admin/components/forms/RenderFields/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { Props } from './types'
@@ -44,6 +44,14 @@ const RenderFields: React.FC<Props> = (props) => {
   const shouldRender = forceRender || isIntersecting || isAboveViewport
   const operation = useOperation()
 
+  const actualDivRef = useRef(null)
+
+  useEffect(() => {
+    if (!forceRender && actualDivRef.current) {
+      intersectionRef(actualDivRef.current)
+    }
+  }, [forceRender, actualDivRef, intersectionRef])
+
   useEffect(() => {
     if (shouldRender && !hasRendered) {
       setHasRendered(true)
@@ -76,7 +84,7 @@ const RenderFields: React.FC<Props> = (props) => {
         ]
           .filter(Boolean)
           .join(' ')}
-        ref={intersectionRef}
+        ref={actualDivRef}
       >
         {hasRendered &&
           fieldsToRender.map((reducedField, fieldIndex) => {

--- a/packages/payload/src/admin/components/forms/RenderFields/index.tsx
+++ b/packages/payload/src/admin/components/forms/RenderFields/index.tsx
@@ -113,6 +113,7 @@ const RenderFields: React.FC<Props> = (props) => {
                       readOnly,
                     },
                     fieldTypes,
+                    forceRender,
                     indexPath:
                       'indexPath' in props ? `${props?.indexPath}.${fieldIndex}` : `${fieldIndex}`,
                     path: field.path || (isFieldAffectingData && 'name' in field ? field.name : ''),

--- a/packages/payload/src/admin/components/forms/RenderFields/index.tsx
+++ b/packages/payload/src/admin/components/forms/RenderFields/index.tsx
@@ -37,20 +37,12 @@ const RenderFields: React.FC<Props> = (props) => {
 
   const { i18n, t } = useTranslation('general')
   const [hasRendered, setHasRendered] = useState(Boolean(forceRender))
-  const [intersectionRef, entry] = useIntersect(intersectionObserverOptions)
+  const [intersectionRef, entry] = useIntersect(intersectionObserverOptions, forceRender)
 
   const isIntersecting = Boolean(entry?.isIntersecting)
   const isAboveViewport = entry?.boundingClientRect?.top < 0
   const shouldRender = forceRender || isIntersecting || isAboveViewport
   const operation = useOperation()
-
-  const actualDivRef = useRef(null)
-
-  useEffect(() => {
-    if (!forceRender && actualDivRef.current) {
-      intersectionRef(actualDivRef.current)
-    }
-  }, [forceRender, actualDivRef, intersectionRef])
 
   useEffect(() => {
     if (shouldRender && !hasRendered) {
@@ -84,7 +76,7 @@ const RenderFields: React.FC<Props> = (props) => {
         ]
           .filter(Boolean)
           .join(' ')}
-        ref={actualDivRef}
+        ref={intersectionRef}
       >
         {hasRendered &&
           fieldsToRender.map((reducedField, fieldIndex) => {

--- a/packages/payload/src/admin/components/forms/field-types/Array/ArrayRow.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/ArrayRow.tsx
@@ -24,6 +24,7 @@ type ArrayRowProps = UseDraggableSortableReturn &
     CustomRowLabel?: RowLabelType
     addRow: (rowIndex: number) => void
     duplicateRow: (rowIndex: number) => void
+    forceRender?: boolean
     hasMaxRows?: boolean
     moveRow: (fromIndex: number, toIndex: number) => void
     readOnly?: boolean
@@ -40,6 +41,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
   duplicateRow,
   fieldTypes,
   fields,
+  forceRender = false,
   hasMaxRows,
   indexPath,
   labels,
@@ -126,10 +128,11 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
             path: createNestedFieldPath(path, field),
           }))}
           fieldTypes={fieldTypes}
+          forceRender={forceRender}
           indexPath={indexPath}
+          margins="small"
           permissions={permissions?.fields}
           readOnly={readOnly}
-          margins="small"
         />
       </Collapsible>
     </div>

--- a/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
@@ -32,6 +32,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
     admin: { className, components, condition, description, readOnly },
     fieldTypes,
     fields,
+    forceRender = false,
     indexPath,
     localized,
     maxRows,
@@ -234,6 +235,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
                   duplicateRow={duplicateRow}
                   fieldTypes={fieldTypes}
                   fields={fields}
+                  forceRender={forceRender}
                   hasMaxRows={hasMaxRows}
                   indexPath={indexPath}
                   labels={labels}

--- a/packages/payload/src/admin/components/forms/field-types/Array/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Array/types.ts
@@ -4,6 +4,7 @@ import type { ArrayField } from '../../../../../fields/config/types'
 
 export type Props = Omit<ArrayField, 'type'> & {
   fieldTypes: FieldTypes
+  forceRender?: boolean
   indexPath: string
   label: false | string
   path?: string

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/BlockRow.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/BlockRow.tsx
@@ -24,6 +24,7 @@ type BlockFieldProps = UseDraggableSortableReturn &
     addRow: (rowIndex: number, blockType: string) => void
     blockToRender: Block
     duplicateRow: (rowIndex: number) => void
+    forceRender?: boolean
     hasMaxRows?: boolean
     moveRow: (fromIndex: number, toIndex: number) => void
     readOnly: boolean
@@ -40,6 +41,7 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
   blocks,
   duplicateRow,
   fieldTypes,
+  forceRender,
   hasMaxRows,
   indexPath,
   labels,
@@ -130,6 +132,7 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
             path: createNestedFieldPath(path, field),
           }))}
           fieldTypes={fieldTypes}
+          forceRender={forceRender}
           indexPath={indexPath}
           margins="small"
           permissions={permissions?.blocks?.[row.blockType]?.fields}

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -37,6 +37,7 @@ const BlocksField: React.FC<Props> = (props) => {
     admin: { className, condition, description, readOnly },
     blocks,
     fieldTypes,
+    forceRender = false,
     indexPath,
     label,
     labels: labelsFromProps,
@@ -238,6 +239,7 @@ const BlocksField: React.FC<Props> = (props) => {
                       blocks={blocks}
                       duplicateRow={duplicateRow}
                       fieldTypes={fieldTypes}
+                      forceRender={forceRender}
                       hasMaxRows={hasMaxRows}
                       indexPath={indexPath}
                       labels={labels}

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/types.ts
@@ -4,6 +4,7 @@ import type { BlockField } from '../../../../../fields/config/types'
 
 export type Props = Omit<BlockField, 'type'> & {
   fieldTypes: FieldTypes
+  forceRender?: boolean
   indexPath: string
   path?: string
   permissions: FieldPermissions

--- a/packages/payload/src/admin/components/forms/field-types/Group/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Group/index.tsx
@@ -14,9 +14,9 @@ import { WatchChildErrors } from '../../WatchChildErrors'
 import withCondition from '../../withCondition'
 import { useRow } from '../Row/provider'
 import { useTabs } from '../Tabs/provider'
+import { fieldBaseClass } from '../shared'
 import './index.scss'
 import { GroupProvider, useGroup } from './provider'
-import { fieldBaseClass } from '../shared'
 
 const baseClass = 'group-field'
 
@@ -26,6 +26,7 @@ const Group: React.FC<Props> = (props) => {
     admin: { className, description, hideGutter = false, readOnly, style, width },
     fieldTypes,
     fields,
+    forceRender = false,
     indexPath,
     label,
     path: pathFromProps,
@@ -88,6 +89,7 @@ const Group: React.FC<Props> = (props) => {
               path: createNestedFieldPath(path, subField),
             }))}
             fieldTypes={fieldTypes}
+            forceRender={forceRender}
             indexPath={indexPath}
             margins="small"
             permissions={permissions?.fields}

--- a/packages/payload/src/admin/components/forms/field-types/Group/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Group/types.ts
@@ -4,6 +4,7 @@ import type { GroupField } from '../../../../../fields/config/types'
 
 export type Props = Omit<GroupField, 'type'> & {
   fieldTypes: FieldTypes
+  forceRender?: boolean
   indexPath: string
   path?: string
   permissions: FieldPermissions

--- a/packages/payload/src/admin/components/forms/field-types/Row/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Row/index.tsx
@@ -14,6 +14,7 @@ const Row: React.FC<Props> = (props) => {
     admin: { className, readOnly },
     fieldTypes,
     fields,
+    forceRender = false,
     indexPath,
     path,
     permissions,
@@ -28,6 +29,7 @@ const Row: React.FC<Props> = (props) => {
           path: createNestedFieldPath(path, field),
         }))}
         fieldTypes={fieldTypes}
+        forceRender={forceRender}
         indexPath={indexPath}
         permissions={permissions}
         readOnly={readOnly}

--- a/packages/payload/src/admin/components/forms/field-types/Row/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Row/types.ts
@@ -4,6 +4,7 @@ import type { RowField } from '../../../../../fields/config/types'
 
 export type Props = Omit<RowField, 'type'> & {
   fieldTypes: FieldTypes
+  forceRender?: boolean
   indexPath: string
   path?: string
   permissions: FieldPermissions

--- a/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
@@ -18,9 +18,9 @@ import { createNestedFieldPath } from '../../Form/createNestedFieldPath'
 import RenderFields from '../../RenderFields'
 import { WatchChildErrors } from '../../WatchChildErrors'
 import withCondition from '../../withCondition'
+import { fieldBaseClass } from '../shared'
 import './index.scss'
 import { TabsProvider } from './provider'
-import { fieldBaseClass } from '../shared'
 
 const baseClass = 'tabs-field'
 
@@ -72,6 +72,7 @@ const TabsField: React.FC<Props> = (props) => {
   const {
     admin: { className, readOnly },
     fieldTypes,
+    forceRender = false,
     indexPath,
     path,
     permissions,
@@ -188,7 +189,7 @@ const TabsField: React.FC<Props> = (props) => {
                     }
                   })}
                   fieldTypes={fieldTypes}
-                  forceRender
+                  forceRender={forceRender}
                   indexPath={indexPath}
                   key={String(activeTabConfig.label)}
                   margins="small"

--- a/packages/payload/src/admin/components/forms/field-types/Tabs/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Tabs/types.ts
@@ -4,6 +4,7 @@ import type { TabsField } from '../../../../../fields/config/types'
 
 export type Props = Omit<TabsField, 'type'> & {
   fieldTypes: FieldTypes
+  forceRender?: boolean
   indexPath: string
   path?: string
   permissions: FieldPermissions

--- a/packages/payload/src/admin/hooks/useIntersect.tsx
+++ b/packages/payload/src/admin/hooks/useIntersect.tsx
@@ -3,7 +3,10 @@ import { useEffect, useRef, useState } from 'react'
 
 type Intersect = [setNode: React.Dispatch<Element>, entry: IntersectionObserverEntry]
 
-const useIntersect = ({ root = null, rootMargin = '0px', threshold = 0 } = {}): Intersect => {
+const useIntersect = (
+  { root = null, rootMargin = '0px', threshold = 0 } = {},
+  disable?: boolean,
+): Intersect => {
   const [entry, updateEntry] = useState<IntersectionObserverEntry>()
   const [node, setNode] = useState(null)
 
@@ -16,13 +19,16 @@ const useIntersect = ({ root = null, rootMargin = '0px', threshold = 0 } = {}): 
   )
 
   useEffect(() => {
+    if (disable) {
+      return
+    }
     const { current: currentObserver } = observer
     currentObserver.disconnect()
 
     if (node) currentObserver.observe(node)
 
     return () => currentObserver.disconnect()
-  }, [node])
+  }, [node, disable])
 
   return [setNode, entry]
 }

--- a/packages/richtext-lexical/src/field/features/Blocks/component/BlockContent.tsx
+++ b/packages/richtext-lexical/src/field/features/Blocks/component/BlockContent.tsx
@@ -163,6 +163,7 @@ export const BlockContent: React.FC<Props> = (props) => {
             path: createNestedFieldPath(null, field),
           }))}
           fieldTypes={field.fieldTypes}
+          forceRender
           margins="small"
           permissions={field.permissions?.blocks?.[fields?.data?.blockType]?.fields}
           readOnly={field.admin.readOnly}


### PR DESCRIPTION
## Description

Fixes #3683

**2 Changes:**

- Previously, even with `forceRender` set to true in RenderFields, the component would still unnecessarily re-render, due to the useIntersect hook. I made some changes which prevent that. Should be a good, general improvement.
- All forms, sub-forms, sub-sub-forms etc. in Lexical's Blocks Field now have `forceRender` set to true. This fixes the issue mentioned in the issue

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
