### PR TITLE
fix(plugin-seo): Add new type inference for  DRAFT

### DIFF
--- a/docs/plugins/seo.mdx
+++ b/docs/plugins/seo.mdx
@@ -109,10 +109,18 @@ A function that allows you to return any meta title, including from document's c
 
 ```ts
 // payload.config.ts
+
+type Project = {
+  title: string
+  description: string
+}
+
+const generateTitleFromProject: GenerateTitle<Project> = function generateTitle({ doc }) { return doc.title }
+
 {
   // ...
   seoPlugin({
-    generateTitle: ({ ...docInfo, doc, locale }) => `Website.com — ${doc?.title?.value}`,
+    generateTitle: generateTitleFromProject,
   })
 }
 ```
@@ -123,10 +131,19 @@ A function that allows you to return any meta description, including from docume
 
 ```ts
 // payload.config.ts
+
+type Project = {
+  title: string
+  description: string
+}
+
+const generateDescriptionFromProject: GenerateDescription<Project> = function generateDescription({ doc }) { return doc.description }
+
+
 {
   // ...
   seoPlugin({
-    generateDescription: ({ ...docInfo, doc, locale }) => doc?.excerpt?.value
+    generateDescription: generateDescriptionFromProject
   })
 }
 ```

--- a/packages/plugin-seo/src/types.ts
+++ b/packages/plugin-seo/src/types.ts
@@ -1,23 +1,32 @@
 import type { ContextType } from 'payload/dist/admin/components/utilities/DocumentInfo/types'
 import type { Field } from 'payload/dist/fields/config/types'
+import type { Fields, FormField } from 'payload/dist/admin/components/forms/Form/types'
 
-export type GenerateTitle = <T = any>(
-  args: ContextType & { doc: T; locale?: string },
+type GetFormFields<T> = {
+  [K in keyof T]: T[K] extends object
+    ? T[K] extends any[]
+      ? GetFormFields<T[K]>[]
+      : GetFormFields<T[K]>
+    : FormField
+}
+
+export type GenerateTitle<T = any> = (
+  args: ContextType & { doc: GetFormFields<T>; locale?: string },
 ) => Promise<string> | string
 
-export type GenerateDescription = <T = any>(
+export type GenerateDescription = (
   args: ContextType & {
-    doc: T
+    doc: Fields
     locale?: string
   },
 ) => Promise<string> | string
 
-export type GenerateImage = <T = any>(
-  args: ContextType & { doc: T; locale?: string },
+export type GenerateImage = (
+  args: ContextType & { doc: Fields; locale?: string },
 ) => Promise<string> | string
 
-export type GenerateURL = <T = any>(
-  args: ContextType & { doc: T; locale?: string },
+export type GenerateURL = (
+  args: ContextType & { doc: Fields; locale?: string },
 ) => Promise<string> | string
 
 export interface PluginConfig {

--- a/test/plugin-seo/config.ts
+++ b/test/plugin-seo/config.ts
@@ -8,6 +8,11 @@ import { Pages } from './collections/Pages'
 import { Users } from './collections/Users'
 import { seed } from './seed'
 
+import { Page } from './payload-types'
+import { GenerateTitle } from '../../packages/plugin-seo/src/types'
+
+const generateTitle: GenerateTitle<Page> = ({ doc }) => `Website.com — ${doc?.title.value}`
+
 const mockModulePath = path.resolve(__dirname, './mocks/mockFSModule.js')
 
 export default buildConfigWithDefaults({


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/4544

## Description

Updates the documentation and the types for the generator functions used in the SEO plugin to better match the actual type used

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
