### PR TITLE
Fix: upload related issues

### DIFF
--- a/packages/payload/src/admin/hooks/useThumbnail.ts
+++ b/packages/payload/src/admin/hooks/useThumbnail.ts
@@ -48,6 +48,10 @@ const useThumbnail = (
       return `${pathURL}/${sizes[adminThumbnail].filename}`
     }
 
+    if (url) {
+      return url as string
+    }
+
     return `${pathURL}/${filename}`
   }
 

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -67,7 +67,7 @@ export const generateFileData = async <T>({
     const { filename, url } = data as FileData
 
     try {
-      if (url && url.startsWith('/')) {
+      if (url && url.startsWith('/') && !disableLocalStorage) {
         const filePath = `${staticPath}/${filename}`
         const response = await getFileByPath(filePath)
         file = response as UploadedFile

--- a/packages/payload/src/uploads/getFileByURL.ts
+++ b/packages/payload/src/uploads/getFileByURL.ts
@@ -3,9 +3,9 @@ import path from 'path'
 import type { File } from './types'
 
 const getFileByURL = async (url: string): Promise<File> => {
-  const { default: fetch } = (await import('node-fetch')) as any
-
   if (typeof url === 'string') {
+    const { default: fetch } = (await import('node-fetch')) as any
+
     const res = await fetch(url, {
       headers: {
         'Content-Type': 'application/json',

--- a/packages/payload/src/uploads/getFileByURL.ts
+++ b/packages/payload/src/uploads/getFileByURL.ts
@@ -2,13 +2,8 @@ import path from 'path'
 
 import type { File } from './types'
 
-const importDynamic = (modulePath: string) => import(modulePath)
-
 const getFileByURL = async (url: string): Promise<File> => {
-  async function fetch(...args) {
-    const { default: fetch } = await importDynamic('node-fetch')
-    return fetch(...args)
-  }
+  const { default: fetch } = (await import('node-fetch')) as any
 
   if (typeof url === 'string') {
     const res = await fetch(url, {

--- a/packages/payload/src/uploads/getFileByURL.ts
+++ b/packages/payload/src/uploads/getFileByURL.ts
@@ -1,24 +1,21 @@
-import fetch from 'node-fetch'
 import path from 'path'
 
 import type { File } from './types'
 
 const getFileByURL = async (url: string): Promise<File> => {
   if (typeof url === 'string') {
-    const res = await fetch(url, {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      method: 'GET',
-    })
-    const data = await res.buffer()
+    const res = await fetch(url)
+    const blob = await res.blob()
+    const arrayBuffer = await blob.arrayBuffer()
+
+    const data = Buffer.from(arrayBuffer)
     const name = path.basename(url)
 
     return {
       name,
       data,
-      mimetype: res.headers.get('content-type') || undefined,
-      size: Number(res.headers.get('content-length')) || 0,
+      mimetype: blob.type || undefined,
+      size: blob.size || 0,
     }
   }
 }

--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -234,7 +234,7 @@ export default async function resizeAndTransformImageSizes({
       }
 
       const imageToResize = sharpBase.clone()
-      let resized = imageToResize.resize(imageResizeConfig)
+      let resized = imageToResize
 
       if (
         req.query?.uploadEdits?.focalPoint &&
@@ -283,6 +283,8 @@ export default async function resizeAndTransformImageSizes({
           top: safeOffsetY,
           width: safeResizeWidth,
         })
+      } else {
+        resized = imageToResize.resize(imageResizeConfig)
       }
 
       if (imageResizeConfig.formatOptions) {


### PR DESCRIPTION
## Description

Closes #4421
Closes #4422
Closes #4408
Closes #4336

1. #4421 `node-fetch` was throwing ESM errors, there are limitations with the package so this has been removed and native nodejs fetch is used instead
2. #4408 when the thumbnail size is undefined, the file thumbnail should return the original file url before trying to return `${pathURL}/${filename}` 
3. #4422 the focal point isn't working at all, we are applying the image resize config **before** the upload edits and it should come after. We fixed this before, not sure when / why it was reintroduced.
4. #4336 ensure external file is always fetched when `disableLocalStorage: true`

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
