### PR TITLE
feat(richtext-lexical)!: rename TreeviewFeature into TreeViewFeature

### DIFF
--- a/packages/richtext-lexical/src/field/features/debug/TreeView/index.ts
+++ b/packages/richtext-lexical/src/field/features/debug/TreeView/index.ts
@@ -1,6 +1,6 @@
 import type { FeatureProvider } from '../../types'
 
-export const TreeviewFeature = (): FeatureProvider => {
+export const TreeViewFeature = (): FeatureProvider => {
   return {
     feature: () => {
       return {

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -261,7 +261,7 @@ export { consolidateHTMLConverters } from './field/features/converters/html/fiel
 export { lexicalHTML } from './field/features/converters/html/field'
 
 export { TestRecorderFeature } from './field/features/debug/TestRecorder'
-export { TreeviewFeature } from './field/features/debug/TreeView'
+export { TreeViewFeature } from './field/features/debug/TreeView'
 
 export { BoldTextFeature } from './field/features/format/Bold'
 export { InlineCodeTextFeature } from './field/features/format/InlineCode'

--- a/test/fields/collections/Lexical/index.ts
+++ b/test/fields/collections/Lexical/index.ts
@@ -3,7 +3,7 @@ import type { CollectionConfig } from '../../../../packages/payload/src/collecti
 import {
   BlocksFeature,
   LinkFeature,
-  TreeviewFeature,
+  TreeViewFeature,
   UploadFeature,
   lexicalEditor,
 } from '../../../../packages/richtext-lexical/src'
@@ -42,7 +42,7 @@ export const LexicalFields: CollectionConfig = {
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,
           //TestRecorderFeature(),
-          TreeviewFeature(),
+          TreeViewFeature(),
           BlocksFeature({
             blocks: [
               RichTextBlock,
@@ -67,7 +67,7 @@ export const LexicalFields: CollectionConfig = {
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,
           //TestRecorderFeature(),
-          TreeviewFeature(),
+          TreeViewFeature(),
           //HTMLConverterFeature(),
           LinkFeature({
             fields: [

--- a/test/fields/collections/LexicalMigrate/index.ts
+++ b/test/fields/collections/LexicalMigrate/index.ts
@@ -5,7 +5,7 @@ import {
   LexicalPluginToLexicalFeature,
   LinkFeature,
   SlateToLexicalFeature,
-  TreeviewFeature,
+  TreeViewFeature,
   UploadFeature,
   lexicalEditor,
   lexicalHTML,
@@ -35,7 +35,7 @@ export const LexicalMigrateFields: CollectionConfig = {
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,
           LexicalPluginToLexicalFeature(),
-          TreeviewFeature(),
+          TreeViewFeature(),
           HTMLConverterFeature(),
           LinkFeature({
             fields: [
@@ -75,7 +75,7 @@ export const LexicalMigrateFields: CollectionConfig = {
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,
           SlateToLexicalFeature(),
-          TreeviewFeature(),
+          TreeViewFeature(),
           HTMLConverterFeature(),
           LinkFeature({
             fields: [

--- a/test/fields/collections/RichText/index.ts
+++ b/test/fields/collections/RichText/index.ts
@@ -4,7 +4,7 @@ import {
   BlocksFeature,
   HTMLConverterFeature,
   LinkFeature,
-  TreeviewFeature,
+  TreeViewFeature,
   UploadFeature,
   lexicalEditor,
 } from '../../../../packages/richtext-lexical/src'
@@ -34,7 +34,7 @@ const RichTextFields: CollectionConfig = {
       editor: lexicalEditor({
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,
-          TreeviewFeature(),
+          TreeViewFeature(),
           HTMLConverterFeature({}),
           LinkFeature({
             fields: [
@@ -102,7 +102,7 @@ const RichTextFields: CollectionConfig = {
         },
       },
       editor: lexicalEditor({
-        features: ({ defaultFeatures }) => [...defaultFeatures, TreeviewFeature()],
+        features: ({ defaultFeatures }) => [...defaultFeatures, TreeViewFeature()],
       }),
     },
     {


### PR DESCRIPTION
## Description

**Breaking:** If you import `TreeviewFeature`, you have to rename the import to use `TreeViewFeature` (capitalized "V")

Closes https://github.com/payloadcms/payload/pull/4436

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
