### PR TITLE
fix: disable webpack hot reload on production

### DIFF
--- a/packages/bundler-webpack/src/configs/base.ts
+++ b/packages/bundler-webpack/src/configs/base.ts
@@ -78,7 +78,6 @@ export const getBaseConfig = (payloadConfig: SanitizedConfig): Configuration => 
         filename: path.normalize('./index.html'),
         template: payloadConfig.admin.indexHTML,
       }),
-      new webpack.HotModuleReplacementPlugin(),
     ],
     resolve: {
       alias: {


### PR DESCRIPTION
## Description

This fixes a regression. The issue is #3289 and it was fixed in #3319, but that was for Payload 1. Since Payload 2, the Webpack bundler is a separate package and apparently has the same issue. I've applied the same fix.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
- [x] I'm confident I don't have to do any of the above