### PR TITLE
fix: query relationships by explicit id field

### DIFF
--- a/packages/db-postgres/src/queries/getTableColumnFromPath.ts
+++ b/packages/db-postgres/src/queries/getTableColumnFromPath.ts
@@ -349,7 +349,7 @@ export const getTableColumnFromPath = ({
             table: newAliasTable,
           })
 
-          if (newCollectionPath === '') {
+          if (newCollectionPath === '' || newCollectionPath === 'id') {
             return {
               columnName: `${field.relationTo}ID`,
               constraints,

--- a/packages/payload/src/database/getLocalizedPaths.ts
+++ b/packages/payload/src/database/getLocalizedPaths.ts
@@ -62,6 +62,17 @@ export async function getLocalizedPaths({
         return paths
       }
 
+      if (!matchedField && currentPath === 'id' && i === pathSegments.length - 1) {
+        lastIncompletePath.path = currentPath
+        const idField: Field = {
+          name: 'id',
+          type: payload.db.defaultIDType as 'text',
+        }
+        lastIncompletePath.field = idField
+        lastIncompletePath.complete = true
+        return paths
+      }
+
       if (matchedField) {
         if ('hidden' in matchedField && matchedField.hidden && !overrideAccess) {
           lastIncompletePath.invalid = true


### PR DESCRIPTION
## Description

Fixes querying relationship by explicit `id` field

Fixes #4240
