### PR TITLE
fix(plugin-form-builder): removes use of slate in rich-text serializer

### DIFF
--- a/packages/plugin-form-builder/src/utilities/serializeRichText.ts
+++ b/packages/plugin-form-builder/src/utilities/serializeRichText.ts
@@ -1,5 +1,4 @@
 import escapeHTML from 'escape-html'
-import { Text } from 'slate'
 
 import { replaceDoubleCurlys } from './replaceDoubleCurlys'
 
@@ -8,14 +7,19 @@ interface Node {
   children?: Node[]
   code?: boolean
   italic?: boolean
+  text?: string
   type?: string
   url?: string
+}
+
+const isTextNode = (node: Node): node is Node & { text: string } => {
+  return 'text' in node
 }
 
 export const serialize = (children?: Node[], submissionData?: any): string | undefined =>
   children
     ?.map((node: Node) => {
-      if (Text.isText(node)) {
+      if (isTextNode(node)) {
         let text = `<span>${escapeHTML(replaceDoubleCurlys(node.text, submissionData))}</span>`
 
         if (node.bold) {
@@ -104,7 +108,7 @@ export const serialize = (children?: Node[], submissionData?: any): string | und
         <p>
           ${serialize(node.children, submissionData)}
         </p>
-     `
+      `
       }
     })
     .filter(Boolean)


### PR DESCRIPTION
## Description

#4299 

Removes the use of `slate` in the rich-text serializer in the `form-builder` plugin.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
