### PR TITLE
Allow migrations in production builds

### DIFF
--- a/packages/payload/src/database/migrations/readMigrationFiles.ts
+++ b/packages/payload/src/database/migrations/readMigrationFiles.ts
@@ -22,7 +22,7 @@ export const readMigrationFiles = async ({
   const files = fs
     .readdirSync(payload.db.migrationDir)
     .sort()
-    .filter((f) => f.endsWith('.ts'))
+    .filter((f) => f.endsWith('.ts') || f.endsWith('.js'))
     .map((file) => {
       return path.resolve(payload.db.migrationDir, file)
     })


### PR DESCRIPTION
## Description

It is not possible to run migrations in a production build. This is due to the filtering on .ts extensions and the migrationsDir path which is set to src/migrations (can be overridden in the payload config). In production we should look in dist/migrations and use the .js extension.

In some cases running migrations in production is necessary. We use for example AWS App-runner to host Payload. There is no external access to the AWS DocumentDB database so we run the migrations in a service container which automates the migration process on each new deployment.

- [x ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x ] Existing test suite passes locally with my changes
