### PR TITLE
chore(next): ssr collapsible field

### DIFF
--- a/packages/dev/src/collections/Pages/index.ts
+++ b/packages/dev/src/collections/Pages/index.ts
@@ -118,6 +118,18 @@ export const Pages: CollectionConfig = {
       required: true,
     },
     {
+      label: ({ data }) => `This is ${data?.title || 'Untitled'}`,
+      type: 'collapsible',
+      fields: [
+        {
+          name: 'collapsibleText',
+          label: 'Collapsible Text',
+          type: 'text',
+          required: true,
+        },
+      ],
+    },
+    {
       name: 'group',
       label: 'Group',
       type: 'group',

--- a/packages/dev/src/collections/Pages/index.ts
+++ b/packages/dev/src/collections/Pages/index.ts
@@ -120,6 +120,9 @@ export const Pages: CollectionConfig = {
     {
       label: ({ data }) => `This is ${data?.title || 'Untitled'}`,
       type: 'collapsible',
+      admin: {
+        initCollapsed: true,
+      },
       fields: [
         {
           name: 'collapsibleText',

--- a/packages/next/src/utilities/createClientConfig.ts
+++ b/packages/next/src/utilities/createClientConfig.ts
@@ -7,6 +7,7 @@ export const sanitizeField = (f) => {
   if ('hooks' in field) delete field.hooks
   if ('validate' in field) delete field.validate
   if ('defaultValue' in field) delete field.defaultValue
+  if ('label' in field) delete field.label
 
   if ('fields' in field) {
     field.fields = sanitizeFields(field.fields)
@@ -25,6 +26,10 @@ export const sanitizeField = (f) => {
 
     if ('condition' in field.admin) {
       delete field.admin.condition
+    }
+
+    if ('description' in field.admin) {
+      delete field.admin.description
     }
   }
 

--- a/packages/ui/src/forms/RowLabel/index.tsx
+++ b/packages/ui/src/forms/RowLabel/index.tsx
@@ -1,35 +1,16 @@
-'use client'
 import React from 'react'
-import { useTranslation } from '../../providers/Translation'
-
-import type { Props } from './types'
-
+import { Props, isComponent } from './types'
+import getSiblingData from '../Form/getSiblingData'
+import getDataByPath from '../Form/getDataByPath'
 import { getTranslation } from '@payloadcms/translations'
-import { useWatchForm } from '../Form/context'
-import { isComponent } from './types'
 
 const baseClass = 'row-label'
 
-export const RowLabel: React.FC<Props> = ({ className, ...rest }) => {
-  return (
-    <span
-      className={[baseClass, className].filter(Boolean).join(' ')}
-      style={{
-        pointerEvents: 'none',
-      }}
-    >
-      <RowLabelContent {...rest} />
-    </span>
-  )
-}
+export const RowLabel: React.FC<Props> = (props) => {
+  const { className, label, path, rowNumber, data: dataFromProps, i18n } = props
 
-const RowLabelContent: React.FC<Omit<Props, 'className'>> = (props) => {
-  const { label, path, rowNumber } = props
-
-  const { i18n } = useTranslation()
-  const { getDataByPath, getSiblingData } = useWatchForm()
-  const collapsibleData = getSiblingData(path)
-  const arrayData = getDataByPath(path)
+  const collapsibleData = getSiblingData(dataFromProps, path)
+  const arrayData = getDataByPath(dataFromProps, path)
   const data = arrayData || collapsibleData
 
   if (isComponent(label)) {
@@ -38,7 +19,12 @@ const RowLabelContent: React.FC<Omit<Props, 'className'>> = (props) => {
   }
 
   return (
-    <React.Fragment>
+    <span
+      className={[baseClass, className].filter(Boolean).join(' ')}
+      style={{
+        pointerEvents: 'none',
+      }}
+    >
       {typeof label === 'function'
         ? label({
             data,
@@ -46,6 +32,6 @@ const RowLabelContent: React.FC<Omit<Props, 'className'>> = (props) => {
             path,
           })
         : getTranslation(label, i18n)}
-    </React.Fragment>
+    </span>
   )
 }

--- a/packages/ui/src/forms/RowLabel/types.ts
+++ b/packages/ui/src/forms/RowLabel/types.ts
@@ -1,12 +1,16 @@
 import React from 'react'
 
 import { RowLabel, RowLabelComponent } from 'payload/types'
+import { FormState } from '../..'
+import { I18n } from '@payloadcms/translations'
 
 export type Props = {
   className?: string
   label?: RowLabel
   path: string
   rowNumber?: number
+  data: FormState
+  i18n: I18n
 }
 
 export function isComponent(label: RowLabel): label is RowLabelComponent {

--- a/packages/ui/src/forms/WatchChildErrors/getNestedFieldState.ts
+++ b/packages/ui/src/forms/WatchChildErrors/getNestedFieldState.ts
@@ -16,6 +16,7 @@ export const getNestedFieldState = ({
 }): {
   errorCount: number
   fieldState: FormState
+  pathSegments: string[]
 } => {
   let pathSegments = pathSegmentsFromProps
 
@@ -25,5 +26,8 @@ export const getNestedFieldState = ({
 
   const result = getFieldStateFromPaths({ formState, pathSegments })
 
-  return result
+  return {
+    ...result,
+    pathSegments,
+  }
 }

--- a/packages/ui/src/forms/WatchChildErrors/index.ts
+++ b/packages/ui/src/forms/WatchChildErrors/index.ts
@@ -1,36 +1,24 @@
 'use client'
 import React from 'react'
 
-import type { Field } from 'payload/types'
-
 import useThrottledEffect from '../../hooks/useThrottledEffect'
 import { useAllFormFields, useFormSubmitted } from '../Form/context'
-import { buildPathSegments } from './buildPathSegments'
 import { getFieldStateFromPaths } from './getFieldStateFromPaths'
 
 type TrackSubSchemaErrorCountProps = {
   /**
    * Only for collapsibles, and unnamed-tabs
    */
-  fieldSchema?: Field[]
-  path: string
+  pathSegments?: string[]
   setErrorCount: (count: number) => void
 }
 
 export const WatchChildErrors: React.FC<TrackSubSchemaErrorCountProps> = ({
-  fieldSchema,
-  path,
+  pathSegments,
   setErrorCount,
 }) => {
   const [formState] = useAllFormFields()
   const hasSubmitted = useFormSubmitted()
-  const [pathSegments] = React.useState(() => {
-    if (fieldSchema) {
-      return buildPathSegments(path, fieldSchema)
-    }
-
-    return [`${path}.`]
-  })
 
   useThrottledEffect(
     () => {

--- a/packages/ui/src/forms/WatchChildErrors/index.ts
+++ b/packages/ui/src/forms/WatchChildErrors/index.ts
@@ -6,9 +6,6 @@ import { useAllFormFields, useFormSubmitted } from '../Form/context'
 import { getFieldStateFromPaths } from './getFieldStateFromPaths'
 
 type TrackSubSchemaErrorCountProps = {
-  /**
-   * Only for collapsibles, and unnamed-tabs
-   */
   pathSegments?: string[]
   setErrorCount: (count: number) => void
 }
@@ -22,7 +19,7 @@ export const WatchChildErrors: React.FC<TrackSubSchemaErrorCountProps> = ({
 
   useThrottledEffect(
     () => {
-      if (hasSubmitted) {
+      if (true) {
         const { errorCount } = getFieldStateFromPaths({ formState, pathSegments })
         setErrorCount(errorCount)
       }

--- a/packages/ui/src/forms/WatchChildErrors/index.ts
+++ b/packages/ui/src/forms/WatchChildErrors/index.ts
@@ -19,7 +19,7 @@ export const WatchChildErrors: React.FC<TrackSubSchemaErrorCountProps> = ({
 
   useThrottledEffect(
     () => {
-      if (true) {
+      if (hasSubmitted) {
         const { errorCount } = getFieldStateFromPaths({ formState, pathSegments })
         setErrorCount(errorCount)
       }

--- a/packages/ui/src/forms/field-types/Code/Input/index.tsx
+++ b/packages/ui/src/forms/field-types/Code/Input/index.tsx
@@ -26,7 +26,9 @@ export const CodeInput: React.FC<{
 
   const memoizedValidate = useCallback(
     (value, options) => {
-      return validate(value, { ...options, required })
+      if (typeof validate === 'function') {
+        return validate(value, { ...options, required })
+      }
     },
     [validate, required],
   )

--- a/packages/ui/src/forms/field-types/Collapsible/Input/index.tsx
+++ b/packages/ui/src/forms/field-types/Collapsible/Input/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { Fragment, useCallback, useEffect, useState } from 'react'
+import React, { Fragment, useCallback, useState } from 'react'
 
 import type { DocumentPreferences } from 'payload/types'
 
@@ -24,7 +24,6 @@ export const CollapsibleInput: React.FC<{
 
   const { getPreference, setPreference } = usePreferences()
   const { preferencesKey } = useDocumentInfo()
-  const [collapsedOnMount, setCollapsedOnMount] = useState<boolean>()
   const [errorCount, setErrorCount] = useState(0)
   const { i18n } = useTranslation()
 
@@ -58,24 +57,6 @@ export const CollapsibleInput: React.FC<{
     [preferencesKey, fieldPreferencesKey, getPreference, setPreference, path],
   )
 
-  useEffect(() => {
-    const fetchInitialState = async () => {
-      const preferences = await getPreference(preferencesKey)
-      if (preferences) {
-        const initCollapsedFromPref = path
-          ? preferences?.fields?.[path]?.collapsed
-          : preferences?.fields?.[fieldPreferencesKey]?.collapsed
-        setCollapsedOnMount(Boolean(initCollapsedFromPref))
-      } else {
-        setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
-      }
-    }
-
-    fetchInitialState()
-  }, [getPreference, preferencesKey, fieldPreferencesKey, initCollapsed, path])
-
-  if (typeof collapsedOnMount !== 'boolean') return null
-
   return (
     <Fragment>
       <WatchChildErrors pathSegments={pathSegments} setErrorCount={setErrorCount} />
@@ -88,7 +69,7 @@ export const CollapsibleInput: React.FC<{
             {errorCount > 0 && <ErrorPill count={errorCount} withMessage i18n={i18n} />}
           </div>
         }
-        initCollapsed={collapsedOnMount}
+        initCollapsed={initCollapsed}
         onToggle={onToggle}
       >
         {children}

--- a/packages/ui/src/forms/field-types/Collapsible/Input/index.tsx
+++ b/packages/ui/src/forms/field-types/Collapsible/Input/index.tsx
@@ -1,0 +1,92 @@
+'use client'
+import React, { useCallback, useEffect, useState } from 'react'
+
+import type { DocumentPreferences } from 'payload/types'
+
+import { Collapsible } from '../../../../elements/Collapsible'
+import { ErrorPill } from '../../../../elements/ErrorPill'
+import { useDocumentInfo } from '../../../../providers/DocumentInfo'
+import { usePreferences } from '../../../../providers/Preferences'
+import { useTranslation } from '../../../..'
+
+export const CollapsibleInput: React.FC<{
+  initCollapsed?: boolean
+  children: React.ReactNode
+  path: string
+  baseClass: string
+  RowLabel?: React.ReactNode
+  fieldPreferencesKey?: string
+}> = (props) => {
+  const { initCollapsed, children, path, baseClass, RowLabel, fieldPreferencesKey } = props
+
+  const { getPreference, setPreference } = usePreferences()
+  const { preferencesKey } = useDocumentInfo()
+  const [collapsedOnMount, setCollapsedOnMount] = useState<boolean>()
+  const [errorCount, setErrorCount] = useState(0)
+  const { i18n } = useTranslation()
+
+  const onToggle = useCallback(
+    async (newCollapsedState: boolean) => {
+      const existingPreferences: DocumentPreferences = await getPreference(preferencesKey)
+
+      setPreference(preferencesKey, {
+        ...existingPreferences,
+        ...(path
+          ? {
+              fields: {
+                ...(existingPreferences?.fields || {}),
+                [path]: {
+                  ...existingPreferences?.fields?.[path],
+                  collapsed: newCollapsedState,
+                },
+              },
+            }
+          : {
+              fields: {
+                ...(existingPreferences?.fields || {}),
+                [fieldPreferencesKey]: {
+                  ...existingPreferences?.fields?.[fieldPreferencesKey],
+                  collapsed: newCollapsedState,
+                },
+              },
+            }),
+      })
+    },
+    [preferencesKey, fieldPreferencesKey, getPreference, setPreference, path],
+  )
+
+  useEffect(() => {
+    const fetchInitialState = async () => {
+      const preferences = await getPreference(preferencesKey)
+      if (preferences) {
+        const initCollapsedFromPref = path
+          ? preferences?.fields?.[path]?.collapsed
+          : preferences?.fields?.[fieldPreferencesKey]?.collapsed
+        setCollapsedOnMount(Boolean(initCollapsedFromPref))
+      } else {
+        setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
+      }
+    }
+
+    fetchInitialState()
+  }, [getPreference, preferencesKey, fieldPreferencesKey, initCollapsed, path])
+
+  if (typeof collapsedOnMount !== 'boolean') return null
+
+  return (
+    <Collapsible
+      className={`${baseClass}__collapsible`}
+      collapsibleStyle={errorCount > 0 ? 'error' : 'default'}
+      header={
+        <div className={`${baseClass}__row-label-wrap`}>
+          {RowLabel}
+          {errorCount > 0 && <ErrorPill count={errorCount} withMessage i18n={i18n} />}
+        </div>
+      }
+      initCollapsed={collapsedOnMount}
+      onToggle={onToggle}
+    >
+      {children}
+    </Collapsible>
+  )
+}

--- a/packages/ui/src/forms/field-types/Collapsible/Input/index.tsx
+++ b/packages/ui/src/forms/field-types/Collapsible/Input/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { Fragment, useCallback, useEffect, useState } from 'react'
 
 import type { DocumentPreferences } from 'payload/types'
 
@@ -8,6 +8,7 @@ import { ErrorPill } from '../../../../elements/ErrorPill'
 import { useDocumentInfo } from '../../../../providers/DocumentInfo'
 import { usePreferences } from '../../../../providers/Preferences'
 import { useTranslation } from '../../../..'
+import { WatchChildErrors } from '../../../WatchChildErrors'
 
 export const CollapsibleInput: React.FC<{
   initCollapsed?: boolean
@@ -16,8 +17,10 @@ export const CollapsibleInput: React.FC<{
   baseClass: string
   RowLabel?: React.ReactNode
   fieldPreferencesKey?: string
+  pathSegments?: string[]
 }> = (props) => {
-  const { initCollapsed, children, path, baseClass, RowLabel, fieldPreferencesKey } = props
+  const { initCollapsed, children, path, baseClass, RowLabel, fieldPreferencesKey, pathSegments } =
+    props
 
   const { getPreference, setPreference } = usePreferences()
   const { preferencesKey } = useDocumentInfo()
@@ -74,19 +77,22 @@ export const CollapsibleInput: React.FC<{
   if (typeof collapsedOnMount !== 'boolean') return null
 
   return (
-    <Collapsible
-      className={`${baseClass}__collapsible`}
-      collapsibleStyle={errorCount > 0 ? 'error' : 'default'}
-      header={
-        <div className={`${baseClass}__row-label-wrap`}>
-          {RowLabel}
-          {errorCount > 0 && <ErrorPill count={errorCount} withMessage i18n={i18n} />}
-        </div>
-      }
-      initCollapsed={collapsedOnMount}
-      onToggle={onToggle}
-    >
-      {children}
-    </Collapsible>
+    <Fragment>
+      <WatchChildErrors pathSegments={pathSegments} setErrorCount={setErrorCount} />
+      <Collapsible
+        className={`${baseClass}__collapsible`}
+        collapsibleStyle={errorCount > 0 ? 'error' : 'default'}
+        header={
+          <div className={`${baseClass}__row-label-wrap`}>
+            {RowLabel}
+            {errorCount > 0 && <ErrorPill count={errorCount} withMessage i18n={i18n} />}
+          </div>
+        }
+        initCollapsed={collapsedOnMount}
+        onToggle={onToggle}
+      >
+        {children}
+      </Collapsible>
+    </Fragment>
   )
 }

--- a/packages/ui/src/forms/field-types/Collapsible/Wrapper/index.tsx
+++ b/packages/ui/src/forms/field-types/Collapsible/Wrapper/index.tsx
@@ -1,0 +1,36 @@
+'use client'
+import React from 'react'
+
+import { fieldBaseClass } from '../../shared'
+import { useFormFields } from '../../../Form/context'
+
+const baseClass = 'collapsible-field'
+
+export const CollapsibleFieldWrapper: React.FC<{
+  className?: string
+  path: string
+  children: React.ReactNode
+  id?: string
+}> = (props) => {
+  const { children, className, path, id } = props
+
+  const field = useFormFields(([fields]) => fields[path])
+
+  const { valid } = field || {}
+
+  return (
+    <div
+      className={[
+        fieldBaseClass,
+        baseClass,
+        className,
+        !valid ? `${baseClass}--has-error` : `${baseClass}--has-no-error`,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      id={id}
+    >
+      {children}
+    </div>
+  )
+}

--- a/packages/ui/src/forms/field-types/Collapsible/index.tsx
+++ b/packages/ui/src/forms/field-types/Collapsible/index.tsx
@@ -1,20 +1,15 @@
-'use client'
-import React, { useCallback, useEffect, useState } from 'react'
+import React from 'react'
 
-import type { DocumentPreferences } from 'payload/types'
 import type { Props } from './types'
 
-import { Collapsible } from '../../../elements/Collapsible'
-import { ErrorPill } from '../../../elements/ErrorPill'
-import { useDocumentInfo } from '../../../providers/DocumentInfo'
-import { usePreferences } from '../../../providers/Preferences'
 import FieldDescription from '../../FieldDescription'
-import { useFormSubmitted } from '../../Form/context'
 import { createNestedFieldPath } from '../../Form/createNestedFieldPath'
 import RenderFields from '../../RenderFields'
+import { CollapsibleFieldWrapper } from './Wrapper'
+import { CollapsibleInput } from './Input'
+import { getNestedFieldState } from '../../WatchChildErrors/getNestedFieldState'
 import { RowLabel } from '../../RowLabel'
-import { WatchChildErrors } from '../../WatchChildErrors'
-import { fieldBaseClass } from '../shared'
+
 import './index.scss'
 
 const baseClass = 'collapsible-field'
@@ -28,92 +23,35 @@ const CollapsibleField: React.FC<Props> = (props) => {
     label,
     path,
     permissions,
+    i18n,
+    config,
+    payload,
+    user,
+    formState,
   } = props
 
-  const { getPreference, setPreference } = usePreferences()
-  const { preferencesKey } = useDocumentInfo()
-  const [collapsedOnMount, setCollapsedOnMount] = useState<boolean>()
+  const { fieldState: nestedFieldState } = getNestedFieldState({
+    formState,
+    path,
+    fieldSchema: fields,
+  })
+
   const fieldPreferencesKey = `collapsible-${indexPath.replace(/\./g, '__')}`
-  const [errorCount, setErrorCount] = useState(0)
-  const submitted = useFormSubmitted()
-
-  const onToggle = useCallback(
-    async (newCollapsedState: boolean) => {
-      const existingPreferences: DocumentPreferences = await getPreference(preferencesKey)
-
-      setPreference(preferencesKey, {
-        ...existingPreferences,
-        ...(path
-          ? {
-              fields: {
-                ...(existingPreferences?.fields || {}),
-                [path]: {
-                  ...existingPreferences?.fields?.[path],
-                  collapsed: newCollapsedState,
-                },
-              },
-            }
-          : {
-              fields: {
-                ...(existingPreferences?.fields || {}),
-                [fieldPreferencesKey]: {
-                  ...existingPreferences?.fields?.[fieldPreferencesKey],
-                  collapsed: newCollapsedState,
-                },
-              },
-            }),
-      })
-    },
-    [preferencesKey, fieldPreferencesKey, getPreference, setPreference, path],
-  )
-
-  useEffect(() => {
-    const fetchInitialState = async () => {
-      const preferences = await getPreference(preferencesKey)
-      if (preferences) {
-        const initCollapsedFromPref = path
-          ? preferences?.fields?.[path]?.collapsed
-          : preferences?.fields?.[fieldPreferencesKey]?.collapsed
-        setCollapsedOnMount(Boolean(initCollapsedFromPref))
-      } else {
-        setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
-      }
-    }
-
-    fetchInitialState()
-  }, [getPreference, preferencesKey, fieldPreferencesKey, initCollapsed, path])
-
-  if (typeof collapsedOnMount !== 'boolean') return null
-
-  const fieldHasErrors = submitted && errorCount > 0
 
   return (
-    <div
-      className={[
-        fieldBaseClass,
-        baseClass,
-        className,
-        fieldHasErrors ? `${baseClass}--has-error` : `${baseClass}--has-no-error`,
-      ]
-        .filter(Boolean)
-        .join(' ')}
+    <CollapsibleFieldWrapper
+      className={className}
+      path={path}
       id={`field-${fieldPreferencesKey}${path ? `-${path.replace(/\./g, '__')}` : ''}`}
     >
-      <WatchChildErrors fieldSchema={fields} path={path} setErrorCount={setErrorCount} />
-      <Collapsible
-        className={`${baseClass}__collapsible`}
-        collapsibleStyle={errorCount > 0 ? 'error' : 'default'}
-        header={
-          <div className={`${baseClass}__row-label-wrap`}>
-            <RowLabel label={label} path={path} />
-            {errorCount > 0 && <ErrorPill count={errorCount} withMessage />}
-          </div>
-        }
-        initCollapsed={collapsedOnMount}
-        onToggle={onToggle}
+      <CollapsibleInput
+        initCollapsed={initCollapsed}
+        baseClass={baseClass}
+        RowLabel={<RowLabel data={formState} label={label} path={path} i18n={i18n} />}
+        path={path}
+        fieldPreferencesKey={fieldPreferencesKey}
       >
-        [RenderFields]
-        {/* <RenderFields
+        <RenderFields
           fieldSchema={fields.map((field) => ({
             ...field,
             path: createNestedFieldPath(path, field),
@@ -124,10 +62,15 @@ const CollapsibleField: React.FC<Props> = (props) => {
           margins="small"
           permissions={permissions}
           readOnly={readOnly}
-        /> */}
-      </Collapsible>
-      <FieldDescription description={description} path={path} />
-    </div>
+          i18n={i18n}
+          config={config}
+          payload={payload}
+          formState={nestedFieldState}
+          user={user}
+        />
+      </CollapsibleInput>
+      <FieldDescription description={description} path={path} i18n={i18n} />
+    </CollapsibleFieldWrapper>
   )
 }
 

--- a/packages/ui/src/forms/field-types/Collapsible/index.tsx
+++ b/packages/ui/src/forms/field-types/Collapsible/index.tsx
@@ -30,7 +30,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
     formState,
   } = props
 
-  const { fieldState: nestedFieldState } = getNestedFieldState({
+  const { fieldState: nestedFieldState, pathSegments } = getNestedFieldState({
     formState,
     path,
     fieldSchema: fields,
@@ -50,6 +50,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
         RowLabel={<RowLabel data={formState} label={label} path={path} i18n={i18n} />}
         path={path}
         fieldPreferencesKey={fieldPreferencesKey}
+        pathSegments={pathSegments}
       >
         <RenderFields
           fieldSchema={fields.map((field) => ({

--- a/packages/ui/src/forms/field-types/Collapsible/index.tsx
+++ b/packages/ui/src/forms/field-types/Collapsible/index.tsx
@@ -16,7 +16,7 @@ const baseClass = 'collapsible-field'
 
 const CollapsibleField: React.FC<Props> = (props) => {
   const {
-    admin: { className, description, initCollapsed, readOnly },
+    admin: { className, description, initCollapsed: initCollapsedFromProps, readOnly },
     fieldTypes,
     fields,
     indexPath,
@@ -28,6 +28,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
     payload,
     user,
     formState,
+    docPreferences,
   } = props
 
   const { fieldState: nestedFieldState, pathSegments } = getNestedFieldState({
@@ -37,6 +38,12 @@ const CollapsibleField: React.FC<Props> = (props) => {
   })
 
   const fieldPreferencesKey = `collapsible-${indexPath.replace(/\./g, '__')}`
+
+  const initCollapsed = Boolean(
+    docPreferences
+      ? docPreferences?.fields?.[path || fieldPreferencesKey]?.collapsed
+      : initCollapsedFromProps,
+  )
 
   return (
     <CollapsibleFieldWrapper

--- a/packages/ui/src/forms/field-types/Collapsible/types.ts
+++ b/packages/ui/src/forms/field-types/Collapsible/types.ts
@@ -1,10 +1,11 @@
 import type { FieldTypes } from 'payload/config'
 import type { FieldPermissions } from 'payload/auth'
 import type { CollapsibleField } from 'payload/types'
+import { FormFieldBase } from '../shared'
 
-export type Props = Omit<CollapsibleField, 'type'> & {
-  fieldTypes: FieldTypes
-  indexPath: string
-  path?: string
-  permissions: FieldPermissions
-}
+export type Props = FormFieldBase &
+  Omit<CollapsibleField, 'type'> & {
+    fieldTypes: FieldTypes
+    indexPath: string
+    permissions: FieldPermissions
+  }

--- a/packages/ui/src/forms/field-types/Group/Errors/index.tsx
+++ b/packages/ui/src/forms/field-types/Group/Errors/index.tsx
@@ -1,0 +1,21 @@
+'use client'
+import React, { Fragment } from 'react'
+import { ErrorPill, useTranslation } from '../../../..'
+import { WatchChildErrors } from '../../../WatchChildErrors'
+
+export const GroupFieldErrors: React.FC<{
+  pathSegments: string[]
+}> = (props) => {
+  const { pathSegments } = props
+
+  const [errorCount, setErrorCount] = React.useState(0)
+
+  const { i18n } = useTranslation()
+
+  return (
+    <Fragment>
+      <WatchChildErrors pathSegments={pathSegments} setErrorCount={setErrorCount} />{' '}
+      <ErrorPill count={errorCount} i18n={i18n} withMessage />
+    </Fragment>
+  )
+}

--- a/packages/ui/src/forms/field-types/Group/Wrapper/index.tsx
+++ b/packages/ui/src/forms/field-types/Group/Wrapper/index.tsx
@@ -1,15 +1,13 @@
 'use client'
 import React from 'react'
 
-import { useCollapsible } from '../../../elements/Collapsible/provider'
-import { useFormSubmitted } from '../../Form/context'
-import { useRow } from '../Row/provider'
-import { useTabs } from '../Tabs/provider'
-import { fieldBaseClass } from '../shared'
-import { useGroup } from './provider'
+import { useCollapsible } from '../../../../elements/Collapsible/provider'
+import { useFormSubmitted } from '../../../Form/context'
+import { useRow } from '../../Row/provider'
+import { useTabs } from '../../Tabs/provider'
+import { fieldBaseClass } from '../../shared'
+import { useGroup } from '../provider'
 import { GroupField } from 'payload/types'
-
-import './index.scss'
 
 const baseClass = 'group-field'
 

--- a/packages/ui/src/forms/field-types/Group/index.tsx
+++ b/packages/ui/src/forms/field-types/Group/index.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 
 import type { Props } from './types'
-import { ErrorPill } from '../../../elements/ErrorPill'
 import FieldDescription from '../../FieldDescription'
 import { createNestedFieldPath } from '../../Form/createNestedFieldPath'
 import RenderFields from '../../RenderFields'
-import { getNestedFieldState } from '../../WatchChildErrors/getNestedFieldState'
 import { GroupProvider } from './provider'
 import { GroupWrapper } from './Wrapper'
 import { withCondition } from '../../withCondition'
+import { getNestedFieldState } from '../../WatchChildErrors/getNestedFieldState'
+import { GroupFieldErrors } from './Errors'
+import { buildPathSegments } from '../../WatchChildErrors/buildPathSegments'
 
 import './index.scss'
 
@@ -35,18 +36,18 @@ const Group: React.FC<Props> = (props) => {
 
   const path = pathFromProps || name
 
-  const { fieldState: nestedFieldState, errorCount } = getNestedFieldState({
+  const { fieldState: nestedFieldState } = getNestedFieldState({
     formState,
     path,
     fieldSchema: fields,
   })
 
-  const groupHasErrors = errorCount > 0
-
   const fieldSchema = fields.map((subField) => ({
     ...subField,
     path: createNestedFieldPath(path, subField),
   }))
+
+  const pathSegments = buildPathSegments(path, fieldSchema)
 
   return (
     <GroupWrapper
@@ -77,7 +78,7 @@ const Group: React.FC<Props> = (props) => {
                 />
               </header>
             )}
-            {groupHasErrors && <ErrorPill count={errorCount} withMessage i18n={i18n} />}
+            <GroupFieldErrors pathSegments={pathSegments} />
           </div>
           <RenderFields
             fieldSchema={fieldSchema}

--- a/packages/ui/src/forms/field-types/Tabs/Tab/index.tsx
+++ b/packages/ui/src/forms/field-types/Tabs/Tab/index.tsx
@@ -1,42 +1,30 @@
-import { I18n, getTranslation } from '@payloadcms/translations'
-import { Field, Tab } from 'payload/types'
+'use client'
+import { getTranslation } from '@payloadcms/translations'
+import { NamedTab, Tab } from 'payload/types'
 import React from 'react'
 import { ErrorPill } from '../../../../elements/ErrorPill'
-import { getNestedFieldState } from '../../../WatchChildErrors/getNestedFieldState'
-import { FormState } from '../../../Form/types'
+import { WatchChildErrors } from '../../../WatchChildErrors'
+import { useTranslation } from '../../../..'
+
 import './index.scss'
 
 type TabProps = {
   isActive?: boolean
-  parentPath: string
   setIsActive: () => void
-  tab: Tab
-  i18n: I18n
-  formState: FormState
-  fieldSchema: Field[]
+  pathSegments: string[]
+  path: string
+  label: Tab['label']
+  name: NamedTab['name']
 }
 
 const baseClass = 'tabs-field__tab-button'
 
 export const TabComponent: React.FC<TabProps> = (props) => {
-  const { isActive, parentPath, setIsActive, tab, i18n, formState, fieldSchema } = props
+  const { isActive, setIsActive, pathSegments, name, label } = props
 
-  const isNamedTab = 'name' in tab
+  const { i18n } = useTranslation()
 
-  const pathSegments = []
-
-  if (parentPath) pathSegments.push(parentPath)
-  if (isNamedTab) pathSegments.push(tab.name)
-
-  const path = pathSegments.join('.')
-
-  const nestedFieldState = getNestedFieldState({
-    formState,
-    path,
-    fieldSchema,
-  })
-
-  const errorCount = nestedFieldState.errorCount || 0
+  const [errorCount, setErrorCount] = React.useState(0)
 
   const tabHasErrors = errorCount > 0
 
@@ -52,7 +40,8 @@ export const TabComponent: React.FC<TabProps> = (props) => {
       onClick={setIsActive}
       type="button"
     >
-      {tab.label ? getTranslation(tab.label, i18n) : isNamedTab && tab.name}
+      <WatchChildErrors pathSegments={pathSegments} setErrorCount={setErrorCount} />
+      {label ? getTranslation(label, i18n) : name}
       {tabHasErrors && <ErrorPill i18n={i18n} count={errorCount} />}
     </button>
   )

--- a/packages/ui/src/forms/field-types/Tabs/Wrapper/index.tsx
+++ b/packages/ui/src/forms/field-types/Tabs/Wrapper/index.tsx
@@ -1,8 +1,7 @@
 'use client'
 import React from 'react'
-import { useCollapsible } from '../../../elements/Collapsible/provider'
-import { fieldBaseClass } from '../shared'
-import './index.scss'
+import { useCollapsible } from '../../../../elements/Collapsible/provider'
+import { fieldBaseClass } from '../../shared'
 
 const baseClass = 'tabs-field'
 

--- a/packages/ui/src/forms/field-types/Tabs/index.tsx
+++ b/packages/ui/src/forms/field-types/Tabs/index.tsx
@@ -5,7 +5,6 @@ import type { Props } from './types'
 import FieldDescription from '../../FieldDescription'
 import { createNestedFieldPath } from '../../Form/createNestedFieldPath'
 import RenderFields from '../../RenderFields'
-import './index.scss'
 import { TabsProvider } from './provider'
 import { TabComponent } from './Tab'
 import { Wrapper } from './Wrapper'
@@ -13,6 +12,8 @@ import { getTranslation } from '@payloadcms/translations'
 import { toKebabCase } from 'payload/utilities'
 import { Tab } from 'payload/types'
 import { withCondition } from '../../withCondition'
+
+import './index.scss'
 
 const baseClass = 'tabs-field'
 

--- a/packages/ui/src/forms/field-types/Tabs/index.tsx
+++ b/packages/ui/src/forms/field-types/Tabs/index.tsx
@@ -14,6 +14,7 @@ import { Tab } from 'payload/types'
 import { withCondition } from '../../withCondition'
 
 import './index.scss'
+import { buildPathSegments } from '../../WatchChildErrors/buildPathSegments'
 
 const baseClass = 'tabs-field'
 
@@ -94,18 +95,20 @@ const TabsField: React.FC<Props> = async (props) => {
       <TabsProvider>
         <div className={`${baseClass}__tabs-wrap`}>
           <div className={`${baseClass}__tabs`}>
-            {tabs.map((tabConfig, tabIndex) => {
+            {tabs.map((tab, tabIndex) => {
+              const tabPath = [path, 'name' in tab && tab.name].filter(Boolean)?.join('.')
+              const pathSegments = buildPathSegments(tabPath, tab.fields)
+
               return (
                 <TabComponent
+                  path={tabPath}
                   isActive={activeTabIndex === tabIndex}
                   key={tabIndex}
-                  parentPath={path}
                   setIsActive={undefined}
                   // setIsActive={() => handleTabChange(tabIndex)}
-                  tab={tabConfig}
-                  i18n={i18n}
-                  formState={formState}
-                  fieldSchema={getTabFieldSchema({ tabConfig, path })}
+                  pathSegments={pathSegments}
+                  name={'name' in tab && tab.name}
+                  label={tab.label}
                 />
               )
             })}


### PR DESCRIPTION
## Description

Server renders the collapsible field as well as the `RowLabel` component. Functions defined on the field `label` property no longer send current data through as args—it's now initial data. This is because functions are not serializable as props, and so they cannot be sent for client components to execute (client components are subscribed to form state). To render dynamic strings that display current form state, you must now use a custom component and use Payload's React hooks, i.e. `useFormFields`. The same will be true of the field `description` property. It is possible that we can support some type of interpolation in the future, i.e. double curly braces.

This PR also does the following: 
- Properly sanitizes `label` and `description` from the `createClientConfig` function
- Properly subscribes to child errors in the `tabs` and `group` fields

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.