### PR TITLE
fix: tab field error when using the same interface name

### DIFF
--- a/packages/payload/src/graphql/registerSchema.ts
+++ b/packages/payload/src/graphql/registerSchema.ts
@@ -22,7 +22,6 @@ export default function registerGraphQLSchema(payload: Payload): void {
     blockInputTypes: {},
     blockTypes: {},
     groupTypes: {},
-    tabTypes: {},
   }
 
   if (payload.config.localization) {

--- a/packages/payload/src/graphql/schema/buildObjectType.ts
+++ b/packages/payload/src/graphql/schema/buildObjectType.ts
@@ -508,7 +508,7 @@ function buildObjectType({
           const interfaceName =
             tab?.interfaceName || combineParentName(parentName, toWords(tab.name, true))
 
-          if (!payload.types.tabTypes[interfaceName]) {
+          if (!payload.types.groupTypes[interfaceName]) {
             const objectType = buildObjectType({
               name: interfaceName,
               fields: tab.fields,
@@ -518,14 +518,18 @@ function buildObjectType({
             })
 
             if (Object.keys(objectType.getFields()).length) {
-              return {
-                ...tabSchema,
-                [tab.name]: { type: objectType },
-              }
+              payload.types.groupTypes[interfaceName] = objectType
             }
           }
 
-          return tabSchema
+          if (!payload.types.groupTypes[interfaceName]) {
+            return tabSchema
+          }
+
+          return {
+            ...tabSchema,
+            [tab.name]: { type: payload.types.groupTypes[interfaceName] },
+          }
         }
 
         return {

--- a/packages/payload/src/payload.ts
+++ b/packages/payload/src/payload.ts
@@ -256,7 +256,6 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
     fallbackLocaleInputType?: any
     groupTypes: any
     localeInputType?: any
-    tabTypes: any
   }
 
   unlock = async <T extends keyof TGeneratedTypes['collections']>(


### PR DESCRIPTION
## Description

Closes #4572 

Correctly returns tab interface names, currently using the same interface name for tab fields in different collections will throw an error.

Add this field to 2 collections in the `_community` test suite to reproduce the error:

```
{
  type: 'tabs',
  tabs: [
    {
      name: 'tab1',
      interfaceName: 'test',
      fields: [
        {
          name: 'text',
          type: 'text',
        },
      ],
    },
  ],
}
```

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
