### PR TITLE
chore: updates default type value for graphql playground type

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -288,7 +288,7 @@ export type Locale = {
    * label of supported locale
    * @example "English"
    */
-  label: string | Record<string, string>
+  label: Record<string, string> | string
   /**
    * if true, defaults textAligmnent on text fields to RTL
    */
@@ -663,7 +663,7 @@ export type Config = {
     api?: string
     /** @default "/graphql"  */
     graphQL?: string
-    /** @default "/playground" */
+    /** @default "/graphql-playground" */
     graphQLPlayground?: string
   }
   /**


### PR DESCRIPTION
## Description

Fixes #4037 

Updates default path value for `graphQLPlayground` from `/playground` to correct path of `/graphql-playground`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
