### PR TITLE
Docs: adds examples and descriptions to field hook docs

### DIFF
--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -18,10 +18,10 @@ Field-level hooks offer incredible potential for encapsulating your logic. They 
 
 **All field types provide the following hooks:**
 
-- `beforeValidate`
-- `beforeChange`
-- `afterChange`
-- `afterRead`
+- [beforeValidate](#beforevalidate)
+- [beforeChange](#beforechange)
+- [afterChange](#afterchange)
+- [afterRead](#afterread)
 
 ## Config
 
@@ -89,6 +89,99 @@ All field hooks can optionally modify the return value of the field before the o
   field, otherwise GraphQL will produce errors. If you need to change the shape or type of data,
   reconsider Field Hooks and instead evaluate if Collection / Global hooks might suit you better.
 </Banner>
+
+## Examples of Field Hooks
+
+To better illustrate how field-level hooks can be applied, here are some specific examples. These demonstrate the flexibility and potential of field hooks in different contexts. Remember, these examples are just a starting point - the true potential of field-level hooks lies in their adaptability to a wide array of use cases.
+
+### beforeValidate
+
+Runs before the `update` operation. This hook allows you to pre-process or format field data before it undergoes validation.
+
+```ts
+import { Field } from 'payload/types'
+
+const usernameField: Field = {
+  name: 'username',
+  type: 'text',
+  hooks: {
+    beforeValidate: [({ value }) => {
+      // Trim whitespace and convert to lowercase
+      return value.trim().toLowerCase()
+    }],
+  }
+}
+```
+
+In this example, the `beforeValidate` hook is used to process the `username` field. The hook takes the incoming value of the field and transforms it by trimming whitespace and converting it to lowercase. This ensures that the username is stored in a consistent format in the database.
+
+### beforeChange
+
+Immediately following validation, `beforeChange` hooks will run within `create` and `update` operations. At this stage, you can be confident that the field data that will be saved to the document is valid in accordance to your field validations.
+
+```ts
+import { Field } from 'payload/types'
+
+const emailField: Field = {
+  name: 'email',
+  type: 'email',
+  hooks: {
+    beforeChange: [({ value, operation }) => {
+      if (operation === 'create') {
+        // Perform additional validation or transformation for 'create' operation
+      }
+      return value
+    }],
+  }
+}
+```
+
+In the `emailField`, the `beforeChange` hook checks the `operation` type. If the operation is `create`, it performs additional validation or transformation on the email field value. This allows for operation-specific logic to be applied to the field.
+
+### afterChange
+
+The `afterChange` hook is executed after a field's value has been changed and saved in the database. This hook is useful for post-processing or triggering side effects based on the new value of the field.
+
+```ts
+import { Field } from 'payload/types'
+
+const passwordField: Field = {
+  name: 'password',
+  type: 'text',
+  hooks: {
+    afterChange: [({ value, previousValue, req }) => {
+      if (value !== previousValue) {
+        // Log or perform an action due to the password change
+        console.log(`Password for user ${req.user.id} has been changed.`)
+      }
+    }],
+  }
+}
+```
+
+In this example, the `afterChange` hook is attached to the `passwordField`. The hook compares the current `value` of the field with the `previousValue`. If there's a change in the password, it logs a message indicating that the user's password has been changed. This can be particularly useful for audit trails, security monitoring, or triggering additional actions like sending a password change confirmation email to the user.
+
+### afterRead
+
+The `afterRead` hook is invoked after a field value is read from the database. This is ideal for formatting or transforming the field data for output.
+
+```ts
+import { Field } from 'payload/types'
+
+const dateField: Field = {
+  name: 'createdAt',
+  type: 'date',
+  hooks: {
+    afterRead: [({ value }) => {
+      // Format date for display
+      return new Date(value).toLocaleDateString()
+    }],
+  }
+}
+```
+
+Here, the `afterRead` hook for the `dateField` is used to format the date into a more readable format using `toLocaleDateString()`. This hook modifies the way the date is presented to the user, making it more user-friendly.
+
 
 ## TypeScript
 

--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -145,21 +145,27 @@ The `afterChange` hook is executed after a field's value has been changed and sa
 ```ts
 import { Field } from 'payload/types'
 
-const passwordField: Field = {
-  name: 'password',
-  type: 'text',
+const membershipStatusField: Field = {
+  name: 'membershipStatus',
+  type: 'select',
+  options: [
+    { label: 'Standard', value: 'standard' },
+    { label: 'Premium', value: 'premium' },
+    { label: 'VIP', value: 'vip' }
+  ],
   hooks: {
     afterChange: [({ value, previousValue, req }) => {
       if (value !== previousValue) {
-        // Log or perform an action due to the password change
-        console.log(`Password for user ${req.user.id} has been changed.`)
+        // Log or perform an action when the membership status changes
+        console.log(`User ID ${req.user.id} changed their membership status from ${previousValue} to ${value}.`)
+        // Here, you can implement actions that could track conversions from one tier to another
       }
     }],
   }
 }
 ```
 
-In this example, the `afterChange` hook is attached to the `passwordField`. The hook compares the current `value` of the field with the `previousValue`. If there's a change in the password, it logs a message indicating that the user's password has been changed. This can be particularly useful for audit trails, security monitoring, or triggering additional actions like sending a password change confirmation email to the user.
+In this example, the `afterChange` hook is used with a `membershipStatusField`, which allows users to select their membership level (Standard, Premium, VIP). The hook monitors changes in the membership status. When a change occurs, it logs the update and can be used to trigger further actions, such as tracking conversion from one tier to another or notifying them about changes in their membership benefits.
 
 ### afterRead
 


### PR DESCRIPTION
## Description

#4425 

Adds examples & descriptions to field hooks documentation.

![Screen Shot 2023-12-11 at 12 14 58 PM](https://github.com/payloadcms/payload/assets/35232443/1ace152c-29d8-48a2-91a6-168cab93dcb4)
![Screen Shot 2023-12-11 at 12 15 07 PM](https://github.com/payloadcms/payload/assets/35232443/3fbe02dd-5f65-4892-bf0c-24c6f759441b)
![Screen Shot 2023-12-11 at 1 10 26 PM](https://github.com/payloadcms/payload/assets/35232443/f7a0ccdf-c67c-4823-902e-a764907fa7a3)
![Screen Shot 2023-12-11 at 12 15 27 PM](https://github.com/payloadcms/payload/assets/35232443/1e861507-020e-4976-ab5f-171677199c82)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
