### PR TITLE
fix: duplicate documents with required localized fields

### DIFF
--- a/packages/payload/src/translations/en.json
+++ b/packages/payload/src/translations/en.json
@@ -69,6 +69,8 @@
     "invalidFileType": "Invalid file type",
     "invalidFileTypeValue": "Invalid file type: {{value}}",
     "loadingDocument": "There was a problem loading the document with ID of {{id}}.",
+    "localesNotSaved_one": "The following locale could not be saved:",
+    "localesNotSaved_other": "The following locales could not be saved:",
     "missingEmail": "Missing email.",
     "missingIDOfDocument": "Missing ID of document to update.",
     "missingIDOfVersion": "Missing ID of version.",

--- a/packages/payload/src/translations/translation-schema.json
+++ b/packages/payload/src/translations/translation-schema.json
@@ -268,6 +268,12 @@
         "loadingDocument": {
           "type": "string"
         },
+        "localesNotSaved_one": {
+          "type": "string"
+        },
+        "localesNotSaved_other": {
+          "type": "string"
+        },
         "missingEmail": {
           "type": "string"
         },
@@ -348,6 +354,8 @@
         "invalidFileType",
         "invalidFileTypeValue",
         "loadingDocument",
+        "localesNotSaved_one",
+        "localesNotSaved_other",
         "missingEmail",
         "missingIDOfDocument",
         "missingIDOfVersion",

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -223,7 +223,7 @@ describe('Localization', () => {
       await page.locator('#action-save').click()
 
       // verify that the locale did copy
-      await expect(page.locator('#field-title')).toContainText(englishTitle)
+      await expect(page.locator('#field-title')).toHaveValue(englishTitle)
       // expect that the document has a new id
       expect(page.url()).not.toStrictEqual(originalDocURL)
     })


### PR DESCRIPTION
## Description

fixes https://github.com/payloadcms/payload/issues/4232

This changes how duplicating documents handles errors when other locales are present. The current behavior was creating a document, getting a success toast, then trying to patch each additional locale, if one failed the document was supposed to be deleted entirely. Instead it was not calling delete, so you'd have two toasts, one with a success, one with the validation error and the document would be partially copied.

With this change we always try and create a document and show the first error if it exists, then for every other locale, attempt to patch every other locale and only show one error at the end which lists all the locales that had trouble. Then finally, navigate to the duplicate document.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
