### PR TITLE
fix(plugin-cloud-storage): slow get file performance for large collections

### DIFF
--- a/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
@@ -10,6 +10,9 @@ export async function getFilePrefix({
   const imageSizes = (collection?.upload as IncomingUploadType)?.imageSizes || []
   const files = await req.payload.find({
     collection: collection.slug,
+    depth: 0,
+    limit: 1,
+    pagination: false,
     where: {
       or: [
         {


### PR DESCRIPTION
## Description

fixes #4651 

Any time a file is requested the static handler calls getFilePrefix which uses `payload.find()`. This change optimizes the find request by limiting it to 1 doc with depth 0 and disables pagination.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
