### PR TITLE
fix: live preview ready event

### DIFF
--- a/packages/payload/src/admin/components/views/LivePreview/Context/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Context/index.tsx
@@ -125,10 +125,12 @@ export const LivePreviewProvider: React.FC<LivePreviewProviderProps> = (props) =
   // Unlike iframe elements which have an `onLoad` handler, there is no way to access `window.open` on popups
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      const data = JSON.parse(event.data)
+      if (url.startsWith(event.origin)) {
+        const data = JSON.parse(event.data)
 
-      if (url.startsWith(event.origin) && data.type === 'payload-live-preview' && data.ready) {
-        setAppIsReady(true)
+        if (data.type === 'payload-live-preview' && data.ready) {
+          setAppIsReady(true)
+        }
       }
     }
 


### PR DESCRIPTION
## Description

Some browser plugins send postMessages to payload. The JSON.parse method will fail on these messages.

Not exactly this issue https://github.com/payloadcms/payload/issues/3779, but the same problem. 
Probably an addition to https://github.com/payloadcms/payload/pull/3781

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
