### PR TITLE
fix: serverURL reading undefined in some places

### DIFF
--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -45,6 +45,10 @@ export const sanitizeConfig = (incomingConfig: Config): SanitizedConfig => {
     isMergeableObject: isPlainObject,
   }) as Config
 
+  if (!configWithDefaults.serverURL) {
+    configWithDefaults.serverURL = ''
+  }
+
   const config: Partial<SanitizedConfig> = sanitizeAdminConfig(configWithDefaults)
 
   if (config.localization && config.localization.locales?.length > 0) {
@@ -90,10 +94,6 @@ export const sanitizeConfig = (incomingConfig: Config): SanitizedConfig => {
 
   if (config.globals.length > 0) {
     config.globals = sanitizeGlobals(config as SanitizedConfig)
-  }
-
-  if (typeof config.serverURL === 'undefined') {
-    config.serverURL = ''
   }
 
   if (config.serverURL !== '') {

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -12,6 +12,7 @@ import { audioSlug, enlargeSlug, mediaSlug, reduceSlug, relationSlug } from './s
 const mockModulePath = path.resolve(__dirname, './mocks/mockFSModule.js')
 
 export default buildConfigWithDefaults({
+  serverURL: undefined,
   admin: {
     webpack: (config) => ({
       ...config,

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -84,6 +84,22 @@ describe('Collections - Uploads', () => {
       })
     })
 
+    it('should have valid image url', async () => {
+      const formData = new FormData()
+      formData.append('file', fs.createReadStream(path.join(__dirname, './image.png')))
+
+      const { status, doc } = await client.create({
+        file: true,
+        data: formData,
+      })
+
+      expect(status).toBe(201)
+      const expectedPath = path.join(__dirname, './media')
+      expect(await fileExists(path.join(expectedPath, doc.filename))).toBe(true)
+
+      expect(doc.url).not.toContain('undefined')
+    })
+
     it('creates images that do not require all sizes', async () => {
       const formData = new FormData()
       formData.append('file', fs.createReadStream(path.join(__dirname, './small.png')))


### PR DESCRIPTION
## Description

Closes #3237

Formats `serverURL` before `sanitizeCollection()` is called. This prevents `serverURL` being passed as `undefined` when generating the upload collection URLs. 

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
