### PR TITLE
fix: adds null to non-required field unions

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
@@ -194,7 +194,7 @@ const TabsField: React.FC<Props> = (props) => {
                   key={String(activeTabConfig.label)}
                   margins="small"
                   permissions={
-                    tabHasName(activeTabConfig)
+                    tabHasName(activeTabConfig) && permissions?.[activeTabConfig.name]
                       ? permissions[activeTabConfig.name].fields
                       : permissions
                   }

--- a/packages/payload/src/graphql/schema/buildMutationInputType.ts
+++ b/packages/payload/src/graphql/schema/buildMutationInputType.ts
@@ -39,7 +39,7 @@ import type {
 } from '../../fields/config/types'
 import type { Payload } from '../../payload'
 
-import { fieldAffectsData, tabHasName } from '../../fields/config/types'
+import { fieldAffectsData, optionIsObject, tabHasName } from '../../fields/config/types'
 import { toWords } from '../../utilities/formatLabels'
 import { groupOrTabHasRequiredSubfield } from '../../utilities/groupOrTabHasRequiredSubfield'
 import combineParentName from '../utilities/combineParentName'
@@ -208,7 +208,7 @@ function buildMutationInputType(
       let type: GraphQLType = new GraphQLEnumType({
         name: formattedName,
         values: field.options.reduce((values, option) => {
-          if (typeof option === 'object' && option.value) {
+          if (optionIsObject(option)) {
             return {
               ...values,
               [formatName(option.value)]: {
@@ -217,16 +217,12 @@ function buildMutationInputType(
             }
           }
 
-          if (typeof option === 'string') {
-            return {
-              ...values,
-              [option]: {
-                value: option,
-              },
-            }
+          return {
+            ...values,
+            [formatName(option)]: {
+              value: option,
+            },
           }
-
-          return values
         }, {}),
       })
 

--- a/packages/payload/src/graphql/schema/buildObjectType.ts
+++ b/packages/payload/src/graphql/schema/buildObjectType.ts
@@ -478,7 +478,6 @@ function buildObjectType({
             tab?.interfaceName || combineParentName(parentName, toWords(tab.name, true))
 
           if (!payload.types.tabTypes[interfaceName]) {
-            // eslint-disable-next-line no-param-reassign
             payload.types.tabTypes[interfaceName] = buildObjectType({
               name: interfaceName,
               fields: tab.fields,

--- a/packages/payload/src/graphql/schema/withOperators.ts
+++ b/packages/payload/src/graphql/schema/withOperators.ts
@@ -198,7 +198,7 @@ const defaults: DefaultsType = {
           new GraphQLEnumType({
             name: `${combineParentName(parentName, field.name)}_Input`,
             values: field.options.reduce((values, option) => {
-              if (typeof option === 'object' && option.value) {
+              if (optionIsObject(option)) {
                 return {
                   ...values,
                   [formatName(option.value)]: {
@@ -207,16 +207,12 @@ const defaults: DefaultsType = {
                 }
               }
 
-              if (typeof option === 'string') {
-                return {
-                  ...values,
-                  [option]: {
-                    value: option,
-                  },
-                }
+              return {
+                ...values,
+                [formatName(option)]: {
+                  value: option,
+                },
               }
-
-              return values
             }, {}),
           }),
       })),

--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -10,6 +10,8 @@ describe('configToJSONSchema', () => {
         {
           fields: [
             {
+              name: 'someRequiredField',
+              type: 'array',
               fields: [
                 {
                   name: 'someRequiredField',
@@ -17,8 +19,6 @@ describe('configToJSONSchema', () => {
                   type: 'text',
                 },
               ],
-              name: 'someRequiredField',
-              type: 'array',
             },
           ],
           slug: 'test',
@@ -29,6 +29,7 @@ describe('configToJSONSchema', () => {
 
     const sanitizedConfig = sanitizeConfig(config)
     const schema = configToJSONSchema(sanitizedConfig, 'text')
+    console.log(JSON.stringify(schema?.definitions?.test))
     expect(schema?.definitions?.test).toStrictEqual({
       additionalProperties: false,
       properties: {
@@ -46,10 +47,10 @@ describe('configToJSONSchema', () => {
                 type: 'string',
               },
             },
-            required: ['someRequiredField'],
+            required: ['someRequiredField', 'id'],
             type: 'object',
           },
-          type: 'array',
+          type: ['array', 'null'],
         },
       },
       required: ['id'],

--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -29,7 +29,7 @@ describe('configToJSONSchema', () => {
 
     const sanitizedConfig = sanitizeConfig(config)
     const schema = configToJSONSchema(sanitizedConfig, 'text')
-    console.log(JSON.stringify(schema?.definitions?.test))
+
     expect(schema?.definitions?.test).toStrictEqual({
       additionalProperties: false,
       properties: {

--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -41,13 +41,13 @@ describe('configToJSONSchema', () => {
             additionalProperties: false,
             properties: {
               id: {
-                type: 'string',
+                type: ['string', 'null'],
               },
               someRequiredField: {
                 type: 'string',
               },
             },
-            required: ['someRequiredField', 'id'],
+            required: ['someRequiredField'],
             type: 'object',
           },
           type: ['array', 'null'],

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -18,12 +18,12 @@ const fieldIsRequired = (field: Field) => {
   const isMarkedRequired = 'required' in field && field.required === true
   if (fieldAffectsData(field) && isMarkedRequired) return true
 
-  // if any group subfields are required, this field is then required
+  // if any subfields are required, this field is required
   if ('fields' in field && field.type !== 'array') {
     return field.fields.some((subField) => fieldIsRequired(subField))
   }
 
-  // if any tab subfields have required fields, this field is then required
+  // if any tab subfields have required fields, this field is required
   if (field.type === 'tabs') {
     return field.tabs.some((tab) => {
       if ('name' in tab) {

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -321,22 +321,13 @@ function fieldsToJSONSchema(
           }
 
           case 'array': {
-            const alteredFields = field.fields.map((subField) => {
-              if ('name' in subField && subField.name === 'id') {
-                return {
-                  ...subField,
-                  required: true,
-                }
-              }
-              return subField
-            })
             fieldSchema = {
               items: {
                 additionalProperties: false,
                 type: 'object',
                 ...fieldsToJSONSchema(
                   collectionIDFieldTypes,
-                  alteredFields,
+                  field.fields,
                   interfaceNameDefinitions,
                 ),
               },

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -28,7 +28,7 @@ const fieldIsRequired = (field: Field) => {
   return false
 }
 
-function returnOptionEnums(options: Option[]): string[] {
+function buildOptionEnums(options: Option[]): string[] {
   return options.map((option) => {
     if (typeof option === 'object' && 'value' in option) {
       return option.value
@@ -134,7 +134,7 @@ function fieldsToJSONSchema(
 
           case 'radio': {
             fieldSchema = {
-              enum: returnOptionEnums(field.options),
+              enum: buildOptionEnums(field.options),
               type: withNullableType('string', isRequired),
             }
 
@@ -142,7 +142,7 @@ function fieldsToJSONSchema(
           }
 
           case 'select': {
-            const optionEnums = returnOptionEnums(field.options)
+            const optionEnums = buildOptionEnums(field.options)
 
             if (field.hasMany) {
               fieldSchema = {


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/3777

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

When a field is not required, append the `null` type to the generated type as a union. This PR also reduces looping in some places.

#### Before
```ts
// autogenerated payload-types.ts file
export interface Post {
  optionalText?: string;
  requiredText: string;
}
```

#### After
```ts
// autogenerated payload-types.ts file
export interface Post {
  optionalText?: string | null;
  requiredText: string;
}
```

This is a simplified case, but the nullability stretches across all applicable fields:
- text
- number
- upload
- relationship
- textarea
- code
- email
- date
- select
- radio
- point
- array
- blocks
- checkbox


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
