### PR TITLE
chore(db-postgres): add uuid to dependencies

### DIFF
--- a/packages/db-postgres/package.json
+++ b/packages/db-postgres/package.json
@@ -26,7 +26,8 @@
     "drizzle-orm": "0.28.5",
     "pg": "8.11.3",
     "prompts": "2.4.2",
-    "to-snake-case": "1.0.0"
+    "to-snake-case": "1.0.0",
+    "uuid": "9.0.0"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,6 +490,9 @@ importers:
       to-snake-case:
         specifier: 1.0.0
         version: 1.0.0
+      uuid:
+        specifier: 9.0.0
+        version: 9.0.0
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## Description

The `uuid` package was missing from the dependencies of the postgres adapter.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes