### PR TITLE
fix(db-mongodb): versions pagination

### DIFF
--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -61,7 +61,7 @@ export const findVersions: FindVersions = async function findVersions(
     lean: true,
     leanWithId: true,
     limit,
-    offset: skip,
+    offset: skip || 0,
     options,
     page,
     pagination,

--- a/packages/payload/src/collections/requestHandlers/findVersions.ts
+++ b/packages/payload/src/collections/requestHandlers/findVersions.ts
@@ -16,7 +16,7 @@ export default async function findVersionsHandler<T extends TypeWithID = any>(
   next: NextFunction,
 ): Promise<Response<PaginatedDocs<T>> | void> {
   try {
-    let page
+    let page: number | undefined
 
     if (typeof req.query.page === 'string') {
       const parsedPage = parseInt(req.query.page, 10)

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -28,7 +28,7 @@ import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 
 import wait from '../../packages/payload/src/utilities/wait'
-import { changeLocale } from '../helpers'
+import { changeLocale, saveDocAndAssert } from '../helpers'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil'
 import { initPayloadE2E } from '../helpers/configHelpers'
 import { autosaveSlug, draftSlug, titleToDelete } from './shared'
@@ -133,6 +133,20 @@ describe('versions', () => {
       )
       await expect(page.locator('.row-1 .cell-_status')).toContainText('Draft')
       await expect(page.locator('.row-2 .cell-_status')).toContainText('Draft')
+    })
+
+    test('collection - displays proper versions pagination', async () => {
+      await page.goto(url.create)
+
+      // save a version and check count
+      await page.locator('#field-title').fill('title')
+      await page.locator('#field-description').fill('description')
+      await saveDocAndAssert(page)
+
+      await page.goto(`${page.url()}/versions`)
+
+      const paginationItems = page.locator('.versions__page-info')
+      await expect(paginationItems).toHaveText('1-1 of 1')
     })
 
     test('should retain localized data during autosave', async () => {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -115,6 +115,16 @@ describe('Versions', () => {
         expect(collectionLocalVersionID).toBeDefined()
       })
 
+      it('should properly paginate versions', async () => {
+        const versions = await payload.findVersions({
+          collection,
+          limit: 1,
+        })
+
+        expect(versions.docs).toHaveLength(1)
+        expect(versions.page).toBe(1)
+      })
+
       it('should allow saving multiple versions of models with unique fields', async () => {
         const autosavePost = await payload.create({
           collection,


### PR DESCRIPTION
## Description

Fixes a bug with the pagination of versions where the `offset` argument was being set to `undefined` and causing `page` to result in `NaN`. Simply falling back to `0` fixes this. This was causing the information rendered beneath the versions table to display incorrectly. Adds both int and e2e tests.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes