### PR TITLE
chore: add indexes to preferences for performance

### DIFF
--- a/packages/payload/src/preferences/preferencesCollection.ts
+++ b/packages/payload/src/preferences/preferencesCollection.ts
@@ -12,6 +12,7 @@ const preferenceAccess: Access = ({ req }) => ({
 })
 
 const getPreferencesCollection = (config: Config): CollectionConfig => ({
+  slug: 'payload-preferences',
   access: {
     delete: preferenceAccess,
     read: preferenceAccess,
@@ -39,6 +40,7 @@ const getPreferencesCollection = (config: Config): CollectionConfig => ({
   fields: [
     {
       name: 'user',
+      type: 'relationship',
       hooks: {
         beforeValidate: [
           ({ req }) => {
@@ -52,22 +54,22 @@ const getPreferencesCollection = (config: Config): CollectionConfig => ({
           },
         ],
       },
+      index: true,
       relationTo: config.collections
         .filter((collectionConfig) => collectionConfig.auth)
         .map((collectionConfig) => collectionConfig.slug),
       required: true,
-      type: 'relationship',
     },
     {
       name: 'key',
       type: 'text',
+      index: true,
     },
     {
       name: 'value',
       type: 'json',
     },
   ],
-  slug: 'payload-preferences',
 })
 
 export default getPreferencesCollection


### PR DESCRIPTION
## Description

Indexes on preferences were removed in 2.0 when we moved to database adapters as we were able to have a compound index directly in the collection. Since that is no longer the case this change just adds standard indexes on the fields used to query on.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
