### PR TITLE
chore: make default views callable

### DIFF
--- a/packages/payload/src/admin/components/elements/DocumentHeader/Tabs/getCustomViews.ts
+++ b/packages/payload/src/admin/components/elements/DocumentHeader/Tabs/getCustomViews.ts
@@ -20,7 +20,7 @@ export const getCustomViews = (args: {
         ? collection?.admin?.components?.views?.Edit
         : undefined
 
-    const defaultViewKeys = Object.keys(defaultCollectionViews)
+    const defaultViewKeys = Object.keys(defaultCollectionViews())
 
     customViews = Object.entries(collectionViewsConfig || {}).reduce((prev, [key, view]) => {
       if (defaultViewKeys.includes(key)) {
@@ -38,7 +38,7 @@ export const getCustomViews = (args: {
         ? global?.admin?.components?.views?.Edit
         : undefined
 
-    const defaultViewKeys = Object.keys(defaultGlobalViews)
+    const defaultViewKeys = Object.keys(defaultGlobalViews())
 
     customViews = Object.entries(globalViewsConfig || {}).reduce((prev, [key, view]) => {
       if (defaultViewKeys.includes(key)) {

--- a/packages/payload/src/admin/components/views/Global/Routes/CustomComponent.tsx
+++ b/packages/payload/src/admin/components/views/Global/Routes/CustomComponent.tsx
@@ -17,9 +17,9 @@ export type globalViewType =
   | 'Version'
   | 'Versions'
 
-export const defaultGlobalViews: {
+export const defaultGlobalViews = (): {
   [key in globalViewType]: React.ComponentType<any>
-} = {
+} => ({
   API,
   Default: DefaultGlobalEdit,
   LivePreview: LivePreviewView,
@@ -27,7 +27,7 @@ export const defaultGlobalViews: {
   Relationships: null,
   Version: VersionView,
   Versions: VersionsView,
-}
+})
 
 export const CustomGlobalComponent = (
   args: GlobalEditViewProps & {
@@ -43,18 +43,14 @@ export const CustomGlobalComponent = (
   // For example, the Edit view:
   // 1. Edit?.Default
   // 2. Edit?.Default?.Component
-  // TODO: Remove the `@ts-ignore` when a Typescript wizard arrives
-  // For some reason `Component` does not exist on type `Edit[view]` no matter how narrow the type is
   const Component =
     typeof Edit === 'object' && typeof Edit[view] === 'function'
       ? Edit[view]
       : typeof Edit === 'object' &&
         typeof Edit?.[view] === 'object' &&
-        // @ts-ignore
         typeof Edit[view].Component === 'function'
-      ? // @ts-ignore
-        Edit[view].Component
-      : defaultGlobalViews[view]
+      ? Edit[view].Component
+      : defaultGlobalViews()[view]
 
   if (Component) {
     return <Component {...args} />

--- a/packages/payload/src/admin/components/views/collections/Edit/Routes/CustomComponent.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Routes/CustomComponent.tsx
@@ -17,9 +17,9 @@ export type collectionViewType =
   | 'Version'
   | 'Versions'
 
-export const defaultCollectionViews: {
+export const defaultCollectionViews = (): {
   [key in collectionViewType]: React.ComponentType<any>
-} = {
+} => ({
   API,
   Default: DefaultCollectionEdit,
   LivePreview: LivePreviewView,
@@ -27,7 +27,7 @@ export const defaultCollectionViews: {
   Relationships: null,
   Version: VersionView,
   Versions: VersionsView,
-}
+})
 
 export const CustomCollectionComponent = (
   args: CollectionEditViewProps & {
@@ -43,18 +43,15 @@ export const CustomCollectionComponent = (
   // For example, the Edit view:
   // 1. Edit?.Default
   // 2. Edit?.Default?.Component
-  // TODO: Remove the `@ts-ignore` when a Typescript wizard arrives
-  // For some reason `Component` does not exist on type `Edit[view]` no matter how narrow the type is
+
   const Component =
     typeof Edit === 'object' && typeof Edit[view] === 'function'
       ? Edit[view]
       : typeof Edit === 'object' &&
         typeof Edit?.[view] === 'object' &&
-        // @ts-ignore
         typeof Edit[view].Component === 'function'
-      ? // @ts-ignore
-        Edit[view].Component
-      : defaultCollectionViews[view]
+      ? Edit[view].Component
+      : defaultCollectionViews()[view]
 
   if (Component) {
     return <Component {...args} />


### PR DESCRIPTION
## Description

In some cases you may want to wrap an Edit view tab section (default, version, live preview). If you attempt to re-use the built in tab like so:

```tsx
import React from 'react'

import type { FieldTypes } from 'payload/dist/admin/components/forms/field-types'
import type { CollectionEditViewProps } from 'payload/dist/admin/components/views/types'
import { DefaultCollectionEdit } from 'payload/dist/admin/components/views/collections/Edit/Default/index'

export const EditWrapper: React.FC<
  CollectionEditViewProps & {
    fieldTypes: FieldTypes
  }
> = (props) => {
  return (
    <React.Fragment>
      {/* custom code here */}
      <DefaultCollectionEdit {...props} />
    </React.Fragment>
  )
}
```

The following error would be thrown and the admin panel would not load.

```
ReferenceError: Cannot access 'DefaultCollectionEdit' before initialization
```

This changes initializes the views by calling a function to return them instead of the static definition which is the root cause of this error.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
