### PR TITLE
feat: add context to auth and globals local API

### DIFF
--- a/packages/payload/src/auth/operations/local/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/local/forgotPassword.ts
@@ -1,4 +1,4 @@
-import type { GeneratedTypes } from '../../..'
+import type { GeneratedTypes, RequestContext } from '../../..'
 import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 import type { Result } from '../forgotPassword'
@@ -11,6 +11,7 @@ import forgotPassword from '../forgotPassword'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
   collection: T
+  context?: RequestContext
   data: {
     email: string
   }
@@ -25,12 +26,13 @@ async function localForgotPassword<T extends keyof GeneratedTypes['collections']
 ): Promise<Result> {
   const {
     collection: collectionSlug,
+    context,
     data,
     disableEmail,
     expiration,
     req = {} as PayloadRequest,
   } = options
-  setRequestContext(req)
+  setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
 

--- a/packages/payload/src/auth/operations/local/login.ts
+++ b/packages/payload/src/auth/operations/local/login.ts
@@ -1,6 +1,6 @@
 import type { Response } from 'express'
 
-import type { PayloadRequest } from '../../../express/types'
+import type { PayloadRequest, RequestContext } from '../../../express/types'
 import type { GeneratedTypes } from '../../../index'
 import type { Payload } from '../../../payload'
 import type { Result } from '../login'
@@ -13,6 +13,7 @@ import login from '../login'
 
 export type Options<TSlug extends keyof GeneratedTypes['collections']> = {
   collection: TSlug
+  context?: RequestContext
   data: {
     email: string
     password: string
@@ -32,6 +33,7 @@ async function localLogin<TSlug extends keyof GeneratedTypes['collections']>(
 ): Promise<Result & { user: GeneratedTypes['collections'][TSlug] }> {
   const {
     collection: collectionSlug,
+    context,
     data,
     depth,
     fallbackLocale,
@@ -41,7 +43,7 @@ async function localLogin<TSlug extends keyof GeneratedTypes['collections']>(
     res,
     showHiddenFields,
   } = options
-  setRequestContext(req)
+  setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
 

--- a/packages/payload/src/auth/operations/local/resetPassword.ts
+++ b/packages/payload/src/auth/operations/local/resetPassword.ts
@@ -1,4 +1,4 @@
-import type { GeneratedTypes } from '../../../'
+import type { GeneratedTypes, RequestContext } from '../../../'
 import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 import type { Result } from '../resetPassword'
@@ -11,6 +11,7 @@ import resetPassword from '../resetPassword'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
   collection: T
+  context?: RequestContext
   data: {
     password: string
     token: string
@@ -23,9 +24,15 @@ async function localResetPassword<T extends keyof GeneratedTypes['collections']>
   payload: Payload,
   options: Options<T>,
 ): Promise<Result> {
-  const { collection: collectionSlug, data, overrideAccess, req = {} as PayloadRequest } = options
+  const {
+    collection: collectionSlug,
+    context,
+    data,
+    overrideAccess,
+    req = {} as PayloadRequest,
+  } = options
 
-  setRequestContext(req)
+  setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
 

--- a/packages/payload/src/auth/operations/local/unlock.ts
+++ b/packages/payload/src/auth/operations/local/unlock.ts
@@ -1,4 +1,4 @@
-import type { GeneratedTypes } from '../../../'
+import type { GeneratedTypes, RequestContext } from '../../../'
 import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 
@@ -10,6 +10,7 @@ import unlock from '../unlock'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
   collection: T
+  context?: RequestContext
   data: {
     email
   }
@@ -23,11 +24,12 @@ async function localUnlock<T extends keyof GeneratedTypes['collections']>(
 ): Promise<boolean> {
   const {
     collection: collectionSlug,
+    context,
     data,
     overrideAccess = true,
     req = {} as PayloadRequest,
   } = options
-  setRequestContext(req)
+  setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
 

--- a/packages/payload/src/auth/operations/local/verifyEmail.ts
+++ b/packages/payload/src/auth/operations/local/verifyEmail.ts
@@ -1,4 +1,4 @@
-import type { GeneratedTypes } from '../../../'
+import type { GeneratedTypes, RequestContext } from '../../../'
 import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 
@@ -9,6 +9,7 @@ import verifyEmail from '../verifyEmail'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
   collection: T
+  context?: RequestContext
   req?: PayloadRequest
   token: string
 }
@@ -17,8 +18,8 @@ async function localVerifyEmail<T extends keyof GeneratedTypes['collections']>(
   payload: Payload,
   options: Options<T>,
 ): Promise<boolean> {
-  const { collection: collectionSlug, req = {} as PayloadRequest, token } = options
-  setRequestContext(req)
+  const { collection: collectionSlug, context, req = {} as PayloadRequest, token } = options
+  setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
 

--- a/packages/payload/src/globals/operations/local/findOne.ts
+++ b/packages/payload/src/globals/operations/local/findOne.ts
@@ -1,4 +1,4 @@
-import type { GeneratedTypes } from '../../..'
+import type { GeneratedTypes, RequestContext } from '../../..'
 import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 import type { Document } from '../../../types'
@@ -10,6 +10,7 @@ import { i18nInit } from '../../../translations/init'
 import findOne from '../findOne'
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
+  context?: RequestContext
   depth?: number
   draft?: boolean
   fallbackLocale?: string
@@ -26,6 +27,7 @@ export default async function findOneLocal<T extends keyof GeneratedTypes['globa
   options: Options<T>,
 ): Promise<GeneratedTypes['globals'][T]> {
   const {
+    context,
     depth,
     draft = false,
     fallbackLocale = null,
@@ -56,7 +58,7 @@ export default async function findOneLocal<T extends keyof GeneratedTypes['globa
     t: i18n.t,
     user,
   } as PayloadRequest
-  setRequestContext(req)
+  setRequestContext(req, context)
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
 

--- a/packages/payload/src/globals/operations/local/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/local/findVersionByID.ts
@@ -1,4 +1,4 @@
-import type { GeneratedTypes } from '../../../'
+import type { GeneratedTypes, RequestContext } from '../../../'
 import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 import type { Document } from '../../../types'
@@ -11,6 +11,7 @@ import { i18nInit } from '../../../translations/init'
 import findVersionByID from '../findVersionByID'
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
+  context?: RequestContext
   depth?: number
   disableErrors?: boolean
   fallbackLocale?: string
@@ -29,15 +30,16 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
 ): Promise<TypeWithVersion<GeneratedTypes['globals'][T]>> {
   const {
     id,
+    context,
     depth,
     disableErrors = false,
     fallbackLocale = null,
     locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
     overrideAccess = true,
+    req: incomingReq,
     showHiddenFields,
     slug: globalSlug,
     user,
-    req: incomingReq,
   } = options
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug)
@@ -57,7 +59,7 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
     transactionID: incomingReq?.transactionID,
     user,
   } as PayloadRequest
-  setRequestContext(req)
+  setRequestContext(req, context)
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
 

--- a/packages/payload/src/globals/operations/local/findVersions.ts
+++ b/packages/payload/src/globals/operations/local/findVersions.ts
@@ -1,4 +1,4 @@
-import type { GeneratedTypes } from '../../../'
+import type { GeneratedTypes, RequestContext } from '../../../'
 import type { PaginatedDocs } from '../../../database/types'
 import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
@@ -12,6 +12,7 @@ import { i18nInit } from '../../../translations/init'
 import findVersions from '../findVersions'
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
+  context?: RequestContext
   depth?: number
   fallbackLocale?: string
   limit?: number
@@ -31,6 +32,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   options: Options<T>,
 ): Promise<PaginatedDocs<TypeWithVersion<GeneratedTypes['globals'][T]>>> {
   const {
+    context,
     depth,
     fallbackLocale = null,
     limit,
@@ -62,7 +64,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
     transactionID: incomingReq?.transactionID,
     user,
   } as PayloadRequest
-  setRequestContext(req)
+  setRequestContext(req, context)
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
 

--- a/packages/payload/src/globals/operations/local/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/local/restoreVersion.ts
@@ -1,4 +1,4 @@
-import type { GeneratedTypes } from '../../../'
+import type { GeneratedTypes, RequestContext } from '../../../'
 import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 import type { Document } from '../../../types'
@@ -10,6 +10,7 @@ import { i18nInit } from '../../../translations/init'
 import restoreVersion from '../restoreVersion'
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
+  context?: RequestContext
   depth?: number
   fallbackLocale?: string
   id: string
@@ -27,6 +28,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
 ): Promise<GeneratedTypes['globals'][T]> {
   const {
     id,
+    context,
     depth,
     fallbackLocale = null,
     locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
@@ -54,7 +56,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
     transactionID: incomingReq?.transactionID,
     user,
   } as PayloadRequest
-  setRequestContext(req)
+  setRequestContext(req, context)
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
 

--- a/packages/payload/src/globals/operations/local/update.ts
+++ b/packages/payload/src/globals/operations/local/update.ts
@@ -1,6 +1,6 @@
 import type { DeepPartial } from 'ts-essentials'
 
-import type { GeneratedTypes } from '../../../'
+import type { GeneratedTypes, RequestContext } from '../../../'
 import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 import type { Document } from '../../../types'
@@ -12,6 +12,7 @@ import { i18nInit } from '../../../translations/init'
 import update from '../update'
 
 export type Options<TSlug extends keyof GeneratedTypes['globals']> = {
+  context?: RequestContext
   data: DeepPartial<Omit<GeneratedTypes['globals'][TSlug], 'id'>>
   depth?: number
   draft?: boolean
@@ -29,6 +30,7 @@ export default async function updateLocal<TSlug extends keyof GeneratedTypes['gl
   options: Options<TSlug>,
 ): Promise<GeneratedTypes['globals'][TSlug]> {
   const {
+    context,
     data,
     depth,
     draft,
@@ -58,7 +60,7 @@ export default async function updateLocal<TSlug extends keyof GeneratedTypes['gl
     transactionID: incomingReq?.transactionID,
     user,
   } as PayloadRequest
-  setRequestContext(req)
+  setRequestContext(req, context)
 
   if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
 

--- a/test/hooks/globals/Data/index.ts
+++ b/test/hooks/globals/Data/index.ts
@@ -67,6 +67,10 @@ export const DataHooksGlobal: GlobalConfig = {
 
         afterRead: [
           ({ global, field, context }) => {
+            if (context['field_beforeChange_GlobalAndField_override']) {
+              return context['field_beforeChange_GlobalAndField_override']
+            }
+
             return (
               (context['field_beforeChange_GlobalAndField'] as string) +
               JSON.stringify(global) +

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -251,6 +251,22 @@ describe('Hooks', () => {
       expect(retrievedDoc.value).toEqual('data from local API')
     })
 
+    it('should pass context from local API to global hooks', async () => {
+      const globalDocument = await payload.findGlobal({
+        slug: dataHooksGlobalSlug,
+      })
+
+      expect(globalDocument.field_globalAndField).not.toEqual('data from local API context')
+
+      const globalDocumentWithContext = await payload.findGlobal({
+        slug: dataHooksGlobalSlug,
+        context: {
+          field_beforeChange_GlobalAndField_override: 'data from local API context',
+        },
+      })
+      expect(globalDocumentWithContext.field_globalAndField).toEqual('data from local API context')
+    })
+
     it('should pass context from rest API to hooks', async () => {
       const params = new URLSearchParams({
         context_secretValue: 'data from rest API',


### PR DESCRIPTION
## Description

`context`, while present in the local API operations for collections, is not present in the local API operations for globals and auth.

I don't know why, I must have forgotten it somehow. This PR adds it

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
