### PR TITLE
fix: error on graphql multiple queries

### DIFF
--- a/packages/db-mongodb/src/transactions/commitTransaction.ts
+++ b/packages/db-mongodb/src/transactions/commitTransaction.ts
@@ -5,6 +5,6 @@ export const commitTransaction: CommitTransaction = async function commitTransac
     return
   }
   await this.sessions[id].commitTransaction()
-  await this.sessions[id].endSession()
+  await this.sessions[id]?.endSession()
   delete this.sessions[id]
 }

--- a/packages/db-mongodb/src/transactions/commitTransaction.ts
+++ b/packages/db-mongodb/src/transactions/commitTransaction.ts
@@ -4,7 +4,8 @@ export const commitTransaction: CommitTransaction = async function commitTransac
   if (!this.sessions[id]?.inTransaction()) {
     return
   }
+
   await this.sessions[id].commitTransaction()
-  await this.sessions[id]?.endSession()
+  await this.sessions[id].endSession()
   delete this.sessions[id]
 }

--- a/packages/db-mongodb/src/transactions/rollbackTransaction.ts
+++ b/packages/db-mongodb/src/transactions/rollbackTransaction.ts
@@ -5,9 +5,10 @@ export const rollbackTransaction: RollbackTransaction = async function rollbackT
 ) {
   if (!this.sessions[id]?.inTransaction()) {
     this.payload.logger.warn('rollbackTransaction called when no transaction exists')
+    delete this.sessions[id]
     return
   }
-  await this.sessions[id].abortTransaction()
-  await this.sessions[id].endSession()
+  await this.sessions[id]?.abortTransaction()
+  await this.sessions[id]?.endSession()
   delete this.sessions[id]
 }

--- a/packages/db-mongodb/src/transactions/rollbackTransaction.ts
+++ b/packages/db-mongodb/src/transactions/rollbackTransaction.ts
@@ -3,12 +3,21 @@ import type { RollbackTransaction } from 'payload/database'
 export const rollbackTransaction: RollbackTransaction = async function rollbackTransaction(
   id = '',
 ) {
-  if (!this.sessions[id]?.inTransaction()) {
+  // if multiple operations are using the same transaction, the first will flow through and delete the session.
+  // subsequent calls should be ignored.
+  if (!this.sessions[id]) {
+    return
+  }
+
+  // when session exists but is not inTransaction something unexpected is happening to the session
+  if (!this.sessions[id].inTransaction()) {
     this.payload.logger.warn('rollbackTransaction called when no transaction exists')
     delete this.sessions[id]
     return
   }
-  await this.sessions[id]?.abortTransaction()
-  await this.sessions[id]?.endSession()
+
+  // the first call for rollback should be aborted and deleted causing any other operations with the same transaction to fail
+  await this.sessions[id].abortTransaction()
+  await this.sessions[id].endSession()
   delete this.sessions[id]
 }

--- a/packages/db-postgres/src/transactions/commitTransaction.ts
+++ b/packages/db-postgres/src/transactions/commitTransaction.ts
@@ -1,6 +1,7 @@
 import type { CommitTransaction } from 'payload/database'
 
 export const commitTransaction: CommitTransaction = async function commitTransaction(id) {
+  // if the session was deleted it has already been aborted
   if (!this.sessions[id]) {
     return
   }

--- a/packages/db-postgres/src/transactions/rollbackTransaction.ts
+++ b/packages/db-postgres/src/transactions/rollbackTransaction.ts
@@ -3,12 +3,15 @@ import type { RollbackTransaction } from 'payload/database'
 export const rollbackTransaction: RollbackTransaction = async function rollbackTransaction(
   id = '',
 ) {
+  // if multiple operations are using the same transaction, the first will flow through and delete the session.
+  // subsequent calls should be ignored.
   if (!this.sessions[id]) {
-    this.payload.logger.warn('rollbackTransaction called when no transaction exists')
     return
   }
 
+  // end the session promise in failure by calling reject
   await this.sessions[id].reject()
 
+  // delete the session causing any other operations with the same transaction to fail
   delete this.sessions[id]
 }

--- a/packages/payload/src/auth/graphql/resolvers/access.ts
+++ b/packages/payload/src/auth/graphql/resolvers/access.ts
@@ -18,7 +18,7 @@ const formatConfigNames = (results, configs) => {
 function accessResolver(payload: Payload) {
   async function resolver(_, args, context) {
     const options = {
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     const accessResults = await access(options)

--- a/packages/payload/src/auth/graphql/resolvers/access.ts
+++ b/packages/payload/src/auth/graphql/resolvers/access.ts
@@ -1,3 +1,4 @@
+import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 
 import formatName from '../../../graphql/utilities/formatName'

--- a/packages/payload/src/auth/graphql/resolvers/forgotPassword.ts
+++ b/packages/payload/src/auth/graphql/resolvers/forgotPassword.ts
@@ -11,7 +11,7 @@ function forgotPasswordResolver(collection: Collection): any {
       },
       disableEmail: args.disableEmail,
       expiration: args.expiration,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     await forgotPassword(options)

--- a/packages/payload/src/auth/graphql/resolvers/forgotPassword.ts
+++ b/packages/payload/src/auth/graphql/resolvers/forgotPassword.ts
@@ -1,4 +1,5 @@
 import type { Collection } from '../../../collections/config/types'
+import type { PayloadRequest } from '../../../express/types'
 
 import forgotPassword from '../../operations/forgotPassword'
 

--- a/packages/payload/src/auth/graphql/resolvers/init.ts
+++ b/packages/payload/src/auth/graphql/resolvers/init.ts
@@ -1,3 +1,5 @@
+import type { PayloadRequest } from '../../../express/types'
+
 import init from '../../operations/init'
 
 function initResolver(collection: string) {

--- a/packages/payload/src/auth/graphql/resolvers/init.ts
+++ b/packages/payload/src/auth/graphql/resolvers/init.ts
@@ -4,7 +4,7 @@ function initResolver(collection: string) {
   async function resolver(_, args, context) {
     const options = {
       collection,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     return init(options)

--- a/packages/payload/src/auth/graphql/resolvers/login.ts
+++ b/packages/payload/src/auth/graphql/resolvers/login.ts
@@ -11,7 +11,7 @@ function loginResolver(collection: Collection) {
         password: args.password,
       },
       depth: 0,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
       res: context.res,
     }
 

--- a/packages/payload/src/auth/graphql/resolvers/login.ts
+++ b/packages/payload/src/auth/graphql/resolvers/login.ts
@@ -1,4 +1,5 @@
 import type { Collection } from '../../../collections/config/types'
+import type { PayloadRequest } from '../../../express/types'
 
 import login from '../../operations/login'
 

--- a/packages/payload/src/auth/graphql/resolvers/logout.ts
+++ b/packages/payload/src/auth/graphql/resolvers/logout.ts
@@ -1,4 +1,5 @@
 import type { Collection } from '../../../collections/config/types'
+import type { PayloadRequest } from '../../../express/types'
 
 import logout from '../../operations/logout'
 

--- a/packages/payload/src/auth/graphql/resolvers/logout.ts
+++ b/packages/payload/src/auth/graphql/resolvers/logout.ts
@@ -6,7 +6,7 @@ function logoutResolver(collection: Collection): any {
   async function resolver(_, args, context) {
     const options = {
       collection,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
       res: context.res,
     }
 

--- a/packages/payload/src/auth/graphql/resolvers/me.ts
+++ b/packages/payload/src/auth/graphql/resolvers/me.ts
@@ -1,4 +1,5 @@
 import type { Collection } from '../../../collections/config/types'
+import type { PayloadRequest } from '../../../express/types'
 
 import me from '../../operations/me'
 

--- a/packages/payload/src/auth/graphql/resolvers/me.ts
+++ b/packages/payload/src/auth/graphql/resolvers/me.ts
@@ -7,10 +7,11 @@ function meResolver(collection: Collection): any {
     const options = {
       collection,
       depth: 0,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
     return me(options)
   }
+
   return resolver
 }
 

--- a/packages/payload/src/auth/graphql/resolvers/refresh.ts
+++ b/packages/payload/src/auth/graphql/resolvers/refresh.ts
@@ -17,7 +17,7 @@ function refreshResolver(collection: Collection) {
     const options = {
       collection,
       depth: 0,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
       res: context.res,
       token,
     }

--- a/packages/payload/src/auth/graphql/resolvers/refresh.ts
+++ b/packages/payload/src/auth/graphql/resolvers/refresh.ts
@@ -1,4 +1,5 @@
 import type { Collection } from '../../../collections/config/types'
+import type { PayloadRequest } from '../../../express/types'
 
 import getExtractJWT from '../../getExtractJWT'
 import refresh from '../../operations/refresh'

--- a/packages/payload/src/auth/graphql/resolvers/resetPassword.ts
+++ b/packages/payload/src/auth/graphql/resolvers/resetPassword.ts
@@ -13,7 +13,7 @@ function resetPasswordResolver(collection: Collection) {
       collection,
       data: args,
       depth: 0,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
       res: context.res,
     }
 

--- a/packages/payload/src/auth/graphql/resolvers/resetPassword.ts
+++ b/packages/payload/src/auth/graphql/resolvers/resetPassword.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 import type { Collection } from '../../../collections/config/types'
+import type { PayloadRequest } from '../../../express/types'
 
 import resetPassword from '../../operations/resetPassword'
 

--- a/packages/payload/src/auth/graphql/resolvers/unlock.ts
+++ b/packages/payload/src/auth/graphql/resolvers/unlock.ts
@@ -1,4 +1,5 @@
 import type { Collection } from '../../../collections/config/types'
+import type { PayloadRequest } from '../../../express/types'
 
 import unlock from '../../operations/unlock'
 

--- a/packages/payload/src/auth/graphql/resolvers/unlock.ts
+++ b/packages/payload/src/auth/graphql/resolvers/unlock.ts
@@ -7,12 +7,13 @@ function unlockResolver(collection: Collection) {
     const options = {
       collection,
       data: { email: args.email },
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     const result = await unlock(options)
     return result
   }
+
   return resolver
 }
 

--- a/packages/payload/src/auth/graphql/resolvers/verifyEmail.ts
+++ b/packages/payload/src/auth/graphql/resolvers/verifyEmail.ts
@@ -11,7 +11,7 @@ function verifyEmailResolver(collection: Collection) {
     const options = {
       api: 'GraphQL',
       collection,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
       res: context.res,
       token: args.token,
     }

--- a/packages/payload/src/auth/graphql/resolvers/verifyEmail.ts
+++ b/packages/payload/src/auth/graphql/resolvers/verifyEmail.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 import type { Collection } from '../../../collections/config/types'
+import type { PayloadRequest } from '../../../express/types'
 
 import verifyEmail from '../../operations/verifyEmail'
 

--- a/packages/payload/src/collections/graphql/resolvers/create.ts
+++ b/packages/payload/src/collections/graphql/resolvers/create.ts
@@ -37,7 +37,7 @@ export default function createResolver<TSlug extends keyof GeneratedTypes['colle
       data: args.data,
       depth: 0,
       draft: args.draft,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     const result = await create(options)

--- a/packages/payload/src/collections/graphql/resolvers/delete.ts
+++ b/packages/payload/src/collections/graphql/resolvers/delete.ts
@@ -30,7 +30,7 @@ export default function getDeleteResolver<TSlug extends keyof GeneratedTypes['co
       id: args.id,
       collection,
       depth: 0,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     const result = await deleteByID(options)

--- a/packages/payload/src/collections/graphql/resolvers/docAccess.ts
+++ b/packages/payload/src/collections/graphql/resolvers/docAccess.ts
@@ -18,7 +18,7 @@ export function docAccessResolver(): Resolver {
   async function resolver(_, args, context) {
     return docAccess({
       id: args.id,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     })
   }
 

--- a/packages/payload/src/collections/graphql/resolvers/find.ts
+++ b/packages/payload/src/collections/graphql/resolvers/find.ts
@@ -36,7 +36,7 @@ export default function findResolver(collection: Collection): Resolver {
       draft: args.draft,
       limit: args.limit,
       page: args.page,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
       sort: args.sort,
       where: args.where,
     }

--- a/packages/payload/src/collections/graphql/resolvers/findVersionByID.ts
+++ b/packages/payload/src/collections/graphql/resolvers/findVersionByID.ts
@@ -31,7 +31,7 @@ export default function findVersionByIDResolver(collection: Collection): Resolve
       collection,
       depth: 0,
       draft: args.draft,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     const result = await findVersionByID(options)

--- a/packages/payload/src/collections/graphql/resolvers/findVersions.ts
+++ b/packages/payload/src/collections/graphql/resolvers/findVersions.ts
@@ -35,7 +35,7 @@ export default function findVersionsResolver(collection: Collection): Resolver {
       depth: 0,
       limit: args.limit,
       page: args.page,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
       sort: args.sort,
       where: args.where,
     }

--- a/packages/payload/src/collections/graphql/resolvers/restoreVersion.ts
+++ b/packages/payload/src/collections/graphql/resolvers/restoreVersion.ts
@@ -23,7 +23,7 @@ export default function restoreVersionResolver(collection: Collection): Resolver
       id: args.id,
       collection,
       depth: 0,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     const result = await restoreVersion(options)

--- a/packages/payload/src/collections/graphql/resolvers/update.ts
+++ b/packages/payload/src/collections/graphql/resolvers/update.ts
@@ -36,7 +36,7 @@ export default function updateResolver<TSlug extends keyof GeneratedTypes['colle
       data: args.data,
       depth: 0,
       draft: args.draft,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     const result = await updateByID<TSlug>(options)

--- a/packages/payload/src/globals/graphql/resolvers/docAccess.ts
+++ b/packages/payload/src/globals/graphql/resolvers/docAccess.ts
@@ -16,7 +16,7 @@ export function docAccessResolver(global: SanitizedGlobalConfig): Resolver {
   async function resolver(_, context) {
     return docAccess({
       globalConfig: global,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     })
   }
 

--- a/packages/payload/src/globals/graphql/resolvers/findOne.ts
+++ b/packages/payload/src/globals/graphql/resolvers/findOne.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 
-import type { Document } from '../../../types'
+import type { Document, PayloadRequest } from '../../../types'
 import type { SanitizedGlobalConfig } from '../../config/types'
 
 import findOne from '../../operations/findOne'

--- a/packages/payload/src/globals/graphql/resolvers/findOne.ts
+++ b/packages/payload/src/globals/graphql/resolvers/findOne.ts
@@ -16,7 +16,7 @@ export default function findOneResolver(globalConfig: SanitizedGlobalConfig): Do
       depth: 0,
       draft: args.draft,
       globalConfig,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
       slug,
     }
 

--- a/packages/payload/src/globals/graphql/resolvers/findVersionByID.ts
+++ b/packages/payload/src/globals/graphql/resolvers/findVersionByID.ts
@@ -31,7 +31,7 @@ export default function findVersionByIDResolver(globalConfig: SanitizedGlobalCon
       depth: 0,
       draft: args.draft,
       globalConfig,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     const result = await findVersionByID(options)

--- a/packages/payload/src/globals/graphql/resolvers/findVersions.ts
+++ b/packages/payload/src/globals/graphql/resolvers/findVersions.ts
@@ -29,7 +29,7 @@ export default function findVersionsResolver(globalConfig: SanitizedGlobalConfig
       globalConfig,
       limit: args.limit,
       page: args.page,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
       sort: args.sort,
       where: args.where,
     }

--- a/packages/payload/src/globals/graphql/resolvers/restoreVersion.ts
+++ b/packages/payload/src/globals/graphql/resolvers/restoreVersion.ts
@@ -22,7 +22,7 @@ export default function restoreVersionResolver(globalConfig: SanitizedGlobalConf
       id: args.id,
       depth: 0,
       globalConfig,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
     }
 
     const result = await restoreVersion(options)

--- a/packages/payload/src/globals/graphql/resolvers/update.ts
+++ b/packages/payload/src/globals/graphql/resolvers/update.ts
@@ -35,7 +35,7 @@ export default function updateResolver<TSlug extends keyof GeneratedTypes['globa
       depth: 0,
       draft: args.draft,
       globalConfig,
-      req: context.req,
+      req: { ...context.req } as PayloadRequest,
       slug,
     }
 

--- a/test/collections-graphql/config.ts
+++ b/test/collections-graphql/config.ts
@@ -12,14 +12,13 @@ export interface Relation {
 
 const openAccess = {
   create: () => true,
+  delete: () => true,
   read: () => true,
   update: () => true,
-  delete: () => true,
 }
 
 const collectionWithName = (collectionSlug: string): CollectionConfig => {
   return {
-    slug: collectionSlug,
     access: openAccess,
     fields: [
       {
@@ -27,6 +26,7 @@ const collectionWithName = (collectionSlug: string): CollectionConfig => {
         type: 'text',
       },
     ],
+    slug: collectionSlug,
   }
 }
 
@@ -35,47 +35,27 @@ export const relationSlug = 'relation'
 
 export const pointSlug = 'point'
 
+export const errorOnHookSlug = 'error-on-hooks'
+
 export default buildConfigWithDefaults({
-  graphQL: {
-    schemaOutputFile: path.resolve(__dirname, 'schema.graphql'),
-    queries: (GraphQL) => {
-      return {
-        QueryWithInternalError: {
-          type: new GraphQL.GraphQLObjectType({
-            name: 'QueryWithInternalError',
-            fields: {
-              text: {
-                type: GraphQL.GraphQLString,
-              },
-            },
-          }),
-          resolve: () => {
-            // Throwing an internal error with potentially sensitive data
-            throw new Error('Lost connection to the Pentagon. Secret data: ******')
-          },
-        },
-      }
-    },
-  },
   collections: [
     {
-      slug: 'users',
-      auth: true,
       access: openAccess,
+      auth: true,
       fields: [],
+      slug: 'users',
     },
     {
-      slug: pointSlug,
       access: openAccess,
       fields: [
         {
-          type: 'point',
           name: 'point',
+          type: 'point',
         },
       ],
+      slug: pointSlug,
     },
     {
-      slug,
       access: openAccess,
       fields: [
         {
@@ -92,173 +72,173 @@ export default buildConfigWithDefaults({
         },
         {
           name: 'min',
-          type: 'number',
           min: 10,
+          type: 'number',
         },
         // Relationship
         {
           name: 'relationField',
-          type: 'relationship',
           relationTo: relationSlug,
+          type: 'relationship',
         },
         {
           name: 'relationToCustomID',
-          type: 'relationship',
           relationTo: 'custom-ids',
+          type: 'relationship',
         },
         // Relation hasMany
         {
           name: 'relationHasManyField',
-          type: 'relationship',
-          relationTo: relationSlug,
           hasMany: true,
+          relationTo: relationSlug,
+          type: 'relationship',
         },
         // Relation multiple relationTo
         {
           name: 'relationMultiRelationTo',
-          type: 'relationship',
           relationTo: [relationSlug, 'dummy'],
+          type: 'relationship',
         },
         // Relation multiple relationTo hasMany
         {
           name: 'relationMultiRelationToHasMany',
-          type: 'relationship',
-          relationTo: [relationSlug, 'dummy'],
           hasMany: true,
+          relationTo: [relationSlug, 'dummy'],
+          type: 'relationship',
         },
         {
           name: 'A1',
-          type: 'group',
           fields: [
             {
-              type: 'text',
               name: 'A2',
               defaultValue: 'textInRowInGroup',
+              type: 'text',
             },
           ],
+          type: 'group',
         },
         {
           name: 'B1',
-          type: 'group',
           fields: [
             {
-              type: 'collapsible',
-              label: 'Collapsible',
               fields: [
                 {
-                  type: 'text',
                   name: 'B2',
                   defaultValue: 'textInRowInGroup',
+                  type: 'text',
                 },
               ],
+              label: 'Collapsible',
+              type: 'collapsible',
             },
           ],
+          type: 'group',
         },
         {
           name: 'C1',
-          type: 'group',
           fields: [
             {
-              type: 'text',
               name: 'C2Text',
+              type: 'text',
             },
             {
-              type: 'row',
               fields: [
                 {
-                  type: 'collapsible',
-                  label: 'Collapsible2',
                   fields: [
                     {
                       name: 'C2',
-                      type: 'group',
                       fields: [
                         {
-                          type: 'row',
                           fields: [
                             {
-                              type: 'collapsible',
-                              label: 'Collapsible2',
                               fields: [
                                 {
-                                  type: 'text',
                                   name: 'C3',
+                                  type: 'text',
                                 },
                               ],
+                              label: 'Collapsible2',
+                              type: 'collapsible',
                             },
                           ],
+                          type: 'row',
                         },
                       ],
+                      type: 'group',
                     },
                   ],
+                  label: 'Collapsible2',
+                  type: 'collapsible',
                 },
               ],
+              type: 'row',
             },
           ],
+          type: 'group',
         },
         {
-          type: 'tabs',
           tabs: [
             {
-              label: 'Tab1',
               name: 'D1',
               fields: [
                 {
                   name: 'D2',
-                  type: 'group',
                   fields: [
                     {
-                      type: 'row',
                       fields: [
                         {
-                          type: 'collapsible',
-                          label: 'Collapsible2',
                           fields: [
                             {
-                              type: 'tabs',
                               tabs: [
                                 {
-                                  label: 'Tab1',
                                   fields: [
                                     {
                                       name: 'D3',
-                                      type: 'group',
                                       fields: [
                                         {
-                                          type: 'row',
                                           fields: [
                                             {
-                                              type: 'collapsible',
-                                              label: 'Collapsible2',
                                               fields: [
                                                 {
-                                                  type: 'text',
                                                   name: 'D4',
+                                                  type: 'text',
                                                 },
                                               ],
+                                              label: 'Collapsible2',
+                                              type: 'collapsible',
                                             },
                                           ],
+                                          type: 'row',
                                         },
                                       ],
+                                      type: 'group',
                                     },
                                   ],
+                                  label: 'Tab1',
                                 },
                               ],
+                              type: 'tabs',
                             },
                           ],
+                          label: 'Collapsible2',
+                          type: 'collapsible',
                         },
                       ],
+                      type: 'row',
                     },
                   ],
+                  type: 'group',
                 },
               ],
+              label: 'Tab1',
             },
           ],
+          type: 'tabs',
         },
       ],
+      slug,
     },
     {
-      slug: 'custom-ids',
       access: {
         read: () => true,
       },
@@ -272,47 +252,98 @@ export default buildConfigWithDefaults({
           type: 'text',
         },
       ],
+      slug: 'custom-ids',
     },
     collectionWithName(relationSlug),
     collectionWithName('dummy'),
     {
-      slug: 'payload-api-test-ones',
-      access: {
-        read: () => true,
-      },
+      ...collectionWithName(errorOnHookSlug),
       fields: [
         {
-          name: 'payloadAPI',
+          name: 'title',
           type: 'text',
-          hooks: {
-            afterRead: [({ req }) => req.payloadAPI],
-          },
+        },
+        {
+          name: 'errorBeforeChange',
+          type: 'checkbox',
         },
       ],
+      hooks: {
+        afterDelete: [
+          ({ doc }) => {
+            if (doc?.errorAfterDelete) {
+              throw new Error('Error After Delete Thrown')
+            }
+          },
+        ],
+        beforeChange: [
+          ({ originalDoc }) => {
+            if (originalDoc?.errorBeforeChange) {
+              throw new Error('Error Before Change Thrown')
+            }
+          },
+        ],
+      },
     },
     {
-      slug: 'payload-api-test-twos',
       access: {
         read: () => true,
       },
       fields: [
         {
           name: 'payloadAPI',
-          type: 'text',
           hooks: {
             afterRead: [({ req }) => req.payloadAPI],
           },
+          type: 'text',
+        },
+      ],
+      slug: 'payload-api-test-ones',
+    },
+    {
+      access: {
+        read: () => true,
+      },
+      fields: [
+        {
+          name: 'payloadAPI',
+          hooks: {
+            afterRead: [({ req }) => req.payloadAPI],
+          },
+          type: 'text',
         },
         {
           name: 'relation',
-          type: 'relationship',
           relationTo: 'payload-api-test-ones',
+          type: 'relationship',
         },
       ],
+      slug: 'payload-api-test-twos',
     },
   ],
+  graphQL: {
+    queries: (GraphQL) => {
+      return {
+        QueryWithInternalError: {
+          resolve: () => {
+            // Throwing an internal error with potentially sensitive data
+            throw new Error('Lost connection to the Pentagon. Secret data: ******')
+          },
+          type: new GraphQL.GraphQLObjectType({
+            name: 'QueryWithInternalError',
+            fields: {
+              text: {
+                type: GraphQL.GraphQLString,
+              },
+            },
+          }),
+        },
+      }
+    },
+    schemaOutputFile: path.resolve(__dirname, 'schema.graphql'),
+  },
   onInit: async (payload) => {
-    const user = await payload.create({
+    await payload.create({
       collection: 'users',
       data: {
         email: devUser.email,
@@ -331,8 +362,8 @@ export default buildConfigWithDefaults({
     await payload.create({
       collection: slug,
       data: {
-        title: 'has custom ID relation',
         relationToCustomID: 1,
+        title: 'has custom ID relation',
       },
     })
 
@@ -353,23 +384,23 @@ export default buildConfigWithDefaults({
     await payload.create({
       collection: slug,
       data: {
-        title: 'with-description',
         description: 'description',
+        title: 'with-description',
       },
     })
 
     await payload.create({
       collection: slug,
       data: {
-        title: 'numPost1',
         number: 1,
+        title: 'numPost1',
       },
     })
     await payload.create({
       collection: slug,
       data: {
-        title: 'numPost2',
         number: 2,
+        title: 'numPost2',
       },
     })
 
@@ -390,15 +421,15 @@ export default buildConfigWithDefaults({
     await payload.create({
       collection: slug,
       data: {
-        title: 'rel to hasMany',
         relationHasManyField: rel1.id,
+        title: 'rel to hasMany',
       },
     })
     await payload.create({
       collection: slug,
       data: {
-        title: 'rel to hasMany 2',
         relationHasManyField: rel2.id,
+        title: 'rel to hasMany 2',
       },
     })
 
@@ -406,11 +437,11 @@ export default buildConfigWithDefaults({
     await payload.create({
       collection: slug,
       data: {
-        title: 'rel to multi',
         relationMultiRelationTo: {
           relationTo: relationSlug,
           value: rel2.id,
         },
+        title: 'rel to multi',
       },
     })
 
@@ -418,7 +449,6 @@ export default buildConfigWithDefaults({
     await payload.create({
       collection: slug,
       data: {
-        title: 'rel to multi hasMany',
         relationMultiRelationToHasMany: [
           {
             relationTo: relationSlug,
@@ -429,6 +459,7 @@ export default buildConfigWithDefaults({
             value: rel2.id,
           },
         ],
+        title: 'rel to multi hasMany',
       },
     })
 

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -67,11 +67,31 @@ describe('collections-graphql', () => {
           title
         }
       }`
-      const response = await client.request(query, { title })
+      const response = (await client.request(query, { title })) as any
       const doc: Post = response.createPost
 
       expect(doc).toMatchObject({ title })
       expect(doc.id).toBeDefined()
+    })
+
+    it('should read using multiple queries', async () => {
+      const query = `query {
+          postIDs: Posts {
+            docs {
+              id
+            }
+          }
+          posts: Posts {
+            docs {
+              id
+              title
+            }
+          }
+      }`
+      const response = await client.request(query)
+      const { postIDs, posts } = response
+      expect(postIDs.docs).toBeDefined()
+      expect(posts.docs).toBeDefined()
     })
 
     it('should read', async () => {
@@ -685,11 +705,11 @@ describe('collections-graphql', () => {
 
       // language=graphQL
       const query = `query {
-        Posts(where: { title: { exists: true }}) {
-          docs {
-            badFieldName
+          Posts(where: { title: { exists: true }}) {
+              docs {
+                  badFieldName
+              }
           }
-        }
       }`
       await client.request(query).catch((err) => {
         error = err
@@ -702,12 +722,12 @@ describe('collections-graphql', () => {
       let error
       // language=graphQL
       const query = `mutation {
-        createPost(data: {min: 1}) {
-          id
-          min
-          createdAt
-          updatedAt
-        }
+          createPost(data: {min: 1}) {
+              id
+              min
+              createdAt
+              updatedAt
+          }
       }`
 
       await client.request(query).catch((err) => {
@@ -722,21 +742,21 @@ describe('collections-graphql', () => {
       let error
       // language=graphQL
       const query = `mutation createTest {
-        test1:createUser(data: { email: "test@test.com", password: "test" }) {
-          email
-        }
+          test1:createUser(data: { email: "test@test.com", password: "test" }) {
+              email
+          }
 
-        test2:createUser(data: { email: "test2@test.com", password: "" }) {
-          email
-        }
+          test2:createUser(data: { email: "test2@test.com", password: "" }) {
+              email
+          }
 
-        test3:createUser(data: { email: "test@test.com", password: "test" }) {
-          email
-        }
+          test3:createUser(data: { email: "test@test.com", password: "test" }) {
+              email
+          }
 
-        test4:createUser(data: { email: "", password: "test" }) {
-          email
-        }
+          test4:createUser(data: { email: "", password: "test" }) {
+              email
+          }
       }`
 
       await client.request(query).catch((err) => {
@@ -775,9 +795,9 @@ describe('collections-graphql', () => {
       let error
       // language=graphQL
       const query = `query {
-        QueryWithInternalError {
-            text
-        }
+          QueryWithInternalError {
+              text
+          }
       }`
 
       await client.request(query).catch((err) => {

--- a/test/helpers/idToString.ts
+++ b/test/helpers/idToString.ts
@@ -1,0 +1,4 @@
+import type { Payload } from '../../packages/payload/src'
+
+export const idToString = (id: number | string, payload: Payload): string =>
+  `${payload.db.defaultIDType === 'number' ? id : `"${id}"`}`


### PR DESCRIPTION
## Description

fixes #3605
~Draft: This needs to also come with a way to make graphql return a partially successful response. Effectively this change is doing bad things where an error could be returned for a mutation but also in the same request commit a separate mutation.~
As it turns out, our GraphQL implmentation already returns errors and results at the same time making the response accurate to the database changes being committed or rolled back.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
