### PR TITLE
chore(next): wires admin.hidden property

### DIFF
--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -1,9 +1,10 @@
 import type { SanitizedConfig } from 'payload/types'
 
+import { auth } from '@payloadcms/next/utilities/auth'
 import { translations } from '@payloadcms/translations/client'
 import { RootProvider, buildComponentMap } from '@payloadcms/ui'
 import '@payloadcms/ui/scss/app.scss'
-import { cookies, headers } from 'next/headers'
+import { headers as getHeaders } from 'next/headers'
 import { createClientConfig } from 'payload/config'
 import { deepMerge } from 'payload/utilities'
 import React from 'react'
@@ -30,10 +31,16 @@ export const RootLayout = async ({
   const config = await configPromise
   const clientConfig = await createClientConfig(config)
 
+  const headers = getHeaders()
+
+  const { cookies, user } = await auth({
+    config: configPromise,
+    headers,
+  })
   const lang =
     getRequestLanguage({
-      cookies: cookies(),
-      headers: headers(),
+      cookies,
+      headers,
     }) ?? clientConfig.i18n.fallbackLanguage
 
   const dir = rtlLanguages.includes(lang) ? 'RTL' : 'LTR'

--- a/packages/next/src/pages/Dashboard/Default/index.tsx
+++ b/packages/next/src/pages/Dashboard/Default/index.tsx
@@ -8,10 +8,14 @@ import './index.scss'
 
 const baseClass = 'dashboard'
 
-export const DefaultDashboard: React.FC<{
+export type DashboardProps = {
   Link: React.ComponentType<any>
   config: SanitizedConfig
-}> = (props) => {
+  visibleCollections: string[]
+  visibleGlobals: string[]
+}
+
+export const DefaultDashboard: React.FC<DashboardProps> = (props) => {
   const {
     Link,
     config: {
@@ -19,6 +23,8 @@ export const DefaultDashboard: React.FC<{
         components: { afterDashboard, beforeDashboard },
       },
     },
+    visibleCollections,
+    visibleGlobals,
   } = props
 
   return (
@@ -27,7 +33,11 @@ export const DefaultDashboard: React.FC<{
       <Gutter className={`${baseClass}__wrap`}>
         {Array.isArray(beforeDashboard) &&
           beforeDashboard.map((Component, i) => <Component key={i} />)}
-        <DefaultDashboardClient Link={Link} />
+        <DefaultDashboardClient
+          Link={Link}
+          visibleCollections={visibleCollections}
+          visibleGlobals={visibleGlobals}
+        />
         {Array.isArray(afterDashboard) &&
           afterDashboard.map((Component, i) => <Component key={i} />)}
       </Gutter>

--- a/packages/next/src/pages/Dashboard/index.tsx
+++ b/packages/next/src/pages/Dashboard/index.tsx
@@ -3,7 +3,10 @@ import type { SanitizedConfig } from 'payload/types'
 
 import { HydrateClientUser, RenderCustomComponent } from '@payloadcms/ui'
 import Link from 'next/link'
+import { isEntityHidden } from 'payload/utilities'
 import React, { Fragment } from 'react'
+
+import type { DashboardProps } from './Default'
 
 import { getNextI18n } from '../../utilities/getNextI18n'
 import { initPage } from '../../utilities/initPage'
@@ -45,6 +48,27 @@ export const Dashboard = async ({
 
   const CustomDashboardComponent = config.admin.components?.views?.Dashboard
 
+  const visibleCollections: string[] = config.collections.reduce((acc, collection) => {
+    if (!isEntityHidden({ hidden: collection.admin.hidden, user })) {
+      acc.push(collection.slug)
+    }
+    return acc
+  }, [])
+
+  const visibleGlobals: string[] = config.globals.reduce((acc, global) => {
+    if (!isEntityHidden({ hidden: global.admin.hidden, user })) {
+      acc.push(global.slug)
+    }
+    return acc
+  }, [])
+
+  const componentProps: DashboardProps = {
+    Link,
+    config,
+    visibleCollections,
+    visibleGlobals,
+  }
+
   return (
     <Fragment>
       <HydrateClientUser permissions={permissions} user={user} />
@@ -53,11 +77,7 @@ export const Dashboard = async ({
           typeof CustomDashboardComponent === 'function' ? CustomDashboardComponent : undefined
         }
         DefaultComponent={DefaultDashboard}
-        componentProps={{
-          Link,
-          config,
-          user,
-        }}
+        componentProps={componentProps}
       />
     </Fragment>
   )

--- a/packages/next/src/pages/Document/index.tsx
+++ b/packages/next/src/pages/Document/index.tsx
@@ -105,10 +105,15 @@ export const Document = async ({
       config,
       docPermissions,
       routeSegments: params.segments,
+      user,
     })
 
     CustomView = collectionViews?.CustomView
     DefaultView = collectionViews?.DefaultView
+
+    if (!CustomView && !DefaultView) {
+      return notFound()
+    }
 
     try {
       data = await payload.findByID({
@@ -140,10 +145,15 @@ export const Document = async ({
       docPermissions,
       globalConfig,
       routeSegments: params.segments,
+      user,
     })
 
     CustomView = globalViews?.CustomView
     DefaultView = globalViews?.DefaultView
+
+    if (!CustomView && !DefaultView) {
+      return notFound()
+    }
 
     data = await payload.findGlobal({
       slug: globalSlug,
@@ -207,10 +217,6 @@ export const Document = async ({
     searchParams,
     updatedAt: data?.updatedAt?.toString(),
     user,
-  }
-
-  if (!DefaultView && !CustomView) {
-    return notFound()
   }
 
   return (

--- a/packages/next/src/pages/List/index.tsx
+++ b/packages/next/src/pages/List/index.tsx
@@ -9,6 +9,7 @@ import {
   TableColumnsProvider,
 } from '@payloadcms/ui'
 import { notFound } from 'next/navigation'
+import { isEntityHidden } from 'payload/utilities'
 import React, { Fragment } from 'react'
 
 import type { DefaultListViewProps, ListPreferences } from './Default/types'
@@ -97,8 +98,12 @@ export const ListView = async ({
 
   if (collectionConfig) {
     const {
-      admin: { components: { views: { List: CustomList } = {} } = {} },
+      admin: { components: { views: { List: CustomList } = {} } = {}, hidden },
     } = collectionConfig
+
+    if (isEntityHidden({ hidden, user })) {
+      return notFound()
+    }
 
     let CustomListView = null
 

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -22,7 +22,8 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
-    "src/withPayload.js" /* Include the withPayload.js file in the build */
+    "src/withPayload.js" /* Include the withPayload.js file in the build */,
+    "../payload/src/utilities/isEntityHidden.ts"
   ],
   "references": [
     { "path": "../payload" },

--- a/packages/payload/src/exports/utilities.ts
+++ b/packages/payload/src/exports/utilities.ts
@@ -26,10 +26,12 @@ export { getObjectDotNotation } from '../utilities/getObjectDotNotation'
 
 export { default as getUniqueListBy } from '../utilities/getUniqueListBy'
 
+export { isEntityHidden } from '../utilities/isEntityHidden'
 export { isNumber } from '../utilities/isNumber'
 export { isValidID } from '../utilities/isValidID'
 export { setsAreEqual } from '../utilities/setsAreEqual'
 export { splitPathByArrayFields } from '../utilities/splitPathByArrayFields'
+
 export { default as toKebabCase } from '../utilities/toKebabCase'
 
 export { default as wait } from '../utilities/wait'

--- a/packages/payload/src/utilities/isEntityHidden.ts
+++ b/packages/payload/src/utilities/isEntityHidden.ts
@@ -1,0 +1,14 @@
+import type { User } from 'payload/auth'
+
+import type { SanitizedCollectionConfig } from '../collections/config/types'
+import type { SanitizedGlobalConfig } from '../globals/config/types'
+
+export const isEntityHidden = ({
+  hidden,
+  user,
+}: {
+  hidden: SanitizedCollectionConfig['admin']['hidden'] | SanitizedGlobalConfig['admin']['hidden']
+  user: User
+}) => {
+  return typeof hidden === 'function' ? hidden({ user }) : hidden === true
+}

--- a/packages/ui/src/elements/Nav/index.tsx
+++ b/packages/ui/src/elements/Nav/index.tsx
@@ -4,6 +4,7 @@ import type { SanitizedConfig } from 'payload/types'
 
 import { getTranslation } from '@payloadcms/translations'
 import Link from 'next/link'
+import { isEntityHidden } from 'payload/utilities'
 import React from 'react'
 
 import type { EntityToGroup } from '../../utilities/groupNavItems'
@@ -38,25 +39,21 @@ export const DefaultNav: React.FC<{
   const groups = groupNavItems(
     [
       ...collections
-        .filter(
-          ({ admin: { hidden } }) => !(typeof hidden === 'function' ? hidden({ user }) : hidden),
-        )
+        .filter(({ admin: { hidden } }) => !isEntityHidden({ hidden, user }))
         .map((collection) => {
           const entityToGroup: EntityToGroup = {
-            entity: collection,
             type: EntityType.collection,
+            entity: collection,
           }
 
           return entityToGroup
         }),
       ...globals
-        .filter(
-          ({ admin: { hidden } }) => !(typeof hidden === 'function' ? hidden({ user }) : hidden),
-        )
+        .filter(({ admin: { hidden } }) => !isEntityHidden({ hidden, user }))
         .map((global) => {
           const entityToGroup: EntityToGroup = {
-            entity: global,
             type: EntityType.global,
+            entity: global,
           }
 
           return entityToGroup
@@ -74,7 +71,7 @@ export const DefaultNav: React.FC<{
         {groups.map(({ entities, label }, key) => {
           return (
             <NavGroup key={key} label={label}>
-              {entities.map(({ entity, type }, i) => {
+              {entities.map(({ type, entity }, i) => {
                 let entityLabel: string
                 let href: string
                 let id: string

--- a/packages/ui/src/utilities/buildComponentMap/index.tsx
+++ b/packages/ui/src/utilities/buildComponentMap/index.tsx
@@ -33,7 +33,7 @@ export const buildComponentMap = (args: {
 
   // Collections
   const collections = config.collections.reduce((acc, collectionConfig) => {
-    const { fields, slug } = collectionConfig
+    const { slug, fields } = collectionConfig
 
     const editViewFromConfig = collectionConfig?.admin?.components?.views?.Edit
     const listViewFromConfig = collectionConfig?.admin?.components?.views?.List
@@ -115,7 +115,7 @@ export const buildComponentMap = (args: {
 
   // Globals
   const globals = config.globals.reduce((acc, globalConfig) => {
-    const { fields, slug } = globalConfig
+    const { slug, fields } = globalConfig
 
     const mappedFields = mapFields({
       DefaultCell,


### PR DESCRIPTION
## Description

Wires in the `admin.hidden` property by invoking them server-side on the pages such as list and edit, and returning 404s as needed. Also creates a new `isEntityHidden` utility to standardize the logic. We could alternatively completely sanitize hidden configs from the client via `createClientConfig`, `buildComponentMap`, etc, except that the current `user` is sent through the `hidden` function, which would require us to somehow invoke these functions again as the user changes, but there might also be cases where need to reference hidden configs from within visible ones. Works for dashboard cards and main nav, too.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.