### PR TITLE
fix(db-postgres): query using blockType

### DIFF
--- a/packages/db-postgres/src/queries/buildQuery.ts
+++ b/packages/db-postgres/src/queries/buildQuery.ts
@@ -75,6 +75,7 @@ const buildQuery = async function buildQuery({
         pathSegments: sortPath.replace(/__/g, '.').split('.'),
         selectFields,
         tableName,
+        value: sortPath,
       })
       orderBy.column = sortTable?.[sortTableColumnName]
     } catch (err) {

--- a/packages/db-postgres/src/queries/getTableColumnFromPath.ts
+++ b/packages/db-postgres/src/queries/getTableColumnFromPath.ts
@@ -344,9 +344,6 @@ export const getTableColumnFromPath = ({
             table: blockTableColumn.table,
           }
         }
-        // if (pathSegments[1] === 'blockType') {
-        //   throw new APIError('Querying on blockType is not supported')
-        // }
         break
       }
 

--- a/packages/db-postgres/src/queries/getTableColumnFromPath.ts
+++ b/packages/db-postgres/src/queries/getTableColumnFromPath.ts
@@ -48,6 +48,10 @@ type Args = {
    * If creating a new table name for arrays and blocks, this suffix should be appended to the table name
    */
   tableNameSuffix?: string
+  /**
+   * The raw value of the query before sanitization
+   */
+  value: unknown
 }
 /**
  * Transforms path to table and column name
@@ -70,6 +74,7 @@ export const getTableColumnFromPath = ({
   selectFields,
   tableName,
   tableNameSuffix = '',
+  value,
 }: Args): TableColumn => {
   const fieldPath = incomingSegments[0]
   let locale = incomingLocale
@@ -131,6 +136,7 @@ export const getTableColumnFromPath = ({
           selectFields,
           tableName: newTableName,
           tableNameSuffix,
+          value,
         })
       }
       case 'tab': {
@@ -151,6 +157,7 @@ export const getTableColumnFromPath = ({
             selectFields,
             tableName: newTableName,
             tableNameSuffix: `${tableNameSuffix}${toSnakeCase(field.name)}_`,
+            value,
           })
         }
         return getTableColumnFromPath({
@@ -169,6 +176,7 @@ export const getTableColumnFromPath = ({
           selectFields,
           tableName: newTableName,
           tableNameSuffix,
+          value,
         })
       }
 
@@ -204,6 +212,7 @@ export const getTableColumnFromPath = ({
           selectFields,
           tableName: newTableName,
           tableNameSuffix: `${tableNameSuffix}${toSnakeCase(field.name)}_`,
+          value,
         })
       }
 
@@ -241,12 +250,39 @@ export const getTableColumnFromPath = ({
           rootTableName,
           selectFields,
           tableName: newTableName,
+          value,
         })
       }
 
       case 'blocks': {
         let blockTableColumn: TableColumn
         let newTableName: string
+
+        // handle blockType queries
+        if (pathSegments[1] === 'blockType') {
+          // find the block config using the value
+          const blockTypes = Array.isArray(value) ? value : [value]
+          blockTypes.forEach((blockType) => {
+            const block = field.blocks.find((block) => block.slug === blockType)
+            newTableName = `${tableName}_blocks_${toSnakeCase(block.slug)}`
+            joins[newTableName] = eq(
+              adapter.tables[tableName].id,
+              adapter.tables[newTableName]._parentID,
+            )
+            constraints.push({
+              columnName: '_path',
+              table: adapter.tables[newTableName],
+              value: pathSegments[0],
+            })
+          })
+          return {
+            constraints,
+            field,
+            getNotNullColumnByValue: () => 'id',
+            table: adapter.tables[tableName],
+          }
+        }
+
         const hasBlockField = field.blocks.some((block) => {
           newTableName = `${tableName}_blocks_${toSnakeCase(block.slug)}`
           constraintPath = `${constraintPath}${field.name}.%.`
@@ -267,6 +303,7 @@ export const getTableColumnFromPath = ({
               rootTableName,
               selectFields: blockSelectFields,
               tableName: newTableName,
+              value,
             })
           } catch (error) {
             // this is fine, not every block will have the field
@@ -307,9 +344,9 @@ export const getTableColumnFromPath = ({
             table: blockTableColumn.table,
           }
         }
-        if (pathSegments[1] === 'blockType') {
-          throw new APIError('Querying on blockType is not supported')
-        }
+        // if (pathSegments[1] === 'blockType') {
+        //   throw new APIError('Querying on blockType is not supported')
+        // }
         break
       }
 
@@ -397,6 +434,7 @@ export const getTableColumnFromPath = ({
           rootTableName: newTableName,
           selectFields,
           tableName: newTableName,
+          value,
         })
       }
 

--- a/packages/db-postgres/src/queries/parseParams.ts
+++ b/packages/db-postgres/src/queries/parseParams.ts
@@ -63,11 +63,6 @@ export async function parseParams({
             where: condition,
           })
           if (builtConditions.length > 0) {
-            // if (result) {
-            //   result = operatorMap[conditionOperator](result, ...builtConditions)
-            // } else {
-            //   result = operatorMap[conditionOperator](...builtConditions)
-            // }
             result = operatorMap[conditionOperator](...builtConditions)
           }
         } else {

--- a/packages/db-postgres/src/queries/parseParams.ts
+++ b/packages/db-postgres/src/queries/parseParams.ts
@@ -63,11 +63,12 @@ export async function parseParams({
             where: condition,
           })
           if (builtConditions.length > 0) {
-            if (result) {
-              result = operatorMap[conditionOperator](result, ...builtConditions)
-            } else {
-              result = operatorMap[conditionOperator](...builtConditions)
-            }
+            // if (result) {
+            //   result = operatorMap[conditionOperator](result, ...builtConditions)
+            // } else {
+            //   result = operatorMap[conditionOperator](...builtConditions)
+            // }
+            result = operatorMap[conditionOperator](...builtConditions)
           }
         } else {
           // It's a path - and there can be multiple comparisons on a single path.
@@ -77,6 +78,7 @@ export async function parseParams({
           if (typeof pathOperators === 'object') {
             for (const operator of Object.keys(pathOperators)) {
               if (validOperators.includes(operator as Operator)) {
+                const val = where[relationOrPath][operator]
                 const {
                   columnName,
                   constraints: queryConstraints,
@@ -95,9 +97,8 @@ export async function parseParams({
                   pathSegments: relationOrPath.replace(/__/g, '.').split('.'),
                   selectFields,
                   tableName,
+                  value: val,
                 })
-
-                const val = where[relationOrPath][operator]
 
                 queryConstraints.forEach(({ columnName: col, table: constraintTable, value }) => {
                   if (typeof value === 'string' && value.indexOf('%') > -1) {

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -116,6 +116,10 @@ const BlockFields: CollectionConfig = {
   fields: [
     getBlocksField(),
     {
+      ...getBlocksField(),
+      name: 'duplicate',
+    },
+    {
       ...getBlocksField('localized'),
       name: 'collapsedByDefaultBlocks',
       admin: {

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -100,8 +100,8 @@ describe('Fields', () => {
       const { id } = await payload.create({
         collection: 'text-fields',
         data: {
-          text,
           localizedHasMany,
+          text,
         },
         locale: 'en',
       })
@@ -977,6 +977,70 @@ describe('Fields', () => {
       expect(result.docs).toHaveLength(1)
       expect(result.docs[0]).toMatchObject(blockDoc)
     })
+
+    it('should query by blockType', async () => {
+      const text = 'blockType query test'
+
+      const hit = await payload.create({
+        collection: blockFieldsSlug,
+        data: {
+          blocks: [
+            {
+              blockType: 'content',
+              text,
+            },
+          ],
+        },
+      })
+      const miss = await payload.create({
+        collection: blockFieldsSlug,
+        data: {
+          blocks: [
+            {
+              blockType: 'number',
+              number: 5,
+            },
+          ],
+          duplicate: [
+            {
+              blockType: 'content',
+              text,
+            },
+          ],
+        },
+      })
+
+      const { docs: equalsDocs } = await payload.find({
+        collection: blockFieldsSlug,
+        where: {
+          and: [
+            {
+              'blocks.blockType': { equals: 'content' },
+            },
+            {
+              'blocks.text': { equals: text },
+            },
+          ],
+        },
+      })
+
+      const { docs: inDocs } = await payload.find({
+        collection: blockFieldsSlug,
+        where: {
+          'blocks.blockType': { in: ['content'] },
+        },
+      })
+
+      const equalsHitResult = equalsDocs.find(({ id }) => id === hit.id)
+      const inHitResult = inDocs.find(({ id }) => id === hit.id)
+      const equalsMissResult = equalsDocs.find(({ id }) => id === miss.id)
+      const inMissResult = inDocs.find(({ id }) => id === miss.id)
+
+      expect(equalsHitResult.id).toStrictEqual(hit.id)
+      expect(inHitResult.id).toStrictEqual(hit.id)
+      expect(equalsMissResult).toBeUndefined()
+      expect(inMissResult).toBeUndefined()
+    })
   })
 
   describe('json', () => {
@@ -1175,8 +1239,8 @@ describe('Fields', () => {
         expect(existsFalseResult.docs).toHaveLength(0)
 
         await payload.update({
-          collection: 'select-fields',
           id,
+          collection: 'select-fields',
           data: {
             select: null,
           },
@@ -1257,8 +1321,8 @@ describe('Fields', () => {
       expect(nodes).toBeDefined()
       const child = nodes.flatMap((n) => n.children).find((c) => c.doc)
       expect(child).toMatchObject({
-        linkType: 'internal',
         type: 'link',
+        linkType: 'internal',
       })
       expect(child.doc.relationTo).toEqual('array-fields')
 
@@ -1337,8 +1401,8 @@ describe('Fields', () => {
       expect(existsFalseResult.docs).toHaveLength(0)
 
       await payload.update({
-        collection: 'select-fields',
         id,
+        collection: 'select-fields',
         data: {
           select: null,
         },


### PR DESCRIPTION
## Description

Fix #3838 

In MongoDB the blockType is easily queried on because it takes shape in the actual document saved. This PR matches the functionality for postgres by looking at the value of the query for blockTypes and adding joins and constraints to the query to make sure the path matches and exists in the appropriate block table.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
