### PR TITLE
fix(db-postgres) incorrect currentTableName in find for blocks

### DIFF
--- a/packages/db-postgres/src/find/traverseFields.ts
+++ b/packages/db-postgres/src/find/traverseFields.ts
@@ -128,15 +128,16 @@ export const traverseFields = ({
                 with: {},
               }
 
-              if (adapter.tables[`${topLevelTableName}_blocks_${toSnakeCase(block.slug)}_locales`])
-                withBlock.with._locales = _locales
+              const tableName = `${topLevelTableName}_blocks_${toSnakeCase(block.slug)}`
+
+              if (adapter.tables[`${tableName}_locales`]) withBlock.with._locales = _locales
               topLevelArgs.with[blockKey] = withBlock
 
               traverseFields({
                 _locales,
                 adapter,
                 currentArgs: withBlock,
-                currentTableName,
+                currentTableName: tableName,
                 depth,
                 fields: block.fields,
                 path: '',

--- a/packages/db-postgres/src/upsertRow/index.ts
+++ b/packages/db-postgres/src/upsertRow/index.ts
@@ -305,6 +305,7 @@ export const upsertRow = async <T extends TypeWithID>({
   findManyArgs.where = eq(adapter.tables[tableName].id, insertedRow.id)
 
   const doc = await db.query[tableName].findFirst(findManyArgs)
+  console.log(JSON.stringify(doc))
 
   // //////////////////////////////////
   // TRANSFORM DATA

--- a/packages/db-postgres/src/upsertRow/index.ts
+++ b/packages/db-postgres/src/upsertRow/index.ts
@@ -305,7 +305,6 @@ export const upsertRow = async <T extends TypeWithID>({
   findManyArgs.where = eq(adapter.tables[tableName].id, insertedRow.id)
 
   const doc = await db.query[tableName].findFirst(findManyArgs)
-  console.log(JSON.stringify(doc))
 
   // //////////////////////////////////
   // TRANSFORM DATA

--- a/test/localization/collections/NestedToArrayAndBlock/index.ts
+++ b/test/localization/collections/NestedToArrayAndBlock/index.ts
@@ -21,6 +21,10 @@ export const NestedToArrayAndBlock: CollectionConfig = {
                   type: 'text',
                   localized: true,
                 },
+                {
+                  name: 'textNotLocalized',
+                  type: 'text',
+                },
               ],
             },
           ],

--- a/test/localization/collections/NestedToArrayAndBlock/index.ts
+++ b/test/localization/collections/NestedToArrayAndBlock/index.ts
@@ -1,0 +1,31 @@
+import type { CollectionConfig } from '../../../../packages/payload/src/collections/config/types'
+
+export const nestedToArrayAndBlockCollectionSlug = 'nested-to-array-and-block'
+
+export const NestedToArrayAndBlock: CollectionConfig = {
+  slug: nestedToArrayAndBlockCollectionSlug,
+  fields: [
+    {
+      type: 'blocks',
+      name: 'blocks',
+      blocks: [
+        {
+          slug: 'block',
+          fields: [
+            {
+              name: 'array',
+              type: 'array',
+              fields: [
+                {
+                  name: 'text',
+                  type: 'text',
+                  localized: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -3,6 +3,7 @@ import type { LocalizedPost } from './payload-types'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults'
 import { devUser } from '../credentials'
 import { ArrayCollection } from './collections/Array'
+import { NestedToArrayAndBlock } from './collections/NestedToArrayAndBlock'
 import {
   defaultLocale,
   englishTitle,
@@ -231,6 +232,7 @@ export default buildConfigWithDefaults({
         },
       ],
     },
+    NestedToArrayAndBlock,
   ],
   globals: [
     {

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -809,9 +809,9 @@ describe('Localization', () => {
 
   describe('Nested To Array And Block', () => {
     it('should be equal to the created document', async () => {
-      const x = await payload.create({
+      const { id, blocks } = await payload.create({
         collection: nestedToArrayAndBlockCollectionSlug,
-        locale: 'en',
+        locale: defaultLocale,
         data: {
           blocks: [
             {
@@ -827,10 +827,37 @@ describe('Localization', () => {
         },
       })
 
-      const row = x.blocks[0].array[0].text
+      await payload.update({
+        collection: nestedToArrayAndBlockCollectionSlug,
+        locale: spanishLocale,
+        id,
+        data: {
+          blocks: (blocks as { array: { text: string }[] }[]).map((block) => ({
+            ...block,
+            array: block.array.map((item) => ({ ...item, text: 'spanish' })),
+          })),
+        },
+      })
 
-      expect(row.text).toEqual('english')
-      expect(row.textNotLocalized).toEqual('test')
+      const docDefaultLocale = await payload.findByID({
+        collection: nestedToArrayAndBlockCollectionSlug,
+        locale: defaultLocale,
+        id,
+      })
+
+      const docSpanishLocale = await payload.findByID({
+        collection: nestedToArrayAndBlockCollectionSlug,
+        locale: spanishLocale,
+        id,
+      })
+
+      const rowDefault = docDefaultLocale.blocks[0].array[0]
+      const rowSpanish = docSpanishLocale.blocks[0].array[0]
+
+      expect(rowDefault.text).toEqual('english')
+      expect(rowDefault.textNotLocalized).toEqual('test')
+      expect(rowSpanish.text).toEqual('spanish')
+      expect(rowSpanish.textNotLocalized).toEqual('test')
     })
   })
 })

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -819,6 +819,7 @@ describe('Localization', () => {
               array: [
                 {
                   text: 'english',
+                  textNotLocalized: 'test',
                 },
               ],
             },
@@ -826,7 +827,10 @@ describe('Localization', () => {
         },
       })
 
-      expect(x.blocks[0].array[0].text).toEqual('english')
+      const row = x.blocks[0].array[0].text
+
+      expect(row.text).toEqual('english')
+      expect(row.textNotLocalized).toEqual('test')
     })
   })
 })

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -9,9 +9,10 @@ import { devUser } from '../credentials'
 import { initPayloadTest } from '../helpers/configHelpers'
 import { RESTClient } from '../helpers/rest'
 import { arrayCollectionSlug } from './collections/Array'
+import { nestedToArrayAndBlockCollectionSlug } from './collections/NestedToArrayAndBlock'
 import configPromise from './config'
+import { defaultLocale } from './shared'
 import {
-  defaultLocale,
   englishTitle,
   localizedPostsSlug,
   relationEnglishTitle,
@@ -803,6 +804,29 @@ describe('Localization', () => {
       })
 
       expect(nestedFieldRes.docs.map(({ id }) => id)).toContain(post1.id)
+    })
+  })
+
+  describe('Nested To Array And Block', () => {
+    it('should be equal to the created document', async () => {
+      const x = await payload.create({
+        collection: nestedToArrayAndBlockCollectionSlug,
+        locale: 'en',
+        data: {
+          blocks: [
+            {
+              blockType: 'block',
+              array: [
+                {
+                  text: 'english',
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      expect(x.blocks[0].array[0].text).toEqual('english')
     })
   })
 })


### PR DESCRIPTION
## Description

fixes #4208 

Pass the correct `currentTableName` into the `traverseFields` function in `type` equals `blocks` case. This resolves the issue where nested localized fields to blocks weren't being fetched from the database.

In my test case, the tables generated for the NestedToArrayAndBlock collection are as follows:
- nested_to_array_and_block
- nested_to_array_and_block_blocks_block
- nested_to_array_and_block_blocks_block_array
- nested_to_array_and_block_blocks_block_array_locales

Before this correction, the table "nested_to_array_and_block_blocks_block_array_locales" wasn't joining.

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
