### PR TITLE
fix(db-postgres): validateExistingBlockIsIdentical with arrays

### DIFF
--- a/packages/db-postgres/src/schema/validateExistingBlockIsIdentical.ts
+++ b/packages/db-postgres/src/schema/validateExistingBlockIsIdentical.ts
@@ -17,8 +17,7 @@ const getFlattenedFieldNames = (fields: Field[], prefix: string = ''): string[] 
     let fieldPrefix = prefix
 
     if (
-      field.type === 'blocks' ||
-      field.type === 'array' ||
+      ['array', 'blocks', 'relationship', 'upload'].includes(field.type) ||
       ('hasMany' in field && field.hasMany === true)
     ) {
       return fieldsToUse

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -246,6 +246,22 @@ const BlockFields: CollectionConfig = {
             },
           ],
         },
+        {
+          slug: 'block-b',
+          fields: [
+            {
+              name: 'items',
+              type: 'array',
+              fields: [
+                {
+                  name: 'title2',
+                  type: 'text',
+                  required: true,
+                },
+              ],
+            },
+          ],
+        },
       ],
     },
     {


### PR DESCRIPTION
## Description

fixes #4775 

The validation function was not taking into account situations where fields would be passed along to other tables. 
We also should validate that the additional tables have the correct columns. Suppose you have reused a block slug and included an array with different fields, the current validate function doesn't cover this.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
