### PR TITLE
fix: upload fit not accounted for when editing focal point or crop

### DIFF
--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -244,6 +244,7 @@ export default async function resizeAndTransformImageSizes({
         const resizeAspectRatio = resizeWidth / resizeHeight
         const originalAspectRatio = dimensions.width / dimensions.height
         const prioritizeHeight = resizeAspectRatio < originalAspectRatio
+
         // Scale the image up or down to fit the resize dimensions
         const scaledImage = imageToResize.resize({
           height: prioritizeHeight ? resizeHeight : null,

--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -131,7 +131,7 @@ const preventResize = (
 
   const isWidthOrHeightNotDefined = !desiredHeight || !desiredWidth
   if (isWidthOrHeightNotDefined) {
-    // If with and height are not defined, it means there is a format conversion
+    // If width and height are not defined, it means there is a format conversion
     // and the image needs to be "resized" (transformed).
     return false // needs resize
   }
@@ -156,9 +156,10 @@ const preventResize = (
  * @returns true if the image should passed directly to sharp
  */
 const applyPayloadAdjustments = (
-  { height, width, withoutEnlargement, withoutReduction }: ImageSize,
+  { fit, height, width, withoutEnlargement, withoutReduction }: ImageSize,
   original: ProbedImageSize,
 ) => {
+  if (fit === 'contain' || fit === 'inside') return false
   if (!isNumber(height) && !isNumber(width)) return false
 
   const targetAspectRatio = width / height
@@ -243,7 +244,6 @@ export default async function resizeAndTransformImageSizes({
         const resizeAspectRatio = resizeWidth / resizeHeight
         const originalAspectRatio = dimensions.width / dimensions.height
         const prioritizeHeight = resizeAspectRatio < originalAspectRatio
-
         // Scale the image up or down to fit the resize dimensions
         const scaledImage = imageToResize.resize({
           height: prioritizeHeight ? resizeHeight : null,
@@ -251,6 +251,7 @@ export default async function resizeAndTransformImageSizes({
         })
         const { info: scaledImageInfo } = await scaledImage.toBuffer({ resolveWithObject: true })
 
+        console.log(scaledImageInfo)
         // Focal point adjustments
         const focalPoint = {
           x: isNumber(req.query.uploadEdits.focalPoint?.x)

--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -251,7 +251,6 @@ export default async function resizeAndTransformImageSizes({
         })
         const { info: scaledImageInfo } = await scaledImage.toBuffer({ resolveWithObject: true })
 
-        console.log(scaledImageInfo)
         // Focal point adjustments
         const focalPoint = {
           x: isNumber(req.query.uploadEdits.focalPoint?.x)

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -97,6 +97,41 @@ export default buildConfigWithDefaults({
       fields: [],
     },
     {
+      slug: 'object-fit',
+      upload: {
+        staticURL: '/object-fit',
+        staticDir: './object-fit',
+        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
+        imageSizes: [
+          {
+            name: 'fitContain',
+            width: 400,
+            height: 300,
+            fit: 'contain',
+          },
+          {
+            name: 'fitInside',
+            width: 300,
+            height: 400,
+            fit: 'inside',
+          },
+          {
+            name: 'fitCover',
+            width: 900,
+            height: 300,
+            fit: 'cover',
+          },
+          {
+            name: 'fitOutside',
+            width: 900,
+            height: 200,
+            fit: 'outside',
+          },
+        ],
+      },
+      fields: [],
+    },
+    {
       slug: 'crop-only',
       upload: {
         focalPoint: false,


### PR DESCRIPTION
## Description

Editing the crop or focal point of an image will currently cancel out the `fit` position, these adjustments should only be applied when `fit` is not `contain` or `inside`.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes