### PR TITLE
fix(plugin-nested-docs): sync write transaction errors

### DIFF
--- a/test/plugin-nested-docs/config.ts
+++ b/test/plugin-nested-docs/config.ts
@@ -8,17 +8,10 @@ import { seed } from './seed'
 export default buildConfigWithDefaults({
   collections: [Pages, Users],
   localization: {
-    locales: ['en', 'es', 'de'],
     defaultLocale: 'en',
     fallback: true,
+    locales: ['en', 'es', 'de'],
   },
-  plugins: [
-    nestedDocs({
-      collections: ['pages'],
-      generateLabel: (_, doc) => doc.title as string,
-      generateURL: (docs) => docs.reduce((url, doc) => `${url}/${doc.slug}`, ''),
-    }),
-  ],
   onInit: async (payload) => {
     await payload.create({
       collection: 'users',
@@ -30,4 +23,11 @@ export default buildConfigWithDefaults({
 
     await seed(payload)
   },
+  plugins: [
+    nestedDocs({
+      collections: ['pages'],
+      generateLabel: (_, doc) => doc.title as string,
+      generateURL: (docs) => docs.reduce((url, doc) => `${url}/${doc.slug}`, ''),
+    }),
+  ],
 })

--- a/test/plugin-nested-docs/seed/index.ts
+++ b/test/plugin-nested-docs/seed/index.ts
@@ -1,7 +1,9 @@
 import type { Payload } from '../../../packages/payload/src'
+import type { PayloadRequest } from '../../../packages/payload/src/express/types'
 
 export const seed = async (payload: Payload): Promise<boolean> => {
   payload.logger.info('Seeding data...')
+  const req = {} as PayloadRequest
 
   try {
     await payload.create({
@@ -10,40 +12,45 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         email: 'demo@payloadcms.com',
         password: 'demo',
       },
+      req,
     })
 
     const { id: parentID } = await payload.create({
       collection: 'pages',
       data: {
-        title: 'Parent page',
         slug: 'parent-page',
+        title: 'Parent page',
       },
+      req,
     })
 
     const { id: childID } = await payload.create({
       collection: 'pages',
       data: {
-        title: 'Child page',
-        slug: 'child-page',
         parent: parentID,
+        slug: 'child-page',
+        title: 'Child page',
       },
+      req,
     })
 
     await payload.create({
       collection: 'pages',
       data: {
-        title: 'Grandchild page',
-        slug: 'grandchild-page',
         parent: childID,
+        slug: 'grandchild-page',
+        title: 'Grandchild page',
       },
+      req,
     })
 
     await payload.create({
       collection: 'pages',
       data: {
-        title: 'Sister page',
         slug: 'sister-page',
+        title: 'Sister page',
       },
+      req,
     })
     return true
   } catch (err) {


### PR DESCRIPTION
## Description

fixes https://github.com/payloadcms/payload/issues/4077

This error was not being caught because our CI test suite does not use transactions through mongoDB memory server.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
