### PR TITLE
fix(live-preview): ensures field schema exists before traversing fields

### DIFF
--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -23,7 +23,7 @@ export const handleMessage = async <T>(args: {
 
       if (!payloadLivePreviewFieldSchema) {
         // eslint-disable-next-line no-console
-        console.error(
+        console.warn(
           'Payload Live Preview: No `fieldSchemaJSON` was received from the parent window.',
         )
 

--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -21,15 +21,17 @@ export const handleMessage = async <T>(args: {
         payloadLivePreviewFieldSchema = eventData.fieldSchemaJSON
       }
 
-      const mergedData = await mergeData<T>({
-        depth,
-        fieldSchema: payloadLivePreviewFieldSchema,
-        incomingData: eventData.data,
-        initialData,
-        serverURL,
-      })
+      if (payloadLivePreviewFieldSchema) {
+        const mergedData = await mergeData<T>({
+          depth,
+          fieldSchema: payloadLivePreviewFieldSchema,
+          incomingData: eventData.data,
+          initialData,
+          serverURL,
+        })
 
-      return mergedData
+        return mergedData
+      }
     }
   }
 

--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -21,17 +21,24 @@ export const handleMessage = async <T>(args: {
         payloadLivePreviewFieldSchema = eventData.fieldSchemaJSON
       }
 
-      if (payloadLivePreviewFieldSchema) {
-        const mergedData = await mergeData<T>({
-          depth,
-          fieldSchema: payloadLivePreviewFieldSchema,
-          incomingData: eventData.data,
-          initialData,
-          serverURL,
-        })
+      if (!payloadLivePreviewFieldSchema) {
+        // eslint-disable-next-line no-console
+        console.error(
+          'Payload Live Preview: No `fieldSchemaJSON` was received from the parent window.',
+        )
 
-        return mergedData
+        return initialData
       }
+
+      const mergedData = await mergeData<T>({
+        depth,
+        fieldSchema: payloadLivePreviewFieldSchema,
+        incomingData: eventData.data,
+        initialData,
+        serverURL,
+      })
+
+      return mergedData
     }
   }
 

--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -24,7 +24,7 @@ export const handleMessage = async <T>(args: {
       if (!payloadLivePreviewFieldSchema) {
         // eslint-disable-next-line no-console
         console.warn(
-          'Payload Live Preview: No `fieldSchemaJSON` was received from the parent window.',
+          'Payload Live Preview: No `fieldSchemaJSON` was received from the parent window. Unable to merge data.',
         )
 
         return initialData


### PR DESCRIPTION
## Description

Closes #3806 by ensuring that the field schema exists before traversing the fields to merge data.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
