### PR TITLE
fix(richtext-lexical): lexicalHTML field now works when used inside of row fields

### DIFF
--- a/packages/richtext-lexical/src/field/features/converters/html/field/index.ts
+++ b/packages/richtext-lexical/src/field/features/converters/html/field/index.ts
@@ -80,11 +80,11 @@ export const lexicalHTML: (
                 }
               }
 
-              if ('fields' in curField && 'name' in curField) {
-                const result = findFieldPathAndSiblingFields(curField.fields, [
-                  ...path,
-                  curField.name,
-                ])
+              if ('fields' in curField) {
+                const result = findFieldPathAndSiblingFields(
+                  curField.fields,
+                  'name' in curField ? [...path, curField.name] : [...path],
+                )
                 if (result) {
                   return result
                 }


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/4034#issuecomment-1848771272

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
