### PR TITLE
docs(plugin-nested-docs): clarifies that relationships are intra-collection

### DIFF
--- a/packages/plugin-nested-docs/README.md
+++ b/packages/plugin-nested-docs/README.md
@@ -6,7 +6,7 @@ A plugin for [Payload CMS](https://github.com/payloadcms/payload) to easily allo
 
 Core features:
 
-- Allows for [parent/child](#parent) relationships between documents
+- Allows for [parent/child](#parent) relationships between documents within the same Collection
 - Automatically populates [breadcrumbs](#breadcrumbs) data
 
 ## Installation


### PR DESCRIPTION
…onships are only supported between documents within the same collection

## Description

Please see conversation here: https://github.com/payloadcms/payload/issues/4367

Currently, when reading the README for `plugin-nested-docs`, it's somewhat unclear if the plugin supports parent/child relationships between different collections.

This PR makes a minimal update to the README to make clear that the plugin does *not* support this type of relationship.

I think this is valuable to improve the developer experience, as it would have saved me a significant amount of time tinkering with the plugin to see it it would support such a use case - if this limitation had been clearly documented, I would have known that it was not possible when I read the README.
- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:
(none apply)