### PR TITLE
fix: vite not replacing env vars correctly when building

### DIFF
--- a/packages/bundler-vite/src/config.ts
+++ b/packages/bundler-vite/src/config.ts
@@ -63,7 +63,6 @@ export const getViteConfig = async (payloadConfig: SanitizedConfig): Promise<Inl
     'module.hot': 'undefined',
     'process.argv': '[]',
     'process.cwd': 'function () { return "/" }',
-    'process.env': '{}',
     'process?.cwd': 'function () { return "/" }',
   }
 


### PR DESCRIPTION
## Description
- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

Fixes https://github.com/payloadcms/payload/issues/4033

Allows for env vars to be replaced correctly when vite does its `define` string replacement.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
