### PR TITLE
chore: updates hover styles for list control and file detail buttons

### DIFF
--- a/packages/payload/src/admin/components/elements/FileDetails/index.scss
+++ b/packages/payload/src/admin/components/elements/FileDetails/index.scss
@@ -1,7 +1,7 @@
 @import '../../../scss/styles.scss';
 
 .file-details {
-  background-color: var(--theme-elevation-100);
+  background-color: var(--theme-elevation-50);
 
   header {
     display: flex;

--- a/packages/payload/src/admin/components/elements/ListControls/index.scss
+++ b/packages/payload/src/admin/components/elements/ListControls/index.scss
@@ -28,14 +28,11 @@
       margin-left: base(0.5);
     }
 
-    .btn {
-      background-color: var(--theme-elevation-100);
-      cursor: pointer;
-      padding: 0 base(0.25);
-      border-radius: $style-radius-s;
+    .pill {
+      background-color: var(--theme-elevation-200);
 
       &:hover {
-        background-color: var(--theme-elevation-200);
+        background-color: var(--theme-elevation-150);
       }
     }
   }

--- a/packages/payload/src/admin/components/elements/ListControls/index.tsx
+++ b/packages/payload/src/admin/components/elements/ListControls/index.tsx
@@ -128,17 +128,16 @@ const ListControls: React.FC<Props> = (props) => {
               {t('filters')}
             </Pill>
             {enableSort && (
-              <Button
+              <Pill
                 aria-controls={`${baseClass}-sort`}
                 aria-expanded={visibleDrawer === 'sort'}
-                buttonStyle={visibleDrawer === 'sort' ? undefined : 'secondary'}
                 className={`${baseClass}__toggle-sort`}
-                icon="chevron"
-                iconStyle="none"
+                icon={<Chevron />}
                 onClick={() => setVisibleDrawer(visibleDrawer !== 'sort' ? 'sort' : undefined)}
+                pillStyle="light"
               >
                 {t('sort')}
-              </Button>
+              </Pill>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Description

Updates button background color on hover so it's less similar to the bg.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Chore (non-breaking change which does not add functionality)


**File details** (button on the left is hovered)
Before:
<img width="510" alt="file-before-light" src="https://github.com/payloadcms/payload/assets/67977755/4be9c144-6312-4275-a6d5-300e372dd10f">
After:
<img width="514" alt="file-after-light" src="https://github.com/payloadcms/payload/assets/67977755/365cdb3a-31b7-41c9-a9a5-4aeaa4237bfb">

Before:
<img width="503" alt="file-before-dark" src="https://github.com/payloadcms/payload/assets/67977755/857b7671-c70f-4368-a8b4-458b1802ece9">
After:
<img width="481" alt="file-after-dark" src="https://github.com/payloadcms/payload/assets/67977755/20997d33-14e4-4b86-b0d6-eda58b76630d">

**List Controls** (button on the far left is hovered)
Before:
<img width="321" alt="before-light" src="https://github.com/payloadcms/payload/assets/67977755/10ae6fd1-fdcb-4f44-84f5-97a0c8116873">
After:
<img width="310" alt="after-light" src="https://github.com/payloadcms/payload/assets/67977755/b7d82da1-9d63-4f2e-9106-e65250b58819">

Before:
<img width="315" alt="before-dark" src="https://github.com/payloadcms/payload/assets/67977755/964e634d-5609-4a45-a164-80146cbc8b0f">
After:
<img width="332" alt="after-dark" src="https://github.com/payloadcms/payload/assets/67977755/b5348a6d-2ee9-41fd-bfdc-a08b12e349a7">