### PR TITLE
fix(plugin-nested-docs): await populate breadcrumbs on resaveChildren

### DIFF
--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -32,7 +32,7 @@ const resaveChildren =
             collection: collection.slug,
             data: {
               ...child,
-              breadcrumbs: populateBreadcrumbs(req, pluginConfig, collection, child),
+              breadcrumbs: await populateBreadcrumbs(req, pluginConfig, collection, child),
             },
             depth: 0,
             draft: updateAsDraft,


### PR DESCRIPTION
## Description

fixes https://github.com/payloadcms/payload/issues/4072

This is an attempt to fix the problem, since I cannot reproduce it there isn't a way to know if this is effective. The code change is a good idea regardless.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes