### PR TITLE
fix: afterLogin hook write conflicts

### DIFF
--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -115,6 +115,8 @@ async function login<TSlug extends keyof GeneratedTypes['collections']>(
         })
       }
 
+      if (shouldCommit) await commitTransaction(req)
+
       throw new AuthenticationError(req.t)
     }
 

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -18,8 +18,8 @@ import sanitizeInternalFields from '../../utilities/sanitizeInternalFields'
 import isLocked from '../isLocked'
 import { authenticateLocalStrategy } from '../strategies/local/authenticate'
 import { incrementLoginAttempts } from '../strategies/local/incrementLoginAttempts'
+import { resetLoginAttempts } from '../strategies/local/resetLoginAttempts'
 import { getFieldsToSign } from './getFieldsToSign'
-import unlock from './unlock'
 
 export type Result = {
   exp?: number
@@ -119,12 +119,10 @@ async function login<TSlug extends keyof GeneratedTypes['collections']>(
     }
 
     if (maxLoginAttemptsEnabled) {
-      await unlock({
-        collection: {
-          config: collectionConfig,
-        },
-        data,
-        overrideAccess: true,
+      await resetLoginAttempts({
+        collection: collectionConfig,
+        doc: user,
+        payload: req.payload,
         req,
       })
     }

--- a/packages/payload/src/auth/strategies/local/incrementLoginAttempts.ts
+++ b/packages/payload/src/auth/strategies/local/incrementLoginAttempts.ts
@@ -52,5 +52,6 @@ export const incrementLoginAttempts = async ({
     id: doc.id,
     collection: collection.slug,
     data,
+    req,
   })
 }

--- a/packages/payload/src/auth/strategies/local/resetLoginAttempts.ts
+++ b/packages/payload/src/auth/strategies/local/resetLoginAttempts.ts
@@ -15,6 +15,7 @@ export const resetLoginAttempts = async ({
   payload,
   req,
 }: Args): Promise<void> => {
+  if (!('lockUntil' in doc && typeof doc.lockUntil === 'string') || doc.loginAttempts === 0) return
   await payload.update({
     id: doc.id,
     collection: collection.slug,
@@ -22,6 +23,7 @@ export const resetLoginAttempts = async ({
       lockUntil: null,
       loginAttempts: 0,
     },
+    overrideAccess: true,
     req,
   })
 }

--- a/test/admin/collections/Users.ts
+++ b/test/admin/collections/Users.ts
@@ -4,10 +4,10 @@ import { usersCollectionSlug } from '../slugs'
 
 export const Users: CollectionConfig = {
   slug: usersCollectionSlug,
-  auth: true,
   admin: {
     useAsTitle: 'email',
   },
+  auth: true,
   fields: [
     {
       name: 'textField',

--- a/test/hooks/collections/Users/afterLoginHook.ts
+++ b/test/hooks/collections/Users/afterLoginHook.ts
@@ -1,7 +1,7 @@
 import type { AfterLoginHook } from '../../../../packages/payload/src/collections/config/types'
 
 export const afterLoginHook: AfterLoginHook = async ({ req, user }) => {
-  await req.payload.update({
+  return req.payload.update({
     id: user.id,
     collection: 'hooks-users',
     data: {

--- a/test/hooks/collections/Users/afterLoginHook.ts
+++ b/test/hooks/collections/Users/afterLoginHook.ts
@@ -1,0 +1,12 @@
+import type { AfterLoginHook } from '../../../../packages/payload/src/collections/config/types'
+
+export const afterLoginHook: AfterLoginHook = async ({ req, user }) => {
+  await req.payload.update({
+    id: user.id,
+    collection: 'hooks-users',
+    data: {
+      afterLoginHook: true,
+    },
+    req,
+  })
+}

--- a/test/hooks/collections/Users/index.ts
+++ b/test/hooks/collections/Users/index.ts
@@ -6,8 +6,9 @@ import type { Payload } from '../../../../packages/payload/src/payload'
 
 import { AuthenticationError } from '../../../../packages/payload/src/errors'
 import { devUser, regularUser } from '../../../credentials'
+import { afterLoginHook } from './afterLoginHook'
 
-const beforeLoginHook: BeforeLoginHook = ({ user, req }) => {
+const beforeLoginHook: BeforeLoginHook = ({ req, user }) => {
   const isAdmin = user.roles.includes('admin') ? user : undefined
   if (!isAdmin) {
     throw new AuthenticationError(req.t)
@@ -33,16 +34,21 @@ const Users: CollectionConfig = {
   fields: [
     {
       name: 'roles',
-      label: 'Role',
       type: 'select',
-      options: ['admin', 'user'],
       defaultValue: 'user',
+      hasMany: true,
+      label: 'Role',
+      options: ['admin', 'user'],
       required: true,
       saveToJWT: true,
-      hasMany: true,
+    },
+    {
+      name: 'afterLoginHook',
+      type: 'checkbox',
     },
   ],
   hooks: {
+    afterLogin: [afterLoginHook],
     beforeLogin: [beforeLoginHook],
   },
 }


### PR DESCRIPTION
## Description

1. Improves unlock login in login to reduce the db calls.
2. Passes `req` correctly so that hooks can use the same transaction and modify the user without having write conflicts.

Related discussion: https://github.com/payloadcms/payload/issues/4583#issuecomment-1903908271

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
