### PR TITLE
fix: upload options breaking

### DIFF
--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -184,34 +184,31 @@ export default async function resizeAndTransformImageSizes({
       }
       let resized = sharpBase.clone()
 
-      const hasEdited = req.query?.uploadEdits
+      const hasEdits = req.query?.uploadEdits
 
-      if (hasEdited && imageResizeConfig.width && imageResizeConfig.height) {
+      if (hasEdits && imageResizeConfig.width && imageResizeConfig.height) {
         const { height, width } = imageResizeConfig
 
-        const focalPoint = {
-          x: 0.5,
-          y: 0.5,
-        }
-
-        if (req.query?.uploadEdits?.focalPoint) {
-          if (isNumber(req.query.uploadEdits.focalPoint?.x)) {
-            focalPoint.x = req.query.uploadEdits.focalPoint.x
-          }
-          if (isNumber(req.query.uploadEdits.focalPoint?.y)) {
-            focalPoint.y = req.query.uploadEdits.focalPoint.y
-          }
-        }
-
+        const targetAspectRatio = width / height
         const originalAspectRatio = dimensions.width / dimensions.height
-        const targetAspectRatio = imageResizeConfig.width / imageResizeConfig.height
 
         if (originalAspectRatio === targetAspectRatio) {
-          resized = resized.resize({
-            height,
-            width,
-          })
+          resized = resized.resize(imageResizeConfig)
         } else {
+          const focalPoint = {
+            x: 0.5,
+            y: 0.5,
+          }
+
+          if (req.query.uploadEdits?.focalPoint) {
+            if (isNumber(req.query.uploadEdits.focalPoint?.x)) {
+              focalPoint.x = req.query.uploadEdits.focalPoint.x
+            }
+            if (isNumber(req.query.uploadEdits.focalPoint?.y)) {
+              focalPoint.y = req.query.uploadEdits.focalPoint.y
+            }
+          }
+
           const prioritizeHeight = originalAspectRatio > targetAspectRatio
 
           const { info } = await resized

--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -182,10 +182,11 @@ export default async function resizeAndTransformImageSizes({
       if (!needsResize(imageResizeConfig, dimensions)) {
         return createResult(imageResizeConfig.name)
       }
-
       let resized = sharpBase.clone()
 
-      if (req.query && imageResizeConfig.width && imageResizeConfig.height) {
+      const hasEdited = req.query?.uploadEdits
+
+      if (hasEdited && imageResizeConfig.width && imageResizeConfig.height) {
         const { height, width } = imageResizeConfig
 
         const focalPoint = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -1028,7 +1032,7 @@ importers:
         version: 4.4.9(@types/node@20.5.7)(sass@1.69.4)(terser@5.19.2)
       webpack:
         specifier: ^5.78.0
-        version: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
+        version: 5.88.2(@swc/core@1.3.76)(webpack-cli@4.10.0)
 
   packages/plugin-cloud:
     dependencies:
@@ -1071,7 +1075,7 @@ importers:
         version: 29.1.1(@babel/core@7.22.20)(jest@29.6.4)(typescript@5.2.2)
       webpack:
         specifier: ^5.78.0
-        version: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
+        version: 5.88.2(@swc/core@1.3.76)(webpack-cli@4.10.0)
 
   packages/plugin-cloud-storage:
     dependencies:
@@ -1117,7 +1121,7 @@ importers:
         version: 9.1.1(typescript@5.2.2)
       webpack:
         specifier: ^5.78.0
-        version: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
+        version: 5.88.2(@swc/core@1.3.76)(webpack-cli@4.10.0)
 
   packages/plugin-form-builder:
     dependencies:
@@ -5204,6 +5208,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-darwin-x64@1.3.76:
@@ -5220,6 +5225,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf@1.3.76:
@@ -5236,6 +5242,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu@1.3.76:
@@ -5252,6 +5259,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl@1.3.76:
@@ -5268,6 +5276,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu@1.3.76:
@@ -5284,6 +5293,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl@1.3.76:
@@ -5300,6 +5310,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc@1.3.76:
@@ -5316,6 +5327,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc@1.3.76:
@@ -5332,6 +5344,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc@1.3.76:
@@ -5348,6 +5361,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core@1.3.76:
@@ -5391,6 +5405,7 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.78
       '@swc/core-win32-ia32-msvc': 1.3.78
       '@swc/core-win32-x64-msvc': 1.3.78
+    dev: true
 
   /@swc/jest@0.2.29(@swc/core@1.3.76):
     resolution: {integrity: sha512-8reh5RvHBsSikDC3WGCd5ZTd2BXKkyOdK7QwynrCH58jk2cQFhhHhFBg/jvnWZehUQe/EoOImLENc9/DwbBFow==}
@@ -14064,7 +14079,7 @@ packages:
       uuid: 8.3.2
       webpack: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
       webpack-bundle-analyzer: 4.9.1
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.9.1)(webpack@5.88.2)
+      webpack-cli: 4.10.0(webpack@5.88.2)
       webpack-dev-middleware: 6.0.1(webpack@5.88.2)
       webpack-hot-middleware: 2.25.4
     transitivePeerDependencies:
@@ -16032,7 +16047,7 @@ packages:
       klona: 2.0.6
       neo-async: 2.6.2
       sass: 1.69.4
-      webpack: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
+      webpack: 5.88.2(@swc/core@1.3.76)(webpack-cli@4.10.0)
 
   /sass@1.69.4:
     resolution: {integrity: sha512-+qEreVhqAy8o++aQfCJwp0sklr2xyEzkm9Pp/Igu9wNPoe7EZEQ8X/MBvvXggI2ql607cxKg/RKOwDj6pp2XDA==}
@@ -16975,6 +16990,7 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.19.2
       webpack: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
+    dev: true
 
   /terser@5.19.2:
     resolution: {integrity: sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==}
@@ -17848,6 +17864,41 @@ packages:
       webpack-bundle-analyzer: 4.9.1
       webpack-merge: 5.9.0
 
+  /webpack-cli@4.10.0(webpack@5.88.2):
+    resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      '@webpack-cli/generators': '*'
+      '@webpack-cli/migrate': '*'
+      webpack: 4.x.x || 5.x.x
+      webpack-bundle-analyzer: '*'
+      webpack-dev-server: '*'
+    peerDependenciesMeta:
+      '@webpack-cli/generators':
+        optional: true
+      '@webpack-cli/migrate':
+        optional: true
+      webpack-bundle-analyzer:
+        optional: true
+      webpack-dev-server:
+        optional: true
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.88.2)
+      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
+      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)
+      colorette: 2.0.20
+      commander: 7.2.0
+      cross-spawn: 7.0.3
+      fastest-levenshtein: 1.0.16
+      import-local: 3.1.0
+      interpret: 2.2.0
+      rechoir: 0.7.1
+      webpack: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
+      webpack-merge: 5.9.0
+    dev: true
+
   /webpack-dev-middleware@6.0.1(webpack@5.88.2):
     resolution: {integrity: sha512-PZPZ6jFinmqVPJZbisfggDiC+2EeGZ1ZByyMP5sOFJcPPWSexalISz+cvm+j+oYPT7FIJyxT76esjnw9DhE5sw==}
     engines: {node: '>= 14.15.0'}
@@ -17958,12 +18009,13 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.9(@swc/core@1.3.78)(webpack@5.88.2)
       watchpack: 2.4.0
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.9.1)(webpack@5.88.2)
+      webpack-cli: 4.10.0(webpack@5.88.2)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
@@ -18276,7 +18328,3 @@ packages:
     name: readable-stream
     version: 0.3.1
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -1032,7 +1028,7 @@ importers:
         version: 4.4.9(@types/node@20.5.7)(sass@1.69.4)(terser@5.19.2)
       webpack:
         specifier: ^5.78.0
-        version: 5.88.2(@swc/core@1.3.76)(webpack-cli@4.10.0)
+        version: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
 
   packages/plugin-cloud:
     dependencies:
@@ -1075,7 +1071,7 @@ importers:
         version: 29.1.1(@babel/core@7.22.20)(jest@29.6.4)(typescript@5.2.2)
       webpack:
         specifier: ^5.78.0
-        version: 5.88.2(@swc/core@1.3.76)(webpack-cli@4.10.0)
+        version: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
 
   packages/plugin-cloud-storage:
     dependencies:
@@ -1121,7 +1117,7 @@ importers:
         version: 9.1.1(typescript@5.2.2)
       webpack:
         specifier: ^5.78.0
-        version: 5.88.2(@swc/core@1.3.76)(webpack-cli@4.10.0)
+        version: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
 
   packages/plugin-form-builder:
     dependencies:
@@ -5208,7 +5204,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64@1.3.76:
@@ -5225,7 +5220,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf@1.3.76:
@@ -5242,7 +5236,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu@1.3.76:
@@ -5259,7 +5252,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl@1.3.76:
@@ -5276,7 +5268,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu@1.3.76:
@@ -5293,7 +5284,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl@1.3.76:
@@ -5310,7 +5300,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc@1.3.76:
@@ -5327,7 +5316,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc@1.3.76:
@@ -5344,7 +5332,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc@1.3.76:
@@ -5361,7 +5348,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core@1.3.76:
@@ -5405,7 +5391,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.78
       '@swc/core-win32-ia32-msvc': 1.3.78
       '@swc/core-win32-x64-msvc': 1.3.78
-    dev: true
 
   /@swc/jest@0.2.29(@swc/core@1.3.76):
     resolution: {integrity: sha512-8reh5RvHBsSikDC3WGCd5ZTd2BXKkyOdK7QwynrCH58jk2cQFhhHhFBg/jvnWZehUQe/EoOImLENc9/DwbBFow==}
@@ -14079,7 +14064,7 @@ packages:
       uuid: 8.3.2
       webpack: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
       webpack-bundle-analyzer: 4.9.1
-      webpack-cli: 4.10.0(webpack@5.88.2)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.9.1)(webpack@5.88.2)
       webpack-dev-middleware: 6.0.1(webpack@5.88.2)
       webpack-hot-middleware: 2.25.4
     transitivePeerDependencies:
@@ -16047,7 +16032,7 @@ packages:
       klona: 2.0.6
       neo-async: 2.6.2
       sass: 1.69.4
-      webpack: 5.88.2(@swc/core@1.3.76)(webpack-cli@4.10.0)
+      webpack: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
 
   /sass@1.69.4:
     resolution: {integrity: sha512-+qEreVhqAy8o++aQfCJwp0sklr2xyEzkm9Pp/Igu9wNPoe7EZEQ8X/MBvvXggI2ql607cxKg/RKOwDj6pp2XDA==}
@@ -16990,7 +16975,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.19.2
       webpack: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
-    dev: true
 
   /terser@5.19.2:
     resolution: {integrity: sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==}
@@ -17864,41 +17848,6 @@ packages:
       webpack-bundle-analyzer: 4.9.1
       webpack-merge: 5.9.0
 
-  /webpack-cli@4.10.0(webpack@5.88.2):
-    resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      '@webpack-cli/generators': '*'
-      '@webpack-cli/migrate': '*'
-      webpack: 4.x.x || 5.x.x
-      webpack-bundle-analyzer: '*'
-      webpack-dev-server: '*'
-    peerDependenciesMeta:
-      '@webpack-cli/generators':
-        optional: true
-      '@webpack-cli/migrate':
-        optional: true
-      webpack-bundle-analyzer:
-        optional: true
-      webpack-dev-server:
-        optional: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.88.2)
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)
-      colorette: 2.0.20
-      commander: 7.2.0
-      cross-spawn: 7.0.3
-      fastest-levenshtein: 1.0.16
-      import-local: 3.1.0
-      interpret: 2.2.0
-      rechoir: 0.7.1
-      webpack: 5.88.2(@swc/core@1.3.78)(webpack-cli@4.10.0)
-      webpack-merge: 5.9.0
-    dev: true
-
   /webpack-dev-middleware@6.0.1(webpack@5.88.2):
     resolution: {integrity: sha512-PZPZ6jFinmqVPJZbisfggDiC+2EeGZ1ZByyMP5sOFJcPPWSexalISz+cvm+j+oYPT7FIJyxT76esjnw9DhE5sw==}
     engines: {node: '>= 14.15.0'}
@@ -18009,13 +17958,12 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.9(@swc/core@1.3.78)(webpack@5.88.2)
       watchpack: 2.4.0
-      webpack-cli: 4.10.0(webpack@5.88.2)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.9.1)(webpack@5.88.2)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
@@ -18328,3 +18276,7 @@ packages:
     name: readable-stream
     version: 0.3.1
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Description

Closes #3877 

Unedited uploads were still getting passed through `sharp.extract` that handles the image crop and focal point selected.
This results in upload options (like fit, position, withoutEnlargement) to be ignored because there is nothing to resize by the time they get called.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes