### PR TITLE
chore(templates): fix e-commerce template jsx component type error

### DIFF
--- a/templates/ecommerce/src/app/_components/Media/index.tsx
+++ b/templates/ecommerce/src/app/_components/Media/index.tsx
@@ -18,11 +18,7 @@ export const Media: React.FC<Props> = props => {
           }
         : {})}
     >
-      {isVideo ? (
-        <Video {...props} />
-      ) : (
-        <Image {...props} /> // eslint-disable-line
-      )}
+      {isVideo ? <Video {...props} /> : <Image {...props} />}
     </Tag>
   )
 }

--- a/templates/ecommerce/tsconfig.json
+++ b/templates/ecommerce/tsconfig.json
@@ -22,7 +22,10 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "paths": {
+      "react": ["./node_modules/@types/react"],
+    }
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
## Description

Patch e-commerce template yarn build fails due to "Tag' cannot be used as a JSX component."

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Change to the [templates](../templates/) directory (does not affect core functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
