### PR TITLE
feat(plugin-form-builder):Add validation for form ID when creating a form submissions

### DIFF
--- a/test/plugin-form-builder/int.spec.ts
+++ b/test/plugin-form-builder/int.spec.ts
@@ -4,6 +4,7 @@ import payload from '../../packages/payload/src'
 import { serializeSlate } from '../../packages/plugin-form-builder/src/utilities/slate/serializeSlate'
 import { initPayloadTest } from '../helpers/configHelpers'
 import { formSubmissionsSlug, formsSlug } from './shared'
+import { ValidationError } from '../../packages/payload/src/errors'
 
 describe('Form Builder Plugin', () => {
   let form: Form
@@ -41,7 +42,7 @@ describe('Form Builder Plugin', () => {
 
     it('adds form submissions collection', async () => {
       const { docs: formSubmissions } = await payload.find({ collection: formSubmissionsSlug })
-      expect(formSubmissions).toHaveLength(0)
+      expect(formSubmissions).toHaveLength(1)
     })
   })
 
@@ -115,6 +116,25 @@ describe('Form Builder Plugin', () => {
       expect(formSubmission.submissionData).toHaveLength(1)
       expect(formSubmission.submissionData[0]).toHaveProperty('field', 'name')
       expect(formSubmission.submissionData[0]).toHaveProperty('value', 'Test Submission')
+    })
+
+    it('does not create a form submission for a non-existing form', async () => {
+      const req = async () =>
+        payload.create({
+          collection: formSubmissionsSlug,
+          data: {
+            form: '659c7c2f98ffb5d83df9dadb',
+            submissionData: [
+              {
+                field: 'name',
+                value: 'Test Submission',
+              },
+            ],
+          },
+          depth: 0,
+        })
+
+      await expect(req).rejects.toThrow(ValidationError)
     })
 
     it('replaces curly braces with data when using slate serializer', async () => {

--- a/test/plugin-form-builder/seed/index.ts
+++ b/test/plugin-form-builder/seed/index.ts
@@ -1,7 +1,7 @@
 import type { Payload } from '../../../packages/payload/src'
 import type { PayloadRequest } from '../../../packages/payload/src/express/types'
 
-import { formsSlug, pagesSlug } from '../shared'
+import { formSubmissionsSlug, formsSlug, pagesSlug } from '../shared'
 
 export const seed = async (payload: Payload): Promise<boolean> => {
   payload.logger.info('Seeding data...')
@@ -48,6 +48,23 @@ export const seed = async (payload: Payload): Promise<boolean> => {
             label: 'Email',
             name: 'email',
             required: true,
+          },
+        ],
+      },
+    })
+
+    await payload.create({
+      collection: formSubmissionsSlug,
+      data: {
+        form: formID,
+        submissionData: [
+          {
+            field: 'name',
+            value: 'Test Submission',
+          },
+          {
+            field: 'email',
+            value: 'tester@example.com',
           },
         ],
       },


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/4471

## Description

Adds a validate function on the form field to check that the form it's going to be attached to actually exists.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
