### PR TITLE
fix: exclude files from bundle if aliased

### DIFF
--- a/packages/bundler-vite/src/config.ts
+++ b/packages/bundler-vite/src/config.ts
@@ -91,6 +91,7 @@ export const getViteConfig = async (payloadConfig: SanitizedConfig): Promise<Inl
         // Dependencies that need aliases should be excluded
         // from pre-bundling
         '@payloadcms/bundler-vite',
+        ...(Object.keys(absoluteAliases) || []),
       ],
       include: ['payload/components/root', 'react-dom/client'],
     },


### PR DESCRIPTION
## Description

Package: `@payloadcms/bundler-vite`

Fixes an issue where the vite bundler would not respect aliased files in dev mode.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
