### PR TITLE
chore(richtext-lexical): Slash Menu: Don't show scroll bar if not needed

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/plugins/SlashMenu/index.scss
+++ b/packages/richtext-lexical/src/field/lexical/plugins/SlashMenu/index.scss
@@ -14,7 +14,7 @@ html[data-theme='light'] {
   list-style: none;
   font-family: var(--font-body);
   max-height: 300px;
-  overflow-y: scroll;
+  overflow-y: auto;
   z-index: 10;
   position: absolute;
 


### PR DESCRIPTION
## Description

If there are only few elements enabled in the slash menu, we don't need to show the scroll bar.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
