### PR TITLE
fix: handles null upload field values

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Upload/Input.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Upload/Input.tsx
@@ -88,7 +88,7 @@ const UploadInput: React.FC<UploadInputProps> = (props) => {
   })
 
   useEffect(() => {
-    if (typeof value !== 'undefined' && value !== '') {
+    if (value !== null && typeof value !== 'undefined' && value !== '') {
       const fetchFile = async () => {
         const response = await fetch(`${serverURL}${api}/${relationTo}/${value}`, {
           credentials: 'include',


### PR DESCRIPTION
## Description

When removing a file from an upload field, the value is stored as `null`. This fix prevents the upload input component from trying to fetch a file.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
