### PR TITLE
chore: deflakes e2e tests

### DIFF
--- a/test/_community/e2e.spec.ts
+++ b/test/_community/e2e.spec.ts
@@ -6,10 +6,10 @@ import { AdminUrlUtil } from '../helpers/adminUrlUtil'
 import { initPayloadE2E } from '../helpers/configHelpers'
 
 const { beforeAll, describe } = test
-let url: AdminUrlUtil
 
 describe('Admin Panel', () => {
   let page: Page
+  let url: AdminUrlUtil
 
   beforeAll(async ({ browser }) => {
     const { serverURL } = await initPayloadE2E(__dirname)

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -38,16 +38,17 @@ const { afterEach, beforeAll, beforeEach, describe } = test
 const title = 'Title'
 const description = 'Description'
 
-let url: AdminUrlUtil
-let serverURL: string
-
 describe('admin', () => {
   let page: Page
+  let url: AdminUrlUtil
+  let customViewsURL: AdminUrlUtil
+  let serverURL: string
 
   beforeAll(async ({ browser }) => {
     serverURL = (await initPayloadE2E(__dirname)).serverURL
     await clearDocs() // Clear any seeded data from onInit
     url = new AdminUrlUtil(serverURL, postsSlug)
+    customViewsURL = new AdminUrlUtil(serverURL, customViews2Slug)
 
     const context = await browser.newContext()
     page = await context.newPage()
@@ -164,8 +165,7 @@ describe('admin', () => {
     })
 
     test('collection - should render custom tab label', async () => {
-      const url = new AdminUrlUtil(serverURL, customViews2Slug)
-      await page.goto(url.create)
+      await page.goto(customViewsURL.create)
       await page.locator('#field-title').fill('Test')
       await saveDocAndAssert(page)
       const docURL = page.url()
@@ -181,8 +181,7 @@ describe('admin', () => {
     })
 
     test('collection - should render custom tab component', async () => {
-      const url = new AdminUrlUtil(serverURL, customViews2Slug)
-      await page.goto(url.create)
+      await page.goto(customViewsURL.create)
       await page.locator('#field-title').fill('Test')
       await saveDocAndAssert(page)
 

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -16,10 +16,10 @@ import { slug } from './shared'
  */
 
 const { beforeAll, describe } = test
-let url: AdminUrlUtil
 
 describe('auth', () => {
   let page: Page
+  let url: AdminUrlUtil
 
   beforeAll(async ({ browser }) => {
     const { serverURL } = await initPayloadE2E(__dirname)

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -9,29 +9,29 @@ import { mobileBreakpoint } from './config'
 import { startLivePreviewDemo } from './startLivePreviewDemo'
 
 const { beforeAll, describe } = test
-let url: AdminUrlUtil
-let serverURL: string
-
-const goToDoc = async (page: Page) => {
-  await page.goto(url.list)
-  const linkToDoc = page.locator('tbody tr:first-child .cell-id a').first()
-  expect(linkToDoc).toBeTruthy()
-  await linkToDoc.click()
-}
-
-const goToCollectionPreview = async (page: Page): Promise<void> => {
-  await goToDoc(page)
-  await page.goto(`${page.url()}/preview`)
-}
-
-const goToGlobalPreview = async (page: Page, slug: string): Promise<void> => {
-  const global = new AdminUrlUtil(serverURL, slug)
-  const previewURL = `${global.global(slug)}/preview`
-  await page.goto(previewURL)
-}
 
 describe('Live Preview', () => {
   let page: Page
+  let serverURL: string
+  let url: AdminUrlUtil
+
+  const goToDoc = async (page: Page) => {
+    await page.goto(url.list)
+    const linkToDoc = page.locator('tbody tr:first-child .cell-id a').first()
+    expect(linkToDoc).toBeTruthy()
+    await linkToDoc.click()
+  }
+
+  const goToCollectionPreview = async (page: Page): Promise<void> => {
+    await goToDoc(page)
+    await page.goto(`${page.url()}/preview`)
+  }
+
+  const goToGlobalPreview = async (page: Page, slug: string): Promise<void> => {
+    const global = new AdminUrlUtil(serverURL, slug)
+    const previewURL = `${global.global(slug)}/preview`
+    await page.goto(previewURL)
+  }
 
   beforeAll(async ({ browser }) => {
     const { serverURL: incomingServerURL, payload } = await initPayloadE2E(__dirname)

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -36,11 +36,11 @@ import { autosaveSlug, draftGlobalSlug, draftSlug, titleToDelete } from './share
 
 const { beforeAll, describe } = test
 
-let page: Page
-let url: AdminUrlUtil
-let serverURL: string
-
 describe('versions', () => {
+  let page: Page
+  let url: AdminUrlUtil
+  let serverURL: string
+
   beforeAll(async ({ browser }) => {
     const config = await initPayloadE2E(__dirname)
     serverURL = config.serverURL


### PR DESCRIPTION
## Description

E2e tests have been a bit flaky, specifically the `'collection - should render useAsTitle field'` test. This was not previously a problem because our string matching used to be lax, i.e. `title` used to pass `[Untitled]` because the substring is contained within. I attempted to fix this previously in #3961. The `url` variable was being overridden across tests within the same file, but tests have continued to fail randomly since merging this fix. This is because `url` is being overridden _across test suites_ too. We're only seeing this now because our tests have become more strict.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
