### PR TITLE
fix(richtext-lexical): do not remove adjacent paragraph node when inserting certain nodes in empty editor

### DIFF
--- a/packages/richtext-lexical/src/field/features/Blocks/plugin/index.tsx
+++ b/packages/richtext-lexical/src/field/features/Blocks/plugin/index.tsx
@@ -39,8 +39,16 @@ export function BlocksPlugin(): JSX.Element | null {
               const { focus } = selection
               const focusNode = focus.getNode()
 
-              // First, delete currently selected node if it's an empty paragraph
-              if ($isParagraphNode(focusNode) && focusNode.getTextContentSize() === 0) {
+              // First, delete currently selected node if it's an empty paragraph and if there are sufficient
+              // paragraph nodes (more than 1) left in the parent node, so that we don't "trap" the user
+              if (
+                $isParagraphNode(focusNode) &&
+                focusNode.getTextContentSize() === 0 &&
+                focusNode
+                  .getParent()
+                  .getChildren()
+                  .filter((node) => $isParagraphNode(node)).length > 1
+              ) {
                 focusNode.remove()
               }
 

--- a/packages/richtext-lexical/src/field/features/Relationship/plugins/index.tsx
+++ b/packages/richtext-lexical/src/field/features/Relationship/plugins/index.tsx
@@ -54,8 +54,16 @@ export function RelationshipPlugin(props?: RelationshipFeatureProps): JSX.Elemen
           const { focus } = selection
           const focusNode = focus.getNode()
 
-          // First, delete currently selected node if it's an empty paragraph
-          if ($isParagraphNode(focusNode) && focusNode.getTextContentSize() === 0) {
+          // First, delete currently selected node if it's an empty paragraph and if there are sufficient
+          // paragraph nodes (more than 1) left in the parent node, so that we don't "trap" the user
+          if (
+            $isParagraphNode(focusNode) &&
+            focusNode.getTextContentSize() === 0 &&
+            focusNode
+              .getParent()
+              .getChildren()
+              .filter((node) => $isParagraphNode(node)).length > 1
+          ) {
             focusNode.remove()
           }
 

--- a/packages/richtext-lexical/src/field/features/Upload/plugin/index.tsx
+++ b/packages/richtext-lexical/src/field/features/Upload/plugin/index.tsx
@@ -53,8 +53,16 @@ export function UploadPlugin(): JSX.Element | null {
               const { focus } = selection
               const focusNode = focus.getNode()
 
-              // First, delete currently selected node if it's an empty paragraph
-              if ($isParagraphNode(focusNode) && focusNode.getTextContentSize() === 0) {
+              // First, delete currently selected node if it's an empty paragraph and if there are sufficient
+              // paragraph nodes (more than 1) left in the parent node, so that we don't "trap" the user
+              if (
+                $isParagraphNode(focusNode) &&
+                focusNode.getTextContentSize() === 0 &&
+                focusNode
+                  .getParent()
+                  .getChildren()
+                  .filter((node) => $isParagraphNode(node)).length > 1
+              ) {
                 focusNode.remove()
               }
 


### PR DESCRIPTION
## Description

Previously, when adding a block node to an empty editor, the editor is filled with the block node, with no possibility of adding any new nodes after or before it.

Now, it inserts a new paragraph node after inserting the block node, so that you have the chance of continuing writing or adding new nodes.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
