### PR TITLE
fix: detect language from request headers accept-language

### DIFF
--- a/packages/payload/src/admin/components/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -97,7 +97,7 @@ const RelationshipField: React.FC<Props> = (props) => {
                 }
               }
             } else {
-              setErrorLoading(t('errors:unspecific'))
+              setErrorLoading(t('error:unspecific'))
             }
           }
         }, Promise.resolve())

--- a/packages/payload/src/translations/defaultOptions.ts
+++ b/packages/payload/src/translations/defaultOptions.ts
@@ -5,10 +5,10 @@ import translations from './index'
 export const defaultOptions: InitOptions = {
   debug: false,
   detection: {
-    caches: ['cookie', 'localStorage'],
+    caches: ['header', 'cookie', 'localStorage'],
     lookupCookie: 'lng',
     lookupLocalStorage: 'lng',
-    order: ['cookie', 'localStorage'],
+    order: ['header', 'cookie', 'localStorage'],
   },
   fallbackLng: 'en',
   interpolation: {


### PR DESCRIPTION
## Description

Allows reading the language from request headers.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
