### PR TITLE
fix(db-mongodb): migration errors with transactionOptions false

### DIFF
--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -107,7 +107,7 @@ export function mongooseAdapter({
     extendViteConfig(payload.config)
 
     if (transactionOptions === false) {
-      beginTransactionFunction = undefined
+      beginTransactionFunction = () => null
     }
 
     return createDatabaseAdapter<MongooseAdapter>({


### PR DESCRIPTION
## Description

Fix #4719 

Migrations error when using `transactionOptions: false` because the function is undefined. This change makes it so the function is always defined on the MongoDB adapter but return null when using `transactionOptions: false`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes