### PR TITLE
fix(richtext-lexical): nested editor may lose focus when writing

### DIFF
--- a/test/fields/lexical.e2e.spec.ts
+++ b/test/fields/lexical.e2e.spec.ts
@@ -479,15 +479,13 @@ describe('lexical', () => {
       for (let i = 0; i < 18; i++) {
         await page.keyboard.press('ArrowRight')
       }
-      await page.keyboard.type(' inserted text')
+      await page.keyboard.type('2345')
 
       /**
        * 3. In the issue, after writing one character, the cursor focuses back into the parent editor and writes the text there.
        * This checks that this does not happen, and that it writes the text in the correct position (so, in nestedEditorParagraph, NOT in parentEditorParagraph)
        */
-      await expect(nestedEditorParagraph).toHaveText(
-        'Some text below relationship node 1 inserted text',
-      )
+      await expect(nestedEditorParagraph).toHaveText('Some text below relationship node 12345')
     })
   })
 })


### PR DESCRIPTION
## Description

Fixes #4108 

Notes on how this is fixed can be found in the code

## Notes
Notes for me:
- The issue does not happen if node.setFields is not called in BlockContent
- The issue only happens for a nested lexical editor. It does not happen for nested slate editors

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
