### PR TITLE
docs: fix broken links to public demo

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -59,7 +59,7 @@ export const Orders: CollectionConfig = {
 #### More collection config examples
 
 You can find an assortment
-of [example collection configs](https://github.com/payloadcms/public-demo/tree/master/src/collections) in the Public
+of [example collection configs](https://github.com/payloadcms/public-demo/tree/master/src/payload/collections) in the Public
 Demo source code on GitHub.
 
 ### Admin options

--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -59,7 +59,7 @@ export default Nav
 
 #### Global config example
 
-You can find an [example Global config](https://github.com/payloadcms/public-demo/blob/master/src/globals/MainMenu.ts) in the Public Demo source code on GitHub.
+You can find an [example Global config](https://github.com/payloadcms/public-demo/blob/master/src/payload/globals/MainMenu.ts) in the Public Demo source code on GitHub.
 
 ### Admin options
 


### PR DESCRIPTION
## Description

There are deprecated links in the documentation. This PR fixes those.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [X] I have made corresponding changes to the documentation

I have not completed the above checklist, as I think that all of the checklist items are not needed for this PR.