### PR TITLE
docs: Fix RowLabel code snippet that causes compilation error

### DIFF
--- a/docs/fields/array.mdx
+++ b/docs/fields/array.mdx
@@ -63,6 +63,7 @@ In addition to the default [field admin config](/docs/fields/overview#admin-conf
 
 ```ts
 import { CollectionConfig } from 'payload/types'
+import { RowLabelArgs } from 'payload/dist/admin/components/forms/RowLabel/types'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',
@@ -97,7 +98,7 @@ export const ExampleCollection: CollectionConfig = {
       ],
       admin: {
         components: {
-          RowLabel: ({ data, index }) => {
+          RowLabel: ({ data, index }: RowLabelArgs) => {
             return data?.title || `Slide ${String(index).padStart(2, '0')}`
           },
         },


### PR DESCRIPTION
## Description

[When referring to the `RowLabel` documentation of the `array` field](https://payloadcms.com/docs/fields/array#example), there is a code snippet provided that looks like the following:

```ts
{
  ...
      admin: {
        components: {
          RowLabel: ({ data, index }) => {
            return data?.title || `Slide ${String(index).padStart(2, '0')}`
          },
        },
      },
  ...
}
```

A type error occurs when directly using this snippet:

```
Type '({ data, index }: { data: any; index: any; }) => string' is not assignable to type 'RowLabel'.
  Type '({ data, index }: { data: any; index: any; }) => string' is not assignable to type 'FunctionComponent<RowLabelArgs>'.
    Types of parameters '__0' and 'props' are incompatible.
      Type 'RowLabelArgs' is not assignable to type '{ data: any; index: any; }'.
        Property 'index' is optional in type 'RowLabelArgs' but required in type '{ data: any; index: any; }'.
```

[This same error can be observed in this workflow run.](https://github.com/payloadcms/payload/actions/runs/7347790630/job/20394326431)
Moreover, both `data` and `index` are implicitly typed as `any`, which errors when `strict` is set to true in `tsconfig.json`. 

Unfortunately, it seems that type inference is not strong enough here, even though all situations should lead to it being typed as `RowLabelArgs`.

Proposal is to put an explicit type in the docs for `RowLabelArgs` so no more compilation error should occur when copying the snippet.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
