### PR TITLE
chore(logs): add console error for missing script when running `npm run payload`

### DIFF
--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -56,30 +56,33 @@ const args = minimist(process.argv.slice(2))
 const scriptIndex = args._.findIndex((x) => x === 'build')
 
 const script = scriptIndex === -1 ? args._[0] : args._[scriptIndex]
+if (script) {
+  if (script.startsWith('migrate')) {
+    migrate(args).then(() => process.exit(0))
+  } else {
+    switch (script.toLowerCase()) {
+      case 'build': {
+        build()
+        break
+      }
 
-if (script.startsWith('migrate')) {
-  migrate(args).then(() => process.exit(0))
-} else {
-  switch (script.toLowerCase()) {
-    case 'build': {
-      build()
-      break
+      case 'generate:types': {
+        generateTypes()
+        break
+      }
+
+      case 'generate:graphqlschema': {
+        generateGraphQLSchema()
+        break
+      }
+
+      default:
+        console.log(`Unknown script "${script}".`)
+        break
     }
-
-    case 'generate:types': {
-      generateTypes()
-      break
-    }
-
-    case 'generate:graphqlschema': {
-      generateGraphQLSchema()
-      break
-    }
-
-    default:
-      console.log(`Unknown script "${script}".`)
-      break
   }
+} else {
+  console.error('No payload script specified. Did you mean to run `payload migrate`?')
 }
 
 /**


### PR DESCRIPTION
## Description

This pull request addresses the issue described in #5077, where running `npm run payload` results in a misleading error.

#### Changes Made
- Fixed the misleading error by adding a null check for the script variable in index.js to prevent the TypeError.
- Tested the fix locally to ensure it resolves the reported issue without introducing any regressions.


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
