### PR TITLE
fix: formats locales with multiple labels for versions locale selector

### DIFF
--- a/packages/payload/src/admin/components/views/Version/RenderFieldsToDiff/index.tsx
+++ b/packages/payload/src/admin/components/views/Version/RenderFieldsToDiff/index.tsx
@@ -43,11 +43,11 @@ const RenderFieldsToDiff: React.FC<Props> = ({
           if (field.localized) {
             return (
               <div className={`${baseClass}__field`} key={i}>
-                {locales.map((locale) => {
+                {locales.map((locale, index) => {
                   const versionLocaleValue = versionValue?.[locale]
                   const comparisonLocaleValue = comparisonValue?.[locale]
                   return (
-                    <div className={`${baseClass}__locale`} key={locale}>
+                    <div className={`${baseClass}__locale`} key={[locale, index].join('-')}>
                       <div className={`${baseClass}__locale-value`}>
                         <Component
                           comparison={comparisonLocaleValue}

--- a/packages/payload/src/admin/components/views/Version/SelectLocales/index.tsx
+++ b/packages/payload/src/admin/components/views/Version/SelectLocales/index.tsx
@@ -4,12 +4,26 @@ import { useTranslation } from 'react-i18next'
 import type { Props } from './types'
 
 import ReactSelect from '../../../elements/ReactSelect'
+import { useLocale } from '../../../utilities/Locale'
 import './index.scss'
 
 const baseClass = 'select-version-locales'
 
 const SelectLocales: React.FC<Props> = ({ onChange, options, value }) => {
   const { t } = useTranslation('version')
+  const { code } = useLocale()
+
+  const format = (items) => {
+    return items.map((item) => {
+      if (typeof item.label === 'string') return item
+      if (typeof item.label !== 'string' && item.label[code]) {
+        return {
+          label: item.label[code],
+          value: item.value,
+        }
+      }
+    })
+  }
 
   return (
     <div className={baseClass}>
@@ -17,9 +31,9 @@ const SelectLocales: React.FC<Props> = ({ onChange, options, value }) => {
       <ReactSelect
         isMulti
         onChange={onChange}
-        options={options}
+        options={format(options)}
         placeholder={t('selectLocales')}
-        value={value}
+        value={format(value)}
       />
     </div>
   )


### PR DESCRIPTION
## Description

Closes #4357 - the locale selector was causing the versions view to break when incoming locales have multiple labels. Fix works for globals and collections.

Localization config shape that would cause it to break:
```ts
  localization: {
    defaultLocale: 'en',
    locales: [
      {
        label: {
          es: 'Español',
          en: 'Spanish',
        },
        code: 'es',
      },
      {
        label: {
          es: 'Inglés',
          en: 'English',
        },
        code: 'en',
      },
    ],
  },
```

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes