### PR TITLE
Retry DB connects with configurable timeout

### DIFF
--- a/packages/db-mongodb/src/connect.ts
+++ b/packages/db-mongodb/src/connect.ts
@@ -45,17 +45,12 @@ export const connect: Connect = async function connect(this: MongooseAdapter, pa
     }
   }
 
-  try {
-    this.connection = (await mongoose.connect(urlToConnect, connectionOptions)).connection
+  this.connection = (await mongoose.connect(urlToConnect, connectionOptions)).connection
 
-    if (process.env.PAYLOAD_DROP_DATABASE === 'true') {
-      this.payload.logger.info('---- DROPPING DATABASE ----')
-      await mongoose.connection.dropDatabase()
-      this.payload.logger.info('---- DROPPED DATABASE ----')
-    }
-    this.payload.logger.info(successfulConnectionMessage)
-  } catch (err) {
-    this.payload.logger.error(`Error: cannot connect to MongoDB. Details: ${err.message}`, err)
-    process.exit(1)
+  if (process.env.PAYLOAD_DROP_DATABASE === 'true') {
+    this.payload.logger.info('---- DROPPING DATABASE ----')
+    await mongoose.connection.dropDatabase()
+    this.payload.logger.info('---- DROPPED DATABASE ----')
   }
+  this.payload.logger.info(successfulConnectionMessage)
 }

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -46,6 +46,7 @@ export interface Args {
     /** Set false to disable $facet aggregation in non-supporting databases, Defaults to true */
     useFacet?: boolean
   }
+  connectTimeout?: number
   migrationDir?: string
   /** The URL to connect to MongoDB or false to start payload and prevent connecting */
   url: false | string
@@ -87,6 +88,7 @@ declare module 'payload' {
 export function mongooseAdapter({
   autoPluralization = true,
   connectOptions,
+  connectTimeout = 10,
   migrationDir: migrationDirArg,
   url,
 }: Args): MongooseAdapterResult {
@@ -99,6 +101,7 @@ export function mongooseAdapter({
 
     return createDatabaseAdapter<MongooseAdapter>({
       name: 'mongoose',
+      connectTimeout: connectTimeout,
 
       // Mongoose-specific
       autoPluralization,

--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -15,20 +15,15 @@ export const connect: Connect = async function connect(this: PostgresAdapter, pa
     ...this.enums,
   }
 
-  try {
-    this.pool = new Pool(this.poolOptions)
-    await this.pool.connect()
+  this.pool = new Pool(this.poolOptions)
+  await this.pool.connect()
 
-    this.drizzle = drizzle(this.pool, { schema: this.schema })
-    if (process.env.PAYLOAD_DROP_DATABASE === 'true') {
-      this.payload.logger.info('---- DROPPING TABLES ----')
-      await this.drizzle.execute(sql`drop schema public cascade;
+  this.drizzle = drizzle(this.pool, { schema: this.schema })
+  if (process.env.PAYLOAD_DROP_DATABASE === 'true') {
+    this.payload.logger.info('---- DROPPING TABLES ----')
+    await this.drizzle.execute(sql`drop schema public cascade;
       create schema public;`)
-      this.payload.logger.info('---- DROPPED TABLES ----')
-    }
-  } catch (err) {
-    payload.logger.error(`Error: cannot connect to Postgres. Details: ${err.message}`, err)
-    process.exit(1)
+    this.payload.logger.info('---- DROPPED TABLES ----')
   }
 
   // Only push schema if not in production

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -49,6 +49,7 @@ export function postgresAdapter(args: Args): PostgresAdapterResult {
 
     return createDatabaseAdapter<PostgresAdapter>({
       name: 'postgres',
+      connectTimeout: args.connectTimeout || 10,
 
       // Postgres-specific
       drizzle: undefined,

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -14,6 +14,7 @@ import type { Pool, PoolConfig } from 'pg'
 export type DrizzleDB = NodePgDatabase<Record<string, unknown>>
 
 export type Args = {
+  connectTimeout?: number
   migrationDir?: string
   pool: PoolConfig
   push?: boolean

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -22,6 +22,8 @@ export interface BaseDatabaseAdapter {
    */
   connect?: Connect
 
+  connectTimeout?: number
+
   create: Create
 
   createGlobal: CreateGlobal


### PR DESCRIPTION
## Description

- Don't let DB `connect` method kill the main process when not able to connect to DB
- Instead retry connecting in main `init` method until a configurable timeout is reached (defaults to 10s)

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
