### PR TITLE
fix: omit field default value if read access returns false

### DIFF
--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -250,6 +250,7 @@ export const promise = async ({
     }
 
     // Execute access control
+    let allowDefaultValue = true
     if (triggerAccessControl && field.access && field.access.read) {
       const result = overrideAccess
         ? true
@@ -262,6 +263,7 @@ export const promise = async ({
           })
 
       if (!result) {
+        allowDefaultValue = false
         delete siblingDoc[field.name]
       }
     }
@@ -269,6 +271,7 @@ export const promise = async ({
     // Set defaultValue on the field for globals being returned without being first created
     // or collection documents created prior to having a default
     if (
+      allowDefaultValue &&
       typeof siblingDoc[field.name] === 'undefined' &&
       typeof field.defaultValue !== 'undefined'
     ) {


### PR DESCRIPTION
## Description

If the user does not have access to a field, do not send back the default value.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
