### PR TITLE
fix(templates): yarn v1 dep resolution workaround

### DIFF
--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -31,5 +31,8 @@
     "nodemon": "^2.0.6",
     "ts-node": "^9.1.1",
     "typescript": "^4.8.4"
+  },
+  "resolutions": {
+    "jackspeak": "2.1.1"
   }
 }

--- a/templates/ecommerce/package.json
+++ b/templates/ecommerce/package.json
@@ -71,5 +71,8 @@
     "slate": "0.91.4",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
+  },
+  "resolutions": {
+    "jackspeak": "2.1.1"
   }
 }

--- a/templates/website/package.json
+++ b/templates/website/package.json
@@ -68,5 +68,8 @@
     "slate": "0.91.4",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
+  },
+  "resolutions": {
+    "jackspeak": "2.1.1"
   }
 }


### PR DESCRIPTION
## Description

This is a temporary workaround for our templates for yarn v1. It adds a `resolutions` key to `package.json` which allows yarn v1 to resolve the downstream dependency properly.

Full details on the issue are in #4109.

A more comprehensive fix will likely come in the future.