### PR TITLE
docs: slate linebreak serialization in 'Generating HTML' example

### DIFF
--- a/docs/rich-text/slate.mdx
+++ b/docs/rich-text/slate.mdx
@@ -266,6 +266,10 @@ const serialize = (children) =>
         text = <em key={i}>{text}</em>;
       }
 
+      if (node.text === '') {
+        text = <br />;
+      }
+
       // Handle other leaf types here...
 
       return <Fragment key={i}>{text}</Fragment>;


### PR DESCRIPTION
## Description

**Summary:** Line breaks aren't rendered properly based on the current Rich Text serializer example for Slate. I think this would be a great addition for the docs since the current recommendation's linebreaks don't really match what's inputted from Payload.

Example:

| Input in the Editor |
|--------|
| ![image](https://github.com/payloadcms/payload/assets/38070918/9b2ae95e-26e9-468a-adf1-48dd92c45bbe) | 

| ❌ Result **Before** the change | ![image](https://github.com/payloadcms/payload/assets/38070918/5496bf90-6531-4811-92ee-d8e30d8c1b27) |
|--------|--------|
| ✅ Result **After** the change | ![image](https://github.com/payloadcms/payload/assets/38070918/1b72637e-a09d-44ee-864b-1772ba3de5a9) | 

I feel that the second one is the expected result that most people want.

### There is a way to add line breaks without adding this change (but not good)
While testing, I also noticed that pressing [**SHIFT + ENTER**] on the Slate Editor in Payload is what actually adds "line breaks" (but it's still within one text node, so it doesn't actually create a "new node", it just adds '\n' to the same text node. 
- ❌ It feels counterintuitive to tell the content managers to use that Hotkey every time they write an article and want to add spacing between paragraphs. 
- ❌ It's also hard to check which parts I used **SHIFT + ENTER** on the UX side because there's no visual feedback (it looks exactly the same as pressing ENTER).

### Related Community Help Threads on Discord: 
- https://discord.com/channels/967097582721572934/1165352935992086689
- https://discord.com/channels/967097582721572934/1165367035082063963

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation