### PR TITLE
fix(examples): ensures next middleware is built, removes dotenv alias

### DIFF
--- a/examples/custom-server/src/payload.config.ts
+++ b/examples/custom-server/src/payload.config.ts
@@ -21,16 +21,6 @@ export default buildConfig({
     components: {
       beforeLogin: [BeforeLogin],
     },
-    webpack: config => ({
-      ...config,
-      resolve: {
-        ...config.resolve,
-        alias: {
-          ...config.resolve.alias,
-          dotenv: path.resolve(__dirname, './dotenv.js'),
-        },
-      },
-    }),
   },
   editor: slateEditor({}),
   db: mongooseAdapter({

--- a/examples/custom-server/src/server.ts
+++ b/examples/custom-server/src/server.ts
@@ -29,7 +29,7 @@ const start = async (): Promise<void> => {
     app.listen(PORT, async () => {
       payload.logger.info(`Next.js is now building...`)
       // @ts-expect-error
-      await nextBuild(path.join(__dirname, '../'))
+      await nextBuild(path.join(__dirname, '..'))
       process.exit()
     })
 


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/3653

Next was not including middleware due to a trailing slash being passing into their build function.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Change to the [examples](../examples/) directory (does not affect core functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
