### PR TITLE
fix: "The punycode module is deprecated" warning by updating nodemailer

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -105,7 +105,7 @@
     "minimist": "1.2.8",
     "mkdirp": "1.0.4",
     "monaco-editor": "0.38.0",
-    "nodemailer": "6.9.4",
+    "nodemailer": "6.9.8",
     "object-to-formdata": "4.5.1",
     "passport": "0.6.0",
     "passport-anonymous": "1.0.1",

--- a/packages/plugin-cloud/package.json
+++ b/packages/plugin-cloud/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/credential-providers": "^3.289.0",
     "@aws-sdk/lib-storage": "^3.267.0",
     "amazon-cognito-identity-js": "^6.1.2",
-    "nodemailer": "^6.9.1",
+    "nodemailer": "6.9.8",
     "resend": "^0.17.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,8 +748,8 @@ importers:
         specifier: 0.38.0
         version: 0.38.0
       nodemailer:
-        specifier: 6.9.4
-        version: 6.9.4
+        specifier: 6.9.8
+        version: 6.9.8
       object-to-formdata:
         specifier: 4.5.1
         version: 4.5.1
@@ -1067,8 +1067,8 @@ importers:
         specifier: ^6.1.2
         version: 6.3.6
       nodemailer:
-        specifier: ^6.9.1
-        version: 6.9.4
+        specifier: 6.9.8
+        version: 6.9.8
       resend:
         specifier: ^0.17.2
         version: 0.17.2
@@ -13593,8 +13593,8 @@ packages:
   /node-releases@2.0.13:
     resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
 
-  /nodemailer@6.9.4:
-    resolution: {integrity: sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA==}
+  /nodemailer@6.9.8:
+    resolution: {integrity: sha512-cfrYUk16e67Ks051i4CntM9kshRYei1/o/Gi8K1d+R34OIs21xdFnW7Pt7EucmVKA0LKtqUGNcjMZ7ehjl49mQ==}
     engines: {node: '>=6.0.0'}
     dev: false
 


### PR DESCRIPTION
## Description

Updating the nodemailer version fixes the "The punycode module is deprecated" warning which occured for every single startup.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
