### PR TITLE
fix(richtext-lexical): Blocks field: should not prompt for unsaved changes due to value comparison between null and non-existent props

### DIFF
--- a/packages/richtext-lexical/src/field/features/Blocks/component/BlockContent.tsx
+++ b/packages/richtext-lexical/src/field/features/Blocks/component/BlockContent.tsx
@@ -90,17 +90,17 @@ export const BlockContent: React.FC<Props> = (props) => {
       // does not have, even if it's undefined.
       // Currently, this happens if a block has another sub-blocks field. Inside of formData, that sub-blocks field has an undefined blockName property.
       // Inside of fields.data however, that sub-blocks blockName property does not exist at all.
-      function removeUndefinedRecursively(obj: object) {
+      function removeUndefinedAndNullRecursively(obj: object) {
         Object.keys(obj).forEach((key) => {
           if (obj[key] && typeof obj[key] === 'object') {
-            removeUndefinedRecursively(obj[key])
-          } else if (obj[key] === undefined) {
+            removeUndefinedAndNullRecursively(obj[key])
+          } else if (obj[key] === undefined || obj[key] === null) {
             delete obj[key]
           }
         })
       }
-      removeUndefinedRecursively(newFormData)
-      removeUndefinedRecursively(formData)
+      removeUndefinedAndNullRecursively(newFormData)
+      removeUndefinedAndNullRecursively(formData)
 
       // Only update if the data has actually changed. Otherwise, we may be triggering an unnecessary value change,
       // which would trigger the "Leave without saving" dialog unnecessarily


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
