### PR TITLE
fix: Fix boolean in Cell is not showing

### DIFF
--- a/packages/payload/src/admin/components/views/collections/List/Cell/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/List/Cell/index.tsx
@@ -68,7 +68,8 @@ const DefaultCell: React.FC<Props> = (props) => {
     )
   }
 
-  let CellComponent: React.FC<CellComponentProps> = cellData && cellComponents[field.type]
+  let CellComponent: React.FC<CellComponentProps> | false =
+    cellData !== null && typeof cellData !== 'undefined' && cellComponents[field.type]
 
   if (!CellComponent) {
     if (collection.upload && fieldAffectsData(field) && field.name === 'filename') {


### PR DESCRIPTION
Fix Checkbox CellComponent is not appear when value is false

## Description

![image](https://github.com/payloadcms/payload/assets/47362439/45d6f28f-fb34-4b3c-b70a-ee40eb907795)

As you can see in the picture above, I can't see the Checkbox type Cell when value is false.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
