### PR TITLE
fix(next): properly copies url object in createPayloadRequest

### DIFF
--- a/packages/next/src/utilities/createPayloadRequest.ts
+++ b/packages/next/src/utilities/createPayloadRequest.ts
@@ -98,8 +98,6 @@ export const createPayloadRequest = async ({
     transactionID: undefined,
     payloadDataLoader: undefined,
     payloadUploadSizes: {},
-    searchParams,
-    pathname,
     ...urlPropertiesObject,
   }
 

--- a/packages/next/src/utilities/createPayloadRequest.ts
+++ b/packages/next/src/utilities/createPayloadRequest.ts
@@ -36,7 +36,22 @@ export const createPayloadRequest = async ({
   }
 
   const urlProperties = new URL(request.url)
-  const { searchParams, pathname } = urlProperties
+
+  // NOTE: URL properties are not enumerable, so we need to convert them to an object
+  const urlPropertiesObject = {
+    searchParams: urlProperties.searchParams,
+    pathname: urlProperties.pathname,
+    port: urlProperties.port,
+    protocol: urlProperties.protocol,
+    search: urlProperties.search,
+    origin: urlProperties.origin,
+    href: urlProperties.href,
+    host: urlProperties.host,
+    hash: urlProperties.hash,
+  }
+
+  const { searchParams, pathname } = urlPropertiesObject
+
   const isGraphQL = !config.graphQL.disable && pathname === `/api${config.routes.graphQL}`
 
   const { data, file } = await getDataAndFile({
@@ -47,6 +62,7 @@ export const createPayloadRequest = async ({
 
   let requestFallbackLocale
   let requestLocale
+
   if (config.localization) {
     const locales = getRequestLocales({
       localization: config.localization,
@@ -82,7 +98,9 @@ export const createPayloadRequest = async ({
     transactionID: undefined,
     payloadDataLoader: undefined,
     payloadUploadSizes: {},
-    ...urlProperties,
+    searchParams,
+    pathname,
+    ...urlPropertiesObject,
   }
 
   const req: PayloadRequest = Object.assign(request, customRequest)


### PR DESCRIPTION
## Description

The URL object created via `new URL()` is not enumerable. This means that it cannot be spread or assigned like plain objects can. This meant that in `createPayloadRequest`, the `searchParams` property was missing from all handlers that rely on it. To get around this, we can simply build a fresh object based off the constructed URL object, and spread _that_ instead.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.