### PR TITLE
chore(examples/custom-server): next should not handle /admin/* routes

### DIFF
--- a/examples/custom-server/src/server.ts
+++ b/examples/custom-server/src/server.ts
@@ -42,7 +42,11 @@ const start = async (): Promise<void> => {
 
   const nextHandler = nextApp.getRequestHandler()
 
-  app.use((req, res) => nextHandler(req, res))
+  app.use((req, res, nxt) => {
+    if (req.url.startsWith(payload.config.routes.admin)) return nxt();
+
+    return nextHandler(req, res);
+  });
 
   nextApp.prepare().then(() => {
     payload.logger.info('Next.js started')


### PR DESCRIPTION
## Description

restrict next handler usage to only routes that are not `/admin/*`

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [x] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
