### PR TITLE
fix: passes date options to the react-datepicker in filter UI

### DIFF
--- a/packages/payload/src/admin/components/elements/WhereBuilder/Condition/Date/index.tsx
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/Condition/Date/index.tsx
@@ -6,10 +6,14 @@ import DatePicker from '../../../DatePicker'
 
 const baseClass = 'condition-value-date'
 
-const DateField: React.FC<Props> = ({ disabled, onChange, value }) => (
-  <div className={baseClass}>
-    <DatePicker onChange={onChange} readOnly={disabled} value={value} />
-  </div>
-)
+const DateField: React.FC<Props> = ({ admin, disabled, onChange, value }) => {
+  const { date } = admin || {}
+
+  return (
+    <div className={baseClass}>
+      <DatePicker {...date} onChange={onChange} readOnly={disabled} value={value} />
+    </div>
+  )
+}
 
 export default DateField

--- a/packages/payload/src/admin/components/elements/WhereBuilder/Condition/Date/types.ts
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/Condition/Date/types.ts
@@ -1,4 +1,8 @@
+import type { Props as DateType } from '../../../../../components/elements/DatePicker/types'
 export type Props = {
+  admin?: {
+    date?: DateType
+  }
   disabled?: boolean
   onChange: () => void
   value: Date

--- a/packages/payload/src/admin/components/elements/WhereBuilder/index.tsx
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/index.tsx
@@ -27,7 +27,13 @@ const reduceFields = (fields, i18n) =>
       const operators = fieldTypes[field.type].operators.reduce((acc, operator) => {
         if (!operatorKeys.has(operator.value)) {
           operatorKeys.add(operator.value)
-          return [...acc, operator]
+          return [
+            ...acc,
+            {
+              ...operator,
+              label: i18n.t(`operators:${operator.label}`),
+            },
+          ]
         }
         return acc
       }, [])

--- a/packages/payload/src/admin/components/elements/WhereBuilder/index.tsx
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/index.tsx
@@ -23,14 +23,20 @@ const baseClass = 'where-builder'
 const reduceFields = (fields, i18n) =>
   flattenTopLevelFields(fields).reduce((reduced, field) => {
     if (typeof fieldTypes[field.type] === 'object') {
+      const operatorKeys = new Set()
+      const operators = fieldTypes[field.type].operators.reduce((acc, operator) => {
+        if (!operatorKeys.has(operator.value)) {
+          operatorKeys.add(operator.value)
+          return [...acc, operator]
+        }
+        return acc
+      }, [])
+
       const formattedField = {
         label: getTranslation(field.label || field.name, i18n),
         value: field.name,
         ...fieldTypes[field.type],
-        operators: fieldTypes[field.type].operators.map((operator) => ({
-          ...operator,
-          label: i18n.t(`operators:${operator.label}`),
-        })),
+        operators,
         props: {
           ...field,
         },


### PR DESCRIPTION
## Description

Closes #4222 

Passes date admin options to the React datepicker displayed in the filter interface.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
