### PR TITLE
Removes incorrect information from Nested Docs Plugin documentation

### DIFF
--- a/packages/plugin-nested-docs/README.md
+++ b/packages/plugin-nested-docs/README.md
@@ -62,9 +62,7 @@ The `parent` relationship field is automatically added to every document which a
 
 #### Breadcrumbs
 
-The `breadcrumbs` field is an array which dynamically populates all parent relationships of a document up to the top level. It does not store any data in the database, and instead, acts as a `virtual` field which is dynamically populated each time the document is loaded.
-
-The `breadcrumbs` array stores the following fields:
+The `breadcrumbs` field is an array which dynamically populates all parent relationships of a document up to the top level and stores the following fields.
 
 - `label`
 


### PR DESCRIPTION
Fixes the issue outlined here https://github.com/payloadcms/payload/issues/3691

## Description

Clears this bug off the board - https://github.com/payloadcms/payload/issues/3691. Documentation was incorrect, breadcrumbs are saved to the database.

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have made corresponding changes to the documentation
