### PR TITLE
fix: prevents row overflow and fixes margin

### DIFF
--- a/packages/payload/src/admin/components/forms/RenderFields/index.scss
+++ b/packages/payload/src/admin/components/forms/RenderFields/index.scss
@@ -13,6 +13,7 @@
 
   & > .field-type {
     margin-bottom: var(--spacing-field);
+    max-width: 100%;
 
     &[type='hidden'] {
       margin-bottom: 0;

--- a/packages/payload/src/admin/components/forms/field-types/Row/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Row/index.tsx
@@ -34,7 +34,7 @@ const Row: React.FC<Props> = (props) => {
           fieldTypes={fieldTypes}
           forceRender={forceRender}
           indexPath={indexPath}
-          margins="small"
+          margins={false}
           permissions={permissions}
           readOnly={readOnly}
         />

--- a/packages/payload/src/admin/components/forms/field-types/Row/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Row/index.tsx
@@ -34,7 +34,7 @@ const Row: React.FC<Props> = (props) => {
           fieldTypes={fieldTypes}
           forceRender={forceRender}
           indexPath={indexPath}
-          margins={false}
+          margins="small"
           permissions={permissions}
           readOnly={readOnly}
         />


### PR DESCRIPTION
## Description

Closes #4697. Fixes overflow and squashed margins with row field.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.
- 
Before:
<img width="1690" alt="Screenshot 2024-01-05 at 1 58 22 PM" src="https://github.com/payloadcms/payload/assets/67977755/ae1f92cc-f2c4-4d02-9cd3-2837fef6a3a2">

After:
<img width="1689" alt="Screenshot 2024-01-05 at 1 58 52 PM" src="https://github.com/payloadcms/payload/assets/67977755/f8a04296-4408-450f-a551-32b6db4eff4d">

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update
