### PR TITLE
feat: Add option to provide an existing storageClient on Azure client

### DIFF
--- a/packages/plugin-cloud-storage/src/adapters/azure/index.ts
+++ b/packages/plugin-cloud-storage/src/adapters/azure/index.ts
@@ -10,12 +10,44 @@ import { getHandleUpload } from './handleUpload'
 import { getHandler } from './staticHandler'
 import { extendWebpackConfig } from './webpack'
 
-export interface Args {
-  allowContainerCreate: boolean
-  baseURL: string
-  connectionString: string
+export type Args = {
+  /**
+   * The name of the container to use
+   * @see https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#containers
+   * @example
+   * ```ts
+   * const containerName = 'my-container'
+   * ```
+   */
   containerName: string
-}
+  baseURL: string
+  /**
+   * Allow the adapter to create the container if it doesn't exist
+   */
+  allowContainerCreate: boolean
+} & (
+  | {
+      /**
+       * Connection string for the Azure Storage Account
+       * @see https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string
+       */
+      connectionString: string
+      storageClient?: never
+    }
+  | {
+      /**
+       * A custom Azure Storage Client
+       * @see https://docs.microsoft.com/en-us/javascript/api/@azure/storage-blob/containerclient?view=azure-node-latest
+       * @example
+       * ```ts
+       * import { ContainerClient } from '@azure/storage-blob'
+       * const containerClient = new ContainerClient(connectionString, containerName)
+       * ```
+       */
+      storageClient: ContainerClient
+      connectionString?: never
+    }
+)
 
 export const azureBlobStorageAdapter = ({
   allowContainerCreate,
@@ -23,7 +55,12 @@ export const azureBlobStorageAdapter = ({
   connectionString,
   containerName,
 }: Args): Adapter => {
-  let storageClient: ContainerClient | null = null
+  let storageClient: ContainerClient | null = customStorageClient ?? null
+
+  if (!connectionString && !customStorageClient) {
+    throw new Error('You must provide a connection string or a storage client')
+  }
+
   const getStorageClient = () => {
     if (storageClient) return storageClient
     const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString)

--- a/packages/plugin-cloud-storage/src/adapters/azure/index.ts
+++ b/packages/plugin-cloud-storage/src/adapters/azure/index.ts
@@ -54,6 +54,7 @@ export const azureBlobStorageAdapter = ({
   baseURL,
   connectionString,
   containerName,
+  storageClient: customStorageClient,
 }: Args): Adapter => {
   let storageClient: ContainerClient | null = customStorageClient ?? null
 


### PR DESCRIPTION
Hello.

This allows us to instantiate the adapter using an existing storageClient.

This is helpful in case we don't have the connectionString, but rather an SAS token, instantiating the adapter without the connectionString was impossible before.

Old PR: https://github.com/payloadcms/plugin-cloud-storage/pull/28

