### PR TITLE
fix: error handling when duplicating documents fails

### DIFF
--- a/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
+++ b/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
@@ -85,10 +85,13 @@ const Duplicate: React.FC<Props> = ({ id, collection, slug }) => {
       }
 
       let duplicateID
+      let abort = false
 
       if (localization) {
         duplicateID = await create(localization.defaultLocale)
-        let abort = false
+        if (!duplicateID) {
+          return
+        }
 
         await localization.localeCodes
           .filter((locale) => locale !== localization.defaultLocale)
@@ -133,9 +136,9 @@ const Duplicate: React.FC<Props> = ({ id, collection, slug }) => {
             }
           }, Promise.resolve())
 
-        if (abort) {
+        if (abort && duplicateID) {
           // delete the duplicate doc to prevent incomplete
-          await requests.delete(`${serverURL}${api}/${slug}/${id}`, {
+          await requests.delete(`${serverURL}${api}/${slug}/${duplicateID}`, {
             headers: {
               'Accept-Language': i18n.language,
             },
@@ -143,6 +146,10 @@ const Duplicate: React.FC<Props> = ({ id, collection, slug }) => {
         }
       } else {
         duplicateID = await create()
+      }
+
+      if (!duplicateID) {
+        return
       }
 
       toast.success(


### PR DESCRIPTION
## Description

fixes #3750

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
