### PR TITLE
fix(richtext-lexical): visual bug after rearranging blocks

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.tsx
@@ -56,6 +56,7 @@ function hideTargetLine(
   }
   if (lastTargetBlockElem) {
     lastTargetBlockElem.style.opacity = '1'
+    lastTargetBlockElem.style.transform = 'translate(0, 0)'
     //lastTargetBlockElem.style.border = 'none'
   }
 }


### PR DESCRIPTION
## Description

This pull request fixes a visual glitch found after rearranging blocks inside the lexical editor. Reproducible in `fields` test suite.

### Before 
![Before](https://github.com/payloadcms/payload/assets/56494343/19d2f2da-fe35-4472-8dca-3a1cffc69323)

### After
![After](https://github.com/payloadcms/payload/assets/56494343/d6472b20-1690-42d3-8d09-449bca7e054c)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
