### PR TITLE
chore: undo adding DocumentInfo state to ActionsProvider

### DIFF
--- a/packages/payload/src/admin/components/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/payload/src/admin/components/elements/DocumentDrawer/DrawerContent.tsx
@@ -15,7 +15,6 @@ import buildStateFromSchema from '../../forms/Form/buildStateFromSchema'
 import { fieldTypes } from '../../forms/field-types'
 import { useRelatedCollections } from '../../forms/field-types/Relationship/AddNew/useRelatedCollections'
 import X from '../../icons/X'
-import { useActions } from '../../utilities/ActionsProvider'
 import { useAuth } from '../../utilities/Auth'
 import { useConfig } from '../../utilities/Config'
 import { DocumentInfoProvider, useDocumentInfo } from '../../utilities/DocumentInfo'
@@ -190,11 +189,6 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = (props) => {
   const { id: idFromProps, collectionSlug, onSave: onSaveFromProps } = props
   const [collectionConfig] = useRelatedCollections(collectionSlug)
   const [id, setId] = useState<null | string>(idFromProps)
-  const { setDocumentInfo } = useActions()
-
-  useEffect(() => {
-    setDocumentInfo({ id, collection: collectionConfig })
-  }, [setDocumentInfo, id, collectionConfig])
 
   const onSave = useCallback<DocumentDrawerProps['onSave']>(
     (args) => {

--- a/packages/payload/src/admin/components/elements/ListDrawer/DrawerContent.tsx
+++ b/packages/payload/src/admin/components/elements/ListDrawer/DrawerContent.tsx
@@ -13,7 +13,6 @@ import usePayloadAPI from '../../../hooks/usePayloadAPI'
 import { useUseTitleField } from '../../../hooks/useUseAsTitle'
 import Label from '../../forms/Label'
 import X from '../../icons/X'
-import { useActions } from '../../utilities/ActionsProvider'
 import { useAuth } from '../../utilities/Auth'
 import { useConfig } from '../../utilities/Config'
 import { DocumentInfoProvider } from '../../utilities/DocumentInfo'
@@ -60,7 +59,6 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
   const [page, setPage] = useState(1)
   const [where, setWhere] = useState(null)
   const [search, setSearch] = useState('')
-  const { setDocumentInfo } = useActions()
 
   const {
     collections,
@@ -79,10 +77,6 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
         enabledCollectionConfigs?.[0]
       )
     })
-
-  useEffect(() => {
-    setDocumentInfo({ collection: selectedCollectionConfig })
-  }, [setDocumentInfo, selectedCollectionConfig])
 
   const [selectedOption, setSelectedOption] = useState<{ label: string; value: string }>(() =>
     selectedCollectionConfig
@@ -199,7 +193,7 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
       sort,
     }
 
-    void setPreference(preferenceKey, newPreferences, true)
+    setPreference(preferenceKey, newPreferences, true)
   }, [sort, limit, setPreference, preferenceKey])
 
   const onCreateNew = useCallback(

--- a/packages/payload/src/admin/components/utilities/ActionsProvider/index.tsx
+++ b/packages/payload/src/admin/components/utilities/ActionsProvider/index.tsx
@@ -1,33 +1,14 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
-
-import type { SanitizedCollectionConfig } from '../../../../collections/config/types'
-import type { SanitizedGlobalConfig } from '../../../../globals/config/types'
 
 import { useConfig } from '../../utilities/Config'
 
-type DocumentInfo = {
-  collection?: SanitizedCollectionConfig | null
-  global?: SanitizedGlobalConfig | null
-  id?: null | number | string
-}
 type ActionsContextType = {
   actions: React.ComponentType<any>[]
-  documentInfo: DocumentInfo
-  setDocumentInfo: (data: DocumentInfo) => void
   setViewActions: (actions: React.ComponentType<any>[]) => void
-}
-
-const defaultDocumentInfo: DocumentInfo = {
-  id: null,
-  collection: null,
-  global: null,
 }
 
 const ActionsContext = createContext<ActionsContextType>({
   actions: [],
-  documentInfo: defaultDocumentInfo,
-  setDocumentInfo: () => {},
   setViewActions: () => {},
 })
 
@@ -36,15 +17,6 @@ export const useActions = () => useContext(ActionsContext)
 export const ActionsProvider = ({ children }) => {
   const [viewActions, setViewActions] = useState([])
   const [adminActions, setAdminActions] = useState([])
-  const { id: idFromParams } = useParams<{ id: string }>()
-
-  const [documentInfo, setDocumentInfo] = useState<DocumentInfo>(() => {
-    return {
-      id: idFromParams,
-      collection: null,
-      global: null,
-    }
-  })
 
   const {
     admin: {
@@ -59,9 +31,7 @@ export const ActionsProvider = ({ children }) => {
   const combinedActions = [...viewActions, ...adminActions]
 
   return (
-    <ActionsContext.Provider
-      value={{ actions: combinedActions, documentInfo, setDocumentInfo, setViewActions }}
-    >
+    <ActionsContext.Provider value={{ actions: combinedActions, setViewActions }}>
       {children}
     </ActionsContext.Provider>
   )

--- a/packages/payload/src/admin/components/views/Account/index.tsx
+++ b/packages/payload/src/admin/components/views/Account/index.tsx
@@ -10,7 +10,6 @@ import usePayloadAPI from '../../../hooks/usePayloadAPI'
 import { useStepNav } from '../../elements/StepNav'
 import buildStateFromSchema from '../../forms/Form/buildStateFromSchema'
 import { fieldTypes } from '../../forms/field-types'
-import { useActions } from '../../utilities/ActionsProvider'
 import { useAuth } from '../../utilities/Auth'
 import { useConfig } from '../../utilities/Config'
 import { useDocumentInfo } from '../../utilities/DocumentInfo'
@@ -46,11 +45,6 @@ const AccountView: React.FC = () => {
   } = useConfig()
 
   const { t } = useTranslation('authentication')
-
-  const { setDocumentInfo } = useActions()
-  useEffect(() => {
-    setDocumentInfo({ id, collection: collection })
-  }, [collection, setDocumentInfo, id])
 
   const { fields } = collection || {}
 
@@ -123,9 +117,7 @@ const AccountView: React.FC = () => {
       setInternalState(state)
     }
 
-    if (dataToRender) {
-      void awaitInternalState()
-    }
+    if (dataToRender) awaitInternalState()
   }, [
     dataToRender,
     fields,

--- a/packages/payload/src/admin/components/views/Global/index.tsx
+++ b/packages/payload/src/admin/components/views/Global/index.tsx
@@ -9,7 +9,6 @@ import type { IndexProps } from './types'
 import usePayloadAPI from '../../../hooks/usePayloadAPI'
 import buildStateFromSchema from '../../forms/Form/buildStateFromSchema'
 import { fieldTypes } from '../../forms/field-types'
-import { useActions } from '../../utilities/ActionsProvider'
 import { useAuth } from '../../utilities/Auth'
 import { useConfig } from '../../utilities/Config'
 import { useDocumentEvents } from '../../utilities/DocumentEvents'
@@ -42,11 +41,6 @@ const GlobalView: React.FC<IndexProps> = (props) => {
   const { reportUpdate } = useDocumentEvents()
 
   const { slug, admin: { components: { views: { Edit: Edit } = {} } = {} } = {}, fields } = global
-
-  const { setDocumentInfo } = useActions()
-  useEffect(() => {
-    setDocumentInfo({ global })
-  }, [global, setDocumentInfo])
 
   const onSave = useCallback(
     async (json) => {

--- a/packages/payload/src/admin/components/views/collections/Edit/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/index.tsx
@@ -12,7 +12,6 @@ import type { IndexProps } from './types'
 import usePayloadAPI from '../../../../hooks/usePayloadAPI'
 import buildStateFromSchema from '../../../forms/Form/buildStateFromSchema'
 import { fieldTypes } from '../../../forms/field-types'
-import { useActions } from '../../../utilities/ActionsProvider'
 import { useAuth } from '../../../utilities/Auth'
 import { useConfig } from '../../../utilities/Config'
 import { useDocumentInfo } from '../../../utilities/DocumentInfo'
@@ -63,11 +62,6 @@ const EditView: React.FC<IndexProps> = (props) => {
     isEditing ? `${serverURL}${api}/${collectionSlug}/${id}` : '',
     { initialData: null, initialParams: { depth: 0, draft: 'true', 'fallback-locale': 'null' } },
   )
-
-  const { setDocumentInfo } = useActions()
-  useEffect(() => {
-    setDocumentInfo({ id, collection: collection })
-  }, [id, collection, setDocumentInfo])
 
   const buildState = useCallback(
     async (doc, overrides?: Partial<Parameters<typeof buildStateFromSchema>[0]>) => {


### PR DESCRIPTION
## Description

will get the document info from react router instead. Reverts #4696 

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
