### PR TITLE
fix: resets actions array when navigating out of view with actions

### DIFF
--- a/packages/payload/src/admin/components/views/API/index.tsx
+++ b/packages/payload/src/admin/components/views/API/index.tsx
@@ -219,6 +219,10 @@ export const API: React.FC<EditViewProps> = (props) => {
       editConfig && 'API' in editConfig && 'actions' in editConfig.API ? editConfig.API.actions : []
 
     setViewActions(apiActions)
+
+    return () => {
+      setViewActions([])
+    }
   }, [collection, global, setViewActions])
 
   const localeOptions =

--- a/packages/payload/src/admin/components/views/Global/Default.tsx
+++ b/packages/payload/src/admin/components/views/Global/Default.tsx
@@ -58,6 +58,10 @@ const DefaultGlobalView: React.FC<DefaultGlobalViewProps> = (props) => {
         : []
 
     setViewActions(defaultActions)
+
+    return () => {
+      setViewActions([])
+    }
   }, [global.slug, location.pathname, global?.admin?.components?.views?.Edit, setViewActions])
 
   return (

--- a/packages/payload/src/admin/components/views/LivePreview/index.tsx
+++ b/packages/payload/src/admin/components/views/LivePreview/index.tsx
@@ -193,6 +193,10 @@ export const LivePreviewView: React.FC<
         : []
 
     setViewActions(livePreviewActions)
+
+    return () => {
+      setViewActions([])
+    }
   }, [collection, global, setViewActions])
 
   const breakpoints: LivePreviewConfig['breakpoints'] = [

--- a/packages/payload/src/admin/components/views/Version/Version.tsx
+++ b/packages/payload/src/admin/components/views/Version/Version.tsx
@@ -184,6 +184,10 @@ const VersionView: React.FC<Props> = ({ collection, global }) => {
         : []
 
     setViewActions(versionActions)
+
+    return () => {
+      setViewActions([])
+    }
   }, [collection, global, setViewActions])
 
   let metaTitle: string

--- a/packages/payload/src/admin/components/views/Versions/index.tsx
+++ b/packages/payload/src/admin/components/views/Versions/index.tsx
@@ -136,6 +136,10 @@ const VersionsView: React.FC<IndexProps> = (props) => {
         : []
 
     setViewActions(versionsActions)
+
+    return () => {
+      setViewActions([])
+    }
   }, [collection, global, setViewActions])
 
   return (

--- a/packages/payload/src/admin/components/views/collections/Edit/Default.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default.tsx
@@ -91,6 +91,10 @@ const DefaultEditView: React.FC<DefaultEditViewProps> = (props) => {
         : []
 
     setViewActions(defaultActions)
+
+    return () => {
+      setViewActions([])
+    }
   }, [id, location.pathname, collection?.admin?.components?.views?.Edit, setViewActions])
 
   return (

--- a/packages/payload/src/admin/components/views/collections/List/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/List/index.tsx
@@ -83,6 +83,10 @@ const ListView: React.FC<ListIndexProps> = (props) => {
     if (CustomList && typeof CustomList === 'object' && 'actions' in CustomList) {
       setViewActions(CustomList.actions || [])
     }
+
+    return () => {
+      setViewActions([])
+    }
   }, [CustomList, setViewActions])
 
   useEffect(() => {

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -310,6 +310,14 @@ describe('admin', () => {
       await page.goto(`${globalWithPreview.global(globalSlug)}/api`)
       await expect(page.locator('.app-header .global-api-button')).toHaveCount(1)
     })
+
+    test('should reset actions array when navigating from view with actions to view without actions', async () => {
+      await page.goto(geoUrl.list)
+      await expect(page.locator('.app-header .collection-list-button')).toHaveCount(1)
+      await page.locator('button.nav-toggler[aria-label="Open Menu"][tabindex="0"]').click()
+      await page.locator(`#nav-posts`).click()
+      await expect(page.locator('.app-header .collection-list-button')).toHaveCount(0)
+    })
   })
 
   describe('ui', () => {


### PR DESCRIPTION
## Description

Previously when in a view that has an `actions` defined in it and then navigating to a view without any `actions`, the `actions` array would stay set to the last "known" `actions`.

Need to reset actions array on navigation to prevent this from happening.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
