### PR TITLE
fix(richtext-slate): adds use client to top of tsx files importing from payload core

### DIFF
--- a/packages/richtext-slate/src/field/RichText.tsx
+++ b/packages/richtext-slate/src/field/RichText.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { BaseEditor, BaseOperation } from 'slate'
 import type { HistoryEditor } from 'slate-history'
 import type { ReactEditor } from 'slate-react'

--- a/packages/richtext-slate/src/field/elements/EnabledRelationshipsCondition.tsx
+++ b/packages/richtext-slate/src/field/elements/EnabledRelationshipsCondition.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { SanitizedCollectionConfig } from 'payload/types'
 
 import { useConfig } from 'payload/components/utilities'

--- a/packages/richtext-slate/src/field/elements/link/Button/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/Button/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { Fields } from 'payload/types'
 
 import { useModal } from '@faceless-ui/modal'

--- a/packages/richtext-slate/src/field/elements/link/Element/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/Element/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { Fields } from 'payload/types'
 import type { HTMLAttributes } from 'react'
 

--- a/packages/richtext-slate/src/field/elements/link/LinkDrawer/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/LinkDrawer/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Drawer } from 'payload/components/elements'
 import { Form, FormSubmit, RenderFields } from 'payload/components/forms'
 import { fieldTypes } from 'payload/components/forms'

--- a/packages/richtext-slate/src/field/elements/relationship/Button/Fields/index.tsx
+++ b/packages/richtext-slate/src/field/elements/relationship/Button/Fields/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { RelationshipComponent } from 'payload/components/fields/Relationship'
 import { SelectComponent } from 'payload/components/fields/Select'
 import { useFormFields } from 'payload/components/forms'

--- a/packages/richtext-slate/src/field/elements/relationship/Button/index.tsx
+++ b/packages/richtext-slate/src/field/elements/relationship/Button/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useListDrawer } from 'payload/components/elements'
 import React, { Fragment, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/packages/richtext-slate/src/field/elements/relationship/Element/index.tsx
+++ b/packages/richtext-slate/src/field/elements/relationship/Element/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { HTMLAttributes } from 'react'
 
 import { Button } from 'payload/components'

--- a/packages/richtext-slate/src/field/elements/upload/Button/index.tsx
+++ b/packages/richtext-slate/src/field/elements/upload/Button/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useListDrawer } from 'payload/components/elements'
 import React, { Fragment, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/packages/richtext-slate/src/field/elements/upload/Element/UploadDrawer/index.tsx
+++ b/packages/richtext-slate/src/field/elements/upload/Element/UploadDrawer/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { SanitizedCollectionConfig } from 'payload/types'
 
 import { useModal } from '@faceless-ui/modal'

--- a/packages/richtext-slate/src/field/elements/upload/Element/index.tsx
+++ b/packages/richtext-slate/src/field/elements/upload/Element/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { SanitizedCollectionConfig } from 'payload/types'
 import type { HTMLAttributes } from 'react'
 


### PR DESCRIPTION
## Description

@payloadcms/richtext-slate

Adds the `use client` directive to the top of any tsx file that imports from `payload/components/*`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
