### PR TITLE
fix(db-postgres): indexes not created for non unique field names

### DIFF
--- a/packages/db-postgres/src/schema/createIndex.ts
+++ b/packages/db-postgres/src/schema/createIndex.ts
@@ -6,10 +6,11 @@ import type { GenericColumn } from '../types'
 type CreateIndexArgs = {
   columnName: string
   name: string | string[]
+  tableName: string
   unique?: boolean
 }
 
-export const createIndex = ({ name, columnName, unique }: CreateIndexArgs) => {
+export const createIndex = ({ name, columnName, tableName, unique }: CreateIndexArgs) => {
   return (table: { [x: string]: GenericColumn }) => {
     let columns
     if (Array.isArray(name)) {
@@ -20,7 +21,8 @@ export const createIndex = ({ name, columnName, unique }: CreateIndexArgs) => {
     } else {
       columns = [table[name]]
     }
-    if (unique) return uniqueIndex(`${columnName}_idx`).on(columns[0], ...columns.slice(1))
-    return index(`${columnName}_idx`).on(columns[0], ...columns.slice(1))
+    if (unique)
+      return uniqueIndex(`${tableName}_${columnName}_idx`).on(columns[0], ...columns.slice(1))
+    return index(`${tableName}_${columnName}_idx`).on(columns[0], ...columns.slice(1))
   }
 }

--- a/packages/db-postgres/src/schema/traverseFields.ts
+++ b/packages/db-postgres/src/schema/traverseFields.ts
@@ -32,9 +32,9 @@ import { validateExistingBlockIsIdentical } from './validateExistingBlockIsIdent
 
 type Args = {
   adapter: PostgresAdapter
-  buildTexts: boolean
   buildNumbers: boolean
   buildRelationships: boolean
+  buildTexts: boolean
   columnPrefix?: string
   columns: Record<string, PgColumnBuilder>
   disableNotNull: boolean
@@ -56,18 +56,18 @@ type Args = {
 
 type Result = {
   hasLocalizedField: boolean
-  hasLocalizedManyTextField: boolean
   hasLocalizedManyNumberField: boolean
+  hasLocalizedManyTextField: boolean
   hasLocalizedRelationshipField: boolean
-  hasManyTextField: 'index' | boolean
   hasManyNumberField: 'index' | boolean
+  hasManyTextField: 'index' | boolean
 }
 
 export const traverseFields = ({
   adapter,
-  buildTexts,
   buildNumbers,
   buildRelationships,
+  buildTexts,
   columnPrefix,
   columns,
   disableNotNull,
@@ -122,7 +122,7 @@ export const traverseFields = ({
       if (
         (field.unique || field.index) &&
         !['array', 'blocks', 'group', 'point', 'relationship', 'upload'].includes(field.type) &&
-        !(field.type === 'number' && field.hasMany === true)
+        !('hasMany' in field && field.hasMany === true)
       ) {
         const unique = disableUnique !== true && field.unique
         if (unique) {
@@ -132,9 +132,10 @@ export const traverseFields = ({
           }
           adapter.fieldConstraints[rootTableName][`${columnName}_idx`] = constraintValue
         }
-        targetIndexes[`${field.name}Idx`] = createIndex({
+        targetIndexes[`${newTableName}_${field.name}Idx`] = createIndex({
           name: fieldName,
           columnName,
+          tableName: newTableName,
           unique,
         })
       }
@@ -314,8 +315,8 @@ export const traverseFields = ({
         }
 
         const {
-          hasManyTextField: subHasManyTextField,
           hasManyNumberField: subHasManyNumberField,
+          hasManyTextField: subHasManyTextField,
           relationsToBuild: subRelationsToBuild,
         } = buildTable({
           adapter,
@@ -395,8 +396,8 @@ export const traverseFields = ({
             }
 
             const {
-              hasManyTextField: subHasManyTextField,
               hasManyNumberField: subHasManyNumberField,
+              hasManyTextField: subHasManyTextField,
               relationsToBuild: subRelationsToBuild,
             } = buildTable({
               adapter,
@@ -465,16 +466,16 @@ export const traverseFields = ({
         if (!('name' in field)) {
           const {
             hasLocalizedField: groupHasLocalizedField,
-            hasLocalizedManyTextField: groupHasLocalizedManyTextField,
             hasLocalizedManyNumberField: groupHasLocalizedManyNumberField,
+            hasLocalizedManyTextField: groupHasLocalizedManyTextField,
             hasLocalizedRelationshipField: groupHasLocalizedRelationshipField,
-            hasManyTextField: groupHasManyTextField,
             hasManyNumberField: groupHasManyNumberField,
+            hasManyTextField: groupHasManyTextField,
           } = traverseFields({
             adapter,
-            buildTexts,
             buildNumbers,
             buildRelationships,
+            buildTexts,
             columnPrefix,
             columns,
             disableNotNull,
@@ -507,16 +508,16 @@ export const traverseFields = ({
 
         const {
           hasLocalizedField: groupHasLocalizedField,
-          hasLocalizedManyTextField: groupHasLocalizedManyTextField,
           hasLocalizedManyNumberField: groupHasLocalizedManyNumberField,
+          hasLocalizedManyTextField: groupHasLocalizedManyTextField,
           hasLocalizedRelationshipField: groupHasLocalizedRelationshipField,
-          hasManyTextField: groupHasManyTextField,
           hasManyNumberField: groupHasManyNumberField,
+          hasManyTextField: groupHasManyTextField,
         } = traverseFields({
           adapter,
-          buildTexts,
           buildNumbers,
           buildRelationships,
+          buildTexts,
           columnPrefix: `${columnName}_`,
           columns,
           disableNotNull: disableNotNullFromHere,
@@ -550,16 +551,16 @@ export const traverseFields = ({
 
         const {
           hasLocalizedField: tabHasLocalizedField,
-          hasLocalizedManyTextField: tabHasLocalizedManyTextField,
           hasLocalizedManyNumberField: tabHasLocalizedManyNumberField,
+          hasLocalizedManyTextField: tabHasLocalizedManyTextField,
           hasLocalizedRelationshipField: tabHasLocalizedRelationshipField,
-          hasManyTextField: tabHasManyTextField,
           hasManyNumberField: tabHasManyNumberField,
+          hasManyTextField: tabHasManyTextField,
         } = traverseFields({
           adapter,
-          buildTexts,
           buildNumbers,
           buildRelationships,
+          buildTexts,
           columnPrefix,
           columns,
           disableNotNull: disableNotNullFromHere,
@@ -593,16 +594,16 @@ export const traverseFields = ({
         const disableNotNullFromHere = Boolean(field.admin?.condition) || disableNotNull
         const {
           hasLocalizedField: rowHasLocalizedField,
-          hasLocalizedManyTextField: rowHasLocalizedManyTextField,
           hasLocalizedManyNumberField: rowHasLocalizedManyNumberField,
+          hasLocalizedManyTextField: rowHasLocalizedManyTextField,
           hasLocalizedRelationshipField: rowHasLocalizedRelationshipField,
-          hasManyTextField: rowHasManyTextField,
           hasManyNumberField: rowHasManyNumberField,
+          hasManyTextField: rowHasManyTextField,
         } = traverseFields({
           adapter,
-          buildTexts,
           buildNumbers,
           buildRelationships,
+          buildTexts,
           columnPrefix,
           columns,
           disableNotNull: disableNotNullFromHere,
@@ -663,10 +664,10 @@ export const traverseFields = ({
 
   return {
     hasLocalizedField,
-    hasLocalizedManyTextField,
     hasLocalizedManyNumberField,
+    hasLocalizedManyTextField,
     hasLocalizedRelationshipField,
-    hasManyTextField,
     hasManyNumberField,
+    hasManyTextField,
   }
 }


### PR DESCRIPTION
## Description

While working with the Drizzle team on some other issues it was discovered that our index naming method was preventing all of the indexes from being made properly because they need to be unique across all table names.

Changes include
- naming of indexes
- fixed condition to cover `hasMany: true` text fields

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
