### PR TITLE
chore(next): migrates getNextT to getNextI18n

### DIFF
--- a/packages/next/src/pages/CreateFirstUser/index.tsx
+++ b/packages/next/src/pages/CreateFirstUser/index.tsx
@@ -5,7 +5,7 @@ import type { SanitizedConfig } from 'payload/types'
 import { Form, FormSubmit, MinimalTemplate, buildStateFromSchema } from '@payloadcms/ui'
 import React from 'react'
 
-import { getNextT } from '../../utilities/getNextT'
+import { getNextI18n } from '../../utilities/getNextI18n'
 import { initPage } from '../../utilities/initPage'
 import { meta } from '../../utilities/meta'
 import { CreateFirstUserFields } from './index.client'
@@ -18,7 +18,7 @@ export const generateMetadata = async ({
 }: {
   config: Promise<SanitizedConfig>
 }): Promise<Metadata> => {
-  const t = await getNextT({
+  const { t } = await getNextI18n({
     config: await config,
   })
 
@@ -52,21 +52,21 @@ export const CreateFirstUser: React.FC<{
   const fields = [
     {
       name: 'email',
+      type: 'email',
       label: t('general:emailAddress'),
       required: true,
-      type: 'email',
     },
     {
       name: 'password',
+      type: 'password',
       label: t('general:password'),
       required: true,
-      type: 'password',
     },
     {
       name: 'confirm-password',
+      type: 'confirmPassword',
       label: t('authentication:confirmPassword'),
       required: true,
-      type: 'confirmPassword',
     },
   ] as Field[]
 

--- a/packages/next/src/pages/Document/index.tsx
+++ b/packages/next/src/pages/Document/index.tsx
@@ -136,9 +136,9 @@ export const Document = async ({
     DefaultView = globalViews?.DefaultView
 
     data = await payload.findGlobal({
+      slug: globalSlug,
       depth: 0,
       locale: locale.code,
-      slug: globalSlug,
       user,
     })
 

--- a/packages/next/src/pages/ForgotPassword/index.tsx
+++ b/packages/next/src/pages/ForgotPassword/index.tsx
@@ -5,7 +5,7 @@ import { Button, Email, Form, FormSubmit, MinimalTemplate, Translation } from '@
 import Link from 'next/link'
 import React from 'react'
 
-import { getNextT } from '../../utilities/getNextT'
+import { getNextI18n } from '../../utilities/getNextI18n'
 import { initPage } from '../../utilities/initPage'
 import { meta } from '../../utilities/meta'
 
@@ -16,7 +16,7 @@ export const generateMetadata = async ({
 }: {
   config: Promise<SanitizedConfig>
 }): Promise<Metadata> => {
-  const t = await getNextT({
+  const { t } = await getNextI18n({
     config: await config,
   })
 

--- a/packages/next/src/pages/Login/index.tsx
+++ b/packages/next/src/pages/Login/index.tsx
@@ -6,7 +6,7 @@ import { Logo } from '@payloadcms/ui/graphics'
 import { redirect } from 'next/navigation'
 import React, { Fragment } from 'react'
 
-import { getNextT } from '../../utilities/getNextT'
+import { getNextI18n } from '../../utilities/getNextI18n'
 import { initPage } from '../../utilities/initPage'
 import { meta } from '../../utilities/meta'
 import { LoginForm } from './LoginForm'
@@ -19,7 +19,7 @@ export const generateMetadata = async ({
 }: {
   config: Promise<SanitizedConfig>
 }): Promise<Metadata> => {
-  const t = await getNextT({
+  const { t } = await getNextI18n({
     config: await config,
   })
 

--- a/packages/next/src/pages/Logout/index.tsx
+++ b/packages/next/src/pages/Logout/index.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from 'next'
 import type { SanitizedConfig } from 'payload/types'
 
-import { Button, MinimalTemplate } from '@payloadcms/ui'
+import { MinimalTemplate } from '@payloadcms/ui'
 import React from 'react'
 
-import { getNextT } from '../../utilities/getNextT'
+import { getNextI18n } from '../../utilities/getNextI18n'
 import { meta } from '../../utilities/meta'
 import { LogoutClient } from './LogoutClient'
 import './index.scss'
@@ -16,7 +16,7 @@ export const generateMetadata = async ({
 }: {
   config: Promise<SanitizedConfig>
 }): Promise<Metadata> => {
-  const t = await getNextT({
+  const { t } = await getNextI18n({
     config: await config,
   })
 

--- a/packages/next/src/pages/ResetPassword/index.tsx
+++ b/packages/next/src/pages/ResetPassword/index.tsx
@@ -14,7 +14,7 @@ import {
 import Link from 'next/link'
 import React from 'react'
 
-import { getNextT } from '../../utilities/getNextT'
+import { getNextI18n } from '../../utilities/getNextI18n'
 import { initPage } from '../../utilities/initPage'
 import { meta } from '../../utilities/meta'
 import './index.scss'
@@ -26,7 +26,7 @@ export const generateMetadata = async ({
 }: {
   config: Promise<SanitizedConfig>
 }): Promise<Metadata> => {
-  const t = await getNextT({
+  const { t } = await getNextI18n({
     config: await config,
   })
 

--- a/packages/next/src/pages/Unauthorized/index.tsx
+++ b/packages/next/src/pages/Unauthorized/index.tsx
@@ -4,7 +4,7 @@ import type { SanitizedConfig } from 'payload/types'
 import { MinimalTemplate } from '@payloadcms/ui'
 import React from 'react'
 
-import { getNextT } from '../../utilities/getNextT'
+import { getNextI18n } from '../../utilities/getNextI18n'
 import { meta } from '../../utilities/meta'
 import { UnauthorizedClient } from './UnauthorizedClient'
 
@@ -13,7 +13,7 @@ export const generateMetadata = async ({
 }: {
   config: Promise<SanitizedConfig>
 }): Promise<Metadata> => {
-  const t = await getNextT({
+  const { t } = await getNextI18n({
     config: await config,
   })
 

--- a/packages/next/src/pages/Verify/index.tsx
+++ b/packages/next/src/pages/Verify/index.tsx
@@ -5,7 +5,7 @@ import { Button, Logo, MinimalTemplate } from '@payloadcms/ui'
 import { redirect } from 'next/navigation'
 import React from 'react'
 
-import { getNextT } from '../../utilities/getNextT'
+import { getNextI18n } from '../../utilities/getNextI18n'
 import { initPage } from '../../utilities/initPage'
 import { meta } from '../../utilities/meta'
 import './index.scss'
@@ -17,7 +17,7 @@ export const generateMetadata = async ({
 }: {
   config: Promise<SanitizedConfig>
 }): Promise<Metadata> => {
-  const t = await getNextT({
+  const { t } = await getNextI18n({
     config: await config,
   })
 

--- a/packages/next/src/utilities/getNextI18n.ts
+++ b/packages/next/src/utilities/getNextI18n.ts
@@ -1,4 +1,4 @@
-import type { TFunction } from '@payloadcms/translations'
+import type { I18n } from '@payloadcms/translations'
 import type { SanitizedConfig } from 'payload/types'
 
 import { initI18n } from '@payloadcms/translations'
@@ -7,13 +7,13 @@ import { cookies, headers } from 'next/headers'
 
 import { getRequestLanguage } from './getRequestLanguage'
 
-export const getNextT = async ({
+export const getNextI18n = async ({
   config,
   language,
 }: {
   config: SanitizedConfig
   language?: string
-}): Promise<TFunction> => {
+}): Promise<I18n> => {
   const i18n = initI18n({
     config: config.i18n,
     context: 'client',
@@ -21,5 +21,5 @@ export const getNextT = async ({
     translations,
   })
 
-  return i18n.t
+  return i18n
 }


### PR DESCRIPTION
## Description

There are times where we need to access the `i18n` object on the server. Previously, we had a `getNextT` function which returns just the `t` function from i18n. But there are cases where we need the full object, not just `t` (like metadata). This changes the function to return `i18n` object which _contains_ `t`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.