### PR TITLE
fix(db-postgres): indexes not creating for relationships, arrays, has…

### DIFF
--- a/packages/db-postgres/src/schema/build.ts
+++ b/packages/db-postgres/src/schema/build.ts
@@ -27,9 +27,9 @@ type Args = {
   adapter: PostgresAdapter
   baseColumns?: Record<string, PgColumnBuilder>
   baseExtraConfig?: Record<string, (cols: GenericColumns) => IndexBuilder | UniqueConstraintBuilder>
-  buildTexts?: boolean
   buildNumbers?: boolean
   buildRelationships?: boolean
+  buildTexts?: boolean
   disableNotNull: boolean
   disableUnique: boolean
   fields: Field[]
@@ -42,8 +42,8 @@ type Args = {
 }
 
 type Result = {
-  hasManyTextField: 'index' | boolean
   hasManyNumberField: 'index' | boolean
+  hasManyTextField: 'index' | boolean
   relationsToBuild: Map<string, string>
 }
 
@@ -51,9 +51,9 @@ export const buildTable = ({
   adapter,
   baseColumns = {},
   baseExtraConfig = {},
-  buildTexts,
   buildNumbers,
   buildRelationships,
+  buildTexts,
   disableNotNull,
   disableUnique = false,
   fields,
@@ -100,16 +100,16 @@ export const buildTable = ({
   columns.id = idColTypeMap[idColType]('id').primaryKey()
   ;({
     hasLocalizedField,
-    hasLocalizedManyTextField,
     hasLocalizedManyNumberField,
+    hasLocalizedManyTextField,
     hasLocalizedRelationshipField,
-    hasManyTextField,
     hasManyNumberField,
+    hasManyTextField,
   } = traverseFields({
     adapter,
-    buildTexts,
     buildNumbers,
     buildRelationships,
+    buildTexts,
     columns,
     disableNotNull,
     disableUnique,
@@ -196,12 +196,12 @@ export const buildTable = ({
     const textsTableName = `${rootTableName}_texts`
     const columns: Record<string, PgColumnBuilder> = {
       id: serial('id').primaryKey(),
-      text: varchar('text'),
       order: integer('order').notNull(),
       parent: parentIDColumnMap[idColType]('parent_id')
         .references(() => table.id, { onDelete: 'cascade' })
         .notNull(),
       path: varchar('path').notNull(),
+      text: varchar('text'),
     }
 
     if (hasLocalizedManyTextField) {
@@ -210,15 +210,15 @@ export const buildTable = ({
 
     textsTable = pgTable(textsTableName, columns, (cols) => {
       const indexes: Record<string, IndexBuilder> = {
-        orderParentIdx: index('order_parent_idx').on(cols.order, cols.parent),
+        orderParentIdx: index(`${textsTableName}_order_parent_idx`).on(cols.order, cols.parent),
       }
 
       if (hasManyTextField === 'index') {
-        indexes.text_idx = index('text_idx').on(cols.text)
+        indexes.text_idx = index(`${textsTableName}_text_idx`).on(cols.text)
       }
 
       if (hasLocalizedManyTextField) {
-        indexes.localeParent = index('locale_parent').on(cols.locale, cols.parent)
+        indexes.localeParent = index(`${textsTableName}_locale_parent`).on(cols.locale, cols.parent)
       }
 
       return indexes
@@ -254,15 +254,18 @@ export const buildTable = ({
 
     numbersTable = pgTable(numbersTableName, columns, (cols) => {
       const indexes: Record<string, IndexBuilder> = {
-        orderParentIdx: index('order_parent_idx').on(cols.order, cols.parent),
+        orderParentIdx: index(`${numbersTableName}_order_parent_idx`).on(cols.order, cols.parent),
       }
 
       if (hasManyNumberField === 'index') {
-        indexes.numberIdx = index('number_idx').on(cols.number)
+        indexes.numberIdx = index(`${numbersTableName}_number_idx`).on(cols.number)
       }
 
       if (hasLocalizedManyNumberField) {
-        indexes.localeParent = index('locale_parent').on(cols.locale, cols.parent)
+        indexes.localeParent = index(`${numbersTableName}_locale_parent`).on(
+          cols.locale,
+          cols.parent,
+        )
       }
 
       return indexes
@@ -313,13 +316,13 @@ export const buildTable = ({
 
       relationshipsTable = pgTable(relationshipsTableName, relationshipColumns, (cols) => {
         const result: Record<string, unknown> = {
-          order: index('order_idx').on(cols.order),
-          parentIdx: index('parent_idx').on(cols.parent),
-          pathIdx: index('path_idx').on(cols.path),
+          order: index(`${relationshipsTableName}_order_idx`).on(cols.order),
+          parentIdx: index(`${relationshipsTableName}_parent_idx`).on(cols.parent),
+          pathIdx: index(`${relationshipsTableName}_path_idx`).on(cols.path),
         }
 
         if (hasLocalizedRelationshipField) {
-          result.localeIdx = index('locale_idx').on(cols.locale)
+          result.localeIdx = index(`${relationshipsTableName}_locale_idx`).on(cols.locale)
         }
 
         return result
@@ -381,5 +384,5 @@ export const buildTable = ({
 
   adapter.relations[`relations_${tableName}`] = tableRelations
 
-  return { hasManyTextField, hasManyNumberField, relationsToBuild }
+  return { hasManyNumberField, hasManyTextField, relationsToBuild }
 }

--- a/packages/db-postgres/src/schema/traverseFields.ts
+++ b/packages/db-postgres/src/schema/traverseFields.ts
@@ -242,17 +242,18 @@ export const traverseFields = ({
             string,
             (cols: GenericColumns) => IndexBuilder | UniqueConstraintBuilder
           > = {
-            orderIdx: (cols) => index('order_idx').on(cols.order),
-            parentIdx: (cols) => index('parent_idx').on(cols.parent),
+            orderIdx: (cols) => index(`${selectTableName}_order_idx`).on(cols.order),
+            parentIdx: (cols) => index(`${selectTableName}_parent_idx`).on(cols.parent),
           }
 
           if (field.localized) {
             baseColumns.locale = adapter.enums.enum__locales('locale').notNull()
-            baseExtraConfig.localeIdx = (cols) => index('locale_idx').on(cols.locale)
+            baseExtraConfig.localeIdx = (cols) =>
+              index(`${selectTableName}_locale_idx`).on(cols.locale)
           }
 
           if (field.index) {
-            baseExtraConfig.value = (cols) => index('value_idx').on(cols.value)
+            baseExtraConfig.value = (cols) => index(`${selectTableName}_value_idx`).on(cols.value)
           }
 
           buildTable({
@@ -305,13 +306,14 @@ export const traverseFields = ({
           string,
           (cols: GenericColumns) => IndexBuilder | UniqueConstraintBuilder
         > = {
-          _orderIdx: (cols) => index('_order_idx').on(cols._order),
-          _parentIDIdx: (cols) => index('_parent_id_idx').on(cols._parentID),
+          _orderIdx: (cols) => index(`${arrayTableName}_order_idx`).on(cols._order),
+          _parentIDIdx: (cols) => index(`${arrayTableName}_parent_id_idx`).on(cols._parentID),
         }
 
         if (field.localized && adapter.payload.config.localization) {
           baseColumns._locale = adapter.enums.enum__locales('_locale').notNull()
-          baseExtraConfig._localeIdx = (cols) => index('_locale_idx').on(cols._locale)
+          baseExtraConfig._localeIdx = (cols) =>
+            index(`${arrayTableName}_locale_idx`).on(cols._locale)
         }
 
         const {
@@ -385,14 +387,15 @@ export const traverseFields = ({
               string,
               (cols: GenericColumns) => IndexBuilder | UniqueConstraintBuilder
             > = {
-              _orderIdx: (cols) => index('order_idx').on(cols._order),
-              _parentIDIdx: (cols) => index('parent_id_idx').on(cols._parentID),
-              _pathIdx: (cols) => index('path_idx').on(cols._path),
+              _orderIdx: (cols) => index(`${blockTableName}_order_idx`).on(cols._order),
+              _parentIDIdx: (cols) => index(`${blockTableName}_parent_id_idx`).on(cols._parentID),
+              _pathIdx: (cols) => index(`${blockTableName}_path_idx`).on(cols._path),
             }
 
             if (field.localized && adapter.payload.config.localization) {
               baseColumns._locale = adapter.enums.enum__locales('_locale').notNull()
-              baseExtraConfig._localeIdx = (cols) => index('locale_idx').on(cols._locale)
+              baseExtraConfig._localeIdx = (cols) =>
+                index(`${blockTableName}_locale_idx`).on(cols._locale)
             }
 
             const {


### PR DESCRIPTION
…many and blocks

## Description

This change prefixes table names to the remainder of built-in prostgres fields so that all indexes have unique names.

![image](https://github.com/payloadcms/payload/assets/6434612/d6d36f9c-53b3-4036-b10f-e10a8f25f9f1)
![image](https://github.com/payloadcms/payload/assets/6434612/aa5da57f-e955-4d73-93d5-35ced6a3c9e8)
![image](https://github.com/payloadcms/payload/assets/6434612/4fdf51c4-e343-45fb-8534-020fe3ec3c6b)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
