### PR TITLE
docs: improves afterInput example

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -572,13 +572,15 @@ With these properties you can add multiple components before and after the input
 
 ```tsx
 import React from 'react'
+import { Field } from 'payload/types'
+
 import './style.scss'
 
 const ClearButton: React.FC = () => {
   return <button onClick={() => {/* ... */}}>X</button>
 }
 
-const fieldField: Field = {
+const titleField: Field = {
   name: 'title',
   type: 'text',
   admin: {


### PR DESCRIPTION
## Description

Improves `afterInput` example in docs [here](https://payloadcms.com/docs/admin/components#afterinput-and-beforeinput).

Before:
![Screen Shot 2023-12-04 at 2 29 57 PM](https://github.com/payloadcms/payload/assets/35232443/96c19fda-b4d9-4866-ac4f-f42de1347f58)

After:
![Screen Shot 2023-12-04 at 2 29 48 PM](https://github.com/payloadcms/payload/assets/35232443/5db0ddba-44af-4d47-ade5-74030042c254)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
