### PR TITLE
docs: add example for /me API in the absence of logged in user

### DIFF
--- a/docs/authentication/operations.mdx
+++ b/docs/authentication/operations.mdx
@@ -77,7 +77,7 @@ Returns either a logged in user with token or null when there is no logged in us
 
 `GET http://localhost:3000/api/[collection-slug]/me`
 
-Example response:
+Example response for logged in user:
 
 ```ts
 {
@@ -92,7 +92,15 @@ Example response:
 }
 ```
 
-**Example GraphQL Query**:
+Example response when there is no logged in user:
+
+```ts
+{
+  user: null
+}
+```
+
+**Example GraphQL Query for logged in user**:
 
 ```graphql
 query {
@@ -101,6 +109,16 @@ query {
       email
     }
     exp
+  }
+}
+```
+
+**Example GraphQL Query when there is no logged in user**:
+
+```graphql
+query {
+  me[collection-singular-label] {
+    user: null
   }
 }
 ```


### PR DESCRIPTION
## Description

Explicitly document the result in case no logged in user is present. The statement `Returns either a logged in user with token or null when there is no logged in user.` can be confusing.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] This change requires a documentation update

