### PR TITLE
docs: updates `verify` to `verifyEmail` in `local-api` docs

### DIFF
--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -357,7 +357,7 @@ const result = await payload.unlock({
 
 ```js
 // Returned result will be a boolean representing success or failure
-const result = await payload.verify({
+const result = await payload.verifyEmail({
   collection: 'users', // required
   token: 'afh3o2jf2p3f...', // the token saved on the user as `_verificationToken`
 })


### PR DESCRIPTION
## Description

Updates auth operation `verify` to the correct verbiage of `verifyEmail` in Local API docs

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
