### PR TITLE
docs: adds Props import to cell-component example

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -442,7 +442,9 @@ These are the props that will be passed to your custom Cell to use in your own c
 
 ```tsx
 import React from 'react'
+import { Props } from 'payload/dist/admin/components/views/collections/List/Cell/types'
 import './index.scss'
+
 const baseClass = 'custom-cell'
 
 const CustomCell: React.FC<Props> = (props) => {

--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -442,7 +442,7 @@ These are the props that will be passed to your custom Cell to use in your own c
 
 ```tsx
 import React from 'react'
-import { Props } from 'payload/dist/admin/components/views/collections/List/Cell/types'
+import { Props } from 'payload/components/views/Cell'
 import './index.scss'
 
 const baseClass = 'custom-cell'

--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -442,7 +442,7 @@ These are the props that will be passed to your custom Cell to use in your own c
 
 ```tsx
 import React from 'react'
-import { Props } from 'payload/components/views/Cell'
+import type { Props } from 'payload/components/views/Cell'
 import './index.scss'
 
 const baseClass = 'custom-cell'


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/3912

Adds `Props` import to cell component example in `admin/components`

`Before`:
![Screen Shot 2023-10-30 at 10 36 43 AM](https://github.com/payloadcms/payload/assets/35232443/85cd0684-b723-4042-90cc-660b3c10ac93)


`After`: 
![Screen Shot 2023-10-30 at 11 15 42 AM](https://github.com/payloadcms/payload/assets/35232443/1e05290b-5335-4924-a200-4527e295a01f)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
