### PR TITLE
DRAFT: fix(richtext-lexical): link drawers nested in link drawers not functioning properly

### DIFF
--- a/packages/richtext-lexical/src/field/features/Link/drawer/baseFields.ts
+++ b/packages/richtext-lexical/src/field/features/Link/drawer/baseFields.ts
@@ -41,7 +41,7 @@ export const getBaseFields = (
 
   // Appending the uuid to the field group name ensures that the field group name is unique if two
   // Link drawers are open at the same time (e.g. you open a link drawer from a link drawer in some higher editor depth)
-  const fieldGroupName = `fields_${uuid}`
+  const fieldGroupName = `linkDrawer_fields_${uuid}`
 
   const baseFields = [
     {

--- a/packages/richtext-lexical/src/field/features/Link/drawer/baseFields.ts
+++ b/packages/richtext-lexical/src/field/features/Link/drawer/baseFields.ts
@@ -16,6 +16,7 @@ const translations = extractTranslations([
 ])
 
 export const getBaseFields = (
+  uuid: string,
   config: Config,
   enabledCollections: false | string[],
   disabledCollections: false | string[],
@@ -38,6 +39,10 @@ export const getBaseFields = (
       .map(({ slug }) => slug)
   }
 
+  // Appending the uuid to the field group name ensures that the field group name is unique if two
+  // Link drawers are open at the same time (e.g. you open a link drawer from a link drawer in some higher editor depth)
+  const fieldGroupName = `fields_${uuid}`
+
   const baseFields = [
     {
       name: 'text',
@@ -46,7 +51,7 @@ export const getBaseFields = (
       type: 'text',
     },
     {
-      name: 'fields',
+      name: fieldGroupName,
       admin: {
         style: {
           borderBottom: 0,
@@ -79,6 +84,7 @@ export const getBaseFields = (
           type: 'text',
         },
       ] as Field[],
+      label: '',
       type: 'group',
     },
   ]
@@ -90,14 +96,16 @@ export const getBaseFields = (
       value: 'internal',
     })
     ;(baseFields[1].fields[1] as TextField).admin = {
-      condition: ({ fields }) => fields?.linkType !== 'internal',
+      condition: (data) => {
+        return data[fieldGroupName]?.linkType !== 'internal'
+      },
     }
 
     baseFields[1].fields.push({
       name: 'doc',
       admin: {
-        condition: ({ fields }) => {
-          return fields?.linkType === 'internal'
+        condition: (data) => {
+          return data[fieldGroupName]?.linkType === 'internal'
         },
       },
       label: translations['fields:chooseDocumentToLink'],

--- a/packages/richtext-lexical/src/field/features/Link/plugins/floatingLinkEditor/LinkEditor/index.tsx
+++ b/packages/richtext-lexical/src/field/features/Link/plugins/floatingLinkEditor/LinkEditor/index.tsx
@@ -22,7 +22,7 @@ import {
   useLocale,
 } from 'payload/components/utilities'
 import { sanitizeFields } from 'payload/config'
-import { getTranslation } from 'payload/utilities'
+import { deepCopyObject, getTranslation } from 'payload/utilities'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -108,8 +108,8 @@ export function LinkEditor({
       }
 
       // Initial state:
-      const data: LinkPayload = {
-        fields: {
+      const data: any = {
+        [`linkDrawer_fields_${uuid}`]: {
           doc: undefined,
           linkType: undefined,
           newTab: undefined,
@@ -190,7 +190,7 @@ export function LinkEditor({
     }
 
     return true
-  }, [anchorElem, editor, fieldSchema, config, getDocPreferences, locale, t, user, i18n])
+  }, [anchorElem, editor, fieldSchema, config, getDocPreferences, locale, t, user, i18n, uuid])
 
   useEffect(() => {
     return mergeRegister(
@@ -324,11 +324,15 @@ export function LinkEditor({
         handleModalSubmit={(fields: Fields, data: Data) => {
           closeModal(drawerSlug)
 
+          data.fields = deepCopyObject(data[`linkDrawer_fields_${uuid}`])
+          delete data[`linkDrawer_fields_${uuid}`]
+
           if (data?.fields?.doc?.value) {
             data.fields.doc.value = {
-              id: data.fields.doc.value,
+              id: data?.fields?.doc.value,
             }
           }
+
           const newLinkPayload: LinkPayload = data as LinkPayload
 
           editor.dispatchCommand(TOGGLE_LINK_COMMAND, newLinkPayload)

--- a/packages/richtext-lexical/src/field/features/Link/plugins/floatingLinkEditor/LinkEditor/index.tsx
+++ b/packages/richtext-lexical/src/field/features/Link/plugins/floatingLinkEditor/LinkEditor/index.tsx
@@ -64,6 +64,7 @@ export function LinkEditor({
 
   const [fieldSchema] = useState(() => {
     const fieldsUnsanitized = transformExtraFields(
+      uuid,
       customFieldSchema,
       config,
       i18n,

--- a/packages/richtext-lexical/src/field/features/Link/plugins/floatingLinkEditor/utilities.ts
+++ b/packages/richtext-lexical/src/field/features/Link/plugins/floatingLinkEditor/utilities.ts
@@ -2,7 +2,6 @@ import type { i18n } from 'i18next'
 import type { SanitizedConfig } from 'payload/config'
 import type { Field, GroupField } from 'payload/types'
 
-import { useEditorConfigContext } from '../../../../lexical/config/EditorConfigProvider'
 import { getBaseFields } from '../../drawer/baseFields'
 
 /**
@@ -46,11 +45,11 @@ export function transformExtraFields(
   if (Array.isArray(customFieldSchema) || fields.length > 0) {
     // find field with name 'fields' and add the extra fields to it
     const fieldsField: GroupField = fields.find(
-      (field) => field.type === 'group' && field.name === `fields_${uuid}`,
+      (field) => field.type === 'group' && field.name === `linkDrawer_fields_${uuid}`,
     ) as GroupField
     if (!fieldsField) {
       throw new Error(
-        `Could not find field with name "fields_${uuid}". This is required to add fields to the link field.`,
+        `Could not find field with name "linkDrawer_fields_${uuid}". This is required to add fields to the link field.`,
       )
     }
     fieldsField.fields = Array.isArray(fieldsField.fields) ? fieldsField.fields : []

--- a/packages/richtext-lexical/src/field/features/Link/plugins/floatingLinkEditor/utilities.ts
+++ b/packages/richtext-lexical/src/field/features/Link/plugins/floatingLinkEditor/utilities.ts
@@ -2,12 +2,14 @@ import type { i18n } from 'i18next'
 import type { SanitizedConfig } from 'payload/config'
 import type { Field, GroupField } from 'payload/types'
 
+import { useEditorConfigContext } from '../../../../lexical/config/EditorConfigProvider'
 import { getBaseFields } from '../../drawer/baseFields'
 
 /**
  * This function is run to enrich the basefields which every link has with potential, custom user-added fields.
  */
 export function transformExtraFields(
+  uuid: string,
   customFieldSchema:
     | ((args: { config: SanitizedConfig; defaultFields: Field[]; i18n: i18n }) => Field[])
     | Field[],
@@ -16,7 +18,7 @@ export function transformExtraFields(
   enabledCollections?: false | string[],
   disabledCollections?: false | string[],
 ): Field[] {
-  const baseFields: Field[] = getBaseFields(config, enabledCollections, disabledCollections)
+  const baseFields: Field[] = getBaseFields(uuid, config, enabledCollections, disabledCollections)
 
   const fields =
     typeof customFieldSchema === 'function'
@@ -44,11 +46,11 @@ export function transformExtraFields(
   if (Array.isArray(customFieldSchema) || fields.length > 0) {
     // find field with name 'fields' and add the extra fields to it
     const fieldsField: GroupField = fields.find(
-      (field) => field.type === 'group' && field.name === 'fields',
+      (field) => field.type === 'group' && field.name === `fields_${uuid}`,
     ) as GroupField
     if (!fieldsField) {
       throw new Error(
-        'Could not find field with name "fields". This is required to add fields to the link field.',
+        `Could not find field with name "fields_${uuid}". This is required to add fields to the link field.`,
       )
     }
     fieldsField.fields = Array.isArray(fieldsField.fields) ? fieldsField.fields : []

--- a/test/fields/collections/Lexical/index.ts
+++ b/test/fields/collections/Lexical/index.ts
@@ -42,6 +42,103 @@ export const LexicalFields: CollectionConfig = {
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,
           //TestRecorderFeature(),
+          UploadFeature({
+            collections: {
+              uploads: {
+                fields: [
+                  {
+                    name: 'linkType',
+                    defaultValue: 'custom',
+                    options: [
+                      {
+                        label: 'Custom',
+                        value: 'custom',
+                      },
+                      {
+                        label: 'AA',
+                        value: 'aa',
+                      },
+                    ],
+                    required: true,
+                    type: 'radio',
+                  },
+                  {
+                    name: 'doc',
+                    admin: {
+                      condition: (data) => {
+                        return data?.linkType === 'custom'
+                      },
+                    },
+                    required: true,
+                    type: 'text',
+                  },
+                  {
+                    name: 'caption',
+                    type: 'richText',
+                    editor: lexicalEditor({
+                      features: ({ defaultFeatures }) => [
+                        ...defaultFeatures,
+                        //TestRecorderFeature(),
+                        UploadFeature({
+                          collections: {
+                            uploads: {
+                              fields: [
+                                {
+                                  name: 'linkType',
+                                  defaultValue: 'custom',
+                                  options: [
+                                    {
+                                      label: 'Custom',
+                                      value: 'custom',
+                                    },
+                                    {
+                                      label: 'AA',
+                                      value: 'aa',
+                                    },
+                                  ],
+                                  required: true,
+                                  type: 'radio',
+                                },
+                                {
+                                  name: 'doc',
+                                  admin: {
+                                    condition: (data) => {
+                                      return data?.linkType === 'custom'
+                                    },
+                                  },
+                                  required: true,
+                                  type: 'text',
+                                },
+                                {
+                                  name: 'caption',
+                                  type: 'richText',
+                                  editor: lexicalEditor(),
+                                },
+                              ],
+                            },
+                          },
+                        }),
+                        TreeviewFeature(),
+                        BlocksFeature({
+                          blocks: [
+                            RichTextBlock,
+                            TextBlock,
+                            UploadAndRichTextBlock,
+                            SelectFieldBlock,
+                            RelationshipBlock,
+                            RelationshipHasManyBlock,
+                            SubBlockBlock,
+                            RadioButtonsBlock,
+                            ConditionalLayoutBlock,
+                          ],
+                        }),
+                      ],
+                    }),
+                  },
+                ],
+              },
+            },
+          }),
           TreeviewFeature(),
           BlocksFeature({
             blocks: [

--- a/test/fields/collections/Upload/index.ts
+++ b/test/fields/collections/Upload/index.ts
@@ -2,7 +2,23 @@ import path from 'path'
 
 import type { CollectionConfig } from '../../../../packages/payload/src/collections/config/types'
 
+import {
+  BlocksFeature,
+  TreeviewFeature,
+  lexicalEditor,
+} from '../../../../packages/richtext-lexical/src'
 import { uploadsSlug } from '../../slugs'
+import {
+  ConditionalLayoutBlock,
+  RadioButtonsBlock,
+  RelationshipBlock,
+  RelationshipHasManyBlock,
+  RichTextBlock,
+  SelectFieldBlock,
+  SubBlockBlock,
+  TextBlock,
+  UploadAndRichTextBlock,
+} from '../Lexical/blocks'
 
 const Uploads: CollectionConfig = {
   slug: uploadsSlug,
@@ -27,6 +43,30 @@ const Uploads: CollectionConfig = {
     {
       type: 'richText',
       name: 'richText',
+    },
+    {
+      type: 'richText',
+      name: 'richText2',
+      editor: lexicalEditor({
+        features: ({ defaultFeatures }) => [
+          ...defaultFeatures,
+          //TestRecorderFeature(),
+          TreeviewFeature(),
+          BlocksFeature({
+            blocks: [
+              RichTextBlock,
+              TextBlock,
+              UploadAndRichTextBlock,
+              SelectFieldBlock,
+              RelationshipBlock,
+              RelationshipHasManyBlock,
+              SubBlockBlock,
+              RadioButtonsBlock,
+              ConditionalLayoutBlock,
+            ],
+          }),
+        ],
+      }),
     },
   ],
 }


### PR DESCRIPTION
## Description

TODO:

- [ ] Remove unnecessary changes in test suite 
- [ ] Figure out DX for people who want to add custom fields with, let's say, conditions to other fields. Instead of being able to do data.fields.someField, they now have to do data.linkDrawer_fields_someuuidhere.someField while not knowing the uuid. This is also an issue for the Blocks field
- [ ] Both Links, Blocks and Uploads are now doing this wrapping-in-custom-group. Every time it's done in a slightly different way → figure out a uniform way to handle this. On load, the group wrapping needs to happen for both field schema and field data. On save, group unwrapping needs to happen for field data. **Maybe there instead needs to be a smart way inside of the form to handle that, instead of manually doing group wrapping and unwrapping**. Some kind of `fieldsParentPathName` or something like that which can be set inside of the form and affects the paths of all sub-fields (as that's what causes radio buttons with identical path to not work anymore).
- [ ] Add 4 e2e tests:
  - [ ] Saving and loading data from link drawer fields
  - [ ] Saving and loading data from Upload drawer extra fields
  - [ ] Using the conditional radio fields in a link drawer inside of a link drawer (what this issue fixes)
  - [ ] Using the conditional radio fields in an upload drawer inside of an upload drawer (what this issue fixes)
- [ ] Unrelated, but I find `fields` being used in Form stuff (e.g. Form fields property) to be confusing. It could mean both field schema and field data. Maybe we can rename every mention of `fields` to either `fieldSchema` or `fieldData` (similar to what the `buildStateFromSchema` function accepts)


https://github.com/payloadcms/payload/assets/70709113/b3ca8638-ea96-4833-9626-e8cac43d8be1


This video shows the issue which this PR fixed. Nested Link drawer fields do not work properly because they are wrapped in a group which is not unique. Appending the uuid to the group's field name fixes this.

The same thing happens for the upload drawer fields:


https://github.com/payloadcms/payload/assets/70709113/bc05fa58-2c9b-4d1d-94d2-a724ec80b6a2



- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
