### PR TITLE
fix: polymorphic hasMany relationships missing in postgres admin

### DIFF
--- a/packages/payload/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
+++ b/packages/payload/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
@@ -281,9 +281,9 @@ export const addFieldStatePromise = async ({
                   return {
                     relationTo: relationship.relationTo,
                     value:
-                      typeof relationship.value === 'string'
-                        ? relationship.value
-                        : relationship.value?.id,
+                      relationship.value && typeof relationship.value === 'object'
+                        ? relationship.value?.id
+                        : relationship.value,
                   }
                 }
                 if (typeof relationship === 'object' && relationship !== null) {

--- a/packages/payload/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -21,6 +21,7 @@ import { useFormProcessing } from '../../Form/context'
 import Label from '../../Label'
 import useField from '../../useField'
 import withCondition from '../../withCondition'
+import { fieldBaseClass } from '../shared'
 import { AddNewRelation } from './AddNew'
 import { createRelationMap } from './createRelationMap'
 import { findOptionsByValue } from './findOptionsByValue'
@@ -28,7 +29,6 @@ import './index.scss'
 import optionsReducer from './optionsReducer'
 import { MultiValueLabel } from './select-components/MultiValueLabel'
 import { SingleValue } from './select-components/SingleValue'
-import { fieldBaseClass } from '../shared'
 
 const maxResultsPerRequest = 10
 
@@ -391,6 +391,7 @@ const Relationship: React.FC<Props> = (props) => {
   }, [])
 
   const valueToRender = findOptionsByValue({ options, value })
+
   if (!Array.isArray(valueToRender) && valueToRender?.value === 'null') valueToRender.value = null
 
   return (

--- a/test/fields/collections/Relationship/index.ts
+++ b/test/fields/collections/Relationship/index.ts
@@ -18,7 +18,6 @@ const RelationshipFields: CollectionConfig = {
       name: 'relationHasManyPolymorphic',
       type: 'relationship',
       relationTo: ['text-fields', 'array-fields'],
-      required: true,
       hasMany: true,
     },
     {

--- a/test/fields/collections/Relationship/index.ts
+++ b/test/fields/collections/Relationship/index.ts
@@ -15,6 +15,13 @@ const RelationshipFields: CollectionConfig = {
       type: 'relationship',
     },
     {
+      name: 'relationHasManyPolymorphic',
+      type: 'relationship',
+      relationTo: ['text-fields', 'array-fields'],
+      required: true,
+      hasMany: true,
+    },
+    {
       name: 'relationToSelf',
       relationTo: relationshipFieldsSlug,
       type: 'relationship',

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -1356,14 +1356,18 @@ describe('fields', () => {
 
     test('should display `hasMany` polymorphic relationships', async () => {
       await page.goto(url.create)
-      const field = page.locator('#field-relationshipHasManyPolymorphic')
+      const field = page.locator('#field-relationHasManyPolymorphic')
       await field.click()
 
-      const value = page.locator('#field-relationHasManyPolymorphic .multi-value').first()
+      await page
+        .locator('.rs__option', {
+          hasText: exactText('Seeded text document'),
+        })
+        .click()
 
       await expect(
-        value
-          .locator('.relationship--multi-value-label__text', {
+        page
+          .locator('#field-relationHasManyPolymorphic .relationship--multi-value-label__text', {
             hasText: exactText('Seeded text document'),
           })
           .first(),

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -6,7 +6,7 @@ import path from 'path'
 import payload from '../../packages/payload/src'
 import { mapAsync } from '../../packages/payload/src/utilities/mapAsync'
 import wait from '../../packages/payload/src/utilities/wait'
-import { saveDocAndAssert, saveDocHotkeyAndAssert } from '../helpers'
+import { exactText, saveDocAndAssert, saveDocHotkeyAndAssert } from '../helpers'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil'
 import { initPayloadE2E } from '../helpers/configHelpers'
 import { RESTClient } from '../helpers/rest'
@@ -1352,6 +1352,37 @@ describe('fields', () => {
       await page.locator('.rs__option:has-text("Seeded text document")').click()
       await field.locator('.clear-indicator').click()
       await expect(field.locator('.rs__placeholder')).toBeVisible()
+    })
+
+    test('should display `hasMany` polymorphic relationships', async () => {
+      await page.goto(url.create)
+      const field = page.locator('#field-relationshipHasManyPolymorphic')
+      await field.click()
+
+      const value = page.locator('#field-relationHasManyPolymorphic .multi-value').first()
+
+      await expect(
+        value
+          .locator('.relationship--multi-value-label__text', {
+            hasText: exactText('Seeded text document'),
+          })
+          .first(),
+      ).toBeVisible()
+
+      // await fill the required fields then save the document and check again
+      await page.locator('#field-relationship').click()
+      await page.locator('#field-relationship .rs__option:has-text("Seeded text document")').click()
+      await saveDocAndAssert(page)
+
+      const valueAfterSave = page.locator('#field-relationHasManyPolymorphic .multi-value').first()
+
+      await expect(
+        valueAfterSave
+          .locator('.relationship--multi-value-label__text', {
+            hasText: exactText('Seeded text document'),
+          })
+          .first(),
+      ).toBeVisible()
     })
 
     test('should populate relationship dynamic default value', async () => {


### PR DESCRIPTION
## Description

The admin panel was not handling `hasMany` polymorphic relationships properly when using a Postgres database. This was because `addFieldStatePromise` was setting the wrong value based on `typeof` `string`, but IDs in Postgres are numbers. This was causing the selected values to disappear after the document is saved.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
