### PR TITLE
fix: Wait for transaction to complete on commit

### DIFF
--- a/packages/db-postgres/src/transactions/commitTransaction.ts
+++ b/packages/db-postgres/src/transactions/commitTransaction.ts
@@ -7,9 +7,9 @@ export const commitTransaction: CommitTransaction = async function commitTransac
   }
 
   try {
-    this.sessions[id].resolve()
+    await this.sessions[id].resolve()
   } catch (err: unknown) {
-    this.sessions[id].reject()
+    await this.sessions[id].reject()
   }
 
   delete this.sessions[id]

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -86,8 +86,8 @@ declare module 'payload' {
     sessions: {
       [id: string]: {
         db: DrizzleTransaction
-        reject: () => void
-        resolve: () => void
+        reject: () => Promise<void>
+        resolve: () => Promise<void>
       }
     }
     tables: Record<string, GenericTable>

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -56,8 +56,8 @@ export type PostgresAdapter = BaseDatabaseAdapter & {
   sessions: {
     [id: string]: {
       db: DrizzleTransaction
-      reject: () => void
-      resolve: () => void
+      reject: () => Promise<void>
+      resolve: () => Promise<void>
     }
   }
   tables: Record<string, GenericTable>

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -116,8 +116,8 @@ export interface BaseDatabaseAdapter {
   sessions?: {
     [id: string]: {
       db: unknown
-      reject: () => void
-      resolve: () => void
+      reject: () => Promise<void>
+      resolve: () => Promise<void>
     }
   }
 


### PR DESCRIPTION
## Description

Currently transactions are committed asynchronously and are not awaited. That causes problems at least with in-series local API calls that are supposed to commit transactions (do not provide transaction ID) but end up completing commit too late.

Fixes #4581

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
