### PR TITLE
fix: query validation on relationship fields

### DIFF
--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -120,24 +120,28 @@ export async function validateSearchParam({
           if (segments[0] === 'parent' || segments[0] === 'version') {
             segments.shift()
           } else {
-            segments.forEach((segment, pathIndex) => {
-              if (fieldAccess[segment]) {
-                if (pathIndex === segments.length - 1) {
-                  fieldAccess = fieldAccess[segment]
-                } else if ('fields' in fieldAccess[segment]) {
-                  fieldAccess = fieldAccess[segment].fields
-                } else if ('blocks' in fieldAccess[segment]) {
-                  fieldAccess = fieldAccess[segment]
+            if (['json', 'relationship', 'richText'].includes(field.type)) {
+              fieldAccess = fieldAccess[field.name]
+            } else {
+              segments.forEach((segment, pathIndex) => {
+                if (fieldAccess[segment]) {
+                  if (pathIndex === segments.length - 1) {
+                    fieldAccess = fieldAccess[segment]
+                  } else if ('fields' in fieldAccess[segment]) {
+                    fieldAccess = fieldAccess[segment].fields
+                  } else if ('blocks' in fieldAccess[segment]) {
+                    fieldAccess = fieldAccess[segment]
+                  }
                 }
-              }
-            })
+              })
+            }
           }
 
           fieldAccess = fieldAccess.read.permission
         } else {
           fieldAccess = policies[entityType][entitySlug].fields
 
-          if (['json', 'richText'].includes(field.type)) {
+          if (['json', 'relationship', 'richText'].includes(field.type)) {
             fieldAccess = fieldAccess[field.name]
           } else {
             segments.forEach((segment, pathIndex) => {

--- a/test/relationships/config.ts
+++ b/test/relationships/config.ts
@@ -42,6 +42,8 @@ export const defaultAccessRelSlug = 'strict-access'
 export const chainedRelSlug = 'chained'
 export const customIdSlug = 'custom-id'
 export const customIdNumberSlug = 'custom-id-number'
+export const polymorphicRelationshipsSlug = 'polymorphic-relationships'
+
 export default buildConfigWithDefaults({
   collections: [
     {
@@ -231,6 +233,16 @@ export default buildConfigWithDefaults({
       ],
 
       slug: 'movieReviews',
+    },
+    {
+      slug: polymorphicRelationshipsSlug,
+      fields: [
+        {
+          type: 'relationship',
+          name: 'polymorphic',
+          relationTo: ['movies'],
+        },
+      ],
     },
   ],
   onInit: async (payload) => {

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -563,6 +563,46 @@ describe('Relationships', () => {
       })
     })
   })
+
+  describe('Polymorphic Relationships', () => {
+    it('should allow REST querying on polymorphic relationships', async () => {
+      const movie = await payload.create({
+        collection: 'movies',
+        data: {
+          name: 'Pulp Fiction 2',
+        },
+      })
+      await payload.create({
+        collection: 'polymorphic-relationships',
+        data: {
+          polymorphic: {
+            value: movie.id,
+            relationTo: 'movies',
+          },
+        },
+      })
+
+      const query = await client.find({
+        slug: 'polymorphic-relationships',
+        query: {
+          and: [
+            {
+              'polymorphic.value': {
+                equals: movie.id,
+              },
+            },
+            {
+              'polymorphic.relationTo': {
+                equals: 'movies',
+              },
+            },
+          ],
+        },
+      })
+
+      expect(query.result.docs).toHaveLength(1)
+    })
+  })
 })
 
 async function createPost(overrides?: Partial<Post>) {


### PR DESCRIPTION
## Description

Fixes an issue where `relationship` fields were not being properly handled when query validation was run.

Example query:
```ts
{
  and: [
    {
      'relationFieldName.relationTo': {
        equals: 'some-slug'
      }
    },
    {
      'relationFieldName.value': {
        equals: 'some-id'
      }
    }
  ]
}
```

Before, `segments` would look like `['relationFieldName', 'relationTo']` or `['relationFieldName', 'value']`. This would break when looping over segments, as there are no nested fields within  a relationship field, and [this check](https://github.com/payloadcms/payload/pull/4353/files#diff-a40acf7016cda84d34aeb6018205b35ca86222e5116c79a095d26f2b84b5458fR149) (pathIndex === segments.length - 1) would never hit because `relationTo` is not a field name on `policies[entityType][entitySlug].fields`.

This resulted in an error when attempting to read the `read` permissions off of the `fieldAccess` object since its shape was never overwritten and was still in the form of `policies[entityType][entitySlug].fields` or:

```ts
{
  relationFieldName: {
    read: {
      permission: true,
    },
  },
  updatedAt: {
    read: {
      permission: true,
    },
  },
  createdAt: {
    read: {
      permission: true,
    },
  },
}
``` 


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
