### PR TITLE
Added the new option typing for incoming upload type used by Collecti…

### DIFF
--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -74,6 +74,7 @@ export type IncomingUploadType = {
   staticOptions?: serveStatic.ServeStaticOptions<express.Response<any, Record<string, any>>>
   staticURL?: string
   trimOptions?: ImageUploadTrimOptions
+  filesRequiredOnCreate?: boolean
 }
 
 export type Upload = {


### PR DESCRIPTION
…onConfig

## Description

I just needed to add this type to the incominguploadtype. Previously there was a merged feature to add an option to not require file data to user media.

- [X ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ X] Chore (non-breaking change which does not add functionality)
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [] I have added tests that prove my fix is effective or that my feature works
- [X ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
