### PR TITLE
fix: removes `max-width` from field-types class & sets it on uploads

### DIFF
--- a/packages/payload/src/admin/components/forms/RenderFields/index.scss
+++ b/packages/payload/src/admin/components/forms/RenderFields/index.scss
@@ -13,7 +13,6 @@
 
   & > .field-type {
     margin-bottom: var(--spacing-field);
-    max-width: 100%;
 
     &[type='hidden'] {
       margin-bottom: 0;

--- a/packages/payload/src/admin/components/forms/field-types/Upload/index.scss
+++ b/packages/payload/src/admin/components/forms/field-types/Upload/index.scss
@@ -2,6 +2,7 @@
 
 .upload {
   position: relative;
+  max-width: 100%;
 
   &__wrap {
     background: var(--theme-elevation-50);


### PR DESCRIPTION
## Description

Fixes #4823 

Reverts a fix from this #4704 which was added to fix an overflow issue on media uploads when the file name was very large. See #4697.

The `max-width: 100%` on `.field-types` created width issues with other field types, such as `tabs`.

This PR updates the max-width to be correctly set on uploads specifically instead of cascading down to all field types.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
