### PR TITLE
fix: remove No Options dropdown from hasMany fields

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Number/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Number/index.tsx
@@ -151,7 +151,7 @@ const NumberField: React.FC<Props> = (props) => {
             if (isOverHasMany) {
               return t('validation:limitReached', { max: maxRows, value: value.length + 1 })
             }
-            return t('general:noOptions')
+            return null
           }}
           numberOnly
           onChange={handleHasManyChange}
@@ -170,7 +170,7 @@ const NumberField: React.FC<Props> = (props) => {
             onChange={handleChange}
             onWheel={(e) => {
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
+              // @ts-expect-error
               e.target.blur()
             }}
             placeholder={getTranslation(placeholder, i18n)}

--- a/packages/payload/src/admin/components/forms/field-types/Text/Input.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Text/Input.tsx
@@ -110,7 +110,7 @@ const TextInput: React.FC<TextInputProps> = (props) => {
               if (isOverHasMany) {
                 return t('validation:limitReached', { max: maxRows, value: value.length + 1 })
               }
-              return t('general:noOptions')
+              return null
             }}
             onChange={onChange}
             options={[]}


### PR DESCRIPTION
## Description

When entering new values into field type 'text' or 'number' when you first focus the field the dropdown shows "No Options"
![image](https://github.com/payloadcms/payload/assets/6434612/5a8d5fdb-edc2-41af-adfa-4a92bfb5c532)

This PR removes the missleading message:
![image](https://github.com/payloadcms/payload/assets/6434612/4d1c0c26-9e27-4fd8-9075-358cc21da529)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
