### PR TITLE
fix(richtext-lexical): incorrect caret positioning when selecting second line of multi-line paragraph

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/utils/setFloatingElemPosition.ts
+++ b/packages/richtext-lexical/src/field/lexical/utils/setFloatingElemPosition.ts
@@ -61,9 +61,15 @@ export function setFloatingElemPosition(
 
   floatingElem.style.opacity = '1'
 
-  if (specialHandlingForCaret && top == 0) {
-    top -= 46 // Especially this arbitrary number needs refactoring (this is for the caret)
+  if (specialHandlingForCaret && top == 0 /* 0 Happens when selecting 1st line */) {
+    top -= 44 // Especially this arbitrary number needs refactoring (this is for the caret)
     // rotate too
+    floatingElem.style.transform = `translate(${left}px, ${top}px) rotate(180deg)`
+  } else if (
+    specialHandlingForCaret &&
+    top === -63 /* -63 Happens when selecting 2nd line in multi-line paragraph */
+  ) {
+    top += 18 // Especially this arbitrary number needs refactoring (this is for the caret)
     floatingElem.style.transform = `translate(${left}px, ${top}px) rotate(180deg)`
   } else {
     floatingElem.style.transform = `translate(${left}px, ${top}px)`


### PR DESCRIPTION
## Description

Quick, dirty fix. Function will need refactoring in the future anyways

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
