### PR TITLE
chore: horizontal overflow of list table on desktop

### DIFF
--- a/packages/payload/src/admin/components/views/collections/List/index.scss
+++ b/packages/payload/src/admin/components/views/collections/List/index.scss
@@ -39,11 +39,28 @@
   }
 
   .table {
+    // extend the table all the way to the viewport edges
+    // this is to visually indicate overflowing content
+    display: flex;
+    width: calc(100% + calc(var(--gutter-h) * 2));
+    max-width: unset;
+    left: calc(var(--gutter-h) * -1);
+    position: relative;
+    padding-left: var(--gutter-h);
+
+    &::after {
+      content: '';
+      height: 1px;
+      padding-right: var(--gutter-h);
+    }
+
     table {
       width: 100%;
       overflow: auto;
 
-      [class^="cell"] > p, [class^="cell"] > span, [class^="cell"] > a {
+      [class^='cell'] > p,
+      [class^='cell'] > span,
+      [class^='cell'] > a {
         line-clamp: 4;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 4;
@@ -147,23 +164,6 @@
 
     &__search-input {
       margin: 0;
-    }
-
-    // on mobile, extend the table all the way to the viewport edges
-    // this is to visually indicate overflowing content
-    .table {
-      display: flex;
-      width: calc(100% + calc(var(--gutter-h) * 2));
-      max-width: unset;
-      left: calc(var(--gutter-h) * -1);
-      position: relative;
-      padding-left: var(--gutter-h);
-
-      &::after {
-        content: '';
-        height: 1px;
-        padding-right: var(--gutter-h);
-      }
     }
 
     &__page-controls {


### PR DESCRIPTION
## Description

Follows up with #4262 by adjusting the horizontal overflow of the list table on desktop to match the behavior of mobile.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore

## Checklist:

- [x] Existing test suite passes locally with my changes
