### PR TITLE
fix: fixes creation of related documents within a transaction if filterOptions is used

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -107,6 +107,7 @@ export type ValidateOptions<TData, TSiblingData, TFieldConfig> = {
   id?: number | string
   operation?: Operation
   payload?: Payload
+  req?: PayloadRequest
   siblingData: Partial<TSiblingData>
   t: TFunction
   user?: Partial<User>

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -120,6 +120,7 @@ export const promise = async ({
         jsonError,
         operation,
         payload: req.payload,
+        req,
         siblingData: merge(siblingDoc, siblingData, { arrayMerge: (_, source) => source }),
         t: req.t,
         user: req.user,

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -222,7 +222,7 @@ export const richText: Validate<object, unknown, RichTextField, RichTextField> =
 
 const validateFilterOptions: Validate = async (
   value,
-  { id, data, filterOptions, payload, relationTo, siblingData, t, user },
+  { id, data, filterOptions, payload, relationTo, siblingData, t, user, req },
 ) => {
   if (!canUseDOM && typeof filterOptions !== 'undefined' && value) {
     const options: {
@@ -269,6 +269,7 @@ const validateFilterOptions: Validate = async (
             depth: 0,
             limit: 0,
             pagination: false,
+            req,
             where: findWhere,
           })
 


### PR DESCRIPTION
## Description

Fixes #4078 

Fixes validation of `filterOptions` by passing in the current `PayloadRequest`, so it will use the active transaction (if any). In case this is not done, the validation code will fail to see any new documents that were created within the transaction (because it runs outside it) and thus throw a ValidationError.

The test I have written is currently only effective under Postgres, because the current MongoDB tests do not use a ReplicaSet (and thus no transactions are possible). I have verified that the test also passes if a local MongoDB ReplicaSet is used (via Docker), however I am unsure how this could be done with mongodb-memory-server or if that is even necessary.

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
