### PR TITLE
feat: allow non-unique auth email

### DIFF
--- a/packages/payload/src/auth/strategies/local/register.ts
+++ b/packages/payload/src/auth/strategies/local/register.ts
@@ -56,7 +56,7 @@ export const registerLocalStrategy = async ({
     ) {
       error = new ValidationError(
         [
-          { field: 'email', message: 'A user with the given email is already registered' },
+          { field: 'email', message: req.t('error:userWithEmailAlreadyExists') },
           ...error.data.slice(1),
         ],
         req.t,

--- a/packages/payload/src/auth/strategies/local/register.ts
+++ b/packages/payload/src/auth/strategies/local/register.ts
@@ -20,34 +20,49 @@ export const registerLocalStrategy = async ({
   payload,
   req,
 }: Args): Promise<Record<string, unknown>> => {
-  const existingUser = await payload.find({
-    collection: collection.slug,
-    depth: 0,
-    where: {
-      email: {
-        equals: doc.email,
-      },
-    },
-  })
-
-  if (existingUser.docs.length > 0) {
-    throw new ValidationError([
-      { field: 'email', message: 'A user with the given email is already registered' },
-    ])
-  }
-
   const { hash, salt } = await generatePasswordSaltHash({ password })
 
   const sanitizedDoc = { ...doc }
   if (sanitizedDoc.password) delete sanitizedDoc.password
 
-  return payload.db.create({
-    collection: collection.slug,
-    data: {
-      ...sanitizedDoc,
-      hash,
-      salt,
-    },
-    req,
-  })
+  try {
+    return await payload.db.create({
+      collection: collection.slug,
+      data: {
+        ...sanitizedDoc,
+        hash,
+        salt,
+      },
+      req,
+    })
+  } catch (error) {
+    // Handle uniqueness error from MongoDB
+    if (error.code === 11000 && error.keyValue) {
+      error = new ValidationError(
+        [
+          {
+            field: Object.keys(error.keyValue)[0],
+            message: req.t('error:valueMustBeUnique'),
+          },
+        ],
+        req.t,
+      )
+    }
+
+    if (
+      error instanceof ValidationError &&
+      error.data[0].field === 'email' &&
+      error.data[0].message === req.t('error:valueMustBeUnique')
+    ) {
+      error = new ValidationError(
+        [
+          { field: 'email', message: 'A user with the given email is already registered' },
+          ...error.data.slice(1),
+        ],
+        req.t,
+      )
+    }
+
+    throw error
+  }
 }

--- a/packages/payload/src/translations/en.json
+++ b/packages/payload/src/translations/en.json
@@ -90,7 +90,8 @@
     "unspecific": "An error has occurred.",
     "userLocked": "This user is locked due to having too many failed login attempts.",
     "valueMustBeUnique": "Value must be unique",
-    "verificationTokenInvalid": "Verification token is invalid."
+    "verificationTokenInvalid": "Verification token is invalid.",
+    "userWithEmailAlreadyExists": "A user with the given email is already registered."
   },
   "fields": {
     "addLabel": "Add {{label}}",

--- a/packages/payload/src/translations/translation-schema.json
+++ b/packages/payload/src/translations/translation-schema.json
@@ -333,6 +333,9 @@
         },
         "verificationTokenInvalid": {
           "type": "string"
+        },
+        "userWithEmailAlreadyExists": {
+          "type": "string"
         }
       },
       "required": [

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -757,7 +757,7 @@ describe('collections-graphql', () => {
       expect(error.response.errors[1].path[0]).toEqual('test3')
       expect(error.response.errors[1].extensions.name).toEqual('ValidationError')
       expect(error.response.errors[1].extensions.data[0].message).toEqual(
-        'A user with the given email is already registered',
+        'A user with the given email is already registered.',
       )
       expect(error.response.errors[1].extensions.data[0].field).toEqual('email')
 


### PR DESCRIPTION
## Description

Users of the multi-tenancy plugin want to register multiple users with the same email in the same collection belonging to different tenants (https://github.com/joas8211/payload-tenancy/issues/23). I'm working on feature for the multi-tenant plugin that would support the usecase. There's no way to implement it without modifying local auth strategy or registering custom auth strategy because uniqueness of email field is validated manually in registeration method.

@DanRibbens commented on a discussion that "built-in auth needs to have unique email fields or we would need to disable the workflow for forgot password / reset password or change it to somehow work with more than one user record" (https://github.com/payloadcms/payload/discussions/3560#discussioncomment-7374789). I agree that disabling email uniqueness validation breaks local strategy if no custom validation is applied. But I don't consider that a problem.

With these changes disabling of unique validation for email field is possible by setting `unique: false` and custom validation can be used instead. Also a fix was applied for unique custom field error handling when using MongoDB, and translation was added for the error message that was previously hardcoded.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
