### PR TITLE
chore: standardize req passed through the local API

### DIFF
--- a/packages/payload/src/auth/operations/local/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/local/forgotPassword.ts
@@ -3,10 +3,8 @@ import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 import type { Result } from '../forgotPassword'
 
-import { getDataLoader } from '../../../collections/dataloader'
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import forgotPassword from '../forgotPassword'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
@@ -24,15 +22,7 @@ async function localForgotPassword<T extends keyof GeneratedTypes['collections']
   payload: Payload,
   options: Options<T>,
 ): Promise<Result> {
-  const {
-    collection: collectionSlug,
-    context,
-    data,
-    disableEmail,
-    expiration,
-    req = {} as PayloadRequest,
-  } = options
-  setRequestContext(req, context)
+  const { collection: collectionSlug, data, disableEmail, expiration } = options
 
   const collection = payload.collections[collectionSlug]
 
@@ -44,12 +34,7 @@ async function localForgotPassword<T extends keyof GeneratedTypes['collections']
     )
   }
 
-  req.payloadAPI = req.payloadAPI || 'local'
-  req.payload = payload
-  req.i18n = i18nInit(payload.config.i18n)
-
-  if (!req.t) req.t = req.i18n.t
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   return forgotPassword({
     collection,

--- a/packages/payload/src/auth/operations/local/login.ts
+++ b/packages/payload/src/auth/operations/local/login.ts
@@ -5,10 +5,8 @@ import type { GeneratedTypes } from '../../../index'
 import type { Payload } from '../../../payload'
 import type { Result } from '../login'
 
-import { getDataLoader } from '../../../collections/dataloader'
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import login from '../login'
 
 export type Options<TSlug extends keyof GeneratedTypes['collections']> = {
@@ -33,25 +31,14 @@ async function localLogin<TSlug extends keyof GeneratedTypes['collections']>(
 ): Promise<Result & { user: GeneratedTypes['collections'][TSlug] }> {
   const {
     collection: collectionSlug,
-    context,
     data,
     depth,
-    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
-    locale: localeArg = null,
     overrideAccess = true,
-    req = {} as PayloadRequest,
     res,
     showHiddenFields,
   } = options
-  setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
-  const localizationConfig = payload?.config?.localization
-  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
-  const locale = localeArg || req?.locale || defaultLocale
-  const fallbackLocale = localizationConfig
-    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
-    : null
 
   if (!collection) {
     throw new APIError(
@@ -59,12 +46,7 @@ async function localLogin<TSlug extends keyof GeneratedTypes['collections']>(
     )
   }
 
-  req.payloadAPI = req.payloadAPI || 'local'
-  req.payload = payload
-  req.i18n = i18nInit(payload.config.i18n)
-
-  if (!req.t) req.t = req.i18n.t
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   const args = {
     collection,
@@ -74,12 +56,6 @@ async function localLogin<TSlug extends keyof GeneratedTypes['collections']>(
     req,
     res,
     showHiddenFields,
-  }
-
-  if (locale) args.req.locale = locale
-  if (fallbackLocale) {
-    args.req.fallbackLocale =
-      typeof fallbackLocaleArg !== 'undefined' ? fallbackLocaleArg : fallbackLocale || defaultLocale
   }
 
   return login<TSlug>(args)

--- a/packages/payload/src/auth/operations/local/resetPassword.ts
+++ b/packages/payload/src/auth/operations/local/resetPassword.ts
@@ -3,10 +3,8 @@ import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 import type { Result } from '../resetPassword'
 
-import { getDataLoader } from '../../../collections/dataloader'
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import resetPassword from '../resetPassword'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
@@ -24,15 +22,7 @@ async function localResetPassword<T extends keyof GeneratedTypes['collections']>
   payload: Payload,
   options: Options<T>,
 ): Promise<Result> {
-  const {
-    collection: collectionSlug,
-    context,
-    data,
-    overrideAccess,
-    req = {} as PayloadRequest,
-  } = options
-
-  setRequestContext(req, context)
+  const { collection: collectionSlug, data, overrideAccess } = options
 
   const collection = payload.collections[collectionSlug]
 
@@ -44,12 +34,7 @@ async function localResetPassword<T extends keyof GeneratedTypes['collections']>
     )
   }
 
-  req.payload = payload
-  req.payloadAPI = req.payloadAPI || 'local'
-  req.i18n = i18nInit(payload.config.i18n)
-
-  if (!req.t) req.t = req.i18n.t
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   return resetPassword({
     collection,

--- a/packages/payload/src/auth/operations/local/unlock.ts
+++ b/packages/payload/src/auth/operations/local/unlock.ts
@@ -2,10 +2,8 @@ import type { GeneratedTypes, RequestContext } from '../../../'
 import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 
-import { getDataLoader } from '../../../collections/dataloader'
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import unlock from '../unlock'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
@@ -22,14 +20,7 @@ async function localUnlock<T extends keyof GeneratedTypes['collections']>(
   payload: Payload,
   options: Options<T>,
 ): Promise<boolean> {
-  const {
-    collection: collectionSlug,
-    context,
-    data,
-    overrideAccess = true,
-    req = {} as PayloadRequest,
-  } = options
-  setRequestContext(req, context)
+  const { collection: collectionSlug, data, overrideAccess = true } = options
 
   const collection = payload.collections[collectionSlug]
 
@@ -39,12 +30,7 @@ async function localUnlock<T extends keyof GeneratedTypes['collections']>(
     )
   }
 
-  req.payload = payload
-  req.payloadAPI = req.payloadAPI || 'local'
-  req.i18n = i18nInit(payload.config.i18n)
-
-  if (!req.t) req.t = req.i18n.t
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   return unlock({
     collection,

--- a/packages/payload/src/auth/operations/local/verifyEmail.ts
+++ b/packages/payload/src/auth/operations/local/verifyEmail.ts
@@ -3,8 +3,7 @@ import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import verifyEmail from '../verifyEmail'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
@@ -18,8 +17,7 @@ async function localVerifyEmail<T extends keyof GeneratedTypes['collections']>(
   payload: Payload,
   options: Options<T>,
 ): Promise<boolean> {
-  const { collection: collectionSlug, context, req = {} as PayloadRequest, token } = options
-  setRequestContext(req, context)
+  const { collection: collectionSlug, token } = options
 
   const collection = payload.collections[collectionSlug]
 
@@ -29,9 +27,7 @@ async function localVerifyEmail<T extends keyof GeneratedTypes['collections']>(
     )
   }
 
-  req.payload = payload
-  req.payloadAPI = req.payloadAPI || 'local'
-  req.i18n = i18nInit(payload.config.i18n)
+  const req = createLocalReq(options, payload)
 
   return verifyEmail({
     collection,

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -61,7 +61,16 @@ export default async function createLocal<TSlug extends keyof GeneratedTypes['co
   }
 
   const req = createLocalReq(options, payload)
-  req.files.file = (file ?? (await getFileByPath(filePath))) as UploadedFile
+  const fileToSet = (file ?? (await getFileByPath(filePath))) as UploadedFile
+  if (fileToSet) {
+    if (req?.files) {
+      req.files.file = fileToSet
+    } else {
+      req.files = {
+        file: fileToSet,
+      }
+    }
+  }
 
   return create<TSlug>({
     collection,

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -8,10 +8,8 @@ import type { Document } from '../../../types'
 import type { File } from '../../../uploads/types'
 
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
 import getFileByPath from '../../../uploads/getFileByPath'
-import { getDataLoader } from '../../dataloader'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import create from '../create'
 
 export type Options<TSlug extends keyof GeneratedTypes['collections']> = {
@@ -44,30 +42,17 @@ export default async function createLocal<TSlug extends keyof GeneratedTypes['co
 ): Promise<GeneratedTypes['collections'][TSlug]> {
   const {
     collection: collectionSlug,
-    context,
     data,
     depth,
     disableVerificationEmail,
     draft,
-    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     file,
     filePath,
-    locale: localeArg = null,
     overrideAccess = true,
     overwriteExistingFiles = false,
-    req = {} as PayloadRequest,
     showHiddenFields,
-    user,
   } = options
-  setRequestContext(req, context)
-
   const collection = payload.collections[collectionSlug]
-  const localizationConfig = payload?.config?.localization
-  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
-  const locale = localeArg || req.locale || defaultLocale
-  const fallbackLocale = localizationConfig
-    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
-    : null
 
   if (!collection) {
     throw new APIError(
@@ -75,20 +60,8 @@ export default async function createLocal<TSlug extends keyof GeneratedTypes['co
     )
   }
 
-  req.payloadAPI = req.payloadAPI || 'local'
-  req.locale = locale
-  req.fallbackLocale =
-    typeof fallbackLocaleArg !== 'undefined' ? fallbackLocaleArg : fallbackLocale || defaultLocale
-  req.payload = payload
-  req.i18n = i18nInit(payload.config.i18n)
-  req.files = {
-    file: (file ?? (await getFileByPath(filePath))) as UploadedFile,
-  }
-
-  if (typeof user !== 'undefined') req.user = user
-
-  if (!req.t) req.t = req.i18n.t
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
+  req.files.file = (file ?? (await getFileByPath(filePath))) as UploadedFile
 
   return create<TSlug>({
     collection,

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -5,9 +5,7 @@ import type { Document, Where } from '../../../types'
 import type { BulkOperationResult } from '../../config/types'
 
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
-import { getDataLoader } from '../../dataloader'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import deleteOperation from '../delete'
 import deleteByID from '../deleteByID'
 
@@ -59,24 +57,13 @@ async function deleteLocal<TSlug extends keyof GeneratedTypes['collections']>(
   const {
     id,
     collection: collectionSlug,
-    context,
     depth,
-    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
-    locale: localeArg = null,
     overrideAccess = true,
-    req: incomingReq = {} as PayloadRequest,
     showHiddenFields,
-    user,
     where,
   } = options
 
   const collection = payload.collections[collectionSlug]
-  const localizationConfig = payload?.config?.localization
-  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
-  const locale = localeArg || incomingReq?.locale || defaultLocale
-  const fallbackLocale = localizationConfig
-    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
-    : null
 
   if (!collection) {
     throw new APIError(
@@ -84,22 +71,7 @@ async function deleteLocal<TSlug extends keyof GeneratedTypes['collections']>(
     )
   }
 
-  const req = {
-    fallbackLocale:
-      typeof fallbackLocaleArg !== 'undefined'
-        ? fallbackLocaleArg
-        : fallbackLocale || defaultLocale,
-    i18n: i18nInit(payload.config.i18n),
-    locale: locale,
-    payload,
-    payloadAPI: 'local',
-    transactionID: incomingReq?.transactionID,
-    user,
-  } as PayloadRequest
-  setRequestContext(req, context)
-
-  if (!req.t) req.t = req.i18n.t
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   const args = {
     id,

--- a/packages/payload/src/collections/operations/local/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/local/findVersionByID.ts
@@ -5,9 +5,7 @@ import type { Document } from '../../../types'
 import type { TypeWithVersion } from '../../../versions/types'
 
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
-import { getDataLoader } from '../../dataloader'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import findVersionByID from '../findVersionByID'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
@@ -35,24 +33,13 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
   const {
     id,
     collection: collectionSlug,
-    context,
     depth,
     disableErrors = false,
-    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
-    locale: localeArg = null,
     overrideAccess = true,
-    req = {} as PayloadRequest,
     showHiddenFields,
   } = options
-  setRequestContext(req, context)
 
   const collection = payload.collections[collectionSlug]
-  const localizationConfig = payload?.config?.localization
-  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
-  const locale = localeArg || req.locale || defaultLocale
-  const fallbackLocale = localizationConfig
-    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
-    : null
 
   if (!collection) {
     throw new APIError(
@@ -62,15 +49,7 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
     )
   }
 
-  req.payloadAPI = req.payloadAPI || 'local'
-  req.locale = locale
-  req.fallbackLocale =
-    typeof fallbackLocaleArg !== 'undefined' ? fallbackLocaleArg : fallbackLocale || defaultLocale
-  req.i18n = i18nInit(payload.config.i18n)
-  req.payload = payload
-
-  if (!req.t) req.t = req.i18n.t
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   return findVersionByID({
     id,

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -6,9 +6,7 @@ import type { Document, Where } from '../../../types'
 import type { TypeWithVersion } from '../../../versions/types'
 
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
-import { getDataLoader } from '../../dataloader'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import findVersions from '../findVersions'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
@@ -37,27 +35,16 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
 ): Promise<PaginatedDocs<TypeWithVersion<GeneratedTypes['collections'][T]>>> {
   const {
     collection: collectionSlug,
-    context,
     depth,
-    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     limit,
-    locale: localeArg = null,
     overrideAccess = true,
     page,
-    req: incomingReq,
     showHiddenFields,
     sort,
-    user,
     where,
   } = options
 
   const collection = payload.collections[collectionSlug]
-  const localizationConfig = payload?.config?.localization
-  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
-  const locale = localeArg || incomingReq?.locale || defaultLocale
-  const fallbackLocale = localizationConfig
-    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
-    : null
 
   if (!collection) {
     throw new APIError(
@@ -65,23 +52,7 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
     )
   }
 
-  const i18n = i18nInit(payload.config.i18n)
-  const req = {
-    fallbackLocale:
-      typeof fallbackLocaleArg !== 'undefined'
-        ? fallbackLocaleArg
-        : fallbackLocale || defaultLocale,
-    i18n,
-    locale,
-    payload,
-    payloadAPI: 'local',
-    transactionID: incomingReq?.transactionID,
-    user,
-  } as PayloadRequest
-  setRequestContext(req, context)
-
-  if (!req.t) req.t = req.i18n.t
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   return findVersions({
     collection,

--- a/packages/payload/src/collections/operations/local/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/local/restoreVersion.ts
@@ -4,9 +4,7 @@ import type { Payload } from '../../../payload'
 import type { Document } from '../../../types'
 
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
-import { getDataLoader } from '../../dataloader'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import restoreVersion from '../restoreVersion'
 
 export type Options<T extends keyof GeneratedTypes['collections']> = {
@@ -30,26 +28,9 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   payload: Payload,
   options: Options<T>,
 ): Promise<GeneratedTypes['collections'][T]> {
-  const {
-    id,
-    collection: collectionSlug,
-    context,
-    depth,
-    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
-    locale: localeArg = null,
-    overrideAccess = true,
-    req: incomingReq,
-    showHiddenFields,
-    user,
-  } = options
+  const { id, collection: collectionSlug, depth, overrideAccess = true, showHiddenFields } = options
 
   const collection = payload.collections[collectionSlug]
-  const localizationConfig = payload?.config?.localization
-  const defaultLocale = localizationConfig ? localizationConfig.defaultLocale : null
-  const locale = localeArg || incomingReq?.locale || defaultLocale
-  const fallbackLocale = localizationConfig
-    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
-    : null
 
   if (!collection) {
     throw new APIError(
@@ -59,23 +40,7 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
     )
   }
 
-  const i18n = i18nInit(payload.config.i18n)
-  const req = {
-    fallbackLocale:
-      typeof fallbackLocaleArg !== 'undefined'
-        ? fallbackLocaleArg
-        : fallbackLocale || defaultLocale,
-    i18n,
-    locale,
-    payload,
-    payloadAPI: 'local',
-    t: i18n.t,
-    transactionID: incomingReq?.transactionID,
-    user,
-  } as PayloadRequest
-  setRequestContext(req, context)
-
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   const args = {
     id,

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -89,7 +89,16 @@ async function updateLocal<TSlug extends keyof GeneratedTypes['collections']>(
   }
 
   const req = createLocalReq(options, payload)
-  req.files.file = (file ?? (await getFileByPath(filePath))) as UploadedFile
+  const fileToSet = (file ?? (await getFileByPath(filePath))) as UploadedFile
+  if (fileToSet) {
+    if (req?.files) {
+      req.files.file = fileToSet
+    } else {
+      req.files = {
+        file: fileToSet,
+      }
+    }
+  }
 
   const args = {
     id,

--- a/packages/payload/src/globals/operations/local/findOne.ts
+++ b/packages/payload/src/globals/operations/local/findOne.ts
@@ -3,10 +3,8 @@ import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 import type { Document } from '../../../types'
 
-import { getDataLoader } from '../../../collections/dataloader'
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import findOne from '../findOne'
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
@@ -27,55 +25,28 @@ export default async function findOneLocal<T extends keyof GeneratedTypes['globa
   options: Options<T>,
 ): Promise<GeneratedTypes['globals'][T]> {
   const {
-    context,
+    slug: globalSlug,
     depth,
     draft = false,
-    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
-    locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
     overrideAccess = true,
     showHiddenFields,
-    slug: globalSlug,
-    user,
   } = options
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug)
-  const localizationConfig = payload?.config?.localization
-  const defaultLocale = payload?.config?.localization
-    ? payload?.config?.localization?.defaultLocale
-    : null
-  const fallbackLocale = localizationConfig
-    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
-    : null
 
   if (!globalConfig) {
     throw new APIError(`The global with slug ${String(globalSlug)} can't be found.`)
   }
 
-  const i18n = i18nInit(payload.config.i18n)
-
-  const req = {
-    fallbackLocale:
-      typeof fallbackLocaleArg !== 'undefined'
-        ? fallbackLocaleArg
-        : fallbackLocale || defaultLocale,
-    i18n,
-    locale: locale ?? options.req?.locale ?? defaultLocale,
-    payload,
-    payloadAPI: 'local',
-    t: i18n.t,
-    user,
-  } as PayloadRequest
-  setRequestContext(req, context)
-
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   return findOne({
+    slug: globalSlug as string,
     depth,
     draft,
     globalConfig,
     overrideAccess,
     req,
     showHiddenFields,
-    slug: globalSlug as string,
   })
 }

--- a/packages/payload/src/globals/operations/local/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/local/findVersionByID.ts
@@ -4,10 +4,8 @@ import type { Payload } from '../../../payload'
 import type { Document } from '../../../types'
 import type { TypeWithVersion } from '../../../versions/types'
 
-import { getDataLoader } from '../../../collections/dataloader'
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import findVersionByID from '../findVersionByID'
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
@@ -30,48 +28,20 @@ export default async function findVersionByIDLocal<T extends keyof GeneratedType
 ): Promise<TypeWithVersion<GeneratedTypes['globals'][T]>> {
   const {
     id,
-    context,
+    slug: globalSlug,
     depth,
     disableErrors = false,
-    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
-    locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
     overrideAccess = true,
-    req: incomingReq,
     showHiddenFields,
-    slug: globalSlug,
-    user,
   } = options
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug)
-  const localizationConfig = payload?.config?.localization
-  const defaultLocale = payload?.config?.localization
-    ? payload?.config?.localization?.defaultLocale
-    : null
-  const fallbackLocale = localizationConfig
-    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
-    : null
-  const i18n = i18nInit(payload.config.i18n)
 
   if (!globalConfig) {
     throw new APIError(`The global with slug ${String(globalSlug)} can't be found.`)
   }
 
-  const req = {
-    fallbackLocale:
-      typeof fallbackLocaleArg !== 'undefined'
-        ? fallbackLocaleArg
-        : fallbackLocale || defaultLocale,
-    i18n,
-    locale,
-    payload,
-    payloadAPI: 'local',
-    t: i18n.t,
-    transactionID: incomingReq?.transactionID,
-    user,
-  } as PayloadRequest
-  setRequestContext(req, context)
-
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   return findVersionByID({
     id,

--- a/packages/payload/src/globals/operations/local/findVersions.ts
+++ b/packages/payload/src/globals/operations/local/findVersions.ts
@@ -5,10 +5,8 @@ import type { Payload } from '../../../payload'
 import type { Document, Where } from '../../../types'
 import type { TypeWithVersion } from '../../../versions/types'
 
-import { getDataLoader } from '../../../collections/dataloader'
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import findVersions from '../findVersions'
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
@@ -32,51 +30,23 @@ export default async function findVersionsLocal<T extends keyof GeneratedTypes['
   options: Options<T>,
 ): Promise<PaginatedDocs<TypeWithVersion<GeneratedTypes['globals'][T]>>> {
   const {
-    context,
+    slug: globalSlug,
     depth,
-    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
     limit,
-    locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
     overrideAccess = true,
     page,
-    req: incomingReq,
     showHiddenFields,
-    slug: globalSlug,
     sort,
-    user,
     where,
   } = options
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug)
-  const localizationConfig = payload?.config?.localization
-  const defaultLocale = payload?.config?.localization
-    ? payload?.config?.localization?.defaultLocale
-    : null
-  const fallbackLocale = localizationConfig
-    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
-    : null
-  const i18n = i18nInit(payload.config.i18n)
 
   if (!globalConfig) {
     throw new APIError(`The global with slug ${String(globalSlug)} can't be found.`)
   }
 
-  const req = {
-    fallbackLocale:
-      typeof fallbackLocaleArg !== 'undefined'
-        ? fallbackLocaleArg
-        : fallbackLocale || defaultLocale,
-    i18n,
-    locale,
-    payload,
-    payloadAPI: 'local',
-    t: i18n.t,
-    transactionID: incomingReq?.transactionID,
-    user,
-  } as PayloadRequest
-  setRequestContext(req, context)
-
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   return findVersions({
     depth,

--- a/packages/payload/src/globals/operations/local/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/local/restoreVersion.ts
@@ -3,10 +3,8 @@ import type { PayloadRequest } from '../../../express/types'
 import type { Payload } from '../../../payload'
 import type { Document } from '../../../types'
 
-import { getDataLoader } from '../../../collections/dataloader'
 import { APIError } from '../../../errors'
-import { setRequestContext } from '../../../express/setRequestContext'
-import { i18nInit } from '../../../translations/init'
+import { createLocalReq } from '../../../utilities/createLocalReq'
 import restoreVersion from '../restoreVersion'
 
 export type Options<T extends keyof GeneratedTypes['globals']> = {
@@ -26,49 +24,15 @@ export default async function restoreVersionLocal<T extends keyof GeneratedTypes
   payload: Payload,
   options: Options<T>,
 ): Promise<GeneratedTypes['globals'][T]> {
-  const {
-    id,
-    context,
-    depth,
-    fallbackLocale: fallbackLocaleArg = options?.req?.fallbackLocale,
-    locale = payload.config.localization ? payload.config.localization?.defaultLocale : null,
-    overrideAccess = true,
-    req: incomingReq,
-    showHiddenFields,
-    slug: globalSlug,
-    user,
-  } = options
+  const { id, slug: globalSlug, depth, overrideAccess = true, showHiddenFields } = options
 
   const globalConfig = payload.globals.config.find((config) => config.slug === globalSlug)
-  const localizationConfig = payload?.config?.localization
-  const defaultLocale = payload?.config?.localization
-    ? payload?.config?.localization?.defaultLocale
-    : null
-  const fallbackLocale = localizationConfig
-    ? localizationConfig.locales.find(({ code }) => locale === code)?.fallbackLocale
-    : null
-  const i18n = i18nInit(payload.config.i18n)
 
   if (!globalConfig) {
     throw new APIError(`The global with slug ${String(globalSlug)} can't be found.`)
   }
 
-  const req = {
-    fallbackLocale:
-      typeof fallbackLocaleArg !== 'undefined'
-        ? fallbackLocaleArg
-        : fallbackLocale || defaultLocale,
-    i18n,
-    locale,
-    payload,
-    payloadAPI: 'local',
-    t: i18n.t,
-    transactionID: incomingReq?.transactionID,
-    user,
-  } as PayloadRequest
-  setRequestContext(req, context)
-
-  if (!req.payloadDataLoader) req.payloadDataLoader = getDataLoader(req)
+  const req = createLocalReq(options, payload)
 
   return restoreVersion({
     id,

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -1,0 +1,60 @@
+import type { Payload, RequestContext } from '..'
+import type { PayloadRequest } from '../exports/types'
+
+import { getDataLoader } from '../collections/dataloader'
+import { i18nInit } from '../translations/init'
+
+function getRequestContext(
+  req: PayloadRequest = { context: null } as PayloadRequest,
+  context: RequestContext = {},
+): RequestContext {
+  if (req.context) {
+    if (Object.keys(req.context).length === 0 && req.context.constructor === Object) {
+      // if req.context is `{}` avoid unnecessary spread
+      return context
+    } else {
+      return { ...req.context, ...context }
+    }
+  } else {
+    return context
+  }
+}
+
+type CreateLocalReq = (
+  options: {
+    collection?: number | string | symbol
+    context?: RequestContext
+    fallbackLocale?: string
+    locale?: string
+    req?: PayloadRequest
+    user?: Document
+  },
+  payload: Payload,
+) => PayloadRequest
+export const createLocalReq: CreateLocalReq = (
+  { collection, context, fallbackLocale, locale, req = {} as PayloadRequest, user },
+  payload,
+) => {
+  const i18n = req?.i18n || i18nInit(payload.config.i18n)
+
+  if (payload.config?.localization) {
+    const defaultLocale = payload.config.localization.defaultLocale
+    req.locale = locale || req?.locale || defaultLocale
+    const fallbackLocaleFromConfig = payload.config.localization.locales.find(
+      ({ code }) => req.locale === code,
+    )?.fallbackLocale
+    req.fallbackLocale =
+      fallbackLocale || req?.fallbackLocale || fallbackLocaleFromConfig || defaultLocale
+  }
+
+  req.context = getRequestContext(req, context)
+  req.payloadAPI = req?.payloadAPI || 'local'
+  req.payload = payload
+  req.i18n = i18n
+  req.t = i18n.t
+  req.user = user || req?.user || null
+  req.collection = collection ? payload.collections?.[collection] : null
+  req.payloadDataLoader = req?.payloadDataLoader || getDataLoader(req)
+
+  return req
+}

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -43,8 +43,11 @@ export const createLocalReq: CreateLocalReq = (
     const fallbackLocaleFromConfig = payload.config.localization.locales.find(
       ({ code }) => req.locale === code,
     )?.fallbackLocale
+    const definedFallbackLocale = fallbackLocale || req?.fallbackLocale
     req.fallbackLocale =
-      fallbackLocale || req?.fallbackLocale || fallbackLocaleFromConfig || defaultLocale
+      typeof definedFallbackLocale !== 'undefined'
+        ? definedFallbackLocale
+        : fallbackLocaleFromConfig || defaultLocale
   }
 
   req.context = getRequestContext(req, context)

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -43,11 +43,11 @@ export const createLocalReq: CreateLocalReq = (
     const fallbackLocaleFromConfig = payload.config.localization.locales.find(
       ({ code }) => req.locale === code,
     )?.fallbackLocale
-    const definedFallbackLocale = fallbackLocale || req?.fallbackLocale
-    req.fallbackLocale =
-      typeof definedFallbackLocale !== 'undefined'
-        ? definedFallbackLocale
-        : fallbackLocaleFromConfig || defaultLocale
+    if (typeof fallbackLocale !== 'undefined') {
+      req.fallbackLocale = fallbackLocale
+    } else if (typeof req?.fallbackLocale === 'undefined') {
+      req.fallbackLocale = fallbackLocaleFromConfig || defaultLocale
+    }
   }
 
   req.context = getRequestContext(req, context)

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -35,7 +35,7 @@ export const createLocalReq: CreateLocalReq = (
   { collection, context, fallbackLocale, locale, req = {} as PayloadRequest, user },
   payload,
 ) => {
-  const i18n = req?.i18n || i18nInit(payload.config.i18n)
+  const i18n = req?.i18n || i18nInit(payload.config?.i18n)
 
   if (payload.config?.localization) {
     const defaultLocale = payload.config.localization.defaultLocale


### PR DESCRIPTION
## Description

Adds `createLocalReq` that standardizes how the req is built up when using the local API. This allows for fixes/changes to be made in one place instead within every Local API file. This also ensures that req's will be generated the same way for all operations.

Before, some operations were mutating the req passed in, while others were building up entirely new objects. Now we mutate the incoming req if it exists, or builds up a new one on an empty object if a request is not passed through to the local API. This allows existing properties to remain untouched and more context can be had within operations since the req is always mutated now.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
