### PR TITLE
chore(next): ssr array field

### DIFF
--- a/packages/dev/src/collections/Pages/index.ts
+++ b/packages/dev/src/collections/Pages/index.ts
@@ -48,6 +48,7 @@ export const Pages: CollectionConfig = {
       label: 'Title',
       type: 'text',
       required: true,
+      defaultValue: 'This is a default value',
       admin: {
         description: 'This is a description',
       },
@@ -89,19 +90,24 @@ export const Pages: CollectionConfig = {
       label: 'Number',
       type: 'number',
       required: true,
+      defaultValue: 4,
+      admin: {
+        description: 'Defaults to 4',
+      },
     },
     {
       name: 'select',
       label: 'Select',
       type: 'select',
       required: true,
+      defaultValue: 'option-2',
       options: [
         {
           label: 'Option 1',
           value: 'option-1',
         },
         {
-          label: 'Option 2',
+          label: 'Option 2 (This is a default value)',
           value: 'option-2',
         },
       ],
@@ -111,6 +117,7 @@ export const Pages: CollectionConfig = {
       name: 'textarea',
       label: 'Textarea',
       required: true,
+      defaultValue: 'This is a default value',
       admin: {
         rows: 10,
       },
@@ -185,23 +192,25 @@ export const Pages: CollectionConfig = {
           label: 'Group Text',
           type: 'text',
           required: true,
+          defaultValue: 'This is a default value',
         },
       ],
     },
-    // {
-    //   name: 'array',
-    //   label: 'Array',
-    //   type: 'array',
-    //   required: true,
-    //   fields: [
-    //     {
-    //       name: 'arrayText',
-    //       label: 'Array Text',
-    //       type: 'text',
-    //       required: true,
-    //     },
-    //   ],
-    // },
+    {
+      name: 'array',
+      label: 'Array',
+      type: 'array',
+      required: true,
+      fields: [
+        {
+          name: 'arrayText',
+          label: 'Array Text',
+          type: 'text',
+          required: true,
+          defaultValue: 'This is a default value',
+        },
+      ],
+    },
     {
       label: 'Tabs',
       type: 'tabs',

--- a/packages/next/src/pages/Account/index.tsx
+++ b/packages/next/src/pages/Account/index.tsx
@@ -75,7 +75,6 @@ export const Account = async ({
 
     const formState = await buildStateFromSchema({
       id: user?.id,
-      config,
       data: data || {},
       fieldSchema,
       locale: locale.code,

--- a/packages/next/src/pages/CreateFirstUser/index.tsx
+++ b/packages/next/src/pages/CreateFirstUser/index.tsx
@@ -90,7 +90,6 @@ export const CreateFirstUser: React.FC<{
   ] as Field[]
 
   const formState = await buildStateFromSchema({
-    config,
     fieldSchema: fields,
     locale: locale.code,
     operation: 'create',

--- a/packages/next/src/pages/Document/index.tsx
+++ b/packages/next/src/pages/Document/index.tsx
@@ -152,7 +152,6 @@ export const Document = async ({
 
   const formState = await buildStateFromSchema({
     id,
-    config,
     data: data || {},
     fieldSchema: formatFields(fields, isEditing),
     locale: locale.code,

--- a/packages/ui/src/elements/DocumentFields/index.tsx
+++ b/packages/ui/src/elements/DocumentFields/index.tsx
@@ -2,15 +2,14 @@
 import React from 'react'
 
 import type { CollectionPermission, GlobalPermission, User } from 'payload/auth'
-import type { Description, DocumentPreferences, Payload, SanitizedConfig } from 'payload/types'
+import type { Description, DocumentPreferences } from 'payload/types'
 import type { Locale } from 'payload/config'
 
 import RenderFields from '../../forms/RenderFields'
 import { Gutter } from '../Gutter'
 import { Document } from 'payload/types'
-import { FormState } from '../../forms/Form/types'
 import { useTranslation } from '../../providers/Translation'
-import { createFieldMap } from '../../forms/RenderFields/createFieldMap'
+import { buildFieldMap } from '../../forms/RenderFields/buildFieldMap'
 
 import './index.scss'
 
@@ -25,10 +24,9 @@ export const DocumentFields: React.FC<{
   docPermissions: CollectionPermission | GlobalPermission
   docPreferences: DocumentPreferences
   data: Document
-  formState: FormState
   user: User
   locale?: Locale
-  fieldMap?: ReturnType<typeof createFieldMap>
+  fieldMap?: ReturnType<typeof buildFieldMap>
 }> = (props) => {
   const {
     AfterFields,
@@ -39,7 +37,6 @@ export const DocumentFields: React.FC<{
     docPermissions,
     docPreferences,
     data,
-    formState,
     user,
     locale,
     fieldMap,

--- a/packages/ui/src/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
@@ -12,7 +12,6 @@ import { getDefaultValue } from 'payload/utilities'
 import { iterateFields } from './iterateFields'
 
 type Args = {
-  config: SanitizedConfig
   data: Data
   field: NonPresentationalField
   fullData: Data
@@ -31,7 +30,7 @@ type Args = {
 
 export const addFieldStatePromise = async ({
   id,
-  config,
+
   data,
   field,
   fullData,
@@ -71,7 +70,6 @@ export const addFieldStatePromise = async ({
       validationResult = await validate(data?.[field.name], {
         ...field,
         id,
-        config,
         data: fullData,
         operation,
         siblingData: data,
@@ -104,7 +102,6 @@ export const addFieldStatePromise = async ({
             acc.promises.push(
               iterateFields({
                 id,
-                config,
                 data: row,
                 fields: field.fields,
                 fullData,
@@ -193,7 +190,6 @@ export const addFieldStatePromise = async ({
               acc.promises.push(
                 iterateFields({
                   id,
-                  config,
                   data: row,
                   fields: block.fields,
                   fullData,
@@ -255,7 +251,6 @@ export const addFieldStatePromise = async ({
       case 'group': {
         await iterateFields({
           id,
-          config,
           data: data?.[field.name] || {},
           fields: field.fields,
           fullData,
@@ -355,7 +350,6 @@ export const addFieldStatePromise = async ({
     // Handle field types that do not use names (row, etc)
     await iterateFields({
       id,
-      config,
       data,
       fields: field.fields,
       fullData,
@@ -372,7 +366,6 @@ export const addFieldStatePromise = async ({
     const promises = field.tabs.map((tab) =>
       iterateFields({
         id,
-        config,
         data: tabHasName(tab) ? data?.[tab.name] : data,
         fields: tab.fields,
         fullData,

--- a/packages/ui/src/forms/Form/buildStateFromSchema/index.ts
+++ b/packages/ui/src/forms/Form/buildStateFromSchema/index.ts
@@ -1,14 +1,13 @@
 import type { TFunction } from '@payloadcms/translations'
 
 import type { User } from 'payload/auth'
-import type { Field as FieldSchema, Data, SanitizedConfig } from 'payload/types'
+import type { Field as FieldSchema, Data } from 'payload/types'
 import type { FormState } from '../types'
 
 import { iterateFields } from './iterateFields'
 import { Locale } from 'payload/config'
 
 type Args = {
-  config: SanitizedConfig
   data?: Data
   fieldSchema: FieldSchema[] | undefined
   id?: number | string
@@ -23,24 +22,13 @@ type Args = {
 }
 
 const buildStateFromSchema = async (args: Args): Promise<FormState> => {
-  const {
-    id,
-    config,
-    data: fullData = {},
-    fieldSchema,
-    locale,
-    operation,
-    preferences,
-    t,
-    user,
-  } = args
+  const { id, data: fullData = {}, fieldSchema, locale, operation, preferences, t, user } = args
 
   if (fieldSchema) {
     const state: FormState = {}
 
     await iterateFields({
       id,
-      config,
       data: fullData,
       fields: fieldSchema,
       fullData,

--- a/packages/ui/src/forms/Form/buildStateFromSchema/iterateFields.ts
+++ b/packages/ui/src/forms/Form/buildStateFromSchema/iterateFields.ts
@@ -7,7 +7,6 @@ import { fieldIsPresentationalOnly } from 'payload/types'
 import { addFieldStatePromise } from './addFieldStatePromise'
 
 type Args = {
-  config: SanitizedConfig
   data: Data
   fields: FieldSchema[]
   fullData: Data
@@ -26,7 +25,6 @@ type Args = {
 
 export const iterateFields = async ({
   id,
-  config,
   data,
   fields,
   fullData,
@@ -54,7 +52,6 @@ export const iterateFields = async ({
       promises.push(
         addFieldStatePromise({
           id,
-          config,
           data,
           field,
           fullData,

--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -94,12 +94,15 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
     }
 
     case 'ADD_ROW': {
-      const { blockType, path, rowIndex: rowIndexFromArgs, subFieldState } = action
+      const { blockType, path, rowIndex: rowIndexFromArgs } = action
+      const subFieldState: FormState = {}
+
       const rowIndex =
         typeof rowIndexFromArgs === 'number' ? rowIndexFromArgs : state[path]?.rows?.length || 0
 
-      const rowsMetadata = [...(state[path]?.rows || [])]
-      rowsMetadata.splice(
+      const withNewRow = [...(state[path]?.rows || [])]
+
+      withNewRow.splice(
         rowIndex,
         0,
         // new row
@@ -129,7 +132,7 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
         [path]: {
           ...state[path],
           disableFormData: true,
-          rows: rowsMetadata,
+          rows: withNewRow,
           value: siblingRows.length,
         },
       }
@@ -138,7 +141,9 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
     }
 
     case 'REPLACE_ROW': {
-      const { blockType, path, rowIndex: rowIndexArg, subFieldState } = action
+      const { blockType, path, rowIndex: rowIndexArg } = action
+      const subFieldState: FormState = {}
+
       const { remainingFields, rows: siblingRows } = separateRows(path, state)
       const rowIndex = Math.max(0, Math.min(rowIndexArg, siblingRows?.length - 1 || 0))
 

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -119,7 +119,6 @@ export type ADD_ROW = {
   blockType?: string
   path: string
   rowIndex?: number
-  subFieldState?: FormState
   type: 'ADD_ROW'
 }
 
@@ -127,7 +126,6 @@ export type REPLACE_ROW = {
   blockType?: string
   path: string
   rowIndex: number
-  subFieldState?: FormState
   type: 'REPLACE_ROW'
 }
 
@@ -175,18 +173,6 @@ export type FieldAction =
 export type FormFieldsContext = [FormState, Dispatch<FieldAction>]
 
 export type Context = {
-  addFieldRow: ({
-    data,
-    path,
-    rowIndex,
-  }: {
-    data?: Data
-    path: string
-    /*
-     * by default the new row will be added to the end of the list
-     */
-    rowIndex?: number
-  }) => Promise<void>
   buildRowErrors: () => void
   createFormData: CreateFormData
   disabled: boolean
@@ -201,16 +187,6 @@ export type Context = {
   getField: GetField
   getFields: GetFields
   getSiblingData: GetSiblingData
-  removeFieldRow: ({ path, rowIndex }: { path: string; rowIndex: number }) => void
-  replaceFieldRow: ({
-    data,
-    path,
-    rowIndex,
-  }: {
-    data?: Data
-    path: string
-    rowIndex: number
-  }) => Promise<void>
   replaceState: (state: FormState) => void
   reset: Reset
   setModified: SetModified

--- a/packages/ui/src/forms/RenderFields/buildFieldMap.tsx
+++ b/packages/ui/src/forms/RenderFields/buildFieldMap.tsx
@@ -8,6 +8,7 @@ import DefaultDescription from '../FieldDescription'
 import { fieldAffectsData, fieldIsPresentationalOnly } from 'payload/types'
 import { fieldTypes } from '../field-types'
 import { FormFieldBase } from '../field-types/shared'
+import { FormState } from '../../forms/Form/types'
 
 export type ReducedField = {
   type: keyof typeof fieldTypes
@@ -28,7 +29,7 @@ export type ReducedTab = {
   subfields?: ReducedField[]
 }
 
-export const createFieldMap = (args: {
+export const buildFieldMap = (args: {
   fieldSchema: FieldWithPath[]
   filter?: (field: Field) => boolean
   operation?: 'create' | 'update'
@@ -147,12 +148,11 @@ export const createFieldMap = (args: {
             </Fragment>
           )
 
-        // Group, Array, and Collapsible fields have nested fields
         const nestedFieldMap =
           'fields' in field &&
           field.fields &&
           Array.isArray(field.fields) &&
-          createFieldMap({
+          buildFieldMap({
             fieldSchema: field.fields,
             filter,
             operation,
@@ -161,13 +161,13 @@ export const createFieldMap = (args: {
             parentPath: path,
           })
 
-        // Tabs
+        // `tabs` fields require a field map of each of its tab's nested fields
         const tabs =
           'tabs' in field &&
           field.tabs &&
           Array.isArray(field.tabs) &&
           field.tabs.map((tab) => {
-            const tabFieldMap = createFieldMap({
+            const tabFieldMap = buildFieldMap({
               fieldSchema: tab.fields,
               filter,
               operation,

--- a/packages/ui/src/forms/RenderFields/types.ts
+++ b/packages/ui/src/forms/RenderFields/types.ts
@@ -2,14 +2,14 @@ import type { FieldPermissions, User } from 'payload/auth'
 import type { Document, DocumentPreferences, Field } from 'payload/types'
 import { FormState } from '../Form/types'
 import { Locale } from 'payload/config'
-import { createFieldMap } from './createFieldMap'
+import { buildFieldMap } from './buildFieldMap'
 
 export type Props = {
   className?: string
   forceRender?: boolean
   margins?: 'small' | false
   data?: Document
-  fieldMap: ReturnType<typeof createFieldMap>
+  fieldMap: ReturnType<typeof buildFieldMap>
   docPreferences?: DocumentPreferences
   permissions?:
     | {

--- a/packages/ui/src/forms/WatchChildErrors/buildPathSegments.ts
+++ b/packages/ui/src/forms/WatchChildErrors/buildPathSegments.ts
@@ -1,11 +1,11 @@
 import type { TabAsField } from 'payload/types'
 
 import { tabHasName } from 'payload/types'
-import { createFieldMap } from '../RenderFields/createFieldMap'
+import { buildFieldMap } from '../RenderFields/buildFieldMap'
 
 export const buildPathSegments = (
   parentPath: string,
-  fieldMap: ReturnType<typeof createFieldMap>,
+  fieldMap: ReturnType<typeof buildFieldMap>,
 ): string[] => {
   const pathNames = fieldMap.reduce((acc, subField) => {
     if (subField.subfields && subField.isFieldAffectingData) {

--- a/packages/ui/src/forms/WatchChildErrors/index.ts
+++ b/packages/ui/src/forms/WatchChildErrors/index.ts
@@ -5,11 +5,11 @@ import useThrottledEffect from '../../hooks/useThrottledEffect'
 import { useAllFormFields, useFormSubmitted } from '../Form/context'
 import { getFieldStateFromPaths } from './getFieldStateFromPaths'
 import { buildPathSegments } from './buildPathSegments'
-import { createFieldMap } from '../RenderFields/createFieldMap'
+import { buildFieldMap } from '../RenderFields/buildFieldMap'
 
 type TrackSubSchemaErrorCountProps = {
   path: string
-  fieldMap?: ReturnType<typeof createFieldMap>
+  fieldMap?: ReturnType<typeof buildFieldMap>
   setErrorCount: (count: number) => void
 }
 

--- a/packages/ui/src/forms/field-types/Array/ArrayRow.tsx
+++ b/packages/ui/src/forms/field-types/Array/ArrayRow.tsx
@@ -4,36 +4,39 @@ import { useTranslation } from '../../../providers/Translation'
 import type { UseDraggableSortableReturn } from '../../../elements/DraggableSortable/useDraggableSortable/types'
 import type { Row } from '../../Form/types'
 import type { RowLabel as RowLabelType } from 'payload/types'
-import type { Props } from './types'
 
-import { getTranslation } from '@payloadcms/translations'
 import { ArrayAction } from '../../../elements/ArrayAction'
 import { Collapsible } from '../../../elements/Collapsible'
 import { ErrorPill } from '../../../elements/ErrorPill'
 import { useFormSubmitted } from '../../Form/context'
-import { createNestedFieldPath } from '../../Form/createNestedFieldPath'
 import RenderFields from '../../RenderFields'
-import { RowLabel } from '../../RowLabel'
 import HiddenInput from '../HiddenInput'
+import { FieldPathProvider } from '../../FieldPathProvider'
+import { buildFieldMap } from '../../RenderFields/buildFieldMap'
+import { FieldPermissions } from 'payload/auth'
+
 import './index.scss'
 
 const baseClass = 'array-field'
 
-type ArrayRowProps = UseDraggableSortableReturn &
-  Pick<Props, 'indexPath' | 'labels' | 'path' | 'permissions'> & {
-    CustomRowLabel?: RowLabelType
-    addRow: (rowIndex: number) => void
-    duplicateRow: (rowIndex: number) => void
-    forceRender?: boolean
-    hasMaxRows?: boolean
-    moveRow: (fromIndex: number, toIndex: number) => void
-    readOnly?: boolean
-    removeRow: (rowIndex: number) => void
-    row: Row
-    rowCount: number
-    rowIndex: number
-    setCollapse: (rowID: string, collapsed: boolean) => void
-  }
+type ArrayRowProps = UseDraggableSortableReturn & {
+  CustomRowLabel?: RowLabelType
+  addRow: (rowIndex: number) => void
+  duplicateRow: (rowIndex: number) => void
+  forceRender?: boolean
+  hasMaxRows?: boolean
+  moveRow: (fromIndex: number, toIndex: number) => void
+  readOnly?: boolean
+  removeRow: (rowIndex: number) => void
+  row: Row
+  rowCount: number
+  rowIndex: number
+  setCollapse: (rowID: string, collapsed: boolean) => void
+  indexPath: string
+  path: string
+  permissions: FieldPermissions
+  fieldMap: ReturnType<typeof buildFieldMap>
+}
 
 export const ArrayRow: React.FC<ArrayRowProps> = ({
   CustomRowLabel,
@@ -43,7 +46,6 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
   forceRender = false,
   hasMaxRows,
   indexPath,
-  labels,
   listeners,
   moveRow,
   path: parentPath,
@@ -62,10 +64,10 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
   const { i18n } = useTranslation()
   const hasSubmitted = useFormSubmitted()
 
-  const fallbackLabel = `${getTranslation(labels.singular, i18n)} ${String(rowIndex + 1).padStart(
-    2,
-    '0',
-  )}`
+  // const fallbackLabel = `${getTranslation(labels.singular, i18n)} ${String(rowIndex + 1).padStart(
+  //   2,
+  //   '0',
+  // )}`
 
   const childErrorPathsCount = row.childErrorPaths?.size
   const fieldHasErrors = hasSubmitted && childErrorPathsCount > 0
@@ -110,26 +112,28 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
         }}
         header={
           <div className={`${baseClass}__row-header`}>
-            <RowLabel
+            {/* <RowLabel
               label={CustomRowLabel || fallbackLabel}
               path={path}
               rowNumber={rowIndex + 1}
-            />
+            /> */}
             {fieldHasErrors && <ErrorPill count={childErrorPathsCount} withMessage i18n={i18n} />}
           </div>
         }
         onToggle={(collapsed) => setCollapse(row.id, collapsed)}
       >
         <HiddenInput name={`${path}.id`} value={row.id} />
-        <RenderFields
-          className={`${baseClass}__fields`}
-          fieldMap={fieldMap}
-          forceRender={forceRender}
-          indexPath={indexPath}
-          margins="small"
-          permissions={permissions?.fields}
-          readOnly={readOnly}
-        />
+        <FieldPathProvider path={path}>
+          <RenderFields
+            className={`${baseClass}__fields`}
+            fieldMap={fieldMap}
+            forceRender={forceRender}
+            indexPath={indexPath}
+            margins="small"
+            permissions={permissions?.fields}
+            readOnly={readOnly}
+          />
+        </FieldPathProvider>
       </Collapsible>
     </div>
   )

--- a/packages/ui/src/forms/field-types/Array/index.tsx
+++ b/packages/ui/src/forms/field-types/Array/index.tsx
@@ -45,7 +45,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
   const maxRows = 'maxRows' in props ? props.maxRows : undefined
 
   const { setDocFieldPreferences } = useDocumentInfo()
-  const { addFieldRow, dispatchFields, removeFieldRow, setModified } = useForm()
+  const { dispatchFields, setModified } = useForm()
   const submitted = useFormSubmitted()
   const { code: locale } = useLocale()
   const { i18n, t } = useTranslation()
@@ -93,15 +93,20 @@ const ArrayFieldType: React.FC<Props> = (props) => {
   })
 
   const addRow = useCallback(
-    async (rowIndex: number) => {
-      await addFieldRow({ path, rowIndex, fieldMap })
+    (rowIndex: number) => {
+      dispatchFields({
+        path,
+        rowIndex,
+        type: 'ADD_ROW',
+      })
+
       setModified(true)
 
       setTimeout(() => {
         scrollToID(`${path}-row-${rowIndex + 1}`)
       }, 0)
     },
-    [addFieldRow, path, setModified],
+    [dispatchFields, path, setModified],
   )
 
   const duplicateRow = useCallback(
@@ -118,10 +123,10 @@ const ArrayFieldType: React.FC<Props> = (props) => {
 
   const removeRow = useCallback(
     (rowIndex: number) => {
-      removeFieldRow({ path, rowIndex })
+      dispatchFields({ path, rowIndex, type: 'REMOVE_ROW' })
       setModified(true)
     },
-    [removeFieldRow, path, setModified],
+    [dispatchFields, path, setModified],
   )
 
   const moveRow = useCallback(
@@ -214,14 +219,13 @@ const ArrayFieldType: React.FC<Props> = (props) => {
               {(draggableSortableItemProps) => (
                 <ArrayRow
                   {...draggableSortableItemProps}
-                  CustomRowLabel={CustomRowLabel}
+                  // CustomRowLabel={CustomRowLabel}
                   fieldMap={fieldMap}
                   addRow={addRow}
                   duplicateRow={duplicateRow}
                   forceRender={forceRender}
                   hasMaxRows={hasMaxRows}
                   indexPath={indexPath}
-                  labels={labels}
                   moveRow={moveRow}
                   path={path}
                   permissions={permissions}

--- a/packages/ui/src/forms/field-types/Array/types.ts
+++ b/packages/ui/src/forms/field-types/Array/types.ts
@@ -5,7 +5,6 @@ export type Props = FormFieldBase & {
   forceRender?: boolean
   indexPath: string
   label: false | string
-  path?: string
   permissions: FieldPermissions
   name?: string
 }

--- a/packages/ui/src/forms/field-types/Tabs/Tab/index.tsx
+++ b/packages/ui/src/forms/field-types/Tabs/Tab/index.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react'
 import { ErrorPill } from '../../../../elements/ErrorPill'
 import { WatchChildErrors } from '../../../WatchChildErrors'
 import { useFormSubmitted, useTranslation } from '../../../..'
-import { ReducedTab } from '../../../RenderFields/createFieldMap'
+import { ReducedTab } from '../../../RenderFields/buildFieldMap'
 
 import './index.scss'
 

--- a/packages/ui/src/forms/field-types/shared.ts
+++ b/packages/ui/src/forms/field-types/shared.ts
@@ -7,11 +7,11 @@ import {
   DocumentPreferences,
   JSONField,
   RowLabel,
-  Tab,
   Validate,
 } from 'payload/types'
-import { ReducedTab, createFieldMap } from '../RenderFields/createFieldMap'
+import { ReducedTab, buildFieldMap } from '../RenderFields/buildFieldMap'
 import { Option } from 'payload/types'
+import { FormState } from '../..'
 
 export const fieldBaseClass = 'field-type'
 
@@ -25,7 +25,8 @@ export type FormFieldBase = {
   Label?: React.ReactNode
   Description?: React.ReactNode
   Error?: React.ReactNode
-  fieldMap?: ReturnType<typeof createFieldMap>
+  fieldMap?: ReturnType<typeof buildFieldMap>
+  initialSubfieldState?: FormState
   style?: React.CSSProperties
   width?: string
   className?: string

--- a/packages/ui/src/views/Edit/action.ts
+++ b/packages/ui/src/views/Edit/action.ts
@@ -42,7 +42,6 @@ export const getFormStateFromServer = async (
 
   const result = await buildStateFromSchema({
     id,
-    config: payload.config,
     data,
     fieldSchema: collectionConfig.fields,
     locale: locale.code,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -14,7 +14,7 @@ import { SetStepNav } from './SetStepNav'
 // import { Upload } from '../Upload'
 import { EditViewProps } from '../types'
 import { getFormStateFromServer } from './action'
-import { createFieldMap } from '../../forms/RenderFields/createFieldMap'
+import { buildFieldMap } from '../../forms/RenderFields/buildFieldMap'
 
 import './index.scss'
 
@@ -27,7 +27,7 @@ export const DefaultEditView: React.FC<EditViewProps> = async (props) => {
     config,
     // customHeader,
     data,
-    formState,
+    formState: initialState,
     // isLoading,
     // onSave: onSaveFromProps,
     docPreferences,
@@ -101,7 +101,7 @@ export const DefaultEditView: React.FC<EditViewProps> = async (props) => {
     user,
   })
 
-  const fieldMap = createFieldMap({
+  const fieldMap = buildFieldMap({
     permissions: docPermissions.fields,
     fieldSchema: fields,
     operation: isEditing ? 'update' : 'create',
@@ -115,7 +115,7 @@ export const DefaultEditView: React.FC<EditViewProps> = async (props) => {
           // action={action}
           className={`${baseClass}__form`}
           disabled={!hasSavePermission}
-          initialState={formState}
+          initialState={initialState}
           method={id ? 'PATCH' : 'POST'}
           onChange={[onChange]}
           // onSuccess={onSave}
@@ -184,7 +184,6 @@ export const DefaultEditView: React.FC<EditViewProps> = async (props) => {
             docPermissions={docPermissions}
             docPreferences={docPreferences}
             data={data}
-            formState={formState}
             user={user}
             locale={locale}
             fieldMap={fieldMap}


### PR DESCRIPTION
## Description

Wires up array fields. The form component is much simpler now. We no longer have to lookup the row's config when adding / replacing items, and we no longer have to maintain adapter methods into the form's reducer. We simply push a new item to the array and let the server action rebuild form state via `buildStateFromSchema` (see #4924). This function provides the new fields within the array with initial value, etc. using proper locale and permissions.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.