### PR TITLE
chore: remove dirname from payload package

### DIFF
--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -7,11 +7,9 @@ export const defaults: Omit<Config, 'db' | 'editor' | 'secret'> = {
     avatar: 'default',
     buildPath: path.resolve(process.cwd(), './build'),
     components: {},
-    css: path.resolve(__dirname, '../admin/scss/custom.css'),
     dateFormat: 'MMMM do yyyy, h:mm a',
     disable: false,
     inactivityRoute: '/logout-inactivity',
-    indexHTML: path.resolve(__dirname, '../admin/index.html'),
     logoutRoute: '/logout',
     meta: {
       titleSuffix: '- Payload',

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -494,8 +494,6 @@ export type Config = {
     disable?: boolean
     /** The route the user will be redirected to after being inactive for too long. */
     inactivityRoute?: string
-    /** Replace the entirety of the index.html file used by the Admin panel. Reference the base index.html file to ensure your replacement has the appropriate HTML elements. */
-    indexHTML?: string
     livePreview?: LivePreviewConfig & {
       collections?: string[]
       globals?: string[]

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -508,7 +508,7 @@ export type RichTextField<
   ExtraProperties = {},
 > = FieldBase & {
   admin?: Admin
-  editor: RichTextAdapter<Value, AdapterProps, AdapterProps>
+  editor?: RichTextAdapter<Value, AdapterProps, AdapterProps>
   type: 'richText'
 } & ExtraProperties
 

--- a/packages/payload/src/utilities/telemetry/index.ts
+++ b/packages/payload/src/utilities/telemetry/index.ts
@@ -97,7 +97,8 @@ const getGitID = (payload: Payload) => {
 }
 
 const getPackageJSON = async (): Promise<PackageJSON> => {
-  const packageJsonPath = await findUp('package.json', { cwd: __dirname })
+  const [rootDir] = __dirname.split('/.next/')
+  const packageJsonPath = await findUp('package.json', { cwd: rootDir })
   const jsonContent: PackageJSON = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
   return jsonContent
 }

--- a/test/_community/collections/Media/index.ts
+++ b/test/_community/collections/Media/index.ts
@@ -1,14 +1,9 @@
-import path from 'path'
-
 import type { CollectionConfig } from '../../../../packages/payload/src/collections/config/types'
 
 export const mediaSlug = 'media'
 
 export const MediaCollection: CollectionConfig = {
   slug: mediaSlug,
-  // upload: {
-  //   staticDir: path.resolve(__dirname, './media'),
-  // },
   upload: true,
   access: {
     read: () => true,

--- a/test/field-error-states/collections/Upload/index.ts
+++ b/test/field-error-states/collections/Upload/index.ts
@@ -5,7 +5,7 @@ import type { CollectionConfig } from '../../../../packages/payload/src/collecti
 const Uploads: CollectionConfig = {
   slug: 'uploads',
   upload: {
-    staticDir: path.resolve(__dirname, './uploads'),
+    staticDir: path.resolve(process.cwd(), 'test/field-error-states/collections/Upload/uploads'),
   },
   fields: [
     {

--- a/test/fields/collections/Upload/index.ts
+++ b/test/fields/collections/Upload/index.ts
@@ -7,7 +7,7 @@ import { uploadsSlug } from '../../slugs'
 const Uploads: CollectionConfig = {
   slug: uploadsSlug,
   upload: {
-    staticDir: path.resolve(__dirname, './uploads'),
+    staticDir: path.resolve(process.cwd(), 'test/fields/collections/Upload/uploads'),
   },
   fields: [
     {

--- a/test/fields/collections/Upload2/index.ts
+++ b/test/fields/collections/Upload2/index.ts
@@ -7,7 +7,7 @@ import { uploads2Slug } from '../../slugs'
 const Uploads2: CollectionConfig = {
   slug: uploads2Slug,
   upload: {
-    staticDir: path.resolve(__dirname, './uploads2'),
+    staticDir: path.resolve(process.cwd(), 'test/fields/collections/Upload2/uploads2'),
   },
   labels: {
     singular: 'Upload 2',

--- a/test/fields/collections/Uploads3/index.ts
+++ b/test/fields/collections/Uploads3/index.ts
@@ -7,7 +7,7 @@ import { uploads3Slug } from '../../slugs'
 const Uploads3: CollectionConfig = {
   slug: uploads3Slug,
   upload: {
-    staticDir: path.resolve(__dirname, './uploads3'),
+    staticDir: path.resolve(process.cwd(), 'test/fields/collections/Uploads3/uploads3'),
   },
   labels: {
     singular: 'Upload 3',

--- a/test/plugin-seo/collections/Media.ts
+++ b/test/plugin-seo/collections/Media.ts
@@ -7,7 +7,7 @@ import { mediaSlug } from '../shared'
 export const Media: CollectionConfig = {
   slug: mediaSlug,
   upload: {
-    staticDir: path.resolve(__dirname, '../media'),
+    staticDir: path.resolve(process.cwd(), 'test/plugin-seo/media'),
   },
   fields: [
     {

--- a/test/uploads/collections/Upload1/index.ts
+++ b/test/uploads/collections/Upload1/index.ts
@@ -5,7 +5,7 @@ import type { CollectionConfig } from '../../../../packages/payload/src/collecti
 export const Uploads1: CollectionConfig = {
   slug: 'uploads-1',
   upload: {
-    staticDir: path.resolve(__dirname, './uploads'),
+    staticDir: path.resolve(process.cwd(), 'test/uploads/collections/Upload1/uploads'),
   },
   fields: [
     {

--- a/test/uploads/collections/Upload2/index.ts
+++ b/test/uploads/collections/Upload2/index.ts
@@ -5,7 +5,7 @@ import type { CollectionConfig } from '../../../../packages/payload/src/collecti
 export const Uploads2: CollectionConfig = {
   slug: 'uploads-2',
   upload: {
-    staticDir: path.resolve(__dirname, './uploads'),
+    staticDir: path.resolve(process.cwd(), 'test/uploads/collections/Upload2/uploads'),
   },
   admin: {
     enableRichTextRelationship: false,

--- a/test/uploads/collections/admin-thumbnail/index.ts
+++ b/test/uploads/collections/admin-thumbnail/index.ts
@@ -20,7 +20,7 @@ export const adminThumbnailSrc = '/media/image-640x480.png'
 export const AdminThumbnailCol: CollectionConfig = {
   slug: 'admin-thumbnail',
   upload: {
-    staticDir: path.resolve(__dirname, '../../media'),
+    staticDir: path.resolve(process.cwd(), 'test/uploads/media'),
     adminThumbnail: ({ doc }) => {
       if (docHasFilename(doc)) {
         if (doc.mimeType.startsWith('image/')) {

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -48,7 +48,7 @@ export default buildConfigWithDefaults({
       slug: 'gif-resize',
       upload: {
         staticURL: '/media-gif',
-        staticDir: path.resolve(__dirname, './media-gif'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/media-gif'),
         mimeTypes: ['image/gif'],
         resizeOptions: {
           position: 'center',
@@ -79,7 +79,7 @@ export default buildConfigWithDefaults({
       slug: 'no-image-sizes',
       upload: {
         staticURL: '/no-image-sizes',
-        staticDir: path.resolve(__dirname, './no-image-sizes'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/no-image-sizes'),
         mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
         resizeOptions: {
           position: 'center',
@@ -93,7 +93,7 @@ export default buildConfigWithDefaults({
       slug: 'object-fit',
       upload: {
         staticURL: '/object-fit',
-        staticDir: path.resolve(__dirname, './object-fit'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/object-fit'),
         mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
         imageSizes: [
           {
@@ -129,7 +129,7 @@ export default buildConfigWithDefaults({
       upload: {
         focalPoint: false,
         staticURL: '/crop-only',
-        staticDir: path.resolve(__dirname, './crop-only'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/crop-only'),
         mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
         imageSizes: [
           {
@@ -156,7 +156,7 @@ export default buildConfigWithDefaults({
       upload: {
         crop: false,
         staticURL: '/focal-only',
-        staticDir: path.resolve(__dirname, './focal-only'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/focal-only'),
         mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
         imageSizes: [
           {
@@ -182,7 +182,7 @@ export default buildConfigWithDefaults({
       slug: mediaSlug,
       upload: {
         staticURL: '/media',
-        staticDir: path.resolve(__dirname, './media'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/media'),
         // crop: false,
         // focalPoint: false,
         mimeTypes: [
@@ -288,7 +288,7 @@ export default buildConfigWithDefaults({
       slug: enlargeSlug,
       upload: {
         staticURL: '/enlarge',
-        staticDir: path.resolve(__dirname, './media/enlarge'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/media/enlarge'),
         mimeTypes: [
           'image/png',
           'image/jpg',
@@ -336,7 +336,7 @@ export default buildConfigWithDefaults({
       slug: reduceSlug,
       upload: {
         staticURL: '/reduce',
-        staticDir: path.resolve(__dirname, './media/reduce'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/media/reduce'),
         mimeTypes: [
           'image/png',
           'image/jpg',
@@ -378,7 +378,7 @@ export default buildConfigWithDefaults({
       slug: 'media-trim',
       upload: {
         staticURL: '/media-trim',
-        staticDir: path.resolve(__dirname, './media-trim'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/media-trim'),
         mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
         trimOptions: 0,
         imageSizes: [
@@ -420,7 +420,7 @@ export default buildConfigWithDefaults({
       upload: {
         // Either use another web server like `npx serve -l 4000` (http://localhost:4000) or use the static server from the previous collection to serve the media folder (http://localhost:3000/media)
         staticURL: 'http://localhost:3000/media',
-        staticDir: path.resolve(__dirname, './media'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/media'),
       },
       fields: [],
     },
@@ -431,7 +431,7 @@ export default buildConfigWithDefaults({
       slug: 'optional-file',
       upload: {
         staticURL: '/optional',
-        staticDir: path.resolve(__dirname, './optional'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/optional'),
         filesRequiredOnCreate: false,
       },
       fields: [],
@@ -440,14 +440,14 @@ export default buildConfigWithDefaults({
       slug: 'required-file',
       upload: {
         staticURL: '/required',
-        staticDir: path.resolve(__dirname, './required'),
+        staticDir: path.resolve(process.cwd(), 'test/uploads/required'),
         filesRequiredOnCreate: true,
       },
       fields: [],
     },
   ],
   onInit: async (payload) => {
-    const uploadsDir = path.resolve(__dirname, './media')
+    const uploadsDir = path.resolve(process.cwd(), 'test/uploads/media')
     removeFiles(path.normalize(uploadsDir))
 
     await payload.create({
@@ -459,7 +459,7 @@ export default buildConfigWithDefaults({
     })
 
     // Create image
-    const imageFilePath = path.resolve(__dirname, './image.png')
+    const imageFilePath = path.resolve(process.cwd(), 'test/uploads/image.png')
     const imageFile = await getFileByPath(imageFilePath)
 
     const { id: uploadedImage } = await payload.create({
@@ -476,7 +476,7 @@ export default buildConfigWithDefaults({
     })
 
     // Create audio
-    const audioFilePath = path.resolve(__dirname, './audio.mp3')
+    const audioFilePath = path.resolve(process.cwd(), 'test/uploads/audio.mp3')
     const audioFile = await getFileByPath(audioFilePath)
 
     const file = await payload.create({


### PR DESCRIPTION
## Description

Removes `__dirname` within payload since it does not work with NextJS. __dirname resolves to files inside of the `.next` folder. Instead, process.cwd() should be used.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.
