### PR TITLE
fix(richtext-lexical): HTML Converter field not working inside of tabs

### DIFF
--- a/packages/richtext-lexical/src/field/features/converters/html/field/index.ts
+++ b/packages/richtext-lexical/src/field/features/converters/html/field/index.ts
@@ -88,6 +88,16 @@ export const lexicalHTML: (
                 if (result) {
                   return result
                 }
+              } else if ('tabs' in curField) {
+                for (const tab of curField.tabs) {
+                  const result = findFieldPathAndSiblingFields(
+                    tab.fields,
+                    'name' in tab ? [...path, tab.name] : [...path],
+                  )
+                  if (result) {
+                    return result
+                  }
+                }
               }
             }
 


### PR DESCRIPTION
## Description

Fixes #4260 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
