### PR TITLE
fix: handling non-json event.data for live-preview

### DIFF
--- a/packages/payload/src/admin/components/views/LivePreview/Context/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Context/index.tsx
@@ -126,9 +126,13 @@ export const LivePreviewProvider: React.FC<LivePreviewProviderProps> = (props) =
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       if (url.startsWith(event.origin)) {
-        const data = JSON.parse(event.data)
+        let data
 
-        if (data.type === 'payload-live-preview' && data.ready) {
+        try {
+          data = JSON.parse(event.data)
+        } catch (e) {}
+
+        if (data && data.type === 'payload-live-preview' && data.ready) {
           setAppIsReady(true)
         }
       }


### PR DESCRIPTION
## Description

There are browser extensions that emit events with non-JSON data. This can cause errors like:

```
Uncaught SyntaxError: "[object Object]" is not valid JSON
    at JSON.parse (<anonymous>)
    at handleMessage (index.js:143:35)
```

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
