### PR TITLE
fix(richtext-lexical): make editor reactive to initialValue changes

### DIFF
--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -49,7 +49,7 @@ const RichText: React.FC<FieldProps> = (props) => {
     validate: memoizedValidate,
   })
 
-  const { errorMessage, setValue, showError, value } = fieldType
+  const { errorMessage, initialValue, setValue, showError, value } = fieldType
 
   const classes = [
     baseClass,
@@ -77,6 +77,7 @@ const RichText: React.FC<FieldProps> = (props) => {
           <LexicalProvider
             editorConfig={editorConfig}
             fieldProps={props}
+            key={JSON.stringify({ initialValue, path })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More Info in PR description
             onChange={(editorState) => {
               let serializedEditorState = editorState.toJSON()
 

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -77,7 +77,7 @@ const RichText: React.FC<FieldProps> = (props) => {
           <LexicalProvider
             editorConfig={editorConfig}
             fieldProps={props}
-            key={JSON.stringify({ initialValue, path })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More Info in PR description
+            key={JSON.stringify({ initialValue, path })} // makes sure lexical is completely re-rendered when initialValue changes, bypassing the lexical-internal value memoization. That way, external changes to the form will update the editor. More infos in PR description (https://github.com/payloadcms/payload/pull/5010)
             onChange={(editorState) => {
               let serializedEditorState = editorState.toJSON()
 

--- a/packages/richtext-slate/src/field/RichText.tsx
+++ b/packages/richtext-slate/src/field/RichText.tsx
@@ -326,7 +326,7 @@ const RichText: React.FC<FieldProps> = (props) => {
         <Label htmlFor={`field-${path.replace(/\./g, '__')}`} label={label} required={required} />
         <Slate
           editor={editor}
-          key={JSON.stringify({ initialValue, path })}
+          key={JSON.stringify({ initialValue, path })} // makes sure slate is completely re-rendered when initialValue changes, bypassing the slate-internal value memoization. That way, external changes to the form will update the editor
           onChange={handleChange}
           value={valueToRender as any[]}
         >


### PR DESCRIPTION
## Description

```ts
 dispatchFields({
      type: 'REPLACE_STATE',
      state: {
        ...fields,
        lexicalSimple: {
          ...fields.lexicalSimple,
          initialValue: null,
          value: null,
        },
        slateSimple: {
          ...fields.slateSimple,
          initialValue: null,
          value: null,
        },
        title: {
          ...fields.title,
          value: 'Initial title',
        },
      },
    })
```

This currently will (visually) update the slate field, but will NOT update the lexical field, unless you press "Save" after this is run.

That's because value is internally memoized in lexical / slate for it to be performant when you type. By adding a key which consists of `initialValue` and `path`, it forces lexical to completely re-render if `initialValue` is changed due to external forces, like this `dispatchFields` call. Slate already does that. Otherwise, while the parent components would re-render, whatever displays the value in lexical would not re-render, as that part is memoized.

## Why initialValue and not value?

Performance. That way, we won't force complete re-rendering when you just type. Just typing changes the `value`, not the `initialValue`.

This also means that, in order to update richtext fields using `dispatchFields`, you have to pass BOTH `value` and `initialValue`. Just passing in `value` would work for simple fields like text fields, but is not sufficient for richText fields.

## Problems with this solution

Now this PR makes this better. It works just like it works in the Slate editor now. But it's not perfect. Here's an example:
1. Load the editor. initialValue + value is **undefined**
2. Type something. initialValue is **undefined**, value is something
3. Reset. initialValue is **null**, value is null => visual update, because undefined => null. Good!
4. Type something. initialValue is **null**, value is something
5. Reset, initialValue is **null**, value is null. PROBLEM! No visual update, because initialValue changed from null => null. No change detected.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
