### PR TITLE
fix(live-preview): compounds merge results

### DIFF
--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -6,6 +6,10 @@ import { mergeData } from '.'
 // Send this cached value to `mergeData`, instead of `eventData.fieldSchemaJSON` directly
 let payloadLivePreviewFieldSchema = undefined // TODO: type this from `fieldSchemaToJSON` return type
 
+// Each time the data is merged, cache the result as a `previousData` variable
+// This will ensure changes compound overtop of each other
+let payloadLivePreviewPreviousData = undefined
+
 export const handleMessage = async <T>(args: {
   apiRoute?: string
   depth?: number
@@ -37,9 +41,11 @@ export const handleMessage = async <T>(args: {
         depth,
         fieldSchema: payloadLivePreviewFieldSchema,
         incomingData: eventData.data,
-        initialData,
+        initialData: payloadLivePreviewPreviousData || initialData,
         serverURL,
       })
+
+      payloadLivePreviewPreviousData = mergedData
 
       return mergedData
     }

--- a/test/live-preview/int.spec.ts
+++ b/test/live-preview/int.spec.ts
@@ -187,8 +187,7 @@ describe('Collections - Live Preview', () => {
 
     expect(mergedDataWithoutUpload.hero.media).toBeFalsy()
   })
-
-  it('— relationships - populates all types', async () => {
+  it('— relationships - populates monomorphic has one relationships', async () => {
     const initialData: Partial<Page> = {
       title: 'Test Page',
     }
@@ -199,8 +198,71 @@ describe('Collections - Live Preview', () => {
       incomingData: {
         ...initialData,
         relationshipMonoHasOne: testPost.id,
+      },
+      initialData,
+      serverURL,
+      returnNumberOfRequests: true,
+    })
+
+    expect(merge1._numberOfRequests).toEqual(1)
+    expect(merge1.relationshipMonoHasOne).toMatchObject(testPost)
+  })
+
+  it('— relationships - populates monomorphic has many relationships', async () => {
+    const initialData: Partial<Page> = {
+      title: 'Test Page',
+    }
+
+    const merge1 = await mergeData({
+      depth: 1,
+      fieldSchema: schemaJSON,
+      incomingData: {
+        ...initialData,
         relationshipMonoHasMany: [testPost.id],
+      },
+      initialData,
+      serverURL,
+      returnNumberOfRequests: true,
+    })
+
+    expect(merge1._numberOfRequests).toEqual(1)
+    expect(merge1.relationshipMonoHasMany).toMatchObject([testPost])
+  })
+
+  it('— relationships - populates polymorphic has one relationships', async () => {
+    const initialData: Partial<Page> = {
+      title: 'Test Page',
+    }
+
+    const merge1 = await mergeData({
+      depth: 1,
+      fieldSchema: schemaJSON,
+      incomingData: {
+        ...initialData,
         relationshipPolyHasOne: { value: testPost.id, relationTo: postsSlug },
+      },
+      initialData,
+      serverURL,
+      returnNumberOfRequests: true,
+    })
+
+    expect(merge1._numberOfRequests).toEqual(1)
+    expect(merge1.relationshipPolyHasOne).toMatchObject({
+      value: testPost,
+      relationTo: postsSlug,
+    })
+  })
+
+  it('— relationships - populates polymorphic has many relationships', async () => {
+    const initialData: Partial<Page> = {
+      title: 'Test Page',
+    }
+
+    const merge1 = await mergeData({
+      depth: 1,
+      fieldSchema: schemaJSON,
+      incomingData: {
+        ...initialData,
         relationshipPolyHasMany: [{ value: testPost.id, relationTo: postsSlug }],
       },
       initialData,
@@ -208,19 +270,12 @@ describe('Collections - Live Preview', () => {
       returnNumberOfRequests: true,
     })
 
-    expect(merge1._numberOfRequests).toEqual(4)
-    expect(merge1.relationshipMonoHasOne).toMatchObject(testPost)
-    expect(merge1.relationshipMonoHasMany).toMatchObject([testPost])
-
-    expect(merge1.relationshipPolyHasOne).toMatchObject({
-      value: testPost,
-      relationTo: postsSlug,
-    })
-
+    expect(merge1._numberOfRequests).toEqual(1)
     expect(merge1.relationshipPolyHasMany).toMatchObject([
       { value: testPost, relationTo: postsSlug },
     ])
   })
+
   it('— relationships - can clear relationships', async () => {
     const initialData: Partial<Page> = {
       title: 'Test Page',

--- a/test/live-preview/next-app/app/_components/RichText/serialize.tsx
+++ b/test/live-preview/next-app/app/_components/RichText/serialize.tsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react'
 import escapeHTML from 'escape-html'
 import Link from 'next/link'
 import { Text } from 'slate'
+import { CMSLink } from '../Link'
 
 // eslint-disable-next-line no-use-before-define
 type Children = Leaf[]
@@ -85,18 +86,15 @@ const serialize = (children?: Children): React.ReactNode[] =>
         )
       case 'link':
         return (
-          <Link
-            href={escapeHTML(node.url)}
+          <CMSLink
             key={i}
-            {...(node?.newTab
-              ? {
-                  target: '_blank',
-                  rel: 'noopener noreferrer',
-                }
-              : {})}
+            type={node.linkType === 'internal' ? 'reference' : 'custom'}
+            url={node.url}
+            reference={node.doc as any}
+            newTab={Boolean(node?.newTab)}
           >
             {serialize(node?.children)}
-          </Link>
+          </CMSLink>
         )
 
       default:


### PR DESCRIPTION
## Description

Optimizes Live Preview by compounding the result across merges. This ensures that new values are compared to _previous state_ instead of _initial state_. This was especially noticeable in rte since this change: 24dacd671253b6ed2d5b9eba4745dbaa0ef089ac

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes