### PR TITLE
fix(live-preview): property resets rte nodes

### DIFF
--- a/packages/live-preview/src/traverseRichText.ts
+++ b/packages/live-preview/src/traverseRichText.ts
@@ -39,9 +39,27 @@ export const traverseRichText = ({
       result = {}
     }
 
+    // Remove keys from `result` that do not appear in `incomingData`
+    // There's likely another way to do this,
+    // But recursion and references make this very difficult
+    Object.keys(result).forEach((key) => {
+      if (!(key in incomingData)) {
+        delete result[key]
+      }
+    })
+
+    // Iterate over the keys of `incomingData` and populate `result`
     Object.keys(incomingData).forEach((key) => {
       if (!result[key]) {
-        result[key] = incomingData[key]
+        // Instantiate the key in `result` if it doesn't exist
+        // Ensure its type matches the type of the `incomingData`
+        // We don't have a schema to check against here
+        result[key] =
+          incomingData[key] && typeof incomingData[key] === 'object'
+            ? Array.isArray(incomingData[key])
+              ? []
+              : {}
+            : incomingData[key]
       }
 
       const isRelationship = key === 'value' && 'relationTo' in incomingData


### PR DESCRIPTION
## Description

When traversing rich text, properly removes extraneous properties from the result that do not appear in the incoming data. This made it impossible to "clear" properties from rte nodes, such as removing a heading type.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes