### PR TITLE
fix: render date test failed for AEST & ACDT timezones

### DIFF
--- a/packages/payload/src/admin/components/views/collections/List/Cell/cellTypes.spec.tsx
+++ b/packages/payload/src/admin/components/views/collections/List/Cell/cellTypes.spec.tsx
@@ -83,7 +83,7 @@ describe('Cell Types', () => {
     it('renders date', () => {
       const timeStamp = '2020-10-06T14:07:39.033Z'
       const { container } = render(<DateCell data={timeStamp} field={field} />)
-      const dateMatch = /October\s6th\s2020,\s\d{1,2}:07\s[A|P]M/ // Had to account for timezones in CI
+      const dateMatch = /October\s[6|7]th\s2020,\s\d{1,2}:[0|3]7\s[A|P]M/ // Had to account for timezones in CI
       const el = container.querySelector('span')
       expect(el.textContent).toMatch(dateMatch)
     })


### PR DESCRIPTION
## Description

fix: test was failing for Australian timezones - AEST which renders time as October 7th, 12:07AM - and ACDT which would render as October 7th, 12:37AM. Modified regex to allow 6th / 7th and :07 and :37 in the rendered string

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
