### PR TITLE
fix: format fields within tab for list controls

### DIFF
--- a/packages/payload/src/admin/components/views/collections/List/formatFields.tsx
+++ b/packages/payload/src/admin/components/views/collections/List/formatFields.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import type { SanitizedCollectionConfig } from '../../../../../collections/config/types'
 import type { Field } from '../../../../../fields/config/types'
 
@@ -8,29 +6,39 @@ import { fieldAffectsData, fieldIsPresentationalOnly } from '../../../../../fiel
 const formatFields = (config: SanitizedCollectionConfig): Field[] => {
   const hasID =
     config.fields.findIndex((field) => fieldAffectsData(field) && field.name === 'id') > -1
+
+  const defaultIDField: Field = {
+    name: 'id',
+    admin: {
+      disableBulkEdit: true,
+    },
+    label: 'ID',
+    type: 'text',
+  }
+
+  const shouldSkipField = (field: Field): boolean =>
+    !fieldIsPresentationalOnly(field) && (field.hidden === true || field.admin?.disabled === true)
+
   const fields: Field[] = config.fields.reduce(
     (formatted, field) => {
-      if (
-        !fieldIsPresentationalOnly(field) &&
-        (field.hidden === true || field?.admin?.disabled === true)
-      ) {
+      if (shouldSkipField(field)) {
         return formatted
       }
 
-      return [...formatted, field]
+      const formattedField =
+        field.type === 'tabs'
+          ? {
+              ...field,
+              tabs: field.tabs.map((tab) => ({
+                ...tab,
+                fields: tab.fields.filter((tabField) => !shouldSkipField(tabField)),
+              })),
+            }
+          : field
+
+      return [...formatted, formattedField]
     },
-    hasID
-      ? []
-      : [
-          {
-            name: 'id',
-            admin: {
-              disableBulkEdit: true,
-            },
-            label: 'ID',
-            type: 'text',
-          },
-        ],
+    hasID ? [] : [defaultIDField],
   )
 
   return fields


### PR DESCRIPTION
## Description

Issue #4458 found that tab fields with `hidden: true` still show up in the list controls (column selector and filters). This PR updates the `formatFields` function to map over the tab fields.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
