### PR TITLE
chore: disable editing option for svg image types

### DIFF
--- a/packages/payload/src/admin/components/elements/EditUpload/index.scss
+++ b/packages/payload/src/admin/components/elements/EditUpload/index.scss
@@ -70,11 +70,6 @@ $header-height: base(5);
     }
   }
 
-  &__draggable {
-    position: absolute;
-    @include btn-reset;
-  }
-
   &__focalPoint {
     position: absolute;
     top: 50%;

--- a/packages/payload/src/admin/components/elements/EditUpload/index.scss
+++ b/packages/payload/src/admin/components/elements/EditUpload/index.scss
@@ -70,6 +70,11 @@ $header-height: base(5);
     }
   }
 
+  &__draggable {
+    @include btn-reset;
+    position: absolute;
+  }
+
   &__focalPoint {
     position: absolute;
     top: 50%;

--- a/packages/payload/src/admin/components/elements/EditUpload/index.scss
+++ b/packages/payload/src/admin/components/elements/EditUpload/index.scss
@@ -70,6 +70,11 @@ $header-height: base(5);
     }
   }
 
+  &__draggable {
+    position: absolute;
+    @include btn-reset;
+  }
+
   &__focalPoint {
     position: absolute;
     top: 50%;

--- a/packages/payload/src/admin/components/elements/EditUpload/index.tsx
+++ b/packages/payload/src/admin/components/elements/EditUpload/index.tsx
@@ -164,7 +164,15 @@ export const EditUpload: React.FC<{
                 />
               </ReactCrop>
             ) : (
-              <img alt={t('upload:setFocalPoint')} ref={imageRef} src={fileSrcToUse} />
+              <img
+                alt={t('upload:setFocalPoint')}
+                onLoad={(e) => {
+                  setOriginalHeight(e.currentTarget.naturalHeight)
+                  setOriginalWidth(e.currentTarget.naturalWidth)
+                }}
+                ref={imageRef}
+                src={fileSrcToUse}
+              />
             )}
             {showFocalPoint && (
               <DraggableElement

--- a/packages/payload/src/admin/components/elements/EditUpload/index.tsx
+++ b/packages/payload/src/admin/components/elements/EditUpload/index.tsx
@@ -281,7 +281,7 @@ const DraggableElement = ({
 }) => {
   const [position, setPosition] = useState({ x: initialPosition.x, y: initialPosition.y })
   const [isDragging, setIsDragging] = useState(false)
-  const dragRef = useRef<HTMLDivElement | undefined>()
+  const dragRef = useRef<HTMLButtonElement | undefined>()
 
   const getCoordinates = React.useCallback(
     (mouseXArg?: number, mouseYArg?: number, recenter?: boolean) => {
@@ -327,7 +327,7 @@ const DraggableElement = ({
 
       return { x, y }
     },
-    [],
+    [boundsRef, containerRef],
   )
 
   const handleMouseDown = (event) => {
@@ -357,7 +357,7 @@ const DraggableElement = ({
       setCheckBounds(false)
       return
     }
-  }, [getCoordinates, isDragging, checkBounds, setCheckBounds, position.x, position.y])
+  }, [getCoordinates, isDragging, checkBounds, setCheckBounds, position.x, position.y, onDragEnd])
 
   React.useEffect(() => {
     setPosition({ x: initialPosition.x, y: initialPosition.y })
@@ -373,15 +373,16 @@ const DraggableElement = ({
         .join(' ')}
       onMouseMove={handleMouseMove}
     >
-      <div
+      <button
         className={[`${baseClass}__draggable`, className].filter(Boolean).join(' ')}
         onMouseDown={handleMouseDown}
         onMouseUp={onDrop}
         ref={dragRef}
         style={{ left: `${position.x}%`, position: 'absolute', top: `${position.y}%` }}
+        type="button"
       >
         {children}
-      </div>
+      </button>
       <div />
     </div>
   )

--- a/packages/payload/src/admin/components/elements/EditUpload/index.tsx
+++ b/packages/payload/src/admin/components/elements/EditUpload/index.tsx
@@ -378,7 +378,7 @@ const DraggableElement = ({
         onMouseDown={handleMouseDown}
         onMouseUp={onDrop}
         ref={dragRef}
-        style={{ left: `${position.x}%`, position: 'absolute', top: `${position.y}%` }}
+        style={{ left: `${position.x}%`, top: `${position.y}%` }}
         type="button"
       >
         {children}

--- a/packages/payload/src/admin/components/elements/FileDetails/index.tsx
+++ b/packages/payload/src/admin/components/elements/FileDetails/index.tsx
@@ -38,7 +38,7 @@ const FileDetails: React.FC<Props> = (props) => {
             width={width as number}
           />
 
-          {isImage(mimeType as string) && (
+          {isImage(mimeType as string) && mimeType !== 'image/svg+xml' && (
             <UploadActions canEdit={canEdit} showSizePreviews={hasImageSizes && doc.filename} />
           )}
         </div>

--- a/packages/payload/src/admin/components/views/collections/Edit/Upload/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Upload/index.tsx
@@ -123,7 +123,6 @@ export const Upload: React.FC<Props> = (props) => {
 
   const lastSubmittedTime = submitted ? new Date().toISOString() : null
 
-  console.log(value && isImage(value.type))
   return (
     <div className={[fieldBaseClass, baseClass].filter(Boolean).join(' ')}>
       <Error message={errorMessage} showError={showError} />

--- a/packages/payload/src/admin/components/views/collections/Edit/Upload/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Upload/index.tsx
@@ -123,6 +123,7 @@ export const Upload: React.FC<Props> = (props) => {
 
   const lastSubmittedTime = submitted ? new Date().toISOString() : null
 
+  console.log(value && isImage(value.type))
   return (
     <div className={[fieldBaseClass, baseClass].filter(Boolean).join(' ')}>
       <Error message={errorMessage} showError={showError} />
@@ -161,7 +162,7 @@ export const Upload: React.FC<Props> = (props) => {
                   value={value.name}
                 />
 
-                {isImage(value.type) && (
+                {isImage(value.type) && value.type !== 'image/svg+xml' && (
                   <UploadActions
                     canEdit={showCrop || showFocalPoint}
                     showSizePreviews={hasImageSizes && doc.filename && !replacingFile}

--- a/packages/payload/src/uploads/getFileByPath.ts
+++ b/packages/payload/src/uploads/getFileByPath.ts
@@ -4,6 +4,10 @@ import path from 'path'
 
 import type { File } from './types'
 
+const mimeTypeEstimate = {
+  svg: 'image/svg+xml',
+}
+
 const getFileByPath = async (filePath: string): Promise<File> => {
   if (typeof filePath === 'string') {
     const data = fs.readFileSync(filePath)
@@ -11,11 +15,14 @@ const getFileByPath = async (filePath: string): Promise<File> => {
     const { size } = fs.statSync(filePath)
 
     const name = path.basename(filePath)
+    const ext = path.extname(filePath).slice(1)
+
+    const mime = (await mimetype)?.mime || mimeTypeEstimate[ext]
 
     return {
       name,
       data,
-      mimetype: (await mimetype).mime,
+      mimetype: mime,
       size,
     }
   }


### PR DESCRIPTION
## Description

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

The upload edit drawer should not be displayed for **svg** type uploads. #4064

Misc fixes:
- aspect ratio on no-crop images
- linting errors/warnings

## Type of change

- [X] Chore (non-breaking change which does not add functionality)

## Checklist:

- [X] Existing test suite passes locally with my changes