### PR TITLE
fix: prevent sort from saving a new version in version list view

### DIFF
--- a/packages/payload/src/admin/components/elements/SortColumn/index.tsx
+++ b/packages/payload/src/admin/components/elements/SortColumn/index.tsx
@@ -50,6 +50,7 @@ const SortColumn: React.FC<Props> = (props) => {
       {!disable && (
         <div className={`${baseClass}__buttons`}>
           <button
+            type='button'
             aria-label={t('sortByLabelDirection', {
               direction: t('ascending'),
               label: getTranslation(label, i18n),
@@ -60,6 +61,7 @@ const SortColumn: React.FC<Props> = (props) => {
             <Chevron direction="up" />
           </button>
           <button
+            type='button'
             aria-label={t('sortByLabelDirection', {
               direction: t('descending'),
               label: getTranslation(label, i18n),


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/3943

Clicking the sort buttons in the versions list view triggers form submit and creates a new version.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
