### PR TITLE
feat(plugin-search): add maxDepth option to allow relationship popu…

### DIFF
--- a/docs/plugins/search.mdx
+++ b/docs/plugins/search.mdx
@@ -8,13 +8,26 @@ keywords: plugins, search, search plugin, search engine, search index, search re
 
 [![NPM](https://img.shields.io/npm/v/@payloadcms/plugin-search)](https://www.npmjs.com/package/@payloadcms/plugin-search)
 
-This plugin generates records of your documents that are extremely fast to search on. It does so by creating a new `search` collection that is indexed in the database then saving a static copy of each of your documents using only search-critical data. Search records are automatically created, synced, and deleted behind-the-scenes as you manage your application's documents.
+This plugin generates records of your documents that are extremely fast to search on. It does so by creating a
+new `search` collection that is indexed in the database then saving a static copy of each of your documents using only
+search-critical data. Search records are automatically created, synced, and deleted behind-the-scenes as you manage your
+application's documents.
 
-For example, if you have a posts collection that is extremely large and complex, this would allow you to sync just the title, excerpt, and slug of each post so you can query on _that_ instead of the original post directly. Search records are static, so querying them also has the significant advantage of bypassing any hooks that may present be on the original documents. You define exactly what data is synced, and you can even modify or fallback this data before it is saved on a per-document basis.
+For example, if you have a posts collection that is extremely large and complex, this would allow you to sync just the
+title, excerpt, and slug of each post so you can query on _that_ instead of the original post directly. Search records
+are static, so querying them also has the significant advantage of bypassing any hooks that may present be on the
+original documents. You define exactly what data is synced, and you can even modify or fallback this data before it is
+saved on a per-document basis.
 
-To query search results, use all the existing Payload APIs that you are already familiar with. You can also prioritize search results by setting a custom priority for each collection. For example, you may want to list blog posts before pages. Or you may want one specific post to always take appear first. Search records are given a `priority` field that can be used as the `?sort=` parameter in your queries.
+To query search results, use all the existing Payload APIs that you are already familiar with. You can also prioritize
+search results by setting a custom priority for each collection. For example, you may want to list blog posts before
+pages. Or you may want one specific post to always take appear first. Search records are given a `priority` field that
+can be used as the `?sort=` parameter in your queries.
 
-This plugin is a great way to implement a fast, immersive search experience such as a search bar in a front-end application. Many applications may not need the power and complexity of a third-party service like Algolia or ElasticSearch. This plugin provides a first-party alternative that is easy to set up and runs entirely on your own database.
+This plugin is a great way to implement a fast, immersive search experience such as a search bar in a front-end
+application. Many applications may not need the power and complexity of a third-party service like Algolia or
+ElasticSearch. This plugin provides a first-party alternative that is easy to set up and runs entirely on your own
+database.
 
 <Banner type="info">
   This plugin is completely open-source and the [source code can be found here](https://github.com/payloadcms/payload/tree/main/packages/plugin-search). If you need help, check out our [Community Help](https://payloadcms.com/community-help). If you think you've found a bug, please [open a new issue](https://github.com/payloadcms/payload/issues/new?assignees=&labels=plugin%3A%20search&template=bug_report.md&title=plugin-search%3A) with as much detail as possible.
@@ -31,7 +44,8 @@ This plugin is a great way to implement a fast, immersive search experience such
 
 ## Installation
 
-Install the plugin using any JavaScript package manager like [Yarn](https://yarnpkg.com), [NPM](https://npmjs.com), or [PNPM](https://pnpm.io):
+Install the plugin using any JavaScript package manager like [Yarn](https://yarnpkg.com), [NPM](https://npmjs.com),
+or [PNPM](https://pnpm.io):
 
 ```bash
   yarn add @payloadcms/plugin-search
@@ -39,7 +53,8 @@ Install the plugin using any JavaScript package manager like [Yarn](https://yarn
 
 ## Basic Usage
 
-In the `plugins` array of your [Payload config](https://payloadcms.com/docs/configuration/overview), call the plugin with [options](#options):
+In the `plugins` array of your [Payload config](https://payloadcms.com/docs/configuration/overview), call the plugin
+with [options](#options):
 
 ```js
 import { buildConfig } from 'payload/config'
@@ -74,13 +89,19 @@ export default config
 
 #### `collections`
 
-The `collections` property is an array of collection slugs to enable syncing to search. Enabled collections receive a `beforeChange` and `afterDelete` hook that creates, updates, and deletes its respective search record as it changes over time.
+The `collections` property is an array of collection slugs to enable syncing to search. Enabled collections receive
+a `beforeChange` and `afterDelete` hook that creates, updates, and deletes its respective search record as it changes
+over time.
 
 #### `defaultPriorities`
 
-This plugin automatically adds a `priority` field to the `search` collection that can be used as the `?sort=` parameter in your queries. For example, you may want to list blog posts before pages. Or you may want one specific post to always take appear first.
+This plugin automatically adds a `priority` field to the `search` collection that can be used as the `?sort=` parameter
+in your queries. For example, you may want to list blog posts before pages. Or you may want one specific post to always
+take appear first.
 
-The `defaultPriorities` property is used to set a fallback `priority` on search records during the `create` operation. It accepts an object with keys that are your collection slugs and values that can either be a number or a function that returns a number. The function receives the `doc` as an argument, which is the document being created.
+The `defaultPriorities` property is used to set a fallback `priority` on search records during the `create` operation.
+It accepts an object with keys that are your collection slugs and values that can either be a number or a function that
+returns a number. The function receives the `doc` as an argument, which is the document being created.
 
 ```ts
 // payload.config.ts
@@ -97,7 +118,10 @@ The `defaultPriorities` property is used to set a fallback `priority` on search 
 
 #### `searchOverrides`
 
-This plugin automatically creates the `search` collection, but you can override anything on this collection via the `searchOverrides` property. It accepts anything from the [Payload Collection Config](https://payloadcms.com/docs/configuration/collections) and merges it in with the default `search` collection config provided by the plugin.
+This plugin automatically creates the `search` collection, but you can override anything on this collection via
+the `searchOverrides` property. It accepts anything from
+the [Payload Collection Config](https://payloadcms.com/docs/configuration/collections) and merges it in with the
+default `search` collection config provided by the plugin.
 
 ```ts
 // payload.config.ts
@@ -113,7 +137,9 @@ This plugin automatically creates the `search` collection, but you can override 
 
 #### `beforeSync`
 
-Before creating or updating a search record, the `beforeSync` function runs. This is an [afterChange](<[afterChange](https://payloadcms.com/docs/hooks/globals#afterchange)>) hook that allows you to modify the data or provide fallbacks before its search record is created or updated.
+Before creating or updating a search record, the `beforeSync` function runs. This is
+an [afterChange](<[afterChange](https://payloadcms.com/docs/hooks/globals#afterchange)>) hook that allows you to modify
+the data or provide fallbacks before its search record is created or updated.
 
 ```ts
 // payload.config.ts
@@ -131,11 +157,18 @@ Before creating or updating a search record, the `beforeSync` function runs. Thi
 
 #### `syncDrafts`
 
-When `syncDrafts` is true, draft documents will be synced to search. This is false by default. You must have [Payload Drafts](https://payloadcms.com/docs/versions/drafts) enabled for this to apply.
+When `syncDrafts` is true, draft documents will be synced to search. This is false by default. You must
+have [Payload Drafts](https://payloadcms.com/docs/versions/drafts) enabled for this to apply.
+
+#### `maxDepth`
+
+Set this property to `1` or higher to populate the relationships when fetching from the search collection. The default
+is `0` to prevent search results from consuming database resources.
 
 #### `deleteDrafts`
 
-If true, will delete documents from search whose status changes to draft. This is true by default. You must have [Payload Drafts](https://payloadcms.com/docs/versions/drafts) enabled for this to apply.
+If true, will delete documents from search whose status changes to draft. This is true by default. You must
+have [Payload Drafts](https://payloadcms.com/docs/versions/drafts) enabled for this to apply.
 
 ## TypeScript
 

--- a/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
@@ -1,27 +1,25 @@
 import type { CollectionAfterDeleteHook } from 'payload/types'
 
-const deleteFromSearch: CollectionAfterDeleteHook = ({ doc, req: { payload } }) => {
+const deleteFromSearch: CollectionAfterDeleteHook = async ({ doc, req: { payload }, req }) => {
   try {
-    const deleteSearchDoc = async (): Promise<any> => {
-      const searchDocQuery = await payload.find({
-        collection: 'search',
-        depth: 0,
-        where: {
-          'doc.value': {
-            equals: doc.id,
-          },
+    const searchDocQuery = await payload.find({
+      collection: 'search',
+      depth: 0,
+      req,
+      where: {
+        'doc.value': {
+          equals: doc.id,
         },
+      },
+    })
+
+    if (searchDocQuery?.docs?.[0]) {
+      await payload.delete({
+        id: searchDocQuery?.docs?.[0]?.id,
+        collection: 'search',
+        req,
       })
-
-      if (searchDocQuery?.docs?.[0]) {
-        payload.delete({
-          id: searchDocQuery?.docs?.[0]?.id,
-          collection: 'search',
-        })
-      }
     }
-
-    deleteSearchDoc()
   } catch (err: unknown) {
     payload.logger.error({
       err: `Error deleting search doc: ${err}`,

--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -6,6 +6,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
     doc,
     operation,
     req: { payload },
+    req,
     // @ts-expect-error
     searchConfig,
   } = args
@@ -60,6 +61,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
             ...dataToSave,
             priority: defaultPriority,
           },
+          req,
         })
       }
     }
@@ -70,6 +72,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
         const searchDocQuery = await payload.find({
           collection: 'search',
           depth: 0,
+          req,
           where: {
             'doc.value': {
               equals: id,
@@ -94,6 +97,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
                 payload.delete({
                   id: duplicativeDocID,
                   collection: 'search',
+                  req,
                 }),
               ), // eslint-disable-line function-paren-newline
             )
@@ -116,6 +120,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
                   ...dataToSave,
                   priority: foundDoc.priority || defaultPriority,
                 },
+                req,
               })
             } catch (err: unknown) {
               payload.logger.error(`Error updating search document.`)
@@ -128,6 +133,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
               payload.delete({
                 id: searchDocID,
                 collection: 'search',
+                req,
               })
             } catch (err: unknown) {
               payload.logger.error(`Error deleting search document: ${err}`)
@@ -142,6 +148,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
                 ...dataToSave,
                 priority: defaultPriority,
               },
+              req,
             })
           } catch (err: unknown) {
             payload.logger.error(`Error creating search document: ${err}`)

--- a/packages/plugin-search/src/Search/index.ts
+++ b/packages/plugin-search/src/Search/index.ts
@@ -10,6 +10,7 @@ import { LinkToDoc } from './ui'
 export const generateSearchCollection = (searchConfig: SearchConfig): CollectionConfig =>
   deepMerge(
     {
+      slug: 'search',
       access: {
         create: (): boolean => false,
         read: (): boolean => true,
@@ -24,46 +25,45 @@ export const generateSearchCollection = (searchConfig: SearchConfig): Collection
       fields: [
         {
           name: 'title',
+          type: 'text',
           admin: {
             readOnly: true,
           },
-          type: 'text',
         },
         {
           name: 'priority',
+          type: 'number',
           admin: {
             position: 'sidebar',
           },
-          type: 'number',
         },
         {
           name: 'doc',
+          type: 'relationship',
           admin: {
             position: 'sidebar',
             readOnly: true,
           },
           index: true,
-          maxDepth: 0,
+          maxDepth: searchConfig?.maxDepth,
           relationTo: searchConfig?.collections || [],
           required: true,
-          type: 'relationship',
         },
         {
           name: 'docUrl',
+          type: 'ui',
           admin: {
             components: {
               Field: LinkToDoc,
             },
             position: 'sidebar',
           },
-          type: 'ui',
         },
       ],
       labels: {
         plural: 'Search Results',
         singular: 'Search Result',
       },
-      slug: 'search',
     },
     searchConfig?.searchOverrides || {},
   )

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -13,10 +13,11 @@ const Search =
 
     if (collections) {
       const searchConfig: SearchConfig = {
-        ...incomingSearchConfig,
-        deleteDrafts: true,
-        syncDrafts: false,
         // write any config defaults here
+        deleteDrafts: true,
+        maxDepth: 0,
+        syncDrafts: false,
+        ...incomingSearchConfig,
       }
 
       // add afterChange and afterDelete hooks to every search-enabled collection

--- a/packages/plugin-search/src/types.ts
+++ b/packages/plugin-search/src/types.ts
@@ -3,6 +3,7 @@ import type { CollectionAfterChangeHook, CollectionConfig } from 'payload/types'
 
 export interface DocToSync {
   [key: string]: any
+
   doc: {
     relationTo: string
     value: string
@@ -25,6 +26,7 @@ export interface SearchConfig {
     [collection: string]: ((doc: any) => Promise<number> | number) | number
   }
   deleteDrafts?: boolean
+  maxDepth?: number
   searchOverrides?: Partial<CollectionConfig>
   syncDrafts?: boolean
 }


### PR DESCRIPTION
## Description

- Config options were being overwritten by plugin defaults
- Add `maxDepth` config option
- Add `req` to local API calls to respect transactions

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
