### PR TITLE
fix: field paths were being mutated if they ended with the req.locale

### DIFF
--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -104,7 +104,7 @@ export async function validateSearchParam({
         let fieldAccess
         let fieldPath = path
         // remove locale from end of path
-        if (path.endsWith(req.locale)) {
+        if (path.endsWith(`.${req.locale}`)) {
           fieldPath = path.slice(0, -(req.locale.length + 1))
         }
         // remove ".value" from ends of polymorphic relationship paths

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -89,6 +89,12 @@ export default buildConfigWithDefaults({
           localized: true,
         },
         {
+          name: 'children',
+          type: 'relationship',
+          relationTo: localizedPostsSlug,
+          hasMany: true,
+        },
+        {
           type: 'group',
           name: 'group',
           fields: [

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -88,6 +88,16 @@ export default buildConfigWithDefaults({
           type: 'checkbox',
           localized: true,
         },
+        {
+          type: 'group',
+          name: 'group',
+          fields: [
+            {
+              name: 'children',
+              type: 'text',
+            },
+          ],
+        },
       ],
     },
     ArrayCollection,

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -775,9 +775,9 @@ describe('Localization', () => {
         collection,
         id: post1.id,
         data: {
-          children: [post1.id],
+          children: post1.id,
           group: {
-            children: 'some content',
+            children: 'something',
           },
         },
       })
@@ -786,7 +786,7 @@ describe('Localization', () => {
         auth: true,
         query: {
           children: {
-            contains: post1.id,
+            in: post1.id,
           },
         },
       })

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -775,14 +775,25 @@ describe('Localization', () => {
         collection,
         id: post1.id,
         data: {
-          children: post1.id,
+          children: [post1.id],
           group: {
             children: 'some content',
           },
         },
       })
 
-      const { result } = await client.find({
+      const { result: relationshipRes } = await client.find({
+        auth: true,
+        query: {
+          children: {
+            contains: post1.id,
+          },
+        },
+      })
+
+      expect(relationshipRes.docs.map(({ id }) => id)).toContain(post1.id)
+
+      const { result: nestedFieldRes } = await client.find({
         auth: true,
         query: {
           'group.children': {
@@ -791,7 +802,7 @@ describe('Localization', () => {
         },
       })
 
-      expect(result.docs.map(({ id }) => id)).toContain(post1.id)
+      expect(nestedFieldRes.docs.map(({ id }) => id)).toContain(post1.id)
     })
   })
 })


### PR DESCRIPTION
## Description

Fixes an issue with field names that ended with the locale on the req, the field name was removing the locale from the path name and throwing an error. 

#### Before
Querying a field such as `children` internally would attempt to use the field name `childr` when querying by locale `en`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
