### PR TITLE
fix(richtext-slate): Slate RichText contents error color in groups

### DIFF
--- a/packages/richtext-slate/src/field/index.scss
+++ b/packages/richtext-slate/src/field/index.scss
@@ -36,6 +36,7 @@
   }
 
   &__editor {
+    color: var(--theme-elevation-800);
     font-family: var(--font-serif);
     font-size: base(0.625);
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

When a `group` field has an error, its `color` is set to red. This affects the contents of Slate rich text fields.
IMO, this will confuse users, who might think there's an error with this specific field:

![image](https://github.com/payloadcms/payload/assets/10552683/ac1b33fe-16ec-45a1-9f26-70c9d7e62480)

This PR enforces a text color on the entire editor, similar to regular text fields.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
