### PR TITLE
fix: only replace the drawer content with full edit component if it exists

### DIFF
--- a/packages/payload/src/admin/components/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/payload/src/admin/components/elements/DocumentDrawer/DrawerContent.tsx
@@ -52,21 +52,9 @@ const Content: React.FC<DocumentDrawerProps> = ({
 
   const { id, docPermissions, getDocPreferences } = useDocumentInfo()
 
-  // The component definition could come from multiple places in the config
-  // we need to cascade into the proper component from the top-down
-  // 1. "components.Edit"
-  // 2. "components.Edit.Default"
-  // 3. "components.Edit.Default.Component"
-  const CustomEditView =
-    typeof Edit === 'function'
-      ? Edit
-      : typeof Edit === 'object' && typeof Edit.Default === 'function'
-      ? Edit.Default
-      : typeof Edit?.Default === 'object' &&
-        'Component' in Edit.Default &&
-        typeof Edit.Default.Component === 'function'
-      ? Edit.Default.Component
-      : undefined
+  // If they are replacing the entire edit view, use that.
+  // Else let the DefaultEdit determine what to render.
+  const CustomEditView = typeof Edit === 'function' ? Edit : undefined
 
   const [fields, setFields] = useState(() => formatFields(collectionConfig, true))
 


### PR DESCRIPTION
## Description

Fixes an issue when rendering custom edit views on collections within drawers. 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
