### PR TITLE
support drizzle logging config

### DIFF
--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -18,8 +18,9 @@ export const connect: Connect = async function connect(this: PostgresAdapter, pa
   try {
     this.pool = new Pool(this.poolOptions)
     await this.pool.connect()
+    const logger = this.logger || false
 
-    this.drizzle = drizzle(this.pool, { schema: this.schema })
+    this.drizzle = drizzle(this.pool, { schema: this.schema, logger })
     if (process.env.PAYLOAD_DROP_DATABASE === 'true') {
       this.payload.logger.info('---- DROPPING TABLES ----')
       await this.drizzle.execute(sql`drop schema public cascade;

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -50,6 +50,7 @@ export function postgresAdapter(args: Args): PostgresAdapterResult {
       drizzle: undefined,
       enums: {},
       fieldConstraints: {},
+      logger: args.logger,
       pool: undefined,
       poolOptions: args.pool,
       push: args.push,

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -1,6 +1,7 @@
 import type {
   ColumnBaseConfig,
   ColumnDataType,
+  DrizzleConfig,
   ExtractTablesWithRelations,
   Relation,
   Relations,
@@ -16,6 +17,7 @@ export type DrizzleDB = NodePgDatabase<Record<string, unknown>>
 export type Args = {
   migrationDir?: string
   pool: PoolConfig
+  logger?: DrizzleConfig['logger']
   push?: boolean
 }
 
@@ -47,6 +49,7 @@ export type DrizzleTransaction = PgTransaction<
 
 export type PostgresAdapter = BaseDatabaseAdapter & {
   drizzle: DrizzleDB
+  logger: DrizzleConfig['logger']
   enums: Record<string, GenericEnum>
   pool: Pool
   poolOptions: Args['pool']


### PR DESCRIPTION
## Description

Current implementation of db-postgres plugin doesn't expose drizzle logging parameters documented [here](https://orm.drizzle.team/docs/goodies#logging) - so no way to get query logging.

This small PR just threads the config through to the`postgresAdapter` so that users can enable sql logging.

There don't appear to be tests for this plugin, so I haven't added any.

I'd appreciate any suggestions about what documentation I should update.

Any other feedback that would get this change merged would be greatly appreciated. I'm excited about payload but I need visibility into the DB queries being executed to build confidently with it.

https://discordapp.com/channels/967097582721572934/1196159019161755770/1196159019161755770

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
