### PR TITLE
fix(richtext-*): loosen RichTextAdapter types due to re-occuring ts strict mode errors

### DIFF
--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -25,11 +25,7 @@ export type LexicalEditorProps = {
   lexical?: LexicalEditorConfig
 }
 
-export type LexicalRichTextAdapter = RichTextAdapter<
-  SerializedEditorState,
-  AdapterProps,
-  AdapterProps
-> & {
+export type LexicalRichTextAdapter = RichTextAdapter<SerializedEditorState, AdapterProps, any> & {
   editorConfig: SanitizedEditorConfig
 }
 

--- a/packages/richtext-slate/src/index.ts
+++ b/packages/richtext-slate/src/index.ts
@@ -9,9 +9,7 @@ import { richTextRelationshipPromise } from './data/richTextRelationshipPromise'
 import { richTextValidate } from './data/validation'
 import RichTextField from './field'
 
-export function slateEditor(
-  args: AdapterArguments,
-): RichTextAdapter<any[], AdapterArguments, AdapterArguments> {
+export function slateEditor(args: AdapterArguments): RichTextAdapter<any[], AdapterArguments, any> {
   return {
     CellComponent: withMergedProps({
       Component: RichTextCell,

--- a/packages/richtext-slate/src/types.ts
+++ b/packages/richtext-slate/src/types.ts
@@ -73,4 +73,4 @@ export type AdapterArguments = {
   }
 }
 
-export type FieldProps = RichTextFieldProps<any, AdapterArguments, AdapterArguments>
+export type FieldProps = RichTextFieldProps<any[], AdapterArguments, AdapterArguments>


### PR DESCRIPTION
## Description

Resolves Discord issue: https://discord.com/channels/967097582721572934/1182255256269225985/1182333481330688110

In the future, we need to find something better for this than typing this as `any`. This is like the 5th time I had to fix ts strict mode issues due to this generic, so for now, I don't care anymore. This is okay as a temp fix

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
