### PR TITLE
chore: fix telemetry user id type string

### DIFF
--- a/packages/payload/src/utilities/telemetry/events/adminInit.ts
+++ b/packages/payload/src/utilities/telemetry/events/adminInit.ts
@@ -20,8 +20,8 @@ export const adminInit = (req: PayloadRequest): void => {
     domainID = oneWayHash(host, payload.secret)
   }
 
-  if (user && typeof user?.id === 'string') {
-    userID = oneWayHash(user.id, payload.secret)
+  if (user?.id) {
+    userID = oneWayHash(String(user.id), payload.secret)
   }
 
   // eslint-disable-next-line @typescript-eslint/no-floating-promises


### PR DESCRIPTION
## Description

For anonymous telemetry the unique users are not counted for admin init when the database id type is a number. This could happen on any Postgres usage or if a custom id `type: number` was used on the users collection.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
