### PR TITLE
feat: support migrations with js files

### DIFF
--- a/docs/database/migrations.mdx
+++ b/docs/database/migrations.mdx
@@ -46,7 +46,13 @@ export async function down({ payload }: MigrateDownArgs): Promise<void> {
 };
 ```
 
+### Migrations Directory
+
+Each DB adapter has an optional property `migrationDir` where you can override where you want your migrations to be stored/read. If this is not specified, Payload will check the default and possibly make a best effort to find your migrations directory by searching in common locations ie. `./src/migrations`, `./dist/igrations`, `./migrations`, etc.
+
 All database adapters should implement similar migration patterns, but there will be small differences based on the adapter and its specific needs. Below is a list of all migration commands that should be supported by your database adapter.
+
+## Commands
 
 ### Migrate
 

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
 
+import fs from 'fs'
 import path from 'path'
 import { createDatabaseAdapter } from 'payload/database'
 
@@ -42,7 +43,7 @@ export type { MigrateDownArgs, MigrateUpArgs } from './types'
 
 export function postgresAdapter(args: Args): PostgresAdapterResult {
   function adapter({ payload }: { payload: Payload }) {
-    const migrationDir = args.migrationDir || path.resolve(process.cwd(), 'src/migrations')
+    const migrationDir = findMigrationDir(args.migrationDir)
 
     extendWebpackConfig(payload.config)
     extendViteConfig(payload.config)
@@ -53,6 +54,7 @@ export function postgresAdapter(args: Args): PostgresAdapterResult {
       // Postgres-specific
       drizzle: undefined,
       enums: {},
+      fieldConstraints: {},
       pool: undefined,
       poolOptions: args.pool,
       push: args.push,
@@ -60,7 +62,6 @@ export function postgresAdapter(args: Args): PostgresAdapterResult {
       schema: {},
       sessions: {},
       tables: {},
-      fieldConstraints: {},
 
       // DatabaseAdapter
       beginTransaction,
@@ -100,4 +101,43 @@ export function postgresAdapter(args: Args): PostgresAdapterResult {
   }
 
   return adapter
+}
+
+/**
+ * Attempt to find migrations directory.
+ *
+ * Checks for the following directories in order:
+ * - `migrationDir` argument from Payload config
+ * - `src/migrations`
+ * - `dist/migrations`
+ * - `migrations`
+ *
+ * Defaults to `src/migrations`
+ *
+ * @param migrationDir
+ * @returns
+ */
+function findMigrationDir(migrationDir?: string): string {
+  const cwd = process.cwd()
+  const srcDir = path.resolve(cwd, 'src/migrations')
+  const distDir = path.resolve(cwd, 'dist/migrations')
+  const relativeMigrations = path.resolve(cwd, 'migrations')
+
+  // Use arg if provided
+  if (migrationDir) return migrationDir
+
+  // Check other common locations
+  if (fs.existsSync(srcDir)) {
+    return srcDir
+  }
+
+  if (fs.existsSync(distDir)) {
+    return distDir
+  }
+
+  if (fs.existsSync(relativeMigrations)) {
+    return relativeMigrations
+  }
+
+  return srcDir
 }

--- a/packages/payload/src/database/migrations/readMigrationFiles.ts
+++ b/packages/payload/src/database/migrations/readMigrationFiles.ts
@@ -13,22 +13,28 @@ export const readMigrationFiles = async ({
   payload: Payload
 }): Promise<Migration[]> => {
   if (!fs.existsSync(payload.db.migrationDir)) {
-    payload.logger.debug({
+    payload.logger.error({
       msg: `No migration directory found at ${payload.db.migrationDir}`,
     })
     return []
   }
 
+  payload.logger.info({
+    msg: `Reading migration files from ${payload.db.migrationDir}`,
+  })
+
   const files = fs
     .readdirSync(payload.db.migrationDir)
     .sort()
-    .filter((f) => f.endsWith('.ts'))
+    .filter((f) => {
+      return f.endsWith('.ts') || f.endsWith('.js')
+    })
     .map((file) => {
       return path.resolve(payload.db.migrationDir, file)
     })
 
   return files.map((filePath) => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires,import/no-dynamic-require
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const migration = require(filePath) as Migration
     migration.name = path.basename(filePath).split('.')?.[0]
     return migration


### PR DESCRIPTION
## Description

- Add support for migration files written in js
- In addition to using `migrationDir` property from db config. If not set, search in other standard places for migrations.

Resolves #3746 
