### PR TITLE
fix: adjust DocumentFields BeforeFields and AfterFields re-rendering

### DIFF
--- a/packages/payload/src/admin/components/elements/DocumentFields/index.tsx
+++ b/packages/payload/src/admin/components/elements/DocumentFields/index.tsx
@@ -14,8 +14,8 @@ import './index.scss'
 const baseClass = 'document-fields'
 
 export const DocumentFields: React.FC<{
-  AfterFields?: React.FC
-  BeforeFields?: React.FC
+  AfterFields?: React.ReactNode
+  BeforeFields?: React.ReactNode
   description?: Description
   fields: FieldWithPath[]
   hasSavePermission: boolean
@@ -52,7 +52,7 @@ export const DocumentFields: React.FC<{
                 </div>
               )}
             </header>
-            {BeforeFields && <BeforeFields />}
+            {BeforeFields || null}
             <RenderFields
               className={`${baseClass}__fields`}
               fieldSchema={fields}
@@ -64,7 +64,7 @@ export const DocumentFields: React.FC<{
               permissions={permissions.fields}
               readOnly={!hasSavePermission}
             />
-            {AfterFields && <AfterFields />}
+            {AfterFields || null}
           </Gutter>
         </div>
         {hasSidebar && (

--- a/packages/payload/src/admin/components/views/Account/Default.tsx
+++ b/packages/payload/src/admin/components/views/Account/Default.tsx
@@ -69,8 +69,8 @@ const DefaultAccount: React.FC<CollectionEditViewProps> = (props) => {
               permissions={permissions}
             />
             <DocumentFields
-              AfterFields={() => <Settings className={`${baseClass}__settings`} />}
-              BeforeFields={() => (
+              AfterFields={<Settings className={`${baseClass}__settings`} />}
+              BeforeFields={
                 <Auth
                   className={`${baseClass}__auth`}
                   collection={collection}
@@ -79,7 +79,7 @@ const DefaultAccount: React.FC<CollectionEditViewProps> = (props) => {
                   readOnly={!hasSavePermission}
                   useAPIKey={auth.useAPIKey}
                 />
-              )}
+              }
               fields={fields}
               hasSavePermission={hasSavePermission}
               permissions={permissions}

--- a/packages/payload/src/admin/components/views/collections/Edit/Default/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default/index.tsx
@@ -62,7 +62,7 @@ export const DefaultCollectionEdit: React.FC<CollectionEditViewProps> = (props) 
         permissions={permissions}
       />
       <DocumentFields
-        BeforeFields={() => (
+        BeforeFields={
           <Fragment>
             {auth && (
               <Auth
@@ -78,7 +78,7 @@ export const DefaultCollectionEdit: React.FC<CollectionEditViewProps> = (props) 
             )}
             {upload && <Upload collection={collection} internalState={internalState} />}
           </Fragment>
-        )}
+        }
         fields={fields}
         hasSavePermission={hasSavePermission}
         permissions={permissions}


### PR DESCRIPTION

## Description

Fixes an issue where edit BeforeFields and AfterFields were constantly re-rendering.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
