### PR TITLE
fix: mongodb multiple error rollback transaction

### DIFF
--- a/packages/db-mongodb/src/transactions/rollbackTransaction.ts
+++ b/packages/db-mongodb/src/transactions/rollbackTransaction.ts
@@ -1,23 +1,27 @@
 import type { RollbackTransaction } from 'payload/database'
 
-export const rollbackTransaction: RollbackTransaction = async function rollbackTransaction(
-  id = '',
-) {
+export const rollbackTransaction: RollbackTransaction = function rollbackTransaction(id = '') {
   // if multiple operations are using the same transaction, the first will flow through and delete the session.
   // subsequent calls should be ignored.
   if (!this.sessions[id]) {
     return
   }
 
-  // when session exists but is not inTransaction something unexpected is happening to the session
+  // when session exists but inTransaction is false, it is no longer used and can be deleted
   if (!this.sessions[id].inTransaction()) {
-    this.payload.logger.warn('rollbackTransaction called when no transaction exists')
     delete this.sessions[id]
     return
   }
 
   // the first call for rollback should be aborted and deleted causing any other operations with the same transaction to fail
-  await this.sessions[id].abortTransaction()
-  await this.sessions[id].endSession()
+  try {
+    // null coalesce needed when rollback is called multiple times with the same id synchronously
+    this.sessions?.[id].abortTransaction().then(() => {
+      // not supported by DocumentDB
+      this.sessions?.[id].endSession()
+    })
+  } catch (e) {
+    // no action needed
+  }
   delete this.sessions[id]
 }

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -151,7 +151,7 @@ export type BeginTransaction = (
   options?: Record<string, unknown>,
 ) => Promise<null | number | string>
 
-export type RollbackTransaction = (id: number | string) => Promise<void>
+export type RollbackTransaction = (id: number | string) => Promise<void> | void
 
 export type CommitTransaction = (id: number | string) => Promise<void>
 

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -161,18 +161,30 @@ describe('database', () => {
           },
           req,
         })
-
-        try {
-          await payload.create({
+        const promises = [
+          payload.create({
             collection,
             data: {
               throwAfterChange: true,
               title,
             },
             req,
-          })
-        } catch (error: unknown) {
-          // catch error and carry on
+          }),
+          // multiple documents should be able to fail without error
+          payload.create({
+            collection,
+            data: {
+              throwAfterChange: true,
+              title,
+            },
+            req,
+          }),
+        ]
+
+        try {
+          await Promise.all(promises)
+        } catch (e) {
+          // catch errors and carry on
         }
 
         expect(req.transactionID).toBeFalsy()


### PR DESCRIPTION
## Description

fixes https://github.com/payloadcms/payload/issues/4133

When one transaction is used where multiple operations error, the result is that rollbackTransaction is called more than once. If this is happening async the second call to rollbackTransaction would hang on `await sessions[id].abortTransaction()`.

This change makes it non-blocking and the function will not error when called multiple times.

PR also hs a type change to in Payload so the database interface allows the return type for rollbackTransaction to not be async.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
