### PR TITLE
fix(next): properly parses search params in find, update, and delete handlers

### DIFF
--- a/packages/next/src/routes/rest/collections/delete.ts
+++ b/packages/next/src/routes/rest/collections/delete.ts
@@ -5,6 +5,7 @@ import { getTranslation } from '@payloadcms/translations'
 import { deleteOperation } from 'payload/operations'
 import { CollectionRouteHandler } from '../types'
 import qs from 'qs'
+import { isNumber } from 'payload/utilities'
 
 export const deleteDoc: CollectionRouteHandler = async ({ req, collection }) => {
   const { searchParams } = req
@@ -17,7 +18,7 @@ export const deleteDoc: CollectionRouteHandler = async ({ req, collection }) => 
 
   const result = await deleteOperation({
     collection,
-    depth: depth ? Number(depth) : undefined,
+    depth: isNumber(depth) ? Number(depth) : undefined,
     req,
     where,
   })

--- a/packages/next/src/routes/rest/collections/delete.ts
+++ b/packages/next/src/routes/rest/collections/delete.ts
@@ -1,21 +1,25 @@
 import httpStatus from 'http-status'
 
 import type { Where } from 'payload/types'
-import { isNumber } from 'payload/utilities'
 import { getTranslation } from '@payloadcms/translations'
 import { deleteOperation } from 'payload/operations'
 import { CollectionRouteHandler } from '../types'
+import qs from 'qs'
 
 export const deleteDoc: CollectionRouteHandler = async ({ req, collection }) => {
   const { searchParams } = req
-  const depth = searchParams.get('depth')
-  const where = searchParams.get('where')
+
+  // parse using `qs` to handle `where` queries
+  const { where, depth } = qs.parse(searchParams.toString()) as {
+    where?: Where
+    depth?: string
+  }
 
   const result = await deleteOperation({
     collection,
-    depth: isNumber(depth) ? depth : undefined,
+    depth: depth ? Number(depth) : undefined,
     req,
-    where: where ? (JSON.parse(where) as Where) : {},
+    where,
   })
 
   if (result.errors.length === 0) {
@@ -39,6 +43,7 @@ export const deleteDoc: CollectionRouteHandler = async ({ req, collection }) => 
   }
 
   const total = result.docs.length + result.errors.length
+
   const message = req.t('error:unableToDeleteCount', {
     count: result.errors.length,
     label: getTranslation(collection.config.labels[total > 1 ? 'plural' : 'singular'], req.i18n),

--- a/packages/next/src/routes/rest/collections/delete.ts
+++ b/packages/next/src/routes/rest/collections/delete.ts
@@ -1,11 +1,11 @@
 import httpStatus from 'http-status'
 
 import type { Where } from 'payload/types'
+import { isNumber } from 'payload/utilities'
 import { getTranslation } from '@payloadcms/translations'
 import { deleteOperation } from 'payload/operations'
 import { CollectionRouteHandler } from '../types'
 import qs from 'qs'
-import { isNumber } from 'payload/utilities'
 
 export const deleteDoc: CollectionRouteHandler = async ({ req, collection }) => {
   const { searchParams } = req

--- a/packages/next/src/routes/rest/collections/find.ts
+++ b/packages/next/src/routes/rest/collections/find.ts
@@ -1,10 +1,10 @@
 import httpStatus from 'http-status'
 
+import { isNumber } from 'payload/utilities'
 import { findOperation } from 'payload/operations'
 import { CollectionRouteHandler } from '../types'
 import qs from 'qs'
 import { Where } from 'payload/types'
-import { isNumber } from 'payload/utilities'
 
 export const find: CollectionRouteHandler = async ({ req, collection }) => {
   const { searchParams } = req

--- a/packages/next/src/routes/rest/collections/find.ts
+++ b/packages/next/src/routes/rest/collections/find.ts
@@ -1,26 +1,33 @@
 import httpStatus from 'http-status'
 
-import { isNumber } from 'payload/utilities'
 import { findOperation } from 'payload/operations'
 import { CollectionRouteHandler } from '../types'
+import qs from 'qs'
+import { Where } from 'payload/types'
+import { isNumber } from 'payload/utilities'
 
 export const find: CollectionRouteHandler = async ({ req, collection }) => {
   const { searchParams } = req
 
-  const depth = searchParams.get('depth')
-  const limit = searchParams.get('limit')
-  const page = searchParams.get('page')
-  const where = searchParams.get('where')
+  // parse using `qs` to handle `where` queries
+  const { where, page, depth, limit, sort, draft } = qs.parse(searchParams.toString()) as {
+    where?: Where
+    page?: string
+    depth?: string
+    limit?: string
+    sort?: string
+    draft?: string
+  }
 
   const result = await findOperation({
     collection,
     depth: isNumber(depth) ? Number(depth) : undefined,
-    draft: searchParams.get('draft') === 'true',
+    draft: draft === 'true',
     limit: isNumber(limit) ? Number(limit) : undefined,
     page: isNumber(page) ? Number(page) : undefined,
     req,
-    sort: searchParams.get('sort'),
-    where: where ? JSON.parse(where) : undefined,
+    sort,
+    where,
   })
 
   return Response.json(result, {

--- a/packages/next/src/routes/rest/collections/findVersions.ts
+++ b/packages/next/src/routes/rest/collections/findVersions.ts
@@ -2,16 +2,21 @@ import httpStatus from 'http-status'
 
 import { Where } from 'payload/types'
 import { findVersionsOperation } from 'payload/operations'
-import { isNumber } from 'payload/utilities'
 import { CollectionRouteHandler } from '../types'
+import qs from 'qs'
+import { isNumber } from 'payload/utilities'
 
 export const findVersions: CollectionRouteHandler = async ({ req, collection }) => {
   const { searchParams } = req
-  const page = searchParams.get('page')
-  const depth = searchParams.get('depth')
-  const limit = searchParams.get('limit')
-  const where = searchParams.get('where')
-  const sort = searchParams.get('sort')
+
+  // parse using `qs` to handle `where` queries
+  const { where, page, depth, limit, sort } = qs.parse(searchParams.toString()) as {
+    where?: Where
+    page?: string
+    depth?: string
+    limit?: string
+    sort?: string
+  }
 
   const result = await findVersionsOperation({
     collection,
@@ -19,8 +24,8 @@ export const findVersions: CollectionRouteHandler = async ({ req, collection }) 
     limit: isNumber(limit) ? Number(limit) : undefined,
     page: isNumber(page) ? Number(page) : undefined,
     req,
-    sort: sort,
-    where: where ? (JSON.parse(where) as Where) : undefined,
+    sort,
+    where,
   })
 
   return Response.json(result, {

--- a/packages/next/src/routes/rest/collections/findVersions.ts
+++ b/packages/next/src/routes/rest/collections/findVersions.ts
@@ -2,9 +2,9 @@ import httpStatus from 'http-status'
 
 import { Where } from 'payload/types'
 import { findVersionsOperation } from 'payload/operations'
+import { isNumber } from 'payload/utilities'
 import { CollectionRouteHandler } from '../types'
 import qs from 'qs'
-import { isNumber } from 'payload/utilities'
 
 export const findVersions: CollectionRouteHandler = async ({ req, collection }) => {
   const { searchParams } = req

--- a/packages/next/src/routes/rest/collections/update.ts
+++ b/packages/next/src/routes/rest/collections/update.ts
@@ -6,19 +6,25 @@ import { isNumber } from 'payload/utilities'
 import { updateOperation } from 'payload/operations'
 import { getTranslation } from '@payloadcms/translations'
 import { CollectionRouteHandler } from '../types'
+import qs from 'qs'
 
 export const update: CollectionRouteHandler = async ({ req, collection }) => {
   const { searchParams } = req
-  const depth = searchParams.get('depth')
-  const where = searchParams.get('where')
+
+  // parse using `qs` to handle `where` queries
+  const { where, depth, draft } = qs.parse(searchParams.toString()) as {
+    where?: Where
+    depth?: string
+    draft?: string
+  }
 
   const result = await updateOperation({
     collection,
     data: req.data,
     depth: isNumber(depth) ? Number(depth) : undefined,
-    draft: searchParams.get('draft') === 'true',
+    draft: draft === 'true',
     req,
-    where: where ? (JSON.parse(where) as Where) : undefined,
+    where,
   })
 
   if (result.errors.length === 0) {

--- a/packages/next/src/routes/rest/globals/findVersions.ts
+++ b/packages/next/src/routes/rest/globals/findVersions.ts
@@ -5,13 +5,20 @@ import type { Where } from 'payload/types'
 import { findVersionsOperationGlobal } from 'payload/operations'
 import { isNumber } from 'payload/utilities'
 import { GlobalRouteHandler } from '../types'
+import qs from 'qs'
 
 export const findVersions: GlobalRouteHandler = async ({ req, globalConfig }) => {
   const { searchParams } = req
-  const page = searchParams.get('page')
-  const limit = searchParams.get('limit')
-  const depth = searchParams.get('depth')
-  const where = searchParams.get('where')
+
+  // parse using `qs` to handle `where` queries
+  const { where, page, depth, limit, sort, draft } = qs.parse(searchParams.toString()) as {
+    where?: Where
+    page?: string
+    depth?: string
+    limit?: string
+    sort?: string
+    draft?: string
+  }
 
   const result = await findVersionsOperationGlobal({
     depth: isNumber(depth) ? Number(depth) : undefined,
@@ -19,8 +26,8 @@ export const findVersions: GlobalRouteHandler = async ({ req, globalConfig }) =>
     limit: isNumber(limit) ? Number(limit) : undefined,
     page: isNumber(page) ? Number(page) : undefined,
     req,
-    sort: searchParams.get('sort'),
-    where: where ? (JSON.parse(where) as Where) : undefined,
+    sort,
+    where,
   })
 
   return Response.json(result, {


### PR DESCRIPTION
## Description

Some route handlers were not properly parsing `where` search params. This is because the `searchParam` arg is of type `URLSearchParams`, and so when the `where` param is retrieved using `searchParams.get('where')`, it was improperly formatted to what the Payload API expects (a plain object in the shape of the `Where` type). This change simply calls `searchParams.toString()` then parses it using the `qs` package.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.