### PR TITLE
fix: transaction error from access endpoint

### DIFF
--- a/packages/payload/src/utilities/getEntityPolicies.ts
+++ b/packages/payload/src/utilities/getEntityPolicies.ts
@@ -101,9 +101,13 @@ export async function getEntityPolicies<T extends Args>(args: T): Promise<Return
     const mutablePolicies = policiesObj
 
     if (accessLevel === 'field' && docBeingAccessed === undefined) {
-      docBeingAccessed = getEntityDoc()
-      await docBeingAccessed
+      // assign docBeingAccessed first as the promise to avoid multiple calls to getEntityDoc
+      docBeingAccessed = getEntityDoc().then((doc) => {
+        docBeingAccessed = doc
+      })
     }
+    // awaiting the promise to ensure docBeingAccessed is assigned before it is used
+    await docBeingAccessed
 
     const data = req?.body
 

--- a/packages/payload/src/utilities/getEntityPolicies.ts
+++ b/packages/payload/src/utilities/getEntityPolicies.ts
@@ -57,8 +57,10 @@ export async function getEntityPolicies<T extends Args>(args: T): Promise<Return
         if (typeof where === 'object') {
           const paginatedRes = await req.payload.find({
             collection: entity.slug,
+            depth: 0,
             limit: 1,
             overrideAccess: true,
+            pagination: false,
             req,
             where: {
               ...where,
@@ -79,6 +81,7 @@ export async function getEntityPolicies<T extends Args>(args: T): Promise<Return
         return req.payload.findByID({
           id,
           collection: entity.slug,
+          depth: 0,
           overrideAccess: true,
           req,
         })
@@ -98,7 +101,8 @@ export async function getEntityPolicies<T extends Args>(args: T): Promise<Return
     const mutablePolicies = policiesObj
 
     if (accessLevel === 'field' && docBeingAccessed === undefined) {
-      docBeingAccessed = await getEntityDoc()
+      docBeingAccessed = getEntityDoc()
+      await docBeingAccessed
     }
 
     const data = req?.body


### PR DESCRIPTION
## Description

Fixes #4350

Resolves transaction errors by limiting the read of document to once per doc access and reduces database IO.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
