### PR TITLE
fix(richtext-lexical): floating select toolbar caret not positioned correctly if first line is selected

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/plugins/FloatingSelectToolbar/index.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/FloatingSelectToolbar/index.tsx
@@ -111,7 +111,15 @@ function FloatingSelectToolbar({
       setFloatingElemPosition(rangeRect, popupCharStylesEditorElem, anchorElem, 'center')
 
       if (caretRef.current) {
-        setFloatingElemPosition(rangeRect, caretRef.current, popupCharStylesEditorElem, 'center')
+        setFloatingElemPosition(
+          rangeRect, // selection to position around
+          caretRef.current, // what to position
+          popupCharStylesEditorElem, // anchor elem
+          'center',
+          10,
+          5,
+          true,
+        )
       }
     }
   }, [editor, anchorElem])

--- a/packages/richtext-lexical/src/field/lexical/utils/setFloatingElemPosition.ts
+++ b/packages/richtext-lexical/src/field/lexical/utils/setFloatingElemPosition.ts
@@ -8,6 +8,9 @@
 const VERTICAL_GAP = 10
 const HORIZONTAL_OFFSET = 5
 
+// TODO: This works fine with some dirty fixes (looking at you, specialHandlingForCaret). But this definitely needs refactoring and documentation, to be easier to understand and maintain.
+// This is supposed to position the floatingElem based on the parent (anchorElem) and the target (targetRect) which is usually the selected text.
+// So basically, it positions the floatingElem either below or above the target (targetRect) and aligns it to the left or center of the target (targetRect).
 export function setFloatingElemPosition(
   targetRect: ClientRect | null,
   floatingElem: HTMLElement,
@@ -15,6 +18,7 @@ export function setFloatingElemPosition(
   horizontalPosition: 'center' | 'left' = 'left',
   verticalGap: number = VERTICAL_GAP,
   horizontalOffset: number = HORIZONTAL_OFFSET,
+  specialHandlingForCaret = false,
 ): void {
   const scrollerElem = anchorElem.parentElement
 
@@ -56,5 +60,12 @@ export function setFloatingElemPosition(
   left -= anchorElementRect.left
 
   floatingElem.style.opacity = '1'
-  floatingElem.style.transform = `translate(${left}px, ${top}px)`
+
+  if (specialHandlingForCaret && top == 0) {
+    top -= 46 // Especially this arbitrary number needs refactoring (this is for the caret)
+    // rotate too
+    floatingElem.style.transform = `translate(${left}px, ${top}px) rotate(180deg)`
+  } else {
+    floatingElem.style.transform = `translate(${left}px, ${top}px)`
+  }
 }


### PR DESCRIPTION
## Description

Fixes #4041 

This is a dirty fix, but it does its job. Given it's such a minor issue, this dirty fix will suffice for now. When more time is available, the `setFloatingElemPosition` function should be refactored.

Old:
![Screenshot 2023-11-08 at 22 10 54](https://github.com/payloadcms/payload/assets/70709113/97a83ec5-ae73-46f0-9894-08b318273d4b)

New: 
![Screenshot 2023-11-08 at 22 10 09](https://github.com/payloadcms/payload/assets/70709113/d56ce731-bf9a-4e77-a767-25167059b9b1)


Despite it being 

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
