### PR TITLE
fix(db-mongodb): handle null values with exists on clearable fields

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -157,6 +157,23 @@ export const sanitizeQueryValue = ({
 
   if (operator === 'exists') {
     formattedValue = formattedValue === 'true' || formattedValue === true
+
+    // Clearable fields
+    if (['relationship', 'select', 'upload'].includes(field.type)) {
+      if (formattedValue) {
+        return {
+          rawQuery: {
+            $and: [{ [path]: { $exists: true } }, { [path]: { $ne: null } }],
+          },
+        }
+      } else {
+        return {
+          rawQuery: {
+            $or: [{ [path]: { $exists: false } }, { [path]: { $eq: null } }],
+          },
+        }
+      }
+    }
   }
 
   return { operator: formattedOperator, val: formattedValue }

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1145,6 +1145,63 @@ describe('Fields', () => {
         expect(existTrueIDs).toContain(hasJSON.id)
         expect(existFalseIDs).not.toContain(hasJSON.id)
       })
+
+      it('exists should not return null values', async () => {
+        const { id } = await payload.create({
+          collection: 'select-fields',
+          data: {
+            select: 'one',
+          },
+        })
+
+        const existsResult = await payload.find({
+          collection: 'select-fields',
+          where: {
+            id: { equals: id },
+            select: { exists: true },
+          },
+        })
+
+        expect(existsResult.docs).toHaveLength(1)
+
+        const existsFalseResult = await payload.find({
+          collection: 'select-fields',
+          where: {
+            id: { equals: id },
+            select: { exists: false },
+          },
+        })
+
+        expect(existsFalseResult.docs).toHaveLength(0)
+
+        await payload.update({
+          collection: 'select-fields',
+          id,
+          data: {
+            select: null,
+          },
+        })
+
+        const existsTrueResult = await payload.find({
+          collection: 'select-fields',
+          where: {
+            id: { equals: id },
+            select: { exists: true },
+          },
+        })
+
+        expect(existsTrueResult.docs).toHaveLength(0)
+
+        const result = await payload.find({
+          collection: 'select-fields',
+          where: {
+            id: { equals: id },
+            select: { exists: false },
+          },
+        })
+
+        expect(result.docs).toHaveLength(1)
+      })
     })
   })
 
@@ -1247,6 +1304,65 @@ describe('Fields', () => {
       })
 
       expect(query.docs).toBeDefined()
+    })
+  })
+
+  describe('clearable fields - exists', () => {
+    it('exists should not return null values', async () => {
+      const { id } = await payload.create({
+        collection: 'select-fields',
+        data: {
+          select: 'one',
+        },
+      })
+
+      const existsResult = await payload.find({
+        collection: 'select-fields',
+        where: {
+          id: { equals: id },
+          select: { exists: true },
+        },
+      })
+
+      expect(existsResult.docs).toHaveLength(1)
+
+      const existsFalseResult = await payload.find({
+        collection: 'select-fields',
+        where: {
+          id: { equals: id },
+          select: { exists: false },
+        },
+      })
+
+      expect(existsFalseResult.docs).toHaveLength(0)
+
+      await payload.update({
+        collection: 'select-fields',
+        id,
+        data: {
+          select: null,
+        },
+      })
+
+      const existsTrueResult = await payload.find({
+        collection: 'select-fields',
+        where: {
+          id: { equals: id },
+          select: { exists: true },
+        },
+      })
+
+      expect(existsTrueResult.docs).toHaveLength(0)
+
+      const result = await payload.find({
+        collection: 'select-fields',
+        where: {
+          id: { equals: id },
+          select: { exists: false },
+        },
+      })
+
+      expect(result.docs).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
## Description

The Problem:

When a relationship, upload, or select field is cleared from the UI, the value _is not unset_ - it is set to `null` which differs from the initial unset value.

This goes against users' expectations when using an operator like `exists` in the UI. If one of the aforementioned fields is cleared and queried with `exists: true`, values of `null` are returned. The inverse is also true (`exists: false` does not return null values)

Solution:

This PR modifies the functionality of `exists` in order to handle this. This does however diverge from how the `exists` operator works in MongoDB.