### PR TITLE
fix(richtext-lexical): make lexicalHTML() function work for globals

### DIFF
--- a/packages/richtext-lexical/src/field/features/converters/html/field/index.ts
+++ b/packages/richtext-lexical/src/field/features/converters/html/field/index.ts
@@ -61,8 +61,10 @@ export const lexicalHTML: (
     },
     hooks: {
       afterRead: [
-        async ({ collection, field, siblingData }) => {
-          // find the path of this field, as well as its sibling fields, by looking for this `field` in collection.fields and traversing it recursively
+        async ({ collection, field, global, siblingData }) => {
+          const fields = collection ? collection.fields : global.fields
+
+          // find the path of this field, as well as its sibling fields, by looking for this `field` in fields and traversing it recursively
           function findFieldPathAndSiblingFields(
             fields: Field[],
             path: string[],
@@ -91,7 +93,7 @@ export const lexicalHTML: (
 
             return null
           }
-          const { path, siblingFields } = findFieldPathAndSiblingFields(collection.fields, [])
+          const { path, siblingFields } = findFieldPathAndSiblingFields(fields, [])
 
           const lexicalField: RichTextField<SerializedEditorState, AdapterProps> =
             siblingFields.find(


### PR DESCRIPTION
## Description

Fixes #4174 

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
