### PR TITLE
fix: adjusts json field joi schema to allow editorOptions

### DIFF
--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -174,6 +174,7 @@ export const json = baseField.keys({
       Error: componentSchema,
       Label: componentSchema,
     }),
+    editorOptions: joi.object().unknown(), // Editor['options'] @monaco-editor/react
   }),
   defaultValue: joi.alternatives().try(joi.array(), joi.object()),
   type: joi.string().valid('json').required(),


### PR DESCRIPTION
This prevents the JSON Field type from producing an error when `editorOptions` are provided.

Documentation [claims](https://payloadcms.com/docs/fields/json#admin-config) `editorOptions` is supported by JSON Field type, but defining any in a collection config produces an error:

```
[16:08:59] ERROR (payload): There were 1 errors validating your Payload config
[16:08:59] ERROR (payload): 1: Collection "surveys" > Field "content" > "value" does not match any of the allowed types
```

This is because a previous joi validation fix to the code Field type was not applied to JSON fields: https://github.com/payloadcms/payload/pull/2731/files

## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
