### PR TITLE
feat: conditional block row actions

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Blocks/BlockRow.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/BlockRow.tsx
@@ -30,6 +30,7 @@ type BlockFieldProps = UseDraggableSortableReturn &
     readOnly: boolean
     removeRow: (rowIndex: number) => void
     row: Row
+    rowActionsAvailable: boolean
     rowCount: number
     rowIndex: number
     setCollapse: (id: string, collapsed: boolean) => void
@@ -52,6 +53,7 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
   readOnly,
   removeRow,
   row,
+  rowActionsAvailable,
   rowCount,
   rowIndex,
   setCollapse,
@@ -83,7 +85,7 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
     >
       <Collapsible
         actions={
-          !readOnly ? (
+          !readOnly && rowActionsAvailable ? (
             <RowActions
               addRow={addRow}
               blockType={row.blockType}
@@ -101,11 +103,15 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
         className={classNames}
         collapsed={row.collapsed}
         collapsibleStyle={fieldHasErrors ? 'error' : 'default'}
-        dragHandleProps={{
-          id: row.id,
-          attributes,
-          listeners,
-        }}
+        dragHandleProps={
+          rowActionsAvailable
+            ? {
+                id: row.id,
+                attributes,
+                listeners,
+              }
+            : undefined
+        }
         header={
           <div className={`${baseClass}__block-header`}>
             <span className={`${baseClass}__block-number`}>

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback } from 'react'
+import React, { Fragment, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { Props } from './types'
@@ -22,6 +22,7 @@ import { useForm, useFormSubmitted } from '../../Form/context'
 import { NullifyLocaleField } from '../../NullifyField'
 import useField from '../../useField'
 import withCondition from '../../withCondition'
+import { WatchCondition } from '../../withCondition/WatchCondition'
 import { fieldBaseClass } from '../shared'
 import { BlockRow } from './BlockRow'
 import { BlocksDrawer } from './BlocksDrawer'
@@ -34,6 +35,7 @@ const BlocksField: React.FC<Props> = (props) => {
 
   const {
     name,
+    accessRowActions,
     admin: { className, condition, description, readOnly },
     blocks,
     fieldTypes,
@@ -166,6 +168,8 @@ const BlocksField: React.FC<Props> = (props) => {
   const showMinRows = rows.length < minRows || (required && rows.length === 0)
   const showRequired = readOnly && rows.length === 0
 
+  const [rowActionsAvailable, setRowActionsAvailable] = useState(true)
+
   return (
     <div
       className={[
@@ -249,6 +253,7 @@ const BlocksField: React.FC<Props> = (props) => {
                       readOnly={readOnly}
                       removeRow={removeRow}
                       row={row}
+                      rowActionsAvailable={rowActionsAvailable}
                       rowCount={rows.length}
                       rowIndex={i}
                       setCollapse={setCollapse}
@@ -284,7 +289,7 @@ const BlocksField: React.FC<Props> = (props) => {
           )}
         </DraggableSortable>
       )}
-      {!readOnly && !hasMaxRows && (
+      {!readOnly && !hasMaxRows && rowActionsAvailable && (
         <Fragment>
           <DrawerToggler className={`${baseClass}__drawer-toggler`} slug={drawerSlug}>
             <Button
@@ -306,6 +311,12 @@ const BlocksField: React.FC<Props> = (props) => {
           />
         </Fragment>
       )}
+      <WatchCondition
+        condition={accessRowActions}
+        name={name}
+        path={path}
+        setShowField={setRowActionsAvailable}
+      />
     </div>
   )
 }

--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -396,6 +396,7 @@ export const relationship = baseField.keys({
 
 export const blocks = baseField.keys({
   name: joi.string().required(),
+  accessRowActions: joi.func(),
   blocks: joi
     .array()
     .items(

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -584,6 +584,7 @@ export type Block = {
 }
 
 export type BlockField = FieldBase & {
+  accessRowActions?: Condition
   admin?: Admin & {
     initCollapsed?: boolean | false
   }

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -329,6 +329,11 @@ const BlockFields: CollectionConfig = {
         },
       },
     },
+    {
+      ...getBlocksField(),
+      name: 'rowActionsReadOnly',
+      accessRowActions: () => false,
+    },
   ],
 }
 


### PR DESCRIPTION
## Description

We have a use case where we want to have a condition where some users should be able to add/remove/reorder block rows. While other users should just be able to change the content inside the block rows.

I have made the change by adding a new condition to the Block called `accessRowActions`.
If this condition is not present or returns true, it will work like it does now and allow all access to row actions.

If the condition is present and returns false, it will disable the viewing of these actions in admin UI.

When this condition is not present or true:
![before_change](https://github.com/payloadcms/payload/assets/2082176/42a38a78-fd36-4567-bf60-94cdb5128bcf)

When this condition is present and false:
![after_change](https://github.com/payloadcms/payload/assets/2082176/12ec42d8-a970-4172-8f87-5e311c8c387b)

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
