### PR TITLE
fix: handle thrown errors in config-level afterError hook

### DIFF
--- a/packages/payload/src/express/middleware/errorHandler.ts
+++ b/packages/payload/src/express/middleware/errorHandler.ts
@@ -56,7 +56,7 @@ const errorHandler =
         err,
         response,
         req.context,
-        req.collection.config,
+        null,
       )) || {
         response,
         status,

--- a/test/hooks/config.ts
+++ b/test/hooks/config.ts
@@ -1,5 +1,6 @@
 import type { SanitizedConfig } from '../../packages/payload/src/config/types'
 
+import { APIError } from '../../packages/payload/errors'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults'
 import AfterOperation from './collections/AfterOperation'
 import ChainingHooks from './collections/ChainingHooks'
@@ -24,6 +25,18 @@ export const HooksConfig: Promise<SanitizedConfig> = buildConfigWithDefaults({
     DataHooks,
   ],
   globals: [DataHooksGlobal],
+  endpoints: [
+    {
+      path: '/throw-to-after-error',
+      method: 'get',
+      handler: () => {
+        throw new APIError("I'm a teapot", 418)
+      },
+    },
+  ],
+  hooks: {
+    afterError: () => console.log('Running afterError hook'),
+  },
   onInit: async (payload) => {
     await seedHooksUsers(payload)
     await payload.create({

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -462,4 +462,13 @@ describe('Hooks', () => {
       expect(doc.field_globalAndField).toStrictEqual(globalAndFieldString + globalAndFieldString)
     })
   })
+
+  describe('config level after error hook', () => {
+    it('should handle error', async () => {
+      const response = await fetch(`${apiUrl}/throw-to-after-error`)
+      const body = await response.json()
+      expect(response.status).toEqual(418)
+      expect(body).toEqual({ errors: [{ message: "I'm a teapot" }] })
+    })
+  })
 })


### PR DESCRIPTION
## Description

Properly handle thrown errors in config-level afterError hook. Bug was introduced in #3780.

Fixes #5013 