### PR TITLE
fix(templates): pins react-hook-form to v7.45.4

### DIFF
--- a/templates/ecommerce/package.json
+++ b/templates/ecommerce/package.json
@@ -42,7 +42,7 @@
     "qs": "6.11.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.45.1",
+    "react-hook-form": "7.45.4",
     "react-router-dom": "5.3.4",
     "stripe": "^10.2.0"
   },

--- a/templates/ecommerce/yarn.lock
+++ b/templates/ecommerce/yarn.lock
@@ -7685,10 +7685,10 @@ react-helmet@6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
-react-hook-form@^7.45.1:
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.49.0.tgz#9a91edfba6b6983d4b443653a9b225a780a42b3e"
-  integrity sha512-gf4qyY4WiqK2hP/E45UUT6wt3Khl49pleEVcIzxhLBrD6m+GMWtLRk0vMrRv45D1ZH8PnpXFwRPv0Pewske2jw==
+react-hook-form@7.45.4:
+  version "7.45.4"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.45.4.tgz#73d228b704026ae95d7e5f7b207a681b173ec62a"
+  integrity sha512-HGDV1JOOBPZj10LB3+OZgfDBTn+IeEsNOKiq/cxbQAIbKaiJUe/KV8DBUzsx0Gx/7IG/orWqRRm736JwOfUSWQ==
 
 react-i18next@11.18.6:
   version "11.18.6"

--- a/templates/website/package.json
+++ b/templates/website/package.json
@@ -39,7 +39,7 @@
     "qs": "6.11.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.45.1",
+    "react-hook-form": "7.45.4",
     "react-router-dom": "5.3.4"
   },
   "devDependencies": {

--- a/templates/website/yarn.lock
+++ b/templates/website/yarn.lock
@@ -8165,10 +8165,10 @@ react-helmet@6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
-react-hook-form@^7.45.1:
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.49.0.tgz#9a91edfba6b6983d4b443653a9b225a780a42b3e"
-  integrity sha512-gf4qyY4WiqK2hP/E45UUT6wt3Khl49pleEVcIzxhLBrD6m+GMWtLRk0vMrRv45D1ZH8PnpXFwRPv0Pewske2jw==
+react-hook-form@7.45.4:
+  version "7.45.4"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.45.4.tgz#73d228b704026ae95d7e5f7b207a681b173ec62a"
+  integrity sha512-HGDV1JOOBPZj10LB3+OZgfDBTn+IeEsNOKiq/cxbQAIbKaiJUe/KV8DBUzsx0Gx/7IG/orWqRRm736JwOfUSWQ==
 
 react-i18next@11.18.6:
   version "11.18.6"


### PR DESCRIPTION
## Description

Payload Cloud was experiencing build errors on new template deployments due to an incompatibility between Node versions in `react-hook-form`. Here's the exact error:

```bash
error react-hook-form@7.49.0: The engine "node" is incompatible with this module. Expected version ">=18", Got "16.20.2"
```

This is an issue in the `react-hook-form` package, [documented here](https://github.com/react-hook-form/react-hook-form/issues/11281).

To fix this I've pinned `react-hook-form` to a known working version, like this:

```json
"react-hook-form": "7.45.4",
```

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
