### PR TITLE
chore(db-mongodb): add option to disable index hint optimization, which breaks on AWS DocumentDB

### DIFF
--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -55,7 +55,7 @@ export const find: Find = async function find(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.disablePaginationCountIndexHint !== true) {
+  if (!useEstimatedCount && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -55,7 +55,7 @@ export const find: Find = async function find(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount) {
+  if (!useEstimatedCount && this.hintPaginationCountIndex) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -55,7 +55,7 @@ export const find: Find = async function find(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.disablePaginationCountIndexHint) {
+  if (!useEstimatedCount && this.disablePaginationCountIndexHint !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -55,7 +55,7 @@ export const find: Find = async function find(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.hintPaginationCountIndex) {
+  if (!useEstimatedCount && this.disablePaginationCountIndexHint) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -74,7 +74,7 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.disablePaginationCountIndexHint) {
+  if (!useEstimatedCount && this.disablePaginationCountIndexHint !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -74,7 +74,7 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.disablePaginationCountIndexHint !== true) {
+  if (!useEstimatedCount && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -74,7 +74,7 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.hintPaginationCountIndex) {
+  if (!useEstimatedCount && this.disablePaginationCountIndexHint) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -74,7 +74,7 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount) {
+  if (!useEstimatedCount && this.hintPaginationCountIndex) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -71,7 +71,7 @@ export const findVersions: FindVersions = async function findVersions(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount) {
+  if (!useEstimatedCount && this.hintPaginationCountIndex) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -71,7 +71,7 @@ export const findVersions: FindVersions = async function findVersions(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.hintPaginationCountIndex) {
+  if (!useEstimatedCount && this.disablePaginationCountIndexHint) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -71,7 +71,7 @@ export const findVersions: FindVersions = async function findVersions(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.disablePaginationCountIndexHint) {
+  if (!useEstimatedCount && this.disablePaginationCountIndexHint !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -71,7 +71,7 @@ export const findVersions: FindVersions = async function findVersions(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.disablePaginationCountIndexHint !== true) {
+  if (!useEstimatedCount && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -47,7 +47,7 @@ export interface Args {
     useFacet?: boolean
   }
   /** Set to false to disable hinting to MongoDB to use 'id' as index when counting documents for pagination. Disabling this optimization might fix some problems with AWS DocumentDB. Defaults to true */
-  hintPaginationCountIndex?: boolean
+  disablePaginationCountIndexHint?: boolean
   migrationDir?: string
   /** The URL to connect to MongoDB or false to start payload and prevent connecting */
   url: false | string
@@ -89,7 +89,7 @@ declare module 'payload' {
 export function mongooseAdapter({
   autoPluralization = true,
   connectOptions,
-  hintPaginationCountIndex = true,
+  disablePaginationCountIndexHint = true,
   migrationDir: migrationDirArg,
   url,
 }: Args): MongooseAdapterResult {
@@ -108,8 +108,8 @@ export function mongooseAdapter({
       collections: {},
       connectOptions: connectOptions || {},
       connection: undefined,
+      disablePaginationCountIndexHint,
       globals: undefined,
-      hintPaginationCountIndex,
       mongoMemoryServer: undefined,
       sessions: {},
       url,

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -46,7 +46,7 @@ export interface Args {
     /** Set false to disable $facet aggregation in non-supporting databases, Defaults to true */
     useFacet?: boolean
   }
-  /** Set to false to disable hinting to MongoDB to use 'id' as index when counting documents for pagination. Disabling this optimization might fix some problems with AWS DocumentDB. Defaults to true */
+  /** Set to true to disable hinting to MongoDB to use 'id' as index when counting documents for pagination. Disabling this optimization might fix some problems with AWS DocumentDB. Defaults to false */
   disablePaginationCountIndexHint?: boolean
   migrationDir?: string
   /** The URL to connect to MongoDB or false to start payload and prevent connecting */
@@ -89,7 +89,7 @@ declare module 'payload' {
 export function mongooseAdapter({
   autoPluralization = true,
   connectOptions,
-  disablePaginationCountIndexHint = true,
+  disablePaginationCountIndexHint = false,
   migrationDir: migrationDirArg,
   url,
 }: Args): MongooseAdapterResult {

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -46,8 +46,8 @@ export interface Args {
     /** Set false to disable $facet aggregation in non-supporting databases, Defaults to true */
     useFacet?: boolean
   }
-  /** Set to true to disable hinting to MongoDB to use 'id' as index when counting documents for pagination. Disabling this optimization might fix some problems with AWS DocumentDB. Defaults to false */
-  disablePaginationCountIndexHint?: boolean
+  /** Set to true to disable hinting to MongoDB to use 'id' as index. This is currently done when counting documents for pagination. Disabling this optimization might fix some problems with AWS DocumentDB. Defaults to false */
+  disableIndexHints?: boolean
   migrationDir?: string
   /** The URL to connect to MongoDB or false to start payload and prevent connecting */
   url: false | string
@@ -89,7 +89,7 @@ declare module 'payload' {
 export function mongooseAdapter({
   autoPluralization = true,
   connectOptions,
-  disablePaginationCountIndexHint = false,
+  disableIndexHints = false,
   migrationDir: migrationDirArg,
   url,
 }: Args): MongooseAdapterResult {
@@ -108,7 +108,7 @@ export function mongooseAdapter({
       collections: {},
       connectOptions: connectOptions || {},
       connection: undefined,
-      disablePaginationCountIndexHint,
+      disableIndexHints,
       globals: undefined,
       mongoMemoryServer: undefined,
       sessions: {},

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -46,6 +46,8 @@ export interface Args {
     /** Set false to disable $facet aggregation in non-supporting databases, Defaults to true */
     useFacet?: boolean
   }
+  /** Set to false to disable hinting to MongoDB to use 'id' as index when counting documents for pagination. Disabling this optimization might fix some problems with AWS DocumentDB. Defaults to true */
+  hintPaginationCountIndex?: boolean
   migrationDir?: string
   /** The URL to connect to MongoDB or false to start payload and prevent connecting */
   url: false | string
@@ -87,6 +89,7 @@ declare module 'payload' {
 export function mongooseAdapter({
   autoPluralization = true,
   connectOptions,
+  hintPaginationCountIndex = true,
   migrationDir: migrationDirArg,
   url,
 }: Args): MongooseAdapterResult {
@@ -106,6 +109,7 @@ export function mongooseAdapter({
       connectOptions: connectOptions || {},
       connection: undefined,
       globals: undefined,
+      hintPaginationCountIndex,
       mongoMemoryServer: undefined,
       sessions: {},
       url,

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -58,7 +58,7 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.disablePaginationCountIndexHint) {
+  if (!useEstimatedCount && this.disablePaginationCountIndexHint !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -58,7 +58,7 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount) {
+  if (!useEstimatedCount && this.hintPaginationCountIndex) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -58,7 +58,7 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.hintPaginationCountIndex) {
+  if (!useEstimatedCount && this.disablePaginationCountIndexHint) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -58,7 +58,7 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     useEstimatedCount,
   }
 
-  if (!useEstimatedCount && this.disablePaginationCountIndexHint !== true) {
+  if (!useEstimatedCount && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding a hint.
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(


### PR DESCRIPTION
## Description

This gives an option to disable this optimization, which Fixes #3947.

One thing we should also do, which this PR does not do yet, is catch the error mentioned in the issue if it happens, and advise the user to disable this option.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
