### PR TITLE
fix: possible issue with access control not using req

### DIFF
--- a/packages/payload/src/utilities/getEntityPolicies.ts
+++ b/packages/payload/src/utilities/getEntityPolicies.ts
@@ -1,6 +1,5 @@
 import type { CollectionPermission, GlobalPermission } from '../auth/types'
-import type { SanitizedCollectionConfig } from '../collections/config/types'
-import type { TypeWithID } from '../collections/config/types'
+import type { SanitizedCollectionConfig, TypeWithID } from '../collections/config/types'
 import type { Access } from '../config/types'
 import type { PayloadRequest } from '../express/types'
 import type { FieldAccess } from '../fields/config/types'
@@ -60,6 +59,7 @@ export async function getEntityPolicies<T extends Args>(args: T): Promise<Return
             collection: entity.slug,
             limit: 1,
             overrideAccess: true,
+            req,
             where: {
               ...where,
               and: [
@@ -80,6 +80,7 @@ export async function getEntityPolicies<T extends Args>(args: T): Promise<Return
           id,
           collection: entity.slug,
           overrideAccess: true,
+          req,
         })
       }
     }


### PR DESCRIPTION
## Description

All local operations should pass the `req` through for transaction consistency. This PR adds it to two local calls that were missing it in getEntityPolicies.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes