### PR TITLE
chore(plugin-nested-docs): payload added to peerDependencies

### DIFF
--- a/packages/plugin-nested-docs/package.json
+++ b/packages/plugin-nested-docs/package.json
@@ -20,6 +20,9 @@
     "@payloadcms/eslint-config": "workspace:*",
     "payload": "workspace:*"
   },
+  "peerDependencies": {
+    "payload": "^0.18.5 || ^1.0.0 || ^2.0.0"
+  },
   "exports": {
     ".": {
       "default": "./src/index.ts",


### PR DESCRIPTION
## Description

A user was reporting dependency installation issues after updating payload.

```
npm i @payloadcms/plugin-form-builder@latest
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: OMITTED
npm ERR! Found: payload@2.3.0
npm ERR! node_modules/payload
npm ERR!   payload@"^2.3.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer payload@"^0.18.5 || ^1.0.0" from @payloadcms/plugin-nested-docs@1.0.6
npm ERR! node_modules/@payloadcms/plugin-nested-docs
npm ERR!   @payloadcms/plugin-nested-docs@"^1.0.4" from the root project
```

It was resolved by using installing with `npm i @payloadcms/plugin-nested-docs --force` and all other plugins in use.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
