### PR TITLE
Use custom RowLabel in website template example

### DIFF
--- a/templates/website/src/payload/globals/Footer.ts
+++ b/templates/website/src/payload/globals/Footer.ts
@@ -17,6 +17,15 @@ export const Footer: GlobalConfig = {
           appearances: false,
         }),
       ],
+      admin: {
+        components: {
+          RowLabel: ( { data, index } ) => {
+
+            return data?.link?.label;
+          
+          },
+        },
+      },
     },
   ],
 }

--- a/templates/website/src/payload/globals/Header.ts
+++ b/templates/website/src/payload/globals/Header.ts
@@ -17,6 +17,15 @@ export const Header: GlobalConfig = {
           appearances: false,
         }),
       ],
+      admin: {
+        components: {
+          RowLabel: ( { data, index } ) => {
+
+            return data?.link?.label;
+          
+          },
+        },
+      },
     },
   ],
 }


### PR DESCRIPTION
## Description

Mainly using this as a learning opportunity, but while playing around with the website template I noticed that the "Nav Items" use "Nav Item XX" as the row label for each element and though it would be nicer if it would use the actual link label instead.

<img width="1512" alt="image" src="https://github.com/payloadcms/payload/assets/11058666/3ffbea2f-68f0-4821-b01f-baa1a066a210">

Taking a look at the documentation it seems like we can just use `admin.components.RowLabel` for that.

Only issue I have is that ideally it should fallback to the "default" label when the RowLabel component returns undefined, but that doesn't seem to be the case. But I am not sure how to otherwise access the default label value instead.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
