### PR TITLE
fix(templates): Set port on NextServerOptions for Image component support

### DIFF
--- a/examples/custom-server/src/server.ts
+++ b/examples/custom-server/src/server.ts
@@ -38,7 +38,7 @@ const start = async (): Promise<void> => {
 
   const nextApp = next({
     dev: process.env.NODE_ENV !== 'production',
-    port: PORT
+    port: PORT,
   })
 
   const nextHandler = nextApp.getRequestHandler()

--- a/examples/custom-server/src/server.ts
+++ b/examples/custom-server/src/server.ts
@@ -12,7 +12,7 @@ import express from 'express'
 import { getPayloadClient } from './getPayload'
 
 const app = express()
-const PORT = process.env.PORT || 3000
+const PORT = process.env.PORT != null ? parseInt(process.env.PORT) : 3000
 
 const start = async (): Promise<void> => {
   const payload = await getPayloadClient({
@@ -38,6 +38,7 @@ const start = async (): Promise<void> => {
 
   const nextApp = next({
     dev: process.env.NODE_ENV !== 'production',
+    port: PORT
   })
 
   const nextHandler = nextApp.getRequestHandler()

--- a/templates/ecommerce/src/server.ts
+++ b/templates/ecommerce/src/server.ts
@@ -42,7 +42,7 @@ const start = async (): Promise<void> => {
 
   const nextApp = next({
     dev: process.env.NODE_ENV !== 'production',
-    port: PORT
+    port: PORT,
   })
 
   const nextHandler = nextApp.getRequestHandler()

--- a/templates/ecommerce/src/server.ts
+++ b/templates/ecommerce/src/server.ts
@@ -13,7 +13,7 @@ import payload from 'payload'
 import { seed } from './payload/seed'
 
 const app = express()
-const PORT = process.env.PORT || 3000
+const PORT = process.env.PORT != null ? parseInt(process.env.PORT) : 3000
 
 const start = async (): Promise<void> => {
   await payload.init({
@@ -42,6 +42,7 @@ const start = async (): Promise<void> => {
 
   const nextApp = next({
     dev: process.env.NODE_ENV !== 'production',
+    port: PORT
   })
 
   const nextHandler = nextApp.getRequestHandler()

--- a/templates/website/src/server.ts
+++ b/templates/website/src/server.ts
@@ -42,7 +42,7 @@ const start = async (): Promise<void> => {
 
   const nextApp = next({
     dev: process.env.NODE_ENV !== 'production',
-    port: PORT
+    port: PORT,
   })
 
   const nextHandler = nextApp.getRequestHandler()

--- a/templates/website/src/server.ts
+++ b/templates/website/src/server.ts
@@ -13,7 +13,7 @@ import payload from 'payload'
 import { seed } from './payload/seed'
 
 const app = express()
-const PORT = process.env.PORT || 3000
+const PORT = process.env.PORT != null ? parseInt(process.env.PORT) : 3000
 
 const start = async (): Promise<void> => {
   await payload.init({
@@ -42,6 +42,7 @@ const start = async (): Promise<void> => {
 
   const nextApp = next({
     dev: process.env.NODE_ENV !== 'production',
+    port: PORT
   })
 
   const nextHandler = nextApp.getRequestHandler()


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/4800

## Description

If a port OTHER than 3000 is used for the Next/Express server in the project templates and custom server example, the Next.js Image component will still try to serve optimized images via port 3000 (default) unless the port is also set in via `NextServerOptions`, for example...

```js
const nextApp = next({
    dev: process.env.NODE_ENV !== 'production',
    port: PORT
})
```

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
