### PR TITLE
fix(templates): uses context to prevent infinite loop in populateArchiveBlock

### DIFF
--- a/templates/ecommerce/src/payload/hooks/populateArchiveBlock.ts
+++ b/templates/ecommerce/src/payload/hooks/populateArchiveBlock.ts
@@ -2,7 +2,7 @@ import type { AfterReadHook } from 'payload/dist/collections/config/types'
 
 import type { Page, Product } from '../payload-types'
 
-export const populateArchiveBlock: AfterReadHook = async ({ doc, req: { payload } }) => {
+export const populateArchiveBlock: AfterReadHook = async ({ doc, context, req: { payload } }) => {
   // pre-populate the archive block if `populateBy` is `collection`
   // then hydrate it on your front-end
 
@@ -16,10 +16,13 @@ export const populateArchiveBlock: AfterReadHook = async ({ doc, req: { payload 
           }>
         }
 
-        if (archiveBlock.populateBy === 'collection') {
+        if (archiveBlock.populateBy === 'collection' && !context.isPopulatingArchiveBlock) {
           const res: { totalDocs: number; docs: Product[] } = await payload.find({
             collection: archiveBlock?.relationTo || 'products',
             limit: archiveBlock.limit || 10,
+            context: {
+              isPopulatingArchiveBlock: true,
+            },
             where: {
               ...((archiveBlock?.categories?.length || 0) > 0
                 ? {

--- a/templates/website/src/payload/hooks/populateArchiveBlock.ts
+++ b/templates/website/src/payload/hooks/populateArchiveBlock.ts
@@ -2,7 +2,7 @@ import type { AfterReadHook } from 'payload/dist/collections/config/types'
 
 import type { Page, Post } from '../payload-types'
 
-export const populateArchiveBlock: AfterReadHook = async ({ doc, req: { payload } }) => {
+export const populateArchiveBlock: AfterReadHook = async ({ doc, context, req: { payload } }) => {
   // pre-populate the archive block if `populateBy` is `collection`
   // then hydrate it on your front-end
 
@@ -16,10 +16,13 @@ export const populateArchiveBlock: AfterReadHook = async ({ doc, req: { payload 
           }>
         }
 
-        if (archiveBlock.populateBy === 'collection') {
+        if (archiveBlock.populateBy === 'collection' && !context.isPopulatingArchiveBlock) {
           const res: { totalDocs: number; docs: Post[] } = await payload.find({
             collection: archiveBlock.relationTo,
             limit: archiveBlock.limit || 10,
+            context: {
+              isPopulatingArchiveBlock: true,
+            },
             where: {
               ...(archiveBlock?.categories?.length > 0
                 ? {


### PR DESCRIPTION
## Description

Adds an `isPopulatingArchiveBlock` context flag to `populateArchiveBlock` hook to prevent infinite loop when a document with an archive block references itself.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)