### PR TITLE
chore: corrects block name overflow in UI

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Blocks/SectionTitle/index.scss
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/SectionTitle/index.scss
@@ -2,6 +2,7 @@
 
 .section-title {
   position: relative;
+  min-width: 0;
 
   &:after {
     display: block;


### PR DESCRIPTION
## Description

Closes #4131 

Block name div had min-width 100% by default which was causing UI bugginess.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Chore (non-breaking change which does not add functionality)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works