### PR TITLE
fix: generated types for rtf fields using lexical

### DIFF
--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -132,13 +132,23 @@ function fieldsToJSONSchema(
           }
 
           case 'richText': {
-            fieldSchema = {
-              items: {
-                type: 'object',
-              },
-              type: withNullableType('array', isRequired),
+            if ((field.editor as any)?.editorConfig?.lexical) {
+              fieldSchema = {
+                properties: {
+                  root: {
+                    type: 'object',
+                  },
+                },
+                type: withNullableType('object', isRequired),
+              }
+            } else {
+              fieldSchema = {
+                items: {
+                  type: 'object',
+                },
+                type: withNullableType('array', isRequired),
+              }
             }
-
             break
           }
 


### PR DESCRIPTION
## Description

The return type of lexical differs from the types of slate. Unfortunately `generate:types` will always generate something like

```ts
content: {
  [k: string]: unknown;
}[];
```

While using lexial, it should generate 

```ts
content: {
  root: unknown; // or something more specific like RichTextNode
};
```


Don't know how to test these changes or if you will change  the rich text fields that they always return arrays. So I made a draft just for "inspiration".


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation