### PR TITLE
fix(db-mongodb): parse predefined migrations via file arg or name prefix

### DIFF
--- a/packages/db-mongodb/src/createMigration.ts
+++ b/packages/db-mongodb/src/createMigration.ts
@@ -30,8 +30,11 @@ export const createMigration: CreateMigration = async function createMigration({
 
   let migrationFileContent: string | undefined
 
-  // Check for predefined migration
-  if (file) {
+  // Check for predefined migration.
+  // Either passed in via --file or prefixed with @payloadcms/db-mongodb/
+  if (file || migrationName.startsWith('@payloadcms/db-mongodb/')) {
+    if (!file) file = migrationName
+
     const predefinedMigrationName = file.replace('@payloadcms/db-mongodb/', '')
     migrationName = predefinedMigrationName
     const cleanPath = path.join(__dirname, `../predefinedMigrations/${predefinedMigrationName}.js`)


### PR DESCRIPTION
Predefined migrations for migrate:create can now also be parsed from the migrationName in addition to the `--file` flag. This will account for those that are running `npm` and do not leverage `--` to pass the arguments.

Fixes #3735 