### PR TITLE
feat: async live preview urls

### DIFF
--- a/packages/payload/src/admin/components/views/LivePreview/Context/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Context/index.tsx
@@ -125,7 +125,7 @@ export const LivePreviewProvider: React.FC<LivePreviewProviderProps> = (props) =
   // Unlike iframe elements which have an `onLoad` handler, there is no way to access `window.open` on popups
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      if (url.startsWith(event.origin)) {
+      if (url?.startsWith(event.origin)) {
         const data = JSON.parse(event.data)
 
         if (data.type === 'payload-live-preview' && data.ready) {

--- a/packages/payload/src/admin/components/views/LivePreview/Preview/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Preview/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 
 import type { EditViewProps } from '../../types'
 
+import { ShimmerEffect } from '../../../elements/ShimmerEffect'
 import { useAllFormFields } from '../../../forms/Form/context'
 import reduceFieldsToValues from '../../../forms/Form/reduceFieldsToValues'
 import { useDocumentEvents } from '../../../utilities/DocumentEvents'
@@ -94,7 +95,11 @@ export const LivePreview: React.FC<EditViewProps> = (props) => {
           <LivePreviewToolbar {...props} />
           <div className={`${baseClass}__main`}>
             <DeviceContainer>
-              <IFrame ref={iframeRef} setIframeHasLoaded={setIframeHasLoaded} url={url} />
+              {url ? (
+                <IFrame ref={iframeRef} setIframeHasLoaded={setIframeHasLoaded} url={url} />
+              ) : (
+                <ShimmerEffect height="100%" />
+              )}
             </DeviceContainer>
           </div>
         </div>

--- a/packages/payload/src/admin/components/views/LivePreview/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/index.tsx
@@ -195,8 +195,6 @@ export const LivePreviewView: React.FC<
     url,
   })
 
-  if (!url) return null
-
   return (
     <LivePreviewProvider
       {...props}

--- a/packages/payload/src/admin/components/views/LivePreview/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/index.tsx
@@ -164,15 +164,14 @@ export const LivePreviewView: React.FC<
 
   useEffect(() => {
     const getURL = async () => {
-      let newURL = typeof livePreviewConfig?.url === 'string' ? livePreviewConfig?.url : undefined
-
-      if (typeof livePreviewConfig?.url === 'function') {
-        newURL = await livePreviewConfig.url({
-          data,
-          documentInfo,
-          locale,
-        })
-      }
+      const newURL =
+        typeof livePreviewConfig?.url === 'function'
+          ? await livePreviewConfig.url({
+              data,
+              documentInfo,
+              locale,
+            })
+          : livePreviewConfig?.url
 
       setURL(newURL)
     }

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -63,7 +63,11 @@ export type LivePreviewConfig = {
    Use the `useLivePreview` hook to get started in React applications.
    */
   url?:
-    | ((args: { data: Record<string, any>; documentInfo: ContextType; locale: Locale }) => string)
+    | ((args: {
+        data: Record<string, any>
+        documentInfo: ContextType
+        locale: Locale
+      }) => Promise<string> | string)
     | string
 }
 

--- a/test/live-preview/collections/Pages.ts
+++ b/test/live-preview/collections/Pages.ts
@@ -5,7 +5,7 @@ import { CallToAction } from '../blocks/CallToAction'
 import { Content } from '../blocks/Content'
 import { MediaBlock } from '../blocks/MediaBlock'
 import { hero } from '../fields/hero'
-import { pagesSlug } from '../shared'
+import { pagesSlug, tenantsSlug } from '../shared'
 
 export const Pages: CollectionConfig = {
   slug: pagesSlug,
@@ -24,6 +24,14 @@ export const Pages: CollectionConfig = {
       name: 'slug',
       type: 'text',
       required: true,
+      admin: {
+        position: 'sidebar',
+      },
+    },
+    {
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: tenantsSlug,
       admin: {
         position: 'sidebar',
       },

--- a/test/live-preview/collections/Posts.ts
+++ b/test/live-preview/collections/Posts.ts
@@ -5,6 +5,7 @@ import { CallToAction } from '../blocks/CallToAction'
 import { Content } from '../blocks/Content'
 import { MediaBlock } from '../blocks/MediaBlock'
 import { hero } from '../fields/hero'
+import { tenantsSlug } from '../shared'
 
 export const postsSlug = 'posts'
 
@@ -25,6 +26,14 @@ export const Posts: CollectionConfig = {
       name: 'slug',
       type: 'text',
       required: true,
+      admin: {
+        position: 'sidebar',
+      },
+    },
+    {
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: tenantsSlug,
       admin: {
         position: 'sidebar',
       },

--- a/test/live-preview/collections/Tenants.ts
+++ b/test/live-preview/collections/Tenants.ts
@@ -1,0 +1,30 @@
+import type { CollectionConfig } from '../../../packages/payload/src/collections/config/types'
+
+import { tenantsSlug } from '../shared'
+
+export const Tenants: CollectionConfig = {
+  slug: tenantsSlug,
+  access: {
+    read: () => true,
+    create: () => true,
+    update: () => true,
+    delete: () => true,
+  },
+  admin: {
+    useAsTitle: 'title',
+    defaultColumns: ['id', 'clientURL'],
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'clientURL',
+      label: 'Client URL',
+      type: 'text',
+      required: true,
+    },
+  ],
+}

--- a/test/live-preview/config.ts
+++ b/test/live-preview/config.ts
@@ -5,6 +5,7 @@ import Categories from './collections/Categories'
 import { Media } from './collections/Media'
 import { Pages } from './collections/Pages'
 import { Posts } from './collections/Posts'
+import { Tenants } from './collections/Tenants'
 import { Users } from './collections/Users'
 import { Footer } from './globals/Footer'
 import { Header } from './globals/Header'
@@ -18,10 +19,28 @@ export default buildConfigWithDefaults({
     livePreview: {
       // You can also define this per collection or per global
       // The Live Preview config is inherited from the top down
-      url: ({ data, documentInfo }) =>
-        `http://localhost:3001${
+      url: async ({ data, documentInfo }) => {
+        let baseURL = 'http://localhost:3001'
+
+        // For multi-tenant sites, you can use retrieve the tenant's clientURL
+        if (data.tenant) {
+          try {
+            const fullTenant = await fetch(
+              `http://localhost:3000/api/tenants?where[id][equals]=${data.tenant}&limit=1`,
+            )
+              .then((res) => res.json())
+              .then((res) => res?.docs?.[0])
+
+            baseURL = fullTenant?.clientURL
+          } catch (e) {
+            console.error(e)
+          }
+        }
+
+        return `${baseURL}${
           documentInfo?.slug && documentInfo.slug !== 'pages' ? `/${documentInfo.slug}` : ''
-        }${data?.slug && data.slug !== 'home' ? `/${data.slug}` : ''}`,
+        }${data?.slug && data.slug !== 'home' ? `/${data.slug}` : ''}`
+      },
       breakpoints: [mobileBreakpoint],
       collections: ['pages', 'posts'],
       globals: ['header', 'footer'],
@@ -39,7 +58,7 @@ export default buildConfigWithDefaults({
   },
   cors: ['http://localhost:3001'],
   csrf: ['http://localhost:3001'],
-  collections: [Users, Pages, Posts, Categories, Media],
+  collections: [Users, Tenants, Pages, Posts, Categories, Media],
   globals: [Header, Footer],
   onInit: seed,
 })

--- a/test/live-preview/config.ts
+++ b/test/live-preview/config.ts
@@ -11,36 +11,16 @@ import { Footer } from './globals/Footer'
 import { Header } from './globals/Header'
 import { seed } from './seed'
 import { mobileBreakpoint } from './shared'
+import { formatLivePreviewURL } from './utilities/formatLivePreviewURL'
 
 const mockModulePath = path.resolve(__dirname, './mocks/mockFSModule.js')
 
 export default buildConfigWithDefaults({
   admin: {
     livePreview: {
-      // You can also define this per collection or per global
-      // The Live Preview config is inherited from the top down
-      url: async ({ data, documentInfo }) => {
-        let baseURL = 'http://localhost:3001'
-
-        // For multi-tenant sites, you can use retrieve the tenant's clientURL
-        if (data.tenant) {
-          try {
-            const fullTenant = await fetch(
-              `http://localhost:3000/api/tenants?where[id][equals]=${data.tenant}&limit=1`,
-            )
-              .then((res) => res.json())
-              .then((res) => res?.docs?.[0])
-
-            baseURL = fullTenant?.clientURL
-          } catch (e) {
-            console.error(e)
-          }
-        }
-
-        return `${baseURL}${
-          documentInfo?.slug && documentInfo.slug !== 'pages' ? `/${documentInfo.slug}` : ''
-        }${data?.slug && data.slug !== 'home' ? `/${data.slug}` : ''}`
-      },
+      // You can define any of these properties on a per collection or global basis
+      // The Live Preview config cascades from the top down, properties are inherited from here
+      url: formatLivePreviewURL,
       breakpoints: [mobileBreakpoint],
       collections: ['pages', 'posts'],
       globals: ['header', 'footer'],
@@ -58,7 +38,7 @@ export default buildConfigWithDefaults({
   },
   cors: ['http://localhost:3001'],
   csrf: ['http://localhost:3001'],
-  collections: [Users, Tenants, Pages, Posts, Categories, Media],
+  collections: [Users, Pages, Posts, Tenants, Categories, Media],
   globals: [Header, Footer],
   onInit: seed,
 })

--- a/test/live-preview/int.spec.ts
+++ b/test/live-preview/int.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 
-import type { Media, Page, Post } from './payload-types'
+import type { Media, Page, Post, Tenant } from './payload-types'
 
 import { handleMessage } from '../../packages/live-preview/src/handleMessage'
 import { mergeData } from '../../packages/live-preview/src/mergeData'
@@ -13,7 +13,7 @@ import { RESTClient } from '../helpers/rest'
 import { Pages } from './collections/Pages'
 import { postsSlug } from './collections/Posts'
 import configPromise from './config'
-import { pagesSlug } from './shared'
+import { pagesSlug, tenantsSlug } from './shared'
 
 require('isomorphic-fetch')
 
@@ -24,6 +24,7 @@ describe('Collections - Live Preview', () => {
   let serverURL
 
   let testPost: Post
+  let tenant: Tenant
   let media: Media
 
   beforeAll(async () => {
@@ -37,11 +38,20 @@ describe('Collections - Live Preview', () => {
     client = new RESTClient(config, { serverURL, defaultSlug: pagesSlug })
     await client.login()
 
+    tenant = await payload.create({
+      collection: tenantsSlug,
+      data: {
+        title: 'Tenant 1',
+        clientURL: 'http://localhost:3000',
+      },
+    })
+
     testPost = await payload.create({
       collection: postsSlug,
       data: {
         slug: 'post-1',
         title: 'Test Post',
+        tenant: tenant.id,
       },
     })
 

--- a/test/live-preview/payload-types.ts
+++ b/test/live-preview/payload-types.ts
@@ -9,6 +9,7 @@
 export interface Config {
   collections: {
     users: User
+    tenants: Tenant
     pages: Page
     posts: Post
     categories: Category
@@ -34,9 +35,17 @@ export interface User {
   lockUntil?: string | null
   password: string | null
 }
+export interface Tenant {
+  id: string
+  title: string
+  clientURL: string
+  updatedAt: string
+  createdAt: string
+}
 export interface Page {
   id: string
   slug: string
+  tenant?: (string | null) | Tenant
   title: string
   hero: {
     type: 'none' | 'highImpact' | 'lowImpact'

--- a/test/live-preview/payload-types.ts
+++ b/test/live-preview/payload-types.ts
@@ -9,9 +9,9 @@
 export interface Config {
   collections: {
     users: User
-    tenants: Tenant
     pages: Page
     posts: Post
+    tenants: Tenant
     categories: Category
     media: Media
     'payload-preferences': PayloadPreference
@@ -34,13 +34,6 @@ export interface User {
   loginAttempts?: number | null
   lockUntil?: string | null
   password: string | null
-}
-export interface Tenant {
-  id: string
-  title: string
-  clientURL: string
-  updatedAt: string
-  createdAt: string
 }
 export interface Page {
   id: string
@@ -213,6 +206,13 @@ export interface Page {
   updatedAt: string
   createdAt: string
 }
+export interface Tenant {
+  id: string
+  title: string
+  clientURL: string
+  updatedAt: string
+  createdAt: string
+}
 export interface Media {
   id: string
   alt: string
@@ -233,6 +233,7 @@ export interface Media {
 export interface Post {
   id: string
   slug: string
+  tenant?: (string | null) | Tenant
   title: string
   hero: {
     type: 'none' | 'highImpact' | 'lowImpact'

--- a/test/live-preview/seed/home.ts
+++ b/test/live-preview/seed/home.ts
@@ -6,6 +6,7 @@ export const home: Omit<Page, 'createdAt' | 'id' | 'updatedAt'> = {
   meta: {
     description: 'This is an example of live preview on a page.',
   },
+  tenant: '{{TENANT_1_ID}}',
   hero: {
     type: 'highImpact',
     richText: [

--- a/test/live-preview/seed/home.ts
+++ b/test/live-preview/seed/home.ts
@@ -136,4 +136,7 @@ export const home: Omit<Page, 'createdAt' | 'id' | 'updatedAt'> = {
       relationshipInArrayPolyHasOne: { relationTo: 'posts', value: '{{POST_1_ID}}' },
     },
   ],
+  tab: {
+    relationshipInTab: '{{POST_1_ID}}',
+  },
 }

--- a/test/live-preview/seed/index.ts
+++ b/test/live-preview/seed/index.ts
@@ -48,37 +48,38 @@ export const seed: Config['onInit'] = async (payload) => {
   })
 
   const mediaID = payload.db.defaultIDType === 'number' ? media.id : `"${media.id}"`
+  const tenantID = payload.db.defaultIDType === 'number' ? tenant1Doc.id : `"${tenant1Doc.id}"`
 
   const [post1Doc, post2Doc, post3Doc] = await Promise.all([
     await payload.create({
       collection: postsSlug,
       data: JSON.parse(
         JSON.stringify(post1)
-          .replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())
-          .replace(/"\{\{TENANT_1_ID\}\}"/g, `"${tenant1Doc.id.toString()}"`),
+          .replace(/"\{\{IMAGE\}\}"/g, mediaID)
+          .replace(/"\{\{TENANT_1_ID\}\}"/g, tenantID),
       ),
     }),
     await payload.create({
       collection: postsSlug,
       data: JSON.parse(
         JSON.stringify(post2)
-          .replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())
-          .replace(/"\{\{TENANT_1_ID\}\}"/g, `"${tenant1Doc.id.toString()}"`),
+          .replace(/"\{\{IMAGE\}\}"/g, mediaID)
+          .replace(/"\{\{TENANT_1_ID\}\}"/g, tenantID),
       ),
     }),
     await payload.create({
       collection: postsSlug,
       data: JSON.parse(
         JSON.stringify(post3)
-          .replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())
-          .replace(/"\{\{TENANT_1_ID\}\}"/g, `"${tenant1Doc.id.toString()}"`),
+          .replace(/"\{\{IMAGE\}\}"/g, mediaID)
+          .replace(/"\{\{TENANT_1_ID\}\}"/g, tenantID),
       ),
     }),
   ])
 
   const postsPageDoc = await payload.create({
     collection: pagesSlug,
-    data: JSON.parse(JSON.stringify(postsPage).replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())),
+    data: JSON.parse(JSON.stringify(postsPage).replace(/"\{\{IMAGE\}\}"/g, mediaID)),
   })
 
   let postsPageDocID = postsPageDoc.id
@@ -97,20 +98,18 @@ export const seed: Config['onInit'] = async (payload) => {
     collection: pagesSlug,
     data: JSON.parse(
       JSON.stringify(home)
-        .replace(/"\{\{MEDIA_ID\}\}"/g, mediaID.toString())
-        .replace(/"\{\{POSTS_PAGE_ID\}\}"/g, postsPageDocID.toString())
-        .replace(/"\{\{POST_1_ID\}\}"/g, post1DocID.toString())
-        .replace(/"\{\{POST_2_ID\}\}"/g, post2DocID.toString())
-        .replace(/"\{\{POST_3_ID\}\}"/g, post3DocID.toString())
-        .replace(/"\{\{TENANT_1_ID\}\}"/g, `"${tenant1Doc.id.toString()}"`),
+        .replace(/"\{\{MEDIA_ID\}\}"/g, mediaID)
+        .replace(/"\{\{POSTS_PAGE_ID\}\}"/g, postsPageDocID)
+        .replace(/"\{\{POST_1_ID\}\}"/g, post1DocID)
+        .replace(/"\{\{POST_2_ID\}\}"/g, post2DocID)
+        .replace(/"\{\{POST_3_ID\}\}"/g, post3DocID)
+        .replace(/"\{\{TENANT_1_ID\}\}"/g, tenantID),
     ),
   })
 
   await payload.updateGlobal({
     slug: 'header',
-    data: JSON.parse(
-      JSON.stringify(header).replace(/"\{\{POSTS_PAGE_ID\}\}"/g, postsPageDocID.toString()),
-    ),
+    data: JSON.parse(JSON.stringify(header).replace(/"\{\{POSTS_PAGE_ID\}\}"/g, postsPageDocID)),
   })
 
   await payload.updateGlobal({

--- a/test/live-preview/seed/index.ts
+++ b/test/live-preview/seed/index.ts
@@ -5,7 +5,7 @@ import type { Config } from '../../../packages/payload/src/config/types'
 import { devUser } from '../../credentials'
 import removeFiles from '../../helpers/removeFiles'
 import { postsSlug } from '../collections/Posts'
-import { pagesSlug } from '../shared'
+import { pagesSlug, tenantsSlug } from '../shared'
 import { footer } from './footer'
 import { header } from './header'
 import { home } from './home'
@@ -13,6 +13,8 @@ import { post1 } from './post-1'
 import { post2 } from './post-2'
 import { post3 } from './post-3'
 import { postsPage } from './posts-page'
+import { tenant1 } from './tenant-1'
+import { tenant2 } from './tenant-2'
 
 export const seed: Config['onInit'] = async (payload) => {
   const uploadsDir = path.resolve(__dirname, './media')
@@ -25,6 +27,17 @@ export const seed: Config['onInit'] = async (payload) => {
       password: devUser.password,
     },
   })
+
+  const [tenant1Doc] = await Promise.all([
+    await payload.create({
+      collection: tenantsSlug,
+      data: tenant1,
+    }),
+    await payload.create({
+      collection: tenantsSlug,
+      data: tenant2,
+    }),
+  ])
 
   const media = await payload.create({
     collection: 'media',
@@ -39,21 +52,21 @@ export const seed: Config['onInit'] = async (payload) => {
   const [post1Doc, post2Doc, post3Doc] = await Promise.all([
     await payload.create({
       collection: postsSlug,
-      data: JSON.parse(JSON.stringify(post1).replace(/"\{\{IMAGE\}\}"/g, mediaID)),
+      data: JSON.parse(JSON.stringify(post1).replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())),
     }),
     await payload.create({
       collection: postsSlug,
-      data: JSON.parse(JSON.stringify(post2).replace(/"\{\{IMAGE\}\}"/g, mediaID)),
+      data: JSON.parse(JSON.stringify(post2).replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())),
     }),
     await payload.create({
       collection: postsSlug,
-      data: JSON.parse(JSON.stringify(post3).replace(/"\{\{IMAGE\}\}"/g, mediaID)),
+      data: JSON.parse(JSON.stringify(post3).replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())),
     }),
   ])
 
   const postsPageDoc = await payload.create({
     collection: pagesSlug,
-    data: JSON.parse(JSON.stringify(postsPage).replace(/"\{\{IMAGE\}\}"/g, mediaID)),
+    data: JSON.parse(JSON.stringify(postsPage).replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())),
   })
 
   let postsPageDocID = postsPageDoc.id
@@ -72,17 +85,20 @@ export const seed: Config['onInit'] = async (payload) => {
     collection: pagesSlug,
     data: JSON.parse(
       JSON.stringify(home)
-        .replace(/"\{\{MEDIA_ID\}\}"/g, mediaID)
-        .replace(/"\{\{POSTS_PAGE_ID\}\}"/g, postsPageDocID)
-        .replace(/"\{\{POST_1_ID\}\}"/g, post1DocID)
-        .replace(/"\{\{POST_2_ID\}\}"/g, post2DocID)
-        .replace(/"\{\{POST_3_ID\}\}"/g, post3DocID),
+        .replace(/"\{\{MEDIA_ID\}\}"/g, mediaID.toString())
+        .replace(/"\{\{POSTS_PAGE_ID\}\}"/g, postsPageDocID.toString())
+        .replace(/"\{\{POST_1_ID\}\}"/g, post1DocID.toString())
+        .replace(/"\{\{POST_2_ID\}\}"/g, post2DocID.toString())
+        .replace(/"\{\{POST_3_ID\}\}"/g, post3DocID.toString())
+        .replace(/"\{\{TENANT_1_ID\}\}"/g, `"${tenant1Doc.id.toString()}"`),
     ),
   })
 
   await payload.updateGlobal({
     slug: 'header',
-    data: JSON.parse(JSON.stringify(header).replace(/"\{\{POSTS_PAGE_ID\}\}"/g, postsPageDocID)),
+    data: JSON.parse(
+      JSON.stringify(header).replace(/"\{\{POSTS_PAGE_ID\}\}"/g, postsPageDocID.toString()),
+    ),
   })
 
   await payload.updateGlobal({

--- a/test/live-preview/seed/index.ts
+++ b/test/live-preview/seed/index.ts
@@ -52,15 +52,27 @@ export const seed: Config['onInit'] = async (payload) => {
   const [post1Doc, post2Doc, post3Doc] = await Promise.all([
     await payload.create({
       collection: postsSlug,
-      data: JSON.parse(JSON.stringify(post1).replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())),
+      data: JSON.parse(
+        JSON.stringify(post1)
+          .replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())
+          .replace(/"\{\{TENANT_1_ID\}\}"/g, `"${tenant1Doc.id.toString()}"`),
+      ),
     }),
     await payload.create({
       collection: postsSlug,
-      data: JSON.parse(JSON.stringify(post2).replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())),
+      data: JSON.parse(
+        JSON.stringify(post2)
+          .replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())
+          .replace(/"\{\{TENANT_1_ID\}\}"/g, `"${tenant1Doc.id.toString()}"`),
+      ),
     }),
     await payload.create({
       collection: postsSlug,
-      data: JSON.parse(JSON.stringify(post3).replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())),
+      data: JSON.parse(
+        JSON.stringify(post3)
+          .replace(/"\{\{IMAGE\}\}"/g, mediaID.toString())
+          .replace(/"\{\{TENANT_1_ID\}\}"/g, `"${tenant1Doc.id.toString()}"`),
+      ),
     }),
   ])
 

--- a/test/live-preview/seed/post-1.ts
+++ b/test/live-preview/seed/post-1.ts
@@ -7,6 +7,7 @@ export const post1: Omit<Post, 'createdAt' | 'id' | 'updatedAt'> = {
     description: 'This is the first post.',
     image: '{{IMAGE}}',
   },
+  tenant: '{{TENANT_1_ID}}',
   hero: {
     type: 'lowImpact',
     richText: [

--- a/test/live-preview/seed/post-2.ts
+++ b/test/live-preview/seed/post-2.ts
@@ -8,6 +8,7 @@ export const post2: Omit<Post, 'createdAt' | 'id' | 'updatedAt'> = {
     description: 'This is the second post.',
     image: '{{IMAGE}}',
   },
+  tenant: '{{TENANT_1_ID}}',
   hero: {
     type: 'lowImpact',
     richText: [

--- a/test/live-preview/seed/post-3.ts
+++ b/test/live-preview/seed/post-3.ts
@@ -8,6 +8,7 @@ export const post3: Omit<Post, 'createdAt' | 'id' | 'updatedAt'> = {
     description: 'This is the third post.',
     image: '{{IMAGE}}',
   },
+  tenant: '{{TENANT_1_ID}}',
   hero: {
     type: 'lowImpact',
     richText: [

--- a/test/live-preview/seed/tenant-1.ts
+++ b/test/live-preview/seed/tenant-1.ts
@@ -1,0 +1,6 @@
+import type { Tenant } from '../payload-types'
+
+export const tenant1: Omit<Tenant, 'createdAt' | 'id' | 'updatedAt'> = {
+  title: 'Tenant 1',
+  clientURL: 'http://localhost:3001',
+}

--- a/test/live-preview/seed/tenant-2.ts
+++ b/test/live-preview/seed/tenant-2.ts
@@ -2,5 +2,5 @@ import type { Tenant } from '../payload-types'
 
 export const tenant2: Omit<Tenant, 'createdAt' | 'id' | 'updatedAt'> = {
   title: 'Tenant 2',
-  clientURL: 'https://payloadcms.com',
+  clientURL: 'http://localhost:3002',
 }

--- a/test/live-preview/seed/tenant-2.ts
+++ b/test/live-preview/seed/tenant-2.ts
@@ -1,0 +1,6 @@
+import type { Tenant } from '../payload-types'
+
+export const tenant2: Omit<Tenant, 'createdAt' | 'id' | 'updatedAt'> = {
+  title: 'Tenant 2',
+  clientURL: 'https://payloadcms.com',
+}

--- a/test/live-preview/shared.ts
+++ b/test/live-preview/shared.ts
@@ -1,5 +1,7 @@
 export const pagesSlug = 'pages'
 
+export const tenantsSlug = 'tenants'
+
 export const mobileBreakpoint = {
   label: 'Mobile',
   name: 'mobile',

--- a/test/live-preview/utilities/formatLivePreviewURL.ts
+++ b/test/live-preview/utilities/formatLivePreviewURL.ts
@@ -18,7 +18,8 @@ export const formatLivePreviewURL = async ({ data, documentInfo }) => {
   }
 
   // Format the URL as needed, based on the document and data
-  // Can also do this on individual collection or global config, if preferred
+  // I.e. append '/posts' to the URL if the document is a post
+  // You can also do this on individual collection or global config, if preferred
   return `${baseURL}${
     documentInfo?.slug && documentInfo.slug !== 'pages' ? `/${documentInfo.slug}` : ''
   }${data?.slug && data.slug !== 'home' ? `/${data.slug}` : ''}`

--- a/test/live-preview/utilities/formatLivePreviewURL.ts
+++ b/test/live-preview/utilities/formatLivePreviewURL.ts
@@ -1,0 +1,25 @@
+export const formatLivePreviewURL = async ({ data, documentInfo }) => {
+  let baseURL = 'http://localhost:3001'
+
+  // You can run async requests here, if needed
+  // For example, multi-tenant apps may need to lookup additional data
+  if (data.tenant) {
+    try {
+      const fullTenant = await fetch(
+        `http://localhost:3000/api/tenants?where[id][equals]=${data.tenant}&limit=1&depth=0`,
+      )
+        .then((res) => res.json())
+        .then((res) => res?.docs?.[0])
+
+      baseURL = fullTenant?.clientURL
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  // Format the URL as needed, based on the document and data
+  // Can also do this on individual collection or global config, if preferred
+  return `${baseURL}${
+    documentInfo?.slug && documentInfo.slug !== 'pages' ? `/${documentInfo.slug}` : ''
+  }${data?.slug && data.slug !== 'home' ? `/${data.slug}` : ''}`
+}


### PR DESCRIPTION
## Description

Closes #3922 by supporting async Live Preview URLs. Now you can make API requests to format your Live Preview URLs, if needed. This makes it easier to support something like multi-tenant applications which might use a unique URL per tenant. Right now `data` is initial document data, but in the future we might be able to support dynamic URLs by passing the current and previous document through, and automatically reload the iframe.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my change