### PR TITLE
chore: add fieldIsGroupType type guard helper

### DIFF
--- a/packages/payload/src/exports/types.ts
+++ b/packages/payload/src/exports/types.ts
@@ -109,6 +109,7 @@ export {
   fieldHasSubFields,
   fieldIsArrayType,
   fieldIsBlockType,
+  fieldIsGroupType,
   fieldIsLocalized,
   fieldIsPresentationalOnly,
   fieldSupportsMany,

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -692,6 +692,10 @@ export function fieldIsBlockType(field: Field): field is BlockField {
   return field.type === 'blocks'
 }
 
+export function fieldIsGroupType(field: Field): field is GroupField {
+  return field.type === 'group'
+}
+
 export function optionIsObject(option: Option): option is OptionObject {
   return typeof option === 'object'
 }


### PR DESCRIPTION
## Description

Add `fieldIsGroupType` type guard for if a field is a Group field.

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
