### PR TITLE
fix: if no email, do not query for user inside login operation

### DIFF
--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -85,11 +85,14 @@ async function login<TSlug extends keyof GeneratedTypes['collections']>(
 
     const email = unsanitizedEmail ? unsanitizedEmail.toLowerCase().trim() : null
 
-    let user = await payload.db.findOne<any>({
-      collection: collectionConfig.slug,
-      req,
-      where: { email: { equals: email.toLowerCase() } },
-    })
+    let user =
+      typeof email === 'string'
+        ? await payload.db.findOne<any>({
+            collection: collectionConfig.slug,
+            req,
+            where: { email: { equals: email.toLowerCase() } },
+          })
+        : null
 
     if (!user || (args.collection.config.auth.verify && user._verified === false)) {
       throw new AuthenticationError(req.t)


### PR DESCRIPTION
## Description

Login operation was querying for user even when no email is provided.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
