### PR TITLE
chore: re-orders lang detections

### DIFF
--- a/packages/payload/src/translations/defaultOptions.ts
+++ b/packages/payload/src/translations/defaultOptions.ts
@@ -5,10 +5,10 @@ import translations from './index'
 export const defaultOptions: InitOptions = {
   debug: false,
   detection: {
-    caches: ['header', 'cookie', 'localStorage'],
+    caches: ['cookie', 'localStorage', 'header'],
     lookupCookie: 'lng',
     lookupLocalStorage: 'lng',
-    order: ['header', 'cookie', 'localStorage'],
+    order: ['cookie', 'localStorage', 'header'],
   },
   fallbackLng: 'en',
   interpolation: {


### PR DESCRIPTION
## Description

Recently we added the 'header' detection for language detection. The ordering was incorrect and the accept-language header should be checked after cookies and local storage.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
