### PR TITLE
chore(richtext-lexical): Add a hint that the slash menu exists to the user

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/LexicalEditor.tsx
+++ b/packages/richtext-lexical/src/field/lexical/LexicalEditor.tsx
@@ -65,7 +65,7 @@ export const LexicalEditor: React.FC<Pick<LexicalProviderProps, 'editorConfig' |
             </div>
           </div>
         }
-        placeholder={<p className="editor-placeholder">Start typing...</p>}
+        placeholder={<p className="editor-placeholder">Start typing... press '/' to open the slash menu.</p>}
       />
       <OnChangePlugin
         // Selection changes can be ignore here, reducing the

--- a/packages/richtext-lexical/src/field/lexical/LexicalEditor.tsx
+++ b/packages/richtext-lexical/src/field/lexical/LexicalEditor.tsx
@@ -65,7 +65,7 @@ export const LexicalEditor: React.FC<Pick<LexicalProviderProps, 'editorConfig' |
             </div>
           </div>
         }
-        placeholder={<p className="editor-placeholder">Start typing... press '/' to open the slash menu.</p>}
+        placeholder={<p className="editor-placeholder">Start typing, or press '/' for commands...</p>}
       />
       <OnChangePlugin
         // Selection changes can be ignore here, reducing the


### PR DESCRIPTION
## Description

This pull request edits the lexical editor placeholder to give the user a hint that the slash menu exists.

Ideally, in the future the placeholder should be configurable so that plugins that adds a new kind of "keypress" menu would be able to tell the user the same.

I hope this can be included in the next payload patch version release <3

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
