### PR TITLE
feat: previousValue and previousSiblingDoc args added to beforeChange field hooks

### DIFF
--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -6,7 +6,8 @@ desc: Hooks can be added to any fields, and optionally modify the return value o
 keywords: hooks, fields, config, configuration, documentation, Content Management System, cms, headless, javascript, node, react, express
 ---
 
-Field-level hooks offer incredible potential for encapsulating your logic. They help to isolate concerns and package up functionalities to be easily reusable across your projects.
+Field-level hooks offer incredible potential for encapsulating your logic. They help to isolate concerns and package up
+functionalities to be easily reusable across your projects.
 
 **Example use cases include:**
 
@@ -46,7 +47,8 @@ const ExampleField: Field = {
 
 ## Arguments and return values
 
-All field-level hooks are formatted to accept the same arguments, although some arguments may be `undefined` based on which field hook you are utilizing.
+All field-level hooks are formatted to accept the same arguments, although some arguments may be `undefined` based on
+which field hook you are utilizing.
 
 <Banner type="success">
   <strong>Tip:</strong>
@@ -69,10 +71,10 @@ Field Hooks receive one `args` argument that contains the following properties:
 | **`operation`**          | A string relating to which operation the field type is currently executing within. Useful within `beforeValidate`, `beforeChange`, and `afterChange` hooks to differentiate between `create` and `update` operations. |
 | **`originalDoc`**        | The full original document in `update` operations. In the `afterChange` hook, this is the resulting document of the operation.                                                                                        |
 | **`previousDoc`**        | The document before changes were applied, only in `afterChange` hooks.                                                                                                                                                |
-| **`previousSiblingDoc`** | The sibling data from the previous document in `afterChange` hook.                                                                                                                                                    |
+| **`previousSiblingDoc`** | The sibling data of the document before changes being applied, only in `beforeChange` and `afterChange` hook.                                                                                                         |
 | **`req`**                | The Express `request` object. It is mocked for Local API operations.                                                                                                                                                  |
 | **`value`**              | The value of the field.                                                                                                                                                                                               |
-| **`previousValue`**      | The previous value of the field, before changes were applied, only in `afterChange` hooks.                                                                                                                            |
+| **`previousValue`**      | The previous value of the field, before changes, only in `beforeChange` and `afterChange` hooks.                                                                                                                      |
 | **`context`**            | Context passed to this hook. More info can be found under [Context](/docs/hooks/context)                                                                                                                              |
 | **`field`**              | The field which the hook is running against.                                                                                                                                                                          |
 | **`collection`**         | The collection which the field belongs to. If the field belongs to a global, this will be null.                                                                                                                       |
@@ -80,7 +82,8 @@ Field Hooks receive one `args` argument that contains the following properties:
 
 #### Return value
 
-All field hooks can optionally modify the return value of the field before the operation continues. Field Hooks may optionally return the value that should be used within the field.
+All field hooks can optionally modify the return value of the field before the operation continues. Field Hooks may
+optionally return the value that should be used within the field.
 
 <Banner type="warning">
   <strong>Important</strong>
@@ -92,11 +95,14 @@ All field hooks can optionally modify the return value of the field before the o
 
 ## Examples of Field Hooks
 
-To better illustrate how field-level hooks can be applied, here are some specific examples. These demonstrate the flexibility and potential of field hooks in different contexts. Remember, these examples are just a starting point - the true potential of field-level hooks lies in their adaptability to a wide array of use cases.
+To better illustrate how field-level hooks can be applied, here are some specific examples. These demonstrate the
+flexibility and potential of field hooks in different contexts. Remember, these examples are just a starting point - the
+true potential of field-level hooks lies in their adaptability to a wide array of use cases.
 
 ### beforeValidate
 
-Runs before the `update` operation. This hook allows you to pre-process or format field data before it undergoes validation.
+Runs before the `update` operation. This hook allows you to pre-process or format field data before it undergoes
+validation.
 
 ```ts
 import { Field } from 'payload/types'
@@ -113,11 +119,15 @@ const usernameField: Field = {
 }
 ```
 
-In this example, the `beforeValidate` hook is used to process the `username` field. The hook takes the incoming value of the field and transforms it by trimming whitespace and converting it to lowercase. This ensures that the username is stored in a consistent format in the database.
+In this example, the `beforeValidate` hook is used to process the `username` field. The hook takes the incoming value of
+the field and transforms it by trimming whitespace and converting it to lowercase. This ensures that the username is
+stored in a consistent format in the database.
 
 ### beforeChange
 
-Immediately following validation, `beforeChange` hooks will run within `create` and `update` operations. At this stage, you can be confident that the field data that will be saved to the document is valid in accordance to your field validations.
+Immediately following validation, `beforeChange` hooks will run within `create` and `update` operations. At this stage,
+you can be confident that the field data that will be saved to the document is valid in accordance to your field
+validations.
 
 ```ts
 import { Field } from 'payload/types'
@@ -136,11 +146,14 @@ const emailField: Field = {
 }
 ```
 
-In the `emailField`, the `beforeChange` hook checks the `operation` type. If the operation is `create`, it performs additional validation or transformation on the email field value. This allows for operation-specific logic to be applied to the field.
+In the `emailField`, the `beforeChange` hook checks the `operation` type. If the operation is `create`, it performs
+additional validation or transformation on the email field value. This allows for operation-specific logic to be applied
+to the field.
 
 ### afterChange
 
-The `afterChange` hook is executed after a field's value has been changed and saved in the database. This hook is useful for post-processing or triggering side effects based on the new value of the field.
+The `afterChange` hook is executed after a field's value has been changed and saved in the database. This hook is useful
+for post-processing or triggering side effects based on the new value of the field.
 
 ```ts
 import { Field } from 'payload/types'
@@ -165,11 +178,15 @@ const membershipStatusField: Field = {
 }
 ```
 
-In this example, the `afterChange` hook is used with a `membershipStatusField`, which allows users to select their membership level (Standard, Premium, VIP). The hook monitors changes in the membership status. When a change occurs, it logs the update and can be used to trigger further actions, such as tracking conversion from one tier to another or notifying them about changes in their membership benefits.
+In this example, the `afterChange` hook is used with a `membershipStatusField`, which allows users to select their
+membership level (Standard, Premium, VIP). The hook monitors changes in the membership status. When a change occurs, it
+logs the update and can be used to trigger further actions, such as tracking conversion from one tier to another or
+notifying them about changes in their membership benefits.
 
 ### afterRead
 
-The `afterRead` hook is invoked after a field value is read from the database. This is ideal for formatting or transforming the field data for output.
+The `afterRead` hook is invoked after a field value is read from the database. This is ideal for formatting or
+transforming the field data for output.
 
 ```ts
 import { Field } from 'payload/types'
@@ -186,8 +203,9 @@ const dateField: Field = {
 }
 ```
 
-Here, the `afterRead` hook for the `dateField` is used to format the date into a more readable format using `toLocaleDateString()`. This hook modifies the way the date is presented to the user, making it more user-friendly.
-
+Here, the `afterRead` hook for the `dateField` is used to format the date into a more readable format
+using `toLocaleDateString()`. This hook modifies the way the date is presented to the user, making it more
+user-friendly.
 
 ## TypeScript
 

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -38,8 +38,9 @@ export type FieldHookArgs<T extends TypeWithID = any, P = any, S = any> = {
   originalDoc?: T
   /** The document before changes were applied, only in `afterChange` hooks. */
   previousDoc?: T
-  /** The sibling data from the previous document in `afterChange` hook. */
+  /** The sibling data of the document before changes being applied, only in `beforeChange` and `afterChange` hook. */
   previousSiblingDoc?: T
+  /** The previous value of the field, before changes, only in `beforeChange` and `afterChange` hooks. */
   previousValue?: P
   /** The Express request object. It is mocked for Local API operations. */
   req: PayloadRequest

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -88,6 +88,8 @@ export const promise = async ({
           global,
           operation,
           originalDoc: doc,
+          previousSiblingDoc: siblingDoc,
+          previousValue: siblingDoc[field.name],
           req,
           siblingData,
           value: siblingData[field.name],

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -55,29 +55,65 @@ describe('Hooks', () => {
 
   describe('hook execution', () => {
     let doc
-    it('should execute hooks in correct order on create', async () => {
+    const data = {
+      collectionAfterChange: false,
+      collectionAfterRead: false,
+      collectionBeforeChange: false,
+      collectionBeforeRead: false,
+      collectionBeforeValidate: false,
+      fieldAfterChange: false,
+      fieldAfterRead: false,
+      fieldBeforeChange: false,
+      fieldBeforeValidate: false,
+    }
+    beforeEach(async () => {
       doc = await payload.create({
         collection: hooksSlug,
-        data: {
-          collectionAfterChange: false,
-          collectionAfterRead: false,
-          collectionBeforeChange: false,
-          collectionBeforeRead: false,
-          collectionBeforeValidate: false,
-          fieldAfterChange: false,
-          fieldAfterRead: false,
-          fieldBeforeChange: false,
-          fieldBeforeValidate: false,
-        },
+        data,
+      })
+    })
+
+    it('should execute hooks in correct order on create', async () => {
+      expect(doc.collectionAfterChange).toBeTruthy()
+      expect(doc.collectionAfterRead).toBeTruthy()
+      expect(doc.collectionBeforeChange).toBeTruthy()
+      // beforeRead is not run on create operation
+      expect(doc.collectionBeforeRead).toBeFalsy()
+      expect(doc.collectionBeforeValidate).toBeTruthy()
+      expect(doc.fieldAfterChange).toBeTruthy()
+      expect(doc.fieldAfterRead).toBeTruthy()
+      expect(doc.fieldBeforeChange).toBeTruthy()
+      expect(doc.fieldBeforeValidate).toBeTruthy()
+    })
+
+    it('should execute hooks in correct order on update', async () => {
+      doc = await payload.update({
+        id: doc.id,
+        collection: hooksSlug,
+        data,
       })
 
-      expect(doc.fieldBeforeValidate).toEqual(true)
-      expect(doc.collectionBeforeValidate).toEqual(true)
-      expect(doc.fieldBeforeChange).toEqual(true)
-      expect(doc.collectionBeforeChange).toEqual(true)
-      expect(doc.fieldAfterChange).toEqual(true)
-      expect(doc.collectionAfterChange).toEqual(true)
-      expect(doc.fieldAfterRead).toEqual(true)
+      expect(doc.collectionAfterChange).toBeTruthy()
+      expect(doc.collectionAfterRead).toBeTruthy()
+      expect(doc.collectionBeforeChange).toBeTruthy()
+      // beforeRead is not run on update operation
+      expect(doc.collectionBeforeRead).toBeFalsy()
+      expect(doc.collectionBeforeValidate).toBeTruthy()
+      expect(doc.fieldAfterChange).toBeTruthy()
+      expect(doc.fieldAfterRead).toBeTruthy()
+      expect(doc.fieldBeforeChange).toBeTruthy()
+      expect(doc.fieldBeforeValidate).toBeTruthy()
+    })
+
+    it('should execute hooks in correct order on find', async () => {
+      doc = await payload.findByID({
+        id: doc.id,
+        collection: hooksSlug,
+      })
+
+      expect(doc.collectionAfterRead).toBeTruthy()
+      expect(doc.collectionBeforeRead).toBeTruthy()
+      expect(doc.fieldAfterRead).toBeTruthy()
     })
 
     it('should save data generated with afterRead hooks in nested field structures', async () => {


### PR DESCRIPTION
## Description

Requested by enterprise client.
When updating a document you might may want to access the current value in the database for the field value inside of a beforeChange hook. This is difficult to do on deeply nested fields using only `originalDoc`. These two new args make it much more simple.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
