### PR TITLE
fix(db-mongodb): unique sparse for not required fields

### DIFF
--- a/packages/db-mongodb/src/models/buildSchema.ts
+++ b/packages/db-mongodb/src/models/buildSchema.ts
@@ -14,8 +14,10 @@ import type {
   DateField,
   EmailField,
   Field,
+  FieldAffectingData,
   GroupField,
   JSONField,
+  NonPresentationalField,
   NumberField,
   PointField,
   RadioField,
@@ -23,12 +25,12 @@ import type {
   RichTextField,
   RowField,
   SelectField,
+  Tab,
   TabsField,
   TextField,
   TextareaField,
   UploadField,
 } from 'payload/types'
-import type { FieldAffectingData, NonPresentationalField, Tab, UnnamedTab } from 'payload/types'
 
 import { Schema } from 'mongoose'
 import {
@@ -61,7 +63,16 @@ const formatBaseSchema = (field: FieldAffectingData, buildSchemaOptions: BuildSc
     unique: (!disableUnique && field.unique) || false,
   }
 
-  if (schema.unique && (field.localized || draftsEnabled)) {
+  if (
+    schema.unique &&
+    (field.localized ||
+      draftsEnabled ||
+      ('required' in field && !field.required) ||
+      (field.type !== 'group' &&
+        fieldAffectsData(field) &&
+        field.type !== 'tab' &&
+        field?.required !== true))
+  ) {
     schema.sparse = true
   }
 
@@ -79,7 +90,6 @@ const localizeSchema = (
 ) => {
   if (fieldIsLocalized(entity) && localization && Array.isArray(localization.locales)) {
     return {
-      localized: true,
       type: localization.localeCodes.reduce(
         (localeSchema, locale) => ({
           ...localeSchema,
@@ -89,6 +99,7 @@ const localizeSchema = (
           _id: false,
         },
       ),
+      localized: true,
     }
   }
   return schema
@@ -140,7 +151,6 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
   ) => {
     const baseSchema = {
       ...formatBaseSchema(field, buildSchemaOptions),
-      default: undefined,
       type: [
         buildSchema(config, field.fields, {
           allowIDField: true,
@@ -153,6 +163,7 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
           },
         }),
       ],
+      default: undefined,
     }
 
     schema.add({
@@ -166,8 +177,8 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
     buildSchemaOptions: BuildSchemaOptions,
   ): void => {
     const fieldSchema = {
-      default: undefined,
       type: [new Schema({}, { _id: false, discriminatorKey: 'blockType' })],
+      default: undefined,
     }
 
     schema.add({
@@ -187,12 +198,12 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
       if (field.localized && config.localization) {
         config.localization.localeCodes.forEach((localeCode) => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore Possible incorrect typing in mongoose types, this works
+          // @ts-expect-error Possible incorrect typing in mongoose types, this works
           schema.path(`${field.name}.${localeCode}`).discriminator(blockItem.slug, blockSchema)
         })
       } else {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore Possible incorrect typing in mongoose types, this works
+        // @ts-expect-error Possible incorrect typing in mongoose types, this works
         schema.path(field.name).discriminator(blockItem.slug, blockSchema)
       }
     })
@@ -325,14 +336,14 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
     buildSchemaOptions: BuildSchemaOptions,
   ): void => {
     const baseSchema: SchemaTypeOptions<unknown> = {
+      type: {
+        type: String,
+        enum: ['Point'],
+      },
       coordinates: {
+        type: [Number],
         default: field.defaultValue || undefined,
         required: false,
-        type: [Number],
-      },
-      type: {
-        enum: ['Point'],
-        type: String,
       },
     }
     if (buildSchemaOptions.disableUnique && field.unique && field.localized) {
@@ -366,11 +377,11 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
   ): void => {
     const baseSchema = {
       ...formatBaseSchema(field, buildSchemaOptions),
+      type: String,
       enum: field.options.map((option) => {
         if (typeof option === 'object') return option.value
         return option
       }),
-      type: String,
     }
 
     schema.add({
@@ -388,7 +399,6 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
 
     if (field.localized && config.localization) {
       schemaToReturn = {
-        localized: true,
         type: config.localization.localeCodes.reduce((locales, locale) => {
           let localeSchema: { [key: string]: any } = {}
 
@@ -396,56 +406,57 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
             localeSchema = {
               ...formatBaseSchema(field, buildSchemaOptions),
               _id: false,
-              relationTo: { enum: field.relationTo, type: String },
               type: Schema.Types.Mixed,
+              relationTo: { type: String, enum: field.relationTo },
               value: {
-                refPath: `${field.name}.${locale}.relationTo`,
                 type: Schema.Types.Mixed,
+                refPath: `${field.name}.${locale}.relationTo`,
               },
             }
           } else {
             localeSchema = {
               ...formatBaseSchema(field, buildSchemaOptions),
-              ref: field.relationTo,
               type: Schema.Types.Mixed,
+              ref: field.relationTo,
             }
           }
 
           return {
             ...locales,
-            [locale]: field.hasMany ? { default: undefined, type: [localeSchema] } : localeSchema,
+            [locale]: field.hasMany ? { type: [localeSchema], default: undefined } : localeSchema,
           }
         }, {}),
+        localized: true,
       }
     } else if (hasManyRelations) {
       schemaToReturn = {
         ...formatBaseSchema(field, buildSchemaOptions),
         _id: false,
-        relationTo: { enum: field.relationTo, type: String },
         type: Schema.Types.Mixed,
+        relationTo: { type: String, enum: field.relationTo },
         value: {
-          refPath: `${field.name}.relationTo`,
           type: Schema.Types.Mixed,
+          refPath: `${field.name}.relationTo`,
         },
       }
 
       if (field.hasMany) {
         schemaToReturn = {
-          default: undefined,
           type: [schemaToReturn],
+          default: undefined,
         }
       }
     } else {
       schemaToReturn = {
         ...formatBaseSchema(field, buildSchemaOptions),
-        ref: field.relationTo,
         type: Schema.Types.Mixed,
+        ref: field.relationTo,
       }
 
       if (field.hasMany) {
         schemaToReturn = {
-          default: undefined,
           type: [schemaToReturn],
+          default: undefined,
         }
       }
     }
@@ -488,11 +499,11 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
   ): void => {
     const baseSchema = {
       ...formatBaseSchema(field, buildSchemaOptions),
+      type: String,
       enum: field.options.map((option) => {
         if (typeof option === 'object') return option.value
         return option
       }),
-      type: String,
     }
 
     if (buildSchemaOptions.draftsEnabled || !field.required) {
@@ -576,8 +587,8 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
   ): void => {
     const baseSchema = {
       ...formatBaseSchema(field, buildSchemaOptions),
-      ref: field.relationTo,
       type: Schema.Types.Mixed,
+      ref: field.relationTo,
     }
 
     schema.add({

--- a/packages/db-mongodb/src/models/buildSchema.ts
+++ b/packages/db-mongodb/src/models/buildSchema.ts
@@ -67,11 +67,10 @@ const formatBaseSchema = (field: FieldAffectingData, buildSchemaOptions: BuildSc
     schema.unique &&
     (field.localized ||
       draftsEnabled ||
-      ('required' in field && !field.required) ||
-      (field.type !== 'group' &&
-        fieldAffectsData(field) &&
+      (fieldAffectsData(field) &&
+        field.type !== 'group' &&
         field.type !== 'tab' &&
-        field?.required !== true))
+        field.required !== true))
   ) {
     schema.sparse = true
   }

--- a/test/fields/collections/Indexed/index.ts
+++ b/test/fields/collections/Indexed/index.ts
@@ -32,13 +32,20 @@ const IndexedFields: CollectionConfig = {
   fields: [
     {
       name: 'text',
+      type: 'text',
       index: true,
       required: true,
-      type: 'text',
     },
     {
       name: 'uniqueText',
       type: 'text',
+      unique: true,
+    },
+    {
+      name: 'uniqueRequiredText',
+      type: 'text',
+      defaultValue: 'uniqueRequired',
+      required: true,
       unique: true,
     },
     {
@@ -47,11 +54,12 @@ const IndexedFields: CollectionConfig = {
     },
     {
       name: 'group',
+      type: 'group',
       fields: [
         {
           name: 'localizedUnique',
-          localized: true,
           type: 'text',
+          localized: true,
           unique: true,
         },
         {
@@ -64,25 +72,24 @@ const IndexedFields: CollectionConfig = {
           type: 'point',
         },
       ],
-      type: 'group',
     },
     {
+      type: 'collapsible',
       fields: [
         {
           name: 'collapsibleLocalizedUnique',
-          localized: true,
           type: 'text',
+          localized: true,
           unique: true,
         },
         {
           name: 'collapsibleTextUnique',
-          label: 'collapsibleTextUnique',
           type: 'text',
+          label: 'collapsibleTextUnique',
           unique: true,
         },
       ],
       label: 'Collapsible',
-      type: 'collapsible',
     },
   ],
   versions: true,

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -249,6 +249,7 @@ describe('fields', () => {
             unique: uniqueText,
           },
           text: 'text',
+          uniqueRequiredText: 'text',
           uniqueText,
         },
       })

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -594,6 +594,23 @@ describe('Fields', () => {
         return result.error
       }).toBeDefined()
     })
+
+    it('should not throw validation error saving multiple null values unique fields', async () => {
+      const data = {
+        text: 'a',
+        // uniqueText omitted on purpose
+      }
+      await payload.create({
+        collection: 'indexed-fields',
+        data,
+      })
+      const result = await payload.create({
+        collection: 'indexed-fields',
+        data,
+      })
+
+      expect(result.id).toBeDefined()
+    })
   })
 
   describe('array', () => {

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -424,7 +424,7 @@ describe('Fields', () => {
       const definitions: Record<string, IndexDirection> = {}
       const options: Record<string, IndexOptions> = {}
 
-      beforeEach(() => {
+      beforeAll(() => {
         indexes = (payload.db as MongooseAdapter).collections[
           'indexed-fields'
         ].schema.indexes() as [Record<string, IndexDirection>, IndexOptions]
@@ -447,7 +447,7 @@ describe('Fields', () => {
       })
 
       it('should have unique indexes that are not sparse when field is required', () => {
-        expect(definitions.uniqueRequired).toEqual(1)
+        expect(definitions.uniqueRequiredText).toEqual(1)
         expect(options.uniqueText).toMatchObject({ unique: true })
       })
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -441,8 +441,13 @@ describe('Fields', () => {
         expect(definitions.text).toEqual(1)
       })
 
-      it('should have unique indexes', () => {
+      it('should have unique sparse indexes when field is not required', () => {
         expect(definitions.uniqueText).toEqual(1)
+        expect(options.uniqueText).toMatchObject({ sparse: true, unique: true })
+      })
+
+      it('should have unique indexes that are not sparse when field is required', () => {
+        expect(definitions.uniqueRequired).toEqual(1)
         expect(options.uniqueText).toMatchObject({ unique: true })
       })
 
@@ -595,15 +600,17 @@ describe('Fields', () => {
       }).toBeDefined()
     })
 
-    it('should not throw validation error saving multiple null values unique fields', async () => {
+    it('should not throw validation error saving multiple null values for unique fields', async () => {
       const data = {
         text: 'a',
+        uniqueRequiredText: 'a',
         // uniqueText omitted on purpose
       }
       await payload.create({
         collection: 'indexed-fields',
         data,
       })
+      data.uniqueRequiredText = 'b'
       const result = await payload.create({
         collection: 'indexed-fields',
         data,


### PR DESCRIPTION
## Description

When a field is `unique` it is effectively also `required` because you can only have one `undefined` value in the collection before the unique constraint forces a validation error.

Thanks,

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
