### PR TITLE
docs: typo in rate limit window option

### DIFF
--- a/docs/production/preventing-abuse.mdx
+++ b/docs/production/preventing-abuse.mdx
@@ -20,7 +20,7 @@ To prevent DDoS, brute-force, and similar attacks, you can set IP-based rate lim
 
 | Option           | Description                                                                                                             |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| **`window`**     | Time in milliseconds to track requests per IP. Defaults to `90000` (15 minutes).                                        |
+| **`window`**     | Time in milliseconds to track requests per IP. Defaults to `900,000` (15 minutes).                                        |
 | **`max`**        | Number of requests served from a single IP before limiting. Defaults to `500`.                                          |
 | **`skip`**       | Express middleware function that can return true (or promise resulting in true) that will bypass limit.                 |
 | **`trustProxy`** | True or false, to enable to allow requests to pass through a proxy such as a load balancer or an `nginx` reverse proxy. |


### PR DESCRIPTION
## Description

Preventing abuse documentation page says default window duration is `90,000` but should be `900,000`.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] This change is a documentation update

