### PR TITLE
allows for custom date picker props to be passed into the dateTime component

### DIFF
--- a/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
+++ b/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
@@ -22,6 +22,7 @@ const DateTime: React.FC<Props> = (props) => {
     minTime,
     monthsToShow = 1,
     onChange: onChangeFromProps,
+    overrides,
     pickerAppearance = 'default',
     placeholder: placeholderText,
     readOnly,
@@ -77,6 +78,7 @@ const DateTime: React.FC<Props> = (props) => {
     showTimeSelect: pickerAppearance === 'dayAndTime' || pickerAppearance === 'timeOnly',
     timeFormat,
     timeIntervals,
+    ...overrides,
   }
 
   const classes = [baseClass, `${baseClass}__appearance--${pickerAppearance}`]

--- a/packages/payload/src/admin/components/elements/DatePicker/types.ts
+++ b/packages/payload/src/admin/components/elements/DatePicker/types.ts
@@ -1,5 +1,8 @@
+import type { ReactDatePickerProps } from 'react-datepicker'
+
 type SharedProps = {
   displayFormat?: string
+  overrides?: ReactDatePickerProps
   pickerAppearance?: 'dayAndTime' | 'dayOnly' | 'default' | 'monthOnly' | 'timeOnly'
 }
 


### PR DESCRIPTION
## Description

Adds `datePickerProps.overrides` to DateTimeInput component so overrides can be passed into the ReactDatePicker component.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
