### PR TITLE
chore: unable to boot config and endpoints test suites

### DIFF
--- a/test/config/config.ts
+++ b/test/config/config.ts
@@ -1,13 +1,16 @@
-import type { Config } from '../../packages/payload/src/config/types'
-
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults'
-import { openAccess } from '../helpers/configHelpers'
+import { devUser } from '../credentials'
 
-const config: Config = {
+export default buildConfigWithDefaults({
   collections: [
     {
       slug: 'pages',
-      access: openAccess,
+      access: {
+        read: () => true,
+        create: () => true,
+        delete: () => true,
+        update: () => true,
+      },
       endpoints: [
         {
           path: '/hello',
@@ -64,6 +67,13 @@ const config: Config = {
     },
   ],
   custom: { name: 'Customer portal' },
-}
-
-export default buildConfigWithDefaults(config)
+  onInit: async (payload) => {
+    await payload.create({
+      collection: 'users',
+      data: {
+        email: devUser.email,
+        password: devUser.password,
+      },
+    })
+  },
+})

--- a/test/endpoints/config.ts
+++ b/test/endpoints/config.ts
@@ -22,7 +22,7 @@ export default buildConfigWithDefaults({
         delete: () => true,
         update: () => true,
       },
-      endpoints: collectionEndpoints,
+      endpoints: [...(collectionEndpoints || [])],
       fields: [
         {
           name: 'title',
@@ -45,7 +45,7 @@ export default buildConfigWithDefaults({
   globals: [
     {
       slug: globalSlug,
-      endpoints: globalEndpoints,
+      endpoints: [...(globalEndpoints || [])],
       fields: [],
     },
     {
@@ -60,7 +60,7 @@ export default buildConfigWithDefaults({
       ],
     },
   ],
-  endpoints,
+  endpoints: [...(endpoints || [])],
   admin: {
     webpack: (config) => {
       return {

--- a/test/endpoints/config.ts
+++ b/test/endpoints/config.ts
@@ -1,61 +1,28 @@
-import type { Response } from 'express'
-
-import express from 'express'
-
-import type { Config } from '../../packages/payload/src/config/types'
-import type { PayloadRequest } from '../../packages/payload/src/express/types'
+import path from 'path'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults'
 import { devUser } from '../credentials'
-import { openAccess } from '../helpers/configHelpers'
+import { collectionEndpoints } from './endpoints/collections'
+import { globalEndpoints } from './endpoints/globals'
+import { endpoints } from './endpoints/root'
+import {
+  collectionSlug,
+  globalSlug,
+  noEndpointsCollectionSlug,
+  noEndpointsGlobalSlug,
+} from './shared'
 
-export const collectionSlug = 'endpoints'
-export const globalSlug = 'global-endpoints'
-
-export const globalEndpoint = 'global'
-export const applicationEndpoint = 'path'
-export const rootEndpoint = 'root'
-export const noEndpointsCollectionSlug = 'no-endpoints'
-export const noEndpointsGlobalSlug = 'global-no-endpoints'
-
-const MyConfig: Config = {
+export default buildConfigWithDefaults({
   collections: [
     {
       slug: collectionSlug,
-      access: openAccess,
-      endpoints: [
-        {
-          path: '/say-hello/joe-bloggs',
-          method: 'get',
-          handler: (req: PayloadRequest, res: Response): void => {
-            res.json({ message: 'Hey Joey!' })
-          },
-        },
-        {
-          path: '/say-hello/:group/:name',
-          method: 'get',
-          handler: (req: PayloadRequest, res: Response): void => {
-            res.json({ message: `Hello ${req.params.name} @ ${req.params.group}` })
-          },
-        },
-        {
-          path: '/say-hello/:name',
-          method: 'get',
-          handler: (req: PayloadRequest, res: Response): void => {
-            res.json({ message: `Hello ${req.params.name}!` })
-          },
-        },
-        {
-          path: '/whoami',
-          method: 'post',
-          handler: (req: PayloadRequest, res: Response): void => {
-            res.json({
-              name: req.body.name,
-              age: req.body.age,
-            })
-          },
-        },
-      ],
+      access: {
+        read: () => true,
+        create: () => true,
+        delete: () => true,
+        update: () => true,
+      },
+      endpoints: collectionEndpoints,
       fields: [
         {
           name: 'title',
@@ -78,15 +45,7 @@ const MyConfig: Config = {
   globals: [
     {
       slug: globalSlug,
-      endpoints: [
-        {
-          path: `/${globalEndpoint}`,
-          method: 'post',
-          handler: (req: PayloadRequest, res: Response): void => {
-            res.json(req.body)
-          },
-        },
-      ],
+      endpoints: globalEndpoints,
       fields: [],
     },
     {
@@ -101,48 +60,21 @@ const MyConfig: Config = {
       ],
     },
   ],
-  endpoints: [
-    {
-      path: `/${applicationEndpoint}`,
-      method: 'post',
-      handler: (req: PayloadRequest, res: Response): void => {
-        res.json(req.body)
-      },
-    },
-    {
-      path: `/${applicationEndpoint}`,
-      method: 'get',
-      handler: (req: PayloadRequest, res: Response): void => {
-        res.json({ message: 'Hello, world!' })
-      },
-    },
-    {
-      path: `/${applicationEndpoint}/i18n`,
-      method: 'get',
-      handler: (req: PayloadRequest, res: Response): void => {
-        res.json({ message: req.t('general:backToDashboard') })
-      },
-    },
-    {
-      path: `/${rootEndpoint}`,
-      method: 'get',
-      root: true,
-      handler: (req: PayloadRequest, res: Response): void => {
-        res.json({ message: 'Hello, world!' })
-      },
-    },
-    {
-      path: `/${rootEndpoint}`,
-      method: 'post',
-      root: true,
-      handler: [
-        express.json({ type: 'application/json' }),
-        (req: PayloadRequest, res: Response): void => {
-          res.json(req.body)
+  endpoints,
+  admin: {
+    webpack: (config) => {
+      return {
+        ...config,
+        resolve: {
+          ...config.resolve,
+          alias: {
+            ...config.resolve.alias,
+            express: path.resolve(__dirname, './mocks/emptyModule.js'),
+          },
         },
-      ],
+      }
     },
-  ],
+  },
   onInit: async (payload) => {
     await payload.create({
       collection: 'users',
@@ -152,6 +84,4 @@ const MyConfig: Config = {
       },
     })
   },
-}
-
-export default buildConfigWithDefaults(MyConfig)
+})

--- a/test/endpoints/endpoints/collections.ts
+++ b/test/endpoints/endpoints/collections.ts
@@ -1,0 +1,38 @@
+import type { Response } from 'express'
+
+import type { CollectionConfig } from '../../../packages/payload/src/collections/config/types'
+import type { PayloadRequest } from '../../../packages/payload/src/express/types'
+
+export const collectionEndpoints: CollectionConfig['endpoints'] = [
+  {
+    path: '/say-hello/joe-bloggs',
+    method: 'get',
+    handler: (req: PayloadRequest, res: Response): void => {
+      res.json({ message: 'Hey Joey!' })
+    },
+  },
+  {
+    path: '/say-hello/:group/:name',
+    method: 'get',
+    handler: (req: PayloadRequest, res: Response): void => {
+      res.json({ message: `Hello ${req.params.name} @ ${req.params.group}` })
+    },
+  },
+  {
+    path: '/say-hello/:name',
+    method: 'get',
+    handler: (req: PayloadRequest, res: Response): void => {
+      res.json({ message: `Hello ${req.params.name}!` })
+    },
+  },
+  {
+    path: '/whoami',
+    method: 'post',
+    handler: (req: PayloadRequest, res: Response): void => {
+      res.json({
+        name: req.body.name,
+        age: req.body.age,
+      })
+    },
+  },
+]

--- a/test/endpoints/endpoints/globals.ts
+++ b/test/endpoints/endpoints/globals.ts
@@ -1,0 +1,16 @@
+import type { Response } from 'express'
+
+import type { PayloadRequest } from '../../../packages/payload/src/express/types'
+import type { GlobalConfig } from '../../../packages/payload/src/globals/config/types'
+
+import { globalEndpoint } from '../shared'
+
+export const globalEndpoints: GlobalConfig['endpoints'] = [
+  {
+    path: `/${globalEndpoint}`,
+    method: 'post',
+    handler: (req: PayloadRequest, res: Response): void => {
+      res.json(req.body)
+    },
+  },
+]

--- a/test/endpoints/endpoints/root.ts
+++ b/test/endpoints/endpoints/root.ts
@@ -1,0 +1,51 @@
+import type { Response } from 'express'
+
+import express from 'express'
+
+import type { Config } from '../../../packages/payload/src/config/types'
+import type { PayloadRequest } from '../../../packages/payload/src/express/types'
+
+import { applicationEndpoint, rootEndpoint } from '../shared'
+
+export const endpoints: Config['endpoints'] = [
+  {
+    path: `/${applicationEndpoint}`,
+    method: 'post',
+    handler: (req: PayloadRequest, res: Response): void => {
+      res.json(req.body)
+    },
+  },
+  {
+    path: `/${applicationEndpoint}`,
+    method: 'get',
+    handler: (req: PayloadRequest, res: Response): void => {
+      res.json({ message: 'Hello, world!' })
+    },
+  },
+  {
+    path: `/${applicationEndpoint}/i18n`,
+    method: 'get',
+    handler: (req: PayloadRequest, res: Response): void => {
+      res.json({ message: req.t('general:backToDashboard') })
+    },
+  },
+  {
+    path: `/${rootEndpoint}`,
+    method: 'get',
+    root: true,
+    handler: (req: PayloadRequest, res: Response): void => {
+      res.json({ message: 'Hello, world!' })
+    },
+  },
+  {
+    path: `/${rootEndpoint}`,
+    method: 'post',
+    root: true,
+    handler: [
+      express.json({ type: 'application/json' }),
+      (req: PayloadRequest, res: Response): void => {
+        res.json(req.body)
+      },
+    ],
+  },
+]

--- a/test/endpoints/int.spec.ts
+++ b/test/endpoints/int.spec.ts
@@ -8,7 +8,7 @@ import {
   noEndpointsCollectionSlug,
   noEndpointsGlobalSlug,
   rootEndpoint,
-} from './config'
+} from './shared'
 
 require('isomorphic-fetch')
 

--- a/test/endpoints/mocks/emptyModule.js
+++ b/test/endpoints/mocks/emptyModule.js
@@ -1,0 +1,3 @@
+export default {
+  json: () => {},
+}

--- a/test/endpoints/shared.ts
+++ b/test/endpoints/shared.ts
@@ -1,0 +1,13 @@
+export const collectionSlug = 'endpoints'
+
+export const globalSlug = 'global-endpoints'
+
+export const globalEndpoint = 'global'
+
+export const applicationEndpoint = 'path'
+
+export const rootEndpoint = 'root'
+
+export const noEndpointsCollectionSlug = 'no-endpoints'
+
+export const noEndpointsGlobalSlug = 'global-no-endpoints'

--- a/test/helpers/configHelpers.ts
+++ b/test/helpers/configHelpers.ts
@@ -6,7 +6,6 @@ import shelljs from 'shelljs'
 import { v4 as uuid } from 'uuid'
 
 import type { Payload } from '../../packages/payload/src'
-import type { CollectionConfig } from '../../packages/payload/src/collections/config/types'
 import type { InitOptions } from '../../packages/payload/src/config/types'
 
 import payload from '../../packages/payload/src'
@@ -69,11 +68,4 @@ export async function initPayloadTest(options: Options): Promise<InitializedPayl
   }
 
   return { serverURL: `http://localhost:${port}`, payload }
-}
-
-export const openAccess: CollectionConfig['access'] = {
-  read: () => true,
-  create: () => true,
-  delete: () => true,
-  update: () => true,
 }


### PR DESCRIPTION
## Description

The "config" and "endpoints" test suites were previously not bootable because of incorrect Webpack aliasing. These tests run fine during int tests, this is only a problem when attempting to startup these test configs locally.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
