### PR TITLE
chore: adds redirects plugin docs

### DIFF
--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -375,7 +375,7 @@ import {
 
 ## Examples
 
-The [Examples Directory](https://github.com/payloadcms/payload/tree/main/examples) contains an official [Form Builder Plugin Example](https://github.com/payloadcms/payload/tree/main/examples/form-builder) which demonstrates exactly how to configure this plugin into your Payload instance and implement it on your front-end. We've also included an in-depth walk-through of how to build a form from scratch in our [Form Builder Plugin Blog Post](https://payloadcms.com/blog/create-custom-forms-with-the-official-form-builder-plugin).
+The [Examples Directory](https://github.com/payloadcms/payload/tree/main/examples) contains an official [Form Builder Plugin Example](https://github.com/payloadcms/payload/tree/main/examples/form-builder) which demonstrates exactly how to configure this plugin in Payload and implement it on your front-end. We've also included an in-depth walk-through of how to build a form from scratch in our [Form Builder Plugin Blog Post](https://payloadcms.com/blog/create-custom-forms-with-the-official-form-builder-plugin).
 
 ## Troubleshooting
 

--- a/docs/plugins/nested-docs.mdx
+++ b/docs/plugins/nested-docs.mdx
@@ -201,5 +201,5 @@ import { PluginConfig, GenerateURL, GenerateLabel } from '@payloadcms/plugin-nes
 
 ## Examples
 
-The [Examples Directory](https://github.com/payloadcms/payload/tree/main/examples) contains an official [Nested Docs Plugin Example](https://github.com/payloadcms/payload/tree/main/examples/nested-docs) which demonstrates exactly how to configure this plugin into your Payload instance and implement it on your front-end.
+The [Examples Directory](https://github.com/payloadcms/payload/tree/main/examples) contains an official [Nested Docs Plugin Example](https://github.com/payloadcms/payload/tree/main/examples/nested-docs) which demonstrates exactly how to configure this plugin in Payload and implement it on your front-end.
 

--- a/docs/plugins/redirects.mdx
+++ b/docs/plugins/redirects.mdx
@@ -1,0 +1,76 @@
+---
+title: Redirects Plugin
+label: Redirects
+order: 20
+desc: Automatically create redirects for your Payload application
+keywords: plugins, redirects, redirect, plugin, payload, cms, seo, indexing, search, search engine
+---
+
+[![NPM](https://img.shields.io/npm/v/@payloadcms/plugin-redirects)](https://www.npmjs.com/package/@payloadcms/plugin-redirects)
+
+This plugin allows you to easily manage redirects for your application from within your admin panel. It does so by adding a `redirects` collection to your config that allows you specify a redirect from one URL to another. This is useful for SEO, indexing, and search engine ranking when re-platforming or when changing your URL structure. Your front-end application can use this data to automatically redirect users to the correct page using proper HTTP status codes.
+
+For example, if you have a page at `/about` and you want to change it to `/about-us`, you can create a redirect from `/about` to `/about-us`, then you can use this to write HTTP redirects into your front-end application. This will ensure that users are redirected to the correct page without penalty because search engines are notified of the change. This is a very lightweight plugin that will allow you to integrate managed redirects into any front-end framework.
+
+<Banner type="info">
+  This plugin is completely open-source and the [source code can be found here](https://github.com/payloadcms/payload/tree/main/packages/plugin-redirects). If you need help, check out our [Community Help](https://payloadcms.com/community-help). If you think you've found a bug, please [open a new issue](https://github.com/payloadcms/payload/issues/new?assignees=&labels=plugin%3A%redirects&template=bug_report.md&title=plugin-redirects%3A) with as much detail as possible.
+</Banner>
+
+##### Core features
+
+- Adds a `redirects` collection to your config that:
+  - includes a `from` and `to` fields
+  - allows `to` to be a document reference
+
+## Installation
+
+Install the plugin using any JavaScript package manager like [Yarn](https://yarnpkg.com), [NPM](https://npmjs.com), or [PNPM](https://pnpm.io):
+
+```bash
+  yarn add @payloadcms/plugin-redirects
+```
+
+## Basic Usage
+
+In the `plugins` array of your [Payload config](https://payloadcms.com/docs/configuration/overview), call the plugin with [options](#options):
+
+```ts
+import { buildConfig } from "payload/config";
+import redirects from "@payloadcms/plugin-redirects";
+
+const config = buildConfig({
+  collections: [
+    {
+      slug: "pages",
+      fields: [],
+    },
+  ],
+  plugins: [
+    redirects({
+      collections: ["pages"],
+    }),
+  ],
+});
+
+export default config;
+```
+
+### Options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `collections` | `string[]` | An array of collection slugs to populate in the `to` field of each redirect. |
+| `overrides` | `object` | A partial collection config that allows you to override anything on the `redirects` collection. |
+
+## TypeScript
+
+All types can be directly imported:
+
+```ts
+import { PluginConfig } from "@payloadcms/plugin-redirects/types";
+```
+
+## Examples
+
+The [Examples Directory](https://github.com/payloadcms/payload/tree/main/examples) contains an official [Redirects Plugin Example](https://github.com/payloadcms/payload/tree/main/examples/redirects) which demonstrates exactly how to configure this plugin in Payload and implement it on your front-end.
+

--- a/docs/plugins/stripe.mdx
+++ b/docs/plugins/stripe.mdx
@@ -17,7 +17,7 @@ To build a checkout flow on your front-end you can either use [Stripe Checkout](
 The beauty of this plugin is the entirety of your application's content and business logic can be handled in Payload while Stripe handles solely the billing and payment processing. You can build a completely proprietary application that is endlessly customizable and extendable, on APIs and databases that you own. Hosted services like Shopify or BigCommerce might fracture your application's content then charge you for access.
 
 <Banner type="info">
-  This plugin is completely open-source and the [source code can be found here](https://github.com/payloadcms/payload/tree/main/packages/plugin-stripe). If you need help, check out our [Community Help](https://payloadcms.com/community-help). If you think you've found a bug, please [open a new issue](https://github.com/payloadcms/payload/issues/new?assignees=&labels=plugin%3A%20form-builder&template=bug_report.md&title=plugin-form-builder%3A) with as much detail as possible.
+  This plugin is completely open-source and the [source code can be found here](https://github.com/payloadcms/payload/tree/main/packages/plugin-stripe). If you need help, check out our [Community Help](https://payloadcms.com/community-help). If you think you've found a bug, please [open a new issue](https://github.com/payloadcms/payload/issues/new?assignees=&labels=plugin%3A%20stripe&template=bug_report.md&title=plugin-stripe%3A) with as much detail as possible.
 </Banner>
 
 ##### Core features


### PR DESCRIPTION
## Description

Moves the [Redirects Plugin](https://github.com/payloadcms/payload/tree/main/packages/plugin-redirects) (PR here: https://github.com/payloadcms/payload/pull/3673) docs out of the README and into the `/docs` dir so that they can be rendered on the website.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
