### PR TITLE
fix: properly sets tabs key in fieldSchemaToJSON

### DIFF
--- a/packages/payload/src/utilities/fieldSchemaToJSON.ts
+++ b/packages/payload/src/utilities/fieldSchemaToJSON.ts
@@ -74,7 +74,7 @@ export const fieldSchemaToJSON = (fields: Field[]): FieldSchemaJSON => {
             tabFields.push({
               name: tab.name,
               fields: fieldSchemaToJSON(tab.fields),
-              type: 'tab',
+              type: field.type,
             })
             return
           }

--- a/test/live-preview/collections/Pages.ts
+++ b/test/live-preview/collections/Pages.ts
@@ -121,6 +121,23 @@ export const Pages: CollectionConfig = {
                 },
               ],
             },
+            {
+              label: 'Named Tabs',
+              type: 'tabs',
+              tabs: [
+                {
+                  name: 'tab',
+                  label: 'Tab',
+                  fields: [
+                    {
+                      name: 'relationshipInTab',
+                      type: 'relationship',
+                      relationTo: 'posts',
+                    },
+                  ],
+                },
+              ],
+            },
           ],
         },
       ],

--- a/test/live-preview/int.spec.ts
+++ b/test/live-preview/int.spec.ts
@@ -307,6 +307,27 @@ describe('Collections - Live Preview', () => {
     expect(merge2.relationshipPolyHasMany).toEqual([])
   })
 
+  it('— relationships - populates within tabs', async () => {
+    const initialData: Partial<Page> = {
+      title: 'Test Page',
+    }
+
+    const merge1 = await mergeData({
+      depth: 1,
+      fieldSchema: schemaJSON,
+      incomingData: {
+        ...initialData,
+        tab: {
+          relationshipInTab: testPost.id,
+        },
+      },
+      initialData,
+      serverURL,
+    })
+
+    expect(merge1.tab.relationshipInTab).toMatchObject(testPost)
+  })
+
   it('— relationships - populates within arrays', async () => {
     const initialData: Partial<Page> = {
       title: 'Test Page',

--- a/test/live-preview/payload-types.ts
+++ b/test/live-preview/payload-types.ts
@@ -152,11 +152,6 @@ export interface Page {
           }
       )[]
     | null
-  meta?: {
-    title?: string | null
-    description?: string | null
-    image?: string | Media | null
-  }
   relationshipInRichText?:
     | {
         [k: string]: unknown
@@ -198,6 +193,14 @@ export interface Page {
         id?: string | null
       }[]
     | null
+  tab: {
+    relationshipInTab?: (string | null) | Post
+  }
+  meta?: {
+    title?: string | null
+    description?: string | null
+    image?: string | Media | null
+  }
   updatedAt: string
   createdAt: string
 }


### PR DESCRIPTION
## Description

Closes #4304. We were incorrectly setting the `type` property to `tab` instead of `tabs` in [fieldSchemToJSON.ts](https://github.com/payloadcms/payload/blob/main/packages/payload/src/utilities/fieldSchemaToJSON.ts#L77). This prevented the fields within named tabs from being traversed.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
