### PR TITLE
fix(richtext-lexical): z-index issues

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/LexicalEditor.scss
+++ b/packages/richtext-lexical/src/field/lexical/LexicalEditor.scss
@@ -3,7 +3,6 @@
 .rich-text-lexical {
   .editor {
     position: relative;
-    z-index: 1;
   }
 
   .editor-shell {

--- a/packages/richtext-lexical/src/field/lexical/ui/ContentEditable.scss
+++ b/packages/richtext-lexical/src/field/lexical/ui/ContentEditable.scss
@@ -6,7 +6,6 @@
   tab-size: 1;
   outline: 0;
   padding-top: 8px;
-  isolation: isolate;
 
   &:focus-visible {
     outline: none !important;


### PR DESCRIPTION
## Description

1. Slash menu of first editor is hidden behind second editor content
![Screenshot 2023-12-20 at 14 58 35@2x](https://github.com/payloadcms/payload/assets/70709113/10490412-5998-4244-a29d-2fb0fc076ef0)

2. Same issue for a Select field inside of a block

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
