### PR TITLE
fix: disabling API Key does not remove the key

### DIFF
--- a/packages/payload/src/auth/baseFields/apiKey.ts
+++ b/packages/payload/src/auth/baseFields/apiKey.ts
@@ -11,9 +11,12 @@ const encryptKey: FieldHook = ({ req, value }) =>
 const decryptKey: FieldHook = ({ req, value }) =>
   value ? req.payload.decrypt(value as string) : undefined
 
+const clearKey: FieldHook = ({ data, value }) => (data.enableAPIKey === false ? null : value)
+
 export default [
   {
     name: 'enableAPIKey',
+    type: 'checkbox',
     admin: {
       components: {
         Field: () => null,
@@ -21,10 +24,10 @@ export default [
     },
     defaultValue: false,
     label: labels['authentication:enableAPIKey'],
-    type: 'checkbox',
   },
   {
     name: 'apiKey',
+    type: 'text',
     admin: {
       components: {
         Field: () => null,
@@ -32,18 +35,19 @@ export default [
     },
     hooks: {
       afterRead: [decryptKey],
-      beforeChange: [encryptKey],
+      beforeChange: [encryptKey, clearKey],
     },
     label: labels['authentication:apiKey'],
-    type: 'text',
   },
   {
     name: 'apiKeyIndex',
+    type: 'text',
     admin: {
       disabled: true,
     },
     hidden: true,
     hooks: {
+      beforeChange: [clearKey],
       beforeValidate: [
         async ({ data, req, value }) => {
           if (data.apiKey) {
@@ -59,6 +63,5 @@ export default [
         },
       ],
     },
-    type: 'text',
   },
 ] as Field[]

--- a/packages/payload/src/auth/baseFields/apiKey.ts
+++ b/packages/payload/src/auth/baseFields/apiKey.ts
@@ -7,11 +7,9 @@ import { extractTranslations } from '../../translations/extractTranslations'
 const labels = extractTranslations(['authentication:enableAPIKey', 'authentication:apiKey'])
 
 const encryptKey: FieldHook = ({ req, value }) =>
-  value ? req.payload.encrypt(value as string) : undefined
+  value ? req.payload.encrypt(value as string) : null
 const decryptKey: FieldHook = ({ req, value }) =>
   value ? req.payload.decrypt(value as string) : undefined
-
-const clearKey: FieldHook = ({ data, value }) => (data.enableAPIKey === false ? null : value)
 
 export default [
   {
@@ -35,7 +33,7 @@ export default [
     },
     hooks: {
       afterRead: [decryptKey],
-      beforeChange: [encryptKey, clearKey],
+      beforeChange: [encryptKey],
     },
     label: labels['authentication:apiKey'],
   },
@@ -47,7 +45,6 @@ export default [
     },
     hidden: true,
     hooks: {
-      beforeChange: [clearKey],
       beforeValidate: [
         async ({ data, req, value }) => {
           if (data.apiKey) {

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -4,7 +4,7 @@ import { mapAsync } from '../../packages/payload/src/utilities/mapAsync'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults'
 import { devUser } from '../credentials'
 import { AuthDebug } from './AuthDebug'
-import { namedSaveToJWTValue, saveToJWTKey, slug } from './shared'
+import { apiKeysSlug, namedSaveToJWTValue, saveToJWTKey, slug } from './shared'
 
 export default buildConfigWithDefaults({
   admin: {
@@ -171,11 +171,7 @@ export default buildConfigWithDefaults({
       ],
     },
     {
-      slug: 'api-keys',
-      labels: {
-        singular: 'API Key',
-        plural: 'API Keys',
-      },
+      slug: apiKeysSlug,
       access: {
         read: ({ req: { user } }) => {
           if (user.collection === 'api-keys') {
@@ -193,6 +189,10 @@ export default buildConfigWithDefaults({
         useAPIKey: true,
       },
       fields: [],
+      labels: {
+        plural: 'API Keys',
+        singular: 'API Key',
+      },
     },
     {
       slug: 'public-users',

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -30,20 +30,20 @@ describe('auth', () => {
   beforeAll(async ({ browser }) => {
     serverURL = (await initPayloadE2E(__dirname)).serverURL
     apiURL = `${serverURL}/api`
+
+    const context = await browser.newContext()
+    page = await context.newPage()
+    initPageConsoleErrorCatch(page)
+
+    await login({
+      page,
+      serverURL,
+    })
   })
 
   describe('authenticated users', () => {
     beforeAll(async ({ browser }) => {
       url = new AdminUrlUtil(serverURL, slug)
-
-      const context = await browser.newContext()
-      page = await context.newPage()
-      initPageConsoleErrorCatch(page)
-
-      await login({
-        page,
-        serverURL,
-      })
     })
 
     test('should allow change password', async () => {
@@ -76,17 +76,8 @@ describe('auth', () => {
   describe('api-keys', () => {
     let user
 
-    beforeAll(async ({ browser }) => {
+    beforeAll(async () => {
       url = new AdminUrlUtil(serverURL, apiKeysSlug)
-
-      const context = await browser.newContext()
-      page = await context.newPage()
-      initPageConsoleErrorCatch(page)
-
-      await login({
-        page,
-        serverURL,
-      })
 
       user = await payload.create({
         collection: apiKeysSlug,

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -2,40 +2,50 @@ import type { Page } from '@playwright/test'
 
 import { expect, test } from '@playwright/test'
 
+import payload from '../../packages/payload/src'
 import { initPageConsoleErrorCatch, login, saveDocAndAssert } from '../helpers'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil'
 import { initPayloadE2E } from '../helpers/configHelpers'
-import { slug } from './shared'
+import { apiKeysSlug, slug } from './shared'
 
 /**
  * TODO: Auth
  *   create first user
  *   unlock
- *   generate api key
  *   log out
  */
 
 const { beforeAll, describe } = test
 
+const headers = {
+  'Content-Type': 'application/json',
+}
+
 describe('auth', () => {
   let page: Page
   let url: AdminUrlUtil
+  let serverURL: string
+  let apiURL: string
 
   beforeAll(async ({ browser }) => {
-    const { serverURL } = await initPayloadE2E(__dirname)
-    url = new AdminUrlUtil(serverURL, slug)
-
-    const context = await browser.newContext()
-    page = await context.newPage()
-    initPageConsoleErrorCatch(page)
-
-    await login({
-      page,
-      serverURL,
-    })
+    serverURL = (await initPayloadE2E(__dirname)).serverURL
+    apiURL = `${serverURL}/api`
   })
 
   describe('authenticated users', () => {
+    beforeAll(async ({ browser }) => {
+      url = new AdminUrlUtil(serverURL, slug)
+
+      const context = await browser.newContext()
+      page = await context.newPage()
+      initPageConsoleErrorCatch(page)
+
+      await login({
+        page,
+        serverURL,
+      })
+    })
+
     test('should allow change password', async () => {
       await page.goto(url.account)
       const emailBeforeSave = await page.locator('#field-email').inputValue()
@@ -60,6 +70,67 @@ describe('auth', () => {
 
       await expect(page.locator('#users-api-result')).toHaveText('Goodbye, world!')
       await expect(page.locator('#use-auth-result')).toHaveText('Goodbye, world!')
+    })
+  })
+
+  describe('api-keys', () => {
+    let user
+
+    beforeAll(async ({ browser }) => {
+      url = new AdminUrlUtil(serverURL, apiKeysSlug)
+
+      const context = await browser.newContext()
+      page = await context.newPage()
+      initPageConsoleErrorCatch(page)
+
+      await login({
+        page,
+        serverURL,
+      })
+
+      user = await payload.create({
+        collection: apiKeysSlug,
+        data: {
+          enableAPIKey: true,
+        },
+      })
+    })
+
+    test('should enable api key', async () => {
+      await page.goto(url.create)
+
+      // click enable api key checkbox
+      await page.locator('#field-enableAPIKey').click()
+
+      // assert that the value is set
+      const apiKey = await page.locator('#apiKey').inputValue()
+      expect(apiKey).toBeDefined()
+
+      await saveDocAndAssert(page)
+
+      expect(await page.locator('#apiKey').inputValue()).toStrictEqual(apiKey)
+    })
+
+    test('should disable api key', async () => {
+      await page.goto(url.edit(user.id))
+
+      // click enable api key checkbox
+      await page.locator('#field-enableAPIKey').click()
+
+      // assert that the apiKey field is hidden
+      await expect(page.locator('#apiKey')).toBeHidden()
+
+      await saveDocAndAssert(page)
+
+      // use the api key in a fetch to assert that it is disabled
+      const response = await fetch(`${apiURL}/${apiKeysSlug}/me`, {
+        headers: {
+          ...headers,
+          Authorization: `${slug} API-Key ${user.apiKey}`,
+        },
+      }).then((res) => res.json())
+
+      expect(response.user).toBeNull()
     })
   })
 })

--- a/test/auth/shared.ts
+++ b/test/auth/shared.ts
@@ -1,4 +1,5 @@
 export const slug = 'users'
+export const apiKeysSlug = 'api-keys'
 
 export const namedSaveToJWTValue = 'namedSaveToJWT value'
 


### PR DESCRIPTION
## Description

It was reported that when you save the user after unchecking the Enable API Key checkbox, the auth key is not removed from the user as is expected.

This change adds a beforeChange hook to set the apiKey and apiKeyIndex values to null.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
