### PR TITLE
fix(templates/website): missing env vars

### DIFF
--- a/templates/website/.env.example
+++ b/templates/website/.env.example
@@ -1,6 +1,14 @@
+# Payload vars
 PORT=3000
 DATABASE_URI=mongodb://127.0.0.1/payload-template-website
 PAYLOAD_SECRET=3c543dbf662b4d12d8e30854
 PAYLOAD_PUBLIC_SERVER_URL=http://localhost:3000
-PAYLOAD_PUBLIC_SITE_URL=http://localhost:3000
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
+PAYLOAD_PUBLIC_DRAFT_SECRET=demo-draft-secret
+REVALIDATION_KEY=demo-revalation-key
+
+# Next.js vars
+NEXT_PUBLIC_SERVER_URL=http://localhost:3000
+NEXT_PUBLIC_IS_LIVE=
+NEXT_PRIVATE_DRAFT_SECRET=demo-draft-secret
+NEXT_PRIVATE_REVALIDATION_KEY=demo-revalation-key

--- a/templates/website/.env.example
+++ b/templates/website/.env.example
@@ -3,7 +3,6 @@ PORT=3000
 DATABASE_URI=mongodb://127.0.0.1/payload-template-website
 PAYLOAD_SECRET=3c543dbf662b4d12d8e30854
 PAYLOAD_PUBLIC_SERVER_URL=http://localhost:3000
-NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 PAYLOAD_PUBLIC_DRAFT_SECRET=demo-draft-secret
 REVALIDATION_KEY=demo-revalation-key
 

--- a/templates/website/src/payload/hooks/revalidatePage.ts
+++ b/templates/website/src/payload/hooks/revalidatePage.ts
@@ -3,7 +3,7 @@ import type { AfterChangeHook } from 'payload/dist/collections/config/types'
 // ensure that the home page is revalidated at '/' instead of '/home'
 export const formatAppURL = ({ doc }): string => {
   const pathToUse = doc.slug === 'home' ? '' : doc.slug
-  const { pathname } = new URL(`${process.env.PAYLOAD_PUBLIC_SITE_URL}/${pathToUse}`)
+  const { pathname } = new URL(`${process.env.PAYLOAD_PUBLIC_SERVER_URL}/${pathToUse}`)
   return pathname
 }
 
@@ -16,7 +16,7 @@ export const revalidatePage: AfterChangeHook = ({ doc, req }) => {
     try {
       url = formatAppURL({ doc })
       const res = await fetch(
-        `${process.env.PAYLOAD_PUBLIC_SITE_URL}/api/revalidate?secret=${process.env.REVALIDATION_KEY}&revalidatePath=${url}`,
+        `${process.env.PAYLOAD_PUBLIC_SERVER_URL}/api/revalidate?secret=${process.env.REVALIDATION_KEY}&revalidatePath=${url}`,
       )
 
       if (res.ok) {


### PR DESCRIPTION
## Description

Closes #3794. The `.env` within the [Website Template](https://github.com/payloadcms/payload/tree/main/templates/website) has missing vars. These had gone missing at some point, this PR adds them back.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Change to the [templates](../templates/) directory (does not affect core functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
