### PR TITLE
fix: issue where dragging unsortable item would crash the page

### DIFF
--- a/packages/payload/src/admin/components/elements/ReactSelect/MultiValue/index.tsx
+++ b/packages/payload/src/admin/components/elements/ReactSelect/MultiValue/index.tsx
@@ -16,7 +16,7 @@ export const MultiValue: React.FC<MultiValueProps<Option>> = (props) => {
     innerProps,
     isDisabled,
     // @ts-expect-error // TODO Fix this - moduleResolution 16 breaks our declare module
-    selectProps: { customProps: { disableMouseDown, isSortable } = {} } = {},
+    selectProps: { customProps: { disableMouseDown } = {}, isSortable } = {},
   } = props
 
   const { attributes, isDragging, listeners, setNodeRef, transform } = useDraggableSortable({

--- a/packages/payload/src/admin/components/elements/ReactSelect/MultiValue/index.tsx
+++ b/packages/payload/src/admin/components/elements/ReactSelect/MultiValue/index.tsx
@@ -16,11 +16,12 @@ export const MultiValue: React.FC<MultiValueProps<Option>> = (props) => {
     innerProps,
     isDisabled,
     // @ts-expect-error // TODO Fix this - moduleResolution 16 breaks our declare module
-    selectProps: { customProps: { disableMouseDown } = {} } = {},
+    selectProps: { customProps: { disableMouseDown, isSortable } = {} } = {},
   } = props
 
   const { attributes, isDragging, listeners, setNodeRef, transform } = useDraggableSortable({
     id: value.toString(),
+    disabled: !isSortable,
   })
 
   const classes = [

--- a/packages/payload/src/admin/components/elements/ReactSelect/index.tsx
+++ b/packages/payload/src/admin/components/elements/ReactSelect/index.tsx
@@ -33,6 +33,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
   const {
     className,
     components,
+    customProps,
     disabled = false,
     filterOption = undefined,
     isClearable = true,
@@ -45,7 +46,6 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     onMenuOpen,
     options,
     placeholder = t('general:selectValue'),
-    selectProps,
     showError,
     value,
   } = props
@@ -58,7 +58,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     return (
       <Select
         captureMenuScroll
-        customProps={selectProps}
+        customProps={customProps}
         isLoading={isLoading}
         placeholder={getTranslation(placeholder, i18n)}
         {...props}

--- a/packages/payload/src/admin/components/elements/ReactSelect/types.ts
+++ b/packages/payload/src/admin/components/elements/ReactSelect/types.ts
@@ -78,10 +78,6 @@ export type Props = {
   onMenuScrollToBottom?: () => void
   options: Option[] | OptionGroup[]
   placeholder?: string
-  /**
-   * @deprecated Since version 1.0. Will be deleted in version 2.0. Use customProps instead.
-   */
-  selectProps?: CustomSelectProps
   showError?: boolean
   value?: Option | Option[]
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/3299

When `isSortable` was set to false, attempting to drag an item would crash the admin panel.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
