### PR TITLE
fix(live-preview): sends raw js objects through window.postMessage instead of json

### DIFF
--- a/packages/live-preview/src/ready.ts
+++ b/packages/live-preview/src/ready.ts
@@ -8,10 +8,10 @@ export const ready = (args: { serverURL: string }): void => {
     const windowToPostTo: Window = window?.opener || window?.parent
 
     windowToPostTo?.postMessage(
-      JSON.stringify({
+      {
         ready: true,
         type: 'payload-live-preview',
-      }),
+      },
       serverURL,
     )
   }

--- a/packages/payload/src/admin/components/views/LivePreview/Context/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Context/index.tsx
@@ -125,10 +125,13 @@ export const LivePreviewProvider: React.FC<LivePreviewProviderProps> = (props) =
   // Unlike iframe elements which have an `onLoad` handler, there is no way to access `window.open` on popups
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      if (url?.startsWith(event.origin)) {
-        const data = JSON.parse(event.data)
-
-        if (data.type === 'payload-live-preview' && data.ready) {
+      if (
+        url?.startsWith(event.origin) &&
+        event.data &&
+        typeof event.data === 'object' &&
+        event.data.type === 'payload-live-preview'
+      ) {
+        if (event.data.ready) {
           setAppIsReady(true)
         }
       }

--- a/packages/payload/src/admin/components/views/LivePreview/Preview/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/Preview/index.tsx
@@ -51,12 +51,12 @@ export const LivePreview: React.FC<EditViewProps> = (props) => {
 
       prevWindowType.current = previewWindowType
 
-      const message = JSON.stringify({
+      const message = {
         data: values,
         externallyUpdatedRelationship: mostRecentUpdate,
         fieldSchemaJSON: shouldSendSchema ? fieldSchemaJSON : undefined,
         type: 'payload-live-preview',
-      })
+      }
 
       // Post message to external popup window
       if (previewWindowType === 'popup' && popupRef.current) {

--- a/test/live-preview/int.spec.ts
+++ b/test/live-preview/int.spec.ts
@@ -73,13 +73,13 @@ describe('Collections - Live Preview', () => {
     const handledMessage = await handleMessage({
       depth: 1,
       event: {
-        data: JSON.stringify({
+        data: {
           data: {
             title: 'Test Page (Changed)',
           },
           fieldSchemaJSON: schemaJSON,
           type: 'payload-live-preview',
-        }),
+        },
         origin: serverURL,
       } as MessageEvent,
       initialData: {
@@ -95,12 +95,12 @@ describe('Collections - Live Preview', () => {
     const handledMessage = await handleMessage({
       depth: 1,
       event: {
-        data: JSON.stringify({
+        data: {
           data: {
             title: 'Test Page (Changed)',
           },
           type: 'payload-live-preview',
-        }),
+        },
         origin: serverURL,
       } as MessageEvent,
       initialData: {


### PR DESCRIPTION
## Description

Prevents Live Preview from attempting to parse JSON from unrelated post messages sent by browser extensions like React Developer Tools where it would fail and be left uncaught. Supersedes #4254 by sending raw js objects through the window post message events, replacing JSON altogether.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
