### PR TITLE
fix: filterOptions errors cause transaction to abort

### DIFF
--- a/packages/db-mongodb/src/transactions/rollbackTransaction.ts
+++ b/packages/db-mongodb/src/transactions/rollbackTransaction.ts
@@ -17,7 +17,11 @@ export const rollbackTransaction: RollbackTransaction = async function rollbackT
   }
 
   // the first call for rollback should be aborted and deleted causing any other operations with the same transaction to fail
-  await this.sessions[id].abortTransaction()
-  await this.sessions[id].endSession()
+  try {
+    await this.sessions[id].abortTransaction()
+    await this.sessions[id].endSession()
+  } catch (error) {
+    // ignore the error as it is likely a race condition from multiple errors
+  }
   delete this.sessions[id]
 }

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -333,6 +333,7 @@ const validateFilterOptions: Validate = async (
             msg: `Error validating filter options for collection ${collection}`,
           })
         }
+        options[collection] = []
       }),
     )
 

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -332,8 +332,8 @@ const validateFilterOptions: Validate = async (
             err,
             msg: `Error validating filter options for collection ${collection}`,
           })
+          options[collection] = []
         }
-        options[collection] = []
       }),
     )
 

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from 'crypto'
 
-import type { PayloadRequest } from '../../packages/payload/src/express/types'
 import type {
   ChainedRelation,
   CustomIdNumberRelation,
@@ -678,35 +677,6 @@ describe('Relationships', () => {
         })
         expect(count).toBe(1)
         expect(item.text).toBe('sub')
-      })
-    })
-  })
-
-  describe('Creating', () => {
-    describe('With transactions', () => {
-      it('should be able to create filtered relations within a transaction', async () => {
-        const req = {} as PayloadRequest
-        req.transactionID = await payload.db.beginTransaction?.()
-        const related = await payload.create({
-          collection: relationSlug,
-          data: {
-            name: 'parent',
-          },
-          req,
-        })
-        const withRelation = await payload.create({
-          collection: slug,
-          data: {
-            filteredRelation: related.id,
-          },
-          req,
-        })
-
-        if (req.transactionID) {
-          await payload.db.commitTransaction?.(req.transactionID)
-        }
-
-        expect(withRelation.filteredRelation.id).toEqual(related.id)
       })
     })
   })


### PR DESCRIPTION
## Description

fix https://github.com/payloadcms/payload/issues/4350

- fix(db-mongodb): uncaught abortTransaction race condition
- fix: filterOptions errors cause transaction to abort

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
