### PR TITLE
fix(ui): Fix tabs field is not extended to end of parent's width

### DIFF
--- a/packages/payload/src/admin/components/forms/RenderFields/index.scss
+++ b/packages/payload/src/admin/components/forms/RenderFields/index.scss
@@ -13,7 +13,6 @@
 
   & > .field-type {
     margin-bottom: var(--spacing-field);
-    max-width: 100%;
 
     &[type='hidden'] {
       margin-bottom: 0;
@@ -26,6 +25,9 @@
     &:last-child {
       margin-bottom: 0;
     }
+  }
+  & > .field-type:not(.tabs-field) {
+    max-width: 100%;
   }
 
   // at the top-level, add extra margins for the following field types


### PR DESCRIPTION
## Description

![image](https://github.com/payloadcms/payload/assets/47362439/e1dd751e-e616-48f9-b390-73138c016234)

Tabs field width is not extended to the end of parent's width but parent's width except gutter padding.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
