### PR TITLE
test: e2e await fix

### DIFF
--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -224,6 +224,10 @@ describe('Localization', () => {
 
       // verify that the locale did copy
       await expect(page.locator('#field-title')).toHaveValue(englishTitle)
+
+      // await the success toast
+      await expect(page.locator('.Toastify')).toContainText('successfully duplicated')
+
       // expect that the document has a new id
       expect(page.url()).not.toStrictEqual(originalDocURL)
     })


### PR DESCRIPTION
## Description

fix inconsistent e2e failure:
`localization/e2e.spec.ts:209:9` › Localization › localized duplicate › should duplicate even if missing some localized data

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] Existing test suite passes locally with my changes