### PR TITLE
chore: set date to 12UTC for certain picker appearances

### DIFF
--- a/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
+++ b/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
@@ -100,7 +100,6 @@ const DateTime: React.FC<Props> = (props) => {
       <div className={`${baseClass}__input-wrapper`}>
         <DatePicker
           {...dateTimePickerProps}
-          adjustDateOnChange
           dropdownMode="select"
           locale={locale}
           popperModifiers={[

--- a/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
+++ b/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
@@ -21,7 +21,7 @@ const DateTime: React.FC<Props> = (props) => {
     minDate,
     minTime,
     monthsToShow = 1,
-    onChange,
+    onChange: onChangeFromProps,
     pickerAppearance = 'default',
     placeholder: placeholderText,
     readOnly,
@@ -49,6 +49,15 @@ const DateTime: React.FC<Props> = (props) => {
     else if (pickerAppearance === 'timeOnly') dateFormat = 'h:mm a'
     else if (pickerAppearance === 'dayOnly') dateFormat = 'MMM dd'
     else if (pickerAppearance === 'monthOnly') dateFormat = 'MMMM'
+  }
+
+  const onChange = (incomingDate: Date) => {
+    const newDate = incomingDate
+    if (['dayOnly', 'default', 'monthOnly'].includes(pickerAppearance)) {
+      const tzOffset = incomingDate.getTimezoneOffset() / 60
+      newDate.setHours(12 - tzOffset, 0)
+    }
+    if (typeof onChangeFromProps === 'function') onChangeFromProps(newDate)
   }
 
   const dateTimePickerProps = {
@@ -91,6 +100,7 @@ const DateTime: React.FC<Props> = (props) => {
       <div className={`${baseClass}__input-wrapper`}>
         <DatePicker
           {...dateTimePickerProps}
+          adjustDateOnChange
           dropdownMode="select"
           locale={locale}
           onChange={(val) => onChange(val)}

--- a/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
+++ b/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
@@ -53,7 +53,7 @@ const DateTime: React.FC<Props> = (props) => {
 
   const onChange = (incomingDate: Date) => {
     const newDate = incomingDate
-    if (['dayOnly', 'default', 'monthOnly'].includes(pickerAppearance)) {
+    if (newDate instanceof Date && ['dayOnly', 'default', 'monthOnly'].includes(pickerAppearance)) {
       const tzOffset = incomingDate.getTimezoneOffset() / 60
       newDate.setHours(12 - tzOffset, 0)
     }
@@ -103,7 +103,6 @@ const DateTime: React.FC<Props> = (props) => {
           adjustDateOnChange
           dropdownMode="select"
           locale={locale}
-          onChange={(val) => onChange(val)}
           popperModifiers={[
             {
               name: 'preventOverflow',

--- a/packages/payload/src/admin/components/forms/field-types/DateTime/Input.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/DateTime/Input.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { DateField } from '../../../../../exports/types'
+import type { Description } from '../../FieldDescription/types'
+
+import { getTranslation } from '../../../../../utilities/getTranslation'
+import DatePicker from '../../../elements/DatePicker'
+import Error from '../../Error'
+import FieldDescription from '../../FieldDescription'
+import Label from '../../Label'
+import { fieldBaseClass } from '../shared'
+import './index.scss'
+
+const baseClass = 'date-time-field'
+
+export type DateTimeInputProps = Omit<DateField, 'admin' | 'name' | 'type'> & {
+  className?: string
+  datePickerProps?: DateField['admin']['date']
+  description?: Description
+  errorMessage?: string
+  onChange?: (e: Date) => void
+  path: string
+  placeholder?: Record<string, string> | string
+  readOnly?: boolean
+  required?: boolean
+  showError?: boolean
+  style?: React.CSSProperties
+  value?: Date
+  width?: string
+}
+
+export const DateTimeInput: React.FC<DateTimeInputProps> = (props) => {
+  const {
+    className,
+    datePickerProps,
+    description,
+    errorMessage,
+    label,
+    onChange,
+    path,
+    placeholder,
+    readOnly,
+    required,
+    showError,
+    style,
+    value,
+    width,
+  } = props
+
+  const { i18n } = useTranslation()
+
+  return (
+    <div
+      className={[
+        fieldBaseClass,
+        baseClass,
+        className,
+        showError && `${baseClass}--has-error`,
+        readOnly && 'read-only',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={{
+        ...style,
+        width,
+      }}
+    >
+      <div className={`${baseClass}__error-wrap`}>
+        <Error message={errorMessage} showError={showError} />
+      </div>
+      <Label htmlFor={path} label={label} required={required} />
+      <div className={`${baseClass}__input-wrapper`} id={`field-${path.replace(/\./g, '__')}`}>
+        <DatePicker
+          {...datePickerProps}
+          onChange={onChange}
+          placeholder={getTranslation(placeholder, i18n)}
+          readOnly={readOnly}
+          value={value}
+        />
+      </div>
+      <FieldDescription description={description} value={value} />
+    </div>
+  )
+}

--- a/packages/payload/src/admin/components/forms/field-types/DateTime/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/DateTime/index.tsx
@@ -1,20 +1,12 @@
 import React, { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
 
 import type { Props } from './types'
 
 import { date as dateValidation } from '../../../../../fields/validations'
-import { getTranslation } from '../../../../../utilities/getTranslation'
-import DatePicker from '../../../elements/DatePicker'
-import Error from '../../Error'
-import FieldDescription from '../../FieldDescription'
-import Label from '../../Label'
 import useField from '../../useField'
 import withCondition from '../../withCondition'
+import { DateTimeInput } from './Input'
 import './index.scss'
-import { fieldBaseClass } from '../shared'
-
-const baseClass = 'date-time-field'
 
 const DateTime: React.FC<Props> = (props) => {
   const {
@@ -26,8 +18,6 @@ const DateTime: React.FC<Props> = (props) => {
     validate = dateValidation,
   } = props
 
-  const { i18n } = useTranslation()
-
   const path = pathFromProps || name
 
   const memoizedValidate = useCallback(
@@ -37,45 +27,31 @@ const DateTime: React.FC<Props> = (props) => {
     [validate, required],
   )
 
-  const { errorMessage, setValue, showError, value } = useField({
+  const { errorMessage, setValue, showError, value } = useField<Date>({
     condition,
     path,
     validate: memoizedValidate,
   })
 
   return (
-    <div
-      className={[
-        fieldBaseClass,
-        baseClass,
-        className,
-        showError && `${baseClass}--has-error`,
-        readOnly && 'read-only',
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      style={{
-        ...style,
-        width,
+    <DateTimeInput
+      className={className}
+      datePickerProps={date}
+      description={description}
+      errorMessage={errorMessage}
+      label={label}
+      onChange={(incomingDate) => {
+        if (!readOnly) setValue(incomingDate?.toISOString() || null)
       }}
-    >
-      <div className={`${baseClass}__error-wrap`}>
-        <Error message={errorMessage} showError={showError} />
-      </div>
-      <Label htmlFor={path} label={label} required={required} />
-      <div className={`${baseClass}__input-wrapper`} id={`field-${path.replace(/\./g, '__')}`}>
-        <DatePicker
-          {...date}
-          onChange={(incomingDate) => {
-            if (!readOnly) setValue(incomingDate?.toISOString() || null)
-          }}
-          placeholder={getTranslation(placeholder, i18n)}
-          readOnly={readOnly}
-          value={value as Date}
-        />
-      </div>
-      <FieldDescription description={description} value={value} />
-    </div>
+      path={path}
+      placeholder={placeholder}
+      readOnly={readOnly}
+      required={required}
+      showError={showError}
+      style={style}
+      value={value}
+      width={width}
+    />
   )
 }
 

--- a/packages/payload/src/exports/components/forms.ts
+++ b/packages/payload/src/exports/components/forms.ts
@@ -33,9 +33,11 @@ export { fieldTypes } from '../../admin/components/forms/field-types'
 export { default as Checkbox } from '../../admin/components/forms/field-types/Checkbox'
 
 export { default as Collapsible } from '../../admin/components/forms/field-types/Collapsible'
+export { default as Date } from '../../admin/components/forms/field-types/DateTime'
+export { DateTimeInput } from '../../admin/components/forms/field-types/DateTime/Input'
+
 export { default as Group } from '../../admin/components/forms/field-types/Group'
 export { default as HiddenInput } from '../../admin/components/forms/field-types/HiddenInput'
-
 export { default as Select } from '../../admin/components/forms/field-types/Select'
 export { default as SelectInput } from '../../admin/components/forms/field-types/Select/Input'
 export { default as Text } from '../../admin/components/forms/field-types/Text'


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/3800

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

Adjusts time being set in the DB if the picker is of type: `default`, `dayOnly`, `monthOnly`.

This allows consistency for days throughout timezones when saved and time is irrelevant.

NOTE: Before it was saving the time as the current timezone offset, _not_ the current time in that timezone. For that reason I think this is a good change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
