### PR TITLE
chore(richtext-lexical): add proper typing for node replacements

### DIFF
--- a/packages/richtext-lexical/src/field/features/types.ts
+++ b/packages/richtext-lexical/src/field/features/types.ts
@@ -1,6 +1,7 @@
 import type { Transformer } from '@lexical/markdown'
 import type { Klass, LexicalEditor, LexicalNode, SerializedEditorState } from 'lexical'
 import type { SerializedLexicalNode } from 'lexical'
+import type { LexicalNodeReplacement } from 'lexical'
 import type { SanitizedConfig } from 'payload/config'
 import type { PayloadRequest, RichTextField, ValidateOptions } from 'payload/types'
 import type React from 'react'
@@ -78,7 +79,7 @@ export type Feature = {
     converters?: {
       html?: HTMLConverter
     }
-    node: Klass<LexicalNode>
+    node: Klass<LexicalNode> | LexicalNodeReplacement
     populationPromises?: Array<PopulationPromise>
     type: string
     validations?: Array<NodeValidation>

--- a/packages/richtext-lexical/src/field/lexical/nodes/index.ts
+++ b/packages/richtext-lexical/src/field/lexical/nodes/index.ts
@@ -1,4 +1,5 @@
 import type { Klass, LexicalNode } from 'lexical'
+import type { LexicalNodeReplacement } from 'lexical'
 
 import type { SanitizedEditorConfig } from '../config/types'
 
@@ -6,6 +7,6 @@ export function getEnabledNodes({
   editorConfig,
 }: {
   editorConfig: SanitizedEditorConfig
-}): Array<Klass<LexicalNode>> {
+}): Array<Klass<LexicalNode> | LexicalNodeReplacement> {
   return editorConfig.features.nodes.map((node) => node.node)
 }


### PR DESCRIPTION
## Description

A node replacement like

```ts
{
    replace: TextNode,
    with: (node: TextNode) => {
      return new CustomTextNode(node?.__text)
    },
}
```

Is now accepted in the `node` property as well

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
