### PR TITLE
fix: uploads files after validation

### DIFF
--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -171,14 +171,6 @@ async function create<TSlug extends keyof GeneratedTypes['collections']>(
     )
 
     // /////////////////////////////////////
-    // Write files to local storage
-    // /////////////////////////////////////
-
-    if (!collectionConfig.upload.disableLocalStorage) {
-      await uploadFiles(payload, filesToUpload, req.t)
-    }
-
-    // /////////////////////////////////////
     // beforeChange - Collection
     // /////////////////////////////////////
 
@@ -210,6 +202,14 @@ async function create<TSlug extends keyof GeneratedTypes['collections']>(
       req,
       skipValidation: shouldSaveDraft,
     })
+
+    // /////////////////////////////////////
+    // Write files to local storage
+    // /////////////////////////////////////
+
+    if (!collectionConfig.upload.disableLocalStorage) {
+      await uploadFiles(payload, filesToUpload, req.t)
+    }
 
     // /////////////////////////////////////
     // Create

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -195,6 +195,22 @@ describe('uploads', () => {
     expect(await audioUploadImage.getAttribute('src')).toContain(adminThumbnailSrc)
   })
 
+  test('Should detect correct mimeType', async () => {
+    await page.goto(mediaURL.create)
+    await page.setInputFiles('input[type="file"]', path.resolve(__dirname, './image.png'))
+    await saveDocAndAssert(page)
+
+    const imageID = page.url().split('/').pop()
+
+    const { doc: uploadedImage } = await client.findByID({
+      id: imageID,
+      slug: mediaSlug,
+      auth: true,
+    })
+
+    expect(uploadedImage.mimeType).toEqual('image/png')
+  })
+
   describe('image manipulation', () => {
     test('should crop image correctly', async () => {
       const positions = {


### PR DESCRIPTION
## Description

Closes #4214

Upload files were being written to local storage prior to the beforeChange hooks and field validation, as a result uploads that fail validation are still being saved. Moving the upload function to after validation fixes this issue.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
