### PR TITLE
fix(plugin-form-builder): slate serializer should replace curly braces with data for links

### DIFF
--- a/packages/plugin-form-builder/src/utilities/slate/serializeSlate.ts
+++ b/packages/plugin-form-builder/src/utilities/slate/serializeSlate.ts
@@ -122,7 +122,7 @@ export const serializeSlate = (children?: Node[], submissionData?: any): string 
         `
         case 'link':
           return `
-        <a href={${escapeHTML(node.url)}}>
+          <a href={${escapeHTML(replaceDoubleCurlys(node.url, submissionData))}}>
           ${serializeSlate(node.children, submissionData)}
         </a>
       `

--- a/test/plugin-form-builder/int.spec.ts
+++ b/test/plugin-form-builder/int.spec.ts
@@ -1,6 +1,7 @@
 import type { Form } from './payload-types'
 
 import payload from '../../packages/payload/src'
+import { serializeSlate } from '../../packages/plugin-form-builder/src/utilities/slate/serializeSlate'
 import { initPayloadTest } from '../helpers/configHelpers'
 import { formSubmissionsSlug, formsSlug } from './shared'
 
@@ -114,6 +115,33 @@ describe('Form Builder Plugin', () => {
       expect(formSubmission.submissionData).toHaveLength(1)
       expect(formSubmission.submissionData[0]).toHaveProperty('field', 'name')
       expect(formSubmission.submissionData[0]).toHaveProperty('value', 'Test Submission')
+    })
+
+    it('replaces curly braces with data when using slate serializer', async () => {
+      const mockName = 'Test Submission'
+      const mockEmail = 'dev@payloadcms.com'
+
+      const serializedEmail = serializeSlate(
+        [
+          { text: 'Welcome {{name}}. Here is a dynamic ' },
+          {
+            children: [
+              {
+                text: 'link',
+              },
+            ],
+            type: 'link',
+            url: 'www.test.com?email={{email}}',
+          },
+        ],
+        [
+          { field: 'name', value: mockName },
+          { field: 'email', value: mockEmail },
+        ],
+      )
+
+      expect(serializedEmail).toContain(mockName)
+      expect(serializedEmail).toContain(mockEmail)
     })
   })
 })


### PR DESCRIPTION
## Description

Closes https://github.com/payloadcms/payload/issues/4563

Slate serializer was not replacing curly braces with data SPECIFICALLY for links, everywhere else works as expected.

Adds test to `plugin-form-builder` test suite.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
