### PR TITLE
fix: number field validation

### DIFF
--- a/packages/payload/src/fields/validations.spec.ts
+++ b/packages/payload/src/fields/validations.spec.ts
@@ -413,6 +413,11 @@ describe('Field Validations', () => {
       const result = number(val, numberOptions)
       expect(result).toBe(true)
     })
+    it('should validate 0', () => {
+      const val = 0
+      const result = number(val, { ...numberOptions, required: true })
+      expect(result).toBe(true)
+    })
     it('should validate 2', () => {
       const val = 1.5
       const result = number(val, numberOptions)

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -205,8 +205,11 @@ export const number: Validate<unknown, unknown, NumberField> = (
     if (typeof lengthValidationResult === 'string') return lengthValidationResult
   }
 
-  if (!value && required) return t('validation:required')
-  if (!value && !required) return true
+  if (!value && !isNumber(value)) {
+    // if no value is present, validate based on required
+    if (required) return t('validation:required')
+    if (!required) return true
+  }
 
   const numbersToValidate: number[] = Array.isArray(value) ? value : [value]
 


### PR DESCRIPTION
## Description

Fixes issue where validating numbers such as 0 (a falsey number) would result in an incorrect validation. See comment here: https://github.com/payloadcms/payload/pull/4052#issuecomment-1821027932

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
