### PR TITLE
fix: allow json field to be saved empty and reflect value changes

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/JSON/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/JSON/index.tsx
@@ -57,11 +57,10 @@ const JSONField: React.FC<Props> = (props) => {
   const handleChange = useCallback(
     (val) => {
       if (readOnly) return
-      console.log(val)
       setStringValue(val)
 
       try {
-        setValue(JSON.parse(val))
+        setValue(val ? JSON.parse(val) : '')
         setJsonError(undefined)
       } catch (e) {
         setJsonError(e)
@@ -71,10 +70,17 @@ const JSONField: React.FC<Props> = (props) => {
   )
 
   useEffect(() => {
-    if (hasLoadedValue) return
-    setStringValue(JSON.stringify(value ? value : initialValue, null, 2))
-    setHasLoadedValue(true)
-  }, [initialValue, value])
+    const hasValue = value && value.toString().length > 0
+    if (hasLoadedValue) {
+      setStringValue(hasValue ? JSON.stringify(value, null, 2) : '')
+    } else
+      try {
+        setStringValue(JSON.stringify(hasValue ? value : initialValue, null, 2))
+        setHasLoadedValue(true)
+      } catch (e) {
+        setJsonError(e)
+      }
+  }, [initialValue, value, hasLoadedValue])
 
   return (
     <div

--- a/packages/payload/src/admin/components/forms/field-types/JSON/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/JSON/index.tsx
@@ -56,10 +56,10 @@ const JSONField: React.FC<Props> = (props) => {
 
   const handleChange = useCallback(
     (val) => {
-      if (readOnly) return
-      setStringValue(val)
-
       try {
+        if (readOnly) return
+        setStringValue(val)
+
         setValue(val ? JSON.parse(val) : '')
         setJsonError(undefined)
       } catch (e) {
@@ -70,16 +70,17 @@ const JSONField: React.FC<Props> = (props) => {
   )
 
   useEffect(() => {
-    const hasValue = value && value.toString().length > 0
-    if (hasLoadedValue) {
-      setStringValue(hasValue ? JSON.stringify(value, null, 2) : '')
-    } else
-      try {
+    try {
+      const hasValue = value && value.toString().length > 0
+      if (hasLoadedValue) {
+        setStringValue(hasValue ? JSON.stringify(value, null, 2) : '')
+      } else {
         setStringValue(JSON.stringify(hasValue ? value : initialValue, null, 2))
         setHasLoadedValue(true)
-      } catch (e) {
-        setJsonError(e)
       }
+    } catch (e) {
+      setJsonError(e)
+    }
   }, [initialValue, value, hasLoadedValue])
 
   return (

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -106,7 +106,7 @@ export const promise = async ({
 
       if (field.type === 'json' && typeof siblingData[field.name] === 'string') {
         try {
-          JSON.parse(siblingData[field.name] as string)
+          siblingData[field.name] as string
         } catch (e) {
           jsonError = e
         }

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -106,7 +106,7 @@ export const promise = async ({
 
       if (field.type === 'json' && typeof siblingData[field.name] === 'string') {
         try {
-          siblingData[field.name] as string
+          JSON.parse(siblingData[field.name] as string)
         } catch (e) {
           jsonError = e
         }


### PR DESCRIPTION
## Description

Closes #4575

- Reflects updated value/JSON in the Monaco editor
- Fixes JSON field not being able to be saved empty

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
