### PR TITLE
docs: Reword Hooks Overview re: server-only execution

### DIFF
--- a/docs/hooks/overview.mdx
+++ b/docs/hooks/overview.mdx
@@ -36,7 +36,7 @@ If your Hook simply performs a side-effect, such as updating a CRM, it might be 
 
 #### Server-only execution
 
-Payload Hooks do not have any effect within the Payload Admin panel. You can safely [remove your hooks](/docs/admin/webpack#aliasing-server-only-modules) from your Admin panel's code by customizing the Webpack config, which not only keeps your Admin bundles' filesize small but also ensures that any server-side only code does not cause problems within browser environments.
+Payload Hooks are only triggered on the server. You can safely [remove your hooks](/docs/admin/webpack#aliasing-server-only-modules) from your Admin panel's client-side code by customizing the Webpack config, which not only keeps your Admin bundles' filesize small but also ensures that any server-side only code does not cause problems within browser environments.
 
 ## Hook Types
 


### PR DESCRIPTION
## Description

The [Hooks Overview](https://payloadcms.com/docs/hooks/overview#server-only-execution) documentation has a "Server-only execution" section with this note:

> Payload Hooks do not have any effect within the Payload Admin panel. 

This wording is completely technically accurate, but personally I was a little confused by it, wondering whether actions taken in the Admin panel are special-cased and don't trigger Hooks (as opposed to API interactions outside of the admin panel). So this is an attempted clarification to highlight the intent of the paragraph, which was to note that hooks aren't triggered by clientside code and can safely be removed from the clientside bundle.

(But that Hooks *do* have an effect for serverside actions triggered by interactions in the admin panel--which could of course be obvious to people with deeper understanding of Payload than me!).

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
