### PR TITLE
fix(richtext-lexical): remove optional chaining after `this` operator as transpilers are not handling it well

### DIFF
--- a/packages/richtext-lexical/src/field/features/Relationship/nodes/RelationshipNode.tsx
+++ b/packages/richtext-lexical/src/field/features/Relationship/nodes/RelationshipNode.tsx
@@ -142,7 +142,7 @@ export class RelationshipNode extends DecoratorBlockNode {
   }
 
   getTextContent(): string {
-    return `${this?.__data?.relationTo} relation to ${this.__data?.value?.id}`
+    return `${this.__data?.relationTo} relation to ${this.__data?.value?.id}`
   }
 
   setData(data: RelationshipData): void {


### PR DESCRIPTION
## Description

This can cause issues when doing what's described in #4003. When copying the RelationshipFeature into your project and starting it with ts-node, you will get the following error:

Uncaught ReferenceError: _this is not defined

Changing `this?. `to `this.` fixes it

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
