### PR TITLE
chore: adds translated label to verified field

### DIFF
--- a/packages/payload/src/auth/baseFields/verification.ts
+++ b/packages/payload/src/auth/baseFields/verification.ts
@@ -1,5 +1,9 @@
 import type { Field, FieldHook } from '../../fields/config/types'
 
+import { extractTranslations } from '../../translations/extractTranslations'
+
+const labels = extractTranslations(['authentication:verified'])
+
 const autoRemoveVerificationToken: FieldHook = ({ data, operation, originalDoc, value }) => {
   // If a user manually sets `_verified` to true,
   // and it was `false`, set _verificationToken to `null`.
@@ -28,6 +32,7 @@ export default [
         Field: () => null,
       },
     },
+    label: labels['authentication:verified'],
     type: 'checkbox',
   },
   {


### PR DESCRIPTION
## Description

Adds translated label to `verified` field in auth collections. Closes #4458

Before:
<img width="221" alt="Screenshot 2023-12-14 at 3 26 49 PM" src="https://github.com/payloadcms/payload/assets/67977755/7b579072-b6e7-40cb-b554-de5936c0146d">

After:
<img width="252" alt="Screenshot 2023-12-14 at 3 25 58 PM" src="https://github.com/payloadcms/payload/assets/67977755/acceaf01-200e-496a-8221-9215a63de26d">


- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
