### PR TITLE
Fixes the navigation locking out if the modal is closed using the esc…

### DIFF
--- a/packages/payload/src/admin/components/modals/LeaveWithoutSaving/index.tsx
+++ b/packages/payload/src/admin/components/modals/LeaveWithoutSaving/index.tsx
@@ -17,8 +17,15 @@ const Component: React.FC<{
   onCancel: () => void
   onConfirm: () => void
 }> = ({ isActive, onCancel, onConfirm }) => {
-  const { closeModal, openModal } = useModal()
+  const { closeModal, openModal, modalState } = useModal()
   const { t } = useTranslation('general')
+
+  // Manually check for modal state as 'esc' key will not trigger the nav inactivity
+  useEffect(() => {
+    if (!modalState?.[modalSlug]?.isOpen && isActive) {
+      onCancel()
+    }
+  }, [modalState])
 
   useEffect(() => {
     if (isActive) openModal(modalSlug)


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/4116

## Description

The modals would lock navigation out if they were quit using the escape key

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
