### PR TITLE
docs(react-hooks): update useTableColumns import

### DIFF
--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -764,7 +764,7 @@ Returns methods to set and get user preferences. More info can be found [here](h
 Returns methods to manipulate table columns
 
 ```tsx
-import { useTableColumns } from 'payload/components/utilities'
+import { useTableColumns } from 'payload/components/hooks'
 
 const MyComponent: React.FC = () => {
   // highlight-start


### PR DESCRIPTION
## Description

This PR updates the import path for the `useTableColumns` hook in the React Hooks documentation page.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] I have made corresponding changes to the documentation
