### PR TITLE
feat(richtext-lexical): improve link URL validation

### DIFF
--- a/packages/richtext-lexical/src/field/features/Link/drawer/baseFields.ts
+++ b/packages/richtext-lexical/src/field/features/Link/drawer/baseFields.ts
@@ -4,6 +4,8 @@ import type { RadioField, TextField } from 'payload/types'
 
 import { extractTranslations } from 'payload/utilities'
 
+import { validateUrl } from '../../../lexical/utils/url'
+
 const translations = extractTranslations([
   'fields:textToDisplay',
   'fields:linkType',
@@ -77,6 +79,11 @@ export const getBaseFields = (
           label: translations['fields:enterURL'],
           required: true,
           type: 'text',
+          validate: (value: string) => {
+            if (value && !validateUrl(value)) {
+              return 'Invalid URL'
+            }
+          },
         },
       ] as Field[],
       type: 'group',

--- a/packages/richtext-lexical/src/field/lexical/utils/url.ts
+++ b/packages/richtext-lexical/src/field/lexical/utils/url.ts
@@ -26,7 +26,12 @@ const urlRegExp =
   /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z\d.-]+|(?:www.|[-;:&=+$,\w]+@)[A-Za-z\d.-]+)((?:\/[+~%/.\w-]*)?\??[-+=&;%@.\w]*#?\w*)?)/
 
 export function validateUrl(url: string): boolean {
+  console.log('validateUrl testing URL', urlRegExp.test(url), 'for URL', url)
   // TODO Fix UI for link insertion; it should never default to an invalid URL such as https://.
   // Maybe show a dialog where they user can type the URL before inserting it.
-  return url === 'https://' || urlRegExp.test(url)
+  return (
+    url === 'https://' ||
+    urlRegExp.test(url) ||
+    (url.startsWith('tel:+') && !!url.split('tel:+')[1].match(/^\d+$/))
+  )
 }

--- a/packages/richtext-lexical/src/field/lexical/utils/url.ts
+++ b/packages/richtext-lexical/src/field/lexical/utils/url.ts
@@ -26,7 +26,6 @@ const urlRegExp =
   /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z\d.-]+|(?:www.|[-;:&=+$,\w]+@)[A-Za-z\d.-]+)((?:\/[+~%/.\w-]*)?\??[-+=&;%@.\w]*#?\w*)?)/
 
 export function validateUrl(url: string): boolean {
-  console.log('validateUrl testing URL', urlRegExp.test(url), 'for URL', url)
   // TODO Fix UI for link insertion; it should never default to an invalid URL such as https://.
   // Maybe show a dialog where they user can type the URL before inserting it.
   return (


### PR DESCRIPTION
## Description

- Fixes #4358 (URLs starting with tel: did work, but URLs starting with tel:+ (country prefix numbers) did not)
- Adds URL validation to the `url` field in the Link drawer form. This is a nice UX improvement, as you now see immediately if the URL is invalid instead of the drawer just letting you save it, and then rewriting it to "https://" if it's invalid.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
