### PR TITLE
fix: graphql schema generation for fields without queryable subfields

### DIFF
--- a/packages/payload/src/collections/graphql/init.ts
+++ b/packages/payload/src/collections/graphql/init.ts
@@ -189,6 +189,9 @@ function initCollectionsGraphQL(payload: Payload): void {
 
     payload.Mutation.fields[`create${singularName}`] = {
       args: {
+        ...(createMutationInputType
+          ? { data: { type: collection.graphQL.mutationInputType } }
+          : {}),
         draft: { type: GraphQLBoolean },
         ...(payload.config.localization
           ? {
@@ -199,16 +202,14 @@ function initCollectionsGraphQL(payload: Payload): void {
       resolve: createResolver(collection),
       type: collection.graphQL.type,
     }
-    if (createMutationInputType) {
-      payload.Mutation.fields[`create${singularName}`].args.data = {
-        type: collection.graphQL.mutationInputType,
-      }
-    }
 
     payload.Mutation.fields[`update${singularName}`] = {
       args: {
         id: { type: new GraphQLNonNull(idType) },
         autosave: { type: GraphQLBoolean },
+        ...(updateMutationInputType
+          ? { data: { type: collection.graphQL.updateMutationInputType } }
+          : {}),
         draft: { type: GraphQLBoolean },
         ...(payload.config.localization
           ? {
@@ -218,11 +219,6 @@ function initCollectionsGraphQL(payload: Payload): void {
       },
       resolve: updateResolver(collection),
       type: collection.graphQL.type,
-    }
-    if (updateMutationInputType) {
-      payload.Mutation.fields[`update${singularName}`].args.data = {
-        type: collection.graphQL.updateMutationInputType,
-      }
     }
 
     payload.Mutation.fields[`delete${singularName}`] = {

--- a/packages/payload/src/globals/graphql/init.ts
+++ b/packages/payload/src/globals/graphql/init.ts
@@ -36,10 +36,16 @@ function initGlobalsGraphQL(payload: Payload): void {
 
     if (!payload.globals.graphQL) payload.globals.graphQL = {}
 
+    const updateMutationInputType = buildMutationInputType(
+      payload,
+      formattedName,
+      fields,
+      formattedName,
+    )
     payload.globals.graphQL[slug] = {
-      mutationInputType: new GraphQLNonNull(
-        buildMutationInputType(payload, formattedName, fields, formattedName),
-      ),
+      mutationInputType: updateMutationInputType
+        ? new GraphQLNonNull(updateMutationInputType)
+        : null,
       type: buildObjectType({
         name: formattedName,
         fields,
@@ -65,7 +71,6 @@ function initGlobalsGraphQL(payload: Payload): void {
 
     payload.Mutation.fields[`update${formattedName}`] = {
       args: {
-        data: { type: payload.globals.graphQL[slug].mutationInputType },
         draft: { type: GraphQLBoolean },
         ...(payload.config.localization
           ? {
@@ -75,6 +80,12 @@ function initGlobalsGraphQL(payload: Payload): void {
       },
       resolve: updateResolver(global),
       type: payload.globals.graphQL[slug].type,
+    }
+
+    if (payload.globals.graphQL[slug]?.mutationInputType) {
+      payload.Mutation.fields[`update${formattedName}`].args.data = {
+        type: payload.globals.graphQL[slug].mutationInputType,
+      }
     }
 
     payload.Query.fields[`docAccess${formattedName}`] = {

--- a/packages/payload/src/globals/graphql/init.ts
+++ b/packages/payload/src/globals/graphql/init.ts
@@ -71,6 +71,9 @@ function initGlobalsGraphQL(payload: Payload): void {
 
     payload.Mutation.fields[`update${formattedName}`] = {
       args: {
+        ...(updateMutationInputType
+          ? { data: { type: payload.globals.graphQL[slug].mutationInputType } }
+          : {}),
         draft: { type: GraphQLBoolean },
         ...(payload.config.localization
           ? {
@@ -80,12 +83,6 @@ function initGlobalsGraphQL(payload: Payload): void {
       },
       resolve: updateResolver(global),
       type: payload.globals.graphQL[slug].type,
-    }
-
-    if (payload.globals.graphQL[slug]?.mutationInputType) {
-      payload.Mutation.fields[`update${formattedName}`].args.data = {
-        type: payload.globals.graphQL[slug].mutationInputType,
-      }
     }
 
     payload.Query.fields[`docAccess${formattedName}`] = {

--- a/packages/payload/src/graphql/schema/buildObjectType.ts
+++ b/packages/payload/src/graphql/schema/buildObjectType.ts
@@ -92,14 +92,21 @@ function buildObjectType({
         field?.interfaceName || combineParentName(parentName, toWords(field.name, true))
 
       if (!payload.types.arrayTypes[interfaceName]) {
-        // eslint-disable-next-line no-param-reassign
-        payload.types.arrayTypes[interfaceName] = buildObjectType({
+        const objectType = buildObjectType({
           name: interfaceName,
           fields: field.fields,
           forceNullable: isFieldNullable(field, forceNullable),
           parentName: interfaceName,
           payload,
         })
+
+        if (Object.keys(objectType.getFields()).length) {
+          payload.types.arrayTypes[interfaceName] = objectType
+        }
+      }
+
+      if (!payload.types.arrayTypes[interfaceName]) {
+        return objectTypeConfig
       }
 
       const arrayType = new GraphQLList(new GraphQLNonNull(payload.types.arrayTypes[interfaceName]))
@@ -110,12 +117,12 @@ function buildObjectType({
       }
     },
     blocks: (objectTypeConfig: ObjectTypeConfig, field: BlockField) => {
-      const blockTypes = field.blocks.map((block) => {
+      const blockTypes: GraphQLObjectType<any, any>[] = field.blocks.reduce((acc, block) => {
         if (!payload.types.blockTypes[block.slug]) {
           const interfaceName =
             block?.interfaceName || block?.graphQL?.singularName || toWords(block.slug, true)
-          // eslint-disable-next-line no-param-reassign
-          payload.types.blockTypes[block.slug] = buildObjectType({
+
+          const objectType = buildObjectType({
             name: interfaceName,
             fields: [
               ...block.fields,
@@ -128,10 +135,22 @@ function buildObjectType({
             parentName: interfaceName,
             payload,
           })
+
+          if (Object.keys(objectType.getFields()).length) {
+            payload.types.blockTypes[block.slug] = objectType
+          }
         }
 
-        return payload.types.blockTypes[block.slug]
-      })
+        if (payload.types.blockTypes[block.slug]) {
+          acc.push(payload.types.blockTypes[block.slug])
+        }
+
+        return acc
+      }, [])
+
+      if (blockTypes.length === 0) {
+        return objectTypeConfig
+      }
 
       const fullName = combineParentName(parentName, toWords(field.name, true))
 
@@ -177,14 +196,21 @@ function buildObjectType({
         field?.interfaceName || combineParentName(parentName, toWords(field.name, true))
 
       if (!payload.types.groupTypes[interfaceName]) {
-        // eslint-disable-next-line no-param-reassign
-        payload.types.groupTypes[interfaceName] = buildObjectType({
+        const objectType = buildObjectType({
           name: interfaceName,
           fields: field.fields,
           forceNullable: isFieldNullable(field, forceNullable),
           parentName: interfaceName,
           payload,
         })
+
+        if (Object.keys(objectType.getFields()).length) {
+          payload.types.groupTypes[interfaceName] = objectType
+        }
+      }
+
+      if (!payload.types.groupTypes[interfaceName]) {
+        return objectTypeConfig
       }
 
       return {
@@ -483,19 +509,23 @@ function buildObjectType({
             tab?.interfaceName || combineParentName(parentName, toWords(tab.name, true))
 
           if (!payload.types.tabTypes[interfaceName]) {
-            payload.types.tabTypes[interfaceName] = buildObjectType({
+            const objectType = buildObjectType({
               name: interfaceName,
               fields: tab.fields,
               forceNullable,
               parentName: interfaceName,
               payload,
             })
+
+            if (Object.keys(objectType.getFields()).length) {
+              return {
+                ...tabSchema,
+                [tab.name]: { type: objectType },
+              }
+            }
           }
 
-          return {
-            ...tabSchema,
-            [tab.name]: { type: payload.types.tabTypes[interfaceName] },
-          }
+          return tabSchema
         }
 
         return {


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/4459

The issue appeared when a field had no queryable subfields. This could happen when a group, array, tab field, or collection/global only contained fields that did not store any data. The fix is to check if these field types generate types with children fields and conditionally add the parent field to the schema if true else return the existing schema.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
