### PR TITLE
feat(richtext-lexical)!: improve floating select menu Dropdown classNames

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/plugins/FloatingSelectToolbar/ToolbarDropdown/DropDown.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/FloatingSelectToolbar/ToolbarDropdown/DropDown.tsx
@@ -277,7 +277,7 @@ export function DropDown({
         type="button"
       >
         <Icon />
-        <i className={`${buttonClassName}-caret`} />
+        <i className="floating-select-toolbar-popup__dropdown-caret" />
       </button>
 
       {showDropDown &&

--- a/packages/richtext-lexical/src/field/lexical/plugins/FloatingSelectToolbar/ToolbarDropdown/index.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/FloatingSelectToolbar/ToolbarDropdown/index.tsx
@@ -67,18 +67,23 @@ export const ToolbarDropdown = ({
   classNames,
   editor,
   entries,
+  sectionKey,
 }: {
   Icon?: React.FC
   anchorElem: HTMLElement
   classNames?: string[]
   editor: LexicalEditor
   entries: FloatingToolbarSectionEntry[]
+  sectionKey: string
 }) => {
   return (
     <DropDown
       Icon={Icon}
-      buttonAriaLabel="Formatting options"
-      buttonClassName={[baseClass, ...(classNames || [])].filter(Boolean).join(' ')}
+      buttonAriaLabel={`${sectionKey} dropdown`}
+      buttonClassName={[baseClass, `${baseClass}-${sectionKey}`, ...(classNames || [])]
+        .filter(Boolean)
+        .join(' ')}
+      key={sectionKey}
     >
       {entries.length &&
         entries.map((entry) => {

--- a/packages/richtext-lexical/src/field/lexical/plugins/FloatingSelectToolbar/index.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/FloatingSelectToolbar/index.tsx
@@ -110,10 +110,16 @@ function ToolbarSection({
               anchorElem={anchorElem}
               editor={editor}
               entries={section.entries}
+              sectionKey={section.key}
             />
           </React.Suspense>
         ) : (
-          <ToolbarDropdown anchorElem={anchorElem} editor={editor} entries={section.entries} />
+          <ToolbarDropdown
+            anchorElem={anchorElem}
+            editor={editor}
+            entries={section.entries}
+            sectionKey={section.key}
+          />
         ))}
       {section.type === 'buttons' &&
         section.entries.length &&


### PR DESCRIPTION
## Description

- Added extra unique class name for Dropdown button
- Fix incorrect aria label
- Fix incorrect className for Dropdown caret

Breaking:
- Dropdown component has a new mandatory `sectionKey` prop

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
