### PR TITLE
fix(templates): serializes internal links

### DIFF
--- a/templates/ecommerce/src/app/_components/Link/index.tsx
+++ b/templates/ecommerce/src/app/_components/Link/index.tsx
@@ -32,7 +32,9 @@ export const CMSLink: React.FC<CMSLinkType> = ({
 }) => {
   const href =
     type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
-      ? `/${reference.value.slug}`
+      ? `${reference?.relationTo !== 'pages' ? `/${reference?.relationTo}` : ''}/${
+          reference.value.slug
+        }`
       : url
 
   if (!href) return null

--- a/templates/ecommerce/src/app/_components/RichText/serialize.tsx
+++ b/templates/ecommerce/src/app/_components/RichText/serialize.tsx
@@ -5,6 +5,7 @@ import { Text } from 'slate'
 
 import { Label } from '../Label'
 import { LargeBody } from '../LargeBody'
+import { CMSLink } from '../Link'
 
 // eslint-disable-next-line no-use-before-define
 type Children = Leaf[]
@@ -83,18 +84,15 @@ const serialize = (children?: Children): React.ReactNode[] =>
         return <li key={i}>{serialize(node.children)}</li>
       case 'link':
         return (
-          <Link
-            href={escapeHTML(node.url)}
+          <CMSLink
             key={i}
-            {...(node?.newTab
-              ? {
-                  target: '_blank',
-                  rel: 'noopener noreferrer',
-                }
-              : {})}
+            type={node.linkType === 'internal' ? 'reference' : 'custom'}
+            url={node.url}
+            reference={node.doc as any}
+            newTab={Boolean(node?.newTab)}
           >
             {serialize(node?.children)}
-          </Link>
+          </CMSLink>
         )
 
       case 'label':

--- a/templates/website/src/app/_components/Link/index.tsx
+++ b/templates/website/src/app/_components/Link/index.tsx
@@ -32,7 +32,9 @@ export const CMSLink: React.FC<CMSLinkType> = ({
 }) => {
   const href =
     type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
-      ? `/${reference.value.slug}`
+      ? `${reference?.relationTo !== 'pages' ? `/${reference?.relationTo}` : ''}/${
+          reference.value.slug
+        }`
       : url
 
   if (!href) return null

--- a/templates/website/src/app/_components/RichText/serialize.tsx
+++ b/templates/website/src/app/_components/RichText/serialize.tsx
@@ -5,6 +5,7 @@ import { Text } from 'slate'
 
 import { Label } from '../Label'
 import { LargeBody } from '../LargeBody'
+import { CMSLink } from '../Link'
 
 // eslint-disable-next-line no-use-before-define
 type Children = Leaf[]
@@ -83,18 +84,15 @@ const serialize = (children?: Children): React.ReactNode[] =>
         return <li key={i}>{serialize(node.children)}</li>
       case 'link':
         return (
-          <Link
-            href={escapeHTML(node.url)}
+          <CMSLink
             key={i}
-            {...(node?.newTab
-              ? {
-                  target: '_blank',
-                  rel: 'noopener noreferrer',
-                }
-              : {})}
+            type={node.linkType === 'internal' ? 'reference' : 'custom'}
+            url={node.url}
+            reference={node.doc as any}
+            newTab={Boolean(node?.newTab)}
           >
             {serialize(node?.children)}
-          </Link>
+          </CMSLink>
         )
 
       case 'label':


### PR DESCRIPTION
## Description

Properly serializes rich text links within the templates. Previously only external links were working, although the fields existed. Now is possible to link to internal documents as expected.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Change to the [templates](../templates/) directory (does not affect core functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
