### PR TITLE
fix(db-postgres): hasMany select field value is associated with wrong version on publish

### DIFF
--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -34,6 +34,7 @@ export const saveVersion = async ({
   const versionData = deepCopyObject(doc)
   if (draft) versionData._status = 'draft'
   if (versionData._id) delete versionData._id
+  if (versionData.id) delete versionData.id
 
   try {
     if (autosave) {

--- a/test/versions/collections/Versions.ts
+++ b/test/versions/collections/Versions.ts
@@ -51,6 +51,12 @@ const VersionPosts: CollectionConfig = {
       type: 'textarea',
       required: true,
     },
+    {
+      name: 'tags',
+      type: 'select',
+      hasMany: true,
+      options: ['tag1', 'tag2', 'tag3'],
+    },
   ],
 }
 

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -291,13 +291,14 @@ describe('Versions', () => {
         )
       })
 
-      it('should save to version table with correct hasMany select field value (fix #5157)', async () => {
+      // https://github.com/payloadcms/payload/issues/5157
+      it('should save to version table with correct hasMany select field value', async () => {
         // save draft
         const post = await payload.create({
           collection: versionCollectionSlug,
           draft: true,
           data: {
-            title: 'this is title',
+            title: 'title1',
             description: 'this is description',
           },
         })
@@ -305,19 +306,22 @@ describe('Versions', () => {
         await payload.update({
           collection: versionCollectionSlug,
           id: post.id,
-          data: { title: 'this is updated title', tags: ['tag1'], _status: 'published' },
+          data: { title: 'title2', tags: ['tag1'], _status: 'published' },
         })
 
         const versions = await payload.findVersions({
           collection: versionCollectionSlug,
           draft: true,
           where: { parent: { equals: post.id } },
-          sort: 'id',
         })
-        expect(versions.docs.map(({ id, version: { tags } }) => ({ id, tags }))).toStrictEqual([
-          { id: 1, tags: [] },
-          { id: 2, tags: ['tag1'] },
-        ])
+        expect(
+          versions.docs.map(({ version: { title, tags } }) => ({ title, tags })),
+        ).toStrictEqual(
+          expect.arrayContaining([
+            { title: 'title1', tags: [] },
+            { title: 'title2', tags: ['tag1'] },
+          ]),
+        )
       })
     })
 


### PR DESCRIPTION
## Description

fixes #5157

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes