### PR TITLE
fix(richtext-lexical): Blocks: fields without fulfilled condition are now skipped for validation

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -100,6 +100,10 @@ type Admin = {
     Field?: React.ComponentType<any>
     Filter?: React.ComponentType<any>
   }
+  /**
+   * You can programmatically show / hide fields based on what other fields are doing.
+   * This is also run on the server, to determine if the field should be validated.
+   */
   condition?: Condition
   description?: Description
   disableBulkEdit?: boolean

--- a/test/fields/collections/Lexical/blocks.ts
+++ b/test/fields/collections/Lexical/blocks.ts
@@ -2,6 +2,64 @@ import type { Block } from '../../../../packages/payload/src/fields/config/types
 
 import { lexicalEditor } from '../../../../packages/richtext-lexical/src'
 
+export const BlockColumns: any = {
+  type: 'array',
+  name: 'columns',
+  interfaceName: 'BlockColumns',
+  admin: {
+    initCollapsed: true,
+  },
+  fields: [
+    {
+      name: 'text',
+      type: 'text',
+    },
+  ],
+}
+export const ConditionalLayoutBlock: Block = {
+  fields: [
+    {
+      label: 'Layout',
+      name: 'layout',
+      type: 'select',
+      options: ['1', '2', '3'],
+      defaultValue: '1',
+      required: true,
+    },
+    {
+      ...BlockColumns,
+      admin: {
+        condition: (data, siblingData) => {
+          return ['1'].includes(siblingData.layout)
+        },
+      },
+      minRows: 1,
+      maxRows: 1,
+    },
+    {
+      ...BlockColumns,
+      admin: {
+        condition: (data, siblingData) => {
+          return ['2'].includes(siblingData.layout)
+        },
+      },
+      minRows: 2,
+      maxRows: 2,
+    },
+    {
+      ...BlockColumns,
+      admin: {
+        condition: (data, siblingData) => {
+          return ['3'].includes(siblingData.layout)
+        },
+      },
+      minRows: 3,
+      maxRows: 3,
+    },
+  ],
+  slug: 'conditionalLayout',
+}
+
 export const TextBlock: Block = {
   fields: [
     {

--- a/test/fields/collections/Lexical/generateLexicalRichText.ts
+++ b/test/fields/collections/Lexical/generateLexicalRichText.ts
@@ -235,6 +235,31 @@ export function generateLexicalRichText() {
           type: 'paragraph',
           version: 1,
         },
+        {
+          format: '',
+          type: 'block',
+          version: 2,
+          fields: {
+            id: '65588bfa80fb5a147a378e74',
+            blockName: '',
+            blockType: 'conditionalLayout',
+            layout: '1',
+            columns: [
+              {
+                id: '65588bfb80fb5a147a378e75',
+                text: 'text in conditionalLayout block',
+              },
+            ],
+          },
+        }, // Do not remove this blocks node. It ensures that validation passes when it's created
+        {
+          children: [],
+          direction: null,
+          format: '',
+          indent: 0,
+          type: 'paragraph',
+          version: 1,
+        },
       ],
       direction: 'ltr',
     },

--- a/test/fields/collections/Lexical/index.ts
+++ b/test/fields/collections/Lexical/index.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../packages/richtext-lexical/src'
 import { lexicalFieldsSlug } from '../../slugs'
 import {
+  ConditionalLayoutBlock,
   RadioButtonsBlock,
   RelationshipBlock,
   RichTextBlock,
@@ -50,6 +51,7 @@ export const LexicalFields: CollectionConfig = {
               RelationshipBlock,
               SubBlockBlock,
               RadioButtonsBlock,
+              ConditionalLayoutBlock,
             ],
           }),
         ],
@@ -102,6 +104,7 @@ export const LexicalFields: CollectionConfig = {
               RelationshipBlock,
               SubBlockBlock,
               RadioButtonsBlock,
+              ConditionalLayoutBlock,
             ],
           }),
         ],


### PR DESCRIPTION
## Description

Fixes #4000. This now matches what's done in beforeChange hook > promise.ts, where nodes where their conditions is not fulfilled are not validated

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](../templates/) directory (does not affect core functionality)
- [ ] Change to the [examples](../examples/) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
