### PR TITLE
fix: ensures permissions are present on documentInfo

### DIFF
--- a/packages/payload/src/admin/components/elements/DocumentControls/index.tsx
+++ b/packages/payload/src/admin/components/elements/DocumentControls/index.tsx
@@ -33,7 +33,7 @@ export const DocumentControls: React.FC<{
   id?: string
   isAccountView?: boolean
   isEditing?: boolean
-  permissions?: CollectionPermission | GlobalPermission | null
+  permissions?: CollectionPermission | GlobalPermission
 }> = (props) => {
   const {
     id,

--- a/packages/payload/src/admin/components/utilities/DocumentInfo/index.tsx
+++ b/packages/payload/src/admin/components/utilities/DocumentInfo/index.tsx
@@ -40,7 +40,6 @@ export const DocumentInfoProvider: React.FC<Props> = ({
   const [publishedDoc, setPublishedDoc] = useState<TypeWithID & TypeWithTimestamps>(null)
   const [versions, setVersions] = useState<PaginatedDocs<Version>>(null)
   const [unpublishedVersions, setUnpublishedVersions] = useState<PaginatedDocs<Version>>(null)
-  const [docPermissions, setDocPermissions] = useState<DocumentPermissions>(null)
 
   const baseURL = `${serverURL}${api}`
   let slug: string
@@ -61,6 +60,10 @@ export const DocumentInfoProvider: React.FC<Props> = ({
       preferencesKey = `collection-${slug}-${id}`
     }
   }
+
+  const [docPermissions, setDocPermissions] = useState<DocumentPermissions>(
+    permissions[pluralType][slug],
+  )
 
   const getVersions = useCallback(async () => {
     let versionFetchURL
@@ -215,14 +218,14 @@ export const DocumentInfoProvider: React.FC<Props> = ({
           'Accept-Language': i18n.language,
         },
       })
-      const json = await res.json()
-      setDocPermissions(json)
-    } else {
-      // fallback to permissions from the entity type
-      // (i.e. create has no id)
-      setDocPermissions(permissions[pluralType][slug])
+      try {
+        const json = await res.json()
+        setDocPermissions(json)
+      } catch (e) {
+        console.error('Unable to fetch document permissions', e)
+      }
     }
-  }, [serverURL, api, pluralType, slug, id, permissions, i18n.language, code])
+  }, [serverURL, api, pluralType, slug, id, i18n.language, code])
 
   const getDocPreferences = useCallback(async () => {
     return getPreference<DocumentPreferences>(preferencesKey)
@@ -262,6 +265,7 @@ export const DocumentInfoProvider: React.FC<Props> = ({
 
   const value: ContextType = {
     id,
+    slug,
     collection,
     docPermissions,
     getDocPermissions,
@@ -271,7 +275,6 @@ export const DocumentInfoProvider: React.FC<Props> = ({
     preferencesKey,
     publishedDoc,
     setDocFieldPreferences,
-    slug,
     unpublishedVersions,
     versions,
   }

--- a/packages/payload/src/admin/components/utilities/DocumentInfo/types.ts
+++ b/packages/payload/src/admin/components/utilities/DocumentInfo/types.ts
@@ -12,7 +12,7 @@ import type { TypeWithVersion } from '../../../../versions/types'
 
 export type Version = TypeWithVersion<any>
 
-export type DocumentPermissions = CollectionPermission | GlobalPermission | null
+export type DocumentPermissions = CollectionPermission | GlobalPermission
 
 export type ContextType = {
   collection?: SanitizedCollectionConfig


### PR DESCRIPTION
## Description

When a document is in the `create` view, it has no permissions. This change ensures that they are always present by falling back to collection permissions.

This bug was revealed inside of the Relationship field type where `docPermissions` were being accessed but could potentially be null. Leading to incorrect behaviour in some cases.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
