### PR TITLE
fix(i18n): typo in polish translations

### DIFF
--- a/packages/payload/src/translations/pl.json
+++ b/packages/payload/src/translations/pl.json
@@ -164,7 +164,7 @@
     "copied": "Skopiowano",
     "copy": "Skopiuj",
     "create": "Stwórz",
-    "createNew": "Stwórzy nowy",
+    "createNew": "Stwórz nowy",
     "createNewLabel": "Stwórz nowy {{label}}",
     "created": "Utworzono",
     "createdAt": "Data utworzenia",


### PR DESCRIPTION
## Description

I've found yet another typo in polish translations.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
