### PR TITLE
docs: add latest tag to all mentions of create-payload-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Create a cloud account, connect your GitHub, and [deploy in minutes](https://pay
 Before beginning to work with Payload, make sure you have all of the [required software](https://payloadcms.com/docs/getting-started/installation).
 
 ```text
-npx create-payload-app
+npx create-payload-app@latest
 ```
 
 Alternatively, it only takes about five minutes to [create an app from scratch](https://payloadcms.com/docs/getting-started/installation#from-scratch).

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -23,7 +23,7 @@ Payload requires the following software:
 To quickly scaffold a new Payload app in the fastest way possible, you can use [create-payload-app](https://npmjs.com/package/create-payload-app). To do so, run the following command:
 
 ```
-npx create-payload-app
+npx create-payload-app@latest
 ```
 
 Then just follow the prompts! You'll get set up with a new folder and a functioning Payload app inside.

--- a/docs/plugins/build-your-own.mdx
+++ b/docs/plugins/build-your-own.mdx
@@ -84,7 +84,7 @@ If you&apos;re starting from scratch, you can easily setup a dev environment lik
 ```
 mkdir dev
 cd dev
-npx create-payload-app
+npx create-payload-app@latest
 ```
 
 If you&apos;re using the plugin template, the dev folder is built out for you and the `samplePlugin` has already been installed in `dev/payload.config()`.

--- a/docs/typescript/overview.mdx
+++ b/docs/typescript/overview.mdx
@@ -9,7 +9,7 @@ keywords: headless cms, typescript, documentation, Content Management System, cm
 Payload supports TypeScript natively, and not only that, the entirety of the CMS is built with TypeScript. To get started developing with Payload and TypeScript, you can use one of Payload's built-in boilerplates in one line via `create-payload-app`:
 
 ```
-npx create-payload-app
+npx create-payload-app@latest
 ```
 
 Pick a TypeScript project type to get started easily.

--- a/packages/payload/README.md
+++ b/packages/payload/README.md
@@ -52,7 +52,7 @@ Create a cloud account, connect your GitHub, and [deploy in minutes](https://pay
 Before beginning to work with Payload, make sure you have all of the [required software](https://payloadcms.com/docs/getting-started/installation).
 
 ```text
-npx create-payload-app
+npx create-payload-app@latest
 ```
 
 Alternatively, it only takes about five minutes to [create an app from scratch](https://payloadcms.com/docs/getting-started/installation#from-scratch).

--- a/templates/blank/README.md
+++ b/templates/blank/README.md
@@ -1,6 +1,6 @@
 # Payload Blank Template
 
-A blank template for [Payload](https://github.com/payloadcms/payload) to help you get up and running quickly. This repo may have been created by running `npx create-payload-app` and selecting the "blank" template or by cloning this template on [Payload Cloud](https://payloadcms.com/new/clone/blank).
+A blank template for [Payload](https://github.com/payloadcms/payload) to help you get up and running quickly. This repo may have been created by running `npx create-payload-app@latest` and selecting the "blank" template or by cloning this template on [Payload Cloud](https://payloadcms.com/new/clone/blank).
 
 See the official [Examples Directory](https://github.com/payloadcms/payload/tree/main/examples) for details on how to use Payload in a variety of different ways.
 

--- a/templates/ecommerce/README.md
+++ b/templates/ecommerce/README.md
@@ -36,7 +36,7 @@ If you have not done so already, you need to have standalone copy of this repo o
 
   Use the `create-payload-app` CLI to clone this template directly to your machine:
 
-    npx create-payload-app my-project -t ecommerce
+    npx create-payload-app@latest my-project -t ecommerce
 
 #### Method 3
 

--- a/templates/website/README.md
+++ b/templates/website/README.md
@@ -37,7 +37,7 @@ If you have not done so already, you need to have standalone copy of this repo o
 
   Use the `create-payload-app` CLI to clone this template directly to your machine:
 
-    npx create-payload-app my-project -t website
+    npx create-payload-app@latest my-project -t website
 
 #### Method 3
 


### PR DESCRIPTION
Add `@latest` to all mentions of create-payload-app. `npx` does not always use latest by default.