### PR TITLE
fix: unlock user condition always passes due to seconds conversion

### DIFF
--- a/packages/payload/src/auth/strategies/local/incrementLoginAttempts.ts
+++ b/packages/payload/src/auth/strategies/local/incrementLoginAttempts.ts
@@ -20,7 +20,7 @@ export const incrementLoginAttempts = async ({
   } = collection
 
   if ('lockUntil' in doc && typeof doc.lockUntil === 'string') {
-    const lockUntil = Math.floor(new Date(doc.lockUntil).getTime() / 1000)
+    const lockUntil = new Date(doc.lockUntil).getTime()
 
     // Expired lock, restart count at 1
     if (lockUntil < Date.now()) {

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -486,6 +486,7 @@ describe('Auth', () => {
         it('should lock the user after too many attempts', async () => {
           await tryLogin()
           await tryLogin()
+          await tryLogin() // Let it call multiple times, therefore the unlock condition has no bug.
 
           const userResult = await payload.find({
             collection: slug,


### PR DESCRIPTION
## Description

The current behavior now is the following.

1. The user reaches the lock state.
2. The user tries again to log in.
3. In code, it's reached this condition: https://github.com/payloadcms/payload/blob/657d14c07b4c6da4f168a6b6853f932c44527639/packages/payload/src/auth/strategies/local/incrementLoginAttempts.ts#L22
4. The lock time is converted from milliseconds to seconds in https://github.com/payloadcms/payload/blob/657d14c07b4c6da4f168a6b6853f932c44527639/packages/payload/src/auth/strategies/local/incrementLoginAttempts.ts#L23
5. In this condition https://github.com/payloadcms/payload/blob/657d14c07b4c6da4f168a6b6853f932c44527639/packages/payload/src/auth/strategies/local/incrementLoginAttempts.ts#L26 the converted `lockTime` (seconds) is compared with `Date.now()` which according to [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now) it's in milliseconds.
6. Because the seconds will always be smaller than milliseconds, the condition passes and unlocks the account.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
