### PR TITLE
fix(live-preview): avoids unnecessary requests for polymorphic hasMany relationships

### DIFF
--- a/packages/live-preview/src/mergeData.ts
+++ b/packages/live-preview/src/mergeData.ts
@@ -22,7 +22,6 @@ export const mergeData = async <T>({
   const result = { ...initialData }
 
   const populationPromises: Promise<void>[] = []
-  debugger
   traverseFields({
     apiRoute,
     depth,

--- a/packages/live-preview/src/mergeData.ts
+++ b/packages/live-preview/src/mergeData.ts
@@ -22,7 +22,7 @@ export const mergeData = async <T>({
   const result = { ...initialData }
 
   const populationPromises: Promise<void>[] = []
-
+  debugger
   traverseFields({
     apiRoute,
     depth,

--- a/packages/live-preview/src/mergeData.ts
+++ b/packages/live-preview/src/mergeData.ts
@@ -22,6 +22,7 @@ export const mergeData = async <T>({
   const result = { ...initialData }
 
   const populationPromises: Promise<void>[] = []
+
   traverseFields({
     apiRoute,
     depth,

--- a/packages/live-preview/src/traverseFields.ts
+++ b/packages/live-preview/src/traverseFields.ts
@@ -173,7 +173,7 @@ export const traverseFields = <T>({
                 incomingData[fieldName] !== null
 
               const hasOldValue =
-                typeof result[fieldName] &&
+                result[fieldName] &&
                 typeof result[fieldName] === 'object' &&
                 result[fieldName] !== null
 

--- a/packages/live-preview/src/traverseFields.ts
+++ b/packages/live-preview/src/traverseFields.ts
@@ -107,7 +107,7 @@ export const traverseFields = <T>({
         case 'relationship':
           // Handle `hasMany` relationships
           if (fieldJSON.hasMany && Array.isArray(incomingData[fieldName])) {
-            const oldValue = result[fieldName]
+            const oldValue = Array.isArray(result[fieldName]) ? [...result[fieldName]] : []
 
             // slice the array down to the new length
             // this is for when an item is removed from the array


### PR DESCRIPTION
# Description

Properly handles polymorphic `hasOne` relationships so that they are not unnecessarily re-populated every time fields are traversed, regardless of whether they has been modified. Their values were not being properly compared and were being treated as a new value in the next recursion. There's not good way to test for this afaik. The data returned from the hook is unchanged.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
