### PR TITLE
fix(live-preview): re-populates externally updated relationships

### DIFF
--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -39,10 +39,10 @@ export const handleMessage = async <T>(args: {
       const mergedData = await mergeData<T>({
         apiRoute,
         depth,
+        externallyUpdatedRelationship: eventData.externallyUpdatedRelationship,
         fieldSchema: payloadLivePreviewFieldSchema,
         incomingData: eventData.data,
         initialData: payloadLivePreviewPreviousData || initialData,
-        mostRecentUpdate: eventData.mostRecentUpdate,
         serverURL,
       })
 

--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -42,6 +42,7 @@ export const handleMessage = async <T>(args: {
         fieldSchema: payloadLivePreviewFieldSchema,
         incomingData: eventData.data,
         initialData: payloadLivePreviewPreviousData || initialData,
+        mostRecentUpdate: eventData.mostRecentUpdate,
         serverURL,
       })
 

--- a/packages/live-preview/src/mergeData.ts
+++ b/packages/live-preview/src/mergeData.ts
@@ -1,7 +1,7 @@
 import type { PaginatedDocs } from 'payload/database'
 import type { fieldSchemaToJSON } from 'payload/utilities'
 
-import type { PopulationsByCollection } from './types'
+import type { PopulationsByCollection, RecentUpdate } from './types'
 
 import { traverseFields } from './traverseFields'
 
@@ -11,6 +11,7 @@ export const mergeData = async <T>(args: {
   fieldSchema: ReturnType<typeof fieldSchemaToJSON>
   incomingData: Partial<T>
   initialData: T
+  mostRecentUpdate?: RecentUpdate
   returnNumberOfRequests?: boolean
   serverURL: string
 }): Promise<
@@ -24,6 +25,7 @@ export const mergeData = async <T>(args: {
     fieldSchema,
     incomingData,
     initialData,
+    mostRecentUpdate,
     returnNumberOfRequests,
     serverURL,
   } = args
@@ -35,6 +37,7 @@ export const mergeData = async <T>(args: {
   traverseFields({
     fieldSchema,
     incomingData,
+    mostRecentUpdate,
     populationsByCollection,
     result,
   })

--- a/packages/live-preview/src/mergeData.ts
+++ b/packages/live-preview/src/mergeData.ts
@@ -8,10 +8,10 @@ import { traverseFields } from './traverseFields'
 export const mergeData = async <T>(args: {
   apiRoute?: string
   depth?: number
+  externallyUpdatedRelationship?: RecentUpdate
   fieldSchema: ReturnType<typeof fieldSchemaToJSON>
   incomingData: Partial<T>
   initialData: T
-  mostRecentUpdate?: RecentUpdate
   returnNumberOfRequests?: boolean
   serverURL: string
 }): Promise<
@@ -22,10 +22,10 @@ export const mergeData = async <T>(args: {
   const {
     apiRoute,
     depth,
+    externallyUpdatedRelationship,
     fieldSchema,
     incomingData,
     initialData,
-    mostRecentUpdate,
     returnNumberOfRequests,
     serverURL,
   } = args
@@ -35,9 +35,9 @@ export const mergeData = async <T>(args: {
   const populationsByCollection: PopulationsByCollection = {}
 
   traverseFields({
+    externallyUpdatedRelationship,
     fieldSchema,
     incomingData,
-    mostRecentUpdate,
     populationsByCollection,
     result,
   })

--- a/packages/live-preview/src/traverseFields.ts
+++ b/packages/live-preview/src/traverseFields.ts
@@ -5,16 +5,16 @@ import type { PopulationsByCollection, RecentUpdate } from './types'
 import { traverseRichText } from './traverseRichText'
 
 export const traverseFields = <T>(args: {
+  externallyUpdatedRelationship?: RecentUpdate
   fieldSchema: ReturnType<typeof fieldSchemaToJSON>
   incomingData: T
-  mostRecentUpdate?: RecentUpdate
   populationsByCollection: PopulationsByCollection
   result: T
 }): void => {
   const {
+    externallyUpdatedRelationship,
     fieldSchema: fieldSchemas,
     incomingData,
-    mostRecentUpdate,
     populationsByCollection,
     result,
   } = args
@@ -26,8 +26,8 @@ export const traverseFields = <T>(args: {
       switch (fieldSchema.type) {
         case 'richText':
           result[fieldName] = traverseRichText({
+            externallyUpdatedRelationship,
             incomingData: incomingData[fieldName],
-            mostRecentUpdate,
             populationsByCollection,
             result: result[fieldName],
           })
@@ -46,9 +46,9 @@ export const traverseFields = <T>(args: {
               }
 
               traverseFields({
+                externallyUpdatedRelationship,
                 fieldSchema: fieldSchema.fields,
                 incomingData: incomingRow,
-                mostRecentUpdate,
                 populationsByCollection,
                 result: result[fieldName][i],
               })
@@ -79,9 +79,9 @@ export const traverseFields = <T>(args: {
               }
 
               traverseFields({
+                externallyUpdatedRelationship,
                 fieldSchema: incomingBlockJSON.fields,
                 incomingData: incomingBlock,
-                mostRecentUpdate,
                 populationsByCollection,
                 result: result[fieldName][i],
               })
@@ -101,9 +101,9 @@ export const traverseFields = <T>(args: {
           }
 
           traverseFields({
+            externallyUpdatedRelationship,
             fieldSchema: fieldSchema.fields,
             incomingData: incomingData[fieldName] || {},
-            mostRecentUpdate,
             populationsByCollection,
             result: result[fieldName],
           })
@@ -136,7 +136,8 @@ export const traverseFields = <T>(args: {
 
                 const hasChanged = newID !== oldID || newRelation !== oldRelation
                 const hasUpdated =
-                  newRelation === mostRecentUpdate?.entitySlug && newID === mostRecentUpdate?.id
+                  newRelation === externallyUpdatedRelationship?.entitySlug &&
+                  newID === externallyUpdatedRelationship?.id
 
                 if (hasChanged || hasUpdated) {
                   if (!populationsByCollection[newRelation]) {
@@ -153,8 +154,8 @@ export const traverseFields = <T>(args: {
                 // Handle `hasMany` monomorphic
                 const hasChanged = incomingRelation !== result[fieldName][i]?.id
                 const hasUpdated =
-                  fieldSchema.relationTo === mostRecentUpdate?.entitySlug &&
-                  incomingRelation === mostRecentUpdate?.id
+                  fieldSchema.relationTo === externallyUpdatedRelationship?.entitySlug &&
+                  incomingRelation === externallyUpdatedRelationship?.id
 
                 if (hasChanged || hasUpdated) {
                   if (!populationsByCollection[fieldSchema.relationTo]) {
@@ -207,7 +208,8 @@ export const traverseFields = <T>(args: {
 
               const hasChanged = newID !== oldID || newRelation !== oldRelation
               const hasUpdated =
-                newRelation === mostRecentUpdate?.entitySlug && newID === mostRecentUpdate?.id
+                newRelation === externallyUpdatedRelationship?.entitySlug &&
+                newID === externallyUpdatedRelationship?.id
 
               // if the new value/relation is different from the old value/relation
               // populate the new value, otherwise leave it alone
@@ -244,8 +246,8 @@ export const traverseFields = <T>(args: {
 
               const hasChanged = newID !== oldID
               const hasUpdated =
-                fieldSchema.relationTo === mostRecentUpdate?.entitySlug &&
-                newID === mostRecentUpdate?.id
+                fieldSchema.relationTo === externallyUpdatedRelationship?.entitySlug &&
+                newID === externallyUpdatedRelationship?.id
 
               // if the new value is different from the old value
               // populate the new value, otherwise leave it alone

--- a/packages/live-preview/src/traverseRichText.ts
+++ b/packages/live-preview/src/traverseRichText.ts
@@ -1,11 +1,13 @@
-import type { PopulationsByCollection } from './types'
+import type { PopulationsByCollection, RecentUpdate } from './types'
 
 export const traverseRichText = ({
   incomingData,
+  mostRecentUpdate,
   populationsByCollection,
   result,
 }: {
   incomingData: any
+  mostRecentUpdate?: RecentUpdate
   populationsByCollection: PopulationsByCollection
   result: any
 }): any => {
@@ -21,6 +23,7 @@ export const traverseRichText = ({
 
       return traverseRichText({
         incomingData: item,
+        mostRecentUpdate,
         populationsByCollection,
         result: result[index],
       })
@@ -57,8 +60,10 @@ export const traverseRichText = ({
 
       if (isRelationship) {
         const needsPopulation = !result.value || typeof result.value !== 'object'
+        const hasChanged =
+          result && typeof result === 'object' && result.value.id === mostRecentUpdate?.id
 
-        if (needsPopulation) {
+        if (needsPopulation || hasChanged) {
           if (!populationsByCollection[incomingData.relationTo]) {
             populationsByCollection[incomingData.relationTo] = []
           }
@@ -72,6 +77,7 @@ export const traverseRichText = ({
       } else {
         result[key] = traverseRichText({
           incomingData: incomingData[key],
+          mostRecentUpdate,
           populationsByCollection,
           result: result[key],
         })

--- a/packages/live-preview/src/traverseRichText.ts
+++ b/packages/live-preview/src/traverseRichText.ts
@@ -1,13 +1,13 @@
 import type { PopulationsByCollection, RecentUpdate } from './types'
 
 export const traverseRichText = ({
+  externallyUpdatedRelationship,
   incomingData,
-  mostRecentUpdate,
   populationsByCollection,
   result,
 }: {
+  externallyUpdatedRelationship?: RecentUpdate
   incomingData: any
-  mostRecentUpdate?: RecentUpdate
   populationsByCollection: PopulationsByCollection
   result: any
 }): any => {
@@ -22,8 +22,8 @@ export const traverseRichText = ({
       }
 
       return traverseRichText({
+        externallyUpdatedRelationship,
         incomingData: item,
-        mostRecentUpdate,
         populationsByCollection,
         result: result[index],
       })
@@ -61,7 +61,9 @@ export const traverseRichText = ({
       if (isRelationship) {
         const needsPopulation = !result.value || typeof result.value !== 'object'
         const hasChanged =
-          result && typeof result === 'object' && result.value.id === mostRecentUpdate?.id
+          result &&
+          typeof result === 'object' &&
+          result.value.id === externallyUpdatedRelationship?.id
 
         if (needsPopulation || hasChanged) {
           if (!populationsByCollection[incomingData.relationTo]) {
@@ -76,8 +78,8 @@ export const traverseRichText = ({
         }
       } else {
         result[key] = traverseRichText({
+          externallyUpdatedRelationship,
           incomingData: incomingData[key],
-          mostRecentUpdate,
           populationsByCollection,
           result: result[key],
         })

--- a/packages/live-preview/src/types.ts
+++ b/packages/live-preview/src/types.ts
@@ -9,3 +9,10 @@ export type PopulationsByCollection = {
     ref: Record<string, unknown>
   }>
 }
+
+// TODO: import this from `payload/utilities`
+export type RecentUpdate = {
+  entitySlug: string
+  id?: string
+  updatedAt: string
+}

--- a/packages/payload/src/admin/components/views/LivePreview/Preview/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Preview/index.tsx
@@ -4,6 +4,7 @@ import type { EditViewProps } from '../../types'
 
 import { useAllFormFields } from '../../../forms/Form/context'
 import reduceFieldsToValues from '../../../forms/Form/reduceFieldsToValues'
+import { useDocumentEvents } from '../../../utilities/DocumentEvents'
 import { useLivePreviewContext } from '../Context/context'
 import { DeviceContainer } from '../Device'
 import { IFrame } from '../IFrame'
@@ -22,6 +23,8 @@ export const LivePreview: React.FC<EditViewProps> = (props) => {
     setIframeHasLoaded,
     url,
   } = useLivePreviewContext()
+
+  const { mostRecentUpdate } = useDocumentEvents()
 
   const { breakpoint, fieldSchemaJSON } = useLivePreviewContext()
 
@@ -50,6 +53,7 @@ export const LivePreview: React.FC<EditViewProps> = (props) => {
       const message = JSON.stringify({
         data: values,
         fieldSchemaJSON: shouldSendSchema ? fieldSchemaJSON : undefined,
+        mostRecentUpdate,
         type: 'payload-live-preview',
       })
 
@@ -73,6 +77,7 @@ export const LivePreview: React.FC<EditViewProps> = (props) => {
     iframeRef,
     setIframeHasLoaded,
     fieldSchemaJSON,
+    mostRecentUpdate,
   ])
 
   if (previewWindowType === 'iframe') {

--- a/packages/payload/src/admin/components/views/LivePreview/Preview/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Preview/index.tsx
@@ -52,8 +52,8 @@ export const LivePreview: React.FC<EditViewProps> = (props) => {
 
       const message = JSON.stringify({
         data: values,
+        externallyUpdatedRelationship: mostRecentUpdate,
         fieldSchemaJSON: shouldSendSchema ? fieldSchemaJSON : undefined,
-        mostRecentUpdate,
         type: 'payload-live-preview',
       })
 

--- a/test/live-preview/int.spec.ts
+++ b/test/live-preview/int.spec.ts
@@ -586,7 +586,7 @@ describe('Collections - Live Preview', () => {
     expect(merge2._numberOfRequests).toEqual(1)
   })
 
-  it('— relationships - populates updated relationships whose IDs have not changed', async () => {
+  it('— relationships - re-populates externally updated relationships', async () => {
     const initialData: Partial<Page> = {
       title: 'Test Page',
     }
@@ -629,13 +629,13 @@ describe('Collections - Live Preview', () => {
       },
     })
 
-    const mostRecentUpdate = {
+    const externallyUpdatedRelationship = {
       id: updatedTestPost.id.toString(), // TODO: don't cast to string once the types are fixed
       entitySlug: postsSlug,
       updatedAt: updatedTestPost.updatedAt as string,
     }
 
-    // Merge again using the `mostRecentUpdate` argument
+    // Merge again using the `externallyUpdatedRelationship` argument
     const merge2 = await mergeData({
       depth: 1,
       fieldSchema: schemaJSON,
@@ -647,7 +647,7 @@ describe('Collections - Live Preview', () => {
         relationshipPolyHasMany: [{ value: testPost.id, relationTo: postsSlug }],
       },
       initialData: merge1,
-      mostRecentUpdate,
+      externallyUpdatedRelationship,
       serverURL,
       returnNumberOfRequests: true,
     })

--- a/test/live-preview/int.spec.ts
+++ b/test/live-preview/int.spec.ts
@@ -586,11 +586,89 @@ describe('Collections - Live Preview', () => {
     expect(merge2._numberOfRequests).toEqual(1)
   })
 
+  it('— relationships - populates updated relationships whose IDs have not changed', async () => {
+    const initialData: Partial<Page> = {
+      title: 'Test Page',
+    }
+
+    // Populate the relationships
+    const merge1 = await mergeData({
+      depth: 1,
+      fieldSchema: schemaJSON,
+      incomingData: {
+        title: 'Test Page',
+        relationshipMonoHasOne: testPost.id,
+        relationshipMonoHasMany: [testPost.id],
+        relationshipPolyHasOne: { value: testPost.id, relationTo: postsSlug },
+        relationshipPolyHasMany: [{ value: testPost.id, relationTo: postsSlug }],
+      },
+      initialData,
+      serverURL,
+      returnNumberOfRequests: true,
+    })
+
+    expect(merge1._numberOfRequests).toEqual(1)
+    expect(merge1.relationshipMonoHasOne).toMatchObject(testPost)
+    expect(merge1.relationshipMonoHasMany).toMatchObject([testPost])
+
+    expect(merge1.relationshipPolyHasOne).toMatchObject({
+      value: testPost,
+      relationTo: postsSlug,
+    })
+
+    expect(merge1.relationshipPolyHasMany).toMatchObject([
+      { value: testPost, relationTo: postsSlug },
+    ])
+
+    // Update the test post
+    const updatedTestPost = await payload.update({
+      collection: postsSlug,
+      id: testPost.id,
+      data: {
+        title: 'Test Post (Recently Updated)',
+      },
+    })
+
+    const mostRecentUpdate = {
+      id: updatedTestPost.id.toString(), // TODO: don't cast to string once the types are fixed
+      entitySlug: postsSlug,
+      updatedAt: updatedTestPost.updatedAt as string,
+    }
+
+    // Merge again using the `mostRecentUpdate` argument
+    const merge2 = await mergeData({
+      depth: 1,
+      fieldSchema: schemaJSON,
+      incomingData: {
+        title: 'Test Page',
+        relationshipMonoHasOne: testPost.id,
+        relationshipMonoHasMany: [testPost.id],
+        relationshipPolyHasOne: { value: testPost.id, relationTo: postsSlug },
+        relationshipPolyHasMany: [{ value: testPost.id, relationTo: postsSlug }],
+      },
+      initialData: merge1,
+      mostRecentUpdate,
+      serverURL,
+      returnNumberOfRequests: true,
+    })
+
+    expect(merge2._numberOfRequests).toEqual(1)
+    expect(merge2.relationshipMonoHasOne).toMatchObject(updatedTestPost)
+    expect(merge2.relationshipMonoHasMany).toMatchObject([updatedTestPost])
+
+    expect(merge2.relationshipPolyHasOne).toMatchObject({
+      value: updatedTestPost,
+      relationTo: postsSlug,
+    })
+
+    expect(merge2.relationshipPolyHasMany).toMatchObject([
+      { value: updatedTestPost, relationTo: postsSlug },
+    ])
+  })
+
   it('— rich text - merges text changes', async () => {
     // Add a relationship
     const merge1 = await traverseRichText({
-      depth: 1,
-      apiRoute: undefined,
       incomingData: [
         {
           type: 'paragraph',
@@ -602,8 +680,7 @@ describe('Collections - Live Preview', () => {
         },
       ],
       result: [],
-      populationPromises: [],
-      serverURL,
+      populationsByCollection: {},
     })
 
     expect(merge1).toHaveLength(1)
@@ -611,8 +688,6 @@ describe('Collections - Live Preview', () => {
 
     // Update the rich text
     const merge2 = await traverseRichText({
-      depth: 1,
-      apiRoute: undefined,
       incomingData: [
         {
           type: 'paragraph',
@@ -623,9 +698,8 @@ describe('Collections - Live Preview', () => {
           ],
         },
       ],
-      populationPromises: [],
+      populationsByCollection: {},
       result: merge1,
-      serverURL,
     })
 
     expect(merge2).toHaveLength(1)
@@ -635,8 +709,6 @@ describe('Collections - Live Preview', () => {
   it('— rich text - can reset heading type', async () => {
     // Add a heading with an H1 type
     const merge1 = await traverseRichText({
-      depth: 1,
-      apiRoute: undefined,
       incomingData: [
         {
           type: 'h1',
@@ -647,9 +719,8 @@ describe('Collections - Live Preview', () => {
           ],
         },
       ],
-      populationPromises: [],
+      populationsByCollection: {},
       result: [],
-      serverURL,
     })
 
     expect(merge1).toHaveLength(1)
@@ -657,8 +728,6 @@ describe('Collections - Live Preview', () => {
 
     // Update the rich text to remove the heading type
     const merge2 = await traverseRichText({
-      depth: 1,
-      apiRoute: undefined,
       incomingData: [
         {
           children: [
@@ -668,9 +737,8 @@ describe('Collections - Live Preview', () => {
           ],
         },
       ],
-      populationPromises: [],
+      populationsByCollection: {},
       result: merge1,
-      serverURL,
     })
 
     expect(merge2).toHaveLength(1)


### PR DESCRIPTION
## Description

Uses the new `useDocumentEvents` hook from #4284 to re-populate relationships that have been updated. Previously, we were only ever populating relationships if their IDs change. Now, relationships that have been updated in a drawer, for instance, are re-populated as expected.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
