### PR TITLE
fix: allow for nested block fields to be queried

### DIFF
--- a/packages/db-postgres/src/queries/getTableColumnFromPath.ts
+++ b/packages/db-postgres/src/queries/getTableColumnFromPath.ts
@@ -297,6 +297,9 @@ export const getTableColumnFromPath = ({
             table: adapter.tables[newTableName],
           }
         }
+        if (pathSegments[1] === 'blockType') {
+          throw new APIError('Querying on blockType is not supported')
+        }
         break
       }
 

--- a/packages/payload/src/database/queryValidation/validateQueryPaths.ts
+++ b/packages/payload/src/database/queryValidation/validateQueryPaths.ts
@@ -33,7 +33,11 @@ type Args = {
 const flattenWhere = (query: Where): WhereField[] =>
   Object.entries(query).reduce((flattenedConstraints, [key, val]) => {
     if ((key === 'and' || key === 'or') && Array.isArray(val)) {
-      return [...flattenedConstraints, ...val.map((subVal) => flattenWhere(subVal))]
+      const subWhereConstraints: Where[] = val.reduce((acc, subVal) => {
+        const subWhere = flattenWhere(subVal)
+        return [...acc, ...subWhere]
+      }, [])
+      return [...flattenedConstraints, ...subWhereConstraints]
     }
 
     return [...flattenedConstraints, { [key]: val }]

--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -116,10 +116,8 @@ export async function validateSearchParam({
         const segments = fieldPath.split('.')
 
         if (versionFields) {
-          if (fieldPath === 'parent' || fieldPath === 'version') {
-            fieldAccess = policies[entityType][entitySlug]
-          } else if (segments[0] === 'parent' || segments[0] === 'version') {
-            fieldAccess = policies[entityType][entitySlug]
+          fieldAccess = policies[entityType][entitySlug]
+          if (segments[0] === 'parent' || segments[0] === 'version') {
             segments.shift()
           } else {
             segments.forEach((segment, pathIndex) => {

--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -117,11 +117,25 @@ export async function validateSearchParam({
 
         if (versionFields) {
           if (fieldPath === 'parent' || fieldPath === 'version') {
-            fieldAccess = policies[entityType][entitySlug].read.permission
+            fieldAccess = policies[entityType][entitySlug]
           } else if (segments[0] === 'parent' || segments[0] === 'version') {
-            fieldAccess = policies[entityType][entitySlug].read.permission
+            fieldAccess = policies[entityType][entitySlug]
             segments.shift()
+          } else {
+            segments.forEach((segment, pathIndex) => {
+              if (fieldAccess[segment]) {
+                if (pathIndex === segments.length - 1) {
+                  fieldAccess = fieldAccess[segment]
+                } else if ('fields' in fieldAccess[segment]) {
+                  fieldAccess = fieldAccess[segment].fields
+                } else if ('blocks' in fieldAccess[segment]) {
+                  fieldAccess = fieldAccess[segment]
+                }
+              }
+            })
           }
+
+          fieldAccess = fieldAccess.read.permission
         } else {
           fieldAccess = policies[entityType][entitySlug].fields
 

--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -129,10 +129,14 @@ export async function validateSearchParam({
             fieldAccess = fieldAccess[field.name]
           } else {
             segments.forEach((segment, pathIndex) => {
-              if (pathIndex === segments.length - 1) {
-                fieldAccess = fieldAccess[segment]
-              } else {
-                fieldAccess = fieldAccess[segment].fields
+              if (fieldAccess[segment]) {
+                if (pathIndex === segments.length - 1) {
+                  fieldAccess = fieldAccess[segment]
+                } else if ('fields' in fieldAccess[segment]) {
+                  fieldAccess = fieldAccess[segment].fields
+                } else if ('blocks' in fieldAccess[segment]) {
+                  fieldAccess = fieldAccess[segment]
+                }
               }
             })
           }

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -865,11 +865,6 @@ describe('Fields', () => {
                 equals: 'green',
               },
             },
-            {
-              'blocks.blockType': {
-                equals: 'content',
-              },
-            },
           ],
         },
       })


### PR DESCRIPTION
## Description

Fixes a bug where search params were being validated, but fieldAccess was incorrectly accessing properties that do not exist for block fields and throwing an error. This safely sets field access based on the top level block in this scenario.

i.e. you attempt to query with the following:

```ts
?where[layout.someInnerField][equals]=some-text-string
```

There is no way to know the blockType to get finer grain access control within
`database/queryValidation/validateSearchParams.ts` file at this time. However we should still be able to query on the nested fields.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
