### PR TITLE
Fix #4632 where GQL expects a JSON type for relationship ID in where

### DIFF
--- a/packages/payload/src/graphql/schema/withOperators.ts
+++ b/packages/payload/src/graphql/schema/withOperators.ts
@@ -178,7 +178,7 @@ const defaults: DefaultsType = {
     operators: [
       ...[...operators.equality, ...operators.contains].map((operator) => ({
         name: operator,
-        type: GraphQLJSON,
+        type: GraphQLString,
       })),
     ],
   },

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -835,9 +835,7 @@ describe('Versions', () => {
 
         // language=graphQL
         const query = `query {
-            versionsAutosavePosts(where: { parent: { equals: ${formatGraphQLID(
-              collectionGraphQLPostID,
-            )} } }) {
+            versionsAutosavePosts(where: { parent: { equals: "${collectionGraphQLPostID}" } }) {
                 docs {
                     id
                 }
@@ -915,9 +913,7 @@ describe('Versions', () => {
 
         // language=graphQL
         const query = `query {
-            versionsAutosavePosts(where: { parent: { equals: ${formatGraphQLID(
-              collectionGraphQLPostID,
-            )} } }) {
+            versionsAutosavePosts(where: { parent: { equals: "${collectionGraphQLPostID}" } }) {
                 docs {
                     id
                 }


### PR DESCRIPTION
## Description

Closes https://github.com/payloadcms/payload/issues/4632

The GQL schema was expected a JSON type instead of a String for relationships in the `where` for queries. I updated the tests as well to cover this by making them all String type in the queries.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
