### PR TITLE
fix: make outputSchema optional on richtext config

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/RichText/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/RichText/types.ts
@@ -31,7 +31,7 @@ export type RichTextAdapter<
     siblingDoc: Record<string, unknown>
   }) => Promise<void> | null
 
-  outputSchema: ({
+  outputSchema?: ({
     field,
     isRequired,
   }: {

--- a/packages/payload/src/config/schema.ts
+++ b/packages/payload/src/config/schema.ts
@@ -97,7 +97,7 @@ export default joi.object({
       CellComponent: component.required(),
       FieldComponent: component.required(),
       afterReadPromise: joi.func().optional(),
-      outputSchema: joi.func().required(),
+      outputSchema: joi.func().optional(),
       populationPromise: joi.func().optional(),
       validate: joi.func().required(),
     })

--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -434,7 +434,7 @@ export const richText = baseField.keys({
       CellComponent: componentSchema.required(),
       FieldComponent: componentSchema.required(),
       afterReadPromise: joi.func().optional(),
-      outputSchema: joi.func().required(),
+      outputSchema: joi.func().optional(),
       populationPromise: joi.func().optional(),
       validate: joi.func().required(),
     })

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -132,10 +132,20 @@ function fieldsToJSONSchema(
           }
 
           case 'richText': {
-            fieldSchema = field.editor.outputSchema({
-              field,
-              isRequired,
-            })
+            if (field.editor.outputSchema) {
+              fieldSchema = field.editor.outputSchema({
+                field,
+                isRequired,
+              })
+            } else {
+              // Maintain backwards compatibility with existing rich text editors
+              fieldSchema = {
+                items: {
+                  type: 'object',
+                },
+                type: withNullableJSONSchemaType('array', isRequired),
+              }
+            }
 
             break
           }


### PR DESCRIPTION
## Description

Make `outputSchema` optional in rich text config validation in order to be backwards compatible.