### PR TITLE
fix: make admin navigation transition smoother

### DIFF
--- a/packages/payload/src/admin/components/elements/Nav/index.scss
+++ b/packages/payload/src/admin/components/elements/Nav/index.scss
@@ -8,7 +8,6 @@
   height: 100vh;
   width: var(--nav-width);
   border-right: 1px solid var(--theme-elevation-100);
-  overflow-x: hidden;
   opacity: 0;
   transition: opacity var(--nav-trans-time) ease-in-out;
 
@@ -140,10 +139,6 @@
     nav a {
       font-size: base(0.875);
       line-height: base(1.5);
-    }
-
-    &--nav-open {
-      width: 100%;
     }
 
     &__mobile-close {

--- a/packages/payload/src/admin/components/elements/Nav/index.scss
+++ b/packages/payload/src/admin/components/elements/Nav/index.scss
@@ -8,11 +8,12 @@
   height: 100vh;
   width: var(--nav-width);
   border-right: 1px solid var(--theme-elevation-100);
-  transform: translate3d(calc(var(--nav-width) * -1), 0, 0);
+  overflow-x: hidden;
+  opacity: 0;
+  transition: opacity var(--nav-trans-time) ease-in-out;
 
   &--nav-open {
-    transform: translate3d(0, 0, 0);
-    transition: transform var(--nav-trans-time) linear;
+    opacity: 1;
   }
 
   &__header {
@@ -142,7 +143,7 @@
     }
 
     &--nav-open {
-      transition: none;
+      width: 100%;
     }
 
     &__mobile-close {

--- a/packages/payload/src/admin/components/templates/Default/index.scss
+++ b/packages/payload/src/admin/components/templates/Default/index.scss
@@ -45,9 +45,9 @@
       display: block;
       position: absolute;
       inset: 0;
-      background-color: black;
+      background-color: inherit;
       opacity: 0;
-      z-index: 32;
+      z-index: var(--z-status);
       visibility: hidden;
       transition: all var(--nav-trans-time) linear;
     }

--- a/packages/payload/src/admin/components/templates/Default/index.scss
+++ b/packages/payload/src/admin/components/templates/Default/index.scss
@@ -2,17 +2,18 @@
 
 .template-default {
   min-height: 100vh;
-  display: flex;
+  display: grid;
   position: relative;
-  width: calc(100% + var(--nav-width));
-  transform: translate3d(calc(var(--nav-width) * -1), 0, 0);
+  grid-template-columns: 0 auto;
+  transition: grid-template-columns var(--nav-trans-time) linear;
+  isolation: isolate;
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
 
   &--nav-open {
     width: 100%;
-    transition:
-      width var(--nav-trans-time) linear,
-      transform var(--nav-trans-time) linear;
-    transform: translate3d(0, 0, 0);
+    grid-template-columns: var(--nav-width) auto;
 
     .template-default {
       &__nav-overlay {
@@ -38,6 +39,18 @@
     width: 100%;
     flex-grow: 1;
     position: relative;
+    background-color: var(--theme-bg);
+    &:before {
+      content: '';
+      display: block;
+      position: absolute;
+      inset: 0;
+      background-color: black;
+      opacity: 0;
+      z-index: 32;
+      visibility: hidden;
+      transition: all var(--nav-trans-time) linear;
+    }
   }
 
   @include mid-break {
@@ -50,7 +63,12 @@
 
   @include small-break {
     &--nav-open {
-      transition: none;
+      .template-default__wrap {
+        &:before {
+          opacity: 0.7;
+          visibility: visible;
+        }
+      }
     }
 
     &__nav-toggler-wrapper {
@@ -64,7 +82,7 @@
 
     .template-default {
       &__wrap {
-        transition: none;
+        min-width: 100vw;
       }
     }
   }


### PR DESCRIPTION
## Description

I've updated the menu navigation to make it less clunky. I added animations for both opening and closing to create a more cohesive experience. Instead of using `translate3d`, I opted for `grid-template-columns`, as I find it a more modern and effective way to animate dimensions from 0 to auto. I also included a reduced motion query selector for users who prefer to opt-out of animations. Let me know what you think about these changes.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
