### PR TITLE
fix: duplicate document copying to incorrect locale

### DIFF
--- a/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
+++ b/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
@@ -60,14 +60,6 @@ const Duplicate: React.FC<Props> = ({ id, collection, slug }) => {
         if ('createdAt' in data) delete data.createdAt
         if ('updatedAt' in data) delete data.updatedAt
 
-        if (typeof collection.admin.hooks?.beforeDuplicate === 'function') {
-          data = await collection.admin.hooks.beforeDuplicate({
-            collection,
-            data,
-            locale,
-          })
-        }
-
         const result = await requests.post(`${serverURL}${api}/${slug}`, {
           body: JSON.stringify(data),
           headers: {
@@ -112,7 +104,7 @@ const Duplicate: React.FC<Props> = ({ id, collection, slug }) => {
             }
 
             if (!duplicateID) {
-              duplicateID = await create(localization.defaultLocale)
+              duplicateID = await create(locale)
             } else {
               const patchResult = await requests.patch(
                 `${serverURL}${api}/${slug}/${duplicateID}?locale=${locale}`,


### PR DESCRIPTION
## Description

When duplicating a document while on a locale other than the default, the current locale data would save to the default instead.
This makes the duplicate feature copy to every locale individually and pre

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] Existing test suite passes locally with my changes
