### PR TITLE
fix(live-preview): check message data.type before updating preview data

### DIFF
--- a/packages/live-preview/src/handleMessage.ts
+++ b/packages/live-preview/src/handleMessage.ts
@@ -19,41 +19,32 @@ export const handleMessage = async <T>(args: {
 }): Promise<T> => {
   const { apiRoute, depth, event, initialData, serverURL } = args
 
-  if (
-    event.origin === serverURL &&
-    event.data &&
-    typeof event.data === 'object' &&
-    event.data.type === 'payload-live-preview'
-  ) {
-    const { data, externallyUpdatedRelationship, fieldSchemaJSON } = event.data
+  const { data, externallyUpdatedRelationship, fieldSchemaJSON } = event.data
 
-    if (!payloadLivePreviewFieldSchema && fieldSchemaJSON) {
-      payloadLivePreviewFieldSchema = fieldSchemaJSON
-    }
-
-    if (!payloadLivePreviewFieldSchema) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Payload Live Preview: No `fieldSchemaJSON` was received from the parent window. Unable to merge data.',
-      )
-
-      return initialData
-    }
-
-    const mergedData = await mergeData<T>({
-      apiRoute,
-      depth,
-      externallyUpdatedRelationship,
-      fieldSchema: payloadLivePreviewFieldSchema,
-      incomingData: data,
-      initialData: payloadLivePreviewPreviousData || initialData,
-      serverURL,
-    })
-
-    payloadLivePreviewPreviousData = mergedData
-
-    return mergedData
+  if (!payloadLivePreviewFieldSchema && fieldSchemaJSON) {
+    payloadLivePreviewFieldSchema = fieldSchemaJSON
   }
 
-  return initialData
+  if (!payloadLivePreviewFieldSchema) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Payload Live Preview: No `fieldSchemaJSON` was received from the parent window. Unable to merge data.',
+    )
+
+    return initialData
+  }
+
+  const mergedData = await mergeData<T>({
+    apiRoute,
+    depth,
+    externallyUpdatedRelationship,
+    fieldSchema: payloadLivePreviewFieldSchema,
+    incomingData: data,
+    initialData: payloadLivePreviewPreviousData || initialData,
+    serverURL,
+  })
+
+  payloadLivePreviewPreviousData = mergedData
+
+  return mergedData
 }

--- a/packages/live-preview/src/subscribe.ts
+++ b/packages/live-preview/src/subscribe.ts
@@ -10,8 +10,15 @@ export const subscribe = <T>(args: {
   const { apiRoute, callback, depth, initialData, serverURL } = args
 
   const onMessage = async (event: MessageEvent) => {
-    const mergedData = await handleMessage<T>({ apiRoute, depth, event, initialData, serverURL })
-    callback(mergedData)
+    if (
+      event.origin === serverURL &&
+      event.data &&
+      typeof event.data === 'object' &&
+      event.data.type === 'payload-live-preview'
+    ) {
+      const mergedData = await handleMessage<T>({ apiRoute, depth, event, initialData, serverURL })
+      callback(mergedData)
+    }
   }
 
   if (typeof window !== 'undefined') {

--- a/packages/live-preview/src/subscribe.ts
+++ b/packages/live-preview/src/subscribe.ts
@@ -12,7 +12,6 @@ export const subscribe = <T>(args: {
   const onMessage = async (event: MessageEvent) => {
     if (
       event.origin === serverURL &&
-      event.data &&
       typeof event.data === 'object' &&
       event.data.type === 'payload-live-preview'
     ) {


### PR DESCRIPTION
## Description
Live preview will break when other messages from browser extensions are received. With this change, `data.type` is checked before updating data.

Fixes #5056 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
