### PR TITLE
feat: useDocumentEvents

### DIFF
--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -788,7 +788,7 @@ const MyComponent: React.FC = () => {
 
 ### useDocumentEvents
 
-The `useDocumentEvents` hook provides a way of subscribing to cross-document events, such as updates made to nested documents within a drawer. It will report the document events outside of the document being currently edited. This hook provides the following:
+The `useDocumentEvents` hook provides a way of subscribing to cross-document events, such as updates made to nested documents within a drawer. This hook will report document events that are outside the scope of the document currently being edited. This hook provides the following:
 
 | Property                  | Description                                                                                                                               |
 |---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -784,3 +784,31 @@ const MyComponent: React.FC = () => {
     </button>
   )
 }
+```
+
+### useDocumentEvents
+
+The `useDocumentEvents` hook provides a way of subscribing to cross-document events. For example, if you are using `useAllFormFields` to listen for updates in your document, then you update a nested document from within a drawer, the form state would only ever contain document ids. This hook provides the following:
+
+| Property                  | Description                                                                                                                 |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| **`updates`**             | An array of documents which have been updated. Each item is an object containing a `relationTo` and `id` property (if a collection)                                                      |
+| **`reportUpdates`**       | A method to report updates to the context. It accepts an array objects with the `relationTo` and `id` (if a collection)     |
+
+**Example:**
+
+```tsx
+import { useDocumentEvents } from 'payload/components/utilities'
+
+const ListenForNestedUpdates: React.FC = () => {
+  const { updates } = useDocumentEvents()
+
+  useEffect(() => {
+    if (updates && updates.length) {
+      // Do something with the updates
+    }
+  }, [updates])
+
+  return <span>{JSON.stringify(updates, null, 2)}</span>
+}
+```

--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -788,27 +788,29 @@ const MyComponent: React.FC = () => {
 
 ### useDocumentEvents
 
-The `useDocumentEvents` hook provides a way of subscribing to cross-document events. For example, if you are using `useAllFormFields` to listen for updates in your document, then you update a nested document from within a drawer, the form state would only ever contain document ids. This hook provides the following:
+The `useDocumentEvents` hook provides a way of subscribing to cross-document events, such as updates made to nested documents within a drawer. It will report the document events outside of the document being currently edited. This hook provides the following:
 
-| Property                  | Description                                                                                                                 |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| **`updates`**             | An array of documents which have been updated. Each item is an object containing a `relationTo` and `id` property (if a collection)                                                      |
-| **`reportUpdates`**       | A method to report updates to the context. It accepts an array objects with the `relationTo` and `id` (if a collection)     |
+| Property                  | Description                                                                                                                               |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| **`mostRecentUpdate`**    | An object containing the most recently updated document. It contains the `entitySlug`, `id` (if collection), and `updatedAt` properties   |
+| **`reportUpdate`**        | A method used to report updates to documents. It accepts the same arguments as the `mostRecentUpdate` property.                           |
 
 **Example:**
 
 ```tsx
 import { useDocumentEvents } from 'payload/components/utilities'
 
-const ListenForNestedUpdates: React.FC = () => {
-  const { updates } = useDocumentEvents()
+const ListenForUpdates: React.FC = () => {
+  const { mostRecentUpdate } = useDocumentEvents()
 
-  useEffect(() => {
-    if (updates && updates.length) {
-      // Do something with the updates
-    }
-  }, [updates])
-
-  return <span>{JSON.stringify(updates, null, 2)}</span>
+  return (
+    <span>
+      {JSON.stringify(mostRecentUpdate)}
+    </span>
+  )
 }
 ```
+
+<Banner type="info">
+  Right now the `useDocumentEvents` hook only tracks recently updated documents, but in the future it will track more document-related events as needed, such as document creation, deletion, etc.
+</Banner>

--- a/packages/payload/src/admin/Root.tsx
+++ b/packages/payload/src/admin/Root.tsx
@@ -17,6 +17,7 @@ import { StepNavProvider } from './components/elements/StepNav'
 import { AuthProvider } from './components/utilities/Auth'
 import { ConfigProvider } from './components/utilities/Config'
 import { CustomProvider } from './components/utilities/CustomProvider'
+import { DocumentEventsProvider } from './components/utilities/DocumentEvents'
 import { I18n } from './components/utilities/I18n'
 import { LoadingOverlayProvider } from './components/utilities/LoadingOverlay'
 import { LocaleProvider } from './components/utilities/Locale'
@@ -49,11 +50,13 @@ const Root = ({ config: incomingConfig }: { config?: SanitizedConfig }) => {
                         <LocaleProvider>
                           <StepNavProvider>
                             <LoadingOverlayProvider>
-                              <NavProvider>
-                                <CustomProvider>
-                                  <Routes />
-                                </CustomProvider>
-                              </NavProvider>
+                              <DocumentEventsProvider>
+                                <NavProvider>
+                                  <CustomProvider>
+                                    <Routes />
+                                  </CustomProvider>
+                                </NavProvider>
+                              </DocumentEventsProvider>
                             </LoadingOverlayProvider>
                           </StepNavProvider>
                         </LocaleProvider>

--- a/packages/payload/src/admin/components/utilities/DocumentEvents/index.tsx
+++ b/packages/payload/src/admin/components/utilities/DocumentEvents/index.tsx
@@ -2,16 +2,15 @@ import React, { createContext, useContext, useState } from 'react'
 
 import type { UpdatedDocument } from './types'
 
-import { type DocumentEventsContext } from './types'
-
 const Context = createContext({
-  updates: null,
-} as DocumentEventsContext)
+  mostRecentUpdate: null,
+  reportUpdate: (doc: UpdatedDocument) => null, // eslint-disable-line @typescript-eslint/no-unused-vars
+})
 
 export const DocumentEventsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [updates, reportUpdate] = useState<Array<UpdatedDocument>>([])
+  const [mostRecentUpdate, reportUpdate] = useState<UpdatedDocument>(null)
 
-  return <Context.Provider value={{ reportUpdate, updates }}>{children}</Context.Provider>
+  return <Context.Provider value={{ mostRecentUpdate, reportUpdate }}>{children}</Context.Provider>
 }
 
 export const useDocumentEvents = () => useContext(Context)

--- a/packages/payload/src/admin/components/utilities/DocumentEvents/index.tsx
+++ b/packages/payload/src/admin/components/utilities/DocumentEvents/index.tsx
@@ -1,0 +1,17 @@
+import React, { createContext, useContext, useState } from 'react'
+
+import type { UpdatedDocument } from './types'
+
+import { type DocumentEventsContext } from './types'
+
+const Context = createContext({
+  updates: null,
+} as DocumentEventsContext)
+
+export const DocumentEventsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [updates, reportUpdate] = useState<Array<UpdatedDocument>>([])
+
+  return <Context.Provider value={{ reportUpdate, updates }}>{children}</Context.Provider>
+}
+
+export const useDocumentEvents = () => useContext(Context)

--- a/packages/payload/src/admin/components/utilities/DocumentEvents/types.ts
+++ b/packages/payload/src/admin/components/utilities/DocumentEvents/types.ts
@@ -1,0 +1,9 @@
+export type UpdatedDocument = {
+  id?: string
+  relationTo: string
+}
+
+export type DocumentEventsContext = {
+  reportUpdate: (updatedDocument: Array<UpdatedDocument>) => void
+  updates: Array<UpdatedDocument>
+}

--- a/packages/payload/src/admin/components/utilities/DocumentEvents/types.ts
+++ b/packages/payload/src/admin/components/utilities/DocumentEvents/types.ts
@@ -1,9 +1,10 @@
 export type UpdatedDocument = {
+  entitySlug: string
   id?: string
-  relationTo: string
+  updatedAt: string
 }
 
 export type DocumentEventsContext = {
+  mostRecentUpdate: UpdatedDocument
   reportUpdate: (updatedDocument: Array<UpdatedDocument>) => void
-  updates: Array<UpdatedDocument>
 }

--- a/packages/payload/src/admin/components/views/Global/index.tsx
+++ b/packages/payload/src/admin/components/views/Global/index.tsx
@@ -11,6 +11,7 @@ import buildStateFromSchema from '../../forms/Form/buildStateFromSchema'
 import { fieldTypes } from '../../forms/field-types'
 import { useAuth } from '../../utilities/Auth'
 import { useConfig } from '../../utilities/Config'
+import { useDocumentEvents } from '../../utilities/DocumentEvents'
 import { useDocumentInfo } from '../../utilities/DocumentInfo'
 import { EditDepthContext } from '../../utilities/EditDepth'
 import { useLocale } from '../../utilities/Locale'
@@ -37,10 +38,18 @@ const GlobalView: React.FC<IndexProps> = (props) => {
     serverURL,
   } = useConfig()
 
+  const { reportUpdate } = useDocumentEvents()
+
   const { admin: { components: { views: { Edit: Edit } = {} } = {} } = {}, fields, slug } = global
 
   const onSave = useCallback(
     async (json) => {
+      reportUpdate([
+        {
+          relationTo: global.slug,
+        },
+      ])
+
       getVersions()
       getDocPermissions()
       setUpdatedAt(json?.result?.updatedAt)
@@ -59,7 +68,18 @@ const GlobalView: React.FC<IndexProps> = (props) => {
       })
       setInitialState(state)
     },
-    [getVersions, fields, user, locale, t, getDocPermissions, getDocPreferences, config],
+    [
+      getVersions,
+      fields,
+      user,
+      locale,
+      t,
+      getDocPermissions,
+      getDocPreferences,
+      config,
+      global,
+      reportUpdate,
+    ],
   )
 
   const [{ data, isLoading: isLoadingData }] = usePayloadAPI(`${serverURL}${api}/globals/${slug}`, {

--- a/packages/payload/src/admin/components/views/Global/index.tsx
+++ b/packages/payload/src/admin/components/views/Global/index.tsx
@@ -44,11 +44,10 @@ const GlobalView: React.FC<IndexProps> = (props) => {
 
   const onSave = useCallback(
     async (json) => {
-      reportUpdate([
-        {
-          relationTo: global.slug,
-        },
-      ])
+      reportUpdate({
+        entitySlug: global.slug,
+        updatedAt: json?.result?.updatedAt || new Date().toISOString(),
+      })
 
       getVersions()
       getDocPermissions()

--- a/packages/payload/src/admin/components/views/collections/Edit/Default.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default.tsx
@@ -51,13 +51,11 @@ const DefaultEditView: React.FC<DefaultEditViewProps> = (props) => {
 
   const onSave = useCallback(
     async (json) => {
-      reportUpdate([
-        {
-          id,
-          relationTo: collection.slug,
-        },
-      ])
-
+      reportUpdate({
+        id,
+        entitySlug: collection.slug,
+        updatedAt: json?.result?.updatedAt || new Date().toISOString(),
+      })
       if (auth && id === user.id) {
         await refreshCookieAsync()
       }

--- a/packages/payload/src/admin/components/views/collections/Edit/Default.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default.tsx
@@ -9,6 +9,7 @@ import { DocumentHeader } from '../../../elements/DocumentHeader'
 import { FormLoadingOverlayToggle } from '../../../elements/Loading'
 import Form from '../../../forms/Form'
 import { useAuth } from '../../../utilities/Auth'
+import { useDocumentEvents } from '../../../utilities/DocumentEvents'
 import { OperationContext } from '../../../utilities/OperationProvider'
 import { CollectionRoutes } from './Routes'
 import { CustomCollectionComponent } from './Routes/CustomComponent'
@@ -42,12 +43,21 @@ const DefaultEditView: React.FC<DefaultEditViewProps> = (props) => {
     onSave: onSaveFromProps,
   } = props
 
+  const { reportUpdate } = useDocumentEvents()
+
   const { auth } = collection
 
   const classes = [baseClass, isEditing && `${baseClass}--is-editing`].filter(Boolean).join(' ')
 
   const onSave = useCallback(
     async (json) => {
+      reportUpdate([
+        {
+          id,
+          relationTo: collection.slug,
+        },
+      ])
+
       if (auth && id === user.id) {
         await refreshCookieAsync()
       }
@@ -59,7 +69,7 @@ const DefaultEditView: React.FC<DefaultEditViewProps> = (props) => {
         })
       }
     },
-    [id, onSaveFromProps, auth, user, refreshCookieAsync],
+    [id, onSaveFromProps, auth, user, refreshCookieAsync, collection, reportUpdate],
   )
 
   const operation = isEditing ? 'update' : 'create'


### PR DESCRIPTION
## Description

Builds a new `DocumentEvents` context to provide a way of subscribing to cross-document events, such as updates made to nested documents within a drawer. The `useDocumentEvents` hook will report events that are outside the scope of the document being currently edited.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
