### PR TITLE
feat(richtext-lexical)!: link node: change data format to be consistent with relationship field

### DIFF
--- a/packages/richtext-lexical/src/field/features/Link/index.ts
+++ b/packages/richtext-lexical/src/field/features/Link/index.ts
@@ -114,7 +114,9 @@ export const LinkFeature = (props: LinkFeatureProps): FeatureProvider => {
                   const rel: string = node.fields.newTab ? ' rel="noopener noreferrer"' : ''
 
                   const href: string =
-                    node.fields.linkType === 'custom' ? node.fields.url : node.fields.doc?.value?.id
+                    node.fields.linkType === 'custom'
+                      ? node.fields.url
+                      : (node.fields.doc?.value as string)
 
                   return `<a href="${href}"${rel}>${childrenText}</a>`
                 },

--- a/packages/richtext-lexical/src/field/features/Link/index.ts
+++ b/packages/richtext-lexical/src/field/features/Link/index.ts
@@ -143,8 +143,13 @@ export const LinkFeature = (props: LinkFeatureProps): FeatureProvider => {
 
                   const rel: string = node.fields.newTab ? ' rel="noopener noreferrer"' : ''
 
-                  const href: string =
-                    node.fields.linkType === 'custom' ? node.fields.url : node.fields.doc?.value?.id
+                  let href: string = node.fields.url
+                  if (node.fields.linkType === 'internal') {
+                    href =
+                      typeof node.fields.doc?.value === 'string'
+                        ? node.fields.doc?.value
+                        : node.fields.doc?.value?.id
+                  }
 
                   return `<a href="${href}"${rel}>${childrenText}</a>`
                 },

--- a/packages/richtext-lexical/src/field/features/Link/nodes/AutoLinkNode.ts
+++ b/packages/richtext-lexical/src/field/features/Link/nodes/AutoLinkNode.ts
@@ -28,6 +28,15 @@ export class AutoLinkNode extends LinkNode {
   }
 
   static importJSON(serializedNode: SerializedAutoLinkNode): AutoLinkNode {
+    if (
+      serializedNode.version === 1 &&
+      typeof serializedNode.fields?.doc?.value === 'object' &&
+      serializedNode.fields?.doc?.value?.id
+    ) {
+      serializedNode.fields.doc.value = serializedNode.fields.doc.value.id
+      serializedNode.version = 2
+    }
+
     const node = $createAutoLinkNode({ fields: serializedNode.fields })
 
     node.setFormat(serializedNode.format)
@@ -40,7 +49,7 @@ export class AutoLinkNode extends LinkNode {
     return {
       ...super.exportJSON(),
       type: 'autolink',
-      version: 1,
+      version: 2,
     }
   }
 

--- a/packages/richtext-lexical/src/field/features/Link/nodes/LinkNode.ts
+++ b/packages/richtext-lexical/src/field/features/Link/nodes/LinkNode.ts
@@ -27,11 +27,13 @@ export type LinkFields = {
   [key: string]: unknown
   doc: {
     relationTo: string
-    value: {
-      // Actual doc data, populated in afterRead hook
-      [key: string]: unknown
-      id: string
-    }
+    value:
+      | {
+          // Actual doc data, populated in afterRead hook
+          [key: string]: unknown
+          id: string
+        }
+      | string
   } | null
   linkType: 'custom' | 'internal'
   newTab: boolean
@@ -88,6 +90,15 @@ export class LinkNode extends ElementNode {
   }
 
   static importJSON(serializedNode: SerializedLinkNode): LinkNode {
+    if (
+      serializedNode.version === 1 &&
+      typeof serializedNode.fields?.doc?.value === 'object' &&
+      serializedNode.fields?.doc?.value?.id
+    ) {
+      serializedNode.fields.doc.value = serializedNode.fields.doc.value.id
+      serializedNode.version = 2
+    }
+
     const node = $createLinkNode({
       fields: serializedNode.fields,
     })
@@ -131,7 +142,7 @@ export class LinkNode extends ElementNode {
       ...super.exportJSON(),
       fields: this.getFields(),
       type: this.getType(),
-      version: 1,
+      version: 2,
     }
   }
 

--- a/packages/richtext-lexical/src/field/features/Link/plugins/floatingLinkEditor/LinkEditor/index.tsx
+++ b/packages/richtext-lexical/src/field/features/Link/plugins/floatingLinkEditor/LinkEditor/index.tsx
@@ -125,7 +125,7 @@ export function LinkEditor({
         // internal link
         setLinkUrl(
           `/admin/collections/${linkParent.getFields()?.doc?.relationTo}/${linkParent.getFields()
-            ?.doc?.value?.id}`,
+            ?.doc?.value}`,
         )
 
         const relatedField = config.collections.find(
@@ -323,11 +323,6 @@ export function LinkEditor({
         handleModalSubmit={(fields: Fields, data: Data) => {
           closeModal(drawerSlug)
 
-          if (data?.fields?.doc?.value) {
-            data.fields.doc.value = {
-              id: data.fields.doc.value,
-            }
-          }
           const newLinkPayload: LinkPayload = data as LinkPayload
 
           editor.dispatchCommand(TOGGLE_LINK_COMMAND, newLinkPayload)

--- a/packages/richtext-lexical/src/field/features/Link/populationPromise.ts
+++ b/packages/richtext-lexical/src/field/features/Link/populationPromise.ts
@@ -25,13 +25,16 @@ export const linkPopulationPromiseHOC = (
   }) => {
     const promises: Promise<void>[] = []
 
-    if (node?.fields?.doc?.value?.id && node?.fields?.doc?.relationTo) {
+    if (node?.fields?.doc?.value && node?.fields?.doc?.relationTo) {
       const collection = req.payload.collections[node?.fields?.doc?.relationTo]
 
       if (collection) {
         promises.push(
           populate({
-            id: node?.fields?.doc?.value?.id,
+            id:
+              typeof node?.fields?.doc?.value === 'object'
+                ? node?.fields?.doc?.value?.id
+                : node?.fields?.doc?.value,
             collection,
             currentDepth,
             data: node?.fields?.doc,

--- a/packages/richtext-lexical/src/field/features/migrations/LexicalPluginToLexical/converter/converters/link.ts
+++ b/packages/richtext-lexical/src/field/features/migrations/LexicalPluginToLexical/converter/converters/link.ts
@@ -17,9 +17,7 @@ export const LinkConverter: LexicalPluginNodeConverter = {
         doc: (lexicalPluginNode as any).attributes?.doc
           ? {
               relationTo: (lexicalPluginNode as any).attributes?.doc?.relationTo,
-              value: {
-                id: (lexicalPluginNode as any).attributes?.doc?.value,
-              },
+              value: (lexicalPluginNode as any).attributes?.doc?.value,
             }
           : undefined,
         linkType: (lexicalPluginNode as any).attributes?.linkType || 'custom',
@@ -29,7 +27,7 @@ export const LinkConverter: LexicalPluginNodeConverter = {
       format: (lexicalPluginNode as any).format || '',
       indent: (lexicalPluginNode as any).indent || 0,
       type: 'link',
-      version: 1,
+      version: 2,
     } as const as SerializedLinkNode
   },
   nodeTypes: ['link'],

--- a/packages/richtext-lexical/src/field/features/migrations/SlateToLexical/converter/converters/link.ts
+++ b/packages/richtext-lexical/src/field/features/migrations/SlateToLexical/converter/converters/link.ts
@@ -23,7 +23,7 @@ export const SlateLinkConverter: SlateNodeConverter = {
       format: '',
       indent: 0,
       type: 'link',
-      version: 1,
+      version: 2,
     } as const as SerializedLinkNode
   },
   nodeTypes: ['link'],

--- a/test/fields/collections/RichText/generateLexicalRichText.ts
+++ b/test/fields/collections/RichText/generateLexicalRichText.ts
@@ -54,7 +54,7 @@ export function generateLexicalRichText() {
               format: '',
               indent: 0,
               type: 'link',
-              version: 1,
+              version: 2,
               fields: {
                 url: 'https://payloadcms.com',
                 newTab: true,
@@ -86,7 +86,7 @@ export function generateLexicalRichText() {
               format: '',
               indent: 0,
               type: 'link',
-              version: 1,
+              version: 2,
               fields: {
                 url: 'https://',
                 doc: {

--- a/test/fields/collections/RichText/generateLexicalRichText.ts
+++ b/test/fields/collections/RichText/generateLexicalRichText.ts
@@ -90,9 +90,7 @@ export function generateLexicalRichText() {
               fields: {
                 url: 'https://',
                 doc: {
-                  value: {
-                    id: '{{ARRAY_DOC_ID}}',
-                  },
+                  value: '{{ARRAY_DOC_ID}}',
                   relationTo: 'array-fields',
                 },
                 newTab: false,

--- a/test/fields/lexical.int.spec.ts
+++ b/test/fields/lexical.int.spec.ts
@@ -174,7 +174,6 @@ describe('Lexical', () => {
       )
 
       expect(richTextDoc?.lexicalCustomFields).not.toStrictEqual(seededDocument) // The whole seededDocument should not match, as richTextDoc should now contain populated documents not present in the seeded document
-      expect(richTextDoc?.lexicalCustomFields).toMatchObject(seededDocument) // subset of seededDocument should match
 
       const lexical: SerializedEditorState = richTextDoc?.lexicalCustomFields
 


### PR DESCRIPTION
## Description

**BREAKING:**

An unpopulated, internal link node no longer saves the doc `id` under `fields.doc.value.id`. Now, it saves it under `fields.doc.value`.

Migration inside of payload is automatic. If you are reading from the link node inside of your frontend though, you will have to adjust it.

The `version` property of the link node has been changed from `1` to `2`.



- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
