### PR TITLE
feat(plugin-search): add req to beforeSync args for transactions

### DIFF
--- a/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
@@ -1,27 +1,25 @@
 import type { CollectionAfterDeleteHook } from 'payload/types'
 
-const deleteFromSearch: CollectionAfterDeleteHook = ({ doc, req: { payload } }) => {
+const deleteFromSearch: CollectionAfterDeleteHook = async ({ doc, req: { payload }, req }) => {
   try {
-    const deleteSearchDoc = async (): Promise<any> => {
-      const searchDocQuery = await payload.find({
-        collection: 'search',
-        depth: 0,
-        where: {
-          'doc.value': {
-            equals: doc.id,
-          },
+    const searchDocQuery = await payload.find({
+      collection: 'search',
+      depth: 0,
+      req,
+      where: {
+        'doc.value': {
+          equals: doc.id,
         },
+      },
+    })
+
+    if (searchDocQuery?.docs?.[0]) {
+      await payload.delete({
+        id: searchDocQuery?.docs?.[0]?.id,
+        collection: 'search',
+        req,
       })
-
-      if (searchDocQuery?.docs?.[0]) {
-        payload.delete({
-          id: searchDocQuery?.docs?.[0]?.id,
-          collection: 'search',
-        })
-      }
     }
-
-    deleteSearchDoc()
   } catch (err: unknown) {
     payload.logger.error({
       err: `Error deleting search doc: ${err}`,

--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -55,7 +55,6 @@ const syncWithSearch: SyncWithSearch = async (args) => {
   try {
     if (operation === 'create') {
       if (doSync) {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         await payload.create({
           collection: 'search',
           data: {
@@ -93,7 +92,6 @@ const syncWithSearch: SyncWithSearch = async (args) => {
         if (duplicativeDocs.length > 0) {
           try {
             const duplicativeDocIDs = duplicativeDocs.map(({ id }) => id)
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             await payload.delete({
               collection: 'search',
               req,
@@ -110,7 +108,6 @@ const syncWithSearch: SyncWithSearch = async (args) => {
           if (doSync) {
             // update the doc normally
             try {
-              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               await payload.update({
                 id: searchDocID,
                 collection: 'search',
@@ -127,7 +124,6 @@ const syncWithSearch: SyncWithSearch = async (args) => {
           if (deleteDrafts && status === 'draft') {
             // do not include draft docs in search results, so delete the record
             try {
-              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               await payload.delete({
                 id: searchDocID,
                 collection: 'search',
@@ -139,7 +135,6 @@ const syncWithSearch: SyncWithSearch = async (args) => {
           }
         } else if (doSync) {
           try {
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             await payload.create({
               collection: 'search',
               data: {

--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -6,6 +6,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
     doc,
     operation,
     req: { payload },
+    req,
     // @ts-expect-error
     searchConfig,
   } = args
@@ -26,6 +27,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
     dataToSave = await beforeSync({
       originalDoc: doc,
       payload,
+      req,
       searchDoc: dataToSave,
     })
   }

--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -56,7 +56,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
     if (operation === 'create') {
       if (doSync) {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        payload.create({
+        await payload.create({
           collection: 'search',
           data: {
             ...dataToSave,
@@ -92,16 +92,13 @@ const syncWithSearch: SyncWithSearch = async (args) => {
         // to ensure the same, out-of-date result does not appear twice (where only syncing the first found doc)
         if (duplicativeDocs.length > 0) {
           try {
+            const duplicativeDocIDs = duplicativeDocs.map(({ id }) => id)
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            Promise.all(
-              duplicativeDocs.map(({ id: duplicativeDocID }) =>
-                payload.delete({
-                  id: duplicativeDocID,
-                  collection: 'search',
-                  req,
-                }),
-              ), // eslint-disable-line function-paren-newline
-            )
+            await payload.delete({
+              collection: 'search',
+              req,
+              where: { id: { in: duplicativeDocIDs } },
+            })
           } catch (err: unknown) {
             payload.logger.error(`Error deleting duplicative search documents.`)
           }
@@ -114,7 +111,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
             // update the doc normally
             try {
               // eslint-disable-next-line @typescript-eslint/no-floating-promises
-              payload.update({
+              await payload.update({
                 id: searchDocID,
                 collection: 'search',
                 data: {
@@ -131,7 +128,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
             // do not include draft docs in search results, so delete the record
             try {
               // eslint-disable-next-line @typescript-eslint/no-floating-promises
-              payload.delete({
+              await payload.delete({
                 id: searchDocID,
                 collection: 'search',
                 req,
@@ -143,7 +140,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
         } else if (doSync) {
           try {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            payload.create({
+            await payload.create({
               collection: 'search',
               data: {
                 ...dataToSave,

--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -62,6 +62,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
             ...dataToSave,
             priority: defaultPriority,
           },
+          req,
         })
       }
     }
@@ -72,6 +73,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
         const searchDocQuery = await payload.find({
           collection: 'search',
           depth: 0,
+          req,
           where: {
             'doc.value': {
               equals: id,
@@ -96,6 +98,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
                 payload.delete({
                   id: duplicativeDocID,
                   collection: 'search',
+                  req,
                 }),
               ), // eslint-disable-line function-paren-newline
             )
@@ -118,6 +121,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
                   ...dataToSave,
                   priority: foundDoc.priority || defaultPriority,
                 },
+                req,
               })
             } catch (err: unknown) {
               payload.logger.error(`Error updating search document.`)
@@ -130,6 +134,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
               payload.delete({
                 id: searchDocID,
                 collection: 'search',
+                req,
               })
             } catch (err: unknown) {
               payload.logger.error(`Error deleting search document: ${err}`)
@@ -144,6 +149,7 @@ const syncWithSearch: SyncWithSearch = async (args) => {
                 ...dataToSave,
                 priority: defaultPriority,
               },
+              req,
             })
           } catch (err: unknown) {
             payload.logger.error(`Error creating search document: ${err}`)

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -34,7 +34,7 @@ const Search =
                 afterChange: [
                   ...(existingHooks?.afterChange || []),
                   async (args: any) => {
-                    syncWithSearch({
+                    await syncWithSearch({
                       ...args,
                       collection: collection.slug,
                       searchConfig,

--- a/packages/plugin-search/src/types.ts
+++ b/packages/plugin-search/src/types.ts
@@ -1,5 +1,5 @@
 import type { Payload } from 'payload'
-import type { CollectionAfterChangeHook, CollectionConfig } from 'payload/types'
+import type { CollectionAfterChangeHook, CollectionConfig, PayloadRequest } from 'payload/types'
 
 export interface DocToSync {
   [key: string]: any
@@ -15,6 +15,7 @@ export type BeforeSync = (args: {
     [key: string]: any
   }
   payload: Payload
+  req: PayloadRequest
   searchDoc: DocToSync
 }) => DocToSync | Promise<DocToSync>
 

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -22,23 +22,19 @@ describe('Search Plugin', () => {
       collection: 'pages',
       data: {
         _status: 'published',
-        title: 'Hello, world!',
         excerpt: 'This is a test page',
+        title: 'Hello, world!',
       },
     })
 
-    // wait for the search document to be created
-    // we do not await this within the `syncToSearch` hook
-    await wait(200)
-
     const { docs: results } = await payload.find({
       collection: 'search',
+      depth: 0,
       where: {
         'doc.value': {
           equals: pageToSync.id,
         },
       },
-      depth: 0,
     })
 
     expect(results).toHaveLength(1)
@@ -52,8 +48,8 @@ describe('Search Plugin', () => {
       collection: 'pages',
       data: {
         _status: 'draft',
-        title: 'Hello, world!',
         excerpt: 'This is a test page',
+        title: 'Hello, world!',
       },
     })
 
@@ -63,12 +59,12 @@ describe('Search Plugin', () => {
 
     const { docs: results } = await payload.find({
       collection: 'search',
+      depth: 0,
       where: {
         'doc.value': {
           equals: draftPage.id,
         },
       },
-      depth: 0,
     })
 
     expect(results).toHaveLength(0)
@@ -79,23 +75,19 @@ describe('Search Plugin', () => {
       collection: 'pages',
       data: {
         _status: 'published',
-        title: 'Hello, world!',
         excerpt: 'This is a test page',
+        title: 'Hello, world!',
       },
     })
 
-    // wait for the search document to be created
-    // we do not await this within the `syncToSearch` hook
-    await wait(200)
-
     const { docs: results } = await payload.find({
       collection: 'search',
+      depth: 0,
       where: {
         'doc.value': {
           equals: pageToReceiveUpdates.id,
         },
       },
-      depth: 0,
     })
 
     expect(results).toHaveLength(1)
@@ -104,11 +96,11 @@ describe('Search Plugin', () => {
     expect(results[0].excerpt).toBe('This is a test page')
 
     await payload.update({
-      collection: 'pages',
       id: pageToReceiveUpdates.id,
+      collection: 'pages',
       data: {
-        title: 'Hello, world! (updated)',
         excerpt: 'This is a test page (updated)',
+        title: 'Hello, world! (updated)',
       },
     })
 
@@ -119,12 +111,12 @@ describe('Search Plugin', () => {
     // Do not add `limit` to this query, this way we can test if multiple documents were created
     const { docs: updatedResults } = await payload.find({
       collection: 'search',
+      depth: 0,
       where: {
         'doc.value': {
           equals: pageToReceiveUpdates.id,
         },
       },
-      depth: 0,
     })
 
     expect(updatedResults).toHaveLength(1)
@@ -138,8 +130,8 @@ describe('Search Plugin', () => {
       collection: 'pages',
       data: {
         _status: 'published',
-        title: 'Hello, world!',
         excerpt: 'This is a test page',
+        title: 'Hello, world!',
       },
     })
 
@@ -149,20 +141,20 @@ describe('Search Plugin', () => {
 
     const { docs: results } = await payload.find({
       collection: 'search',
+      depth: 0,
       where: {
         'doc.value': {
           equals: page.id,
         },
       },
-      depth: 0,
     })
 
     expect(results).toHaveLength(1)
     expect(results[0].doc.value).toBe(page.id)
 
     await payload.delete({
-      collection: 'pages',
       id: page.id,
+      collection: 'pages',
     })
 
     // wait for the search document to be potentially deleted
@@ -171,12 +163,12 @@ describe('Search Plugin', () => {
 
     const { docs: deletedResults } = await payload.find({
       collection: 'search',
+      depth: 0,
       where: {
         'doc.value': {
           equals: page.id,
         },
       },
-      depth: 0,
     })
 
     expect(deletedResults).toHaveLength(0)


### PR DESCRIPTION
## Description

1. If somebody wanted to interact with the database inside of a `beforeSync` hook, it was not possible to do so without passing the `req`.
2. The hooks have been modified to pass `req` in the database operations and to await all operations for data consistency.
3. Delete hook is now awaited to respect transactions.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
