### PR TITLE
fix(richtext-lexical): HTMLConverter: cannot find nested lexical fields

### DIFF
--- a/packages/payload/src/utilities/flattenTopLevelFields.ts
+++ b/packages/payload/src/utilities/flattenTopLevelFields.ts
@@ -7,6 +7,13 @@ import {
   tabHasName,
 } from '../fields/config/types'
 
+/**
+ * Flattens a collection's fields into a single array of fields, as long
+ * as the fields do not affect data.
+ *
+ * @param fields
+ * @param keepPresentationalFields if true, will skip flattening fields that are presentational only
+ */
 const flattenFields = (
   fields: Field[],
   keepPresentationalFields?: boolean,

--- a/packages/richtext-lexical/src/field/features/converters/html/field/index.ts
+++ b/packages/richtext-lexical/src/field/features/converters/html/field/index.ts
@@ -1,5 +1,5 @@
 import type { SerializedEditorState } from 'lexical'
-import type { RichTextField, TextField } from 'payload/types'
+import type { Field, RichTextField, TextField } from 'payload/types'
 
 import type { LexicalRichTextAdapter, SanitizedEditorConfig } from '../../../../../index'
 import type { AdapterProps } from '../../../../../types'
@@ -44,10 +44,15 @@ export const consolidateHTMLConverters = ({
   return finalConverters
 }
 
-export const lexicalHTML: (lexicalFieldName: string, props: Props) => TextField = (
-  lexicalFieldName,
-  props,
-) => {
+export const lexicalHTML: (
+  /**
+   * A string which matches the lexical field name you want to convert to HTML.
+   *
+   * This has to be a SIBLING field of this lexicalHTML field - otherwise, it won't be able to find the lexical field.
+   **/
+  lexicalFieldName: string,
+  props: Props,
+) => TextField = (lexicalFieldName, props) => {
   const { name = 'lexicalHTML' } = props
   return {
     name: name,
@@ -56,9 +61,40 @@ export const lexicalHTML: (lexicalFieldName: string, props: Props) => TextField 
     },
     hooks: {
       afterRead: [
-        async ({ collection, context, data, originalDoc, siblingData }) => {
+        async ({ collection, field, siblingData }) => {
+          // find the path of this field, as well as its sibling fields, by looking for this `field` in collection.fields and traversing it recursively
+          function findFieldPathAndSiblingFields(
+            fields: Field[],
+            path: string[],
+          ): {
+            path: string[]
+            siblingFields: Field[]
+          } {
+            for (const curField of fields) {
+              if (curField === field) {
+                return {
+                  path: [...path, curField.name],
+                  siblingFields: fields,
+                }
+              }
+
+              if ('fields' in curField && 'name' in curField) {
+                const result = findFieldPathAndSiblingFields(curField.fields, [
+                  ...path,
+                  curField.name,
+                ])
+                if (result) {
+                  return result
+                }
+              }
+            }
+
+            return null
+          }
+          const { path, siblingFields } = findFieldPathAndSiblingFields(collection.fields, [])
+
           const lexicalField: RichTextField<SerializedEditorState, AdapterProps> =
-            collection.fields.find(
+            siblingFields.find(
               (field) => 'name' in field && field.name === lexicalFieldName,
             ) as RichTextField<SerializedEditorState, AdapterProps>
 
@@ -70,7 +106,7 @@ export const lexicalHTML: (lexicalFieldName: string, props: Props) => TextField 
 
           if (!lexicalField) {
             throw new Error(
-              'You cannot use the lexicalHTML field because the lexical field was not found',
+              'You cannot use the lexicalHTML field because the referenced lexical field was not found',
             )
           }
 
@@ -84,7 +120,7 @@ export const lexicalHTML: (lexicalFieldName: string, props: Props) => TextField 
 
           if (!config?.resolvedFeatureMap?.has('htmlConverter')) {
             throw new Error(
-              'You cannot use the lexicalHTML field because the htmlConverter feature was not found',
+              'You cannot use the lexicalHTML field because the linked lexical field does not have a HTMLConverterFeature',
             )
           }
 

--- a/test/fields/collections/LexicalMigrate/data.ts
+++ b/test/fields/collections/LexicalMigrate/data.ts
@@ -3,4 +3,44 @@ import { payloadPluginLexicalData } from './generatePayloadPluginLexicalData'
 export const lexicalMigrateDocData = {
   title: 'Rich Text',
   lexicalWithLexicalPluginData: payloadPluginLexicalData,
+  arrayWithLexicalField: [
+    {
+      lexicalInArrayField: getSimpleLexicalData('array 1'),
+    },
+    {
+      lexicalInArrayField: getSimpleLexicalData('array 2'),
+    },
+  ],
+}
+
+export function getSimpleLexicalData(textContent: string) {
+  return {
+    root: {
+      type: 'root',
+      format: '',
+      indent: 0,
+      version: 1,
+      children: [
+        {
+          children: [
+            {
+              detail: 0,
+              format: 0,
+              mode: 'normal',
+              style: '',
+              text: textContent,
+              type: 'text',
+              version: 1,
+            },
+          ],
+          direction: 'ltr',
+          format: '',
+          indent: 0,
+          type: 'paragraph',
+          version: 1,
+        },
+      ],
+      direction: 'ltr',
+    },
+  }
 }

--- a/test/fields/collections/LexicalMigrate/index.ts
+++ b/test/fields/collections/LexicalMigrate/index.ts
@@ -1,13 +1,16 @@
 import type { CollectionConfig } from '../../../../packages/payload/src/collections/config/types'
 
 import {
+  HTMLConverterFeature,
   LexicalPluginToLexicalFeature,
   LinkFeature,
   TreeviewFeature,
   UploadFeature,
   lexicalEditor,
+  lexicalHTML,
 } from '../../../../packages/richtext-lexical/src'
 import { lexicalMigrateFieldsSlug } from '../../slugs'
+import { getSimpleLexicalData } from './data'
 
 export const LexicalMigrateFields: CollectionConfig = {
   slug: lexicalMigrateFieldsSlug,
@@ -32,6 +35,7 @@ export const LexicalMigrateFields: CollectionConfig = {
           ...defaultFeatures,
           LexicalPluginToLexicalFeature(),
           TreeviewFeature(),
+          HTMLConverterFeature(),
           LinkFeature({
             fields: [
               {
@@ -62,6 +66,44 @@ export const LexicalMigrateFields: CollectionConfig = {
           }),
         ],
       }),
+    },
+    {
+      name: 'lexicalSimple',
+      type: 'richText',
+      editor: lexicalEditor({
+        features: ({ defaultFeatures }) => [...defaultFeatures, HTMLConverterFeature()],
+      }),
+      defaultValue: getSimpleLexicalData('simple'),
+    },
+    lexicalHTML('lexicalSimple', { name: 'lexicalSimple_html' }),
+    {
+      name: 'groupWithLexicalField',
+      type: 'group',
+      fields: [
+        {
+          name: 'lexicalInGroupField',
+          type: 'richText',
+          editor: lexicalEditor({
+            features: ({ defaultFeatures }) => [...defaultFeatures, HTMLConverterFeature()],
+          }),
+          defaultValue: getSimpleLexicalData('group'),
+        },
+        lexicalHTML('lexicalInGroupField', { name: 'lexicalInGroupField_html' }),
+      ],
+    },
+    {
+      name: 'arrayWithLexicalField',
+      type: 'array',
+      fields: [
+        {
+          name: 'lexicalInArrayField',
+          type: 'richText',
+          editor: lexicalEditor({
+            features: ({ defaultFeatures }) => [...defaultFeatures, HTMLConverterFeature()],
+          }),
+        },
+        lexicalHTML('lexicalInArrayField', { name: 'lexicalInArrayField_html' }),
+      ],
     },
   ],
 }

--- a/test/fields/lexical.int.spec.ts
+++ b/test/fields/lexical.int.spec.ts
@@ -1,6 +1,5 @@
 import type { SerializedEditorState } from 'lexical'
 
-import { expect } from '@playwright/test'
 import { GraphQLClient } from 'graphql-request'
 
 import type { SanitizedConfig } from '../../packages/payload/src/config/types'


### PR DESCRIPTION
## Description

Fixes #4034. Previously, it was unable to find lexical fields part of a group or array fields. 

Now, it can find those, as it no longer searches through the collection's top-level fields. Now, it first finds the sibling `Field`s and then searches for the referenced lexical field in them.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
