### PR TITLE
Error Handling: Check that req.collection is truthy before accessing its config property

### DIFF
--- a/packages/payload/src/express/middleware/errorHandler.ts
+++ b/packages/payload/src/express/middleware/errorHandler.ts
@@ -51,12 +51,12 @@ const errorHandler =
       )) || { response, status })
     }
 
-    if (req.collection && typeof config.hooks.afterError === 'function') {
+    if (typeof config.hooks.afterError === 'function') {
       ;({ response, status } = (await config.hooks.afterError(
         err,
         response,
         req.context,
-        req.collection.config,
+        req.collection?.config,
       )) || {
         response,
         status,

--- a/packages/payload/src/express/middleware/errorHandler.ts
+++ b/packages/payload/src/express/middleware/errorHandler.ts
@@ -51,7 +51,7 @@ const errorHandler =
       )) || { response, status })
     }
 
-    if (typeof config.hooks.afterError === 'function') {
+    if (req.collection && typeof config.hooks.afterError === 'function') {
       ;({ response, status } = (await config.hooks.afterError(
         err,
         response,


### PR DESCRIPTION
## Description

Fixes the second error in this log: "TypeError: Cannot read properties of undefined (reading 'config')" 

```
[2023-12-04T23:52:26] | (payload): BadRequestError: request aborted
-- | --
[2023-12-04T23:52:26] | at IncomingMessage.onAborted (/workspace/node_modules/.pnpm/raw-body@2.5.1/node_modules/raw-body/index.js:238:10)
[2023-12-04T23:52:26] | at IncomingMessage.emit (node:events:513:28)
[2023-12-04T23:52:26] | at IncomingMessage.emit (node:domain:489:12)
[2023-12-04T23:52:26] | at IncomingMessage._destroy (node:_http_incoming:224:10)
[2023-12-04T23:52:26] | at _destroy (node:internal/streams/destroy:102:25)
[2023-12-04T23:52:26] | at IncomingMessage.destroy (node:internal/streams/destroy:64:5)
[2023-12-04T23:52:26] | at abortIncoming (node:_http_server:642:9)
[2023-12-04T23:52:26] | at socketOnClose (node:_http_server:636:3)
[2023-12-04T23:52:26] | at Socket.emit (node:events:525:35)
[2023-12-04T23:52:26] | at Socket.emit (node:domain:489:12)
[2023-12-05T00:02:44] | This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
[2023-12-05T00:02:44] | TypeError: Cannot read properties of undefined (reading 'config')
[2023-12-05T00:02:44] | at /workspace/node_modules/.pnpm/payload@2.3.1_@types+react@18.2.13_typescript@5.1.6_webpack@5.83.1/node_modules/payload/dist/express/middleware/errorHandler.js:40:110
[2023-12-05T00:02:44] | at Layer.handle_error (/workspace/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/layer.js:71:5)
[2023-12-05T00:02:44] | at trim_prefix (/workspace/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/index.js:326:13)
[2023-12-05T00:02:44] | at /workspace/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/index.js:286:9
[2023-12-05T00:02:44] | at Function.process_params (/workspace/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/index.js:346:12)
[2023-12-05T00:02:44] | at Function.process_params (/workspace/node_modules/.pnpm/@sentry-internal+tracing@7.60.1/node_modules/@sentry-internal/tracing/cjs/node/integrations/express.js:283:34)
[2023-12-05T00:02:44] | at next (/workspace/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/index.js:280:10)
[2023-12-05T00:02:44] | at Layer.handle_error (/workspace/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/layer.js:67:12)
[2023-12-05T00:02:44] | at trim_prefix (/workspace/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/index.js:326:13)
[2023-12-05T00:02:44] | at /workspace/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/index.js:286:9
```

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
