### PR TITLE
chore: upgrade @types/nodemailer from v6.4.8 to v6.4.14

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -166,7 +166,7 @@
     "@types/minimist": "1.2.2",
     "@types/mkdirp": "1.0.2",
     "@types/node-fetch": "2.6.4",
-    "@types/nodemailer": "6.4.8",
+    "@types/nodemailer": "6.4.14",
     "@types/passport": "1.0.12",
     "@types/passport-anonymous": "1.0.3",
     "@types/passport-jwt": "3.0.9",

--- a/packages/plugin-cloud/package.json
+++ b/packages/plugin-cloud/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/express": "^4.17.9",
     "@types/jest": "^29.5.1",
-    "@types/nodemailer": "^6.4.7",
+    "@types/nodemailer": "6.4.14",
     "payload": "workspace:*",
     "ts-jest": "^29.1.0",
     "webpack": "^5.78.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -926,8 +926,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4
       '@types/nodemailer':
-        specifier: 6.4.8
-        version: 6.4.8
+        specifier: 6.4.14
+        version: 6.4.14
       '@types/passport':
         specifier: 1.0.12
         version: 1.0.12
@@ -1080,8 +1080,8 @@ importers:
         specifier: ^29.5.1
         version: 29.5.4
       '@types/nodemailer':
-        specifier: ^6.4.7
-        version: 6.4.8
+        specifier: 6.4.14
+        version: 6.4.14
       payload:
         specifier: workspace:*
         version: link:../payload
@@ -6045,10 +6045,10 @@ packages:
   /@types/node@20.6.2:
     resolution: {integrity: sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw==}
 
-  /@types/nodemailer@6.4.8:
-    resolution: {integrity: sha512-oVsJSCkqViCn8/pEu2hfjwVO+Gb3e+eTWjg3PcjeFKRItfKpKwHphQqbYmPQrlMk+op7pNNWPbsJIEthpFN/OQ==}
+  /@types/nodemailer@6.4.14:
+    resolution: {integrity: sha512-fUWthHO9k9DSdPCSPRqcu6TWhYyxTBg382vlNIttSe9M7XfsT06y0f24KHXtbnijPGGRIcVvdKHTNikOI6qiHA==}
     dependencies:
-      '@types/node': 20.6.2
+      '@types/node': 16.18.58
     dev: true
 
   /@types/normalize-package-data@2.4.1:


### PR DESCRIPTION
## Description

We've recently upgraded nodemailer to the latest version, so the same should be done for @types/nodemailer

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
