### PR TITLE
fix(docs): corrects type in useField example

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -534,14 +534,13 @@ When swapping out the `Field` component, you'll be responsible for sending and r
 ```tsx
 import { useField } from 'payload/components/forms'
 
-type Props = { path: string }
-
-const CustomTextField: React.FC<Props> = ({ path }) => {
+const CustomTextField: React.FC<{ path: string }> = ({ path }) => {
   // highlight-start
-  const { value, setValue } = useField<Props>({ path })
+  const { value, setValue } = useField<string>({ path })
   // highlight-end
 
-  return <input onChange={(e) => setValue(e.target.value)} value={value.path} />
+
+  return <input onChange={(e) => setValue(e.target.value)} value={value} />
 }
 ```
 


### PR DESCRIPTION
## Description

Fixes `useField` example in docs for `admin/components`. Issue raised by client, see slack convo [here](https://payloadcms.slack.com/archives/C0613L52QQP/p1704358686229259).

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [X] This change is a documentation update

## Checklist:

- [X] I have made corresponding changes to the documentation
