### PR TITLE
feat: use deletion success message from server if provided

### DIFF
--- a/packages/payload/src/admin/components/elements/DeleteDocument/index.tsx
+++ b/packages/payload/src/admin/components/elements/DeleteDocument/index.tsx
@@ -64,7 +64,7 @@ const DeleteDocument: React.FC<Props> = (props) => {
             if (res.status < 400) {
               setDeleting(false)
               toggleModal(modalSlug)
-              toast.success(t('titleDeleted', { label: getTranslation(singular, i18n), title }))
+              toast.success(json.message || t('titleDeleted', { label: getTranslation(singular, i18n), title }))
               return history.push(`${admin}/collections/${slug}`)
             }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

I want to implement a soft delete function. So I figured out, that the `DeleteDocument` component ignores the message of the server response.
Since the delete request will return the deleted document, this change wouldn't break anything, but could be used in a custom delete endpoint.


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
