### PR TITLE
fix(richtext-lexical): blocks content may be hidden behind components outside of the editor

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/LexicalEditor.scss
+++ b/packages/richtext-lexical/src/field/lexical/LexicalEditor.scss
@@ -1,6 +1,11 @@
 @import 'payload/scss';
 
 .rich-text-lexical {
+  .editor {
+    position: relative;
+    z-index: 1;
+  }
+
   .editor-shell {
     position: relative;
 

--- a/test/fields/lexical.e2e.spec.ts
+++ b/test/fields/lexical.e2e.spec.ts
@@ -206,6 +206,8 @@ describe('lexical', () => {
   })
 
   test('ensure blocks content is not hidden behind components outside of the editor', async () => {
+    // This test expects there to be a TreeView below the editor
+
     // This test makes sure there are no z-index issues here
     await navigateToLexicalFields()
     const richTextField = page.locator('.rich-text-lexical').first()


### PR DESCRIPTION
## Description

![Screenshot 2023-11-30 at 13 09 27@2x](https://github.com/payloadcms/payload/assets/70709113/d2e6e79f-00c5-4d8d-853d-bbcb07eb8b83)

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
