### PR TITLE
fix: global permissions for live preview

### DIFF
--- a/packages/payload/src/admin/components/elements/DocumentFields/index.scss
+++ b/packages/payload/src/admin/components/elements/DocumentFields/index.scss
@@ -82,6 +82,35 @@
     color: var(--theme-elevation-400);
   }
 
+  &--force-sidebar-wrap {
+    display: block;
+
+    .document-fields {
+      &__main {
+        width: 100%;
+        min-height: initial;
+      }
+
+      &__sidebar-wrap {
+        position: static;
+        width: 100%;
+        height: initial;
+        border-left: 0;
+      }
+
+      &__sidebar {
+        padding-bottom: base(3.5);
+        overflow: visible;
+      }
+
+      &__sidebar-fields {
+        padding-top: 0;
+        padding-left: var(--gutter-h);
+        padding-bottom: 0;
+      }
+    }
+  }
+
   @include mid-break {
     display: block;
 

--- a/packages/payload/src/admin/components/elements/DocumentFields/index.tsx
+++ b/packages/payload/src/admin/components/elements/DocumentFields/index.tsx
@@ -19,6 +19,7 @@ export const DocumentFields: React.FC<{
   description?: Description
   fieldTypes: FieldTypes
   fields: FieldWithPath[]
+  forceSidebarWrap?: boolean
   hasSavePermission: boolean
   permissions: CollectionPermission | GlobalPermission
 }> = (props) => {
@@ -28,6 +29,7 @@ export const DocumentFields: React.FC<{
     description,
     fieldTypes,
     fields,
+    forceSidebarWrap,
     hasSavePermission,
     permissions,
   } = props
@@ -40,14 +42,15 @@ export const DocumentFields: React.FC<{
     readOnly: !hasSavePermission,
   })
 
-  const hasSidebar = sidebarFields && sidebarFields.length > 0
+  const hasSidebarFields = sidebarFields && sidebarFields.length > 0
 
   return (
     <React.Fragment>
       <div
         className={[
           baseClass,
-          hasSidebar ? `${baseClass}--has-sidebar` : `${baseClass}--no-sidebar`,
+          hasSidebarFields ? `${baseClass}--has-sidebar` : `${baseClass}--no-sidebar`,
+          forceSidebarWrap && `${baseClass}--force-sidebar-wrap`,
         ]
           .filter(Boolean)
           .join(' ')}
@@ -76,7 +79,7 @@ export const DocumentFields: React.FC<{
             {AfterFields || null}
           </Gutter>
         </div>
-        {hasSidebar && (
+        {hasSidebarFields && (
           <div className={`${baseClass}__sidebar-wrap`}>
             <div className={`${baseClass}__sidebar`}>
               <div className={`${baseClass}__sidebar-fields`}>

--- a/packages/payload/src/admin/components/views/LivePreview/index.scss
+++ b/packages/payload/src/admin/components/views/LivePreview/index.scss
@@ -41,18 +41,6 @@
     }
   }
 
-  &__edit {
-    padding-top: calc(var(--base) * 1.5);
-    padding-bottom: base(4);
-    flex-grow: 1;
-    padding-right: calc(var(--base) * 2);
-
-    [dir='rtl'] & {
-      padding-right: 0;
-      padding-left: calc(var(--base) * 2);
-    }
-  }
-
   @include mid-break {
     flex-direction: column;
 
@@ -67,18 +55,6 @@
 
     &__form {
       display: block;
-    }
-
-    &__edit {
-      padding-top: var(--base);
-      padding-bottom: 0;
-      padding-right: var(--gutter-h);
-    }
-  }
-
-  @include small-break {
-    &__edit {
-      padding-top: calc(var(--base) / 2);
     }
   }
 }

--- a/packages/payload/src/admin/components/views/LivePreview/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/index.tsx
@@ -10,9 +10,8 @@ import type { EditViewProps } from '../types'
 
 import { getTranslation } from '../../../../utilities/getTranslation'
 import { DocumentControls } from '../../elements/DocumentControls'
+import { DocumentFields } from '../../elements/DocumentFields'
 import { Gutter } from '../../elements/Gutter'
-import RenderFields from '../../forms/RenderFields'
-import { filterFields } from '../../forms/RenderFields/filterFields'
 import { LeaveWithoutSaving } from '../../modals/LeaveWithoutSaving'
 import { useConfig } from '../../utilities/Config'
 import { useDocumentInfo } from '../../utilities/DocumentInfo'
@@ -46,6 +45,7 @@ const PreviewView: React.FC<
   let id: string
   let fields: Field[] = []
   let label: SanitizedGlobalConfig['label']
+  let description: SanitizedGlobalConfig['admin']['description']
 
   if ('collection' in props) {
     collection = props?.collection
@@ -61,15 +61,9 @@ const PreviewView: React.FC<
     global = props?.global
     fields = props?.global?.fields
     label = props?.global?.label
+    description = props?.global?.admin?.description
+    hasSavePermission = permissions?.update?.permission
   }
-
-  const sidebarFields = filterFields({
-    fieldSchema: fields,
-    fieldTypes,
-    filter: (field) => field?.admin?.position === 'sidebar',
-    permissions: permissions.fields,
-    readOnly: !hasSavePermission,
-  })
 
   return (
     <Fragment>
@@ -124,18 +118,14 @@ const PreviewView: React.FC<
             .filter(Boolean)
             .join(' ')}
         >
-          <Gutter className={`${baseClass}__edit`}>
-            <RenderFields
-              fieldSchema={fields}
-              fieldTypes={fieldTypes}
-              filter={(field) => !field?.admin?.position || field?.admin?.position !== 'sidebar'}
-              permissions={permissions.fields}
-              readOnly={!hasSavePermission}
-            />
-            {sidebarFields && sidebarFields.length > 0 && (
-              <RenderFields fieldTypes={fieldTypes} fields={sidebarFields} />
-            )}
-          </Gutter>
+          <DocumentFields
+            description={description}
+            fieldTypes={fieldTypes}
+            fields={fields}
+            forceSidebarWrap
+            hasSavePermission={hasSavePermission}
+            permissions={permissions}
+          />
         </div>
         <LivePreview {...props} />
       </div>

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -107,15 +107,24 @@ describe('Live Preview', () => {
     await expect(iframe).toBeVisible()
   })
 
+  test('global - can edit fields', async () => {
+    await goToGlobalPreview(page, 'header')
+    const field = page.locator('input#field-navItems__0__link__newTab')
+    await expect(field).toBeVisible()
+    await expect(field).toBeEnabled()
+    await field.check()
+    await saveDocHotkeyAndAssert(page)
+  })
+
   test('properly measures iframe and displays size', async () => {
     await page.goto(url.create)
     await page.locator('#field-title').fill('Title 3')
     await page.locator('#field-slug').fill('slug-3')
 
     await saveDocAndAssert(page)
-    const docURL = page.url()
-    await page.goto(`${docURL}/preview`)
-    expect(page.url()).toBe(`${docURL}/preview`)
+    await goToCollectionPreview(page)
+    expect(page.url()).toContain('/preview')
+
     const iframe = page.locator('iframe')
 
     // Measure the actual iframe size and compare it with the inputs rendered in the toolbar
@@ -148,9 +157,7 @@ describe('Live Preview', () => {
     await page.locator('#field-slug').fill('slug-4')
 
     await saveDocAndAssert(page)
-    const docURL = page.url()
-    await page.goto(`${docURL}/preview`)
-    expect(page.url()).toBe(`${docURL}/preview`)
+    await goToCollectionPreview(page)
 
     const breakpointSelector = page.locator(
       '.live-preview-toolbar select[name="live-preview-breakpoint"]',

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -2,7 +2,7 @@ import type { Page } from '@playwright/test'
 
 import { expect, test } from '@playwright/test'
 
-import { exactText, saveDocAndAssert, saveDocHotkeyAndAssert } from '../helpers'
+import { exactText, saveDocAndAssert } from '../helpers'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil'
 import { initPayloadE2E } from '../helpers/configHelpers'
 import { mobileBreakpoint } from './config'
@@ -76,7 +76,7 @@ describe('Live Preview', () => {
     const field = page.locator('#field-title')
     await expect(field).toBeVisible()
     await field.fill('Title 1')
-    await saveDocHotkeyAndAssert(page)
+    await saveDocAndAssert(page)
   })
 
   test('global - has tab', async () => {
@@ -113,7 +113,7 @@ describe('Live Preview', () => {
     await expect(field).toBeVisible()
     await expect(field).toBeEnabled()
     await field.check()
-    await saveDocHotkeyAndAssert(page)
+    await saveDocAndAssert(page)
   })
 
   test('properly measures iframe and displays size', async () => {
@@ -158,6 +158,7 @@ describe('Live Preview', () => {
 
     await saveDocAndAssert(page)
     await goToCollectionPreview(page)
+    expect(page.url()).toContain('/preview')
 
     const breakpointSelector = page.locator(
       '.live-preview-toolbar select[name="live-preview-breakpoint"]',

--- a/test/live-preview/globals/Footer.ts
+++ b/test/live-preview/globals/Footer.ts
@@ -6,6 +6,7 @@ export const Footer: GlobalConfig = {
   slug: 'footer',
   access: {
     read: () => true,
+    update: () => true,
   },
   fields: [
     {

--- a/test/live-preview/globals/Header.ts
+++ b/test/live-preview/globals/Header.ts
@@ -6,6 +6,7 @@ export const Header: GlobalConfig = {
   slug: 'header',
   access: {
     read: () => true,
+    update: () => true,
   },
   fields: [
     {


### PR DESCRIPTION
## Description

Closes #3846. Incorrect permissions were being passed through to `RenderFields` for the for Live Preview on globals. This PR uses the new `DocumentFields` component which was designed to standardize exactly this sort of thing. It also adds new tests to ensure that the correct permissions are passed through for both globals _and_ collections in Live Preview. The Live Preview e2e test suite was also cleaned up a bit.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
