### PR TITLE
chore: aligns navbar elements when using larger logos

### DIFF
--- a/packages/payload/src/admin/components/elements/StepNav/index.scss
+++ b/packages/payload/src/admin/components/elements/StepNav/index.scss
@@ -56,6 +56,8 @@
   }
 
   span {
+    display: flex;
+    align-items: center;
     max-width: base(8);
     text-overflow: ellipsis;
     overflow: hidden;


### PR DESCRIPTION
## Description

Aligns `navbar` elements when using larger logos.

`Before`:
![Screen Shot 2023-10-31 at 2 49 09 PM](https://github.com/payloadcms/payload/assets/35232443/dce14146-a386-450a-82ed-5dfc0bfc3597)

`After`:
![Screen Shot 2023-10-31 at 2 44 34 PM](https://github.com/payloadcms/payload/assets/35232443/dc8bdada-ba37-41cb-b56a-629472ea66af)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
