### PR TITLE
feat(logger): show local time

### DIFF
--- a/packages/payload/src/utilities/logger.ts
+++ b/packages/payload/src/utilities/logger.ts
@@ -6,7 +6,7 @@ export type PayloadLogger = pino.Logger
 const prettyOptions = {
   colorize: true,
   ignore: 'pid,hostname',
-  translateTime: 'HH:MM:ss',
+  translateTime: 'SYS:HH:MM:ss',
 }
 
 export const defaultLoggerOptions: pino.LoggerOptions = {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

Showing local time in the log is helpful for debugging. Currently payload doesn't respect env variable `TZ` by default. We can modify the default loggerOptions a bit to support this, just like [Directus](https://github.com/directus/directus/blob/e168cb42a989bc9cbdbf68170dd7847ce7ecd81b/api/src/logger.ts#L90C13-L90C13) did.


![image](https://github.com/payloadcms/payload/assets/7382357/47ffa859-9692-4e46-ab2c-498a46026cb6)




- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
