### PR TITLE
feat(ui): adds params context

### DIFF
--- a/packages/ui/src/elements/DocumentHeader/Tabs/ShouldRenderTabs.tsx
+++ b/packages/ui/src/elements/DocumentHeader/Tabs/ShouldRenderTabs.tsx
@@ -1,13 +1,13 @@
 'use client'
 import React from 'react'
-import { useSearchParams } from '../../../providers/SearchParams'
+import { useParams } from '../../../providers/Params'
 
 export const ShouldRenderTabs: React.FC<{
   children: React.ReactNode
 }> = ({ children }) => {
   const {
     params: { collection: collectionSlug, global: globalSlug, segments: [idFromParam] = [] },
-  } = useSearchParams()
+  } = useParams()
 
   const id = idFromParam !== 'create' ? idFromParam : null
 

--- a/packages/ui/src/elements/DocumentHeader/Tabs/ShouldRenderTabs.tsx
+++ b/packages/ui/src/elements/DocumentHeader/Tabs/ShouldRenderTabs.tsx
@@ -6,7 +6,9 @@ export const ShouldRenderTabs: React.FC<{
   children: React.ReactNode
 }> = ({ children }) => {
   const {
-    params: { collection: collectionSlug, global: globalSlug, segments: [idFromParam] = [] },
+    collection: collectionSlug,
+    global: globalSlug,
+    segments: [idFromParam] = [],
   } = useParams()
 
   const id = idFromParam !== 'create' ? idFromParam : null

--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -46,7 +46,7 @@ export const ListControls: React.FC<Props> = (props) => {
     textFieldsToBeSearched,
   } = props
 
-  const { searchParams } = useSearchParams()
+  const searchParams = useSearchParams()
   const shouldInitializeWhereOpened = validateWhereQuery(searchParams?.where)
 
   const [visibleDrawer, setVisibleDrawer] = useState<'columns' | 'sort' | 'where'>(

--- a/packages/ui/src/elements/Localizer/index.tsx
+++ b/packages/ui/src/elements/Localizer/index.tsx
@@ -22,7 +22,7 @@ const Localizer: React.FC<{
 
   const { i18n } = useTranslation()
   const locale = useLocale()
-  const { searchParams } = useSearchParams()
+  const searchParams = useSearchParams()
 
   const localeLabel = getTranslation(locale.label, i18n)
 

--- a/packages/ui/src/elements/Pagination/index.tsx
+++ b/packages/ui/src/elements/Pagination/index.tsx
@@ -21,7 +21,7 @@ const baseClass = 'paginator'
 
 export const Pagination: React.FC<Props> = (props) => {
   const router = useRouter()
-  const { searchParams } = useSearchParams()
+  const searchParams = useSearchParams()
   const pathname = usePathname()
 
   const {

--- a/packages/ui/src/elements/PerPage/index.tsx
+++ b/packages/ui/src/elements/PerPage/index.tsx
@@ -30,7 +30,7 @@ export const PerPage: React.FC<Props> = ({
   modifySearchParams = true,
   resetPage = false,
 }) => {
-  const { searchParams } = useSearchParams()
+  const searchParams = useSearchParams()
   const history = useHistory()
   const { t } = useTranslation()
 

--- a/packages/ui/src/elements/SearchFilter/index.tsx
+++ b/packages/ui/src/elements/SearchFilter/index.tsx
@@ -22,7 +22,7 @@ const SearchFilter: React.FC<Props> = (props) => {
     modifySearchQuery = true,
   } = props
 
-  const { searchParams } = useSearchParams()
+  const searchParams = useSearchParams()
   const history = useHistory()
   const { i18n, t } = useTranslation()
 

--- a/packages/ui/src/elements/SortColumn/index.tsx
+++ b/packages/ui/src/elements/SortColumn/index.tsx
@@ -15,7 +15,7 @@ const baseClass = 'sort-column'
 
 export const SortColumn: React.FC<Props> = (props) => {
   const { name, disable = false, label } = props
-  const { searchParams } = useSearchParams()
+  const searchParams = useSearchParams()
   const history = useHistory()
   const { i18n, t } = useTranslation()
 

--- a/packages/ui/src/elements/SortComplex/index.tsx
+++ b/packages/ui/src/elements/SortComplex/index.tsx
@@ -19,7 +19,7 @@ const SortComplex: React.FC<Props> = (props) => {
   const { collection, handleChange, modifySearchQuery = true } = props
 
   const history = useHistory()
-  const { searchParams } = useSearchParams()
+  const searchParams = useSearchParams()
   const { i18n, t } = useTranslation()
   const [sortOptions, setSortOptions] = useState<OptionObject[]>()
 

--- a/packages/ui/src/elements/WhereBuilder/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/index.tsx
@@ -66,7 +66,7 @@ const WhereBuilder: React.FC<Props> = (props) => {
   const collection = config.collections.find((c) => c.slug === collectionSlug)
   const [reducedFields] = useState(() => reduceFields(collection.fields, i18n))
 
-  const { searchParams } = useSearchParams()
+  const searchParams = useSearchParams()
 
   // This handles initializing the where conditions from the search query (URL). That way, if you pass in
   // query params to the URL, the where conditions will be initialized from those and displayed in the UI.

--- a/packages/ui/src/providers/Locale/index.tsx
+++ b/packages/ui/src/providers/Locale/index.tsx
@@ -20,7 +20,7 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode }> = ({ child
   const defaultLocale =
     localization && localization.defaultLocale ? localization.defaultLocale : 'en'
 
-  const { searchParams } = useSearchParams()
+  const searchParams = useSearchParams()
 
   const [localeCode, setLocaleCode] = useState<string>(
     (searchParams?.locale as string) || defaultLocale,

--- a/packages/ui/src/providers/Params/index.tsx
+++ b/packages/ui/src/providers/Params/index.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { Params } from 'next/dist/shared/lib/router/utils/route-matcher'
+import { useParams as useNextParams } from 'next/navigation'
+import React, { createContext, useContext } from 'react'
+
+interface IParamsContext extends Params {}
+
+const Context = createContext<IParamsContext>({} as IParamsContext)
+
+// TODO: abstract the `next/navigation` dependency out from this provider so that it can be used in other contexts
+export const ParamsProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const params = useNextParams()
+  return <Context.Provider value={params}>{children}</Context.Provider>
+}
+
+export const useParams = (): IParamsContext => useContext(Context)

--- a/packages/ui/src/providers/Root/index.tsx
+++ b/packages/ui/src/providers/Root/index.tsx
@@ -21,6 +21,7 @@ import { CustomProvider } from '../CustomProvider'
 import { ComponentMap } from '../../utilities/buildComponentMap/types'
 import { ComponentMapProvider } from '../ComponentMapProvider'
 import { SearchParamsProvider } from '../SearchParams'
+import { ParamsProvider } from '../Params'
 
 type Props = {
   config: ClientConfig
@@ -64,21 +65,23 @@ export const RootProvider: React.FC<Props> = ({
                   <AuthProvider>
                     <PreferencesProvider>
                       <ThemeProvider>
-                        <SearchParamsProvider>
-                          <LocaleProvider>
-                            <StepNavProvider>
-                              <LoadingOverlayProvider>
-                                <DocumentEventsProvider>
-                                  <ActionsProvider>
-                                    <NavProvider>
-                                      <CustomProvider>{children}</CustomProvider>
-                                    </NavProvider>
-                                  </ActionsProvider>
-                                </DocumentEventsProvider>
-                              </LoadingOverlayProvider>
-                            </StepNavProvider>
-                          </LocaleProvider>
-                        </SearchParamsProvider>
+                        <ParamsProvider>
+                          <SearchParamsProvider>
+                            <LocaleProvider>
+                              <StepNavProvider>
+                                <LoadingOverlayProvider>
+                                  <DocumentEventsProvider>
+                                    <ActionsProvider>
+                                      <NavProvider>
+                                        <CustomProvider>{children}</CustomProvider>
+                                      </NavProvider>
+                                    </ActionsProvider>
+                                  </DocumentEventsProvider>
+                                </LoadingOverlayProvider>
+                              </StepNavProvider>
+                            </LocaleProvider>
+                          </SearchParamsProvider>
+                        </ParamsProvider>
                       </ThemeProvider>
                     </PreferencesProvider>
                     <ModalContainer />

--- a/packages/ui/src/providers/SearchParams/index.tsx
+++ b/packages/ui/src/providers/SearchParams/index.tsx
@@ -1,27 +1,17 @@
 'use client'
-import { Params } from 'next/dist/shared/lib/router/utils/route-matcher'
-import { useSearchParams as useNextSearchParams, useParams as useNextParams } from 'next/navigation'
+import { useSearchParams as useNextSearchParams } from 'next/navigation'
 import qs from 'qs'
 import React, { createContext, useContext } from 'react'
 
-interface IParamsContext {
-  searchParams: qs.ParsedQs
-  params: Params
-}
+interface ISearchParamsContext extends qs.ParsedQs {}
 
-const Context = createContext<IParamsContext>({
-  searchParams: {},
-  params: {},
-} as IParamsContext)
+const Context = createContext<ISearchParamsContext>({} as ISearchParamsContext)
 
 // TODO: abstract the `next/navigation` dependency out from this provider so that it can be used in other contexts
 export const SearchParamsProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const nextSearchParams = useNextSearchParams()
-  const params = useNextParams()
-
   const searchParams = qs.parse(nextSearchParams.toString(), { depth: 10, ignoreQueryPrefix: true })
-
-  return <Context.Provider value={{ searchParams, params }}>{children}</Context.Provider>
+  return <Context.Provider value={searchParams}>{children}</Context.Provider>
 }
 
-export const useSearchParams = (): IParamsContext => useContext(Context)
+export const useSearchParams = (): ISearchParamsContext => useContext(Context)


### PR DESCRIPTION
## Description

Separates _params_ from _search params_ into a standalone context. After second thought it doesn't make sense to introduce the breaking change in #5094, but also it is more performant and expected to set it up this way.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.