### PR TITLE
fix(editorconfig): use off for max_line_length

### DIFF
--- a/examples/draft-preview/next-pages/.editorconfig
+++ b/examples/draft-preview/next-pages/.editorconfig
@@ -7,4 +7,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
-max_line_length = null
+max_line_length = off

--- a/examples/form-builder/next-pages/.editorconfig
+++ b/examples/form-builder/next-pages/.editorconfig
@@ -7,4 +7,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
-max_line_length = null
+max_line_length = off

--- a/examples/live-preview/next-pages/.editorconfig
+++ b/examples/live-preview/next-pages/.editorconfig
@@ -7,4 +7,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
-max_line_length = null
+max_line_length = off

--- a/examples/nested-docs/next-pages/.editorconfig
+++ b/examples/nested-docs/next-pages/.editorconfig
@@ -7,4 +7,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
-max_line_length = null
+max_line_length = off

--- a/examples/redirects/next-pages/.editorconfig
+++ b/examples/redirects/next-pages/.editorconfig
@@ -7,4 +7,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
-max_line_length = null
+max_line_length = off

--- a/templates/ecommerce/.editorconfig
+++ b/templates/ecommerce/.editorconfig
@@ -7,4 +7,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
-max_line_length = null
+max_line_length = off

--- a/templates/website/.editorconfig
+++ b/templates/website/.editorconfig
@@ -7,4 +7,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
-max_line_length = null
+max_line_length = off


### PR DESCRIPTION
Fixes "invalid value for option max_line_length: null"

See: https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length

## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [x] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
