### PR TITLE
fix: ensures docs with the same id are shown in relationship field UI

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Relationship/optionsReducer.ts
@@ -9,7 +9,7 @@ const reduceToIDs = (options) =>
       return [...ids, ...reduceToIDs(option.options)]
     }
 
-    return [...ids, option.value]
+    return [...ids, { id: option.value, relationTo: option.relationTo }]
   }, [])
 
 const sortOptions = (options: Option[]): Option[] =>
@@ -63,10 +63,12 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
       const optionsToAddTo = newOptions.find(
         (optionGroup) => optionGroup.label === collection.labels.plural,
       )
-
       const newSubOptions = docs.reduce((docSubOptions, doc) => {
-        if (loadedIDs.indexOf(doc.id) === -1) {
-          loadedIDs.push(doc.id)
+        if (
+          loadedIDs.filter((item) => item.id === doc.id && item.relationTo === relation).length ===
+          0
+        ) {
+          loadedIDs.push({ id: doc.id, relationTo: relation })
 
           const docTitle = formatUseAsTitle({
             collection,
@@ -89,7 +91,10 @@ const optionsReducer = (state: OptionGroup[], action: Action): OptionGroup[] => 
       }, [])
 
       ids.forEach((id) => {
-        if (!loadedIDs.includes(id)) {
+        if (
+          loadedIDs.filter((item) => item.id === id && item.relationTo === relation).length === 0
+        ) {
+          loadedIDs.push({ id, relationTo: relation })
           newSubOptions.push({
             label: `${i18n.t('general:untitled')} - ID: ${id}`,
             relationTo: relation,


### PR DESCRIPTION
## Description

Closes #4480 
Fixes a bug with the `relationship` field UI. 

Within the dropdown component for the relationship field, we currently filter out any duplicate IDs. With Postgres it is common to see duplicate IDs across collections, as a result, some docs are being incorrectly being filtered out.

The options reducer needs to instead filter for ID _**per collection**_. 

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
