### PR TITLE
chore: adds validation based on condition to fields required property

### DIFF
--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -58,6 +58,15 @@ export const baseField = joi
     unique: joi.boolean().default(false),
     validate: joi.func(),
   })
+  .when('.admin.condition', {
+    is: joi.exist(),
+    otherwise: joi.object({
+      required: joi.boolean().default(false),
+    }),
+    then: joi.object({
+      required: joi.forbidden(),
+    }),
+  })
   .default()
 
 export const idField = baseField.keys({

--- a/test/fields/collections/ConditionalLogic/index.ts
+++ b/test/fields/collections/ConditionalLogic/index.ts
@@ -20,7 +20,6 @@ const ConditionalLogic: CollectionConfig = {
     {
       name: 'fieldToToggle',
       type: 'text',
-      required: true,
       admin: {
         condition: ({ toggleField }) => Boolean(toggleField),
       },

--- a/test/live-preview/fields/hero.ts
+++ b/test/live-preview/fields/hero.ts
@@ -35,7 +35,6 @@ export const hero: Field = {
       name: 'media',
       type: 'upload',
       relationTo: 'media',
-      required: true,
       admin: {
         condition: (_, { type } = {}) => ['highImpact'].includes(type),
       },

--- a/test/live-preview/fields/link.ts
+++ b/test/live-preview/fields/link.ts
@@ -77,7 +77,6 @@ const link: LinkType = ({ appearances, disableLabel = false, overrides = {} } = 
       label: 'Document to link to',
       type: 'relationship',
       relationTo: ['posts', 'pages'],
-      required: true,
       maxDepth: 1,
       admin: {
         condition: (_, siblingData) => siblingData?.type === 'reference',
@@ -87,7 +86,6 @@ const link: LinkType = ({ appearances, disableLabel = false, overrides = {} } = 
       name: 'url',
       label: 'Custom URL',
       type: 'text',
-      required: true,
       admin: {
         condition: (_, siblingData) => siblingData?.type === 'custom',
       },


### PR DESCRIPTION
## Description

Enforces the rule that fields `required` property should not be usable if the `condition` property is defined.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
