### PR TITLE
chore: replaces bg blur in document controls

### DIFF
--- a/packages/payload/src/admin/components/elements/DocumentControls/index.scss
+++ b/packages/payload/src/admin/components/elements/DocumentControls/index.scss
@@ -9,7 +9,7 @@
   display: flex;
   align-items: center;
 
-  &::after {
+  &__divider {
     content: '';
     display: block;
     position: absolute;

--- a/packages/payload/src/admin/components/elements/DocumentControls/index.tsx
+++ b/packages/payload/src/admin/components/elements/DocumentControls/index.tsx
@@ -225,6 +225,7 @@ export const DocumentControls: React.FC<{
           )}
         </div>
       </div>
+      <div className={`${baseClass}__divider`} />
     </Gutter>
   )
 }


### PR DESCRIPTION
## Description

The `DocumentControls` component was not properly blurring its background because a pseudo-element within the component's stylesheet was overriding the `::after` required for the `blur-bg` SCSS mixin to take effect.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
