### PR TITLE
fix: injects array and block ids into fieldSchemaToJSON

### DIFF
--- a/packages/payload/src/utilities/fieldSchemaToJSON.ts
+++ b/packages/payload/src/utilities/fieldSchemaToJSON.ts
@@ -17,12 +17,27 @@ export const fieldSchemaToJSON = (fields: Field[]): FieldSchemaJSON => {
 
     switch (field.type) {
       case 'group':
-      case 'array':
         acc.push({
           name: field.name,
           fields: fieldSchemaToJSON(field.fields),
           type: field.type,
         })
+
+        break
+
+      case 'array':
+        acc.push({
+          name: field.name,
+          fields: fieldSchemaToJSON([
+            ...field.fields,
+            {
+              name: 'id',
+              type: 'text',
+            },
+          ]),
+          type: field.type,
+        })
+
         break
 
       case 'blocks':
@@ -30,19 +45,25 @@ export const fieldSchemaToJSON = (fields: Field[]): FieldSchemaJSON => {
           name: field.name,
           blocks: field.blocks.reduce((acc, block) => {
             acc[block.slug] = {
-              fields: fieldSchemaToJSON(block.fields),
+              fields: fieldSchemaToJSON([
+                ...block.fields,
+                {
+                  name: 'id',
+                  type: 'text',
+                },
+              ]),
             }
 
             return acc
           }, {}),
           type: field.type,
         })
+
         break
 
       case 'row':
       case 'collapsible':
         result = result.concat(fieldSchemaToJSON(field.fields))
-
         break
 
       case 'tabs': {


### PR DESCRIPTION
## Description

Fixes the `fieldSchemaToJSON` utility by injecting array and block ids into the result. These fields are automatically generated by Payload, but are not fed into this function because they are not included in sanitized collection or global configs. This led to ids being lost when merging data in Live Preview.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
