### PR TITLE
Update getExternalFile.ts to check if the url is already a full url b…

### DIFF
--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -11,7 +11,7 @@ export const getExternalFile = async ({ req, data }: Args): Promise<File> => {
   const { url, filename } = data
 
   if (typeof url === 'string') {
-    const fileURL = `${baseUrl}${url}`
+    const fileURL = url.startsWith("http") ? url :`${baseUrl}${url}`;
     const { default: fetch } = (await import('node-fetch')) as any
 
     const res = await fetch(fileURL, {


### PR DESCRIPTION
## Description
Update getExternalFile.ts to check if the URL is already a full URL before appending the base URL

This happens if the cloud storage plugin is used, or if the user has overridden the URL field to use the full URL instead of a relative path.

Fix https://github.com/payloadcms/payload/issues/4422

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation


Happy to add a test if this is needed.