### PR TITLE
chore(next): builds initPage utility

### DIFF
--- a/packages/next/src/pages/CollectionList/index.tsx
+++ b/packages/next/src/pages/CollectionList/index.tsx
@@ -1,7 +1,6 @@
 import { SanitizedConfig } from 'payload/types'
 import React from 'react'
-import { headers as getHeaders } from 'next/headers'
-import { auth } from '../../utilities/auth'
+import { initPage } from '../../utilities/initPage'
 
 export const CollectionList = async ({
   searchParams,
@@ -10,13 +9,6 @@ export const CollectionList = async ({
   searchParams: URLSearchParams
   config: Promise<SanitizedConfig>
 }) => {
-  const headers = getHeaders()
-
-  await auth({
-    headers,
-    searchParams,
-    config: configPromise,
-  })
-
+  await initPage(configPromise)
   return <p>This is the collection list view</p>
 }

--- a/packages/next/src/pages/Dashboard/index.tsx
+++ b/packages/next/src/pages/Dashboard/index.tsx
@@ -2,8 +2,7 @@ import { SanitizedConfig } from 'payload/types'
 import React from 'react'
 import { RenderCustomComponent } from '@payloadcms/ui/elements'
 import { DefaultDashboard } from '@payloadcms/ui/views'
-import { headers as getHeaders } from 'next/headers'
-import { auth } from '../../utilities/auth'
+import { initPage } from '../../utilities/initPage'
 
 export const Dashboard = async ({
   searchParams,
@@ -12,15 +11,7 @@ export const Dashboard = async ({
   searchParams: { [key: string]: string | undefined }
   config: Promise<SanitizedConfig>
 }) => {
-  const headers = getHeaders()
-
-  const config = await configPromise
-
-  await auth({
-    headers,
-    searchParams,
-    config: configPromise,
-  })
+  const { config } = await initPage(configPromise)
 
   const CustomDashboardComponent = config.admin.components?.views?.Dashboard
 

--- a/packages/next/src/pages/Login/index.tsx
+++ b/packages/next/src/pages/Login/index.tsx
@@ -1,7 +1,5 @@
 import React, { Fragment } from 'react'
-import { Trans } from 'react-i18next'
 
-import { Button } from '@payloadcms/ui/elements'
 import { Logo } from '@payloadcms/ui/graphics'
 import { Minimal as MinimalTemplate } from '@payloadcms/ui/templates'
 import './index.scss'
@@ -10,8 +8,9 @@ import type { SanitizedConfig } from 'payload/types'
 import i18n from 'i18next'
 import { meta } from '../../utilities/meta'
 import { Metadata } from 'next'
-import Link from 'next/link'
 import { login } from './action'
+import { initPage } from '../../utilities/initPage'
+import { redirect } from 'next/navigation'
 
 const baseClass = 'login'
 
@@ -30,7 +29,7 @@ export const generateMetadata = async ({
 export const Login: React.FC<{
   config: Promise<SanitizedConfig>
 }> = async ({ config: configPromise }) => {
-  const config = await configPromise
+  const { config, user } = await initPage(configPromise, false)
 
   const {
     admin: { components: { afterLogin, beforeLogin } = {}, logoutRoute, user: userSlug },
@@ -38,36 +37,22 @@ export const Login: React.FC<{
     collections,
   } = config
 
-  const user = null
+  if (user) {
+    redirect(admin)
+  }
 
   const collection = collections.find(({ slug }) => slug === userSlug)
 
   return (
     <MinimalTemplate className={baseClass}>
-      {user ? (
-        <Fragment>
-          <div className={`${baseClass}__wrap`}>
-            <h1>{i18n.t('alreadyLoggedIn')}</h1>
-            <p>
-              {/* <Trans i18nKey="loggedIn" t={i18n.t}> */}
-              <Link href={`${admin}${logoutRoute}`}>{i18n.t('logOut')}</Link>
-              {/* </Trans> */}
-            </p>
-            <Button buttonStyle="secondary" el="link" to={admin}>
-              {i18n.t('general:backToDashboard')}
-            </Button>
-          </div>
-        </Fragment>
-      ) : (
-        <Fragment>
-          <div className={`${baseClass}__brand`}>
-            <Logo config={config} />
-          </div>
-          {Array.isArray(beforeLogin) && beforeLogin.map((Component, i) => <Component key={i} />)}
-          {!collection?.auth?.disableLocalStrategy && <LoginForm action={login} />}
-          {Array.isArray(afterLogin) && afterLogin.map((Component, i) => <Component key={i} />)}
-        </Fragment>
-      )}
+      <Fragment>
+        <div className={`${baseClass}__brand`}>
+          <Logo config={config} />
+        </div>
+        {Array.isArray(beforeLogin) && beforeLogin.map((Component, i) => <Component key={i} />)}
+        {!collection?.auth?.disableLocalStrategy && <LoginForm action={login} />}
+        {Array.isArray(afterLogin) && afterLogin.map((Component, i) => <Component key={i} />)}
+      </Fragment>
     </MinimalTemplate>
   )
 }

--- a/packages/next/src/utilities/auth.ts
+++ b/packages/next/src/utilities/auth.ts
@@ -1,33 +1,16 @@
-import { redirect } from 'next/navigation'
 import { getPayload } from 'payload'
 import { getAuthenticatedUser, getAccessResults } from 'payload/auth'
 import { SanitizedConfig } from 'payload/types'
 import { cache } from 'react'
 
 export const auth = cache(
-  async ({
-    headers,
-    searchParams,
-    config,
-    unauthorizedRedirect = true,
-  }: {
-    headers: any
-    searchParams: { [key: string]: string | undefined }
-    config: Promise<SanitizedConfig>
-    unauthorizedRedirect?: boolean
-  }) => {
+  async ({ headers, config }: { headers: any; config: Promise<SanitizedConfig> }) => {
     const payload = await getPayload({ config })
 
     const user = await getAuthenticatedUser({
       headers,
       payload,
     })
-
-    if (unauthorizedRedirect && !user) {
-      // TODO: revert to: `redirect(`${payload.config.routes.admin}/unauthorized`)`
-      // once unauthorized page is built out
-      redirect(`${payload.config.routes.admin}/login`)
-    }
 
     const permissions = await getAccessResults({
       req: {

--- a/packages/next/src/utilities/initPage.ts
+++ b/packages/next/src/utilities/initPage.ts
@@ -1,0 +1,42 @@
+import { headers as getHeaders } from 'next/headers'
+
+import { auth } from './auth'
+
+import { getPayload } from 'payload'
+import type { SanitizedConfig } from 'payload/types'
+import { redirect } from 'next/navigation'
+
+export const initPage = async (
+  configPromise: Promise<SanitizedConfig>,
+  redirectUnauthenticatedUser = true,
+): Promise<{
+  payload: Awaited<ReturnType<typeof getPayload>>
+  permissions: Awaited<ReturnType<typeof auth>>['permissions']
+  user: Awaited<ReturnType<typeof auth>>['user']
+  config: SanitizedConfig
+}> => {
+  const headers = getHeaders()
+
+  const { permissions, user } = await auth({
+    headers,
+    config: configPromise,
+  })
+
+  const config = await configPromise
+
+  if (redirectUnauthenticatedUser && !user) {
+    // `redirect(`${payload.config.routes.admin}/unauthorized`)` is not built yet
+    redirect(`${config.routes.admin}/login`)
+  }
+
+  const payload = await getPayload({
+    config: configPromise,
+  })
+
+  return {
+    payload,
+    permissions,
+    user,
+    config,
+  }
+}


### PR DESCRIPTION
## Description

Builds a utility function that gets page headers, runs auth, gets payload, and awaits the config. Each of these are needed on every page in the Next.js app, this function makes it easily reusable.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.