### PR TITLE
fix(templates): update fetch request in populateArchiveBlock hook for postgres

### DIFF
--- a/templates/ecommerce/src/payload/hooks/populateArchiveBlock.ts
+++ b/templates/ecommerce/src/payload/hooks/populateArchiveBlock.ts
@@ -26,7 +26,7 @@ export const populateArchiveBlock: AfterReadHook = async ({ doc, req: { payload 
                     categories: {
                       in: archiveBlock?.categories
                         ?.map(cat => {
-                          if (typeof cat === 'string') return cat
+                          if (typeof cat === 'string' || typeof cat === 'number') return cat
                           return cat.id
                         })
                         .join(','),

--- a/templates/website/src/payload/hooks/populateArchiveBlock.ts
+++ b/templates/website/src/payload/hooks/populateArchiveBlock.ts
@@ -26,7 +26,7 @@ export const populateArchiveBlock: AfterReadHook = async ({ doc, req: { payload 
                     categories: {
                       in: archiveBlock.categories
                         .map(cat => {
-                          if (typeof cat === 'string') return cat
+                          if (typeof cat === 'string' || typeof cat === 'number') return cat
                           return cat.id
                         })
                         .join(','),


### PR DESCRIPTION
## Description

Closes #4122 

**Website and Ecommerce templates** - the `populateArchiveBlock` hook expects `typeof id === 'string'` but receives `number` when using Postgres.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Change to the [templates](../templates/) directory (does not affect core functionality)
