### PR TITLE
chore(eslint-config-payload): improve @typescript-eslint/no-unused-vars rule

### DIFF
--- a/packages/eslint-config-payload/eslint-config/index.js
+++ b/packages/eslint-config-payload/eslint-config/index.js
@@ -52,7 +52,18 @@ module.exports = {
     'class-methods-use-this': 'off',
 
     // By default, it errors for unused variables. This is annoying, warnings are enough.
-    '@typescript-eslint/no-unused-vars': 'warn',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      {
+        vars: 'all',
+        args: 'after-used',
+        ignoreRestSiblings: false,
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^ignore',
+      },
+    ],
 
     '@typescript-eslint/no-use-before-define': 'off',
     'arrow-body-style': 0,


### PR DESCRIPTION
## Description

Example:
```ts
Object.entries(flattenedData).filter(
  ([_key, value]) => value && ('text' in value),
)
```
This previously complained "_key is defined but never used". No more! This adds `_` as an ignore pattern to all variables.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
