### PR TITLE
fix: ensures dataloader does not run requests in parallel

### DIFF
--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -86,7 +86,7 @@ const batchAndLoadDocs =
       return batches
     }, {})
 
-    // Run find requests in parallel
+    // Run find requests one after another, so as to not hang transactions
 
     await Object.entries(batchByFindArgs).reduce(async (priorFind, [batchKey, ids]) => {
       await priorFind

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -88,7 +88,9 @@ const batchAndLoadDocs =
 
     // Run find requests in parallel
 
-    const results = Object.entries(batchByFindArgs).map(async ([batchKey, ids]) => {
+    await Object.entries(batchByFindArgs).reduce(async (priorFind, [batchKey, ids]) => {
+      await priorFind
+
       const [
         transactionID,
         collection,
@@ -141,9 +143,7 @@ const batchAndLoadDocs =
           docs[docsIndex] = doc
         }
       })
-    })
-
-    await Promise.all(results)
+    }, Promise.resolve())
 
     // Return docs array,
     // which has now been injected with all fetched docs


### PR DESCRIPTION
## Description

Dataloader was running `find` request populations in parallel, and they are now run one after another. This is because transactions require a single database operation to be performed at a time.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
