### PR TITLE
fix(migrations): safely create migration file when no name passed

### DIFF
--- a/packages/db-mongodb/src/createMigration.ts
+++ b/packages/db-mongodb/src/createMigration.ts
@@ -32,7 +32,7 @@ export const createMigration: CreateMigration = async function createMigration({
 
   // Check for predefined migration.
   // Either passed in via --file or prefixed with @payloadcms/db-mongodb/
-  if (file || migrationName.startsWith('@payloadcms/db-mongodb/')) {
+  if (file || migrationName?.startsWith('@payloadcms/db-mongodb/')) {
     if (!file) file = migrationName
 
     const predefinedMigrationName = file.replace('@payloadcms/db-mongodb/', '')
@@ -59,8 +59,8 @@ export const createMigration: CreateMigration = async function createMigration({
 
   const timestamp = `${formattedDate}_${formattedTime}`
 
-  const formattedName = migrationName.replace(/\W/g, '_')
-  const fileName = `${timestamp}_${formattedName}.ts`
+  const formattedName = migrationName?.replace(/\W/g, '_')
+  const fileName = migrationName ? `${timestamp}_${formattedName}.ts` : `${timestamp}_migration.ts`
   const filePath = `${dir}/${fileName}`
   fs.writeFileSync(filePath, migrationFileContent)
   payload.logger.info({ msg: `Migration created at ${filePath}` })

--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -45,7 +45,7 @@ if (tsConfig?.config?.compilerOptions?.paths) {
 // Allow disabling SWC for debugging
 if (process.env.DISABLE_SWC !== 'true') {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore - bad @swc/register types
+  // @ts-expect-error - bad @swc/register types
   swcRegister(swcOptions)
 }
 


### PR DESCRIPTION
## Description

Safely create migration file if no name is passed.

Fixes #4975
