### PR TITLE
fix: checks for user before accessing properties in preferences update fn

### DIFF
--- a/packages/payload/src/preferences/operations/update.ts
+++ b/packages/payload/src/preferences/operations/update.ts
@@ -14,6 +14,10 @@ async function update(args: PreferenceUpdateRequest) {
     value,
   } = args
 
+  if (!user) {
+    throw new UnauthorizedError(req.t)
+  }
+
   const collection = 'payload-preferences'
 
   const filter = {
@@ -29,10 +33,6 @@ async function update(args: PreferenceUpdateRequest) {
       value: user.id,
     },
     value,
-  }
-
-  if (!user) {
-    throw new UnauthorizedError(req.t)
   }
 
   if (!overrideAccess) {


### PR DESCRIPTION
## Description

Fixes `Cannot read properties of undefined (reading 'collection')` in the preferences update operation when no user is on the req.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
