### PR TITLE
fix: properly exports useDocumentsEvents hook

### DIFF
--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -798,7 +798,7 @@ The `useDocumentEvents` hook provides a way of subscribing to cross-document eve
 **Example:**
 
 ```tsx
-import { useDocumentEvents } from 'payload/components/utilities'
+import { useDocumentEvents } from 'payload/components/hooks'
 
 const ListenForUpdates: React.FC = () => {
   const { mostRecentUpdate } = useDocumentEvents()

--- a/packages/payload/src/exports/components/hooks.ts
+++ b/packages/payload/src/exports/components/hooks.ts
@@ -1,5 +1,6 @@
 export { useStepNav } from '../../admin/components/elements/StepNav'
 export { useTableColumns } from '../../admin/components/elements/TableColumns'
+export { useDocumentEvents } from '../../admin/components/utilities/DocumentEvents'
 export { default as useDebounce } from '../../admin/hooks/useDebounce'
 export { useDebouncedCallback } from '../../admin/hooks/useDebouncedCallback'
 export { useDelay } from '../../admin/hooks/useDelay'


### PR DESCRIPTION
## Description

The new `useDocumentEvents` hook introduced in #4284 was not properly exported from the top-level. This change makes imports easier, i.e. `import { useDocumentEvents } from 'payload/components/hooks'`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
