### PR TITLE
fix(db-postgres): query unset relation

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -77,6 +77,7 @@ export const sanitizeQueryValue = ({
     // Object equality requires the value to be the first key in the object that is being queried.
     if (
       operator === 'equals' &&
+      formattedValue &&
       typeof formattedValue === 'object' &&
       formattedValue.value &&
       formattedValue.relationTo

--- a/packages/db-postgres/src/queries/getTableColumnFromPath.ts
+++ b/packages/db-postgres/src/queries/getTableColumnFromPath.ts
@@ -2,7 +2,7 @@
 import type { SQL } from 'drizzle-orm'
 import type { Field, FieldAffectingData, TabAsField } from 'payload/types'
 
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, like, sql } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
 import { APIError } from 'payload/errors'
 import { fieldAffectsData, tabHasName } from 'payload/types'
@@ -317,20 +317,14 @@ export const getTableColumnFromPath = ({
 
         // Join in the relationships table
         joinAliases.push({
-          condition: eq(
-            (aliasTable || adapter.tables[rootTableName]).id,
-            aliasRelationshipTable.parent,
+          condition: and(
+            eq((aliasTable || adapter.tables[rootTableName]).id, aliasRelationshipTable.parent),
+            like(aliasRelationshipTable.path, `${constraintPath}${field.name}`),
           ),
           table: aliasRelationshipTable,
         })
 
         selectFields[`${relationTableName}.path`] = aliasRelationshipTable.path
-
-        constraints.push({
-          columnName: 'path',
-          table: aliasRelationshipTable,
-          value: `${constraintPath}${field.name}`,
-        })
 
         let newAliasTable
 
@@ -428,7 +422,7 @@ export const getTableColumnFromPath = ({
             columnName: `${columnPrefix}${field.name}`,
             constraints,
             field,
-            pathSegments: pathSegments,
+            pathSegments,
             table: targetTable,
           }
         }

--- a/packages/db-postgres/src/queries/parseParams.ts
+++ b/packages/db-postgres/src/queries/parseParams.ts
@@ -207,6 +207,16 @@ export async function parseParams({
                   break
                 }
 
+                if (operator === 'equals' && queryValue === null) {
+                  constraints.push(isNull(rawColumn || table[columnName]))
+                  break
+                }
+
+                if (operator === 'not_equals' && queryValue === null) {
+                  constraints.push(isNotNull(rawColumn || table[columnName]))
+                  break
+                }
+
                 constraints.push(
                   operatorMap[queryOperator](rawColumn || table[columnName], queryValue),
                 )

--- a/test/relationships/config.ts
+++ b/test/relationships/config.ts
@@ -43,6 +43,7 @@ export const chainedRelSlug = 'chained'
 export const customIdSlug = 'custom-id'
 export const customIdNumberSlug = 'custom-id-number'
 export const polymorphicRelationshipsSlug = 'polymorphic-relationships'
+export const treeSlug = 'tree'
 
 export default buildConfigWithDefaults({
   collections: [
@@ -244,6 +245,20 @@ export default buildConfigWithDefaults({
         },
       ],
     },
+    {
+      slug: treeSlug,
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+        },
+        {
+          name: 'parent',
+          type: 'relationship',
+          relationTo: 'tree',
+        },
+      ],
+    },
   ],
   onInit: async (payload) => {
     await payload.create({
@@ -335,6 +350,21 @@ export default buildConfigWithDefaults({
         customIdRelation: customIdRelation.id,
         customIdNumberRelation: customIdNumberRelation.id,
         filteredRelation: filteredRelation.id,
+      },
+    })
+
+    const root = await payload.create({
+      collection: 'tree',
+      data: {
+        text: 'root',
+      },
+    })
+
+    await payload.create({
+      collection: 'tree',
+      data: {
+        text: 'sub',
+        parent: root.id,
       },
     })
   },

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -22,6 +22,7 @@ import config, {
   defaultAccessRelSlug,
   relationSlug,
   slug,
+  treeSlug,
 } from './config'
 
 let apiUrl
@@ -552,6 +553,64 @@ describe('Relationships', () => {
         })
 
         expect(stanleyNeverMadeMovies.movies).toHaveLength(0)
+      })
+    })
+
+    describe('Hierarchy', () => {
+      it('finds 1 root item with equals', async () => {
+        const {
+          docs: [item],
+          totalDocs: count,
+        } = await payload.find({
+          collection: treeSlug,
+          where: {
+            parent: { equals: null },
+          },
+        })
+        expect(count).toBe(1)
+        expect(item.text).toBe('root')
+      })
+
+      it('finds 1 root item with exists', async () => {
+        const {
+          docs: [item],
+          totalDocs: count,
+        } = await payload.find({
+          collection: treeSlug,
+          where: {
+            parent: { exists: false },
+          },
+        })
+        expect(count).toBe(1)
+        expect(item.text).toBe('root')
+      })
+
+      it('finds 1 sub item with equals', async () => {
+        const {
+          docs: [item],
+          totalDocs: count,
+        } = await payload.find({
+          collection: treeSlug,
+          where: {
+            parent: { not_equals: null },
+          },
+        })
+        expect(count).toBe(1)
+        expect(item.text).toBe('sub')
+      })
+
+      it('finds 1 sub item with exists', async () => {
+        const {
+          docs: [item],
+          totalDocs: count,
+        } = await payload.find({
+          collection: treeSlug,
+          where: {
+            parent: { exists: true },
+          },
+        })
+        expect(count).toBe(1)
+        expect(item.text).toBe('sub')
       })
     })
   })


### PR DESCRIPTION
## Description

This PR improves PostgreSQL adapter by allowing to query documents based on unset relations using `equals: null` and `exists: false`. Also quering set relations is now allowed using `not_equals: null` in addition of `exists: true`.
 
Fixes #4611

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
