### PR TITLE
chore: ensure condition result is always boolean

### DIFF
--- a/packages/payload/src/admin/components/elements/DocumentHeader/Tabs/Tab/index.tsx
+++ b/packages/payload/src/admin/components/elements/DocumentHeader/Tabs/Tab/index.tsx
@@ -54,7 +54,10 @@ export const DocumentTab: React.FC<DocumentTabProps & DocumentTabConfig> = (prop
       ? checkIsActive
       : location.pathname.startsWith(href)
 
-  if (!condition || (condition && condition({ collection, config, documentInfo, global }))) {
+  if (
+    !condition ||
+    (condition && Boolean(condition({ collection, config, documentInfo, global })))
+  ) {
     const labelToRender = typeof label === 'function' ? label({ t }) : label
     const pillToRender = typeof pillLabel === 'function' ? pillLabel({ versions }) : pillLabel
 

--- a/packages/payload/src/admin/components/forms/Form/buildStateFromSchema/iterateFields.ts
+++ b/packages/payload/src/admin/components/forms/Form/buildStateFromSchema/iterateFields.ts
@@ -47,7 +47,7 @@ export const iterateFields = async ({
     if (!fieldIsPresentationalOnly(field) && !field?.admin?.disabled) {
       const passesCondition = Boolean(
         (field?.admin?.condition
-          ? field.admin.condition(fullData || {}, initialData || {}, { user })
+          ? Boolean(field.admin.condition(fullData || {}, initialData || {}, { user }))
           : true) && parentPassesCondition,
       )
 

--- a/packages/payload/src/admin/components/forms/Form/fieldReducer.ts
+++ b/packages/payload/src/admin/components/forms/Form/fieldReducer.ts
@@ -54,10 +54,10 @@ export function fieldReducer(state: Fields, action: FieldAction): Fields {
           // Besides those who still fail their own conditions
 
           if (passesCondition && field.condition) {
-            passesCondition = field.condition(
-              reduceFieldsToValues(state, true),
-              getSiblingData(state, path),
-              { user },
+            passesCondition = Boolean(
+              field.condition(reduceFieldsToValues(state, true), getSiblingData(state, path), {
+                user,
+              }),
             )
           }
 

--- a/packages/payload/src/admin/components/forms/withCondition/WatchCondition.tsx
+++ b/packages/payload/src/admin/components/forms/withCondition/WatchCondition.tsx
@@ -36,7 +36,7 @@ export const WatchCondition: React.FC<Props> = ({
   data.id = id
 
   const hasCondition = Boolean(condition)
-  const isPassingCondition = hasCondition ? condition(data, siblingData, { user }) : true
+  const isPassingCondition = hasCondition ? Boolean(condition(data, siblingData, { user })) : true
   const field = fields[path]
 
   const wasPassingCondition = field?.passesCondition

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -58,7 +58,7 @@ export const promise = async ({
   skipValidation,
 }: Args): Promise<void> => {
   const passesCondition = field.admin?.condition
-    ? field.admin.condition(data, siblingData, { user: req.user })
+    ? Boolean(field.admin.condition(data, siblingData, { user: req.user }))
     : true
   let skipValidationFromHere = skipValidation || !passesCondition
 

--- a/packages/richtext-lexical/src/field/features/Blocks/validate.ts
+++ b/packages/richtext-lexical/src/field/features/Blocks/validate.ts
@@ -44,9 +44,11 @@ export const blockValidationHOC = (
         const fieldValue = 'name' in field ? node.fields[field.name] : null
 
         const passesCondition = field.admin?.condition
-          ? field.admin.condition(fieldValue, node.fields, {
-              user: req?.user,
-            })
+          ? Boolean(
+              field.admin.condition(fieldValue, node.fields, {
+                user: req?.user,
+              }),
+            )
           : true
         if (!passesCondition) {
           continue // Fixes https://github.com/payloadcms/payload/issues/4000


### PR DESCRIPTION
## Description

Closes #4577 

This is not really a fix, since this was no bug in the first place.

But, to make this functionality more robust against user error (if a user returns an object in the condition function which is incorrect, but typescript doesn't warn them as that object is typed as `any`. This happened in https://github.com/payloadcms/payload/issues/4410)

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
