### PR TITLE
fix: enables nested AND/OR queries

### DIFF
--- a/packages/payload/src/graphql/schema/buildWhereInputType.ts
+++ b/packages/payload/src/graphql/schema/buildWhereInputType.ts
@@ -89,26 +89,36 @@ const buildWhereInputType = ({
 
   const fieldName = formatName(name)
 
+  const recursiveFields = {
+    AND: {
+      type: new GraphQLList(
+        new GraphQLInputObjectType({
+          name: `${fieldName}_where_and`,
+          fields: () => ({
+            ...fieldTypes,
+            ...recursiveFields,
+          }),
+        }),
+      ),
+    },
+    OR: {
+      type: new GraphQLList(
+        new GraphQLInputObjectType({
+          name: `${fieldName}_where_or`,
+          fields: () => ({
+            ...fieldTypes,
+            ...recursiveFields,
+          }),
+        }),
+      ),
+    },
+  }
+
   return new GraphQLInputObjectType({
     name: `${fieldName}_where`,
     fields: {
       ...fieldTypes,
-      AND: {
-        type: new GraphQLList(
-          new GraphQLInputObjectType({
-            name: `${fieldName}_where_and`,
-            fields: fieldTypes,
-          }),
-        ),
-      },
-      OR: {
-        type: new GraphQLList(
-          new GraphQLInputObjectType({
-            name: `${fieldName}_where_or`,
-            fields: fieldTypes,
-          }),
-        ),
-      },
+      ...recursiveFields,
     },
   })
 }

--- a/test/_community/schema.graphql
+++ b/test/_community/schema.graphql
@@ -1,18 +1,20 @@
 type Query {
   Post(id: String!, draft: Boolean): Post
-  Posts(where: Post_where, draft: Boolean, page: Int, limit: Int, sort: String): Posts
+  Posts(draft: Boolean, where: Post_where, limit: Int, page: Int, sort: String): Posts
   docAccessPost(id: String!): postsDocAccess
   Media(id: String!, draft: Boolean): Media
-  allMedia(where: Media_where, draft: Boolean, page: Int, limit: Int, sort: String): allMedia
+  allMedia(draft: Boolean, where: Media_where, limit: Int, page: Int, sort: String): allMedia
   docAccessMedia(id: String!): mediaDocAccess
   User(id: String!, draft: Boolean): User
-  Users(where: User_where, draft: Boolean, page: Int, limit: Int, sort: String): Users
+  Users(draft: Boolean, where: User_where, limit: Int, page: Int, sort: String): Users
   docAccessUser(id: String!): usersDocAccess
   meUser: usersMe
   initializedUser: Boolean
+  PayloadPreference(id: String!, draft: Boolean): PayloadPreference
+  PayloadPreferences(draft: Boolean, where: PayloadPreference_where, limit: Int, page: Int, sort: String): PayloadPreferences
+  docAccessPayloadPreference(id: String!): payload_preferencesDocAccess
   Menu(draft: Boolean): Menu
   docAccessMenu: menuDocAccess
-  Preference(key: String): Preference
   Access: Access
 }
 
@@ -51,8 +53,8 @@ input Post_AssociatedMedia_where {
   width: Post_AssociatedMedia_width_operator
   height: Post_AssociatedMedia_height_operator
   id: Post_AssociatedMedia_id_operator
-  OR: [Post_AssociatedMedia_where_or]
   AND: [Post_AssociatedMedia_where_and]
+  OR: [Post_AssociatedMedia_where_or]
 }
 
 input Post_AssociatedMedia_updatedAt_operator {
@@ -83,8 +85,8 @@ input Post_AssociatedMedia_url_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
@@ -94,8 +96,8 @@ input Post_AssociatedMedia_filename_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
@@ -105,8 +107,8 @@ input Post_AssociatedMedia_mimeType_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
@@ -146,21 +148,9 @@ input Post_AssociatedMedia_id_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
-}
-
-input Post_AssociatedMedia_where_or {
-  updatedAt: Post_AssociatedMedia_updatedAt_operator
-  createdAt: Post_AssociatedMedia_createdAt_operator
-  url: Post_AssociatedMedia_url_operator
-  filename: Post_AssociatedMedia_filename_operator
-  mimeType: Post_AssociatedMedia_mimeType_operator
-  filesize: Post_AssociatedMedia_filesize_operator
-  width: Post_AssociatedMedia_width_operator
-  height: Post_AssociatedMedia_height_operator
-  id: Post_AssociatedMedia_id_operator
 }
 
 input Post_AssociatedMedia_where_and {
@@ -173,20 +163,36 @@ input Post_AssociatedMedia_where_and {
   width: Post_AssociatedMedia_width_operator
   height: Post_AssociatedMedia_height_operator
   id: Post_AssociatedMedia_id_operator
+  AND: [Post_AssociatedMedia_where_and]
+  OR: [Post_AssociatedMedia_where_or]
+}
+
+input Post_AssociatedMedia_where_or {
+  updatedAt: Post_AssociatedMedia_updatedAt_operator
+  createdAt: Post_AssociatedMedia_createdAt_operator
+  url: Post_AssociatedMedia_url_operator
+  filename: Post_AssociatedMedia_filename_operator
+  mimeType: Post_AssociatedMedia_mimeType_operator
+  filesize: Post_AssociatedMedia_filesize_operator
+  width: Post_AssociatedMedia_width_operator
+  height: Post_AssociatedMedia_height_operator
+  id: Post_AssociatedMedia_id_operator
+  AND: [Post_AssociatedMedia_where_and]
+  OR: [Post_AssociatedMedia_where_or]
 }
 
 type Posts {
   docs: [Post]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input Post_where {
@@ -195,8 +201,8 @@ input Post_where {
   updatedAt: Post_updatedAt_operator
   createdAt: Post_createdAt_operator
   id: Post_id_operator
-  OR: [Post_where_or]
   AND: [Post_where_and]
+  OR: [Post_where_or]
 }
 
 input Post_text_operator {
@@ -205,8 +211,8 @@ input Post_text_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
@@ -244,17 +250,9 @@ input Post_id_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
-}
-
-input Post_where_or {
-  text: Post_text_operator
-  associatedMedia: Post_associatedMedia_operator
-  updatedAt: Post_updatedAt_operator
-  createdAt: Post_createdAt_operator
-  id: Post_id_operator
 }
 
 input Post_where_and {
@@ -263,6 +261,18 @@ input Post_where_and {
   updatedAt: Post_updatedAt_operator
   createdAt: Post_createdAt_operator
   id: Post_id_operator
+  AND: [Post_where_and]
+  OR: [Post_where_or]
+}
+
+input Post_where_or {
+  text: Post_text_operator
+  associatedMedia: Post_associatedMedia_operator
+  updatedAt: Post_updatedAt_operator
+  createdAt: Post_createdAt_operator
+  id: Post_id_operator
+  AND: [Post_where_and]
+  OR: [Post_where_or]
 }
 
 type postsDocAccess {
@@ -399,16 +409,16 @@ type PostsDeleteDocAccess {
 
 type allMedia {
   docs: [Media]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input Media_where {
@@ -421,8 +431,8 @@ input Media_where {
   width: Media_width_operator
   height: Media_height_operator
   id: Media_id_operator
-  OR: [Media_where_or]
   AND: [Media_where_and]
+  OR: [Media_where_or]
 }
 
 input Media_updatedAt_operator {
@@ -453,8 +463,8 @@ input Media_url_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
@@ -464,8 +474,8 @@ input Media_filename_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
@@ -475,8 +485,8 @@ input Media_mimeType_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
@@ -516,21 +526,9 @@ input Media_id_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
-}
-
-input Media_where_or {
-  updatedAt: Media_updatedAt_operator
-  createdAt: Media_createdAt_operator
-  url: Media_url_operator
-  filename: Media_filename_operator
-  mimeType: Media_mimeType_operator
-  filesize: Media_filesize_operator
-  width: Media_width_operator
-  height: Media_height_operator
-  id: Media_id_operator
 }
 
 input Media_where_and {
@@ -543,6 +541,22 @@ input Media_where_and {
   width: Media_width_operator
   height: Media_height_operator
   id: Media_id_operator
+  AND: [Media_where_and]
+  OR: [Media_where_or]
+}
+
+input Media_where_or {
+  updatedAt: Media_updatedAt_operator
+  createdAt: Media_createdAt_operator
+  url: Media_url_operator
+  filename: Media_filename_operator
+  mimeType: Media_mimeType_operator
+  filesize: Media_filesize_operator
+  width: Media_width_operator
+  height: Media_height_operator
+  id: Media_id_operator
+  AND: [Media_where_and]
+  OR: [Media_where_or]
 }
 
 type mediaDocAccess {
@@ -772,9 +786,11 @@ type User {
   id: String
   updatedAt: DateTime
   createdAt: DateTime
-  email: EmailAddress
+  email: EmailAddress!
   resetPasswordToken: String
   resetPasswordExpiration: DateTime
+  salt: String
+  hash: String
   loginAttempts: Float
   lockUntil: DateTime
   password: String!
@@ -783,21 +799,20 @@ type User {
 """
 A field whose value conforms to the standard internet email address format as specified in HTML Spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address.
 """
-scalar EmailAddress
-  @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
+scalar EmailAddress @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
 
 type Users {
   docs: [User]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input User_where {
@@ -805,8 +820,8 @@ input User_where {
   createdAt: User_createdAt_operator
   email: User_email_operator
   id: User_id_operator
-  OR: [User_where_or]
   AND: [User_where_and]
+  OR: [User_where_or]
 }
 
 input User_updatedAt_operator {
@@ -837,9 +852,8 @@ input User_email_operator {
   like: EmailAddress
   contains: EmailAddress
   in: [EmailAddress]
-  not_in: [[EmailAddress]]
-  all: [[[EmailAddress]]]
-  exists: Boolean
+  not_in: [EmailAddress]
+  all: [EmailAddress]
 }
 
 input User_id_operator {
@@ -848,16 +862,9 @@ input User_id_operator {
   like: String
   contains: String
   in: [String]
-  not_in: [[String]]
-  all: [[[String]]]
+  not_in: [String]
+  all: [String]
   exists: Boolean
-}
-
-input User_where_or {
-  updatedAt: User_updatedAt_operator
-  createdAt: User_createdAt_operator
-  email: User_email_operator
-  id: User_id_operator
 }
 
 input User_where_and {
@@ -865,6 +872,17 @@ input User_where_and {
   createdAt: User_createdAt_operator
   email: User_email_operator
   id: User_id_operator
+  AND: [User_where_and]
+  OR: [User_where_or]
+}
+
+input User_where_or {
+  updatedAt: User_updatedAt_operator
+  createdAt: User_createdAt_operator
+  email: User_email_operator
+  id: User_id_operator
+  AND: [User_where_and]
+  OR: [User_where_or]
 }
 
 type usersDocAccess {
@@ -1001,10 +1019,296 @@ type UsersUnlockDocAccess {
 }
 
 type usersMe {
+  collection: String
+  exp: Int
   token: String
   user: User
-  exp: Int
-  collection: String
+}
+
+type PayloadPreference {
+  id: String
+  user: PayloadPreference_User_Relationship!
+  key: String
+  value: JSON
+  updatedAt: DateTime
+  createdAt: DateTime
+}
+
+type PayloadPreference_User_Relationship {
+  relationTo: PayloadPreference_User_RelationTo
+  value: PayloadPreference_User
+}
+
+enum PayloadPreference_User_RelationTo {
+  users
+}
+
+union PayloadPreference_User = User
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+
+type PayloadPreferences {
+  docs: [PayloadPreference]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input PayloadPreference_where {
+  user: PayloadPreference_user_Relation
+  key: PayloadPreference_key_operator
+  value: PayloadPreference_value_operator
+  updatedAt: PayloadPreference_updatedAt_operator
+  createdAt: PayloadPreference_createdAt_operator
+  id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
+}
+
+input PayloadPreference_user_Relation {
+  relationTo: PayloadPreference_user_Relation_RelationTo
+  value: JSON
+}
+
+enum PayloadPreference_user_Relation_RelationTo {
+  users
+}
+
+input PayloadPreference_key_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadPreference_value_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  within: JSON
+  intersects: JSON
+  exists: Boolean
+}
+
+input PayloadPreference_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadPreference_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadPreference_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadPreference_where_and {
+  user: PayloadPreference_user_Relation
+  key: PayloadPreference_key_operator
+  value: PayloadPreference_value_operator
+  updatedAt: PayloadPreference_updatedAt_operator
+  createdAt: PayloadPreference_createdAt_operator
+  id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
+}
+
+input PayloadPreference_where_or {
+  user: PayloadPreference_user_Relation
+  key: PayloadPreference_key_operator
+  value: PayloadPreference_value_operator
+  updatedAt: PayloadPreference_updatedAt_operator
+  createdAt: PayloadPreference_createdAt_operator
+  id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
+}
+
+type payload_preferencesDocAccess {
+  fields: PayloadPreferencesDocAccessFields
+  create: PayloadPreferencesCreateDocAccess
+  read: PayloadPreferencesReadDocAccess
+  update: PayloadPreferencesUpdateDocAccess
+  delete: PayloadPreferencesDeleteDocAccess
+}
+
+type PayloadPreferencesDocAccessFields {
+  user: PayloadPreferencesDocAccessFields_user
+  key: PayloadPreferencesDocAccessFields_key
+  value: PayloadPreferencesDocAccessFields_value
+  updatedAt: PayloadPreferencesDocAccessFields_updatedAt
+  createdAt: PayloadPreferencesDocAccessFields_createdAt
+}
+
+type PayloadPreferencesDocAccessFields_user {
+  create: PayloadPreferencesDocAccessFields_user_Create
+  read: PayloadPreferencesDocAccessFields_user_Read
+  update: PayloadPreferencesDocAccessFields_user_Update
+  delete: PayloadPreferencesDocAccessFields_user_Delete
+}
+
+type PayloadPreferencesDocAccessFields_user_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_user_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_user_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_user_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key {
+  create: PayloadPreferencesDocAccessFields_key_Create
+  read: PayloadPreferencesDocAccessFields_key_Read
+  update: PayloadPreferencesDocAccessFields_key_Update
+  delete: PayloadPreferencesDocAccessFields_key_Delete
+}
+
+type PayloadPreferencesDocAccessFields_key_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value {
+  create: PayloadPreferencesDocAccessFields_value_Create
+  read: PayloadPreferencesDocAccessFields_value_Read
+  update: PayloadPreferencesDocAccessFields_value_Update
+  delete: PayloadPreferencesDocAccessFields_value_Delete
+}
+
+type PayloadPreferencesDocAccessFields_value_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt {
+  create: PayloadPreferencesDocAccessFields_updatedAt_Create
+  read: PayloadPreferencesDocAccessFields_updatedAt_Read
+  update: PayloadPreferencesDocAccessFields_updatedAt_Update
+  delete: PayloadPreferencesDocAccessFields_updatedAt_Delete
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt {
+  create: PayloadPreferencesDocAccessFields_createdAt_Create
+  read: PayloadPreferencesDocAccessFields_createdAt_Read
+  update: PayloadPreferencesDocAccessFields_createdAt_Update
+  delete: PayloadPreferencesDocAccessFields_createdAt_Delete
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
 }
 
 type Menu {
@@ -1104,23 +1408,12 @@ type MenuUpdateDocAccess {
   where: JSONObject
 }
 
-type Preference {
-  key: String!
-  value: JSON
-  createdAt: DateTime!
-  updatedAt: DateTime!
-}
-
-"""
-The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSON
-
 type Access {
   canAccessAdmin: Boolean!
   posts: postsAccess
   media: mediaAccess
   users: usersAccess
+  payload_preferences: payload_preferencesAccess
   menu: menuAccess
 }
 
@@ -1607,6 +1900,157 @@ type UsersUnlockAccess {
   where: JSONObject
 }
 
+type payload_preferencesAccess {
+  fields: PayloadPreferencesFields
+  create: PayloadPreferencesCreateAccess
+  read: PayloadPreferencesReadAccess
+  update: PayloadPreferencesUpdateAccess
+  delete: PayloadPreferencesDeleteAccess
+}
+
+type PayloadPreferencesFields {
+  user: PayloadPreferencesFields_user
+  key: PayloadPreferencesFields_key
+  value: PayloadPreferencesFields_value
+  updatedAt: PayloadPreferencesFields_updatedAt
+  createdAt: PayloadPreferencesFields_createdAt
+}
+
+type PayloadPreferencesFields_user {
+  create: PayloadPreferencesFields_user_Create
+  read: PayloadPreferencesFields_user_Read
+  update: PayloadPreferencesFields_user_Update
+  delete: PayloadPreferencesFields_user_Delete
+}
+
+type PayloadPreferencesFields_user_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_user_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_user_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_user_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key {
+  create: PayloadPreferencesFields_key_Create
+  read: PayloadPreferencesFields_key_Read
+  update: PayloadPreferencesFields_key_Update
+  delete: PayloadPreferencesFields_key_Delete
+}
+
+type PayloadPreferencesFields_key_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value {
+  create: PayloadPreferencesFields_value_Create
+  read: PayloadPreferencesFields_value_Read
+  update: PayloadPreferencesFields_value_Update
+  delete: PayloadPreferencesFields_value_Delete
+}
+
+type PayloadPreferencesFields_value_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt {
+  create: PayloadPreferencesFields_updatedAt_Create
+  read: PayloadPreferencesFields_updatedAt_Read
+  update: PayloadPreferencesFields_updatedAt_Update
+  delete: PayloadPreferencesFields_updatedAt_Delete
+}
+
+type PayloadPreferencesFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt {
+  create: PayloadPreferencesFields_createdAt_Create
+  read: PayloadPreferencesFields_createdAt_Read
+  update: PayloadPreferencesFields_createdAt_Update
+  delete: PayloadPreferencesFields_createdAt_Delete
+}
+
+type PayloadPreferencesFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesDeleteAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
 type menuAccess {
   fields: MenuFields
   read: MenuReadAccess
@@ -1700,29 +2144,25 @@ type MenuUpdateAccess {
 
 type Mutation {
   createPost(data: mutationPostInput!, draft: Boolean): Post
-  updatePost(id: String!, data: mutationPostUpdateInput!, draft: Boolean, autosave: Boolean): Post
+  updatePost(id: String!, autosave: Boolean, data: mutationPostUpdateInput!, draft: Boolean): Post
   deletePost(id: String!): Post
   createMedia(data: mutationMediaInput!, draft: Boolean): Media
-  updateMedia(
-    id: String!
-    data: mutationMediaUpdateInput!
-    draft: Boolean
-    autosave: Boolean
-  ): Media
+  updateMedia(id: String!, autosave: Boolean, data: mutationMediaUpdateInput!, draft: Boolean): Media
   deleteMedia(id: String!): Media
   createUser(data: mutationUserInput!, draft: Boolean): User
-  updateUser(id: String!, data: mutationUserUpdateInput!, draft: Boolean, autosave: Boolean): User
+  updateUser(id: String!, autosave: Boolean, data: mutationUserUpdateInput!, draft: Boolean): User
   deleteUser(id: String!): User
   refreshTokenUser(token: String): usersRefreshedUser
   logoutUser: String
   unlockUser(email: String!): Boolean!
   loginUser(email: String, password: String): usersLoginResult
-  forgotPasswordUser(email: String!, disableEmail: Boolean, expiration: Int): Boolean!
-  resetPasswordUser(token: String, password: String): usersResetPassword
+  forgotPasswordUser(disableEmail: Boolean, email: String!, expiration: Int): Boolean!
+  resetPasswordUser(password: String, token: String): usersResetPassword
   verifyEmailUser(token: String): Boolean
+  createPayloadPreference(data: mutationPayloadPreferenceInput!, draft: Boolean): PayloadPreference
+  updatePayloadPreference(id: String!, autosave: Boolean, data: mutationPayloadPreferenceUpdateInput!, draft: Boolean): PayloadPreference
+  deletePayloadPreference(id: String!): PayloadPreference
   updateMenu(data: mutationMenuInput!, draft: Boolean): Menu
-  updatePreference(key: String!, value: JSON): Preference
-  deletePreference(key: String!): Preference
 }
 
 input mutationPostInput {
@@ -1764,9 +2204,11 @@ input mutationMediaUpdateInput {
 input mutationUserInput {
   updatedAt: String
   createdAt: String
-  email: String
+  email: String!
   resetPasswordToken: String
   resetPasswordExpiration: String
+  salt: String
+  hash: String
   loginAttempts: Float
   lockUntil: String
   password: String!
@@ -1778,15 +2220,17 @@ input mutationUserUpdateInput {
   email: String
   resetPasswordToken: String
   resetPasswordExpiration: String
+  salt: String
+  hash: String
   loginAttempts: Float
   lockUntil: String
   password: String
 }
 
 type usersRefreshedUser {
-  user: usersJWT
-  refreshedToken: String
   exp: Int
+  refreshedToken: String
+  user: usersJWT
 }
 
 type usersJWT {
@@ -1795,14 +2239,48 @@ type usersJWT {
 }
 
 type usersLoginResult {
+  exp: Int
   token: String
   user: User
-  exp: Int
 }
 
 type usersResetPassword {
   token: String
   user: User
+}
+
+input mutationPayloadPreferenceInput {
+  user: PayloadPreference_UserRelationshipInput
+  key: String
+  value: JSON
+  updatedAt: String
+  createdAt: String
+}
+
+input PayloadPreference_UserRelationshipInput {
+  relationTo: PayloadPreference_UserRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PayloadPreference_UserRelationshipInputRelationTo {
+  users
+}
+
+input mutationPayloadPreferenceUpdateInput {
+  user: PayloadPreferenceUpdate_UserRelationshipInput
+  key: String
+  value: JSON
+  updatedAt: String
+  createdAt: String
+}
+
+input PayloadPreferenceUpdate_UserRelationshipInput {
+  relationTo: PayloadPreferenceUpdate_UserRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PayloadPreferenceUpdate_UserRelationshipInputRelationTo {
+  users
 }
 
 input mutationMenuInput {

--- a/test/collections-graphql/schema.graphql
+++ b/test/collections-graphql/schema.graphql
@@ -1,22 +1,33 @@
 type Query {
   User(id: String!, draft: Boolean): User
-  Users(where: User_where, draft: Boolean, page: Int, limit: Int, sort: String): Users
+  Users(draft: Boolean, where: User_where, limit: Int, page: Int, sort: String): Users
   docAccessUser(id: String!): usersDocAccess
   meUser: usersMe
   initializedUser: Boolean
+  Point(id: String!, draft: Boolean): Point
+  Points(draft: Boolean, where: Point_where, limit: Int, page: Int, sort: String): Points
+  docAccessPoint(id: String!): pointDocAccess
   Post(id: String!, draft: Boolean): Post
-  Posts(where: Post_where, draft: Boolean, page: Int, limit: Int, sort: String): Posts
+  Posts(draft: Boolean, where: Post_where, limit: Int, page: Int, sort: String): Posts
   docAccessPost(id: String!): postsDocAccess
   CustomId(id: Int!, draft: Boolean): CustomId
-  CustomIds(where: CustomId_where, draft: Boolean, page: Int, limit: Int, sort: String): CustomIds
+  CustomIds(draft: Boolean, where: CustomId_where, limit: Int, page: Int, sort: String): CustomIds
   docAccessCustomId(id: Int!): custom_idsDocAccess
   Relation(id: String!, draft: Boolean): Relation
-  Relations(where: Relation_where, draft: Boolean, page: Int, limit: Int, sort: String): Relations
+  Relations(draft: Boolean, where: Relation_where, limit: Int, page: Int, sort: String): Relations
   docAccessRelation(id: String!): relationDocAccess
   Dummy(id: String!, draft: Boolean): Dummy
-  Dummies(where: Dummy_where, draft: Boolean, page: Int, limit: Int, sort: String): Dummies
+  Dummies(draft: Boolean, where: Dummy_where, limit: Int, page: Int, sort: String): Dummies
   docAccessDummy(id: String!): dummyDocAccess
-  Preference(key: String): Preference
+  PayloadApiTestOne(id: String!, draft: Boolean): PayloadApiTestOne
+  PayloadApiTestOnes(draft: Boolean, where: PayloadApiTestOne_where, limit: Int, page: Int, sort: String): PayloadApiTestOnes
+  docAccessPayloadApiTestOne(id: String!): payload_api_test_onesDocAccess
+  PayloadApiTestTwo(id: String!, draft: Boolean): PayloadApiTestTwo
+  PayloadApiTestTwos(draft: Boolean, where: PayloadApiTestTwo_where, limit: Int, page: Int, sort: String): PayloadApiTestTwos
+  docAccessPayloadApiTestTwo(id: String!): payload_api_test_twosDocAccess
+  PayloadPreference(id: String!, draft: Boolean): PayloadPreference
+  PayloadPreferences(draft: Boolean, where: PayloadPreference_where, limit: Int, page: Int, sort: String): PayloadPreferences
+  docAccessPayloadPreference(id: String!): payload_preferencesDocAccess
   Access: Access
   QueryWithInternalError: QueryWithInternalError
 }
@@ -25,9 +36,11 @@ type User {
   id: String
   updatedAt: DateTime
   createdAt: DateTime
-  email: EmailAddress
+  email: EmailAddress!
   resetPasswordToken: String
   resetPasswordExpiration: DateTime
+  salt: String
+  hash: String
   loginAttempts: Float
   lockUntil: DateTime
   password: String!
@@ -41,21 +54,20 @@ scalar DateTime
 """
 A field whose value conforms to the standard internet email address format as specified in HTML Spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address.
 """
-scalar EmailAddress
-  @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
+scalar EmailAddress @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
 
 type Users {
   docs: [User]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input User_where {
@@ -63,8 +75,8 @@ input User_where {
   createdAt: User_createdAt_operator
   email: User_email_operator
   id: User_id_operator
-  OR: [User_where_or]
   AND: [User_where_and]
+  OR: [User_where_or]
 }
 
 input User_updatedAt_operator {
@@ -97,7 +109,6 @@ input User_email_operator {
   in: [EmailAddress]
   not_in: [EmailAddress]
   all: [EmailAddress]
-  exists: Boolean
 }
 
 input User_id_operator {
@@ -111,18 +122,22 @@ input User_id_operator {
   exists: Boolean
 }
 
-input User_where_or {
-  updatedAt: User_updatedAt_operator
-  createdAt: User_createdAt_operator
-  email: User_email_operator
-  id: User_id_operator
-}
-
 input User_where_and {
   updatedAt: User_updatedAt_operator
   createdAt: User_createdAt_operator
   email: User_email_operator
   id: User_id_operator
+  AND: [User_where_and]
+  OR: [User_where_or]
+}
+
+input User_where_or {
+  updatedAt: User_updatedAt_operator
+  createdAt: User_createdAt_operator
+  email: User_email_operator
+  id: User_id_operator
+  AND: [User_where_and]
+  OR: [User_where_or]
 }
 
 type usersDocAccess {
@@ -264,10 +279,217 @@ type UsersUnlockDocAccess {
 }
 
 type usersMe {
+  collection: String
+  exp: Int
   token: String
   user: User
-  exp: Int
-  collection: String
+}
+
+type Point {
+  id: String
+  point: [Float!]
+  updatedAt: DateTime
+  createdAt: DateTime
+}
+
+type Points {
+  docs: [Point]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input Point_where {
+  point: Point_point_operator
+  updatedAt: Point_updatedAt_operator
+  createdAt: Point_createdAt_operator
+  id: Point_id_operator
+  AND: [Point_where_and]
+  OR: [Point_where_or]
+}
+
+input Point_point_operator {
+  equals: [Float]
+  not_equals: [Float]
+  greater_than_equal: [Float]
+  greater_than: [Float]
+  less_than_equal: [Float]
+  less_than: [Float]
+  near: [Float]
+  within: GeoJSONObject
+  intersects: GeoJSONObject
+  exists: Boolean
+}
+
+input GeoJSONObject {
+  coordinates: JSON
+  type: String
+}
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+
+input Point_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Point_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Point_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Point_where_and {
+  point: Point_point_operator
+  updatedAt: Point_updatedAt_operator
+  createdAt: Point_createdAt_operator
+  id: Point_id_operator
+  AND: [Point_where_and]
+  OR: [Point_where_or]
+}
+
+input Point_where_or {
+  point: Point_point_operator
+  updatedAt: Point_updatedAt_operator
+  createdAt: Point_createdAt_operator
+  id: Point_id_operator
+  AND: [Point_where_and]
+  OR: [Point_where_or]
+}
+
+type pointDocAccess {
+  fields: PointDocAccessFields
+  create: PointCreateDocAccess
+  read: PointReadDocAccess
+  update: PointUpdateDocAccess
+  delete: PointDeleteDocAccess
+}
+
+type PointDocAccessFields {
+  point: PointDocAccessFields_point
+  updatedAt: PointDocAccessFields_updatedAt
+  createdAt: PointDocAccessFields_createdAt
+}
+
+type PointDocAccessFields_point {
+  create: PointDocAccessFields_point_Create
+  read: PointDocAccessFields_point_Read
+  update: PointDocAccessFields_point_Update
+  delete: PointDocAccessFields_point_Delete
+}
+
+type PointDocAccessFields_point_Create {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_point_Read {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_point_Update {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_point_Delete {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_updatedAt {
+  create: PointDocAccessFields_updatedAt_Create
+  read: PointDocAccessFields_updatedAt_Read
+  update: PointDocAccessFields_updatedAt_Update
+  delete: PointDocAccessFields_updatedAt_Delete
+}
+
+type PointDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_createdAt {
+  create: PointDocAccessFields_createdAt_Create
+  read: PointDocAccessFields_createdAt_Read
+  update: PointDocAccessFields_createdAt_Update
+  delete: PointDocAccessFields_createdAt_Delete
+}
+
+type PointDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PointDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PointCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PointReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PointUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PointDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
 }
 
 type Post {
@@ -297,7 +519,7 @@ type Relation {
 }
 
 type CustomId {
-  id: Float
+  id: Int
   title: String
   updatedAt: DateTime
   createdAt: DateTime
@@ -365,16 +587,16 @@ type Post_D1_D2_D3 {
 
 type Posts {
   docs: [Post]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input Post_where {
@@ -395,8 +617,8 @@ input Post_where {
   updatedAt: Post_updatedAt_operator
   createdAt: Post_createdAt_operator
   id: Post_id_operator
-  OR: [Post_where_or]
   AND: [Post_where_and]
+  OR: [Post_where_or]
 }
 
 input Post_title_operator {
@@ -442,35 +664,35 @@ input Post_min_operator {
 }
 
 input Post_relationField_operator {
-  equals: String
-  not_equals: String
-  in: [String]
-  not_in: [String]
-  all: [String]
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
   exists: Boolean
 }
 
 input Post_relationToCustomID_operator {
-  equals: String
-  not_equals: String
-  in: [String]
-  not_in: [String]
-  all: [String]
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
   exists: Boolean
 }
 
 input Post_relationHasManyField_operator {
-  equals: String
-  not_equals: String
-  in: [String]
-  not_in: [String]
-  all: [String]
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
   exists: Boolean
 }
 
 input Post_relationMultiRelationTo_Relation {
   relationTo: Post_relationMultiRelationTo_Relation_RelationTo
-  value: String
+  value: JSON
 }
 
 enum Post_relationMultiRelationTo_Relation_RelationTo {
@@ -480,7 +702,7 @@ enum Post_relationMultiRelationTo_Relation_RelationTo {
 
 input Post_relationMultiRelationToHasMany_Relation {
   relationTo: Post_relationMultiRelationToHasMany_Relation_RelationTo
-  value: String
+  value: JSON
 }
 
 enum Post_relationMultiRelationToHasMany_Relation_RelationTo {
@@ -576,26 +798,6 @@ input Post_id_operator {
   exists: Boolean
 }
 
-input Post_where_or {
-  title: Post_title_operator
-  description: Post_description_operator
-  number: Post_number_operator
-  min: Post_min_operator
-  relationField: Post_relationField_operator
-  relationToCustomID: Post_relationToCustomID_operator
-  relationHasManyField: Post_relationHasManyField_operator
-  relationMultiRelationTo: Post_relationMultiRelationTo_Relation
-  relationMultiRelationToHasMany: Post_relationMultiRelationToHasMany_Relation
-  A1__A2: Post_A1__A2_operator
-  B1__B2: Post_B1__B2_operator
-  C1__C2Text: Post_C1__C2Text_operator
-  C1__C2__C3: Post_C1__C2__C3_operator
-  D1__D2__D3__D4: Post_D1__D2__D3__D4_operator
-  updatedAt: Post_updatedAt_operator
-  createdAt: Post_createdAt_operator
-  id: Post_id_operator
-}
-
 input Post_where_and {
   title: Post_title_operator
   description: Post_description_operator
@@ -614,6 +816,30 @@ input Post_where_and {
   updatedAt: Post_updatedAt_operator
   createdAt: Post_createdAt_operator
   id: Post_id_operator
+  AND: [Post_where_and]
+  OR: [Post_where_or]
+}
+
+input Post_where_or {
+  title: Post_title_operator
+  description: Post_description_operator
+  number: Post_number_operator
+  min: Post_min_operator
+  relationField: Post_relationField_operator
+  relationToCustomID: Post_relationToCustomID_operator
+  relationHasManyField: Post_relationHasManyField_operator
+  relationMultiRelationTo: Post_relationMultiRelationTo_Relation
+  relationMultiRelationToHasMany: Post_relationMultiRelationToHasMany_Relation
+  A1__A2: Post_A1__A2_operator
+  B1__B2: Post_B1__B2_operator
+  C1__C2Text: Post_C1__C2Text_operator
+  C1__C2__C3: Post_C1__C2__C3_operator
+  D1__D2__D3__D4: Post_D1__D2__D3__D4_operator
+  updatedAt: Post_updatedAt_operator
+  createdAt: Post_createdAt_operator
+  id: Post_id_operator
+  AND: [Post_where_and]
+  OR: [Post_where_or]
 }
 
 type postsDocAccess {
@@ -1201,16 +1427,16 @@ type PostsDeleteDocAccess {
 
 type CustomIds {
   docs: [CustomId]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input CustomId_where {
@@ -1218,17 +1444,17 @@ input CustomId_where {
   title: CustomId_title_operator
   updatedAt: CustomId_updatedAt_operator
   createdAt: CustomId_createdAt_operator
-  OR: [CustomId_where_or]
   AND: [CustomId_where_and]
+  OR: [CustomId_where_or]
 }
 
 input CustomId_id_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
+  equals: Int
+  not_equals: Int
+  greater_than_equal: Int
+  greater_than: Int
+  less_than_equal: Int
+  less_than: Int
   exists: Boolean
 }
 
@@ -1265,18 +1491,22 @@ input CustomId_createdAt_operator {
   exists: Boolean
 }
 
-input CustomId_where_or {
-  id: CustomId_id_operator
-  title: CustomId_title_operator
-  updatedAt: CustomId_updatedAt_operator
-  createdAt: CustomId_createdAt_operator
-}
-
 input CustomId_where_and {
   id: CustomId_id_operator
   title: CustomId_title_operator
   updatedAt: CustomId_updatedAt_operator
   createdAt: CustomId_createdAt_operator
+  AND: [CustomId_where_and]
+  OR: [CustomId_where_or]
+}
+
+input CustomId_where_or {
+  id: CustomId_id_operator
+  title: CustomId_title_operator
+  updatedAt: CustomId_updatedAt_operator
+  createdAt: CustomId_createdAt_operator
+  AND: [CustomId_where_and]
+  OR: [CustomId_where_or]
 }
 
 type custom_idsDocAccess {
@@ -1408,16 +1638,16 @@ type CustomIdsDeleteDocAccess {
 
 type Relations {
   docs: [Relation]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input Relation_where {
@@ -1425,8 +1655,8 @@ input Relation_where {
   updatedAt: Relation_updatedAt_operator
   createdAt: Relation_createdAt_operator
   id: Relation_id_operator
-  OR: [Relation_where_or]
   AND: [Relation_where_and]
+  OR: [Relation_where_or]
 }
 
 input Relation_name_operator {
@@ -1473,18 +1703,22 @@ input Relation_id_operator {
   exists: Boolean
 }
 
-input Relation_where_or {
-  name: Relation_name_operator
-  updatedAt: Relation_updatedAt_operator
-  createdAt: Relation_createdAt_operator
-  id: Relation_id_operator
-}
-
 input Relation_where_and {
   name: Relation_name_operator
   updatedAt: Relation_updatedAt_operator
   createdAt: Relation_createdAt_operator
   id: Relation_id_operator
+  AND: [Relation_where_and]
+  OR: [Relation_where_or]
+}
+
+input Relation_where_or {
+  name: Relation_name_operator
+  updatedAt: Relation_updatedAt_operator
+  createdAt: Relation_createdAt_operator
+  id: Relation_id_operator
+  AND: [Relation_where_and]
+  OR: [Relation_where_or]
 }
 
 type relationDocAccess {
@@ -1592,16 +1826,16 @@ type RelationDeleteDocAccess {
 
 type Dummies {
   docs: [Dummy]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input Dummy_where {
@@ -1609,8 +1843,8 @@ input Dummy_where {
   updatedAt: Dummy_updatedAt_operator
   createdAt: Dummy_createdAt_operator
   id: Dummy_id_operator
-  OR: [Dummy_where_or]
   AND: [Dummy_where_and]
+  OR: [Dummy_where_or]
 }
 
 input Dummy_name_operator {
@@ -1657,18 +1891,22 @@ input Dummy_id_operator {
   exists: Boolean
 }
 
-input Dummy_where_or {
-  name: Dummy_name_operator
-  updatedAt: Dummy_updatedAt_operator
-  createdAt: Dummy_createdAt_operator
-  id: Dummy_id_operator
-}
-
 input Dummy_where_and {
   name: Dummy_name_operator
   updatedAt: Dummy_updatedAt_operator
   createdAt: Dummy_createdAt_operator
   id: Dummy_id_operator
+  AND: [Dummy_where_and]
+  OR: [Dummy_where_or]
+}
+
+input Dummy_where_or {
+  name: Dummy_name_operator
+  updatedAt: Dummy_updatedAt_operator
+  createdAt: Dummy_createdAt_operator
+  id: Dummy_id_operator
+  AND: [Dummy_where_and]
+  OR: [Dummy_where_or]
 }
 
 type dummyDocAccess {
@@ -1774,25 +2012,725 @@ type DummyDeleteDocAccess {
   where: JSONObject
 }
 
-type Preference {
-  key: String!
-  value: JSON
-  createdAt: DateTime!
-  updatedAt: DateTime!
+type PayloadApiTestOne {
+  id: String
+  payloadAPI: String
+  updatedAt: DateTime
+  createdAt: DateTime
 }
 
-"""
-The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSON
+type PayloadApiTestOnes {
+  docs: [PayloadApiTestOne]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input PayloadApiTestOne_where {
+  payloadAPI: PayloadApiTestOne_payloadAPI_operator
+  updatedAt: PayloadApiTestOne_updatedAt_operator
+  createdAt: PayloadApiTestOne_createdAt_operator
+  id: PayloadApiTestOne_id_operator
+  AND: [PayloadApiTestOne_where_and]
+  OR: [PayloadApiTestOne_where_or]
+}
+
+input PayloadApiTestOne_payloadAPI_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadApiTestOne_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadApiTestOne_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadApiTestOne_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadApiTestOne_where_and {
+  payloadAPI: PayloadApiTestOne_payloadAPI_operator
+  updatedAt: PayloadApiTestOne_updatedAt_operator
+  createdAt: PayloadApiTestOne_createdAt_operator
+  id: PayloadApiTestOne_id_operator
+  AND: [PayloadApiTestOne_where_and]
+  OR: [PayloadApiTestOne_where_or]
+}
+
+input PayloadApiTestOne_where_or {
+  payloadAPI: PayloadApiTestOne_payloadAPI_operator
+  updatedAt: PayloadApiTestOne_updatedAt_operator
+  createdAt: PayloadApiTestOne_createdAt_operator
+  id: PayloadApiTestOne_id_operator
+  AND: [PayloadApiTestOne_where_and]
+  OR: [PayloadApiTestOne_where_or]
+}
+
+type payload_api_test_onesDocAccess {
+  fields: PayloadApiTestOnesDocAccessFields
+  create: PayloadApiTestOnesCreateDocAccess
+  read: PayloadApiTestOnesReadDocAccess
+  update: PayloadApiTestOnesUpdateDocAccess
+  delete: PayloadApiTestOnesDeleteDocAccess
+}
+
+type PayloadApiTestOnesDocAccessFields {
+  payloadAPI: PayloadApiTestOnesDocAccessFields_payloadAPI
+  updatedAt: PayloadApiTestOnesDocAccessFields_updatedAt
+  createdAt: PayloadApiTestOnesDocAccessFields_createdAt
+}
+
+type PayloadApiTestOnesDocAccessFields_payloadAPI {
+  create: PayloadApiTestOnesDocAccessFields_payloadAPI_Create
+  read: PayloadApiTestOnesDocAccessFields_payloadAPI_Read
+  update: PayloadApiTestOnesDocAccessFields_payloadAPI_Update
+  delete: PayloadApiTestOnesDocAccessFields_payloadAPI_Delete
+}
+
+type PayloadApiTestOnesDocAccessFields_payloadAPI_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_payloadAPI_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_payloadAPI_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_payloadAPI_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_updatedAt {
+  create: PayloadApiTestOnesDocAccessFields_updatedAt_Create
+  read: PayloadApiTestOnesDocAccessFields_updatedAt_Read
+  update: PayloadApiTestOnesDocAccessFields_updatedAt_Update
+  delete: PayloadApiTestOnesDocAccessFields_updatedAt_Delete
+}
+
+type PayloadApiTestOnesDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_createdAt {
+  create: PayloadApiTestOnesDocAccessFields_createdAt_Create
+  read: PayloadApiTestOnesDocAccessFields_createdAt_Read
+  update: PayloadApiTestOnesDocAccessFields_createdAt_Update
+  delete: PayloadApiTestOnesDocAccessFields_createdAt_Delete
+}
+
+type PayloadApiTestOnesDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestOnesReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestOnesUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestOnesDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestTwo {
+  id: String
+  payloadAPI: String
+  relation: PayloadApiTestOne
+  updatedAt: DateTime
+  createdAt: DateTime
+}
+
+type PayloadApiTestTwos {
+  docs: [PayloadApiTestTwo]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input PayloadApiTestTwo_where {
+  payloadAPI: PayloadApiTestTwo_payloadAPI_operator
+  relation: PayloadApiTestTwo_relation_operator
+  updatedAt: PayloadApiTestTwo_updatedAt_operator
+  createdAt: PayloadApiTestTwo_createdAt_operator
+  id: PayloadApiTestTwo_id_operator
+  AND: [PayloadApiTestTwo_where_and]
+  OR: [PayloadApiTestTwo_where_or]
+}
+
+input PayloadApiTestTwo_payloadAPI_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadApiTestTwo_relation_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
+input PayloadApiTestTwo_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadApiTestTwo_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadApiTestTwo_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadApiTestTwo_where_and {
+  payloadAPI: PayloadApiTestTwo_payloadAPI_operator
+  relation: PayloadApiTestTwo_relation_operator
+  updatedAt: PayloadApiTestTwo_updatedAt_operator
+  createdAt: PayloadApiTestTwo_createdAt_operator
+  id: PayloadApiTestTwo_id_operator
+  AND: [PayloadApiTestTwo_where_and]
+  OR: [PayloadApiTestTwo_where_or]
+}
+
+input PayloadApiTestTwo_where_or {
+  payloadAPI: PayloadApiTestTwo_payloadAPI_operator
+  relation: PayloadApiTestTwo_relation_operator
+  updatedAt: PayloadApiTestTwo_updatedAt_operator
+  createdAt: PayloadApiTestTwo_createdAt_operator
+  id: PayloadApiTestTwo_id_operator
+  AND: [PayloadApiTestTwo_where_and]
+  OR: [PayloadApiTestTwo_where_or]
+}
+
+type payload_api_test_twosDocAccess {
+  fields: PayloadApiTestTwosDocAccessFields
+  create: PayloadApiTestTwosCreateDocAccess
+  read: PayloadApiTestTwosReadDocAccess
+  update: PayloadApiTestTwosUpdateDocAccess
+  delete: PayloadApiTestTwosDeleteDocAccess
+}
+
+type PayloadApiTestTwosDocAccessFields {
+  payloadAPI: PayloadApiTestTwosDocAccessFields_payloadAPI
+  relation: PayloadApiTestTwosDocAccessFields_relation
+  updatedAt: PayloadApiTestTwosDocAccessFields_updatedAt
+  createdAt: PayloadApiTestTwosDocAccessFields_createdAt
+}
+
+type PayloadApiTestTwosDocAccessFields_payloadAPI {
+  create: PayloadApiTestTwosDocAccessFields_payloadAPI_Create
+  read: PayloadApiTestTwosDocAccessFields_payloadAPI_Read
+  update: PayloadApiTestTwosDocAccessFields_payloadAPI_Update
+  delete: PayloadApiTestTwosDocAccessFields_payloadAPI_Delete
+}
+
+type PayloadApiTestTwosDocAccessFields_payloadAPI_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_payloadAPI_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_payloadAPI_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_payloadAPI_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_relation {
+  create: PayloadApiTestTwosDocAccessFields_relation_Create
+  read: PayloadApiTestTwosDocAccessFields_relation_Read
+  update: PayloadApiTestTwosDocAccessFields_relation_Update
+  delete: PayloadApiTestTwosDocAccessFields_relation_Delete
+}
+
+type PayloadApiTestTwosDocAccessFields_relation_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_relation_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_relation_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_relation_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_updatedAt {
+  create: PayloadApiTestTwosDocAccessFields_updatedAt_Create
+  read: PayloadApiTestTwosDocAccessFields_updatedAt_Read
+  update: PayloadApiTestTwosDocAccessFields_updatedAt_Update
+  delete: PayloadApiTestTwosDocAccessFields_updatedAt_Delete
+}
+
+type PayloadApiTestTwosDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_createdAt {
+  create: PayloadApiTestTwosDocAccessFields_createdAt_Create
+  read: PayloadApiTestTwosDocAccessFields_createdAt_Read
+  update: PayloadApiTestTwosDocAccessFields_createdAt_Update
+  delete: PayloadApiTestTwosDocAccessFields_createdAt_Delete
+}
+
+type PayloadApiTestTwosDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestTwosReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestTwosUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestTwosDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreference {
+  id: String
+  user: PayloadPreference_User_Relationship!
+  key: String
+  value: JSON
+  updatedAt: DateTime
+  createdAt: DateTime
+}
+
+type PayloadPreference_User_Relationship {
+  relationTo: PayloadPreference_User_RelationTo
+  value: PayloadPreference_User
+}
+
+enum PayloadPreference_User_RelationTo {
+  users
+}
+
+union PayloadPreference_User = User
+
+type PayloadPreferences {
+  docs: [PayloadPreference]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input PayloadPreference_where {
+  user: PayloadPreference_user_Relation
+  key: PayloadPreference_key_operator
+  value: PayloadPreference_value_operator
+  updatedAt: PayloadPreference_updatedAt_operator
+  createdAt: PayloadPreference_createdAt_operator
+  id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
+}
+
+input PayloadPreference_user_Relation {
+  relationTo: PayloadPreference_user_Relation_RelationTo
+  value: JSON
+}
+
+enum PayloadPreference_user_Relation_RelationTo {
+  users
+}
+
+input PayloadPreference_key_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadPreference_value_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  within: JSON
+  intersects: JSON
+  exists: Boolean
+}
+
+input PayloadPreference_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadPreference_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadPreference_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadPreference_where_and {
+  user: PayloadPreference_user_Relation
+  key: PayloadPreference_key_operator
+  value: PayloadPreference_value_operator
+  updatedAt: PayloadPreference_updatedAt_operator
+  createdAt: PayloadPreference_createdAt_operator
+  id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
+}
+
+input PayloadPreference_where_or {
+  user: PayloadPreference_user_Relation
+  key: PayloadPreference_key_operator
+  value: PayloadPreference_value_operator
+  updatedAt: PayloadPreference_updatedAt_operator
+  createdAt: PayloadPreference_createdAt_operator
+  id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
+}
+
+type payload_preferencesDocAccess {
+  fields: PayloadPreferencesDocAccessFields
+  create: PayloadPreferencesCreateDocAccess
+  read: PayloadPreferencesReadDocAccess
+  update: PayloadPreferencesUpdateDocAccess
+  delete: PayloadPreferencesDeleteDocAccess
+}
+
+type PayloadPreferencesDocAccessFields {
+  user: PayloadPreferencesDocAccessFields_user
+  key: PayloadPreferencesDocAccessFields_key
+  value: PayloadPreferencesDocAccessFields_value
+  updatedAt: PayloadPreferencesDocAccessFields_updatedAt
+  createdAt: PayloadPreferencesDocAccessFields_createdAt
+}
+
+type PayloadPreferencesDocAccessFields_user {
+  create: PayloadPreferencesDocAccessFields_user_Create
+  read: PayloadPreferencesDocAccessFields_user_Read
+  update: PayloadPreferencesDocAccessFields_user_Update
+  delete: PayloadPreferencesDocAccessFields_user_Delete
+}
+
+type PayloadPreferencesDocAccessFields_user_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_user_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_user_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_user_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key {
+  create: PayloadPreferencesDocAccessFields_key_Create
+  read: PayloadPreferencesDocAccessFields_key_Read
+  update: PayloadPreferencesDocAccessFields_key_Update
+  delete: PayloadPreferencesDocAccessFields_key_Delete
+}
+
+type PayloadPreferencesDocAccessFields_key_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value {
+  create: PayloadPreferencesDocAccessFields_value_Create
+  read: PayloadPreferencesDocAccessFields_value_Read
+  update: PayloadPreferencesDocAccessFields_value_Update
+  delete: PayloadPreferencesDocAccessFields_value_Delete
+}
+
+type PayloadPreferencesDocAccessFields_value_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt {
+  create: PayloadPreferencesDocAccessFields_updatedAt_Create
+  read: PayloadPreferencesDocAccessFields_updatedAt_Read
+  update: PayloadPreferencesDocAccessFields_updatedAt_Update
+  delete: PayloadPreferencesDocAccessFields_updatedAt_Delete
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt {
+  create: PayloadPreferencesDocAccessFields_createdAt_Create
+  read: PayloadPreferencesDocAccessFields_createdAt_Read
+  update: PayloadPreferencesDocAccessFields_createdAt_Update
+  delete: PayloadPreferencesDocAccessFields_createdAt_Delete
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
 
 type Access {
   canAccessAdmin: Boolean!
   users: usersAccess
+  point: pointAccess
   posts: postsAccess
   custom_ids: custom_idsAccess
   relation: relationAccess
   dummy: dummyAccess
+  payload_api_test_ones: payload_api_test_onesAccess
+  payload_api_test_twos: payload_api_test_twosAccess
+  payload_preferences: payload_preferencesAccess
 }
 
 type usersAccess {
@@ -1924,6 +2862,109 @@ type UsersDeleteAccess {
 }
 
 type UsersUnlockAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type pointAccess {
+  fields: PointFields
+  create: PointCreateAccess
+  read: PointReadAccess
+  update: PointUpdateAccess
+  delete: PointDeleteAccess
+}
+
+type PointFields {
+  point: PointFields_point
+  updatedAt: PointFields_updatedAt
+  createdAt: PointFields_createdAt
+}
+
+type PointFields_point {
+  create: PointFields_point_Create
+  read: PointFields_point_Read
+  update: PointFields_point_Update
+  delete: PointFields_point_Delete
+}
+
+type PointFields_point_Create {
+  permission: Boolean!
+}
+
+type PointFields_point_Read {
+  permission: Boolean!
+}
+
+type PointFields_point_Update {
+  permission: Boolean!
+}
+
+type PointFields_point_Delete {
+  permission: Boolean!
+}
+
+type PointFields_updatedAt {
+  create: PointFields_updatedAt_Create
+  read: PointFields_updatedAt_Read
+  update: PointFields_updatedAt_Update
+  delete: PointFields_updatedAt_Delete
+}
+
+type PointFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PointFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PointFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PointFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PointFields_createdAt {
+  create: PointFields_createdAt_Create
+  read: PointFields_createdAt_Read
+  update: PointFields_createdAt_Update
+  delete: PointFields_createdAt_Delete
+}
+
+type PointFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PointFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PointFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PointFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PointCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PointReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PointUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PointDeleteAccess {
   permission: Boolean!
   where: JSONObject
 }
@@ -2844,58 +3885,436 @@ type DummyDeleteAccess {
   where: JSONObject
 }
 
+type payload_api_test_onesAccess {
+  fields: PayloadApiTestOnesFields
+  create: PayloadApiTestOnesCreateAccess
+  read: PayloadApiTestOnesReadAccess
+  update: PayloadApiTestOnesUpdateAccess
+  delete: PayloadApiTestOnesDeleteAccess
+}
+
+type PayloadApiTestOnesFields {
+  payloadAPI: PayloadApiTestOnesFields_payloadAPI
+  updatedAt: PayloadApiTestOnesFields_updatedAt
+  createdAt: PayloadApiTestOnesFields_createdAt
+}
+
+type PayloadApiTestOnesFields_payloadAPI {
+  create: PayloadApiTestOnesFields_payloadAPI_Create
+  read: PayloadApiTestOnesFields_payloadAPI_Read
+  update: PayloadApiTestOnesFields_payloadAPI_Update
+  delete: PayloadApiTestOnesFields_payloadAPI_Delete
+}
+
+type PayloadApiTestOnesFields_payloadAPI_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_payloadAPI_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_payloadAPI_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_payloadAPI_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_updatedAt {
+  create: PayloadApiTestOnesFields_updatedAt_Create
+  read: PayloadApiTestOnesFields_updatedAt_Read
+  update: PayloadApiTestOnesFields_updatedAt_Update
+  delete: PayloadApiTestOnesFields_updatedAt_Delete
+}
+
+type PayloadApiTestOnesFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_createdAt {
+  create: PayloadApiTestOnesFields_createdAt_Create
+  read: PayloadApiTestOnesFields_createdAt_Read
+  update: PayloadApiTestOnesFields_createdAt_Update
+  delete: PayloadApiTestOnesFields_createdAt_Delete
+}
+
+type PayloadApiTestOnesFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestOnesCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestOnesReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestOnesUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestOnesDeleteAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type payload_api_test_twosAccess {
+  fields: PayloadApiTestTwosFields
+  create: PayloadApiTestTwosCreateAccess
+  read: PayloadApiTestTwosReadAccess
+  update: PayloadApiTestTwosUpdateAccess
+  delete: PayloadApiTestTwosDeleteAccess
+}
+
+type PayloadApiTestTwosFields {
+  payloadAPI: PayloadApiTestTwosFields_payloadAPI
+  relation: PayloadApiTestTwosFields_relation
+  updatedAt: PayloadApiTestTwosFields_updatedAt
+  createdAt: PayloadApiTestTwosFields_createdAt
+}
+
+type PayloadApiTestTwosFields_payloadAPI {
+  create: PayloadApiTestTwosFields_payloadAPI_Create
+  read: PayloadApiTestTwosFields_payloadAPI_Read
+  update: PayloadApiTestTwosFields_payloadAPI_Update
+  delete: PayloadApiTestTwosFields_payloadAPI_Delete
+}
+
+type PayloadApiTestTwosFields_payloadAPI_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_payloadAPI_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_payloadAPI_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_payloadAPI_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_relation {
+  create: PayloadApiTestTwosFields_relation_Create
+  read: PayloadApiTestTwosFields_relation_Read
+  update: PayloadApiTestTwosFields_relation_Update
+  delete: PayloadApiTestTwosFields_relation_Delete
+}
+
+type PayloadApiTestTwosFields_relation_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_relation_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_relation_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_relation_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_updatedAt {
+  create: PayloadApiTestTwosFields_updatedAt_Create
+  read: PayloadApiTestTwosFields_updatedAt_Read
+  update: PayloadApiTestTwosFields_updatedAt_Update
+  delete: PayloadApiTestTwosFields_updatedAt_Delete
+}
+
+type PayloadApiTestTwosFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_createdAt {
+  create: PayloadApiTestTwosFields_createdAt_Create
+  read: PayloadApiTestTwosFields_createdAt_Read
+  update: PayloadApiTestTwosFields_createdAt_Update
+  delete: PayloadApiTestTwosFields_createdAt_Delete
+}
+
+type PayloadApiTestTwosFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadApiTestTwosCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestTwosReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestTwosUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadApiTestTwosDeleteAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type payload_preferencesAccess {
+  fields: PayloadPreferencesFields
+  create: PayloadPreferencesCreateAccess
+  read: PayloadPreferencesReadAccess
+  update: PayloadPreferencesUpdateAccess
+  delete: PayloadPreferencesDeleteAccess
+}
+
+type PayloadPreferencesFields {
+  user: PayloadPreferencesFields_user
+  key: PayloadPreferencesFields_key
+  value: PayloadPreferencesFields_value
+  updatedAt: PayloadPreferencesFields_updatedAt
+  createdAt: PayloadPreferencesFields_createdAt
+}
+
+type PayloadPreferencesFields_user {
+  create: PayloadPreferencesFields_user_Create
+  read: PayloadPreferencesFields_user_Read
+  update: PayloadPreferencesFields_user_Update
+  delete: PayloadPreferencesFields_user_Delete
+}
+
+type PayloadPreferencesFields_user_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_user_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_user_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_user_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key {
+  create: PayloadPreferencesFields_key_Create
+  read: PayloadPreferencesFields_key_Read
+  update: PayloadPreferencesFields_key_Update
+  delete: PayloadPreferencesFields_key_Delete
+}
+
+type PayloadPreferencesFields_key_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value {
+  create: PayloadPreferencesFields_value_Create
+  read: PayloadPreferencesFields_value_Read
+  update: PayloadPreferencesFields_value_Update
+  delete: PayloadPreferencesFields_value_Delete
+}
+
+type PayloadPreferencesFields_value_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt {
+  create: PayloadPreferencesFields_updatedAt_Create
+  read: PayloadPreferencesFields_updatedAt_Read
+  update: PayloadPreferencesFields_updatedAt_Update
+  delete: PayloadPreferencesFields_updatedAt_Delete
+}
+
+type PayloadPreferencesFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt {
+  create: PayloadPreferencesFields_createdAt_Create
+  read: PayloadPreferencesFields_createdAt_Read
+  update: PayloadPreferencesFields_createdAt_Update
+  delete: PayloadPreferencesFields_createdAt_Delete
+}
+
+type PayloadPreferencesFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesDeleteAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
 type QueryWithInternalError {
   text: String
 }
 
 type Mutation {
   createUser(data: mutationUserInput!, draft: Boolean): User
-  updateUser(id: String!, data: mutationUserUpdateInput!, draft: Boolean, autosave: Boolean): User
+  updateUser(id: String!, autosave: Boolean, data: mutationUserUpdateInput!, draft: Boolean): User
   deleteUser(id: String!): User
   refreshTokenUser(token: String): usersRefreshedUser
   logoutUser: String
   unlockUser(email: String!): Boolean!
   loginUser(email: String, password: String): usersLoginResult
-  forgotPasswordUser(email: String!, disableEmail: Boolean, expiration: Int): Boolean!
-  resetPasswordUser(token: String, password: String): usersResetPassword
+  forgotPasswordUser(disableEmail: Boolean, email: String!, expiration: Int): Boolean!
+  resetPasswordUser(password: String, token: String): usersResetPassword
   verifyEmailUser(token: String): Boolean
+  createPoint(data: mutationPointInput!, draft: Boolean): Point
+  updatePoint(id: String!, autosave: Boolean, data: mutationPointUpdateInput!, draft: Boolean): Point
+  deletePoint(id: String!): Point
   createPost(data: mutationPostInput!, draft: Boolean): Post
-  updatePost(id: String!, data: mutationPostUpdateInput!, draft: Boolean, autosave: Boolean): Post
+  updatePost(id: String!, autosave: Boolean, data: mutationPostUpdateInput!, draft: Boolean): Post
   deletePost(id: String!): Post
   createCustomId(data: mutationCustomIdInput!, draft: Boolean): CustomId
-  updateCustomId(
-    id: Int!
-    data: mutationCustomIdUpdateInput!
-    draft: Boolean
-    autosave: Boolean
-  ): CustomId
+  updateCustomId(id: Int!, autosave: Boolean, data: mutationCustomIdUpdateInput!, draft: Boolean): CustomId
   deleteCustomId(id: Int!): CustomId
   createRelation(data: mutationRelationInput!, draft: Boolean): Relation
-  updateRelation(
-    id: String!
-    data: mutationRelationUpdateInput!
-    draft: Boolean
-    autosave: Boolean
-  ): Relation
+  updateRelation(id: String!, autosave: Boolean, data: mutationRelationUpdateInput!, draft: Boolean): Relation
   deleteRelation(id: String!): Relation
   createDummy(data: mutationDummyInput!, draft: Boolean): Dummy
-  updateDummy(
-    id: String!
-    data: mutationDummyUpdateInput!
-    draft: Boolean
-    autosave: Boolean
-  ): Dummy
+  updateDummy(id: String!, autosave: Boolean, data: mutationDummyUpdateInput!, draft: Boolean): Dummy
   deleteDummy(id: String!): Dummy
-  updatePreference(key: String!, value: JSON): Preference
-  deletePreference(key: String!): Preference
+  createPayloadApiTestOne(data: mutationPayloadApiTestOneInput!, draft: Boolean): PayloadApiTestOne
+  updatePayloadApiTestOne(id: String!, autosave: Boolean, data: mutationPayloadApiTestOneUpdateInput!, draft: Boolean): PayloadApiTestOne
+  deletePayloadApiTestOne(id: String!): PayloadApiTestOne
+  createPayloadApiTestTwo(data: mutationPayloadApiTestTwoInput!, draft: Boolean): PayloadApiTestTwo
+  updatePayloadApiTestTwo(id: String!, autosave: Boolean, data: mutationPayloadApiTestTwoUpdateInput!, draft: Boolean): PayloadApiTestTwo
+  deletePayloadApiTestTwo(id: String!): PayloadApiTestTwo
+  createPayloadPreference(data: mutationPayloadPreferenceInput!, draft: Boolean): PayloadPreference
+  updatePayloadPreference(id: String!, autosave: Boolean, data: mutationPayloadPreferenceUpdateInput!, draft: Boolean): PayloadPreference
+  deletePayloadPreference(id: String!): PayloadPreference
 }
 
 input mutationUserInput {
   updatedAt: String
   createdAt: String
-  email: String
+  email: String!
   resetPasswordToken: String
   resetPasswordExpiration: String
+  salt: String
+  hash: String
   loginAttempts: Float
   lockUntil: String
   password: String!
@@ -2907,15 +4326,17 @@ input mutationUserUpdateInput {
   email: String
   resetPasswordToken: String
   resetPasswordExpiration: String
+  salt: String
+  hash: String
   loginAttempts: Float
   lockUntil: String
   password: String
 }
 
 type usersRefreshedUser {
-  user: usersJWT
-  refreshedToken: String
   exp: Int
+  refreshedToken: String
+  user: usersJWT
 }
 
 type usersJWT {
@@ -2924,14 +4345,26 @@ type usersJWT {
 }
 
 type usersLoginResult {
+  exp: Int
   token: String
   user: User
-  exp: Int
 }
 
 type usersResetPassword {
   token: String
   user: User
+}
+
+input mutationPointInput {
+  point: [Float]
+  updatedAt: String
+  createdAt: String
+}
+
+input mutationPointUpdateInput {
+  point: [Float]
+  updatedAt: String
+  createdAt: String
 }
 
 input mutationPostInput {
@@ -3103,4 +4536,64 @@ input mutationDummyUpdateInput {
   name: String
   updatedAt: String
   createdAt: String
+}
+
+input mutationPayloadApiTestOneInput {
+  payloadAPI: String
+  updatedAt: String
+  createdAt: String
+}
+
+input mutationPayloadApiTestOneUpdateInput {
+  payloadAPI: String
+  updatedAt: String
+  createdAt: String
+}
+
+input mutationPayloadApiTestTwoInput {
+  payloadAPI: String
+  relation: String
+  updatedAt: String
+  createdAt: String
+}
+
+input mutationPayloadApiTestTwoUpdateInput {
+  payloadAPI: String
+  relation: String
+  updatedAt: String
+  createdAt: String
+}
+
+input mutationPayloadPreferenceInput {
+  user: PayloadPreference_UserRelationshipInput
+  key: String
+  value: JSON
+  updatedAt: String
+  createdAt: String
+}
+
+input PayloadPreference_UserRelationshipInput {
+  relationTo: PayloadPreference_UserRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PayloadPreference_UserRelationshipInputRelationTo {
+  users
+}
+
+input mutationPayloadPreferenceUpdateInput {
+  user: PayloadPreferenceUpdate_UserRelationshipInput
+  key: String
+  value: JSON
+  updatedAt: String
+  createdAt: String
+}
+
+input PayloadPreferenceUpdate_UserRelationshipInput {
+  relationTo: PayloadPreferenceUpdate_UserRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PayloadPreferenceUpdate_UserRelationshipInputRelationTo {
+  users
 }

--- a/test/field-error-states/schema.graphql
+++ b/test/field-error-states/schema.graphql
@@ -1,44 +1,73 @@
 type Query {
-  Post(id: String!, draft: Boolean): Post
-  Posts(where: Post_where, draft: Boolean, page: Int, limit: Int, sort: String): Posts
-  docAccessPost(id: String!): postsDocAccess
+  ErrorField(id: String!, draft: Boolean): ErrorField
+  ErrorFields(draft: Boolean, where: ErrorField_where, limit: Int, page: Int, sort: String): ErrorFields
+  docAccessErrorField(id: String!): error_fieldsDocAccess
+  Upload(id: String!, draft: Boolean): Upload
+  Uploads(draft: Boolean, where: Upload_where, limit: Int, page: Int, sort: String): Uploads
+  docAccessUpload(id: String!): uploadsDocAccess
   User(id: String!, draft: Boolean): User
-  Users(where: User_where, draft: Boolean, page: Int, limit: Int, sort: String): Users
+  Users(draft: Boolean, where: User_where, limit: Int, page: Int, sort: String): Users
   docAccessUser(id: String!): usersDocAccess
   meUser: usersMe
   initializedUser: Boolean
-  Preference(key: String): Preference
+  PayloadPreference(id: String!, draft: Boolean): PayloadPreference
+  PayloadPreferences(draft: Boolean, where: PayloadPreference_where, limit: Int, page: Int, sort: String): PayloadPreferences
+  docAccessPayloadPreference(id: String!): payload_preferencesDocAccess
   Access: Access
 }
 
-type Post {
+type ErrorField {
   id: String
-  arrayField: [Post_ArrayField!]
+  parentArray: [ErrorField_ParentArray!]
+  home: ErrorField_Home
+  tabText: String!
+  text: String!
+  array: [ErrorField_Array!]
+  layout: [ErrorField_Layout!]
+  group: ErrorField_Group
   updatedAt: DateTime
   createdAt: DateTime
 }
 
-type Post_ArrayField {
-  group23field: Post_ArrayField_Group23field
+type ErrorField_ParentArray {
+  childArray: [ErrorField_ParentArray_ChildArray!]!
   id: String
 }
 
-type Post_ArrayField_Group23field {
-  arrayField: [Post_ArrayField_Group23field_ArrayField!]!
-}
-
-type Post_ArrayField_Group23field_ArrayField {
-  group23field: Post_ArrayField_Group23field_ArrayField_Group23field
+type ErrorField_ParentArray_ChildArray {
+  childArrayText: String!
   id: String
 }
 
-type Post_ArrayField_Group23field_ArrayField_Group23field {
-  arrayField: [Post_ArrayField_Group23field_ArrayField_Group23field_ArrayField!]!
+type ErrorField_Home {
+  tabText: String!
+  text: String!
+  array: [ErrorField_Home_Array!]
 }
 
-type Post_ArrayField_Group23field_ArrayField_Group23field_ArrayField {
-  textField: String!
+type ErrorField_Home_Array {
+  requiredArrayText: String
+  arrayText: String
+  group: ErrorField_Home_Array_Group
+  code: String
+  json: JSON
+  email: EmailAddress
+  point: [Float!]
+  radio: ErrorField_Home_Array_radio
+  relationship: User
+  richtext(depth: Int): JSON
+  select: ErrorField_Home_Array_select
+  upload(where: ErrorField_Home_Array_Upload_where): Upload
+  text: String
+  textarea: String
   id: String
+}
+
+type ErrorField_Home_Array_Group {
+  text: String
+  number: Float
+  date: DateTime
+  checkbox: Boolean
 }
 
 """
@@ -46,453 +75,26 @@ A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `dat
 """
 scalar DateTime
 
-type Posts {
-  docs: [Post]
-  totalDocs: Int
-  offset: Int
-  limit: Int
-  totalPages: Int
-  page: Int
-  pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
-  prevPage: Int
-  nextPage: Int
-}
-
-input Post_where {
-  arrayField__group23field__arrayField__group23field__arrayField__textField: Post_arrayField__group23field__arrayField__group23field__arrayField__textField_operator
-  arrayField__group23field__arrayField__group23field__arrayField__id: Post_arrayField__group23field__arrayField__group23field__arrayField__id_operator
-  arrayField__group23field__arrayField__id: Post_arrayField__group23field__arrayField__id_operator
-  arrayField__id: Post_arrayField__id_operator
-  updatedAt: Post_updatedAt_operator
-  createdAt: Post_createdAt_operator
-  id: Post_id_operator
-  OR: [Post_where_or]
-  AND: [Post_where_and]
-}
-
-input Post_arrayField__group23field__arrayField__group23field__arrayField__textField_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input Post_arrayField__group23field__arrayField__group23field__arrayField__id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Post_arrayField__group23field__arrayField__id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Post_arrayField__id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Post_updatedAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input Post_createdAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input Post_id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Post_where_or {
-  arrayField__group23field__arrayField__group23field__arrayField__textField: Post_arrayField__group23field__arrayField__group23field__arrayField__textField_operator
-  arrayField__group23field__arrayField__group23field__arrayField__id: Post_arrayField__group23field__arrayField__group23field__arrayField__id_operator
-  arrayField__group23field__arrayField__id: Post_arrayField__group23field__arrayField__id_operator
-  arrayField__id: Post_arrayField__id_operator
-  updatedAt: Post_updatedAt_operator
-  createdAt: Post_createdAt_operator
-  id: Post_id_operator
-}
-
-input Post_where_and {
-  arrayField__group23field__arrayField__group23field__arrayField__textField: Post_arrayField__group23field__arrayField__group23field__arrayField__textField_operator
-  arrayField__group23field__arrayField__group23field__arrayField__id: Post_arrayField__group23field__arrayField__group23field__arrayField__id_operator
-  arrayField__group23field__arrayField__id: Post_arrayField__group23field__arrayField__id_operator
-  arrayField__id: Post_arrayField__id_operator
-  updatedAt: Post_updatedAt_operator
-  createdAt: Post_createdAt_operator
-  id: Post_id_operator
-}
-
-type postsDocAccess {
-  fields: PostsDocAccessFields
-  create: PostsCreateDocAccess
-  read: PostsReadDocAccess
-  update: PostsUpdateDocAccess
-  delete: PostsDeleteDocAccess
-}
-
-type PostsDocAccessFields {
-  arrayField: PostsDocAccessFields_arrayField
-  updatedAt: PostsDocAccessFields_updatedAt
-  createdAt: PostsDocAccessFields_createdAt
-}
-
-type PostsDocAccessFields_arrayField {
-  create: PostsDocAccessFields_arrayField_Create
-  read: PostsDocAccessFields_arrayField_Read
-  update: PostsDocAccessFields_arrayField_Update
-  delete: PostsDocAccessFields_arrayField_Delete
-  fields: PostsDocAccessFields_arrayField_Fields
-}
-
-type PostsDocAccessFields_arrayField_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_Fields {
-  group23field: PostsDocAccessFields_arrayField_group23field
-  id: PostsDocAccessFields_arrayField_id
-}
-
-type PostsDocAccessFields_arrayField_group23field {
-  create: PostsDocAccessFields_arrayField_group23field_Create
-  read: PostsDocAccessFields_arrayField_group23field_Read
-  update: PostsDocAccessFields_arrayField_group23field_Update
-  delete: PostsDocAccessFields_arrayField_group23field_Delete
-  fields: PostsDocAccessFields_arrayField_group23field_Fields
-}
-
-type PostsDocAccessFields_arrayField_group23field_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_Fields {
-  arrayField: PostsDocAccessFields_arrayField_group23field_arrayField
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField {
-  create: PostsDocAccessFields_arrayField_group23field_arrayField_Create
-  read: PostsDocAccessFields_arrayField_group23field_arrayField_Read
-  update: PostsDocAccessFields_arrayField_group23field_arrayField_Update
-  delete: PostsDocAccessFields_arrayField_group23field_arrayField_Delete
-  fields: PostsDocAccessFields_arrayField_group23field_arrayField_Fields
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_Fields {
-  group23field: PostsDocAccessFields_arrayField_group23field_arrayField_group23field
-  id: PostsDocAccessFields_arrayField_group23field_arrayField_id
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field {
-  create: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_Create
-  read: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_Read
-  update: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_Update
-  delete: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_Delete
-  fields: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_Fields
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_Fields {
-  arrayField: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField {
-  create: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_Create
-  read: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_Read
-  update: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_Update
-  delete: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_Delete
-  fields: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_Fields
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_Fields {
-  textField: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_textField
-  id: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_id
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_textField {
-  create: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Create
-  read: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Read
-  update: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Update
-  delete: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Delete
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_id {
-  create: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_id_Create
-  read: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_id_Read
-  update: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_id_Update
-  delete: PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_id_Delete
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_id_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_id_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_id_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_group23field_arrayField_id_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_id {
-  create: PostsDocAccessFields_arrayField_group23field_arrayField_id_Create
-  read: PostsDocAccessFields_arrayField_group23field_arrayField_id_Read
-  update: PostsDocAccessFields_arrayField_group23field_arrayField_id_Update
-  delete: PostsDocAccessFields_arrayField_group23field_arrayField_id_Delete
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_id_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_id_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_id_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_group23field_arrayField_id_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_id {
-  create: PostsDocAccessFields_arrayField_id_Create
-  read: PostsDocAccessFields_arrayField_id_Read
-  update: PostsDocAccessFields_arrayField_id_Update
-  delete: PostsDocAccessFields_arrayField_id_Delete
-}
-
-type PostsDocAccessFields_arrayField_id_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_id_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_id_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_arrayField_id_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_updatedAt {
-  create: PostsDocAccessFields_updatedAt_Create
-  read: PostsDocAccessFields_updatedAt_Read
-  update: PostsDocAccessFields_updatedAt_Update
-  delete: PostsDocAccessFields_updatedAt_Delete
-}
-
-type PostsDocAccessFields_updatedAt_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_updatedAt_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_updatedAt_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_updatedAt_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_createdAt {
-  create: PostsDocAccessFields_createdAt_Create
-  read: PostsDocAccessFields_createdAt_Read
-  update: PostsDocAccessFields_createdAt_Update
-  delete: PostsDocAccessFields_createdAt_Delete
-}
-
-type PostsDocAccessFields_createdAt_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_createdAt_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_createdAt_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_createdAt_Delete {
-  permission: Boolean!
-}
-
-type PostsCreateDocAccess {
-  permission: Boolean!
-  where: JSONObject
-}
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
 
 """
-The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+A field whose value conforms to the standard internet email address format as specified in HTML Spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address.
 """
-scalar JSONObject
+scalar EmailAddress @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
 
-type PostsReadDocAccess {
-  permission: Boolean!
-  where: JSONObject
-}
-
-type PostsUpdateDocAccess {
-  permission: Boolean!
-  where: JSONObject
-}
-
-type PostsDeleteDocAccess {
-  permission: Boolean!
-  where: JSONObject
+enum ErrorField_Home_Array_radio {
+  mint
+  dark_gray
 }
 
 type User {
   id: String
   updatedAt: DateTime
   createdAt: DateTime
-  email: EmailAddress
+  email: EmailAddress!
   resetPasswordToken: String
   resetPasswordExpiration: DateTime
   salt: String
@@ -502,24 +104,2738 @@ type User {
   password: String!
 }
 
+enum ErrorField_Home_Array_select {
+  mint
+  dark_gray
+}
+
+type Upload {
+  id: String
+  text: String
+  media(where: Upload_Media_where): Upload
+  richText(depth: Int): JSON
+  updatedAt: DateTime
+  createdAt: DateTime
+  url: String
+  filename: String
+  mimeType: String
+  filesize: Float
+  width: Float
+  height: Float
+}
+
+input Upload_Media_where {
+  text: Upload_Media_text_operator
+  media: Upload_Media_media_operator
+  richText: Upload_Media_richText_operator
+  updatedAt: Upload_Media_updatedAt_operator
+  createdAt: Upload_Media_createdAt_operator
+  url: Upload_Media_url_operator
+  filename: Upload_Media_filename_operator
+  mimeType: Upload_Media_mimeType_operator
+  filesize: Upload_Media_filesize_operator
+  width: Upload_Media_width_operator
+  height: Upload_Media_height_operator
+  id: Upload_Media_id_operator
+  AND: [Upload_Media_where_and]
+  OR: [Upload_Media_where_or]
+}
+
+input Upload_Media_text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_Media_media_operator {
+  equals: String
+  not_equals: String
+  exists: Boolean
+}
+
+input Upload_Media_richText_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input Upload_Media_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Upload_Media_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Upload_Media_url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_Media_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_Media_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_Media_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_Media_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_Media_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_Media_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_Media_where_and {
+  text: Upload_Media_text_operator
+  media: Upload_Media_media_operator
+  richText: Upload_Media_richText_operator
+  updatedAt: Upload_Media_updatedAt_operator
+  createdAt: Upload_Media_createdAt_operator
+  url: Upload_Media_url_operator
+  filename: Upload_Media_filename_operator
+  mimeType: Upload_Media_mimeType_operator
+  filesize: Upload_Media_filesize_operator
+  width: Upload_Media_width_operator
+  height: Upload_Media_height_operator
+  id: Upload_Media_id_operator
+  AND: [Upload_Media_where_and]
+  OR: [Upload_Media_where_or]
+}
+
+input Upload_Media_where_or {
+  text: Upload_Media_text_operator
+  media: Upload_Media_media_operator
+  richText: Upload_Media_richText_operator
+  updatedAt: Upload_Media_updatedAt_operator
+  createdAt: Upload_Media_createdAt_operator
+  url: Upload_Media_url_operator
+  filename: Upload_Media_filename_operator
+  mimeType: Upload_Media_mimeType_operator
+  filesize: Upload_Media_filesize_operator
+  width: Upload_Media_width_operator
+  height: Upload_Media_height_operator
+  id: Upload_Media_id_operator
+  AND: [Upload_Media_where_and]
+  OR: [Upload_Media_where_or]
+}
+
+input ErrorField_Home_Array_Upload_where {
+  text: ErrorField_Home_Array_Upload_text_operator
+  media: ErrorField_Home_Array_Upload_media_operator
+  richText: ErrorField_Home_Array_Upload_richText_operator
+  updatedAt: ErrorField_Home_Array_Upload_updatedAt_operator
+  createdAt: ErrorField_Home_Array_Upload_createdAt_operator
+  url: ErrorField_Home_Array_Upload_url_operator
+  filename: ErrorField_Home_Array_Upload_filename_operator
+  mimeType: ErrorField_Home_Array_Upload_mimeType_operator
+  filesize: ErrorField_Home_Array_Upload_filesize_operator
+  width: ErrorField_Home_Array_Upload_width_operator
+  height: ErrorField_Home_Array_Upload_height_operator
+  id: ErrorField_Home_Array_Upload_id_operator
+  AND: [ErrorField_Home_Array_Upload_where_and]
+  OR: [ErrorField_Home_Array_Upload_where_or]
+}
+
+input ErrorField_Home_Array_Upload_text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_media_operator {
+  equals: String
+  not_equals: String
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_richText_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_Home_Array_Upload_where_and {
+  text: ErrorField_Home_Array_Upload_text_operator
+  media: ErrorField_Home_Array_Upload_media_operator
+  richText: ErrorField_Home_Array_Upload_richText_operator
+  updatedAt: ErrorField_Home_Array_Upload_updatedAt_operator
+  createdAt: ErrorField_Home_Array_Upload_createdAt_operator
+  url: ErrorField_Home_Array_Upload_url_operator
+  filename: ErrorField_Home_Array_Upload_filename_operator
+  mimeType: ErrorField_Home_Array_Upload_mimeType_operator
+  filesize: ErrorField_Home_Array_Upload_filesize_operator
+  width: ErrorField_Home_Array_Upload_width_operator
+  height: ErrorField_Home_Array_Upload_height_operator
+  id: ErrorField_Home_Array_Upload_id_operator
+  AND: [ErrorField_Home_Array_Upload_where_and]
+  OR: [ErrorField_Home_Array_Upload_where_or]
+}
+
+input ErrorField_Home_Array_Upload_where_or {
+  text: ErrorField_Home_Array_Upload_text_operator
+  media: ErrorField_Home_Array_Upload_media_operator
+  richText: ErrorField_Home_Array_Upload_richText_operator
+  updatedAt: ErrorField_Home_Array_Upload_updatedAt_operator
+  createdAt: ErrorField_Home_Array_Upload_createdAt_operator
+  url: ErrorField_Home_Array_Upload_url_operator
+  filename: ErrorField_Home_Array_Upload_filename_operator
+  mimeType: ErrorField_Home_Array_Upload_mimeType_operator
+  filesize: ErrorField_Home_Array_Upload_filesize_operator
+  width: ErrorField_Home_Array_Upload_width_operator
+  height: ErrorField_Home_Array_Upload_height_operator
+  id: ErrorField_Home_Array_Upload_id_operator
+  AND: [ErrorField_Home_Array_Upload_where_and]
+  OR: [ErrorField_Home_Array_Upload_where_or]
+}
+
+type ErrorField_Array {
+  requiredArrayText: String
+  arrayText: String
+  group: ErrorField_Array_Group
+  code: String
+  json: JSON
+  email: EmailAddress
+  point: [Float!]
+  radio: ErrorField_Array_radio
+  relationship: User
+  richtext(depth: Int): JSON
+  select: ErrorField_Array_select
+  upload(where: ErrorField_Array_Upload_where): Upload
+  text: String
+  textarea: String
+  id: String
+}
+
+type ErrorField_Array_Group {
+  text: String
+  number: Float
+  date: DateTime
+  checkbox: Boolean
+}
+
+enum ErrorField_Array_radio {
+  mint
+  dark_gray
+}
+
+enum ErrorField_Array_select {
+  mint
+  dark_gray
+}
+
+input ErrorField_Array_Upload_where {
+  text: ErrorField_Array_Upload_text_operator
+  media: ErrorField_Array_Upload_media_operator
+  richText: ErrorField_Array_Upload_richText_operator
+  updatedAt: ErrorField_Array_Upload_updatedAt_operator
+  createdAt: ErrorField_Array_Upload_createdAt_operator
+  url: ErrorField_Array_Upload_url_operator
+  filename: ErrorField_Array_Upload_filename_operator
+  mimeType: ErrorField_Array_Upload_mimeType_operator
+  filesize: ErrorField_Array_Upload_filesize_operator
+  width: ErrorField_Array_Upload_width_operator
+  height: ErrorField_Array_Upload_height_operator
+  id: ErrorField_Array_Upload_id_operator
+  AND: [ErrorField_Array_Upload_where_and]
+  OR: [ErrorField_Array_Upload_where_or]
+}
+
+input ErrorField_Array_Upload_text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_media_operator {
+  equals: String
+  not_equals: String
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_richText_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_Array_Upload_where_and {
+  text: ErrorField_Array_Upload_text_operator
+  media: ErrorField_Array_Upload_media_operator
+  richText: ErrorField_Array_Upload_richText_operator
+  updatedAt: ErrorField_Array_Upload_updatedAt_operator
+  createdAt: ErrorField_Array_Upload_createdAt_operator
+  url: ErrorField_Array_Upload_url_operator
+  filename: ErrorField_Array_Upload_filename_operator
+  mimeType: ErrorField_Array_Upload_mimeType_operator
+  filesize: ErrorField_Array_Upload_filesize_operator
+  width: ErrorField_Array_Upload_width_operator
+  height: ErrorField_Array_Upload_height_operator
+  id: ErrorField_Array_Upload_id_operator
+  AND: [ErrorField_Array_Upload_where_and]
+  OR: [ErrorField_Array_Upload_where_or]
+}
+
+input ErrorField_Array_Upload_where_or {
+  text: ErrorField_Array_Upload_text_operator
+  media: ErrorField_Array_Upload_media_operator
+  richText: ErrorField_Array_Upload_richText_operator
+  updatedAt: ErrorField_Array_Upload_updatedAt_operator
+  createdAt: ErrorField_Array_Upload_createdAt_operator
+  url: ErrorField_Array_Upload_url_operator
+  filename: ErrorField_Array_Upload_filename_operator
+  mimeType: ErrorField_Array_Upload_mimeType_operator
+  filesize: ErrorField_Array_Upload_filesize_operator
+  width: ErrorField_Array_Upload_width_operator
+  height: ErrorField_Array_Upload_height_operator
+  id: ErrorField_Array_Upload_id_operator
+  AND: [ErrorField_Array_Upload_where_and]
+  OR: [ErrorField_Array_Upload_where_or]
+}
+
+union ErrorField_Layout = Block1
+
+type Block1 {
+  tabText: String!
+  text: String!
+  array: [Block1_Array!]
+  id: String
+  blockName: String
+  blockType: String
+}
+
+type Block1_Array {
+  requiredArrayText: String
+  arrayText: String
+  group: Block1_Array_Group
+  code: String
+  json: JSON
+  email: EmailAddress
+  point: [Float!]
+  radio: Block1_Array_radio
+  relationship: User
+  richtext(depth: Int): JSON
+  select: Block1_Array_select
+  upload(where: Block1_Array_Upload_where): Upload
+  text: String
+  textarea: String
+  id: String
+}
+
+type Block1_Array_Group {
+  text: String
+  number: Float
+  date: DateTime
+  checkbox: Boolean
+}
+
+enum Block1_Array_radio {
+  mint
+  dark_gray
+}
+
+enum Block1_Array_select {
+  mint
+  dark_gray
+}
+
+input Block1_Array_Upload_where {
+  text: Block1_Array_Upload_text_operator
+  media: Block1_Array_Upload_media_operator
+  richText: Block1_Array_Upload_richText_operator
+  updatedAt: Block1_Array_Upload_updatedAt_operator
+  createdAt: Block1_Array_Upload_createdAt_operator
+  url: Block1_Array_Upload_url_operator
+  filename: Block1_Array_Upload_filename_operator
+  mimeType: Block1_Array_Upload_mimeType_operator
+  filesize: Block1_Array_Upload_filesize_operator
+  width: Block1_Array_Upload_width_operator
+  height: Block1_Array_Upload_height_operator
+  id: Block1_Array_Upload_id_operator
+  AND: [Block1_Array_Upload_where_and]
+  OR: [Block1_Array_Upload_where_or]
+}
+
+input Block1_Array_Upload_text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Block1_Array_Upload_media_operator {
+  equals: String
+  not_equals: String
+  exists: Boolean
+}
+
+input Block1_Array_Upload_richText_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input Block1_Array_Upload_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Block1_Array_Upload_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Block1_Array_Upload_url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Block1_Array_Upload_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Block1_Array_Upload_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Block1_Array_Upload_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Block1_Array_Upload_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Block1_Array_Upload_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Block1_Array_Upload_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Block1_Array_Upload_where_and {
+  text: Block1_Array_Upload_text_operator
+  media: Block1_Array_Upload_media_operator
+  richText: Block1_Array_Upload_richText_operator
+  updatedAt: Block1_Array_Upload_updatedAt_operator
+  createdAt: Block1_Array_Upload_createdAt_operator
+  url: Block1_Array_Upload_url_operator
+  filename: Block1_Array_Upload_filename_operator
+  mimeType: Block1_Array_Upload_mimeType_operator
+  filesize: Block1_Array_Upload_filesize_operator
+  width: Block1_Array_Upload_width_operator
+  height: Block1_Array_Upload_height_operator
+  id: Block1_Array_Upload_id_operator
+  AND: [Block1_Array_Upload_where_and]
+  OR: [Block1_Array_Upload_where_or]
+}
+
+input Block1_Array_Upload_where_or {
+  text: Block1_Array_Upload_text_operator
+  media: Block1_Array_Upload_media_operator
+  richText: Block1_Array_Upload_richText_operator
+  updatedAt: Block1_Array_Upload_updatedAt_operator
+  createdAt: Block1_Array_Upload_createdAt_operator
+  url: Block1_Array_Upload_url_operator
+  filename: Block1_Array_Upload_filename_operator
+  mimeType: Block1_Array_Upload_mimeType_operator
+  filesize: Block1_Array_Upload_filesize_operator
+  width: Block1_Array_Upload_width_operator
+  height: Block1_Array_Upload_height_operator
+  id: Block1_Array_Upload_id_operator
+  AND: [Block1_Array_Upload_where_and]
+  OR: [Block1_Array_Upload_where_or]
+}
+
+type ErrorField_Group {
+  text: String
+}
+
+type ErrorFields {
+  docs: [ErrorField]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input ErrorField_where {
+  parentArray__childArray__childArrayText: ErrorField_parentArray__childArray__childArrayText_operator
+  parentArray__childArray__id: ErrorField_parentArray__childArray__id_operator
+  parentArray__id: ErrorField_parentArray__id_operator
+  home__tabText: ErrorField_home__tabText_operator
+  home__text: ErrorField_home__text_operator
+  home__array__requiredArrayText: ErrorField_home__array__requiredArrayText_operator
+  home__array__arrayText: ErrorField_home__array__arrayText_operator
+  home__array__group__text: ErrorField_home__array__group__text_operator
+  home__array__group__number: ErrorField_home__array__group__number_operator
+  home__array__group__date: ErrorField_home__array__group__date_operator
+  home__array__group__checkbox: ErrorField_home__array__group__checkbox_operator
+  home__array__code: ErrorField_home__array__code_operator
+  home__array__json: ErrorField_home__array__json_operator
+  home__array__email: ErrorField_home__array__email_operator
+  home__array__point: ErrorField_home__array__point_operator
+  home__array__radio: ErrorField_home__array__radio_operator
+  home__array__relationship: ErrorField_home__array__relationship_operator
+  home__array__richtext: ErrorField_home__array__richtext_operator
+  home__array__select: ErrorField_home__array__select_operator
+  home__array__upload: ErrorField_home__array__upload_operator
+  home__array__text: ErrorField_home__array__text_operator
+  home__array__textarea: ErrorField_home__array__textarea_operator
+  home__array__id: ErrorField_home__array__id_operator
+  tabText: ErrorField_tabText_operator
+  text: ErrorField_text_operator
+  array__requiredArrayText: ErrorField_array__requiredArrayText_operator
+  array__arrayText: ErrorField_array__arrayText_operator
+  array__group__text: ErrorField_array__group__text_operator
+  array__group__number: ErrorField_array__group__number_operator
+  array__group__date: ErrorField_array__group__date_operator
+  array__group__checkbox: ErrorField_array__group__checkbox_operator
+  array__code: ErrorField_array__code_operator
+  array__json: ErrorField_array__json_operator
+  array__email: ErrorField_array__email_operator
+  array__point: ErrorField_array__point_operator
+  array__radio: ErrorField_array__radio_operator
+  array__relationship: ErrorField_array__relationship_operator
+  array__richtext: ErrorField_array__richtext_operator
+  array__select: ErrorField_array__select_operator
+  array__upload: ErrorField_array__upload_operator
+  array__text: ErrorField_array__text_operator
+  array__textarea: ErrorField_array__textarea_operator
+  array__id: ErrorField_array__id_operator
+  group__text: ErrorField_group__text_operator
+  updatedAt: ErrorField_updatedAt_operator
+  createdAt: ErrorField_createdAt_operator
+  id: ErrorField_id_operator
+  AND: [ErrorField_where_and]
+  OR: [ErrorField_where_or]
+}
+
+input ErrorField_parentArray__childArray__childArrayText_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_parentArray__childArray__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_parentArray__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_home__tabText_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_home__text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_home__array__requiredArrayText_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_home__array__arrayText_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_home__array__group__text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_home__array__group__number_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+}
+
+input ErrorField_home__array__group__date_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+}
+
+input ErrorField_home__array__group__checkbox_operator {
+  equals: Boolean
+  not_equals: Boolean
+}
+
+input ErrorField_home__array__code_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+}
+
+input ErrorField_home__array__json_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  within: JSON
+  intersects: JSON
+}
+
+input ErrorField_home__array__email_operator {
+  equals: EmailAddress
+  not_equals: EmailAddress
+  like: EmailAddress
+  contains: EmailAddress
+  in: [EmailAddress]
+  not_in: [EmailAddress]
+  all: [EmailAddress]
+}
+
+input ErrorField_home__array__point_operator {
+  equals: [Float]
+  not_equals: [Float]
+  greater_than_equal: [Float]
+  greater_than: [Float]
+  less_than_equal: [Float]
+  less_than: [Float]
+  near: [Float]
+  within: GeoJSONObject
+  intersects: GeoJSONObject
+}
+
+input GeoJSONObject {
+  coordinates: JSON
+  type: String
+}
+
+input ErrorField_home__array__radio_operator {
+  equals: ErrorField_home__array__radio_Input
+  not_equals: ErrorField_home__array__radio_Input
+  like: ErrorField_home__array__radio_Input
+  contains: ErrorField_home__array__radio_Input
+}
+
+enum ErrorField_home__array__radio_Input {
+  mint
+  dark_gray
+}
+
+input ErrorField_home__array__relationship_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+}
+
+input ErrorField_home__array__richtext_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+}
+
+input ErrorField_home__array__select_operator {
+  equals: ErrorField_home__array__select_Input
+  not_equals: ErrorField_home__array__select_Input
+  in: [ErrorField_home__array__select_Input]
+  not_in: [ErrorField_home__array__select_Input]
+  all: [ErrorField_home__array__select_Input]
+}
+
+enum ErrorField_home__array__select_Input {
+  mint
+  dark_gray
+}
+
+input ErrorField_home__array__upload_operator {
+  equals: String
+  not_equals: String
+}
+
+input ErrorField_home__array__text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_home__array__textarea_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+}
+
+input ErrorField_home__array__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_tabText_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_array__requiredArrayText_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_array__arrayText_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_array__group__text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_array__group__number_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+}
+
+input ErrorField_array__group__date_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+}
+
+input ErrorField_array__group__checkbox_operator {
+  equals: Boolean
+  not_equals: Boolean
+}
+
+input ErrorField_array__code_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+}
+
+input ErrorField_array__json_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  within: JSON
+  intersects: JSON
+}
+
+input ErrorField_array__email_operator {
+  equals: EmailAddress
+  not_equals: EmailAddress
+  like: EmailAddress
+  contains: EmailAddress
+  in: [EmailAddress]
+  not_in: [EmailAddress]
+  all: [EmailAddress]
+}
+
+input ErrorField_array__point_operator {
+  equals: [Float]
+  not_equals: [Float]
+  greater_than_equal: [Float]
+  greater_than: [Float]
+  less_than_equal: [Float]
+  less_than: [Float]
+  near: [Float]
+  within: GeoJSONObject
+  intersects: GeoJSONObject
+}
+
+input ErrorField_array__radio_operator {
+  equals: ErrorField_array__radio_Input
+  not_equals: ErrorField_array__radio_Input
+  like: ErrorField_array__radio_Input
+  contains: ErrorField_array__radio_Input
+}
+
+enum ErrorField_array__radio_Input {
+  mint
+  dark_gray
+}
+
+input ErrorField_array__relationship_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+}
+
+input ErrorField_array__richtext_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+}
+
+input ErrorField_array__select_operator {
+  equals: ErrorField_array__select_Input
+  not_equals: ErrorField_array__select_Input
+  in: [ErrorField_array__select_Input]
+  not_in: [ErrorField_array__select_Input]
+  all: [ErrorField_array__select_Input]
+}
+
+enum ErrorField_array__select_Input {
+  mint
+  dark_gray
+}
+
+input ErrorField_array__upload_operator {
+  equals: String
+  not_equals: String
+}
+
+input ErrorField_array__text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_array__textarea_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+}
+
+input ErrorField_array__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_group__text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input ErrorField_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input ErrorField_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input ErrorField_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input ErrorField_where_and {
+  parentArray__childArray__childArrayText: ErrorField_parentArray__childArray__childArrayText_operator
+  parentArray__childArray__id: ErrorField_parentArray__childArray__id_operator
+  parentArray__id: ErrorField_parentArray__id_operator
+  home__tabText: ErrorField_home__tabText_operator
+  home__text: ErrorField_home__text_operator
+  home__array__requiredArrayText: ErrorField_home__array__requiredArrayText_operator
+  home__array__arrayText: ErrorField_home__array__arrayText_operator
+  home__array__group__text: ErrorField_home__array__group__text_operator
+  home__array__group__number: ErrorField_home__array__group__number_operator
+  home__array__group__date: ErrorField_home__array__group__date_operator
+  home__array__group__checkbox: ErrorField_home__array__group__checkbox_operator
+  home__array__code: ErrorField_home__array__code_operator
+  home__array__json: ErrorField_home__array__json_operator
+  home__array__email: ErrorField_home__array__email_operator
+  home__array__point: ErrorField_home__array__point_operator
+  home__array__radio: ErrorField_home__array__radio_operator
+  home__array__relationship: ErrorField_home__array__relationship_operator
+  home__array__richtext: ErrorField_home__array__richtext_operator
+  home__array__select: ErrorField_home__array__select_operator
+  home__array__upload: ErrorField_home__array__upload_operator
+  home__array__text: ErrorField_home__array__text_operator
+  home__array__textarea: ErrorField_home__array__textarea_operator
+  home__array__id: ErrorField_home__array__id_operator
+  tabText: ErrorField_tabText_operator
+  text: ErrorField_text_operator
+  array__requiredArrayText: ErrorField_array__requiredArrayText_operator
+  array__arrayText: ErrorField_array__arrayText_operator
+  array__group__text: ErrorField_array__group__text_operator
+  array__group__number: ErrorField_array__group__number_operator
+  array__group__date: ErrorField_array__group__date_operator
+  array__group__checkbox: ErrorField_array__group__checkbox_operator
+  array__code: ErrorField_array__code_operator
+  array__json: ErrorField_array__json_operator
+  array__email: ErrorField_array__email_operator
+  array__point: ErrorField_array__point_operator
+  array__radio: ErrorField_array__radio_operator
+  array__relationship: ErrorField_array__relationship_operator
+  array__richtext: ErrorField_array__richtext_operator
+  array__select: ErrorField_array__select_operator
+  array__upload: ErrorField_array__upload_operator
+  array__text: ErrorField_array__text_operator
+  array__textarea: ErrorField_array__textarea_operator
+  array__id: ErrorField_array__id_operator
+  group__text: ErrorField_group__text_operator
+  updatedAt: ErrorField_updatedAt_operator
+  createdAt: ErrorField_createdAt_operator
+  id: ErrorField_id_operator
+  AND: [ErrorField_where_and]
+  OR: [ErrorField_where_or]
+}
+
+input ErrorField_where_or {
+  parentArray__childArray__childArrayText: ErrorField_parentArray__childArray__childArrayText_operator
+  parentArray__childArray__id: ErrorField_parentArray__childArray__id_operator
+  parentArray__id: ErrorField_parentArray__id_operator
+  home__tabText: ErrorField_home__tabText_operator
+  home__text: ErrorField_home__text_operator
+  home__array__requiredArrayText: ErrorField_home__array__requiredArrayText_operator
+  home__array__arrayText: ErrorField_home__array__arrayText_operator
+  home__array__group__text: ErrorField_home__array__group__text_operator
+  home__array__group__number: ErrorField_home__array__group__number_operator
+  home__array__group__date: ErrorField_home__array__group__date_operator
+  home__array__group__checkbox: ErrorField_home__array__group__checkbox_operator
+  home__array__code: ErrorField_home__array__code_operator
+  home__array__json: ErrorField_home__array__json_operator
+  home__array__email: ErrorField_home__array__email_operator
+  home__array__point: ErrorField_home__array__point_operator
+  home__array__radio: ErrorField_home__array__radio_operator
+  home__array__relationship: ErrorField_home__array__relationship_operator
+  home__array__richtext: ErrorField_home__array__richtext_operator
+  home__array__select: ErrorField_home__array__select_operator
+  home__array__upload: ErrorField_home__array__upload_operator
+  home__array__text: ErrorField_home__array__text_operator
+  home__array__textarea: ErrorField_home__array__textarea_operator
+  home__array__id: ErrorField_home__array__id_operator
+  tabText: ErrorField_tabText_operator
+  text: ErrorField_text_operator
+  array__requiredArrayText: ErrorField_array__requiredArrayText_operator
+  array__arrayText: ErrorField_array__arrayText_operator
+  array__group__text: ErrorField_array__group__text_operator
+  array__group__number: ErrorField_array__group__number_operator
+  array__group__date: ErrorField_array__group__date_operator
+  array__group__checkbox: ErrorField_array__group__checkbox_operator
+  array__code: ErrorField_array__code_operator
+  array__json: ErrorField_array__json_operator
+  array__email: ErrorField_array__email_operator
+  array__point: ErrorField_array__point_operator
+  array__radio: ErrorField_array__radio_operator
+  array__relationship: ErrorField_array__relationship_operator
+  array__richtext: ErrorField_array__richtext_operator
+  array__select: ErrorField_array__select_operator
+  array__upload: ErrorField_array__upload_operator
+  array__text: ErrorField_array__text_operator
+  array__textarea: ErrorField_array__textarea_operator
+  array__id: ErrorField_array__id_operator
+  group__text: ErrorField_group__text_operator
+  updatedAt: ErrorField_updatedAt_operator
+  createdAt: ErrorField_createdAt_operator
+  id: ErrorField_id_operator
+  AND: [ErrorField_where_and]
+  OR: [ErrorField_where_or]
+}
+
+type error_fieldsDocAccess {
+  fields: ErrorFieldsDocAccessFields
+  create: ErrorFieldsCreateDocAccess
+  read: ErrorFieldsReadDocAccess
+  update: ErrorFieldsUpdateDocAccess
+  delete: ErrorFieldsDeleteDocAccess
+}
+
+type ErrorFieldsDocAccessFields {
+  parentArray: ErrorFieldsDocAccessFields_parentArray
+  tabText: ErrorFieldsDocAccessFields_tabText
+  text: ErrorFieldsDocAccessFields_text
+  array: ErrorFieldsDocAccessFields_array
+  layout: ErrorFieldsDocAccessFields_layout
+  group: ErrorFieldsDocAccessFields_group
+  updatedAt: ErrorFieldsDocAccessFields_updatedAt
+  createdAt: ErrorFieldsDocAccessFields_createdAt
+}
+
+type ErrorFieldsDocAccessFields_parentArray {
+  create: ErrorFieldsDocAccessFields_parentArray_Create
+  read: ErrorFieldsDocAccessFields_parentArray_Read
+  update: ErrorFieldsDocAccessFields_parentArray_Update
+  delete: ErrorFieldsDocAccessFields_parentArray_Delete
+  fields: ErrorFieldsDocAccessFields_parentArray_Fields
+}
+
+type ErrorFieldsDocAccessFields_parentArray_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_Fields {
+  childArray: ErrorFieldsDocAccessFields_parentArray_childArray
+  id: ErrorFieldsDocAccessFields_parentArray_id
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray {
+  create: ErrorFieldsDocAccessFields_parentArray_childArray_Create
+  read: ErrorFieldsDocAccessFields_parentArray_childArray_Read
+  update: ErrorFieldsDocAccessFields_parentArray_childArray_Update
+  delete: ErrorFieldsDocAccessFields_parentArray_childArray_Delete
+  fields: ErrorFieldsDocAccessFields_parentArray_childArray_Fields
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_Fields {
+  childArrayText: ErrorFieldsDocAccessFields_parentArray_childArray_childArrayText
+  id: ErrorFieldsDocAccessFields_parentArray_childArray_id
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_childArrayText {
+  create: ErrorFieldsDocAccessFields_parentArray_childArray_childArrayText_Create
+  read: ErrorFieldsDocAccessFields_parentArray_childArray_childArrayText_Read
+  update: ErrorFieldsDocAccessFields_parentArray_childArray_childArrayText_Update
+  delete: ErrorFieldsDocAccessFields_parentArray_childArray_childArrayText_Delete
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_childArrayText_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_childArrayText_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_childArrayText_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_childArrayText_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_id {
+  create: ErrorFieldsDocAccessFields_parentArray_childArray_id_Create
+  read: ErrorFieldsDocAccessFields_parentArray_childArray_id_Read
+  update: ErrorFieldsDocAccessFields_parentArray_childArray_id_Update
+  delete: ErrorFieldsDocAccessFields_parentArray_childArray_id_Delete
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_id_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_id_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_id_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_childArray_id_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_id {
+  create: ErrorFieldsDocAccessFields_parentArray_id_Create
+  read: ErrorFieldsDocAccessFields_parentArray_id_Read
+  update: ErrorFieldsDocAccessFields_parentArray_id_Update
+  delete: ErrorFieldsDocAccessFields_parentArray_id_Delete
+}
+
+type ErrorFieldsDocAccessFields_parentArray_id_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_id_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_id_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_parentArray_id_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_tabText {
+  create: ErrorFieldsDocAccessFields_tabText_Create
+  read: ErrorFieldsDocAccessFields_tabText_Read
+  update: ErrorFieldsDocAccessFields_tabText_Update
+  delete: ErrorFieldsDocAccessFields_tabText_Delete
+}
+
+type ErrorFieldsDocAccessFields_tabText_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_tabText_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_tabText_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_tabText_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_text {
+  create: ErrorFieldsDocAccessFields_text_Create
+  read: ErrorFieldsDocAccessFields_text_Read
+  update: ErrorFieldsDocAccessFields_text_Update
+  delete: ErrorFieldsDocAccessFields_text_Delete
+}
+
+type ErrorFieldsDocAccessFields_text_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_text_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_text_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_text_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array {
+  create: ErrorFieldsDocAccessFields_array_Create
+  read: ErrorFieldsDocAccessFields_array_Read
+  update: ErrorFieldsDocAccessFields_array_Update
+  delete: ErrorFieldsDocAccessFields_array_Delete
+  fields: ErrorFieldsDocAccessFields_array_Fields
+}
+
+type ErrorFieldsDocAccessFields_array_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_Fields {
+  requiredArrayText: ErrorFieldsDocAccessFields_array_requiredArrayText
+  arrayText: ErrorFieldsDocAccessFields_array_arrayText
+  group: ErrorFieldsDocAccessFields_array_group
+  code: ErrorFieldsDocAccessFields_array_code
+  json: ErrorFieldsDocAccessFields_array_json
+  email: ErrorFieldsDocAccessFields_array_email
+  point: ErrorFieldsDocAccessFields_array_point
+  radio: ErrorFieldsDocAccessFields_array_radio
+  relationship: ErrorFieldsDocAccessFields_array_relationship
+  richtext: ErrorFieldsDocAccessFields_array_richtext
+  select: ErrorFieldsDocAccessFields_array_select
+  upload: ErrorFieldsDocAccessFields_array_upload
+  text: ErrorFieldsDocAccessFields_array_text
+  textarea: ErrorFieldsDocAccessFields_array_textarea
+  id: ErrorFieldsDocAccessFields_array_id
+}
+
+type ErrorFieldsDocAccessFields_array_requiredArrayText {
+  create: ErrorFieldsDocAccessFields_array_requiredArrayText_Create
+  read: ErrorFieldsDocAccessFields_array_requiredArrayText_Read
+  update: ErrorFieldsDocAccessFields_array_requiredArrayText_Update
+  delete: ErrorFieldsDocAccessFields_array_requiredArrayText_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_requiredArrayText_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_requiredArrayText_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_requiredArrayText_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_requiredArrayText_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_arrayText {
+  create: ErrorFieldsDocAccessFields_array_arrayText_Create
+  read: ErrorFieldsDocAccessFields_array_arrayText_Read
+  update: ErrorFieldsDocAccessFields_array_arrayText_Update
+  delete: ErrorFieldsDocAccessFields_array_arrayText_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_arrayText_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_arrayText_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_arrayText_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_arrayText_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group {
+  create: ErrorFieldsDocAccessFields_array_group_Create
+  read: ErrorFieldsDocAccessFields_array_group_Read
+  update: ErrorFieldsDocAccessFields_array_group_Update
+  delete: ErrorFieldsDocAccessFields_array_group_Delete
+  fields: ErrorFieldsDocAccessFields_array_group_Fields
+}
+
+type ErrorFieldsDocAccessFields_array_group_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_Fields {
+  text: ErrorFieldsDocAccessFields_array_group_text
+  number: ErrorFieldsDocAccessFields_array_group_number
+  date: ErrorFieldsDocAccessFields_array_group_date
+  checkbox: ErrorFieldsDocAccessFields_array_group_checkbox
+}
+
+type ErrorFieldsDocAccessFields_array_group_text {
+  create: ErrorFieldsDocAccessFields_array_group_text_Create
+  read: ErrorFieldsDocAccessFields_array_group_text_Read
+  update: ErrorFieldsDocAccessFields_array_group_text_Update
+  delete: ErrorFieldsDocAccessFields_array_group_text_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_group_text_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_text_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_text_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_text_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_number {
+  create: ErrorFieldsDocAccessFields_array_group_number_Create
+  read: ErrorFieldsDocAccessFields_array_group_number_Read
+  update: ErrorFieldsDocAccessFields_array_group_number_Update
+  delete: ErrorFieldsDocAccessFields_array_group_number_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_group_number_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_number_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_number_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_number_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_date {
+  create: ErrorFieldsDocAccessFields_array_group_date_Create
+  read: ErrorFieldsDocAccessFields_array_group_date_Read
+  update: ErrorFieldsDocAccessFields_array_group_date_Update
+  delete: ErrorFieldsDocAccessFields_array_group_date_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_group_date_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_date_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_date_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_date_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_checkbox {
+  create: ErrorFieldsDocAccessFields_array_group_checkbox_Create
+  read: ErrorFieldsDocAccessFields_array_group_checkbox_Read
+  update: ErrorFieldsDocAccessFields_array_group_checkbox_Update
+  delete: ErrorFieldsDocAccessFields_array_group_checkbox_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_group_checkbox_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_checkbox_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_checkbox_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_group_checkbox_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_code {
+  create: ErrorFieldsDocAccessFields_array_code_Create
+  read: ErrorFieldsDocAccessFields_array_code_Read
+  update: ErrorFieldsDocAccessFields_array_code_Update
+  delete: ErrorFieldsDocAccessFields_array_code_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_code_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_code_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_code_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_code_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_json {
+  create: ErrorFieldsDocAccessFields_array_json_Create
+  read: ErrorFieldsDocAccessFields_array_json_Read
+  update: ErrorFieldsDocAccessFields_array_json_Update
+  delete: ErrorFieldsDocAccessFields_array_json_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_json_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_json_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_json_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_json_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_email {
+  create: ErrorFieldsDocAccessFields_array_email_Create
+  read: ErrorFieldsDocAccessFields_array_email_Read
+  update: ErrorFieldsDocAccessFields_array_email_Update
+  delete: ErrorFieldsDocAccessFields_array_email_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_email_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_email_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_email_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_email_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_point {
+  create: ErrorFieldsDocAccessFields_array_point_Create
+  read: ErrorFieldsDocAccessFields_array_point_Read
+  update: ErrorFieldsDocAccessFields_array_point_Update
+  delete: ErrorFieldsDocAccessFields_array_point_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_point_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_point_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_point_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_point_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_radio {
+  create: ErrorFieldsDocAccessFields_array_radio_Create
+  read: ErrorFieldsDocAccessFields_array_radio_Read
+  update: ErrorFieldsDocAccessFields_array_radio_Update
+  delete: ErrorFieldsDocAccessFields_array_radio_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_radio_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_radio_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_radio_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_radio_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_relationship {
+  create: ErrorFieldsDocAccessFields_array_relationship_Create
+  read: ErrorFieldsDocAccessFields_array_relationship_Read
+  update: ErrorFieldsDocAccessFields_array_relationship_Update
+  delete: ErrorFieldsDocAccessFields_array_relationship_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_relationship_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_relationship_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_relationship_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_relationship_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_richtext {
+  create: ErrorFieldsDocAccessFields_array_richtext_Create
+  read: ErrorFieldsDocAccessFields_array_richtext_Read
+  update: ErrorFieldsDocAccessFields_array_richtext_Update
+  delete: ErrorFieldsDocAccessFields_array_richtext_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_richtext_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_richtext_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_richtext_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_richtext_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_select {
+  create: ErrorFieldsDocAccessFields_array_select_Create
+  read: ErrorFieldsDocAccessFields_array_select_Read
+  update: ErrorFieldsDocAccessFields_array_select_Update
+  delete: ErrorFieldsDocAccessFields_array_select_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_select_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_select_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_select_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_select_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_upload {
+  create: ErrorFieldsDocAccessFields_array_upload_Create
+  read: ErrorFieldsDocAccessFields_array_upload_Read
+  update: ErrorFieldsDocAccessFields_array_upload_Update
+  delete: ErrorFieldsDocAccessFields_array_upload_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_upload_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_upload_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_upload_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_upload_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_text {
+  create: ErrorFieldsDocAccessFields_array_text_Create
+  read: ErrorFieldsDocAccessFields_array_text_Read
+  update: ErrorFieldsDocAccessFields_array_text_Update
+  delete: ErrorFieldsDocAccessFields_array_text_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_text_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_text_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_text_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_text_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_textarea {
+  create: ErrorFieldsDocAccessFields_array_textarea_Create
+  read: ErrorFieldsDocAccessFields_array_textarea_Read
+  update: ErrorFieldsDocAccessFields_array_textarea_Update
+  delete: ErrorFieldsDocAccessFields_array_textarea_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_textarea_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_textarea_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_textarea_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_textarea_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_id {
+  create: ErrorFieldsDocAccessFields_array_id_Create
+  read: ErrorFieldsDocAccessFields_array_id_Read
+  update: ErrorFieldsDocAccessFields_array_id_Update
+  delete: ErrorFieldsDocAccessFields_array_id_Delete
+}
+
+type ErrorFieldsDocAccessFields_array_id_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_id_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_id_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_array_id_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_layout {
+  create: ErrorFieldsDocAccessFields_layout_Create
+  read: ErrorFieldsDocAccessFields_layout_Read
+  update: ErrorFieldsDocAccessFields_layout_Update
+  delete: ErrorFieldsDocAccessFields_layout_Delete
+}
+
+type ErrorFieldsDocAccessFields_layout_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_layout_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_layout_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_layout_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_group {
+  create: ErrorFieldsDocAccessFields_group_Create
+  read: ErrorFieldsDocAccessFields_group_Read
+  update: ErrorFieldsDocAccessFields_group_Update
+  delete: ErrorFieldsDocAccessFields_group_Delete
+  fields: ErrorFieldsDocAccessFields_group_Fields
+}
+
+type ErrorFieldsDocAccessFields_group_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_group_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_group_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_group_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_group_Fields {
+  text: ErrorFieldsDocAccessFields_group_text
+}
+
+type ErrorFieldsDocAccessFields_group_text {
+  create: ErrorFieldsDocAccessFields_group_text_Create
+  read: ErrorFieldsDocAccessFields_group_text_Read
+  update: ErrorFieldsDocAccessFields_group_text_Update
+  delete: ErrorFieldsDocAccessFields_group_text_Delete
+}
+
+type ErrorFieldsDocAccessFields_group_text_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_group_text_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_group_text_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_group_text_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_updatedAt {
+  create: ErrorFieldsDocAccessFields_updatedAt_Create
+  read: ErrorFieldsDocAccessFields_updatedAt_Read
+  update: ErrorFieldsDocAccessFields_updatedAt_Update
+  delete: ErrorFieldsDocAccessFields_updatedAt_Delete
+}
+
+type ErrorFieldsDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_createdAt {
+  create: ErrorFieldsDocAccessFields_createdAt_Create
+  read: ErrorFieldsDocAccessFields_createdAt_Read
+  update: ErrorFieldsDocAccessFields_createdAt_Update
+  delete: ErrorFieldsDocAccessFields_createdAt_Delete
+}
+
+type ErrorFieldsDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
 """
-A field whose value conforms to the standard internet email address format as specified in HTML Spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address.
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
-scalar EmailAddress
-  @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
+scalar JSONObject
+
+type ErrorFieldsReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type ErrorFieldsUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type ErrorFieldsDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type Uploads {
+  docs: [Upload]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input Upload_where {
+  text: Upload_text_operator
+  media: Upload_media_operator
+  richText: Upload_richText_operator
+  updatedAt: Upload_updatedAt_operator
+  createdAt: Upload_createdAt_operator
+  url: Upload_url_operator
+  filename: Upload_filename_operator
+  mimeType: Upload_mimeType_operator
+  filesize: Upload_filesize_operator
+  width: Upload_width_operator
+  height: Upload_height_operator
+  id: Upload_id_operator
+  AND: [Upload_where_and]
+  OR: [Upload_where_or]
+}
+
+input Upload_text_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_media_operator {
+  equals: String
+  not_equals: String
+  exists: Boolean
+}
+
+input Upload_richText_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input Upload_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Upload_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Upload_url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_where_and {
+  text: Upload_text_operator
+  media: Upload_media_operator
+  richText: Upload_richText_operator
+  updatedAt: Upload_updatedAt_operator
+  createdAt: Upload_createdAt_operator
+  url: Upload_url_operator
+  filename: Upload_filename_operator
+  mimeType: Upload_mimeType_operator
+  filesize: Upload_filesize_operator
+  width: Upload_width_operator
+  height: Upload_height_operator
+  id: Upload_id_operator
+  AND: [Upload_where_and]
+  OR: [Upload_where_or]
+}
+
+input Upload_where_or {
+  text: Upload_text_operator
+  media: Upload_media_operator
+  richText: Upload_richText_operator
+  updatedAt: Upload_updatedAt_operator
+  createdAt: Upload_createdAt_operator
+  url: Upload_url_operator
+  filename: Upload_filename_operator
+  mimeType: Upload_mimeType_operator
+  filesize: Upload_filesize_operator
+  width: Upload_width_operator
+  height: Upload_height_operator
+  id: Upload_id_operator
+  AND: [Upload_where_and]
+  OR: [Upload_where_or]
+}
+
+type uploadsDocAccess {
+  fields: UploadsDocAccessFields
+  create: UploadsCreateDocAccess
+  read: UploadsReadDocAccess
+  update: UploadsUpdateDocAccess
+  delete: UploadsDeleteDocAccess
+}
+
+type UploadsDocAccessFields {
+  text: UploadsDocAccessFields_text
+  media: UploadsDocAccessFields_media
+  richText: UploadsDocAccessFields_richText
+  updatedAt: UploadsDocAccessFields_updatedAt
+  createdAt: UploadsDocAccessFields_createdAt
+  url: UploadsDocAccessFields_url
+  filename: UploadsDocAccessFields_filename
+  mimeType: UploadsDocAccessFields_mimeType
+  filesize: UploadsDocAccessFields_filesize
+  width: UploadsDocAccessFields_width
+  height: UploadsDocAccessFields_height
+}
+
+type UploadsDocAccessFields_text {
+  create: UploadsDocAccessFields_text_Create
+  read: UploadsDocAccessFields_text_Read
+  update: UploadsDocAccessFields_text_Update
+  delete: UploadsDocAccessFields_text_Delete
+}
+
+type UploadsDocAccessFields_text_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_text_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_text_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_text_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_media {
+  create: UploadsDocAccessFields_media_Create
+  read: UploadsDocAccessFields_media_Read
+  update: UploadsDocAccessFields_media_Update
+  delete: UploadsDocAccessFields_media_Delete
+}
+
+type UploadsDocAccessFields_media_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_media_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_media_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_media_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_richText {
+  create: UploadsDocAccessFields_richText_Create
+  read: UploadsDocAccessFields_richText_Read
+  update: UploadsDocAccessFields_richText_Update
+  delete: UploadsDocAccessFields_richText_Delete
+}
+
+type UploadsDocAccessFields_richText_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_richText_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_richText_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_richText_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_updatedAt {
+  create: UploadsDocAccessFields_updatedAt_Create
+  read: UploadsDocAccessFields_updatedAt_Read
+  update: UploadsDocAccessFields_updatedAt_Update
+  delete: UploadsDocAccessFields_updatedAt_Delete
+}
+
+type UploadsDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_createdAt {
+  create: UploadsDocAccessFields_createdAt_Create
+  read: UploadsDocAccessFields_createdAt_Read
+  update: UploadsDocAccessFields_createdAt_Update
+  delete: UploadsDocAccessFields_createdAt_Delete
+}
+
+type UploadsDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_url {
+  create: UploadsDocAccessFields_url_Create
+  read: UploadsDocAccessFields_url_Read
+  update: UploadsDocAccessFields_url_Update
+  delete: UploadsDocAccessFields_url_Delete
+}
+
+type UploadsDocAccessFields_url_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_url_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_url_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filename {
+  create: UploadsDocAccessFields_filename_Create
+  read: UploadsDocAccessFields_filename_Read
+  update: UploadsDocAccessFields_filename_Update
+  delete: UploadsDocAccessFields_filename_Delete
+}
+
+type UploadsDocAccessFields_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_mimeType {
+  create: UploadsDocAccessFields_mimeType_Create
+  read: UploadsDocAccessFields_mimeType_Read
+  update: UploadsDocAccessFields_mimeType_Update
+  delete: UploadsDocAccessFields_mimeType_Delete
+}
+
+type UploadsDocAccessFields_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filesize {
+  create: UploadsDocAccessFields_filesize_Create
+  read: UploadsDocAccessFields_filesize_Read
+  update: UploadsDocAccessFields_filesize_Update
+  delete: UploadsDocAccessFields_filesize_Delete
+}
+
+type UploadsDocAccessFields_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_width {
+  create: UploadsDocAccessFields_width_Create
+  read: UploadsDocAccessFields_width_Read
+  update: UploadsDocAccessFields_width_Update
+  delete: UploadsDocAccessFields_width_Delete
+}
+
+type UploadsDocAccessFields_width_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_width_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_width_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_height {
+  create: UploadsDocAccessFields_height_Create
+  read: UploadsDocAccessFields_height_Read
+  update: UploadsDocAccessFields_height_Update
+  delete: UploadsDocAccessFields_height_Delete
+}
+
+type UploadsDocAccessFields_height_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_height_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_height_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
 
 type Users {
   docs: [User]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input User_where {
@@ -527,8 +2843,8 @@ input User_where {
   createdAt: User_createdAt_operator
   email: User_email_operator
   id: User_id_operator
-  OR: [User_where_or]
   AND: [User_where_and]
+  OR: [User_where_or]
 }
 
 input User_updatedAt_operator {
@@ -561,7 +2877,6 @@ input User_email_operator {
   in: [EmailAddress]
   not_in: [EmailAddress]
   all: [EmailAddress]
-  exists: Boolean
 }
 
 input User_id_operator {
@@ -575,18 +2890,22 @@ input User_id_operator {
   exists: Boolean
 }
 
-input User_where_or {
-  updatedAt: User_updatedAt_operator
-  createdAt: User_createdAt_operator
-  email: User_email_operator
-  id: User_id_operator
-}
-
 input User_where_and {
   updatedAt: User_updatedAt_operator
   createdAt: User_createdAt_operator
   email: User_email_operator
   id: User_id_operator
+  AND: [User_where_and]
+  OR: [User_where_or]
+}
+
+input User_where_or {
+  updatedAt: User_updatedAt_operator
+  createdAt: User_createdAt_operator
+  email: User_email_operator
+  id: User_id_operator
+  AND: [User_where_and]
+  OR: [User_where_or]
 }
 
 type usersDocAccess {
@@ -723,341 +3042,1411 @@ type UsersUnlockDocAccess {
 }
 
 type usersMe {
+  collection: String
+  exp: Int
   token: String
   user: User
-  exp: Int
-  collection: String
 }
 
-type Preference {
-  key: String!
+type PayloadPreference {
+  id: String
+  user: PayloadPreference_User_Relationship!
+  key: String
   value: JSON
-  createdAt: DateTime!
-  updatedAt: DateTime!
+  updatedAt: DateTime
+  createdAt: DateTime
 }
 
-"""
-The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSON
+type PayloadPreference_User_Relationship {
+  relationTo: PayloadPreference_User_RelationTo
+  value: PayloadPreference_User
+}
+
+enum PayloadPreference_User_RelationTo {
+  users
+}
+
+union PayloadPreference_User = User
+
+type PayloadPreferences {
+  docs: [PayloadPreference]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input PayloadPreference_where {
+  user: PayloadPreference_user_Relation
+  key: PayloadPreference_key_operator
+  value: PayloadPreference_value_operator
+  updatedAt: PayloadPreference_updatedAt_operator
+  createdAt: PayloadPreference_createdAt_operator
+  id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
+}
+
+input PayloadPreference_user_Relation {
+  relationTo: PayloadPreference_user_Relation_RelationTo
+  value: JSON
+}
+
+enum PayloadPreference_user_Relation_RelationTo {
+  users
+}
+
+input PayloadPreference_key_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadPreference_value_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  within: JSON
+  intersects: JSON
+  exists: Boolean
+}
+
+input PayloadPreference_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadPreference_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadPreference_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadPreference_where_and {
+  user: PayloadPreference_user_Relation
+  key: PayloadPreference_key_operator
+  value: PayloadPreference_value_operator
+  updatedAt: PayloadPreference_updatedAt_operator
+  createdAt: PayloadPreference_createdAt_operator
+  id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
+}
+
+input PayloadPreference_where_or {
+  user: PayloadPreference_user_Relation
+  key: PayloadPreference_key_operator
+  value: PayloadPreference_value_operator
+  updatedAt: PayloadPreference_updatedAt_operator
+  createdAt: PayloadPreference_createdAt_operator
+  id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
+}
+
+type payload_preferencesDocAccess {
+  fields: PayloadPreferencesDocAccessFields
+  create: PayloadPreferencesCreateDocAccess
+  read: PayloadPreferencesReadDocAccess
+  update: PayloadPreferencesUpdateDocAccess
+  delete: PayloadPreferencesDeleteDocAccess
+}
+
+type PayloadPreferencesDocAccessFields {
+  user: PayloadPreferencesDocAccessFields_user
+  key: PayloadPreferencesDocAccessFields_key
+  value: PayloadPreferencesDocAccessFields_value
+  updatedAt: PayloadPreferencesDocAccessFields_updatedAt
+  createdAt: PayloadPreferencesDocAccessFields_createdAt
+}
+
+type PayloadPreferencesDocAccessFields_user {
+  create: PayloadPreferencesDocAccessFields_user_Create
+  read: PayloadPreferencesDocAccessFields_user_Read
+  update: PayloadPreferencesDocAccessFields_user_Update
+  delete: PayloadPreferencesDocAccessFields_user_Delete
+}
+
+type PayloadPreferencesDocAccessFields_user_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_user_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_user_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_user_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key {
+  create: PayloadPreferencesDocAccessFields_key_Create
+  read: PayloadPreferencesDocAccessFields_key_Read
+  update: PayloadPreferencesDocAccessFields_key_Update
+  delete: PayloadPreferencesDocAccessFields_key_Delete
+}
+
+type PayloadPreferencesDocAccessFields_key_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_key_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value {
+  create: PayloadPreferencesDocAccessFields_value_Create
+  read: PayloadPreferencesDocAccessFields_value_Read
+  update: PayloadPreferencesDocAccessFields_value_Update
+  delete: PayloadPreferencesDocAccessFields_value_Delete
+}
+
+type PayloadPreferencesDocAccessFields_value_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_value_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt {
+  create: PayloadPreferencesDocAccessFields_updatedAt_Create
+  read: PayloadPreferencesDocAccessFields_updatedAt_Read
+  update: PayloadPreferencesDocAccessFields_updatedAt_Update
+  delete: PayloadPreferencesDocAccessFields_updatedAt_Delete
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt {
+  create: PayloadPreferencesDocAccessFields_createdAt_Create
+  read: PayloadPreferencesDocAccessFields_createdAt_Read
+  update: PayloadPreferencesDocAccessFields_createdAt_Update
+  delete: PayloadPreferencesDocAccessFields_createdAt_Delete
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
 
 type Access {
   canAccessAdmin: Boolean!
-  posts: postsAccess
+  error_fields: error_fieldsAccess
+  uploads: uploadsAccess
   users: usersAccess
+  payload_preferences: payload_preferencesAccess
 }
 
-type postsAccess {
-  fields: PostsFields
-  create: PostsCreateAccess
-  read: PostsReadAccess
-  update: PostsUpdateAccess
-  delete: PostsDeleteAccess
+type error_fieldsAccess {
+  fields: ErrorFieldsFields
+  create: ErrorFieldsCreateAccess
+  read: ErrorFieldsReadAccess
+  update: ErrorFieldsUpdateAccess
+  delete: ErrorFieldsDeleteAccess
 }
 
-type PostsFields {
-  arrayField: PostsFields_arrayField
-  updatedAt: PostsFields_updatedAt
-  createdAt: PostsFields_createdAt
+type ErrorFieldsFields {
+  parentArray: ErrorFieldsFields_parentArray
+  tabText: ErrorFieldsFields_tabText
+  text: ErrorFieldsFields_text
+  array: ErrorFieldsFields_array
+  layout: ErrorFieldsFields_layout
+  group: ErrorFieldsFields_group
+  updatedAt: ErrorFieldsFields_updatedAt
+  createdAt: ErrorFieldsFields_createdAt
 }
 
-type PostsFields_arrayField {
-  create: PostsFields_arrayField_Create
-  read: PostsFields_arrayField_Read
-  update: PostsFields_arrayField_Update
-  delete: PostsFields_arrayField_Delete
-  fields: PostsFields_arrayField_Fields
+type ErrorFieldsFields_parentArray {
+  create: ErrorFieldsFields_parentArray_Create
+  read: ErrorFieldsFields_parentArray_Read
+  update: ErrorFieldsFields_parentArray_Update
+  delete: ErrorFieldsFields_parentArray_Delete
+  fields: ErrorFieldsFields_parentArray_Fields
 }
 
-type PostsFields_arrayField_Create {
+type ErrorFieldsFields_parentArray_Create {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_Read {
+type ErrorFieldsFields_parentArray_Read {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_Update {
+type ErrorFieldsFields_parentArray_Update {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_Delete {
+type ErrorFieldsFields_parentArray_Delete {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_Fields {
-  group23field: PostsFields_arrayField_group23field
-  id: PostsFields_arrayField_id
+type ErrorFieldsFields_parentArray_Fields {
+  childArray: ErrorFieldsFields_parentArray_childArray
+  id: ErrorFieldsFields_parentArray_id
 }
 
-type PostsFields_arrayField_group23field {
-  create: PostsFields_arrayField_group23field_Create
-  read: PostsFields_arrayField_group23field_Read
-  update: PostsFields_arrayField_group23field_Update
-  delete: PostsFields_arrayField_group23field_Delete
-  fields: PostsFields_arrayField_group23field_Fields
+type ErrorFieldsFields_parentArray_childArray {
+  create: ErrorFieldsFields_parentArray_childArray_Create
+  read: ErrorFieldsFields_parentArray_childArray_Read
+  update: ErrorFieldsFields_parentArray_childArray_Update
+  delete: ErrorFieldsFields_parentArray_childArray_Delete
+  fields: ErrorFieldsFields_parentArray_childArray_Fields
 }
 
-type PostsFields_arrayField_group23field_Create {
+type ErrorFieldsFields_parentArray_childArray_Create {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_Read {
+type ErrorFieldsFields_parentArray_childArray_Read {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_Update {
+type ErrorFieldsFields_parentArray_childArray_Update {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_Delete {
+type ErrorFieldsFields_parentArray_childArray_Delete {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_Fields {
-  arrayField: PostsFields_arrayField_group23field_arrayField
+type ErrorFieldsFields_parentArray_childArray_Fields {
+  childArrayText: ErrorFieldsFields_parentArray_childArray_childArrayText
+  id: ErrorFieldsFields_parentArray_childArray_id
 }
 
-type PostsFields_arrayField_group23field_arrayField {
-  create: PostsFields_arrayField_group23field_arrayField_Create
-  read: PostsFields_arrayField_group23field_arrayField_Read
-  update: PostsFields_arrayField_group23field_arrayField_Update
-  delete: PostsFields_arrayField_group23field_arrayField_Delete
-  fields: PostsFields_arrayField_group23field_arrayField_Fields
+type ErrorFieldsFields_parentArray_childArray_childArrayText {
+  create: ErrorFieldsFields_parentArray_childArray_childArrayText_Create
+  read: ErrorFieldsFields_parentArray_childArray_childArrayText_Read
+  update: ErrorFieldsFields_parentArray_childArray_childArrayText_Update
+  delete: ErrorFieldsFields_parentArray_childArray_childArrayText_Delete
 }
 
-type PostsFields_arrayField_group23field_arrayField_Create {
+type ErrorFieldsFields_parentArray_childArray_childArrayText_Create {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_Read {
+type ErrorFieldsFields_parentArray_childArray_childArrayText_Read {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_Update {
+type ErrorFieldsFields_parentArray_childArray_childArrayText_Update {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_Delete {
+type ErrorFieldsFields_parentArray_childArray_childArrayText_Delete {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_Fields {
-  group23field: PostsFields_arrayField_group23field_arrayField_group23field
-  id: PostsFields_arrayField_group23field_arrayField_id
+type ErrorFieldsFields_parentArray_childArray_id {
+  create: ErrorFieldsFields_parentArray_childArray_id_Create
+  read: ErrorFieldsFields_parentArray_childArray_id_Read
+  update: ErrorFieldsFields_parentArray_childArray_id_Update
+  delete: ErrorFieldsFields_parentArray_childArray_id_Delete
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field {
-  create: PostsFields_arrayField_group23field_arrayField_group23field_Create
-  read: PostsFields_arrayField_group23field_arrayField_group23field_Read
-  update: PostsFields_arrayField_group23field_arrayField_group23field_Update
-  delete: PostsFields_arrayField_group23field_arrayField_group23field_Delete
-  fields: PostsFields_arrayField_group23field_arrayField_group23field_Fields
-}
-
-type PostsFields_arrayField_group23field_arrayField_group23field_Create {
+type ErrorFieldsFields_parentArray_childArray_id_Create {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_Read {
+type ErrorFieldsFields_parentArray_childArray_id_Read {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_Update {
+type ErrorFieldsFields_parentArray_childArray_id_Update {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_Delete {
+type ErrorFieldsFields_parentArray_childArray_id_Delete {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_Fields {
-  arrayField: PostsFields_arrayField_group23field_arrayField_group23field_arrayField
+type ErrorFieldsFields_parentArray_id {
+  create: ErrorFieldsFields_parentArray_id_Create
+  read: ErrorFieldsFields_parentArray_id_Read
+  update: ErrorFieldsFields_parentArray_id_Update
+  delete: ErrorFieldsFields_parentArray_id_Delete
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField {
-  create: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_Create
-  read: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_Read
-  update: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_Update
-  delete: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_Delete
-  fields: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_Fields
-}
-
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_Create {
+type ErrorFieldsFields_parentArray_id_Create {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_Read {
+type ErrorFieldsFields_parentArray_id_Read {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_Update {
+type ErrorFieldsFields_parentArray_id_Update {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_Delete {
+type ErrorFieldsFields_parentArray_id_Delete {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_Fields {
-  textField: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_textField
-  id: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_id
+type ErrorFieldsFields_tabText {
+  create: ErrorFieldsFields_tabText_Create
+  read: ErrorFieldsFields_tabText_Read
+  update: ErrorFieldsFields_tabText_Update
+  delete: ErrorFieldsFields_tabText_Delete
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_textField {
-  create: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Create
-  read: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Read
-  update: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Update
-  delete: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Delete
-}
-
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Create {
+type ErrorFieldsFields_tabText_Create {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Read {
+type ErrorFieldsFields_tabText_Read {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Update {
+type ErrorFieldsFields_tabText_Update {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_textField_Delete {
+type ErrorFieldsFields_tabText_Delete {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_id {
-  create: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_id_Create
-  read: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_id_Read
-  update: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_id_Update
-  delete: PostsFields_arrayField_group23field_arrayField_group23field_arrayField_id_Delete
+type ErrorFieldsFields_text {
+  create: ErrorFieldsFields_text_Create
+  read: ErrorFieldsFields_text_Read
+  update: ErrorFieldsFields_text_Update
+  delete: ErrorFieldsFields_text_Delete
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_id_Create {
+type ErrorFieldsFields_text_Create {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_id_Read {
+type ErrorFieldsFields_text_Read {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_id_Update {
+type ErrorFieldsFields_text_Update {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_group23field_arrayField_id_Delete {
+type ErrorFieldsFields_text_Delete {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_id {
-  create: PostsFields_arrayField_group23field_arrayField_id_Create
-  read: PostsFields_arrayField_group23field_arrayField_id_Read
-  update: PostsFields_arrayField_group23field_arrayField_id_Update
-  delete: PostsFields_arrayField_group23field_arrayField_id_Delete
+type ErrorFieldsFields_array {
+  create: ErrorFieldsFields_array_Create
+  read: ErrorFieldsFields_array_Read
+  update: ErrorFieldsFields_array_Update
+  delete: ErrorFieldsFields_array_Delete
+  fields: ErrorFieldsFields_array_Fields
 }
 
-type PostsFields_arrayField_group23field_arrayField_id_Create {
+type ErrorFieldsFields_array_Create {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_id_Read {
+type ErrorFieldsFields_array_Read {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_id_Update {
+type ErrorFieldsFields_array_Update {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_group23field_arrayField_id_Delete {
+type ErrorFieldsFields_array_Delete {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_id {
-  create: PostsFields_arrayField_id_Create
-  read: PostsFields_arrayField_id_Read
-  update: PostsFields_arrayField_id_Update
-  delete: PostsFields_arrayField_id_Delete
+type ErrorFieldsFields_array_Fields {
+  requiredArrayText: ErrorFieldsFields_array_requiredArrayText
+  arrayText: ErrorFieldsFields_array_arrayText
+  group: ErrorFieldsFields_array_group
+  code: ErrorFieldsFields_array_code
+  json: ErrorFieldsFields_array_json
+  email: ErrorFieldsFields_array_email
+  point: ErrorFieldsFields_array_point
+  radio: ErrorFieldsFields_array_radio
+  relationship: ErrorFieldsFields_array_relationship
+  richtext: ErrorFieldsFields_array_richtext
+  select: ErrorFieldsFields_array_select
+  upload: ErrorFieldsFields_array_upload
+  text: ErrorFieldsFields_array_text
+  textarea: ErrorFieldsFields_array_textarea
+  id: ErrorFieldsFields_array_id
 }
 
-type PostsFields_arrayField_id_Create {
+type ErrorFieldsFields_array_requiredArrayText {
+  create: ErrorFieldsFields_array_requiredArrayText_Create
+  read: ErrorFieldsFields_array_requiredArrayText_Read
+  update: ErrorFieldsFields_array_requiredArrayText_Update
+  delete: ErrorFieldsFields_array_requiredArrayText_Delete
+}
+
+type ErrorFieldsFields_array_requiredArrayText_Create {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_id_Read {
+type ErrorFieldsFields_array_requiredArrayText_Read {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_id_Update {
+type ErrorFieldsFields_array_requiredArrayText_Update {
   permission: Boolean!
 }
 
-type PostsFields_arrayField_id_Delete {
+type ErrorFieldsFields_array_requiredArrayText_Delete {
   permission: Boolean!
 }
 
-type PostsFields_updatedAt {
-  create: PostsFields_updatedAt_Create
-  read: PostsFields_updatedAt_Read
-  update: PostsFields_updatedAt_Update
-  delete: PostsFields_updatedAt_Delete
+type ErrorFieldsFields_array_arrayText {
+  create: ErrorFieldsFields_array_arrayText_Create
+  read: ErrorFieldsFields_array_arrayText_Read
+  update: ErrorFieldsFields_array_arrayText_Update
+  delete: ErrorFieldsFields_array_arrayText_Delete
 }
 
-type PostsFields_updatedAt_Create {
+type ErrorFieldsFields_array_arrayText_Create {
   permission: Boolean!
 }
 
-type PostsFields_updatedAt_Read {
+type ErrorFieldsFields_array_arrayText_Read {
   permission: Boolean!
 }
 
-type PostsFields_updatedAt_Update {
+type ErrorFieldsFields_array_arrayText_Update {
   permission: Boolean!
 }
 
-type PostsFields_updatedAt_Delete {
+type ErrorFieldsFields_array_arrayText_Delete {
   permission: Boolean!
 }
 
-type PostsFields_createdAt {
-  create: PostsFields_createdAt_Create
-  read: PostsFields_createdAt_Read
-  update: PostsFields_createdAt_Update
-  delete: PostsFields_createdAt_Delete
+type ErrorFieldsFields_array_group {
+  create: ErrorFieldsFields_array_group_Create
+  read: ErrorFieldsFields_array_group_Read
+  update: ErrorFieldsFields_array_group_Update
+  delete: ErrorFieldsFields_array_group_Delete
+  fields: ErrorFieldsFields_array_group_Fields
 }
 
-type PostsFields_createdAt_Create {
+type ErrorFieldsFields_array_group_Create {
   permission: Boolean!
 }
 
-type PostsFields_createdAt_Read {
+type ErrorFieldsFields_array_group_Read {
   permission: Boolean!
 }
 
-type PostsFields_createdAt_Update {
+type ErrorFieldsFields_array_group_Update {
   permission: Boolean!
 }
 
-type PostsFields_createdAt_Delete {
+type ErrorFieldsFields_array_group_Delete {
   permission: Boolean!
 }
 
-type PostsCreateAccess {
+type ErrorFieldsFields_array_group_Fields {
+  text: ErrorFieldsFields_array_group_text
+  number: ErrorFieldsFields_array_group_number
+  date: ErrorFieldsFields_array_group_date
+  checkbox: ErrorFieldsFields_array_group_checkbox
+}
+
+type ErrorFieldsFields_array_group_text {
+  create: ErrorFieldsFields_array_group_text_Create
+  read: ErrorFieldsFields_array_group_text_Read
+  update: ErrorFieldsFields_array_group_text_Update
+  delete: ErrorFieldsFields_array_group_text_Delete
+}
+
+type ErrorFieldsFields_array_group_text_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_text_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_text_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_text_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_number {
+  create: ErrorFieldsFields_array_group_number_Create
+  read: ErrorFieldsFields_array_group_number_Read
+  update: ErrorFieldsFields_array_group_number_Update
+  delete: ErrorFieldsFields_array_group_number_Delete
+}
+
+type ErrorFieldsFields_array_group_number_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_number_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_number_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_number_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_date {
+  create: ErrorFieldsFields_array_group_date_Create
+  read: ErrorFieldsFields_array_group_date_Read
+  update: ErrorFieldsFields_array_group_date_Update
+  delete: ErrorFieldsFields_array_group_date_Delete
+}
+
+type ErrorFieldsFields_array_group_date_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_date_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_date_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_date_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_checkbox {
+  create: ErrorFieldsFields_array_group_checkbox_Create
+  read: ErrorFieldsFields_array_group_checkbox_Read
+  update: ErrorFieldsFields_array_group_checkbox_Update
+  delete: ErrorFieldsFields_array_group_checkbox_Delete
+}
+
+type ErrorFieldsFields_array_group_checkbox_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_checkbox_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_checkbox_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_group_checkbox_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_code {
+  create: ErrorFieldsFields_array_code_Create
+  read: ErrorFieldsFields_array_code_Read
+  update: ErrorFieldsFields_array_code_Update
+  delete: ErrorFieldsFields_array_code_Delete
+}
+
+type ErrorFieldsFields_array_code_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_code_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_code_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_code_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_json {
+  create: ErrorFieldsFields_array_json_Create
+  read: ErrorFieldsFields_array_json_Read
+  update: ErrorFieldsFields_array_json_Update
+  delete: ErrorFieldsFields_array_json_Delete
+}
+
+type ErrorFieldsFields_array_json_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_json_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_json_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_json_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_email {
+  create: ErrorFieldsFields_array_email_Create
+  read: ErrorFieldsFields_array_email_Read
+  update: ErrorFieldsFields_array_email_Update
+  delete: ErrorFieldsFields_array_email_Delete
+}
+
+type ErrorFieldsFields_array_email_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_email_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_email_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_email_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_point {
+  create: ErrorFieldsFields_array_point_Create
+  read: ErrorFieldsFields_array_point_Read
+  update: ErrorFieldsFields_array_point_Update
+  delete: ErrorFieldsFields_array_point_Delete
+}
+
+type ErrorFieldsFields_array_point_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_point_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_point_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_point_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_radio {
+  create: ErrorFieldsFields_array_radio_Create
+  read: ErrorFieldsFields_array_radio_Read
+  update: ErrorFieldsFields_array_radio_Update
+  delete: ErrorFieldsFields_array_radio_Delete
+}
+
+type ErrorFieldsFields_array_radio_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_radio_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_radio_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_radio_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_relationship {
+  create: ErrorFieldsFields_array_relationship_Create
+  read: ErrorFieldsFields_array_relationship_Read
+  update: ErrorFieldsFields_array_relationship_Update
+  delete: ErrorFieldsFields_array_relationship_Delete
+}
+
+type ErrorFieldsFields_array_relationship_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_relationship_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_relationship_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_relationship_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_richtext {
+  create: ErrorFieldsFields_array_richtext_Create
+  read: ErrorFieldsFields_array_richtext_Read
+  update: ErrorFieldsFields_array_richtext_Update
+  delete: ErrorFieldsFields_array_richtext_Delete
+}
+
+type ErrorFieldsFields_array_richtext_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_richtext_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_richtext_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_richtext_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_select {
+  create: ErrorFieldsFields_array_select_Create
+  read: ErrorFieldsFields_array_select_Read
+  update: ErrorFieldsFields_array_select_Update
+  delete: ErrorFieldsFields_array_select_Delete
+}
+
+type ErrorFieldsFields_array_select_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_select_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_select_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_select_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_upload {
+  create: ErrorFieldsFields_array_upload_Create
+  read: ErrorFieldsFields_array_upload_Read
+  update: ErrorFieldsFields_array_upload_Update
+  delete: ErrorFieldsFields_array_upload_Delete
+}
+
+type ErrorFieldsFields_array_upload_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_upload_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_upload_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_upload_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_text {
+  create: ErrorFieldsFields_array_text_Create
+  read: ErrorFieldsFields_array_text_Read
+  update: ErrorFieldsFields_array_text_Update
+  delete: ErrorFieldsFields_array_text_Delete
+}
+
+type ErrorFieldsFields_array_text_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_text_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_text_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_text_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_textarea {
+  create: ErrorFieldsFields_array_textarea_Create
+  read: ErrorFieldsFields_array_textarea_Read
+  update: ErrorFieldsFields_array_textarea_Update
+  delete: ErrorFieldsFields_array_textarea_Delete
+}
+
+type ErrorFieldsFields_array_textarea_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_textarea_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_textarea_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_textarea_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_id {
+  create: ErrorFieldsFields_array_id_Create
+  read: ErrorFieldsFields_array_id_Read
+  update: ErrorFieldsFields_array_id_Update
+  delete: ErrorFieldsFields_array_id_Delete
+}
+
+type ErrorFieldsFields_array_id_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_id_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_id_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_array_id_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_layout {
+  create: ErrorFieldsFields_layout_Create
+  read: ErrorFieldsFields_layout_Read
+  update: ErrorFieldsFields_layout_Update
+  delete: ErrorFieldsFields_layout_Delete
+}
+
+type ErrorFieldsFields_layout_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_layout_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_layout_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_layout_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_group {
+  create: ErrorFieldsFields_group_Create
+  read: ErrorFieldsFields_group_Read
+  update: ErrorFieldsFields_group_Update
+  delete: ErrorFieldsFields_group_Delete
+  fields: ErrorFieldsFields_group_Fields
+}
+
+type ErrorFieldsFields_group_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_group_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_group_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_group_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_group_Fields {
+  text: ErrorFieldsFields_group_text
+}
+
+type ErrorFieldsFields_group_text {
+  create: ErrorFieldsFields_group_text_Create
+  read: ErrorFieldsFields_group_text_Read
+  update: ErrorFieldsFields_group_text_Update
+  delete: ErrorFieldsFields_group_text_Delete
+}
+
+type ErrorFieldsFields_group_text_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_group_text_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_group_text_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_group_text_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_updatedAt {
+  create: ErrorFieldsFields_updatedAt_Create
+  read: ErrorFieldsFields_updatedAt_Read
+  update: ErrorFieldsFields_updatedAt_Update
+  delete: ErrorFieldsFields_updatedAt_Delete
+}
+
+type ErrorFieldsFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_createdAt {
+  create: ErrorFieldsFields_createdAt_Create
+  read: ErrorFieldsFields_createdAt_Read
+  update: ErrorFieldsFields_createdAt_Update
+  delete: ErrorFieldsFields_createdAt_Delete
+}
+
+type ErrorFieldsFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type ErrorFieldsFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type ErrorFieldsCreateAccess {
   permission: Boolean!
   where: JSONObject
 }
 
-type PostsReadAccess {
+type ErrorFieldsReadAccess {
   permission: Boolean!
   where: JSONObject
 }
 
-type PostsUpdateAccess {
+type ErrorFieldsUpdateAccess {
   permission: Boolean!
   where: JSONObject
 }
 
-type PostsDeleteAccess {
+type ErrorFieldsDeleteAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type uploadsAccess {
+  fields: UploadsFields
+  create: UploadsCreateAccess
+  read: UploadsReadAccess
+  update: UploadsUpdateAccess
+  delete: UploadsDeleteAccess
+}
+
+type UploadsFields {
+  text: UploadsFields_text
+  media: UploadsFields_media
+  richText: UploadsFields_richText
+  updatedAt: UploadsFields_updatedAt
+  createdAt: UploadsFields_createdAt
+  url: UploadsFields_url
+  filename: UploadsFields_filename
+  mimeType: UploadsFields_mimeType
+  filesize: UploadsFields_filesize
+  width: UploadsFields_width
+  height: UploadsFields_height
+}
+
+type UploadsFields_text {
+  create: UploadsFields_text_Create
+  read: UploadsFields_text_Read
+  update: UploadsFields_text_Update
+  delete: UploadsFields_text_Delete
+}
+
+type UploadsFields_text_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_text_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_text_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_text_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_media {
+  create: UploadsFields_media_Create
+  read: UploadsFields_media_Read
+  update: UploadsFields_media_Update
+  delete: UploadsFields_media_Delete
+}
+
+type UploadsFields_media_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_media_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_media_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_media_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_richText {
+  create: UploadsFields_richText_Create
+  read: UploadsFields_richText_Read
+  update: UploadsFields_richText_Update
+  delete: UploadsFields_richText_Delete
+}
+
+type UploadsFields_richText_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_richText_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_richText_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_richText_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_updatedAt {
+  create: UploadsFields_updatedAt_Create
+  read: UploadsFields_updatedAt_Read
+  update: UploadsFields_updatedAt_Update
+  delete: UploadsFields_updatedAt_Delete
+}
+
+type UploadsFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_createdAt {
+  create: UploadsFields_createdAt_Create
+  read: UploadsFields_createdAt_Read
+  update: UploadsFields_createdAt_Update
+  delete: UploadsFields_createdAt_Delete
+}
+
+type UploadsFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_url {
+  create: UploadsFields_url_Create
+  read: UploadsFields_url_Read
+  update: UploadsFields_url_Update
+  delete: UploadsFields_url_Delete
+}
+
+type UploadsFields_url_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_url_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_url_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_filename {
+  create: UploadsFields_filename_Create
+  read: UploadsFields_filename_Read
+  update: UploadsFields_filename_Update
+  delete: UploadsFields_filename_Delete
+}
+
+type UploadsFields_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_mimeType {
+  create: UploadsFields_mimeType_Create
+  read: UploadsFields_mimeType_Read
+  update: UploadsFields_mimeType_Update
+  delete: UploadsFields_mimeType_Delete
+}
+
+type UploadsFields_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_filesize {
+  create: UploadsFields_filesize_Create
+  read: UploadsFields_filesize_Read
+  update: UploadsFields_filesize_Update
+  delete: UploadsFields_filesize_Delete
+}
+
+type UploadsFields_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_width {
+  create: UploadsFields_width_Create
+  read: UploadsFields_width_Read
+  update: UploadsFields_width_Update
+  delete: UploadsFields_width_Delete
+}
+
+type UploadsFields_width_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_width_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_width_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_height {
+  create: UploadsFields_height_Create
+  read: UploadsFields_height_Read
+  update: UploadsFields_height_Update
+  delete: UploadsFields_height_Delete
+}
+
+type UploadsFields_height_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_height_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_height_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsDeleteAccess {
   permission: Boolean!
   where: JSONObject
 }
@@ -1195,86 +4584,395 @@ type UsersUnlockAccess {
   where: JSONObject
 }
 
+type payload_preferencesAccess {
+  fields: PayloadPreferencesFields
+  create: PayloadPreferencesCreateAccess
+  read: PayloadPreferencesReadAccess
+  update: PayloadPreferencesUpdateAccess
+  delete: PayloadPreferencesDeleteAccess
+}
+
+type PayloadPreferencesFields {
+  user: PayloadPreferencesFields_user
+  key: PayloadPreferencesFields_key
+  value: PayloadPreferencesFields_value
+  updatedAt: PayloadPreferencesFields_updatedAt
+  createdAt: PayloadPreferencesFields_createdAt
+}
+
+type PayloadPreferencesFields_user {
+  create: PayloadPreferencesFields_user_Create
+  read: PayloadPreferencesFields_user_Read
+  update: PayloadPreferencesFields_user_Update
+  delete: PayloadPreferencesFields_user_Delete
+}
+
+type PayloadPreferencesFields_user_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_user_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_user_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_user_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key {
+  create: PayloadPreferencesFields_key_Create
+  read: PayloadPreferencesFields_key_Read
+  update: PayloadPreferencesFields_key_Update
+  delete: PayloadPreferencesFields_key_Delete
+}
+
+type PayloadPreferencesFields_key_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_key_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value {
+  create: PayloadPreferencesFields_value_Create
+  read: PayloadPreferencesFields_value_Read
+  update: PayloadPreferencesFields_value_Update
+  delete: PayloadPreferencesFields_value_Delete
+}
+
+type PayloadPreferencesFields_value_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_value_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt {
+  create: PayloadPreferencesFields_updatedAt_Create
+  read: PayloadPreferencesFields_updatedAt_Read
+  update: PayloadPreferencesFields_updatedAt_Update
+  delete: PayloadPreferencesFields_updatedAt_Delete
+}
+
+type PayloadPreferencesFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt {
+  create: PayloadPreferencesFields_createdAt_Create
+  read: PayloadPreferencesFields_createdAt_Read
+  update: PayloadPreferencesFields_createdAt_Update
+  delete: PayloadPreferencesFields_createdAt_Delete
+}
+
+type PayloadPreferencesFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadPreferencesFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadPreferencesCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadPreferencesDeleteAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
 type Mutation {
-  createPost(data: mutationPostInput!, draft: Boolean): Post
-  updatePost(id: String!, data: mutationPostUpdateInput!, draft: Boolean, autosave: Boolean): Post
-  deletePost(id: String!): Post
+  createErrorField(data: mutationErrorFieldInput!, draft: Boolean): ErrorField
+  updateErrorField(id: String!, autosave: Boolean, data: mutationErrorFieldUpdateInput!, draft: Boolean): ErrorField
+  deleteErrorField(id: String!): ErrorField
+  createUpload(data: mutationUploadInput!, draft: Boolean): Upload
+  updateUpload(id: String!, autosave: Boolean, data: mutationUploadUpdateInput!, draft: Boolean): Upload
+  deleteUpload(id: String!): Upload
   createUser(data: mutationUserInput!, draft: Boolean): User
-  updateUser(id: String!, data: mutationUserUpdateInput!, draft: Boolean, autosave: Boolean): User
+  updateUser(id: String!, autosave: Boolean, data: mutationUserUpdateInput!, draft: Boolean): User
   deleteUser(id: String!): User
   refreshTokenUser(token: String): usersRefreshedUser
   logoutUser: String
   unlockUser(email: String!): Boolean!
   loginUser(email: String, password: String): usersLoginResult
-  forgotPasswordUser(email: String!, disableEmail: Boolean, expiration: Int): Boolean!
-  resetPasswordUser(token: String, password: String): usersResetPassword
+  forgotPasswordUser(disableEmail: Boolean, email: String!, expiration: Int): Boolean!
+  resetPasswordUser(password: String, token: String): usersResetPassword
   verifyEmailUser(token: String): Boolean
-  updatePreference(key: String!, value: JSON): Preference
-  deletePreference(key: String!): Preference
+  createPayloadPreference(data: mutationPayloadPreferenceInput!, draft: Boolean): PayloadPreference
+  updatePayloadPreference(id: String!, autosave: Boolean, data: mutationPayloadPreferenceUpdateInput!, draft: Boolean): PayloadPreference
+  deletePayloadPreference(id: String!): PayloadPreference
 }
 
-input mutationPostInput {
-  arrayField: [mutationPost_ArrayFieldInput]
+input mutationErrorFieldInput {
+  parentArray: [mutationErrorField_ParentArrayInput]
+  home: mutationErrorField_HomeInput
+  tabText: String!
+  text: String!
+  array: [mutationErrorField_ArrayInput]
+  layout: JSON
+  group: mutationErrorField_GroupInput!
   updatedAt: String
   createdAt: String
 }
 
-input mutationPost_ArrayFieldInput {
-  group23field: mutationPost_ArrayField_Group23fieldInput!
+input mutationErrorField_ParentArrayInput {
+  childArray: [mutationErrorField_ParentArray_ChildArrayInput!]
   id: String
 }
 
-input mutationPost_ArrayField_Group23fieldInput {
-  arrayField: [mutationPost_ArrayField_Group23field_ArrayFieldInput!]
-}
-
-input mutationPost_ArrayField_Group23field_ArrayFieldInput {
-  group23field: mutationPost_ArrayField_Group23field_ArrayField_Group23fieldInput!
+input mutationErrorField_ParentArray_ChildArrayInput {
+  childArrayText: String!
   id: String
 }
 
-input mutationPost_ArrayField_Group23field_ArrayField_Group23fieldInput {
-  arrayField: [mutationPost_ArrayField_Group23field_ArrayField_Group23field_ArrayFieldInput!]
+input mutationErrorField_HomeInput {
+  tabText: String!
+  text: String!
+  array: [mutationErrorField_Home_ArrayInput]
 }
 
-input mutationPost_ArrayField_Group23field_ArrayField_Group23field_ArrayFieldInput {
-  textField: String!
+input mutationErrorField_Home_ArrayInput {
+  requiredArrayText: String!
+  arrayText: String
+  group: mutationErrorField_Home_Array_GroupInput!
+  code: String!
+  json: JSON!
+  email: String!
+  point: [Float]!
+  radio: String!
+  relationship: String
+  richtext: JSON!
+  select: ErrorField_Home_Array_select_MutationInput!
+  upload: String!
+  text: String!
+  textarea: String!
   id: String
 }
 
-input mutationPostUpdateInput {
-  arrayField: [mutationPostUpdate_ArrayFieldInput]
+input mutationErrorField_Home_Array_GroupInput {
+  text: String!
+  number: Float!
+  date: String!
+  checkbox: Boolean
+}
+
+enum ErrorField_Home_Array_select_MutationInput {
+  mint
+  dark_gray
+}
+
+input mutationErrorField_ArrayInput {
+  requiredArrayText: String!
+  arrayText: String
+  group: mutationErrorField_Array_GroupInput!
+  code: String!
+  json: JSON!
+  email: String!
+  point: [Float]!
+  radio: String!
+  relationship: String
+  richtext: JSON!
+  select: ErrorField_Array_select_MutationInput!
+  upload: String!
+  text: String!
+  textarea: String!
+  id: String
+}
+
+input mutationErrorField_Array_GroupInput {
+  text: String!
+  number: Float!
+  date: String!
+  checkbox: Boolean
+}
+
+enum ErrorField_Array_select_MutationInput {
+  mint
+  dark_gray
+}
+
+input mutationErrorField_GroupInput {
+  text: String!
+}
+
+input mutationErrorFieldUpdateInput {
+  parentArray: [mutationErrorFieldUpdate_ParentArrayInput]
+  home: mutationErrorFieldUpdate_HomeInput
+  tabText: String
+  text: String
+  array: [mutationErrorFieldUpdate_ArrayInput]
+  layout: JSON
+  group: mutationErrorFieldUpdate_GroupInput!
   updatedAt: String
   createdAt: String
 }
 
-input mutationPostUpdate_ArrayFieldInput {
-  group23field: mutationPostUpdate_ArrayField_Group23fieldInput!
+input mutationErrorFieldUpdate_ParentArrayInput {
+  childArray: [mutationErrorFieldUpdate_ParentArray_ChildArrayInput!]
   id: String
 }
 
-input mutationPostUpdate_ArrayField_Group23fieldInput {
-  arrayField: [mutationPostUpdate_ArrayField_Group23field_ArrayFieldInput!]
-}
-
-input mutationPostUpdate_ArrayField_Group23field_ArrayFieldInput {
-  group23field: mutationPostUpdate_ArrayField_Group23field_ArrayField_Group23fieldInput!
+input mutationErrorFieldUpdate_ParentArray_ChildArrayInput {
+  childArrayText: String!
   id: String
 }
 
-input mutationPostUpdate_ArrayField_Group23field_ArrayField_Group23fieldInput {
-  arrayField: [mutationPostUpdate_ArrayField_Group23field_ArrayField_Group23field_ArrayFieldInput!]
+input mutationErrorFieldUpdate_HomeInput {
+  tabText: String!
+  text: String!
+  array: [mutationErrorFieldUpdate_Home_ArrayInput]
 }
 
-input mutationPostUpdate_ArrayField_Group23field_ArrayField_Group23field_ArrayFieldInput {
-  textField: String!
+input mutationErrorFieldUpdate_Home_ArrayInput {
+  requiredArrayText: String!
+  arrayText: String
+  group: mutationErrorFieldUpdate_Home_Array_GroupInput!
+  code: String!
+  json: JSON!
+  email: String!
+  point: [Float]!
+  radio: String!
+  relationship: String
+  richtext: JSON!
+  select: ErrorFieldUpdate_Home_Array_select_MutationInput!
+  upload: String!
+  text: String!
+  textarea: String!
   id: String
+}
+
+input mutationErrorFieldUpdate_Home_Array_GroupInput {
+  text: String!
+  number: Float!
+  date: String!
+  checkbox: Boolean
+}
+
+enum ErrorFieldUpdate_Home_Array_select_MutationInput {
+  mint
+  dark_gray
+}
+
+input mutationErrorFieldUpdate_ArrayInput {
+  requiredArrayText: String!
+  arrayText: String
+  group: mutationErrorFieldUpdate_Array_GroupInput!
+  code: String!
+  json: JSON!
+  email: String!
+  point: [Float]!
+  radio: String!
+  relationship: String
+  richtext: JSON!
+  select: ErrorFieldUpdate_Array_select_MutationInput!
+  upload: String!
+  text: String!
+  textarea: String!
+  id: String
+}
+
+input mutationErrorFieldUpdate_Array_GroupInput {
+  text: String!
+  number: Float!
+  date: String!
+  checkbox: Boolean
+}
+
+enum ErrorFieldUpdate_Array_select_MutationInput {
+  mint
+  dark_gray
+}
+
+input mutationErrorFieldUpdate_GroupInput {
+  text: String!
+}
+
+input mutationUploadInput {
+  text: String
+  media: String
+  richText: JSON
+  updatedAt: String
+  createdAt: String
+  url: String
+  filename: String
+  mimeType: String
+  filesize: Float
+  width: Float
+  height: Float
+}
+
+input mutationUploadUpdateInput {
+  text: String
+  media: String
+  richText: JSON
+  updatedAt: String
+  createdAt: String
+  url: String
+  filename: String
+  mimeType: String
+  filesize: Float
+  width: Float
+  height: Float
 }
 
 input mutationUserInput {
   updatedAt: String
   createdAt: String
-  email: String
+  email: String!
   resetPasswordToken: String
   resetPasswordExpiration: String
   salt: String
@@ -1298,9 +4996,9 @@ input mutationUserUpdateInput {
 }
 
 type usersRefreshedUser {
-  user: usersJWT
-  refreshedToken: String
   exp: Int
+  refreshedToken: String
+  user: usersJWT
 }
 
 type usersJWT {
@@ -1309,12 +5007,46 @@ type usersJWT {
 }
 
 type usersLoginResult {
+  exp: Int
   token: String
   user: User
-  exp: Int
 }
 
 type usersResetPassword {
   token: String
   user: User
+}
+
+input mutationPayloadPreferenceInput {
+  user: PayloadPreference_UserRelationshipInput
+  key: String
+  value: JSON
+  updatedAt: String
+  createdAt: String
+}
+
+input PayloadPreference_UserRelationshipInput {
+  relationTo: PayloadPreference_UserRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PayloadPreference_UserRelationshipInputRelationTo {
+  users
+}
+
+input mutationPayloadPreferenceUpdateInput {
+  user: PayloadPreferenceUpdate_UserRelationshipInput
+  key: String
+  value: JSON
+  updatedAt: String
+  createdAt: String
+}
+
+input PayloadPreferenceUpdate_UserRelationshipInput {
+  relationTo: PayloadPreferenceUpdate_UserRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PayloadPreferenceUpdate_UserRelationshipInputRelationTo {
+  users
 }

--- a/test/graphql-schema-gen/schema.graphql
+++ b/test/graphql-schema-gen/schema.graphql
@@ -1,35 +1,17 @@
 type Query {
   Collection1(id: String!, draft: Boolean): Collection1
-  Collection1s(
-    where: Collection1_where
-    draft: Boolean
-    page: Int
-    limit: Int
-    sort: String
-  ): Collection1s
+  Collection1s(draft: Boolean, where: Collection1_where, limit: Int, page: Int, sort: String): Collection1s
   docAccessCollection1(id: String!): collection1DocAccess
   Collection2(id: String!, draft: Boolean): Collection2
-  Collection2s(
-    where: Collection2_where
-    draft: Boolean
-    page: Int
-    limit: Int
-    sort: String
-  ): Collection2s
+  Collection2s(draft: Boolean, where: Collection2_where, limit: Int, page: Int, sort: String): Collection2s
   docAccessCollection2(id: String!): collection2DocAccess
   User(id: String!, draft: Boolean): User
-  Users(where: User_where, draft: Boolean, page: Int, limit: Int, sort: String): Users
+  Users(draft: Boolean, where: User_where, limit: Int, page: Int, sort: String): Users
   docAccessUser(id: String!): usersDocAccess
   meUser: usersMe
   initializedUser: Boolean
   PayloadPreference(id: String!, draft: Boolean): PayloadPreference
-  PayloadPreferences(
-    where: PayloadPreference_where
-    draft: Boolean
-    page: Int
-    limit: Int
-    sort: String
-  ): PayloadPreferences
+  PayloadPreferences(draft: Boolean, where: PayloadPreference_where, limit: Int, page: Int, sort: String): PayloadPreferences
   docAccessPayloadPreference(id: String!): payload_preferencesDocAccess
   Access: Access
 }
@@ -75,16 +57,16 @@ scalar DateTime
 
 type Collection1s {
   docs: [Collection1]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input Collection1_where {
@@ -96,8 +78,8 @@ input Collection1_where {
   updatedAt: Collection1_updatedAt_operator
   createdAt: Collection1_createdAt_operator
   id: Collection1_id_operator
-  OR: [Collection1_where_or]
   AND: [Collection1_where_and]
+  OR: [Collection1_where_or]
 }
 
 input Collection1_testing_operator {
@@ -186,17 +168,6 @@ input Collection1_id_operator {
   exists: Boolean
 }
 
-input Collection1_where_or {
-  testing: Collection1_testing_operator
-  title: Collection1_title_operator
-  meta__title: Collection1_meta__title_operator
-  meta__description: Collection1_meta__description_operator
-  meta__id: Collection1_meta__id_operator
-  updatedAt: Collection1_updatedAt_operator
-  createdAt: Collection1_createdAt_operator
-  id: Collection1_id_operator
-}
-
 input Collection1_where_and {
   testing: Collection1_testing_operator
   title: Collection1_title_operator
@@ -206,6 +177,21 @@ input Collection1_where_and {
   updatedAt: Collection1_updatedAt_operator
   createdAt: Collection1_createdAt_operator
   id: Collection1_id_operator
+  AND: [Collection1_where_and]
+  OR: [Collection1_where_or]
+}
+
+input Collection1_where_or {
+  testing: Collection1_testing_operator
+  title: Collection1_title_operator
+  meta__title: Collection1_meta__title_operator
+  meta__description: Collection1_meta__description_operator
+  meta__id: Collection1_meta__id_operator
+  updatedAt: Collection1_updatedAt_operator
+  createdAt: Collection1_createdAt_operator
+  id: Collection1_id_operator
+  AND: [Collection1_where_and]
+  OR: [Collection1_where_or]
 }
 
 type collection1DocAccess {
@@ -483,16 +469,16 @@ type Collection2_NestedGroup {
 
 type Collection2s {
   docs: [Collection2]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input Collection2_where {
@@ -504,8 +490,8 @@ input Collection2_where {
   updatedAt: Collection2_updatedAt_operator
   createdAt: Collection2_createdAt_operator
   id: Collection2_id_operator
-  OR: [Collection2_where_or]
   AND: [Collection2_where_and]
+  OR: [Collection2_where_or]
 }
 
 input Collection2_meta__title_operator {
@@ -596,17 +582,6 @@ input Collection2_id_operator {
   exists: Boolean
 }
 
-input Collection2_where_or {
-  meta__title: Collection2_meta__title_operator
-  meta__description: Collection2_meta__description_operator
-  meta__id: Collection2_meta__id_operator
-  nestedGroup__meta__title: Collection2_nestedGroup__meta__title_operator
-  nestedGroup__meta__description: Collection2_nestedGroup__meta__description_operator
-  updatedAt: Collection2_updatedAt_operator
-  createdAt: Collection2_createdAt_operator
-  id: Collection2_id_operator
-}
-
 input Collection2_where_and {
   meta__title: Collection2_meta__title_operator
   meta__description: Collection2_meta__description_operator
@@ -616,6 +591,21 @@ input Collection2_where_and {
   updatedAt: Collection2_updatedAt_operator
   createdAt: Collection2_createdAt_operator
   id: Collection2_id_operator
+  AND: [Collection2_where_and]
+  OR: [Collection2_where_or]
+}
+
+input Collection2_where_or {
+  meta__title: Collection2_meta__title_operator
+  meta__description: Collection2_meta__description_operator
+  meta__id: Collection2_meta__id_operator
+  nestedGroup__meta__title: Collection2_nestedGroup__meta__title_operator
+  nestedGroup__meta__description: Collection2_nestedGroup__meta__description_operator
+  updatedAt: Collection2_updatedAt_operator
+  createdAt: Collection2_createdAt_operator
+  id: Collection2_id_operator
+  AND: [Collection2_where_and]
+  OR: [Collection2_where_or]
 }
 
 type collection2DocAccess {
@@ -894,21 +884,20 @@ type User {
 """
 A field whose value conforms to the standard internet email address format as specified in HTML Spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address.
 """
-scalar EmailAddress
-  @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
+scalar EmailAddress @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
 
 type Users {
   docs: [User]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input User_where {
@@ -916,8 +905,8 @@ input User_where {
   createdAt: User_createdAt_operator
   email: User_email_operator
   id: User_id_operator
-  OR: [User_where_or]
   AND: [User_where_and]
+  OR: [User_where_or]
 }
 
 input User_updatedAt_operator {
@@ -963,18 +952,22 @@ input User_id_operator {
   exists: Boolean
 }
 
-input User_where_or {
-  updatedAt: User_updatedAt_operator
-  createdAt: User_createdAt_operator
-  email: User_email_operator
-  id: User_id_operator
-}
-
 input User_where_and {
   updatedAt: User_updatedAt_operator
   createdAt: User_createdAt_operator
   email: User_email_operator
   id: User_id_operator
+  AND: [User_where_and]
+  OR: [User_where_or]
+}
+
+input User_where_or {
+  updatedAt: User_updatedAt_operator
+  createdAt: User_createdAt_operator
+  email: User_email_operator
+  id: User_id_operator
+  AND: [User_where_and]
+  OR: [User_where_or]
 }
 
 type usersDocAccess {
@@ -1111,10 +1104,10 @@ type UsersUnlockDocAccess {
 }
 
 type usersMe {
+  collection: String
+  exp: Int
   token: String
   user: User
-  exp: Int
-  collection: String
 }
 
 type PayloadPreference {
@@ -1144,16 +1137,16 @@ scalar JSON
 
 type PayloadPreferences {
   docs: [PayloadPreference]
-  totalDocs: Int
-  offset: Int
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
   limit: Int
-  totalPages: Int
+  nextPage: Int
+  offset: Int
   page: Int
   pagingCounter: Int
-  hasPrevPage: Boolean
-  hasNextPage: Boolean
   prevPage: Int
-  nextPage: Int
+  totalDocs: Int
+  totalPages: Int
 }
 
 input PayloadPreference_where {
@@ -1163,13 +1156,13 @@ input PayloadPreference_where {
   updatedAt: PayloadPreference_updatedAt_operator
   createdAt: PayloadPreference_createdAt_operator
   id: PayloadPreference_id_operator
-  OR: [PayloadPreference_where_or]
   AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
 }
 
 input PayloadPreference_user_Relation {
   relationTo: PayloadPreference_user_Relation_RelationTo
-  value: String
+  value: JSON
 }
 
 enum PayloadPreference_user_Relation_RelationTo {
@@ -1192,6 +1185,8 @@ input PayloadPreference_value_operator {
   not_equals: JSON
   like: JSON
   contains: JSON
+  within: JSON
+  intersects: JSON
   exists: Boolean
 }
 
@@ -1228,15 +1223,6 @@ input PayloadPreference_id_operator {
   exists: Boolean
 }
 
-input PayloadPreference_where_or {
-  user: PayloadPreference_user_Relation
-  key: PayloadPreference_key_operator
-  value: PayloadPreference_value_operator
-  updatedAt: PayloadPreference_updatedAt_operator
-  createdAt: PayloadPreference_createdAt_operator
-  id: PayloadPreference_id_operator
-}
-
 input PayloadPreference_where_and {
   user: PayloadPreference_user_Relation
   key: PayloadPreference_key_operator
@@ -1244,6 +1230,19 @@ input PayloadPreference_where_and {
   updatedAt: PayloadPreference_updatedAt_operator
   createdAt: PayloadPreference_createdAt_operator
   id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
+}
+
+input PayloadPreference_where_or {
+  user: PayloadPreference_user_Relation
+  key: PayloadPreference_key_operator
+  value: PayloadPreference_value_operator
+  updatedAt: PayloadPreference_updatedAt_operator
+  createdAt: PayloadPreference_createdAt_operator
+  id: PayloadPreference_id_operator
+  AND: [PayloadPreference_where_and]
+  OR: [PayloadPreference_where_or]
 }
 
 type payload_preferencesDocAccess {
@@ -2201,38 +2200,23 @@ type PayloadPreferencesDeleteAccess {
 
 type Mutation {
   createCollection1(data: mutationCollection1Input!, draft: Boolean): Collection1
-  updateCollection1(
-    id: String!
-    data: mutationCollection1UpdateInput!
-    draft: Boolean
-    autosave: Boolean
-  ): Collection1
+  updateCollection1(id: String!, autosave: Boolean, data: mutationCollection1UpdateInput!, draft: Boolean): Collection1
   deleteCollection1(id: String!): Collection1
   createCollection2(data: mutationCollection2Input!, draft: Boolean): Collection2
-  updateCollection2(
-    id: String!
-    data: mutationCollection2UpdateInput!
-    draft: Boolean
-    autosave: Boolean
-  ): Collection2
+  updateCollection2(id: String!, autosave: Boolean, data: mutationCollection2UpdateInput!, draft: Boolean): Collection2
   deleteCollection2(id: String!): Collection2
   createUser(data: mutationUserInput!, draft: Boolean): User
-  updateUser(id: String!, data: mutationUserUpdateInput!, draft: Boolean, autosave: Boolean): User
+  updateUser(id: String!, autosave: Boolean, data: mutationUserUpdateInput!, draft: Boolean): User
   deleteUser(id: String!): User
   refreshTokenUser(token: String): usersRefreshedUser
   logoutUser: String
   unlockUser(email: String!): Boolean!
   loginUser(email: String, password: String): usersLoginResult
-  forgotPasswordUser(email: String!, disableEmail: Boolean, expiration: Int): Boolean!
-  resetPasswordUser(token: String, password: String): usersResetPassword
+  forgotPasswordUser(disableEmail: Boolean, email: String!, expiration: Int): Boolean!
+  resetPasswordUser(password: String, token: String): usersResetPassword
   verifyEmailUser(token: String): Boolean
   createPayloadPreference(data: mutationPayloadPreferenceInput!, draft: Boolean): PayloadPreference
-  updatePayloadPreference(
-    id: String!
-    data: mutationPayloadPreferenceUpdateInput!
-    draft: Boolean
-    autosave: Boolean
-  ): PayloadPreference
+  updatePayloadPreference(id: String!, autosave: Boolean, data: mutationPayloadPreferenceUpdateInput!, draft: Boolean): PayloadPreference
   deletePayloadPreference(id: String!): PayloadPreference
 }
 
@@ -2335,9 +2319,9 @@ input mutationUserUpdateInput {
 }
 
 type usersRefreshedUser {
-  user: usersJWT
-  refreshedToken: String
   exp: Int
+  refreshedToken: String
+  user: usersJWT
 }
 
 type usersJWT {
@@ -2346,9 +2330,9 @@ type usersJWT {
 }
 
 type usersLoginResult {
+  exp: Int
   token: String
   user: User
-  exp: Int
 }
 
 type usersResetPassword {


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/3538

Defines `AND` and `OR` types to be recursively included in their own definitions. Using a function to define the `fields` ensures that the types are properly referenced.

`Before`:
![Screen Shot 2023-10-27 at 12 01 06 PM](https://github.com/payloadcms/payload/assets/35232443/11ec368d-b001-4009-92e1-a6b1b8b2dc41)

`After`:
![Screen Shot 2023-10-27 at 12 29 07 PM](https://github.com/payloadcms/payload/assets/35232443/6b0607d1-cabe-4fbe-beb5-fbe13afc9d18)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
