### PR TITLE
docs: fix create-payload-app example

### DIFF
--- a/packages/create-payload-app/README.md
+++ b/packages/create-payload-app/README.md
@@ -10,7 +10,7 @@ CLI for easily starting new Payload project
 
       $ npx create-payload-app
       $ npx create-payload-app my-project
-      $ npx create-payload-app -n my-project -t blog
+      $ npx create-payload-app -n my-project -t website
 
   OPTIONS
 


### PR DESCRIPTION
Replace invalid/deprecated type "blog" with valid type "website"

## Description

Example script for create-payload-app fails.

See https://github.com/payloadcms/payload/issues/4179

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works

Tested new example script on my local machine

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
