### PR TITLE
fix(db-postgres): querying nested blocks fields

### DIFF
--- a/packages/db-postgres/src/queries/getTableColumnFromPath.ts
+++ b/packages/db-postgres/src/queries/getTableColumnFromPath.ts
@@ -240,6 +240,7 @@ export const getTableColumnFromPath = ({
         let newTableName: string
         const hasBlockField = field.blocks.some((block) => {
           newTableName = `${tableName}_blocks_${toSnakeCase(block.slug)}`
+          constraintPath = `${constraintPath}${field.name}.%.`
           let result
           const blockConstraints = []
           const blockSelectFields = {}
@@ -247,7 +248,7 @@ export const getTableColumnFromPath = ({
             result = getTableColumnFromPath({
               adapter,
               collectionPath,
-              constraintPath: '',
+              constraintPath,
               constraints: blockConstraints,
               fields: block.fields,
               joinAliases,

--- a/packages/db-postgres/src/queries/getTableColumnFromPath.ts
+++ b/packages/db-postgres/src/queries/getTableColumnFromPath.ts
@@ -285,7 +285,7 @@ export const getTableColumnFromPath = ({
               adapter.tables[newTableName]._parentID,
             )
           }
-          return result
+          return true
         })
         if (hasBlockField) {
           return {
@@ -294,7 +294,7 @@ export const getTableColumnFromPath = ({
             field: blockTableColumn.field,
             pathSegments: pathSegments.slice(1),
             rawColumn: blockTableColumn.rawColumn,
-            table: adapter.tables[newTableName],
+            table: blockTableColumn.table,
           }
         }
         if (pathSegments[1] === 'blockType') {

--- a/test/_community/collections/Posts/index.ts
+++ b/test/_community/collections/Posts/index.ts
@@ -20,5 +20,21 @@ export const PostsCollection: CollectionConfig = {
         update: () => false,
       },
     },
+    {
+      name: 'layout',
+      type: 'blocks',
+      blocks: [
+        {
+          slug: 'formBlock',
+          fields: [
+            {
+              name: 'form',
+              type: 'relationship',
+              relationTo: 'forms',
+            },
+          ],
+        },
+      ],
+    },
   ],
 }

--- a/test/_community/collections/Posts/index.ts
+++ b/test/_community/collections/Posts/index.ts
@@ -5,7 +5,6 @@ import { mediaSlug } from '../Media'
 export const postsSlug = 'posts'
 
 export const PostsCollection: CollectionConfig = {
-  slug: postsSlug,
   fields: [
     {
       name: 'text',
@@ -13,28 +12,13 @@ export const PostsCollection: CollectionConfig = {
     },
     {
       name: 'associatedMedia',
-      type: 'upload',
-      relationTo: mediaSlug,
       access: {
         create: () => true,
         update: () => false,
       },
-    },
-    {
-      name: 'layout',
-      type: 'blocks',
-      blocks: [
-        {
-          slug: 'formBlock',
-          fields: [
-            {
-              name: 'form',
-              type: 'relationship',
-              relationTo: 'forms',
-            },
-          ],
-        },
-      ],
+      relationTo: mediaSlug,
+      type: 'upload',
     },
   ],
+  slug: postsSlug,
 }

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -1,3 +1,4 @@
+import FormBuilder from '../../packages/plugin-form-builder/src'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults'
 import { devUser } from '../credentials'
 import { MediaCollection } from './collections/Media'
@@ -18,6 +19,7 @@ export default buildConfigWithDefaults({
   graphQL: {
     schemaOutputFile: './test/_community/schema.graphql',
   },
+  plugins: [FormBuilder({})],
 
   onInit: async (payload) => {
     await payload.create({

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -1,4 +1,3 @@
-import FormBuilder from '../../packages/plugin-form-builder/src'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults'
 import { devUser } from '../credentials'
 import { MediaCollection } from './collections/Media'
@@ -19,7 +18,6 @@ export default buildConfigWithDefaults({
   graphQL: {
     schemaOutputFile: './test/_community/schema.graphql',
   },
-  plugins: [FormBuilder({})],
 
   onInit: async (payload) => {
     await payload.create({
@@ -30,24 +28,10 @@ export default buildConfigWithDefaults({
       },
     })
 
-    const { id: formID } = await payload.create({
-      collection: 'forms',
-      data: {
-        title: 'test',
-        confirmationMessage: 'test',
-      },
-    })
-
     await payload.create({
       collection: postsSlug,
       data: {
         text: 'example post',
-        layout: [
-          {
-            blockType: 'formBlock',
-            form: formID,
-          },
-        ],
       },
     })
   },

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -30,10 +30,24 @@ export default buildConfigWithDefaults({
       },
     })
 
+    const { id: formID } = await payload.create({
+      collection: 'forms',
+      data: {
+        title: 'test',
+        confirmationMessage: 'test',
+      },
+    })
+
     await payload.create({
       collection: postsSlug,
       data: {
         text: 'example post',
+        layout: [
+          {
+            blockType: 'formBlock',
+            form: formID,
+          },
+        ],
       },
     })
   },

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -1,88 +1,81 @@
 import type { CollectionConfig } from '../../../../packages/payload/src/collections/config/types'
 import type { BlockField } from '../../../../packages/payload/src/fields/config/types'
 
-import { blockFieldsSlug } from '../../slugs'
+import { blockFieldsSlug, textFieldsSlug } from '../../slugs'
 import { AddCustomBlocks } from './components/AddCustomBlocks'
 import { getBlocksFieldSeedData } from './shared'
 
 export const getBlocksField = (prefix?: string): BlockField => ({
   name: 'blocks',
-  type: 'blocks',
-  required: true,
   blocks: [
     {
-      slug: prefix ? `${prefix}Content` : 'content',
       fields: [
         {
           name: 'text',
-          type: 'text',
           required: true,
+          type: 'text',
         },
         {
           name: 'richText',
           type: 'richText',
         },
       ],
+      slug: prefix ? `${prefix}Content` : 'content',
     },
     {
-      slug: prefix ? `${prefix}Number` : 'number',
       fields: [
         {
           name: 'number',
-          type: 'number',
           required: true,
+          type: 'number',
         },
       ],
+      slug: prefix ? `${prefix}Number` : 'number',
     },
     {
-      slug: prefix ? `${prefix}SubBlocks` : 'subBlocks',
       fields: [
         {
-          type: 'collapsible',
-          label: 'Collapsible within Block',
           fields: [
             {
               name: 'subBlocks',
-              type: 'blocks',
               blocks: [
                 {
-                  slug: 'text',
                   fields: [
                     {
                       name: 'text',
-                      type: 'text',
                       required: true,
+                      type: 'text',
                     },
                   ],
+                  slug: 'text',
                 },
                 {
-                  slug: 'number',
                   fields: [
                     {
                       name: 'number',
-                      type: 'number',
                       required: true,
+                      type: 'number',
                     },
                   ],
+                  slug: 'number',
                 },
               ],
+              type: 'blocks',
             },
           ],
+          label: 'Collapsible within Block',
+          type: 'collapsible',
         },
       ],
+      slug: prefix ? `${prefix}SubBlocks` : 'subBlocks',
     },
     {
-      slug: prefix ? `${prefix}Tabs` : 'tabs',
       fields: [
         {
-          type: 'tabs',
           tabs: [
             {
-              label: 'Tab with Collapsible',
               fields: [
                 {
-                  type: 'collapsible',
-                  label: 'Collapsible within Block',
                   fields: [
                     {
                       // collapsible
@@ -90,9 +83,10 @@ export const getBlocksField = (prefix?: string): BlockField => ({
                       type: 'text',
                     },
                   ],
+                  label: 'Collapsible within Block',
+                  type: 'collapsible',
                 },
                 {
-                  type: 'row',
                   fields: [
                     {
                       // collapsible
@@ -100,28 +94,33 @@ export const getBlocksField = (prefix?: string): BlockField => ({
                       type: 'text',
                     },
                   ],
+                  type: 'row',
                 },
               ],
+              label: 'Tab with Collapsible',
             },
           ],
+          type: 'tabs',
         },
       ],
+      slug: prefix ? `${prefix}Tabs` : 'tabs',
     },
   ],
   defaultValue: getBlocksFieldSeedData(prefix),
+  required: true,
+  type: 'blocks',
 })
 
 const BlockFields: CollectionConfig = {
-  slug: blockFieldsSlug,
   fields: [
     getBlocksField(),
     {
       ...getBlocksField('localized'),
       name: 'collapsedByDefaultBlocks',
-      localized: true,
       admin: {
         initCollapsed: true,
       },
+      localized: true,
     },
     {
       ...getBlocksField('localized'),
@@ -129,135 +128,152 @@ const BlockFields: CollectionConfig = {
       localized: true,
     },
     {
-      type: 'blocks',
       name: 'i18nBlocks',
-      label: {
-        en: 'Block en',
-        es: 'Block es',
-      },
-      labels: {
-        singular: {
-          en: 'Block en',
-          es: 'Block es',
-        },
-        plural: {
-          en: 'Blocks en',
-          es: 'Blocks es',
-        },
-      },
       blocks: [
         {
-          slug: 'text',
-          graphQL: {
-            singularName: 'I18nText',
-          },
-          labels: {
-            singular: {
-              en: 'Text en',
-              es: 'Text es',
-            },
-            plural: {
-              en: 'Texts en',
-              es: 'Texts es',
-            },
-          },
           fields: [
             {
               name: 'text',
               type: 'text',
             },
           ],
+          graphQL: {
+            singularName: 'I18nText',
+          },
+          labels: {
+            plural: {
+              en: 'Texts en',
+              es: 'Texts es',
+            },
+            singular: {
+              en: 'Text en',
+              es: 'Text es',
+            },
+          },
+          slug: 'text',
         },
       ],
+      label: {
+        en: 'Block en',
+        es: 'Block es',
+      },
+      labels: {
+        plural: {
+          en: 'Blocks en',
+          es: 'Blocks es',
+        },
+        singular: {
+          en: 'Block en',
+          es: 'Block es',
+        },
+      },
+      type: 'blocks',
     },
     {
-      type: 'blocks',
       name: 'blocksWithSimilarConfigs',
       blocks: [
         {
-          slug: 'block-a',
           fields: [
             {
-              type: 'array',
               name: 'items',
               fields: [
                 {
-                  type: 'text',
                   name: 'title',
                   required: true,
+                  type: 'text',
                 },
               ],
+              type: 'array',
             },
           ],
+          slug: 'block-a',
         },
         {
-          slug: 'block-b',
           fields: [
             {
-              type: 'array',
               name: 'items',
               fields: [
                 {
-                  type: 'text',
                   name: 'title2',
                   required: true,
+                  type: 'text',
                 },
               ],
+              type: 'array',
             },
           ],
+          slug: 'block-b',
         },
       ],
+      type: 'blocks',
     },
     {
       name: 'blocksWithMinRows',
-      type: 'blocks',
-      minRows: 2,
       blocks: [
         {
-          slug: 'block',
           fields: [
             {
               name: 'blockTitle',
               type: 'text',
             },
           ],
+          slug: 'block',
         },
       ],
+      minRows: 2,
+      type: 'blocks',
     },
     {
       name: 'customBlocks',
-      type: 'blocks',
       blocks: [
         {
-          slug: 'block-1',
           fields: [
             {
               name: 'block1Title',
               type: 'text',
             },
           ],
+          slug: 'block-1',
         },
         {
-          slug: 'block-2',
           fields: [
             {
               name: 'block2Title',
               type: 'text',
             },
           ],
+          slug: 'block-2',
         },
       ],
+      type: 'blocks',
     },
     {
-      type: 'ui',
+      name: 'relationshipBlocks',
+      blocks: [
+        {
+          fields: [
+            {
+              name: 'relationship',
+              relationTo: textFieldsSlug,
+              type: 'relationship',
+            },
+          ],
+          slug: 'relationships',
+        },
+      ],
+      type: 'blocks',
+    },
+    {
       name: 'ui',
       admin: {
         components: {
           Field: AddCustomBlocks,
         },
       },
+      type: 'ui',
     },
   ],
+  slug: blockFieldsSlug,
 }
 
 export default BlockFields

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -29,7 +29,14 @@ import {
 import { tabsDoc } from './collections/Tabs/shared'
 import { defaultText } from './collections/Text/shared'
 import { clearAndSeedEverything } from './seed'
-import { arrayFieldsSlug, groupFieldsSlug, relationshipFieldsSlug, tabsFieldsSlug } from './slugs'
+import {
+  arrayFieldsSlug,
+  blockFieldsSlug,
+  groupFieldsSlug,
+  relationshipFieldsSlug,
+  tabsFieldsSlug,
+  textFieldsSlug,
+} from './slugs'
 
 let client: RESTClient
 let graphQLClient: GraphQLClient
@@ -897,6 +904,35 @@ describe('Fields', () => {
 
       const { docs } = blockFields
       expect(docs).toHaveLength(2)
+    })
+
+    it('should query blocks with nested relationship', async () => {
+      const textDoc = await payload.create({
+        collection: textFieldsSlug,
+        data: {
+          text: 'test',
+        },
+      })
+      const blockDoc = await payload.create({
+        collection: blockFieldsSlug,
+        data: {
+          relationshipBlocks: [
+            {
+              blockType: 'relationships',
+              relationship: textDoc.id,
+            },
+          ],
+        },
+      })
+      const result = await payload.find({
+        collection: blockFieldsSlug,
+        where: {
+          'relationshipBlocks.relationship': { equals: textDoc.id },
+        },
+      })
+
+      expect(result.docs).toHaveLength(1)
+      expect(result.docs[0]).toMatchObject(blockDoc)
     })
   })
 


### PR DESCRIPTION
## Description

fixes https://github.com/payloadcms/payload/issues/4008

Querying on fields inside of a nested block was throwing errors as it was trying to query the wrong table.
Additionally, the `path` constraint was incorrect and ending up with no results where there should have been because it was matching on `relationship` when the path would be something like: `relationshipBlocks.0.relationship`

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
