### PR TITLE
feat(db-postgres): WIP Support native PostgresSQL schema

### DIFF
--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -53,14 +53,15 @@ export function postgresAdapter(args: Args): PostgresAdapterResult {
       // Postgres-specific
       drizzle: undefined,
       enums: {},
+      fieldConstraints: {},
       pool: undefined,
       poolOptions: args.pool,
       push: args.push,
       relations: {},
       schema: {},
+      schemaName: args.schemaName,
       sessions: {},
       tables: {},
-      fieldConstraints: {},
 
       // DatabaseAdapter
       beginTransaction,

--- a/packages/db-postgres/src/schema/build.ts
+++ b/packages/db-postgres/src/schema/build.ts
@@ -1,14 +1,20 @@
 /* eslint-disable no-param-reassign */
 import type { Relation } from 'drizzle-orm'
-import type { IndexBuilder, PgColumnBuilder, UniqueConstraintBuilder } from 'drizzle-orm/pg-core'
+import type {
+  IndexBuilder,
+  PgColumnBuilder,
+  PgTableFn,
+  UniqueConstraintBuilder,
+} from 'drizzle-orm/pg-core'
 import type { Field } from 'payload/types'
 
 import { relations } from 'drizzle-orm'
 import {
+  pgTable as _pgTable,
   index,
   integer,
   numeric,
-  pgTable,
+  pgSchema,
   serial,
   timestamp,
   unique,
@@ -59,6 +65,9 @@ export const buildTable = ({
 }: Args): Result => {
   const columns: Record<string, PgColumnBuilder> = baseColumns
   const indexes: Record<string, (cols: GenericColumns) => IndexBuilder> = {}
+  const pgTable = (
+    adapter.schemaName ? pgSchema(adapter.schemaName).table : _pgTable
+  ) as PgTableFn<undefined>
 
   let hasLocalizedField = false
   let hasLocalizedRelationshipField = false

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -17,6 +17,12 @@ export type Args = {
   migrationDir?: string
   pool: PoolConfig
   push?: boolean
+  /**
+   * Name of the native PostgresSQL schema i.e `content`
+   * @default - no schema - native default is public
+   * @see https://orm.drizzle.team/docs/schemas
+   */
+  schemaName?: string
 }
 
 export type GenericColumn = PgColumn<
@@ -48,11 +54,17 @@ export type DrizzleTransaction = PgTransaction<
 export type PostgresAdapter = BaseDatabaseAdapter & {
   drizzle: DrizzleDB
   enums: Record<string, GenericEnum>
+  /**
+   * An object keyed on each table, with a key value pair where the constraint name is the key, followed by the dot-notation field name
+   * Used for returning properly formed errors from unique fields
+   */
+  fieldConstraints: Record<string, Record<string, string>>
   pool: Pool
   poolOptions: Args['pool']
   push: boolean
   relations: Record<string, GenericRelation>
   schema: Record<string, GenericEnum | GenericRelation | GenericTable>
+  schemaName?: string
   sessions: {
     [id: string]: {
       db: DrizzleTransaction
@@ -61,11 +73,6 @@ export type PostgresAdapter = BaseDatabaseAdapter & {
     }
   }
   tables: Record<string, GenericTable>
-  /**
-   * An object keyed on each table, with a key value pair where the constraint name is the key, followed by the dot-notation field name
-   * Used for returning properly formed errors from unique fields
-   */
-  fieldConstraints: Record<string, Record<string, string>>
 }
 
 export type PostgresAdapterResult = (args: { payload: Payload }) => PostgresAdapter
@@ -79,6 +86,7 @@ declare module 'payload' {
       BaseDatabaseAdapter {
     drizzle: DrizzleDB
     enums: Record<string, GenericEnum>
+    fieldConstraints: Record<string, Record<string, string>>
     pool: Pool
     push: boolean
     relations: Record<string, GenericRelation>
@@ -91,6 +99,5 @@ declare module 'payload' {
       }
     }
     tables: Record<string, GenericTable>
-    fieldConstraints: Record<string, Record<string, string>>
   }
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

This WIP PR aims to add support for native PostgreSQL schemas in the DB adapter. Currently Payload injects all tables into the public schema. Schemas are very commonly used in Postgres to group tables by logic/category. Ideally by leaving business tables in `public` and cms tables in `content` schemas. This makes queries more logical to write for many use cases.

```tsx
 db: postgresAdapter({
       schemaName: "content"
  }),
```

No other change is required and everything should work as usual.

Drizzle queries will then look like this
```sql
SELECT ...columns FROM "content"."<collectionName>" WHERE <X>
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation

x-ref: [Discord thread](https://discord.com/channels/967097582721572934/1163632658362937426)