### PR TITLE
fix: regression of filterOptions using different transaction

### DIFF
--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -314,12 +314,12 @@ const validateFilterOptions: Validate = async (
               falseCollections.push(optionFilter)
             }
 
-            // `req` omitted to prevent transaction errors from aborting the entire transaction
             const result = await payload.find({
               collection,
               depth: 0,
               limit: 0,
               pagination: false,
+              req,
               where: findWhere,
             })
 

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'crypto'
 
+import type { PayloadRequest } from '../../packages/payload/types'
 import type {
   ChainedRelation,
   CustomIdNumberRelation,
@@ -677,6 +678,35 @@ describe('Relationships', () => {
         })
         expect(count).toBe(1)
         expect(item.text).toBe('sub')
+      })
+    })
+  })
+
+  describe('Creating', () => {
+    describe('With transactions', () => {
+      it('should be able to create filtered relations within a transaction', async () => {
+        const req = {} as PayloadRequest
+        req.transactionID = await payload.db.beginTransaction?.()
+        const related = await payload.create({
+          collection: relationSlug,
+          data: {
+            name: 'parent',
+          },
+          req,
+        })
+        const withRelation = await payload.create({
+          collection: slug,
+          data: {
+            filteredRelation: related.id,
+          },
+          req,
+        })
+
+        if (req.transactionID) {
+          await payload.db.commitTransaction?.(req.transactionID)
+        }
+
+        expect(withRelation.filteredRelation.id).toEqual(related.id)
       })
     })
   })


### PR DESCRIPTION
## Description

This change is to fix a regression from https://github.com/payloadcms/payload/pull/5079, when you have a document change in a hook within the same transaction, the `req` must be passed. I've re-added test that was removed to show this is working. Kept the try/catch in the filterOptions to prevent the original issue from coming back again.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
