### PR TITLE
fix(plugin-seo): Updated the types for the SEO plugin generator functions to better match the doc format

### DIFF
--- a/packages/plugin-seo/src/types.ts
+++ b/packages/plugin-seo/src/types.ts
@@ -1,40 +1,42 @@
 import type { ContextType } from 'payload/dist/admin/components/utilities/DocumentInfo/types'
-import type { Field, TextareaField, TextField, UploadField } from 'payload/dist/fields/config/types'
+import type { Field, TextField, TextareaField, UploadField } from 'payload/dist/fields/config/types'
+import type { FormField } from 'payload/types'
 
+// @todo: update typings in 3.0 to infer collection types as expected for 'doc'
 export type GenerateTitle = <T = any>(
-  args: ContextType & { doc: T; locale?: string },
+  args: ContextType & { doc: Record<string, FormField>; locale?: string },
 ) => Promise<string> | string
 
 export type GenerateDescription = <T = any>(
   args: ContextType & {
-    doc: T
+    doc: Record<string, FormField>
     locale?: string
   },
 ) => Promise<string> | string
 
 export type GenerateImage = <T = any>(
-  args: ContextType & { doc: T; locale?: string },
+  args: ContextType & { doc: Record<string, FormField>; locale?: string },
 ) => Promise<string> | string
 
 export type GenerateURL = <T = any>(
-  args: ContextType & { doc: T; locale?: string },
+  args: ContextType & { doc: Record<string, FormField>; locale?: string },
 ) => Promise<string> | string
 
 export interface PluginConfig {
   collections?: string[]
+  fieldOverrides?: {
+    description?: Partial<TextareaField>
+    image?: Partial<UploadField>
+    title?: Partial<TextField>
+  }
   fields?: Field[]
   generateDescription?: GenerateDescription
   generateImage?: GenerateImage
   generateTitle?: GenerateTitle
   generateURL?: GenerateURL
   globals?: string[]
-  tabbedUI?: boolean
-  fieldOverrides?: {
-    title?: Partial<TextField>
-    description?: Partial<TextareaField>
-    image?: Partial<UploadField>
-  }
   interfaceName?: string
+  tabbedUI?: boolean
   uploadsCollection?: string
 }
 


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/4544

## Description

Updates the documentation and the types for the generator functions used in the SEO plugin to better match the actual type used

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
