### PR TITLE
feat: extend locales to have fallbackLocales

### DIFF
--- a/docs/configuration/localization.mdx
+++ b/docs/configuration/localization.mdx
@@ -6,11 +6,13 @@ desc: Add and maintain as many locales as you need by adding Localization to you
 keywords: localization, internationalization, i18n, config, configuration, documentation, Content Management System, cms, headless, javascript, node, react, express
 ---
 
-Payload features deep field-based localization support. Maintaining as many locales as you need is easy. All localization support is opt-in by default. To do so, follow the two steps below.
+Payload features deep field-based localization support. Maintaining as many locales as you need is easy. All
+localization support is opt-in by default. To do so, follow the two steps below.
 
 ### Enabling in the Payload config
 
-Add the `localization` property to your Payload config to enable localization project-wide. You'll need to provide a list of all locales that you'd like to support as well as set a few other options.
+Add the `localization` property to your Payload config to enable localization project-wide. You'll need to provide a
+list of all locales that you'd like to support as well as set a few other options.
 
 **Example Payload config set up for localization:**
 
@@ -57,7 +59,8 @@ export default buildConfig({
 })
 ```
 
-**Example Payload config set up for localization with full locales objects (including [internationalization](/docs/configuration/i18n) support):**
+**Example Payload config set up for localization with full locales objects (
+including [internationalization](/docs/configuration/i18n) support):**
 
 ```ts
 import { buildConfig } from 'payload/config'
@@ -93,35 +96,48 @@ export default buildConfig({
 
 **`locales`**
 
-Array-based list of all locales that you would like to support. These can be strings of locale codes or objects with a `label`, a locale `code`, and the `rtl` (right-to-left) property. The locale codes do not need to be in any specific format. It's up to you to define how to represent your locales. Common patterns are to use two-letter ISO 639 language codes or four-letter language and country codes (ISO 3166‑1) such as `en-US`, `en-UK`, `es-MX`, etc.
+Array-based list of all locales that you would like to support. These can be strings of locale codes or objects with
+a `label`, a locale `code`, `rtl` (right-to-left), and `fallbackLocale` property. The locale codes do not need to be in
+any specific format. It's up to you to define how to represent your locales. Common patterns are to use two-letter ISO
+639 language codes or four-letter language and country codes (ISO 3166‑1) such as `en-US`, `en-UK`, `es-MX`, etc.
 
 **`defaultLocale`**
 
-Required string that matches one of the locale codes from the array provided. By default, if no locale is specified, documents will be returned in this locale.
+Required string that matches one of the locale codes from the array provided. By default, if no locale is specified,
+documents will be returned in this locale.
 
 **`fallback`**
 
-Boolean enabling "fallback" locale functionality. If a document is requested in a locale, but a field does not have a localized value corresponding to the requested locale, then if this property is enabled, the document will automatically fall back to the fallback locale value. If this property is not enabled, the value will not be populated.
+Boolean enabling "fallback" locale functionality. If a document is requested in a locale, but a field does not have a
+localized value corresponding to the requested locale, then if this property is enabled, the document will automatically
+fall back to the fallback locale value. If this property is not enabled, the value will not be populated.
 
 ### Field by field localization
 
-Payload localization works on a **field** level—not a document level. In addition to configuring the base Payload config to support localization, you need to specify each field that you would like to localize.
+Payload localization works on a **field** level—not a document level. In addition to configuring the base Payload config
+to support localization, you need to specify each field that you would like to localize.
 
 **Here is an example of how to enable localization for a field:**
 
 ```js
 {
   name: 'title',
-  type: 'text',
-  // highlight-start
-  localized: true,
+    type
+:
+  'text',
+    // highlight-start
+    localized
+:
+  true,
   // highlight-end
 }
 ```
 
-With the above configuration, the `title` field will now be saved in the database as an object of all locales instead of a single string.
+With the above configuration, the `title` field will now be saved in the database as an object of all locales instead of
+a single string.
 
-All field types with a `name` property support the `localized` property—even the more complex field types like `array`s and `block`s.
+All field types with a `name` property support the `localized` property—even the more complex field types like `array`s
+and `block`s.
 
 <Banner>
   <strong>Note:</strong>
@@ -143,7 +159,8 @@ All field types with a `name` property support the `localized` property—even t
 
 ### Retrieving localized docs
 
-When retrieving documents, you can specify which locale you'd like to receive as well as which fallback locale should be used.
+When retrieving documents, you can specify which locale you'd like to receive as well as which fallback locale should be
+used.
 
 ##### REST API
 
@@ -155,7 +172,8 @@ Specify your desired locale by providing the `locale` query parameter directly i
 
 **`?fallback-locale=`**
 
-Specify fallback locale to be used by providing the `fallback-locale` query parameter. This can be provided as either a valid locale as provided to your base Payload config, or `'null'`, `'false'`, or `'none'` to disable falling back.
+Specify fallback locale to be used by providing the `fallback-locale` query parameter. This can be provided as either a
+valid locale as provided to your base Payload config, or `'null'`, `'false'`, or `'none'` to disable falling back.
 
 **Example:**
 
@@ -167,7 +185,9 @@ fetch('https://localhost:3000/api/pages?locale=es&fallback-locale=none');
 
 In the GraphQL API, you can specify `locale` and `fallbackLocale` args to all relevant queries and mutations.
 
-The `locale` arg will only accept valid locales, but locales will be formatted automatically as valid GraphQL enum values (dashes or special characters will be converted to underscores, spaces will be removed, etc.). If you are curious to see how locales are auto-formatted, you can use the [GraphQL playground](/docs/graphql/overview#graphql-playground).
+The `locale` arg will only accept valid locales, but locales will be formatted automatically as valid GraphQL enum
+values (dashes or special characters will be converted to underscores, spaces will be removed, etc.). If you are curious
+to see how locales are auto-formatted, you can use the [GraphQL playground](/docs/graphql/overview#graphql-playground).
 
 The `fallbackLocale` arg will accept valid locales as well as `none` to disable falling back.
 
@@ -191,7 +211,9 @@ query {
 
 ##### Local API
 
-You can specify `locale` as well as `fallbackLocale` within the Local API as well as properties on the `options` argument. The `locale` property will accept any valid locale, and the `fallbackLocale` property will accept any valid locale as well as `'null'`, `'false'`, `false`, and `'none'`.
+You can specify `locale` as well as `fallbackLocale` within the Local API as well as properties on the `options`
+argument. The `locale` property will accept any valid locale, and the `fallbackLocale` property will accept any valid
+locale as well as `'null'`, `'false'`, `false`, and `'none'`.
 
 **Example:**
 

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -49,10 +49,10 @@ export default async function createLocal<TSlug extends keyof GeneratedTypes['co
     depth,
     disableVerificationEmail,
     draft,
-    fallbackLocale,
+    fallbackLocale: fallbackLocaleArg,
     file,
     filePath,
-    locale = null,
+    locale: localeArg = null,
     overrideAccess = true,
     overwriteExistingFiles = false,
     req = {} as PayloadRequest,
@@ -62,8 +62,11 @@ export default async function createLocal<TSlug extends keyof GeneratedTypes['co
   setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
-  const defaultLocale = payload?.config?.localization
-    ? payload?.config?.localization?.defaultLocale
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
+  const locale = localeArg || req.locale || defaultLocale
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null
 
   if (!collection) {
@@ -73,8 +76,9 @@ export default async function createLocal<TSlug extends keyof GeneratedTypes['co
   }
 
   req.payloadAPI = req.payloadAPI || 'local'
-  req.locale = locale ?? req?.locale ?? defaultLocale
-  req.fallbackLocale = fallbackLocale !== 'undefined' ? fallbackLocale : defaultLocale
+  req.locale = locale
+  req.fallbackLocale =
+    typeof fallbackLocaleArg !== 'undefined' ? fallbackLocaleArg : fallbackLocale || defaultLocale
   req.payload = payload
   req.i18n = i18nInit(payload.config.i18n)
   req.files = {

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -49,7 +49,7 @@ export default async function createLocal<TSlug extends keyof GeneratedTypes['co
     depth,
     disableVerificationEmail,
     draft,
-    fallbackLocale: fallbackLocaleArg,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     file,
     filePath,
     locale: localeArg = null,

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -61,18 +61,21 @@ async function deleteLocal<TSlug extends keyof GeneratedTypes['collections']>(
     collection: collectionSlug,
     context,
     depth,
-    fallbackLocale,
-    locale = null,
+    fallbackLocale: fallbackLocaleArg,
+    locale: localeArg = null,
     overrideAccess = true,
-    req: incomingReq,
+    req: incomingReq = {} as PayloadRequest,
     showHiddenFields,
     user,
     where,
   } = options
 
   const collection = payload.collections[collectionSlug]
-  const defaultLocale = payload?.config?.localization
-    ? payload?.config?.localization?.defaultLocale
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
+  const locale = localeArg || incomingReq.locale || defaultLocale
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null
 
   if (!collection) {
@@ -82,9 +85,12 @@ async function deleteLocal<TSlug extends keyof GeneratedTypes['collections']>(
   }
 
   const req = {
-    fallbackLocale: typeof fallbackLocale !== 'undefined' ? fallbackLocale : defaultLocale,
+    fallbackLocale:
+      typeof fallbackLocaleArg !== 'undefined'
+        ? fallbackLocaleArg
+        : fallbackLocale || defaultLocale,
     i18n: i18nInit(payload.config.i18n),
-    locale: locale ?? defaultLocale,
+    locale: locale,
     payload,
     payloadAPI: 'local',
     transactionID: incomingReq?.transactionID,

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -73,7 +73,7 @@ async function deleteLocal<TSlug extends keyof GeneratedTypes['collections']>(
   const collection = payload.collections[collectionSlug]
   const localizationConfig = payload?.config?.localization
   const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
-  const locale = localeArg || incomingReq.locale || defaultLocale
+  const locale = localeArg || incomingReq?.locale || defaultLocale
   const fallbackLocale = localizationConfig
     ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -61,7 +61,7 @@ async function deleteLocal<TSlug extends keyof GeneratedTypes['collections']>(
     collection: collectionSlug,
     context,
     depth,
-    fallbackLocale: fallbackLocaleArg,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     locale: localeArg = null,
     overrideAccess = true,
     req: incomingReq = {} as PayloadRequest,

--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -44,7 +44,7 @@ export default async function findLocal<T extends keyof GeneratedTypes['collecti
     depth,
     disableErrors,
     draft = false,
-    fallbackLocale: fallbackLocaleArg,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     limit,
     locale: localeArg = null,
     overrideAccess = true,

--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -44,9 +44,9 @@ export default async function findLocal<T extends keyof GeneratedTypes['collecti
     depth,
     disableErrors,
     draft = false,
-    fallbackLocale,
+    fallbackLocale: fallbackLocaleArg,
     limit,
-    locale = null,
+    locale: localeArg = null,
     overrideAccess = true,
     page,
     pagination = true,
@@ -59,8 +59,11 @@ export default async function findLocal<T extends keyof GeneratedTypes['collecti
   setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
-  const defaultLocale = payload?.config?.localization
-    ? payload?.config?.localization?.defaultLocale
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
+  const locale = localeArg || req.locale || defaultLocale
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null
 
   if (!collection) {
@@ -69,19 +72,10 @@ export default async function findLocal<T extends keyof GeneratedTypes['collecti
     )
   }
 
-  let fallbackLocaleToUse = defaultLocale
-
-  if (typeof req.fallbackLocale !== 'undefined') {
-    fallbackLocaleToUse = req.fallbackLocale
-  }
-
-  if (typeof fallbackLocale !== 'undefined') {
-    fallbackLocaleToUse = fallbackLocale
-  }
-
   req.payloadAPI = req.payloadAPI || 'local'
-  req.locale = locale ?? req?.locale ?? defaultLocale
-  req.fallbackLocale = fallbackLocaleToUse
+  req.locale = locale
+  req.fallbackLocale =
+    typeof fallbackLocaleArg !== 'undefined' ? fallbackLocaleArg : fallbackLocale || defaultLocale
   req.i18n = i18nInit(payload.config.i18n)
   req.payload = payload
 

--- a/packages/payload/src/collections/operations/local/findByID.ts
+++ b/packages/payload/src/collections/operations/local/findByID.ts
@@ -40,7 +40,7 @@ export default async function findByIDLocal<T extends keyof GeneratedTypes['coll
     depth,
     disableErrors = false,
     draft = false,
-    fallbackLocale: fallbackLocaleArg,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     locale: localeArg = null,
     overrideAccess = true,
     req = {} as PayloadRequest,

--- a/packages/payload/src/collections/operations/local/findByID.ts
+++ b/packages/payload/src/collections/operations/local/findByID.ts
@@ -40,8 +40,8 @@ export default async function findByIDLocal<T extends keyof GeneratedTypes['coll
     depth,
     disableErrors = false,
     draft = false,
-    fallbackLocale,
-    locale = null,
+    fallbackLocale: fallbackLocaleArg,
+    locale: localeArg = null,
     overrideAccess = true,
     req = {} as PayloadRequest,
     showHiddenFields,
@@ -50,8 +50,11 @@ export default async function findByIDLocal<T extends keyof GeneratedTypes['coll
   setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
-  const defaultLocale = payload?.config?.localization
-    ? payload?.config?.localization?.defaultLocale
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
+  const locale = localeArg || req.locale || defaultLocale
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null
 
   if (!collection) {
@@ -60,19 +63,10 @@ export default async function findByIDLocal<T extends keyof GeneratedTypes['coll
     )
   }
 
-  let fallbackLocaleToUse = defaultLocale
-
-  if (typeof req.fallbackLocale !== 'undefined') {
-    fallbackLocaleToUse = req.fallbackLocale
-  }
-
-  if (typeof fallbackLocale !== 'undefined') {
-    fallbackLocaleToUse = fallbackLocale
-  }
-
   req.payloadAPI = req.payloadAPI || 'local'
-  req.locale = locale ?? req?.locale ?? defaultLocale
-  req.fallbackLocale = fallbackLocaleToUse
+  req.locale = locale
+  req.fallbackLocale =
+    typeof fallbackLocaleArg !== 'undefined' ? fallbackLocaleArg : fallbackLocale || defaultLocale
   req.i18n = i18nInit(payload.config.i18n)
   req.payload = payload
 

--- a/packages/payload/src/collections/operations/local/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/local/findVersionByID.ts
@@ -38,7 +38,7 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
     context,
     depth,
     disableErrors = false,
-    fallbackLocale: fallbackLocaleArg,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     locale: localeArg = null,
     overrideAccess = true,
     req = {} as PayloadRequest,

--- a/packages/payload/src/collections/operations/local/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/local/findVersionByID.ts
@@ -38,8 +38,8 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
     context,
     depth,
     disableErrors = false,
-    fallbackLocale,
-    locale = null,
+    fallbackLocale: fallbackLocaleArg,
+    locale: localeArg = null,
     overrideAccess = true,
     req = {} as PayloadRequest,
     showHiddenFields,
@@ -47,8 +47,11 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
   setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
-  const defaultLocale = payload?.config?.localization
-    ? payload?.config?.localization?.defaultLocale
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
+  const locale = localeArg || req.locale || defaultLocale
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null
 
   if (!collection) {
@@ -59,19 +62,10 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
     )
   }
 
-  let fallbackLocaleToUse = defaultLocale
-
-  if (typeof req.fallbackLocale !== 'undefined') {
-    fallbackLocaleToUse = req.fallbackLocale
-  }
-
-  if (typeof fallbackLocale !== 'undefined') {
-    fallbackLocaleToUse = fallbackLocale
-  }
-
   req.payloadAPI = req.payloadAPI || 'local'
-  req.locale = locale ?? req?.locale ?? defaultLocale
-  req.fallbackLocale = fallbackLocaleToUse
+  req.locale = locale
+  req.fallbackLocale =
+    typeof fallbackLocaleArg !== 'undefined' ? fallbackLocaleArg : fallbackLocale || defaultLocale
   req.i18n = i18nInit(payload.config.i18n)
   req.payload = payload
 

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -39,7 +39,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
     collection: collectionSlug,
     context,
     depth,
-    fallbackLocale: fallbackLocaleArg,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     limit,
     locale: localeArg = null,
     overrideAccess = true,

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -39,9 +39,9 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
     collection: collectionSlug,
     context,
     depth,
-    fallbackLocale,
+    fallbackLocale: fallbackLocaleArg,
     limit,
-    locale = null,
+    locale: localeArg = null,
     overrideAccess = true,
     page,
     req: incomingReq,
@@ -52,8 +52,11 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   } = options
 
   const collection = payload.collections[collectionSlug]
-  const defaultLocale = payload?.config?.localization
-    ? payload?.config?.localization?.defaultLocale
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
+  const locale = localeArg || incomingReq.locale || defaultLocale
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null
 
   if (!collection) {
@@ -64,9 +67,12 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
 
   const i18n = i18nInit(payload.config.i18n)
   const req = {
-    fallbackLocale: typeof fallbackLocale !== 'undefined' ? fallbackLocale : defaultLocale,
+    fallbackLocale:
+      typeof fallbackLocaleArg !== 'undefined'
+        ? fallbackLocaleArg
+        : fallbackLocale || defaultLocale,
     i18n,
-    locale: locale ?? defaultLocale,
+    locale,
     payload,
     payloadAPI: 'local',
     transactionID: incomingReq?.transactionID,

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -54,7 +54,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   const collection = payload.collections[collectionSlug]
   const localizationConfig = payload?.config?.localization
   const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
-  const locale = localeArg || incomingReq.locale || defaultLocale
+  const locale = localeArg || incomingReq?.locale || defaultLocale
   const fallbackLocale = localizationConfig
     ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null

--- a/packages/payload/src/collections/operations/local/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/local/restoreVersion.ts
@@ -46,7 +46,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   const collection = payload.collections[collectionSlug]
   const localizationConfig = payload?.config?.localization
   const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
-  const locale = localeArg || incomingReq.locale || defaultLocale
+  const locale = localeArg || incomingReq?.locale || defaultLocale
   const fallbackLocale = localizationConfig
     ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null

--- a/packages/payload/src/collections/operations/local/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/local/restoreVersion.ts
@@ -35,7 +35,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
     collection: collectionSlug,
     context,
     depth,
-    fallbackLocale: fallbackLocaleArg,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     locale: localeArg = null,
     overrideAccess = true,
     req: incomingReq,

--- a/packages/payload/src/collections/operations/local/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/local/restoreVersion.ts
@@ -35,8 +35,8 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
     collection: collectionSlug,
     context,
     depth,
-    fallbackLocale = null,
-    locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
+    fallbackLocale: fallbackLocaleArg,
+    locale: localeArg = null,
     overrideAccess = true,
     req: incomingReq,
     showHiddenFields,
@@ -44,6 +44,12 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   } = options
 
   const collection = payload.collections[collectionSlug]
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
+  const locale = localeArg || incomingReq.locale || defaultLocale
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
+    : null
 
   if (!collection) {
     throw new APIError(
@@ -55,7 +61,10 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
 
   const i18n = i18nInit(payload.config.i18n)
   const req = {
-    fallbackLocale,
+    fallbackLocale:
+      typeof fallbackLocaleArg !== 'undefined'
+        ? fallbackLocaleArg
+        : fallbackLocale || defaultLocale,
     i18n,
     locale,
     payload,

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -74,10 +74,10 @@ async function updateLocal<TSlug extends keyof GeneratedTypes['collections']>(
     data,
     depth,
     draft,
-    fallbackLocale,
+    fallbackLocale: fallbackLocaleArg,
     file,
     filePath,
-    locale = null,
+    locale: localeArg = null,
     overrideAccess = true,
     overwriteExistingFiles = false,
     req: incomingReq,
@@ -88,8 +88,11 @@ async function updateLocal<TSlug extends keyof GeneratedTypes['collections']>(
 
   const collection = payload.collections[collectionSlug]
   const i18n = i18nInit(payload.config.i18n)
-  const defaultLocale = payload.config.localization
-    ? payload.config.localization?.defaultLocale
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
+  const locale = localeArg || incomingReq.locale || defaultLocale
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null
 
   if (!collection) {
@@ -99,7 +102,10 @@ async function updateLocal<TSlug extends keyof GeneratedTypes['collections']>(
   }
 
   const req = {
-    fallbackLocale: typeof fallbackLocale !== 'undefined' ? fallbackLocale : defaultLocale,
+    fallbackLocale:
+      typeof fallbackLocaleArg !== 'undefined'
+        ? fallbackLocaleArg
+        : fallbackLocale || defaultLocale,
     files: {
       file: file ?? (await getFileByPath(filePath)),
     },

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -74,7 +74,7 @@ async function updateLocal<TSlug extends keyof GeneratedTypes['collections']>(
     data,
     depth,
     draft,
-    fallbackLocale: fallbackLocaleArg,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     file,
     filePath,
     locale: localeArg = null,

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -90,7 +90,7 @@ async function updateLocal<TSlug extends keyof GeneratedTypes['collections']>(
   const i18n = i18nInit(payload.config.i18n)
   const localizationConfig = payload?.config?.localization
   const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
-  const locale = localeArg || incomingReq.locale || defaultLocale
+  const locale = localeArg || incomingReq?.locale || defaultLocale
   const fallbackLocale = localizationConfig
     ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null

--- a/packages/payload/src/config/schema.ts
+++ b/packages/payload/src/config/schema.ts
@@ -137,6 +137,7 @@ export default joi.object({
         joi.array().items(
           joi.object().keys({
             code: joi.string(),
+            fallbackLocale: joi.string(),
             label: joi
               .alternatives()
               .try(

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -11,11 +11,7 @@ import type { DeepRequired } from 'ts-essentials'
 import type { InlineConfig } from 'vite'
 import type { Configuration } from 'webpack'
 
-import type {
-  DocumentTab,
-  DocumentTabComponent,
-  DocumentTabConfig,
-} from '../admin/components/elements/DocumentHeader/Tabs/types'
+import type { DocumentTab } from '../admin/components/elements/DocumentHeader/Tabs/types'
 import type { RichTextAdapter } from '../admin/components/forms/field-types/RichText/types'
 import type { ContextType } from '../admin/components/utilities/DocumentInfo/types'
 import type { User } from '../auth/types'
@@ -288,6 +284,10 @@ export type Locale = {
    * @example "en"
    */
   code: string
+  /**
+   * Code of another locale to use when reading documents with fallback, if not specified defaultLocale is used
+   */
+  fallbackLocale?: string
   /**
    * label of supported locale
    * @example "English"

--- a/packages/payload/src/express/middleware/index.ts
+++ b/packages/payload/src/express/middleware/index.ts
@@ -48,15 +48,15 @@ const middleware = (payload: Payload): any => {
     qsMiddleware({ arrayLimit: 1000, depth: 10 }),
     bodyParser.urlencoded({ extended: true }),
     compression(payload.config.express.compression),
-    localizationMiddleware(payload.config.localization),
+    localizationMiddleware,
     express.json(payload.config.express.json),
     fileUpload({
       parseNested: true,
       ...payload.config.upload,
     }),
     convertPayload,
-    corsHeaders(payload.config),
     authenticate(payload.config),
+    corsHeaders(payload.config),
     ...(payload.config.express.middleware || []),
     ...(payload.config.express.postMiddleware || []),
   ]

--- a/packages/payload/src/globals/operations/local/findOne.ts
+++ b/packages/payload/src/globals/operations/local/findOne.ts
@@ -30,7 +30,7 @@ export default async function findOneLocal<T extends keyof GeneratedTypes['globa
     context,
     depth,
     draft = false,
-    fallbackLocale = null,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
     overrideAccess = true,
     showHiddenFields,
@@ -39,8 +39,12 @@ export default async function findOneLocal<T extends keyof GeneratedTypes['globa
   } = options
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug)
+  const localizationConfig = payload?.config?.localization
   const defaultLocale = payload?.config?.localization
     ? payload?.config?.localization?.defaultLocale
+    : null
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
     : null
 
   if (!globalConfig) {
@@ -50,7 +54,10 @@ export default async function findOneLocal<T extends keyof GeneratedTypes['globa
   const i18n = i18nInit(payload.config.i18n)
 
   const req = {
-    fallbackLocale: fallbackLocale ?? options.req?.fallbackLocale ?? defaultLocale,
+    fallbackLocale:
+      typeof fallbackLocaleArg !== 'undefined'
+        ? fallbackLocaleArg
+        : fallbackLocale || defaultLocale,
     i18n,
     locale: locale ?? options.req?.locale ?? defaultLocale,
     payload,

--- a/packages/payload/src/globals/operations/local/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/local/findVersionByID.ts
@@ -33,7 +33,7 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
     context,
     depth,
     disableErrors = false,
-    fallbackLocale = null,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
     overrideAccess = true,
     req: incomingReq,
@@ -43,6 +43,13 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
   } = options
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug)
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = payload?.config?.localization
+    ? payload?.config?.localization?.defaultLocale
+    : null
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
+    : null
   const i18n = i18nInit(payload.config.i18n)
 
   if (!globalConfig) {
@@ -50,7 +57,10 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
   }
 
   const req = {
-    fallbackLocale,
+    fallbackLocale:
+      typeof fallbackLocaleArg !== 'undefined'
+        ? fallbackLocaleArg
+        : fallbackLocale || defaultLocale,
     i18n,
     locale,
     payload,

--- a/packages/payload/src/globals/operations/local/findVersions.ts
+++ b/packages/payload/src/globals/operations/local/findVersions.ts
@@ -34,7 +34,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   const {
     context,
     depth,
-    fallbackLocale = null,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     limit,
     locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
     overrideAccess = true,
@@ -48,6 +48,13 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   } = options
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug)
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = payload?.config?.localization
+    ? payload?.config?.localization?.defaultLocale
+    : null
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
+    : null
   const i18n = i18nInit(payload.config.i18n)
 
   if (!globalConfig) {
@@ -55,7 +62,10 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   }
 
   const req = {
-    fallbackLocale,
+    fallbackLocale:
+      typeof fallbackLocaleArg !== 'undefined'
+        ? fallbackLocaleArg
+        : fallbackLocale || defaultLocale,
     i18n,
     locale,
     payload,

--- a/packages/payload/src/globals/operations/local/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/local/restoreVersion.ts
@@ -30,7 +30,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
     id,
     context,
     depth,
-    fallbackLocale = null,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
     overrideAccess = true,
     req: incomingReq,
@@ -40,6 +40,13 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   } = options
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug)
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = payload?.config?.localization
+    ? payload?.config?.localization?.defaultLocale
+    : null
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
+    : null
   const i18n = i18nInit(payload.config.i18n)
 
   if (!globalConfig) {
@@ -47,7 +54,10 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   }
 
   const req = {
-    fallbackLocale,
+    fallbackLocale:
+      typeof fallbackLocaleArg !== 'undefined'
+        ? fallbackLocaleArg
+        : fallbackLocale || defaultLocale,
     i18n,
     locale,
     payload,

--- a/packages/payload/src/globals/operations/local/update.ts
+++ b/packages/payload/src/globals/operations/local/update.ts
@@ -34,7 +34,7 @@ export default async function updateLocal<TSlug extends keyof GeneratedTypes['gl
     data,
     depth,
     draft,
-    fallbackLocale = null,
+    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
     overrideAccess = true,
     req: incomingReq,
@@ -44,6 +44,13 @@ export default async function updateLocal<TSlug extends keyof GeneratedTypes['gl
   } = options
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug)
+  const localizationConfig = payload?.config?.localization
+  const defaultLocale = payload?.config?.localization
+    ? payload?.config?.localization?.defaultLocale
+    : null
+  const fallbackLocale = localizationConfig
+    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
+    : null
   const i18n = i18nInit(payload.config.i18n)
 
   if (!globalConfig) {
@@ -51,7 +58,10 @@ export default async function updateLocal<TSlug extends keyof GeneratedTypes['gl
   }
 
   const req = {
-    fallbackLocale,
+    fallbackLocale:
+      typeof fallbackLocaleArg !== 'undefined'
+        ? fallbackLocaleArg
+        : fallbackLocale || defaultLocale,
     i18n,
     locale,
     payload,

--- a/packages/payload/src/localization/middleware.ts
+++ b/packages/payload/src/localization/middleware.ts
@@ -11,7 +11,7 @@ export default function localizationMiddleware(req, res, next) {
   const validLocales = [...localization.localeCodes, 'all']
   const validFallbackLocales = [...localization.localeCodes, 'null']
 
-  let requestedLocale = req.query.locale
+  let requestedLocale = req.query.locale || localization.defaultLocale
   let requestedFallbackLocale = req.query['fallback-locale']
 
   if (req.body) {

--- a/packages/payload/src/localization/middleware.ts
+++ b/packages/payload/src/localization/middleware.ts
@@ -31,8 +31,12 @@ export default function localizationMiddleware(localization: SanitizedLocalizati
         req.locale = requestedLocale
       }
 
+      const fallbackLocale =
+        localization.locales.find(({ code }) => req.locale === code)?.fallbackLocale ||
+        localization.defaultLocale
+
       if (validFallbackLocales.find((locale) => locale === requestedFallbackLocale)) {
-        req.fallbackLocale = requestedFallbackLocale
+        req.fallbackLocale = requestedFallbackLocale || fallbackLocale
       }
     }
 

--- a/packages/payload/src/localization/middleware.ts
+++ b/packages/payload/src/localization/middleware.ts
@@ -1,47 +1,38 @@
-import type { SanitizedLocalizationConfig } from '../config/types'
-
 /**
  * sets request locale
- *
- * @param localization
- * @returns {Function}
  */
-export default function localizationMiddleware(localization: SanitizedLocalizationConfig | false) {
-  const middleware = (req, res, next) => {
-    if (localization) {
-      const validLocales = [...localization.localeCodes, 'all']
-      const validFallbackLocales = [...localization.localeCodes, 'null']
-
-      let requestedLocale = req.query.locale || localization.defaultLocale
-      let requestedFallbackLocale = req.query['fallback-locale'] || localization.defaultLocale
-
-      if (req.body) {
-        if (req.body.locale) requestedLocale = req.body.locale
-        if (req.body['fallback-locale']) {
-          requestedFallbackLocale = req.body['fallback-locale']
-        }
-      }
-
-      if (requestedFallbackLocale === 'none') requestedFallbackLocale = 'null'
-      if (requestedLocale === '*' || requestedLocale === 'all') {
-        requestedLocale = 'all'
-      }
-
-      if (validLocales.find((locale) => locale === requestedLocale)) {
-        req.locale = requestedLocale
-      }
-
-      const fallbackLocale =
-        localization.locales.find(({ code }) => req.locale === code)?.fallbackLocale ||
-        localization.defaultLocale
-
-      if (validFallbackLocales.find((locale) => locale === requestedFallbackLocale)) {
-        req.fallbackLocale = requestedFallbackLocale || fallbackLocale
-      }
-    }
-
-    return next()
+export default function localizationMiddleware(req, res, next) {
+  const localization = req.payload.config.localization
+  if (!localization) {
+    next()
+    return
   }
 
-  return middleware
+  const validLocales = [...localization.localeCodes, 'all']
+  const validFallbackLocales = [...localization.localeCodes, 'null']
+
+  let requestedLocale = req.query.locale
+  let requestedFallbackLocale = req.query['fallback-locale']
+
+  if (req.body) {
+    if (req.body.locale) requestedLocale = req.body.locale
+    if (req.body['fallback-locale']) {
+      requestedFallbackLocale = req.body['fallback-locale']
+    }
+  }
+
+  if (requestedFallbackLocale === 'none') requestedFallbackLocale = 'null'
+  if (requestedLocale === '*' || requestedLocale === 'all') {
+    requestedLocale = 'all'
+  }
+  req.fallbackLocale = validFallbackLocales.find((locale) => locale === requestedFallbackLocale)
+
+  req.locale = validLocales.find((locale) => locale === requestedLocale)
+
+  if (!req.fallbackLocale) {
+    req.fallbackLocale =
+      localization.locales.find(({ code }) => req.locale === code)?.fallbackLocale ||
+      localization.defaultLocale
+  }
+  next()
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -78,7 +78,7 @@ export async function openDocControls(page: Page): Promise<void> {
 
 export async function changeLocale(page: Page, newLocale: string) {
   await page.locator('.localizer >> button').first().click()
-  await page.locator(`.localizer >> a:has-text("${newLocale}")`).click()
+  await page.locator(`.localizer >> a[href="/?locale=${newLocale}"]`).click()
   expect(page.url()).toContain(`locale=${newLocale}`)
 }
 

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -7,6 +7,7 @@ import {
   defaultLocale,
   englishTitle,
   localizedPostsSlug,
+  portugueseLocale,
   relationEnglishTitle,
   relationEnglishTitle2,
   relationSpanishTitle,
@@ -235,7 +236,6 @@ export default buildConfigWithDefaults({
     locales: [
       {
         code: defaultLocale,
-        fallbackLocale: spanishLocale,
         label: 'English',
         rtl: false,
       },
@@ -243,6 +243,11 @@ export default buildConfigWithDefaults({
         code: spanishLocale,
         label: 'Spanish',
         rtl: false,
+      },
+      {
+        code: portugueseLocale,
+        fallbackLocale: spanishLocale,
+        label: 'Portuguese',
       },
       {
         code: 'ar',

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -26,48 +26,26 @@ export type LocalizedPostAllLocale = LocalizedPost & {
 }
 
 const openAccess = {
-  read: () => true,
   create: () => true,
   delete: () => true,
+  read: () => true,
   update: () => true,
 }
 
 export default buildConfigWithDefaults({
-  localization: {
-    locales: [
-      {
-        label: 'English',
-        code: defaultLocale,
-        rtl: false,
-      },
-      {
-        label: 'Spanish',
-        code: spanishLocale,
-        rtl: false,
-      },
-      {
-        label: 'Arabic',
-        code: 'ar',
-        rtl: true,
-      },
-    ],
-    defaultLocale,
-    fallback: true,
-  },
   collections: [
     {
-      slug: 'users',
       auth: true,
       fields: [
         {
           name: 'relation',
-          type: 'relationship',
           relationTo: localizedPostsSlug,
+          type: 'relationship',
         },
       ],
+      slug: 'users',
     },
     {
-      slug: localizedPostsSlug,
       access: openAccess,
       admin: {
         useAsTitle: 'title',
@@ -75,9 +53,9 @@ export default buildConfigWithDefaults({
       fields: [
         {
           name: 'title',
-          type: 'text',
-          localized: true,
           index: true,
+          localized: true,
+          type: 'text',
         },
         {
           name: 'description',
@@ -85,17 +63,16 @@ export default buildConfigWithDefaults({
         },
         {
           name: 'localizedCheckbox',
-          type: 'checkbox',
           localized: true,
+          type: 'checkbox',
         },
         {
           name: 'children',
-          type: 'relationship',
-          relationTo: localizedPostsSlug,
           hasMany: true,
+          relationTo: localizedPostsSlug,
+          type: 'relationship',
         },
         {
-          type: 'group',
           name: 'group',
           fields: [
             {
@@ -103,126 +80,127 @@ export default buildConfigWithDefaults({
               type: 'text',
             },
           ],
+          type: 'group',
         },
       ],
+      slug: localizedPostsSlug,
     },
     ArrayCollection,
     {
-      slug: withRequiredLocalizedFields,
       fields: [
         {
           name: 'title',
-          type: 'text',
-          required: true,
           localized: true,
+          required: true,
+          type: 'text',
         },
         {
           name: 'layout',
-          type: 'blocks',
-          required: true,
-          localized: true,
           blocks: [
             {
-              slug: 'text',
               fields: [
                 {
                   name: 'text',
                   type: 'text',
                 },
               ],
+              slug: 'text',
             },
             {
-              slug: 'number',
               fields: [
                 {
                   name: 'number',
                   type: 'number',
                 },
               ],
+              slug: 'number',
             },
           ],
+          localized: true,
+          required: true,
+          type: 'blocks',
         },
       ],
+      slug: withRequiredLocalizedFields,
     },
     {
-      slug: withLocalizedRelSlug,
       access: openAccess,
       fields: [
         // Relationship
         {
           name: 'localizedRelationship',
-          type: 'relationship',
           relationTo: localizedPostsSlug,
+          type: 'relationship',
         },
         // Relation hasMany
         {
           name: 'localizedRelationHasManyField',
-          type: 'relationship',
-          relationTo: localizedPostsSlug,
           hasMany: true,
+          relationTo: localizedPostsSlug,
+          type: 'relationship',
         },
         // Relation multiple relationTo
         {
           name: 'localizedRelationMultiRelationTo',
-          type: 'relationship',
           relationTo: [localizedPostsSlug, 'dummy'],
+          type: 'relationship',
         },
         // Relation multiple relationTo hasMany
         {
           name: 'localizedRelationMultiRelationToHasMany',
-          type: 'relationship',
-          relationTo: [localizedPostsSlug, 'dummy'],
           hasMany: true,
+          relationTo: [localizedPostsSlug, 'dummy'],
+          type: 'relationship',
         },
       ],
+      slug: withLocalizedRelSlug,
     },
     {
-      slug: relationshipLocalizedSlug,
       fields: [
         {
           name: 'relationship',
-          type: 'relationship',
-          relationTo: localizedPostsSlug,
           localized: true,
+          relationTo: localizedPostsSlug,
+          type: 'relationship',
         },
         {
           name: 'relationshipHasMany',
-          type: 'relationship',
-          relationTo: localizedPostsSlug,
           hasMany: true,
           localized: true,
+          relationTo: localizedPostsSlug,
+          type: 'relationship',
         },
         {
           name: 'relationMultiRelationTo',
-          type: 'relationship',
-          relationTo: [localizedPostsSlug, 'dummy'],
           localized: true,
+          relationTo: [localizedPostsSlug, 'dummy'],
+          type: 'relationship',
         },
         {
           name: 'relationMultiRelationToHasMany',
-          type: 'relationship',
-          relationTo: [localizedPostsSlug, 'dummy'],
           hasMany: true,
           localized: true,
+          relationTo: [localizedPostsSlug, 'dummy'],
+          type: 'relationship',
         },
         {
           name: 'arrayField',
-          label: 'Array Field',
-          type: 'array',
-          localized: true,
           fields: [
             {
-              type: 'relationship',
               name: 'nestedRelation',
               label: 'Nested Relation',
               relationTo: localizedPostsSlug,
+              type: 'relationship',
             },
           ],
+          label: 'Array Field',
+          localized: true,
+          type: 'array',
         },
       ],
+      slug: relationshipLocalizedSlug,
     },
     {
-      slug: 'dummy',
       access: openAccess,
       fields: [
         {
@@ -230,26 +208,49 @@ export default buildConfigWithDefaults({
           type: 'text',
         },
       ],
+      slug: 'dummy',
     },
   ],
   globals: [
     {
-      slug: 'global-array',
       fields: [
         {
           name: 'array',
-          type: 'array',
           fields: [
             {
               name: 'text',
-              type: 'text',
               localized: true,
+              type: 'text',
             },
           ],
+          type: 'array',
         },
       ],
+      slug: 'global-array',
     },
   ],
+  localization: {
+    defaultLocale,
+    fallback: true,
+    locales: [
+      {
+        code: defaultLocale,
+        fallbackLocale: spanishLocale,
+        label: 'English',
+        rtl: false,
+      },
+      {
+        code: spanishLocale,
+        label: 'Spanish',
+        rtl: false,
+      },
+      {
+        code: 'ar',
+        label: 'Arabic',
+        rtl: true,
+      },
+    ],
+  },
   onInit: async (payload) => {
     const collection = localizedPostsSlug
 
@@ -277,12 +278,12 @@ export default buildConfigWithDefaults({
     })
 
     await payload.update({
-      collection,
       id: localizedPost.id,
-      locale: spanishLocale,
+      collection,
       data: {
         title: spanishTitle,
       },
+      locale: spanishLocale,
     })
 
     const localizedRelation = await payload.create({
@@ -293,12 +294,12 @@ export default buildConfigWithDefaults({
     })
 
     await payload.update({
-      collection,
       id: localizedPost.id,
-      locale: spanishLocale,
+      collection,
       data: {
         title: relationSpanishTitle,
       },
+      locale: spanishLocale,
     })
 
     const localizedRelation2 = await payload.create({
@@ -308,47 +309,46 @@ export default buildConfigWithDefaults({
       },
     })
     await payload.update({
-      collection,
       id: localizedPost.id,
-      locale: spanishLocale,
+      collection,
       data: {
         title: relationSpanishTitle2,
       },
+      locale: spanishLocale,
     })
 
     await payload.create({
       collection: withLocalizedRelSlug,
       data: {
-        relationship: localizedRelation.id,
         localizedRelationHasManyField: [localizedRelation.id, localizedRelation2.id],
         localizedRelationMultiRelationTo: { relationTo: collection, value: localizedRelation.id },
         localizedRelationMultiRelationToHasMany: [
           { relationTo: localizedPostsSlug, value: localizedRelation.id },
           { relationTo: localizedPostsSlug, value: localizedRelation2.id },
         ],
+        relationship: localizedRelation.id,
       },
     })
     await payload.create({
       collection: relationshipLocalizedSlug,
-      locale: 'en',
       data: {
-        relationship: localizedRelation.id,
-        relationshipHasMany: [localizedRelation.id, localizedRelation2.id],
-        relationMultiRelationTo: { relationTo: collection, value: localizedRelation.id },
-        relationMultiRelationToHasMany: [
-          { relationTo: localizedPostsSlug, value: localizedRelation.id },
-          { relationTo: localizedPostsSlug, value: localizedRelation2.id },
-        ],
         arrayField: [
           {
             nestedRelation: localizedRelation.id,
           },
         ],
+        relationMultiRelationTo: { relationTo: collection, value: localizedRelation.id },
+        relationMultiRelationToHasMany: [
+          { relationTo: localizedPostsSlug, value: localizedRelation.id },
+          { relationTo: localizedPostsSlug, value: localizedRelation2.id },
+        ],
+        relationship: localizedRelation.id,
+        relationshipHasMany: [localizedRelation.id, localizedRelation2.id],
       },
+      locale: 'en',
     })
 
     const globalArray = await payload.updateGlobal({
-      slug: 'global-array',
       data: {
         array: [
           {
@@ -359,17 +359,18 @@ export default buildConfigWithDefaults({
           },
         ],
       },
+      slug: 'global-array',
     })
 
     await payload.updateGlobal({
-      slug: 'global-array',
-      locale: 'es',
       data: {
         array: globalArray.array.map((row, i) => ({
           ...row,
           text: `test es ${i + 1}`,
         })),
       },
+      locale: 'es',
+      slug: 'global-array',
     })
   },
 })

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -6,6 +6,7 @@ import type { LocalizedPost, WithLocalizedRelationship } from './payload-types'
 
 import payload from '../../packages/payload/src'
 import { devUser } from '../credentials'
+import { englishLocale } from '../globals/config'
 import { initPayloadTest } from '../helpers/configHelpers'
 import { RESTClient } from '../helpers/rest'
 import { arrayCollectionSlug } from './collections/Array'
@@ -37,7 +38,7 @@ describe('Localization', () => {
 
   beforeAll(async () => {
     ;({ serverURL } = await initPayloadTest({ __dirname, init: { local: false } }))
-    client = new RESTClient(config, { serverURL, defaultSlug: collection })
+    client = new RESTClient(config, { defaultSlug: collection, serverURL })
     await client.create({
       data: {
         email: devUser.email,
@@ -65,12 +66,12 @@ describe('Localization', () => {
     })
 
     await payload.update({
-      collection,
       id: postWithLocalizedData.id,
-      locale: spanishLocale,
+      collection,
       data: {
         title: spanishTitle,
       },
+      locale: spanishLocale,
     })
   })
 
@@ -93,19 +94,19 @@ describe('Localization', () => {
 
     it('add spanish translation', async () => {
       const updated = await payload.update({
-        collection,
         id: post1.id,
-        locale: spanishLocale,
+        collection,
         data: {
           title: spanishTitle,
         },
+        locale: spanishLocale,
       })
 
       expect(updated.title).toEqual(spanishTitle)
 
       const localized: any = await payload.findByID({
-        collection,
         id: post1.id,
+        collection,
         locale: 'all',
       })
 
@@ -115,29 +116,70 @@ describe('Localization', () => {
 
     it('should fallback to english translation when empty', async () => {
       await payload.update({
-        collection,
         id: post1.id,
-        locale: spanishLocale,
+        collection,
         data: {
           title: '',
         },
+        locale: spanishLocale,
       })
 
       const retrievedInEnglish = await payload.findByID({
-        collection,
         id: post1.id,
+        collection,
       })
 
       expect(retrievedInEnglish.title).toEqual(englishTitle)
 
       const localizedFallback: any = await payload.findByID({
-        collection,
         id: post1.id,
+        collection,
         locale: 'all',
       })
 
       expect(localizedFallback.title.en).toEqual(englishTitle)
       expect(localizedFallback.title.es).toEqual('')
+    })
+
+    describe('fallback locales', () => {
+      let englishData
+      let spanishData
+      let localizedDoc
+
+      beforeAll(async () => {
+        englishData = {
+          description: 'english description',
+          localizedCheckbox: false,
+        }
+        spanishData = {
+          localizedCheckbox: true,
+          title: 'spanish title',
+        }
+
+        localizedDoc = await payload.create({
+          collection: localizedPostsSlug,
+          data: englishData,
+          locale: englishLocale,
+        })
+
+        await payload.update({
+          id: localizedDoc.id,
+          collection: localizedPostsSlug,
+          data: spanishData,
+          locale: spanishLocale,
+        })
+      })
+
+      it('should return localized fields using fallbackLocale specified in the requested locale config', async () => {
+        const englishDoc = await payload.findByID({
+          id: localizedDoc.id,
+          collection: localizedPostsSlug,
+          locale: englishLocale,
+        })
+
+        expect(englishDoc.title).toStrictEqual(spanishData.title)
+        expect(englishDoc.localizedCheckbox).toStrictEqual(englishData.localizedCheckbox)
+      })
     })
 
     describe('querying', () => {
@@ -152,19 +194,19 @@ describe('Localization', () => {
 
         // @ts-expect-error Force typing
         localizedPost = await payload.update({
-          collection,
           id,
-          locale: spanishLocale,
+          collection,
           data: {
             title: spanishTitle,
           },
+          locale: spanishLocale,
         })
       })
 
       it('unspecified locale returns default', async () => {
         const localized = await payload.findByID({
-          collection,
           id: localizedPost.id,
+          collection,
         })
 
         expect(localized.title).toEqual(englishTitle)
@@ -172,9 +214,9 @@ describe('Localization', () => {
 
       it('specific locale - same as default', async () => {
         const localized = await payload.findByID({
+          id: localizedPost.id,
           collection,
           locale: defaultLocale,
-          id: localizedPost.id,
         })
 
         expect(localized.title).toEqual(englishTitle)
@@ -182,9 +224,9 @@ describe('Localization', () => {
 
       it('specific locale - not default', async () => {
         const localized = await payload.findByID({
+          id: localizedPost.id,
           collection,
           locale: spanishLocale,
-          id: localizedPost.id,
         })
 
         expect(localized.title).toEqual(spanishTitle)
@@ -192,9 +234,9 @@ describe('Localization', () => {
 
       it('all locales', async () => {
         const localized: any = await payload.findByID({
+          id: localizedPost.id,
           collection,
           locale: 'all',
-          id: localizedPost.id,
         })
 
         expect(localized.title.en).toEqual(englishTitle)
@@ -267,7 +309,6 @@ describe('Localization', () => {
       withRelationship = await payload.create({
         collection: withLocalizedRelSlug,
         data: {
-          localizedRelationship: localizedRelation.id,
           localizedRelationHasManyField: [localizedRelation.id, localizedRelation2.id],
           localizedRelationMultiRelationTo: {
             relationTo: localizedPostsSlug,
@@ -277,6 +318,7 @@ describe('Localization', () => {
             { relationTo: localizedPostsSlug, value: localizedRelation.id },
             { relationTo: localizedPostsSlug, value: localizedRelation2.id },
           ],
+          localizedRelationship: localizedRelation.id,
         },
       })
     })
@@ -327,8 +369,8 @@ describe('Localization', () => {
         // the relationship fields themselves are localized on this collection
         const result: any = await payload.find({
           collection: relationshipLocalizedSlug,
-          locale: 'all',
           depth: 1,
+          locale: 'all',
         })
 
         expect(result.docs[0].relationship.en.id).toBeDefined()
@@ -394,9 +436,9 @@ describe('Localization', () => {
 
       it('relationship population uses locale', async () => {
         const result = await payload.findByID({
+          id: withRelationship.id,
           collection: withLocalizedRelSlug,
           depth: 1,
-          id: withRelationship.id,
           locale: spanishLocale,
         })
         expect((result.localizedRelationship as LocalizedPost).title).toEqual(relationSpanishTitle)
@@ -538,11 +580,11 @@ describe('Localization', () => {
       const reversedArrayRows = [...globalArray.array].reverse()
 
       const updatedGlobal = await payload.updateGlobal({
-        slug: 'global-array',
-        locale: 'all',
         data: {
           array: reversedArrayRows,
         },
+        locale: 'all',
+        slug: 'global-array',
       })
 
       expect(updatedGlobal.array[0].text.en).toStrictEqual('test en 2')
@@ -555,34 +597,34 @@ describe('Localization', () => {
       const newDoc = await payload.create({
         collection: withRequiredLocalizedFields,
         data: {
-          title: 'hello',
           layout: [
             {
               blockType: 'text',
               text: 'laiwejfilwaje',
             },
           ],
+          title: 'hello',
         },
       })
 
       await payload.update({
-        collection: withRequiredLocalizedFields,
         id: newDoc.id,
-        locale: spanishLocale,
+        collection: withRequiredLocalizedFields,
         data: {
-          title: 'en espanol, big bird',
           layout: [
             {
               blockType: 'number',
               number: 12,
             },
           ],
+          title: 'en espanol, big bird',
         },
+        locale: spanishLocale,
       })
 
       const updatedDoc = await payload.update({
-        collection: withRequiredLocalizedFields,
         id: newDoc.id,
+        collection: withRequiredLocalizedFields,
         data: {
           title: 'hello x2',
         },
@@ -591,8 +633,8 @@ describe('Localization', () => {
       expect(updatedDoc.layout[0].blockType).toStrictEqual('text')
 
       const spanishDoc = await payload.findByID({
-        collection: withRequiredLocalizedFields,
         id: newDoc.id,
+        collection: withRequiredLocalizedFields,
         locale: spanishLocale,
       })
 
@@ -689,8 +731,8 @@ describe('Localization', () => {
       })
 
       const result = await payload.findByID({
-        collection: localizedPostsSlug,
         id: createResult.id,
+        collection: localizedPostsSlug,
         locale: 'all',
       })
 
@@ -721,9 +763,9 @@ describe('Localization', () => {
 
     it('should use default locale as fallback', async () => {
       const spanishDoc = await payload.findByID({
-        locale: spanishLocale,
-        collection: arrayCollectionSlug,
         id: docID,
+        collection: arrayCollectionSlug,
+        locale: spanishLocale,
       })
 
       expect(spanishDoc.items[0].text).toStrictEqual(englishTitle)
@@ -731,13 +773,13 @@ describe('Localization', () => {
 
     it('should use empty array as value', async () => {
       const updatedSpanishDoc = await payload.update({
-        collection: arrayCollectionSlug,
-        locale: spanishLocale,
-        fallbackLocale: null,
         id: docID,
+        collection: arrayCollectionSlug,
         data: {
           items: [],
         },
+        fallbackLocale: null,
+        locale: spanishLocale,
       })
 
       expect(updatedSpanishDoc.items).toStrictEqual([])
@@ -745,21 +787,21 @@ describe('Localization', () => {
 
     it('should use fallback value if setting null', async () => {
       await payload.update({
-        collection: arrayCollectionSlug,
-        locale: spanishLocale,
         id: docID,
+        collection: arrayCollectionSlug,
         data: {
           items: [],
         },
+        locale: spanishLocale,
       })
 
       const updatedSpanishDoc = await payload.update({
-        collection: arrayCollectionSlug,
-        locale: spanishLocale,
         id: docID,
+        collection: arrayCollectionSlug,
         data: {
           items: null,
         },
+        locale: spanishLocale,
       })
 
       // should return the value of the fallback locale
@@ -772,8 +814,8 @@ describe('Localization', () => {
   describe('Localized - Field Paths', () => {
     it('should allow querying by non-localized field names ending in a locale', async () => {
       await payload.update({
-        collection,
         id: post1.id,
+        collection,
         data: {
           children: post1.id,
           group: {
@@ -821,12 +863,12 @@ async function createLocalizedPost(data: {
   })
 
   await payload.update({
-    collection,
     id: localizedRelation.id,
-    locale: spanishLocale,
+    collection,
     data: {
       title: data.title.es,
     },
+    locale: spanishLocale,
   })
 
   return localizedRelation

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -15,6 +15,7 @@ import {
   defaultLocale,
   englishTitle,
   localizedPostsSlug,
+  portugueseLocale,
   relationEnglishTitle,
   relationEnglishTitle2,
   relationSpanishTitle,
@@ -148,7 +149,6 @@ describe('Localization', () => {
 
       beforeAll(async () => {
         englishData = {
-          description: 'english description',
           localizedCheckbox: false,
         }
         spanishData = {
@@ -168,17 +168,23 @@ describe('Localization', () => {
           data: spanishData,
           locale: spanishLocale,
         })
+        await payload.update({
+          id: localizedDoc.id,
+          collection: localizedPostsSlug,
+          data: { localizedCheckbox: true },
+          locale: portugueseLocale,
+        })
       })
 
       it('should return localized fields using fallbackLocale specified in the requested locale config', async () => {
-        const englishDoc = await payload.findByID({
+        const portugueseDoc = await payload.findByID({
           id: localizedDoc.id,
           collection: localizedPostsSlug,
-          locale: englishLocale,
+          locale: portugueseLocale,
         })
 
-        expect(englishDoc.title).toStrictEqual(spanishData.title)
-        expect(englishDoc.localizedCheckbox).toStrictEqual(englishData.localizedCheckbox)
+        expect(portugueseDoc.title).toStrictEqual(spanishData.title)
+        expect(portugueseDoc.localizedCheckbox).toStrictEqual(true)
       })
     })
 

--- a/test/localization/shared.ts
+++ b/test/localization/shared.ts
@@ -7,6 +7,7 @@ export const relationSpanishTitle2 = `${relationSpanishTitle}2`
 
 export const defaultLocale = 'en'
 export const spanishLocale = 'es'
+export const portugueseLocale = 'pt'
 
 // Slugs
 export const localizedPostsSlug = 'localized-posts'


### PR DESCRIPTION
## Description

https://github.com/payloadcms/payload/discussions/4198

Allows configuring the fallback locale on a locale-by-locale basis in the config. This way you can have different languages fill in from more closely adjacent ones than simply always going back to a single default for all locales.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
