### PR TITLE
fix(live-preview,live-preview-react): removes payload from peer deps

### DIFF
--- a/packages/live-preview-react/package.json
+++ b/packages/live-preview-react/package.json
@@ -25,7 +25,6 @@
     "payload": "workspace:*"
   },
   "peerDependencies": {
-    "payload": "^2.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "exports": {

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -20,9 +20,6 @@
     "@payloadcms/eslint-config": "workspace:*",
     "payload": "workspace:*"
   },
-  "peerDependencies": {
-    "payload": "^2.0.0"
-  },
   "exports": {
     ".": {
       "default": "./src/index.ts",


### PR DESCRIPTION
## Description

Removes `payload` from peer dependencies of `@payloadcms/live-preview` and `@payloadcms/live-preview-react`. Partially closes #4169.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
