### PR TITLE
chore(ui): threads params through context and conditionally renders document tabs

### DIFF
--- a/packages/payload/src/admin/elements/Tab.ts
+++ b/packages/payload/src/admin/elements/Tab.ts
@@ -12,8 +12,6 @@ export type DocumentTabProps = {
   config: SanitizedConfig
   globalConfig?: SanitizedGlobalConfig
   i18n: I18n
-  id: string
-  isEditing?: boolean
 }
 
 export type DocumentTabCondition = (args: {

--- a/packages/ui/src/elements/DocumentHeader/Tabs/ShouldRenderTabs.tsx
+++ b/packages/ui/src/elements/DocumentHeader/Tabs/ShouldRenderTabs.tsx
@@ -1,0 +1,20 @@
+'use client'
+import React from 'react'
+import { useSearchParams } from '../../../providers/SearchParams'
+
+export const ShouldRenderTabs: React.FC<{
+  children: React.ReactNode
+}> = ({ children }) => {
+  const {
+    params: { collection: collectionSlug, global: globalSlug, segments: [idFromParam] = [] },
+  } = useSearchParams()
+
+  const id = idFromParam !== 'create' ? idFromParam : null
+
+  // Don't show tabs when creating new documents
+  if ((collectionSlug && id) || globalSlug) {
+    return children
+  }
+
+  return null
+}

--- a/packages/ui/src/elements/DocumentHeader/Tabs/index.tsx
+++ b/packages/ui/src/elements/DocumentHeader/Tabs/index.tsx
@@ -5,19 +5,19 @@ import { getCustomViews } from './getCustomViews'
 import { getViewConfig } from './getViewConfig'
 import { tabs as defaultViews } from './tabs'
 import { DocumentTabProps } from 'payload/types'
+import { ShouldRenderTabs } from './ShouldRenderTabs'
 
 import './index.scss'
 
 const baseClass = 'doc-tabs'
 
 export const DocumentTabs: React.FC<DocumentTabProps> = (props) => {
-  const { collectionConfig, globalConfig, isEditing } = props
+  const { collectionConfig, globalConfig } = props
 
   const customViews = getCustomViews({ collectionConfig, globalConfig })
 
-  // Don't show tabs when creating new documents
-  if ((collectionConfig && isEditing) || global) {
-    return (
+  return (
+    <ShouldRenderTabs>
       <div className={baseClass}>
         <div className={`${baseClass}__tabs-container`}>
           <ul className={`${baseClass}__tabs`}>
@@ -69,8 +69,6 @@ export const DocumentTabs: React.FC<DocumentTabProps> = (props) => {
           </ul>
         </div>
       </div>
-    )
-  }
-
-  return null
+    </ShouldRenderTabs>
+  )
 }

--- a/packages/ui/src/elements/DocumentHeader/index.tsx
+++ b/packages/ui/src/elements/DocumentHeader/index.tsx
@@ -16,27 +16,13 @@ import './index.scss'
 const baseClass = `doc-header`
 
 export const DocumentHeader: React.FC<{
-  apiURL?: string
   config: SanitizedConfig
   collectionConfig?: SanitizedCollectionConfig
   customHeader?: React.ReactNode
-  data?: any
   globalConfig?: SanitizedGlobalConfig
-  id?: string
-  isEditing?: boolean
   i18n: I18n
 }> = (props) => {
-  const {
-    id,
-    apiURL,
-    config,
-    collectionConfig,
-    customHeader,
-    data,
-    globalConfig,
-    isEditing,
-    i18n,
-  } = props
+  const { config, collectionConfig, customHeader, globalConfig, i18n } = props
 
   const titleFieldConfig = collectionConfig?.fields?.find(
     (f) => 'name' in f && f?.name === collectionConfig?.admin?.useAsTitle,
@@ -52,7 +38,6 @@ export const DocumentHeader: React.FC<{
             useAsTitle={collectionConfig?.admin?.useAsTitle}
             globalLabel={globalConfig?.label}
             globalSlug={globalConfig?.slug}
-            data={data}
             isDate={titleFieldConfig?.type === 'date'}
             dateFormat={
               titleFieldConfig && 'date' in titleFieldConfig?.admin
@@ -62,12 +47,9 @@ export const DocumentHeader: React.FC<{
             fallback={`[${i18n.t('general:untitled')}]`}
           />
           <DocumentTabs
-            apiURL={apiURL}
             config={config}
             collectionConfig={collectionConfig}
             globalConfig={globalConfig}
-            id={id}
-            isEditing={isEditing}
             i18n={i18n}
           />
         </Fragment>

--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -46,8 +46,8 @@ export const ListControls: React.FC<Props> = (props) => {
     textFieldsToBeSearched,
   } = props
 
-  const params = useSearchParams()
-  const shouldInitializeWhereOpened = validateWhereQuery(params?.where)
+  const { searchParams } = useSearchParams()
+  const shouldInitializeWhereOpened = validateWhereQuery(searchParams?.where)
 
   const [visibleDrawer, setVisibleDrawer] = useState<'columns' | 'sort' | 'where'>(
     shouldInitializeWhereOpened ? 'where' : undefined,

--- a/packages/ui/src/elements/Localizer/index.tsx
+++ b/packages/ui/src/elements/Localizer/index.tsx
@@ -22,7 +22,7 @@ const Localizer: React.FC<{
 
   const { i18n } = useTranslation()
   const locale = useLocale()
-  const searchParams = useSearchParams()
+  const { searchParams } = useSearchParams()
 
   const localeLabel = getTranslation(locale.label, i18n)
 

--- a/packages/ui/src/elements/Pagination/index.tsx
+++ b/packages/ui/src/elements/Pagination/index.tsx
@@ -21,7 +21,7 @@ const baseClass = 'paginator'
 
 export const Pagination: React.FC<Props> = (props) => {
   const router = useRouter()
-  const params = useSearchParams()
+  const { searchParams } = useSearchParams()
   const pathname = usePathname()
 
   const {
@@ -41,7 +41,7 @@ export const Pagination: React.FC<Props> = (props) => {
   const updatePage = (page) => {
     if (!disableHistoryChange) {
       const newParams = {
-        ...params,
+        ...searchParams,
       }
 
       newParams.page = page

--- a/packages/ui/src/elements/PerPage/index.tsx
+++ b/packages/ui/src/elements/PerPage/index.tsx
@@ -30,7 +30,7 @@ export const PerPage: React.FC<Props> = ({
   modifySearchParams = true,
   resetPage = false,
 }) => {
-  const params = useSearchParams()
+  const { searchParams } = useSearchParams()
   const history = useHistory()
   const { t } = useTranslation()
 
@@ -63,9 +63,9 @@ export const PerPage: React.FC<Props> = ({
                     history.replace({
                       search: qs.stringify(
                         {
-                          ...params,
+                          ...searchParams,
                           limit: limitNumber,
-                          page: resetPage ? 1 : params.page,
+                          page: resetPage ? 1 : searchParams.page,
                         },
                         { addQueryPrefix: true },
                       ),

--- a/packages/ui/src/elements/RenderTitle/index.tsx
+++ b/packages/ui/src/elements/RenderTitle/index.tsx
@@ -5,6 +5,7 @@ import type { Props } from './types'
 
 import useTitle from '../../hooks/useTitle'
 import IDLabel from '../IDLabel'
+import { useDocumentInfo } from '../../providers/DocumentInfo'
 import './index.scss'
 
 const baseClass = 'render-title'
@@ -15,11 +16,12 @@ const RenderTitle: React.FC<Props> = (props) => {
     useAsTitle,
     globalLabel,
     globalSlug,
-    data,
     element = 'h1',
     fallback = '[untitled]',
     title: titleFromProps,
   } = props
+
+  const { id } = useDocumentInfo()
 
   const titleFromForm = useTitle({
     useAsTitle: useAsTitle,
@@ -28,11 +30,11 @@ const RenderTitle: React.FC<Props> = (props) => {
   })
 
   let title = titleFromForm
-  if (!title) title = data?.id
+  if (!title) title = id?.toString()
   if (!title) title = fallback
   title = titleFromProps || title
 
-  const idAsTitle = title === data?.id
+  const idAsTitle = title === id
 
   const Tag = element
 
@@ -43,7 +45,7 @@ const RenderTitle: React.FC<Props> = (props) => {
         .join(' ')}
       title={title}
     >
-      {idAsTitle ? <IDLabel className={`${baseClass}__id`} id={data?.id} /> : title}
+      {idAsTitle ? <IDLabel className={`${baseClass}__id`} id={id} /> : title}
     </Tag>
   )
 }

--- a/packages/ui/src/elements/RenderTitle/types.ts
+++ b/packages/ui/src/elements/RenderTitle/types.ts
@@ -5,9 +5,6 @@ export type Props = {
   useAsTitle?: SanitizedCollectionConfig['admin']['useAsTitle']
   globalLabel?: SanitizedGlobalConfig['label']
   globalSlug?: SanitizedGlobalConfig['slug']
-  data?: {
-    id?: string
-  }
   element?: React.ElementType
   fallback?: string
   title?: string

--- a/packages/ui/src/elements/SearchFilter/index.tsx
+++ b/packages/ui/src/elements/SearchFilter/index.tsx
@@ -22,11 +22,13 @@ const SearchFilter: React.FC<Props> = (props) => {
     modifySearchQuery = true,
   } = props
 
-  const params = useSearchParams()
+  const { searchParams } = useSearchParams()
   const history = useHistory()
   const { i18n, t } = useTranslation()
 
-  const [search, setSearch] = useState(typeof params?.search === 'string' ? params?.search : '')
+  const [search, setSearch] = useState(
+    typeof searchParams?.search === 'string' ? searchParams?.search : '',
+  )
   const [previousSearch, setPreviousSearch] = useState('')
 
   const placeholder = useRef(t('general:searchBy', { label: getTranslation(fieldLabel, i18n) }))
@@ -40,7 +42,7 @@ const SearchFilter: React.FC<Props> = (props) => {
       if (modifySearchQuery) {
         history.replace({
           search: queryString.stringify({
-            ...params,
+            ...searchParams,
             page: 1,
             search: debouncedSearch || undefined,
           }),
@@ -54,7 +56,7 @@ const SearchFilter: React.FC<Props> = (props) => {
     previousSearch,
     history,
     fieldName,
-    params,
+    searchParams,
     handleChange,
     modifySearchQuery,
     listSearchableFields,

--- a/packages/ui/src/elements/SortColumn/index.tsx
+++ b/packages/ui/src/elements/SortColumn/index.tsx
@@ -15,11 +15,11 @@ const baseClass = 'sort-column'
 
 export const SortColumn: React.FC<Props> = (props) => {
   const { name, disable = false, label } = props
-  const params = useSearchParams()
+  const { searchParams } = useSearchParams()
   const history = useHistory()
   const { i18n, t } = useTranslation()
 
-  const { sort } = params
+  const { sort } = searchParams
 
   const desc = `-${name}`
   const asc = name
@@ -35,14 +35,14 @@ export const SortColumn: React.FC<Props> = (props) => {
       history.push({
         search: queryString.stringify(
           {
-            ...params,
+            ...searchParams,
             sort: newSort,
           },
           { addQueryPrefix: true },
         ),
       })
     },
-    [params, history],
+    [searchParams, history],
   )
 
   return (

--- a/packages/ui/src/elements/SortComplex/index.tsx
+++ b/packages/ui/src/elements/SortComplex/index.tsx
@@ -19,7 +19,7 @@ const SortComplex: React.FC<Props> = (props) => {
   const { collection, handleChange, modifySearchQuery = true } = props
 
   const history = useHistory()
-  const params = useSearchParams()
+  const { searchParams } = useSearchParams()
   const { i18n, t } = useTranslation()
   const [sortOptions, setSortOptions] = useState<OptionObject[]>()
 
@@ -45,11 +45,11 @@ const SortComplex: React.FC<Props> = (props) => {
 
       if (handleChange) handleChange(newSortValue)
 
-      if (params.sort !== newSortValue && modifySearchQuery) {
+      if (searchParams.sort !== newSortValue && modifySearchQuery) {
         history.replace({
           search: queryString.stringify(
             {
-              ...params,
+              ...searchParams,
               sort: newSortValue,
             },
             { addQueryPrefix: true },
@@ -57,7 +57,7 @@ const SortComplex: React.FC<Props> = (props) => {
         })
       }
     }
-  }, [history, params, sortField, sortOrder, modifySearchQuery, handleChange])
+  }, [history, searchParams, sortField, sortOrder, modifySearchQuery, handleChange])
 
   useEffect(() => {
     setSortOptions([

--- a/packages/ui/src/providers/Locale/index.tsx
+++ b/packages/ui/src/providers/Locale/index.tsx
@@ -20,7 +20,7 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode }> = ({ child
   const defaultLocale =
     localization && localization.defaultLocale ? localization.defaultLocale : 'en'
 
-  const searchParams = useSearchParams()
+  const { searchParams } = useSearchParams()
 
   const [localeCode, setLocaleCode] = useState<string>(
     (searchParams?.locale as string) || defaultLocale,

--- a/packages/ui/src/providers/Root/index.tsx
+++ b/packages/ui/src/providers/Root/index.tsx
@@ -20,6 +20,7 @@ import { DocumentEventsProvider } from '../DocumentEvents'
 import { CustomProvider } from '../CustomProvider'
 import { ComponentMap } from '../../utilities/buildComponentMap/types'
 import { ComponentMapProvider } from '../ComponentMapProvider'
+import { SearchParamsProvider } from '../SearchParams'
 
 type Props = {
   config: ClientConfig
@@ -63,19 +64,21 @@ export const RootProvider: React.FC<Props> = ({
                   <AuthProvider>
                     <PreferencesProvider>
                       <ThemeProvider>
-                        <LocaleProvider>
-                          <StepNavProvider>
-                            <LoadingOverlayProvider>
-                              <DocumentEventsProvider>
-                                <ActionsProvider>
-                                  <NavProvider>
-                                    <CustomProvider>{children}</CustomProvider>
-                                  </NavProvider>
-                                </ActionsProvider>
-                              </DocumentEventsProvider>
-                            </LoadingOverlayProvider>
-                          </StepNavProvider>
-                        </LocaleProvider>
+                        <SearchParamsProvider>
+                          <LocaleProvider>
+                            <StepNavProvider>
+                              <LoadingOverlayProvider>
+                                <DocumentEventsProvider>
+                                  <ActionsProvider>
+                                    <NavProvider>
+                                      <CustomProvider>{children}</CustomProvider>
+                                    </NavProvider>
+                                  </ActionsProvider>
+                                </DocumentEventsProvider>
+                              </LoadingOverlayProvider>
+                            </StepNavProvider>
+                          </LocaleProvider>
+                        </SearchParamsProvider>
                       </ThemeProvider>
                     </PreferencesProvider>
                     <ModalContainer />

--- a/packages/ui/src/providers/SearchParams/index.tsx
+++ b/packages/ui/src/providers/SearchParams/index.tsx
@@ -1,16 +1,27 @@
 'use client'
-import { useSearchParams as useNextSearchParams } from 'next/navigation'
+import { Params } from 'next/dist/shared/lib/router/utils/route-matcher'
+import { useSearchParams as useNextSearchParams, useParams as useNextParams } from 'next/navigation'
 import qs from 'qs'
 import React, { createContext, useContext } from 'react'
 
-const Context = createContext({})
-
-export const SearchParamsProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const searchParams = useNextSearchParams()
-
-  const params = qs.parse(searchParams.toString(), { depth: 10, ignoreQueryPrefix: true })
-
-  return <Context.Provider value={params}>{children}</Context.Provider>
+interface IParamsContext {
+  searchParams: qs.ParsedQs
+  params: Params
 }
 
-export const useSearchParams = (): qs.ParsedQs => useContext(Context)
+const Context = createContext<IParamsContext>({
+  searchParams: {},
+  params: {},
+} as IParamsContext)
+
+// TODO: abstract the `next/navigation` dependency out from this provider so that it can be used in other contexts
+export const SearchParamsProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const nextSearchParams = useNextSearchParams()
+  const params = useNextParams()
+
+  const searchParams = qs.parse(nextSearchParams.toString(), { depth: 10, ignoreQueryPrefix: true })
+
+  return <Context.Provider value={{ searchParams, params }}>{children}</Context.Provider>
+}
+
+export const useSearchParams = (): IParamsContext => useContext(Context)

--- a/packages/ui/src/views/Edit/action.ts
+++ b/packages/ui/src/views/Edit/action.ts
@@ -32,7 +32,11 @@ export const getFormStateFromServer = async (
     config: configPromise,
   })
 
-  const collectionConfig = payload.collections[collectionSlug].config
+  const collectionConfig = payload.collections[collectionSlug]?.config
+
+  if (!collectionConfig) {
+    throw new Error(`Collection with slug "${collectionSlug}" not found`)
+  }
 
   const data = reduceFieldsToValues(formState, true)
 


### PR DESCRIPTION
## Description

Extends the `SearchParamsProvider` to return `params` in addition to `searchParams`. This will be helpful when abstracting `next/navigation` completely out from the `ui` package. The document tabs component is now able to conditionally render its tabs based on whether the user is creating a new document, etc. through a new `ShouldRenderTabs` component.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.