### PR TITLE
docs: Included info for loading config outside payload

### DIFF
--- a/docs/rich-text/lexical.mdx
+++ b/docs/rich-text/lexical.mdx
@@ -339,6 +339,31 @@ yourEditorConfig.features = [
 ]
 ```
 
+###Using configs outside payload
+
+There are times where you may want to initiate a headless editor outside of payload but you need access to the payload configs. For example when using NodeJS to seed existing data into payload. 
+
+The Payload config is isomorphic, in that it loads both server-side and client-side code into the same config. When we import the payload config outside of payload, we need to explictly exclude these file extensions so that they are not loaded on the server.
+
+```ts
+const clientFiles = [
+  ".scss",
+  ".css",
+  ".svg",
+  ".png",
+  ".jpg",
+  ".eot",
+  ".ttf",
+  ".woff",
+  ".woff2",
+];
+clientFiles.forEach((ext) => {
+  require.extensions[ext] = () => null;
+});
+import { defaultEditorConfig, defaultEditorFeatures } from '@payloadcms/richtext-lexical' // <= make sure this package is installed
+```
+NOTE: This needs to be done BEFORE importing the editor configs.
+
 ### HTML => Lexical
 
 Once you have your headless editor instance, you can use it to convert HTML to Lexical:


### PR DESCRIPTION

## Description

When trying to use a seed script to import HTML data into the headless editor, it loads client side files causing an error in Node. See this issue for more information: https://github.com/payloadcms/payload/issues/3120

Including this information in the Lexical portion of the docs will help clarify how to properly import the configs when using the headless editor in Node.

- [ x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] Existing test suite passes locally with my changes
- [x ] I have made corresponding changes to the documentation
