### PR TITLE
fix: adds bg color for year/month select options in datepicker

### DIFF
--- a/packages/payload/src/admin/components/elements/DatePicker/index.scss
+++ b/packages/payload/src/admin/components/elements/DatePicker/index.scss
@@ -210,6 +210,10 @@ $cal-icon-width: 18px;
       background: none;
       outline: none;
       cursor: pointer;
+
+      option {
+        background-color: var(--theme-elevation-50);
+      }
     }
 
     &__day-names {


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/4443

On Windows, native select `option` tags inherit the bg of their parent. The parent in this case has a transparent bg, this change sets a bg color for the options within those.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
