### PR TITLE
fix: prevent storing duplicate user preferences

### DIFF
--- a/packages/payload/src/admin/components/elements/ListDrawer/DrawerContent.tsx
+++ b/packages/payload/src/admin/components/elements/ListDrawer/DrawerContent.tsx
@@ -143,7 +143,7 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
       sort,
     }
 
-    setPreference(preferenceKey, newPreferences)
+    setPreference(preferenceKey, newPreferences, true)
   }, [sort, limit, setPreference, preferenceKey])
 
   const onCreateNew = useCallback(

--- a/packages/payload/src/admin/components/elements/TableColumns/index.tsx
+++ b/packages/payload/src/admin/components/elements/TableColumns/index.tsx
@@ -134,7 +134,7 @@ export const TableColumnsProvider: React.FC<{
         })),
       }
 
-      setPreference(preferenceKey, newPreferences)
+      setPreference(preferenceKey, newPreferences, true)
     }
 
     sync()

--- a/packages/payload/src/admin/components/elements/TableColumns/index.tsx
+++ b/packages/payload/src/admin/components/elements/TableColumns/index.tsx
@@ -122,22 +122,12 @@ export const TableColumnsProvider: React.FC<{
 
   useEffect(() => {
     if (!hasInitialized.current) return
+    const columns = tableColumns.map((c) => ({
+      accessor: c.accessor,
+      active: c.active,
+    }))
 
-    const sync = async () => {
-      const currentPreferences = await getPreference<ListPreferences>(preferenceKey)
-
-      const newPreferences = {
-        ...currentPreferences,
-        columns: tableColumns.map((c) => ({
-          accessor: c.accessor,
-          active: c.active,
-        })),
-      }
-
-      setPreference(preferenceKey, newPreferences, true)
-    }
-
-    sync()
+    void setPreference(preferenceKey, { columns }, true)
   }, [tableColumns, preferenceKey, setPreference, getPreference])
 
   const setActiveColumns = useCallback(

--- a/packages/payload/src/admin/components/utilities/Preferences/index.tsx
+++ b/packages/payload/src/admin/components/utilities/Preferences/index.tsx
@@ -1,3 +1,4 @@
+import isDeepEqual from 'deep-equal'
 import React, { createContext, useCallback, useContext, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -7,7 +8,7 @@ import { useConfig } from '../Config'
 
 type PreferencesContext = {
   getPreference: <T = any>(key: string) => Promise<T> | T
-  setPreference: <T = any>(key: string, value: T) => Promise<void>
+  setPreference: <T = any>(key: string, value: T, merge?: boolean) => Promise<void>
 }
 
 const Context = createContext({} as PreferencesContext)
@@ -23,6 +24,7 @@ const requestOptions = (value, language) => ({
 export const PreferencesProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const contextRef = useRef({} as PreferencesContext)
   const preferencesRef = useRef({})
+  const pendingUpdate = useRef({})
   const config = useConfig()
   const { user } = useAuth()
   const { i18n } = useTranslation()
@@ -43,7 +45,7 @@ export const PreferencesProvider: React.FC<{ children?: React.ReactNode }> = ({ 
       const prefs = preferencesRef.current
       if (typeof prefs[key] !== 'undefined') return prefs[key]
       const promise = new Promise((resolve: (value: T) => void) => {
-        ;(async () => {
+        void (async () => {
           const request = await requests.get(`${serverURL}${api}/payload-preferences/${key}`, {
             headers: {
               'Accept-Language': i18n.language,
@@ -65,14 +67,57 @@ export const PreferencesProvider: React.FC<{ children?: React.ReactNode }> = ({ 
   )
 
   const setPreference = useCallback(
-    async (key: string, value: unknown): Promise<void> => {
-      preferencesRef.current[key] = value
-      await requests.post(
-        `${serverURL}${api}/payload-preferences/${key}`,
-        requestOptions(value, i18n.language),
-      )
+    async (key: string, value: unknown, merge = false): Promise<void> => {
+      if (merge === false) {
+        preferencesRef.current[key] = value
+        await requests.post(
+          `${serverURL}${api}/payload-preferences/${key}`,
+          requestOptions(value, i18n.language),
+        )
+        return
+      }
+
+      let newValue = value
+      const currentPreference = await getPreference(key)
+      if (
+        typeof value === 'object' &&
+        typeof preferencesRef.current[key] === 'object' &&
+        typeof newValue === 'object'
+      ) {
+        newValue = { ...(currentPreference || {}), ...value }
+        if (isDeepEqual(newValue, currentPreference)) {
+          return
+        }
+        pendingUpdate.current[key] = {
+          ...pendingUpdate.current[key],
+          ...(newValue as Record<string, unknown>),
+        }
+      } else {
+        if (newValue === currentPreference) {
+          return
+        }
+        pendingUpdate.current[key] = newValue
+      }
+
+      const updatePreference = async () => {
+        if (isDeepEqual(pendingUpdate.current[key], preferencesRef.current[key])) {
+          return
+        }
+        preferencesRef.current[key] = pendingUpdate.current[key]
+
+        await requests.post(
+          `${serverURL}${api}/payload-preferences/${key}`,
+          requestOptions(preferencesRef.current[key], i18n.language),
+        )
+        delete pendingUpdate.current[key]
+      }
+
+      // use timeout to allow multiple changes of different values using the same key in one request
+      setTimeout(() => {
+        void updatePreference()
+      })
     },
-    [api, i18n.language, serverURL],
+    [api, getPreference, i18n.language, pendingUpdate, serverURL],
   )
 
   contextRef.current.getPreference = getPreference

--- a/packages/payload/src/admin/components/views/collections/List/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/List/index.tsx
@@ -135,11 +135,11 @@ const ListView: React.FC<ListIndexProps> = (props) => {
 
       const newPreferences = {
         ...currentPreferences,
-        limit,
-        sort,
+        ...(sort ? { sort } : {}),
+        ...(limit ? { limit } : {}),
       }
 
-      setPreference(preferenceKey, newPreferences)
+      setPreference(preferenceKey, newPreferences, true)
     })()
   }, [sort, limit, preferenceKey, setPreference, getPreference])
 

--- a/packages/payload/src/admin/components/views/collections/List/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/List/index.tsx
@@ -130,18 +130,12 @@ const ListView: React.FC<ListIndexProps> = (props) => {
   // /////////////////////////////////////
 
   useEffect(() => {
-    ;(async () => {
-      const currentPreferences = await getPreference<ListPreferences>(preferenceKey)
+    void setPreference(preferenceKey, { sort }, true)
+  }, [sort, preferenceKey, setPreference])
 
-      const newPreferences = {
-        ...currentPreferences,
-        ...(sort ? { sort } : {}),
-        ...(limit ? { limit } : {}),
-      }
-
-      setPreference(preferenceKey, newPreferences, true)
-    })()
-  }, [sort, limit, preferenceKey, setPreference, getPreference])
+  useEffect(() => {
+    void setPreference(preferenceKey, { limit }, true)
+  }, [limit, preferenceKey, setPreference])
 
   // /////////////////////////////////////
   // Prevent going beyond page limit

--- a/packages/payload/src/preferences/operations/update.ts
+++ b/packages/payload/src/preferences/operations/update.ts
@@ -39,19 +39,19 @@ async function update(args: PreferenceUpdateRequest) {
     await executeAccess({ req }, defaultAccess)
   }
 
-  // TODO: workaround to prevent race-conditions 500 errors from violating unique constraints
   try {
-    await payload.db.create({
-      collection,
-      data: preference,
-      req,
-    })
-  } catch (err: unknown) {
+    // try/catch because we attempt to update without first reading to check if it exists first to save on db calls
     await payload.db.updateOne({
       collection,
       data: preference,
       req,
       where: filter,
+    })
+  } catch (err: unknown) {
+    await payload.db.create({
+      collection,
+      data: preference,
+      req,
     })
   }
 

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -350,6 +350,95 @@ describe('Auth', () => {
         expect(afterToken).toBeNull()
       })
 
+      describe('User Preferences', () => {
+        const key = 'test'
+        const property = 'store'
+        let data
+
+        beforeAll(async () => {
+          const response = await fetch(`${apiUrl}/payload-preferences/${key}`, {
+            body: JSON.stringify({
+              value: { property },
+            }),
+            headers: {
+              Authorization: `JWT ${token}`,
+              'Content-Type': 'application/json',
+            },
+            method: 'post',
+          })
+          data = await response.json()
+        })
+
+        it('should create', async () => {
+          expect(data.doc.key).toStrictEqual(key)
+          expect(data.doc.value.property).toStrictEqual(property)
+        })
+
+        it('should read', async () => {
+          const response = await fetch(`${apiUrl}/payload-preferences/${key}`, {
+            headers: {
+              Authorization: `JWT ${token}`,
+              'Content-Type': 'application/json',
+            },
+            method: 'get',
+          })
+          data = await response.json()
+          expect(data.key).toStrictEqual(key)
+          expect(data.value.property).toStrictEqual(property)
+        })
+
+        it('should update', async () => {
+          const response = await fetch(`${apiUrl}/payload-preferences/${key}`, {
+            body: JSON.stringify({
+              value: { property: 'updated', property2: 'test' },
+            }),
+            headers: {
+              Authorization: `JWT ${token}`,
+              'Content-Type': 'application/json',
+            },
+            method: 'post',
+          })
+
+          data = await response.json()
+
+          const result = await payload.find({
+            collection: 'payload-preferences',
+            depth: 0,
+            where: {
+              key: { equals: key },
+            },
+          })
+
+          expect(data.doc.key).toStrictEqual(key)
+          expect(data.doc.value.property).toStrictEqual('updated')
+          expect(data.doc.value.property2).toStrictEqual('test')
+
+          expect(result.docs).toHaveLength(1)
+        })
+
+        it('should delete', async () => {
+          const response = await fetch(`${apiUrl}/payload-preferences/${key}`, {
+            headers: {
+              Authorization: `JWT ${token}`,
+              'Content-Type': 'application/json',
+            },
+            method: 'delete',
+          })
+
+          data = await response.json()
+
+          const result = await payload.find({
+            collection: 'payload-preferences',
+            depth: 0,
+            where: {
+              key: { equals: key },
+            },
+          })
+
+          expect(result.docs).toHaveLength(0)
+        })
+      })
+
       describe('Account Locking', () => {
         const userEmail = 'lock@me.com'
 


### PR DESCRIPTION
## Description

fixes #3678
In addition to fixing it I also optimized the number of backend calls made by the frontend when updating multiple properties under the same key. A new optional `merge` flag was added to setPreferences to tell the provider to add properties to an existing key without overwriting and batch updates into one POST for each re-render.

I'm unsure how to to best write a test for this.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes