### PR TITLE
fix: add missing `.next` directory to docker builds where required

### DIFF
--- a/templates/blank/.dockerignore
+++ b/templates/blank/.dockerignore
@@ -1,0 +1,5 @@
+.vscode
+node_modules
+.env.example
+build
+dist

--- a/templates/ecommerce/.dockerignore
+++ b/templates/ecommerce/.dockerignore
@@ -1,0 +1,6 @@
+.vscode
+.next
+node_modules
+.env.example
+build
+dist

--- a/templates/ecommerce/Dockerfile
+++ b/templates/ecommerce/Dockerfile
@@ -19,6 +19,11 @@ COPY package*.json  ./
 COPY yarn.lock ./
 
 RUN yarn install --production
+
+# Docker does not provide a mechanism for failing gracefully if a directory does not exist
+# Create the .next directory to avoid errors
+RUN mkdir -p ./.next
+COPY --from=builder /home/node/app/.next ./.next
 COPY --from=builder /home/node/app/dist ./dist
 COPY --from=builder /home/node/app/build ./build
 

--- a/templates/website/.dockerignore
+++ b/templates/website/.dockerignore
@@ -1,0 +1,6 @@
+.vscode
+.next
+node_modules
+.env.example
+build
+dist

--- a/templates/website/Dockerfile
+++ b/templates/website/Dockerfile
@@ -19,6 +19,11 @@ COPY package*.json  ./
 COPY yarn.lock ./
 
 RUN yarn install --production
+
+# Docker does not provide a mechanism for failing gracefully if a directory does not exist
+# Create the .next directory to avoid errors
+RUN mkdir -p ./.next
+COPY --from=builder /home/node/app/.next ./.next
 COPY --from=builder /home/node/app/dist ./dist
 COPY --from=builder /home/node/app/build ./build
 


### PR DESCRIPTION
## Description
Fixes #3992 - missing `.next` directory from build container.
Additionally, add .dockerignore entries to avoid package version conflicts.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
