### PR TITLE
chore: add documentations for field access properties

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -51,21 +51,21 @@ export type FieldHook<T extends TypeWithID = any, P = any, S = any> = (
 
 export type FieldAccess<T extends TypeWithID = any, P = any, U = any> = (args: {
   /**
-   * The full data passed to `create` or `update` the document. `data` is undefined during `read` operation.
+   * The incoming data used to `create` or `update` the document with. `data` is undefined during the `read` operation.
    */
   data?: Partial<T>
   /**
-   * The full document data before `update` is applied. `doc` is undefined during `create` and `update` operation.
+   * The original data of the document before the `update` is applied. `doc` is undefined during the `create` operation.
    */
   doc?: T
   /**
-   * `id` of the document being `read` or `update`. `id` is undefined during `create` operation.
+   * The `id` of the current document being read or updated. `id` is undefined during the `create` operation.
    */
   id?: number | string
   /** The `Express` request object containing the currently authenticated `user` */
   req: PayloadRequest<U>
   /**
-   * Immediately adjacent field data passed to `create`, `read`, and `update` document with.
+   * Immediately adjacent data to this field. For example, if this is a `group` field, then `siblingData` will be the other fields within the group.
    */
   siblingData?: Partial<P>
 }) => Promise<boolean> | boolean

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -50,10 +50,39 @@ export type FieldHook<T extends TypeWithID = any, P = any, S = any> = (
 ) => P | Promise<P>
 
 export type FieldAccess<T extends TypeWithID = any, P = any, U = any> = (args: {
+  /**
+   * For Collection Create Operation: The full data passed to create the document.\
+   * For Collection Read Operation: undefined\
+   * For Collection Update Operation: The full data passed to update the document.\
+   * For Global Read: undefined\
+   * For Global Update: The data passed to update the global with.
+   */
   data?: Partial<T>
+  /**
+   * For Collection Create Operation: undefined\
+   * For Collection Read Operation: The full document data.\
+   * For Collection Update Operation: The full document data, before the update is applied.\
+   * For Global Read: undefined\
+   * For Global Update: undefined
+   */
   doc?: T
+  /**
+   * For Collection Create Operation: undefined\
+   * For Collection Read Operation: `id` of the document being read\
+   * For Collection Update Operation: `id` of the document being updated\
+   * For Global Read: undefined\
+   * For Global Update: undefined\
+   */
   id?: number | string
+  /** The `Express` request object containing the currently authenticated `user` */
   req: PayloadRequest<U>
+  /**
+   * For Collection Create Operation: Immediately adjacent field data passed to create the document.\
+   * For Collection Read Operation: Immediately adjacent field data of the document being read.\
+   * For Collection Update Operation: Immediately adjacent field data passed to update the document with.\
+   * For Global Read: undefined\
+   * For Global Update: undefined
+   */
   siblingData?: Partial<P>
 }) => Promise<boolean> | boolean
 

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -51,37 +51,21 @@ export type FieldHook<T extends TypeWithID = any, P = any, S = any> = (
 
 export type FieldAccess<T extends TypeWithID = any, P = any, U = any> = (args: {
   /**
-   * For Collection Create Operation: The full data passed to create the document.\
-   * For Collection Read Operation: undefined\
-   * For Collection Update Operation: The full data passed to update the document.\
-   * For Global Read: undefined\
-   * For Global Update: The data passed to update the global with.
+   * The full data passed to `create` or `update` the document. `data` is undefined during `read` operation.
    */
   data?: Partial<T>
   /**
-   * For Collection Create Operation: undefined\
-   * For Collection Read Operation: The full document data.\
-   * For Collection Update Operation: The full document data, before the update is applied.\
-   * For Global Read: undefined\
-   * For Global Update: undefined
+   * The full document data before `update` is applied. `doc` is undefined during `create` and `update` operation.
    */
   doc?: T
   /**
-   * For Collection Create Operation: undefined\
-   * For Collection Read Operation: `id` of the document being read\
-   * For Collection Update Operation: `id` of the document being updated\
-   * For Global Read: undefined\
-   * For Global Update: undefined\
+   * `id` of the document being `read` or `update`. `id` is undefined during `create` operation.
    */
   id?: number | string
   /** The `Express` request object containing the currently authenticated `user` */
   req: PayloadRequest<U>
   /**
-   * For Collection Create Operation: Immediately adjacent field data passed to create the document.\
-   * For Collection Read Operation: Immediately adjacent field data of the document being read.\
-   * For Collection Update Operation: Immediately adjacent field data passed to update the document with.\
-   * For Global Read: undefined\
-   * For Global Update: undefined
+   * Immediately adjacent field data passed to `create`, `read`, and `update` document with.
    */
   siblingData?: Partial<P>
 }) => Promise<boolean> | boolean


### PR DESCRIPTION
## Description

Add documentations for field access properties. This is a quality of life improvements for developers that works on field level access control. Instead of alt+tabbing to payload docs, developers can now read the description of each FieldAccess property. It gets better in vscode where hovering the property displays the documentation.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
