### PR TITLE
feat(live-preview): caches field schema

### DIFF
--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -1,5 +1,11 @@
 import { mergeData } from '.'
 
+// For performance reasons, `fieldSchemaJSON` will only be sent once on the initial message
+// We need to cache this value so that it can be used across subsequent messages
+// To do this, save `fieldSchemaJSON` when it arrives as a global variable
+// Send this cached value to `mergeData`, instead of `eventData.fieldSchemaJSON` directly
+let payloadLivePreviewFieldSchema = undefined // TODO: type this from `fieldSchemaToJSON` return type
+
 export const handleMessage = async <T>(args: {
   depth: number
   event: MessageEvent
@@ -11,9 +17,13 @@ export const handleMessage = async <T>(args: {
     const eventData = JSON.parse(event?.data)
 
     if (eventData.type === 'payload-live-preview') {
+      if (!payloadLivePreviewFieldSchema && eventData.fieldSchemaJSON) {
+        payloadLivePreviewFieldSchema = eventData.fieldSchemaJSON
+      }
+
       const mergedData = await mergeData<T>({
         depth,
-        fieldSchema: eventData.fieldSchemaJSON,
+        fieldSchema: payloadLivePreviewFieldSchema,
         incomingData: eventData.data,
         initialData,
         serverURL,

--- a/packages/live-preview/src/ready.ts
+++ b/packages/live-preview/src/ready.ts
@@ -2,11 +2,14 @@ export const ready = (args: { serverURL: string }): void => {
   const { serverURL } = args
 
   if (typeof window !== 'undefined') {
-    // This subscription may have been from either an iframe `src` or `window.open()`
-    // i.e. `window?.opener` || `window?.parent`
-    window?.opener?.postMessage(
+    // This subscription may have been from either an iframe or a popup
+    // We need to report 'ready' to the parent window, whichever it may be
+    // i.e. `window?.opener` for popups, `window?.parent` for iframes
+    const windowToPostTo: Window = window?.opener || window?.parent
+
+    windowToPostTo?.postMessage(
       JSON.stringify({
-        popupReady: true,
+        ready: true,
         type: 'payload-live-preview',
       }),
       serverURL,

--- a/packages/live-preview/src/subscribe.ts
+++ b/packages/live-preview/src/subscribe.ts
@@ -9,7 +9,7 @@ export const subscribe = <T>(args: {
   const { callback, depth, initialData, serverURL } = args
 
   const onMessage = async (event: MessageEvent) => {
-    const mergedData = await handleMessage({ depth, event, initialData, serverURL })
+    const mergedData = await handleMessage<T>({ depth, event, initialData, serverURL })
     callback(mergedData)
   }
 


### PR DESCRIPTION
## Description

Caches `eventData.fieldSchemaJSON` so that it only has to be sent across `window.postMessage` once. Field schemas are potentially large and so this will significantly cut message sizes.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
