### PR TITLE
fix(templates-ecommerce): hook errors for non-string ids

### DIFF
--- a/templates/ecommerce/src/payload/collections/Orders/hooks/clearUserCart.ts
+++ b/templates/ecommerce/src/payload/collections/Orders/hooks/clearUserCart.ts
@@ -6,7 +6,7 @@ export const clearUserCart: AfterChangeHook<Order> = async ({ doc, req, operatio
   const { payload } = req
 
   if (operation === 'create' && doc.orderedBy) {
-    const orderedBy = typeof doc.orderedBy === 'string' ? doc.orderedBy : doc.orderedBy.id
+    const orderedBy = typeof doc.orderedBy === 'object' ? doc.orderedBy.id : doc.orderedBy
 
     const user = await payload.findByID({
       collection: 'users',

--- a/templates/ecommerce/src/payload/collections/Orders/hooks/updateUserPurchases.ts
+++ b/templates/ecommerce/src/payload/collections/Orders/hooks/updateUserPurchases.ts
@@ -6,7 +6,7 @@ export const updateUserPurchases: AfterChangeHook<Order> = async ({ doc, req, op
   const { payload } = req
 
   if ((operation === 'create' || operation === 'update') && doc.orderedBy && doc.items) {
-    const orderedBy = typeof doc.orderedBy === 'string' ? doc.orderedBy : doc.orderedBy.id
+    const orderedBy = typeof doc.orderedBy === 'object' ? doc.orderedBy.id : doc.orderedBy
 
     const user = await payload.findByID({
       collection: 'users',
@@ -20,10 +20,10 @@ export const updateUserPurchases: AfterChangeHook<Order> = async ({ doc, req, op
         data: {
           purchases: [
             ...(user?.purchases?.map(purchase =>
-              typeof purchase === 'string' ? purchase : purchase.id,
+              typeof purchase === 'object' ? purchase.id : purchase,
             ) || []), // eslint-disable-line function-paren-newline
             ...(doc?.items?.map(({ product }) =>
-              typeof product === 'string' ? product : product.id,
+              typeof product === 'object' ? product.id : product,
             ) || []), // eslint-disable-line function-paren-newline
           ],
         },

--- a/templates/ecommerce/src/payload/collections/Users/hooks/resolveDuplicatePurchases.ts
+++ b/templates/ecommerce/src/payload/collections/Users/hooks/resolveDuplicatePurchases.ts
@@ -6,7 +6,7 @@ export const resolveDuplicatePurchases: FieldHook<User> = async ({ value, operat
   if ((operation === 'create' || operation === 'update') && value) {
     return Array.from(
       new Set(
-        value?.map(purchase => (typeof purchase === 'string' ? purchase : purchase.id)) || [],
+        value?.map(purchase => (typeof purchase === 'object' ? purchase.id : purchase)) || [],
       ),
     )
   }


### PR DESCRIPTION
## Description

Fix #4885

The change to the hooks is necessary to support non-string based IDs which is the default for postgres databases and also possible with custom ID fields in mongodb.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
