### PR TITLE
fix: updates req after file crop / resize

### DIFF
--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -187,6 +187,7 @@ export const generateFileData = async <T>({
       fileData.width = info.width
       fileData.height = info.height
       fileData.filesize = info.size
+      req.files.file = fileForResize
     } else {
       filesToSave.push({
         buffer: fileBuffer?.data || file.data,


### PR DESCRIPTION
## Description

Closes #3725 

Updated files on the `req` after crop / resizing - necessary for the cloud storage plugin to access the latest images.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
