### PR TITLE
chore: rename tab button classname to prevent unintention styling

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Tabs/index.scss
+++ b/packages/payload/src/admin/components/forms/field-types/Tabs/index.scss
@@ -48,7 +48,7 @@
     }
   }
 
-  &__tab-button {
+  &__switch-tab-button {
     @extend %btn-reset;
     @extend %h4;
     display: flex;
@@ -85,7 +85,7 @@
     }
   }
 
-  &__tab-button--active {
+  &__switch-tab-button--active {
     opacity: 1 !important;
 
     &:after {
@@ -104,7 +104,7 @@
       margin-right: calc(var(--gutter-h) * -1);
     }
 
-    &__tab-button {
+    &__switch-tab-button {
       margin: 0 base(0.75) 0 0;
       padding-bottom: base(0.5);
 
@@ -117,7 +117,7 @@
 
 html[data-theme='light'] {
   .tabs-field {
-    &__tab-button--has-error {
+    &__switch-tab-button--has-error {
       color: var(--theme-error-750);
       &:after {
         background: var(--theme-error-500);
@@ -128,7 +128,7 @@ html[data-theme='light'] {
 
 html[data-theme='dark'] {
   .tabs-field {
-    &__tab-button--has-error {
+    &__switch-tab-button--has-error {
       color: var(--theme-error-500);
       &:after {
         background: var(--theme-error-500);

--- a/packages/payload/src/admin/components/forms/field-types/Tabs/index.scss
+++ b/packages/payload/src/admin/components/forms/field-types/Tabs/index.scss
@@ -48,7 +48,7 @@
     }
   }
 
-  &__switch-tab-button {
+  &__tab-button {
     @extend %btn-reset;
     @extend %h4;
     display: flex;
@@ -85,7 +85,7 @@
     }
   }
 
-  &__switch-tab-button--active {
+  &__tab-button--active {
     opacity: 1 !important;
 
     &:after {
@@ -104,7 +104,7 @@
       margin-right: calc(var(--gutter-h) * -1);
     }
 
-    &__switch-tab-button {
+    &__tab-button {
       margin: 0 base(0.75) 0 0;
       padding-bottom: base(0.5);
 
@@ -117,7 +117,7 @@
 
 html[data-theme='light'] {
   .tabs-field {
-    &__switch-tab-button--has-error {
+    &__tab-button--has-error {
       color: var(--theme-error-750);
       &:after {
         background: var(--theme-error-500);
@@ -128,7 +128,7 @@ html[data-theme='light'] {
 
 html[data-theme='dark'] {
   .tabs-field {
-    &__switch-tab-button--has-error {
+    &__tab-button--has-error {
       color: var(--theme-error-500);
       &:after {
         background: var(--theme-error-500);

--- a/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
@@ -52,9 +52,9 @@ const TabComponent: React.FC<TabProps> = ({ isActive, parentPath, setIsActive, t
       />
       <button
         className={[
-          `${baseClass}__switch-tab-button`,
-          tabHasErrors && `${baseClass}__switch-tab-button--has-error`,
-          isActive && `${baseClass}__switch-tab-button--active`,
+          `${baseClass}__tab-button`,
+          tabHasErrors && `${baseClass}__tab-button--has-error`,
+          isActive && `${baseClass}__tab-button--active`,
         ]
           .filter(Boolean)
           .join(' ')}
@@ -166,7 +166,9 @@ const TabsField: React.FC<Props> = (props) => {
                 className={[
                   `${baseClass}__tab`,
                   activeTabConfig.label &&
-                    `${baseClass}__tab-${toKebabCase(getTranslation(activeTabConfig.label, i18n))}`,
+                    `${baseClass}__tabConfigLabel-${toKebabCase(
+                      getTranslation(activeTabConfig.label, i18n),
+                    )}`,
                 ]
                   .filter(Boolean)
                   .join(' ')}

--- a/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
@@ -52,9 +52,9 @@ const TabComponent: React.FC<TabProps> = ({ isActive, parentPath, setIsActive, t
       />
       <button
         className={[
-          `${baseClass}__tab-button`,
-          tabHasErrors && `${baseClass}__tab-button--has-error`,
-          isActive && `${baseClass}__tab-button--active`,
+          `${baseClass}__switch-tab-button`,
+          tabHasErrors && `${baseClass}__switch-tab-button--has-error`,
+          isActive && `${baseClass}__switch-tab-button--active`,
         ]
           .filter(Boolean)
           .join(' ')}


### PR DESCRIPTION
## Description

Closes #4107 

Adjusts tab classname to prevent unwanted styling.

Before:
![Screenshot 2023-11-13 at 11 49 44 AM](https://github.com/payloadcms/payload/assets/67977755/aac160a0-f21e-4261-b926-851e453f40ed)

After:
![Screenshot 2023-11-13 at 11 46 05 AM](https://github.com/payloadcms/payload/assets/67977755/06af15df-e245-47ba-a9d6-342b32b55665)


- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change


- [X] Chore (non-breaking change which does not add functionality)

## Checklist:

- [X] Existing test suite passes locally with my changes
