### PR TITLE
docs: improve naming for afterForgotPassword hook example code

### DIFF
--- a/docs/hooks/collections.mdx
+++ b/docs/hooks/collections.mdx
@@ -292,13 +292,11 @@ For auth-enabled Collections, this hook runs after successful `forgotPassword` o
 ```ts
 import { CollectionAfterForgotPasswordHook } from 'payload/types'
 
-const afterLoginHook: CollectionAfterForgotPasswordHook = async ({
-  req, // full express request
-  user, // user being logged in
-  token, // user token
-}) => {
-  return user
-}
+const afterForgetPasswordHook: CollectionAfterForgotPasswordHook = async ({
+  context, 
+  collection,  
+  args, // arguments passed into the operation
+}) => {...}
 ```
 
 ## TypeScript

--- a/docs/hooks/collections.mdx
+++ b/docs/hooks/collections.mdx
@@ -292,10 +292,10 @@ For auth-enabled Collections, this hook runs after successful `forgotPassword` o
 ```ts
 import { CollectionAfterForgotPasswordHook } from 'payload/types'
 
-const afterForgetPasswordHook: CollectionAfterForgotPasswordHook = async ({
-  context, 
-  collection,  
+const afterForgotPasswordHook: CollectionAfterForgotPasswordHook = async ({
   args, // arguments passed into the operation
+  context, 
+  collection, // The collection which this hook is being run on
 }) => {...}
 ```
 


### PR DESCRIPTION
## Description

The documentation has a slightly confusing name for the `afterForgetPassword` hook and the callback properties which it provide were incorrect

## Type of change

- [x] Updated the documentation accordingly
