### PR TITLE
fix: migration regression

### DIFF
--- a/packages/db-mongodb/src/migrateFresh.ts
+++ b/packages/db-mongodb/src/migrateFresh.ts
@@ -43,7 +43,7 @@ export async function migrateFresh(this: MongooseAdapter): Promise<void> {
     msg: `Found ${migrationFiles.length} migration files.`,
   })
 
-  const req = {} as PayloadRequest
+  const req = { payload } as PayloadRequest
 
   // Run all migrate up
   for (const migration of migrationFiles) {

--- a/packages/db-postgres/src/migrate.ts
+++ b/packages/db-postgres/src/migrate.ts
@@ -83,7 +83,7 @@ async function runMigrationFile(payload: Payload, migration: Migration, batch: n
   const { generateDrizzleJson } = require('drizzle-kit/utils')
 
   const start = Date.now()
-  const req = {} as PayloadRequest
+  const req = { payload } as PayloadRequest
 
   payload.logger.info({ msg: `Migrating: ${migration.name}` })
 

--- a/packages/db-postgres/src/migrateFresh.ts
+++ b/packages/db-postgres/src/migrateFresh.ts
@@ -47,7 +47,7 @@ export async function migrateFresh(this: PostgresAdapter): Promise<void> {
     msg: `Found ${migrationFiles.length} migration files.`,
   })
 
-  const req = {} as PayloadRequest
+  const req = { payload } as PayloadRequest
   // Run all migrate up
   for (const migration of migrationFiles) {
     payload.logger.info({ msg: `Migrating: ${migration.name}` })

--- a/packages/db-postgres/src/migrateRefresh.ts
+++ b/packages/db-postgres/src/migrateRefresh.ts
@@ -31,7 +31,7 @@ export async function migrateRefresh(this: PostgresAdapter) {
     msg: `Rolling back batch ${latestBatch} consisting of ${existingMigrations.length} migration(s).`,
   })
 
-  const req = {} as PayloadRequest
+  const req = { payload } as PayloadRequest
 
   // Reverse order of migrations to rollback
   existingMigrations.reverse()

--- a/packages/db-postgres/src/migrateReset.ts
+++ b/packages/db-postgres/src/migrateReset.ts
@@ -24,7 +24,7 @@ export async function migrateReset(this: PostgresAdapter): Promise<void> {
     return
   }
 
-  const req = {} as PayloadRequest
+  const req = { payload } as PayloadRequest
 
   // Rollback all migrations in order
   for (const migration of existingMigrations) {

--- a/packages/payload/src/database/migrations/migrate.ts
+++ b/packages/payload/src/database/migrations/migrate.ts
@@ -27,7 +27,7 @@ export async function migrate(this: BaseDatabaseAdapter): Promise<void> {
     }
 
     const start = Date.now()
-    const req = {} as PayloadRequest
+    const req = { payload } as PayloadRequest
 
     payload.logger.info({ msg: `Migrating: ${migration.name}` })
 

--- a/packages/payload/src/database/migrations/migrateDown.ts
+++ b/packages/payload/src/database/migrations/migrateDown.ts
@@ -32,7 +32,7 @@ export async function migrateDown(this: BaseDatabaseAdapter): Promise<void> {
     }
 
     const start = Date.now()
-    const req = {} as PayloadRequest
+    const req = { payload } as PayloadRequest
 
     try {
       payload.logger.info({ msg: `Migrating down: ${migrationFile.name}` })

--- a/packages/payload/src/database/migrations/migrateRefresh.ts
+++ b/packages/payload/src/database/migrations/migrateRefresh.ts
@@ -28,7 +28,7 @@ export async function migrateRefresh(this: BaseDatabaseAdapter) {
     msg: `Rolling back batch ${latestBatch} consisting of ${existingMigrations.length} migration(s).`,
   })
 
-  const req = {} as PayloadRequest
+  const req = { payload } as PayloadRequest
 
   // Reverse order of migrations to rollback
   existingMigrations.reverse()

--- a/packages/payload/src/database/migrations/migrateReset.ts
+++ b/packages/payload/src/database/migrations/migrateReset.ts
@@ -19,7 +19,7 @@ export async function migrateReset(this: BaseDatabaseAdapter): Promise<void> {
     return
   }
 
-  const req = {} as PayloadRequest
+  const req = { payload } as PayloadRequest
 
   // Rollback all migrations in order
   for (const migration of migrationFiles) {


### PR DESCRIPTION
## Description

Fixes a regression introduced in https://github.com/payloadcms/payload/pull/4726 that causes migrations to error with:

```
..../node_modules/payload/dist/utilities/initTransaction.js:22
    if (typeof payload.db.beginTransaction === 'function') {
                       ^

TypeError: Cannot read properties of undefined (reading 'db')
```

Reported in another issue: https://github.com/payloadcms/payload/issues/4719
More info on discord: https://discord.com/channels/967097582721572934/1194788265757245520

We need test coverage for migrations.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
