### PR TITLE
feat: avoid opening the drawer if there's only one block

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback } from 'react'
+import React, { Fragment, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { Props } from './types'
@@ -166,6 +166,53 @@ const BlocksField: React.FC<Props> = (props) => {
   const showMinRows = rows.length < minRows || (required && rows.length === 0)
   const showRequired = readOnly && rows.length === 0
 
+  const addMore = useMemo(() => {
+    if (readOnly && hasMaxRows) return null
+
+    const hasOneBlock = blocks.length === 1
+    const addMessage = t('addLabel', { label: getTranslation(labels.singular, i18n) })
+    const rowIndex = rows?.length || 0
+
+    if (hasOneBlock) {
+      return (
+        <Button
+          buttonStyle="icon-label"
+          icon="plus"
+          iconPosition="left"
+          iconStyle="with-border"
+          onClick={() => {
+            addRow(rowIndex, blocks[0].slug)
+          }}
+        >
+          {addMessage}
+        </Button>
+      )
+    }
+
+    return (
+      <Fragment>
+        <DrawerToggler className={`${baseClass}__drawer-toggler`} slug={drawerSlug}>
+          <Button
+            buttonStyle="icon-label"
+            el="span"
+            icon="plus"
+            iconPosition="left"
+            iconStyle="with-border"
+          >
+            {addMessage}
+          </Button>
+        </DrawerToggler>
+        <BlocksDrawer
+          addRow={addRow}
+          addRowIndex={rowIndex}
+          blocks={blocks}
+          drawerSlug={drawerSlug}
+          labels={labels}
+        />
+      </Fragment>
+    )
+  }, [addRow, blocks, drawerSlug, hasMaxRows, i18n, labels, readOnly, rows, t])
+
   return (
     <div
       className={[
@@ -284,28 +331,7 @@ const BlocksField: React.FC<Props> = (props) => {
           )}
         </DraggableSortable>
       )}
-      {!readOnly && !hasMaxRows && (
-        <Fragment>
-          <DrawerToggler className={`${baseClass}__drawer-toggler`} slug={drawerSlug}>
-            <Button
-              buttonStyle="icon-label"
-              el="span"
-              icon="plus"
-              iconPosition="left"
-              iconStyle="with-border"
-            >
-              {t('addLabel', { label: getTranslation(labels.singular, i18n) })}
-            </Button>
-          </DrawerToggler>
-          <BlocksDrawer
-            addRow={addRow}
-            addRowIndex={rows?.length || 0}
-            blocks={blocks}
-            drawerSlug={drawerSlug}
-            labels={labels}
-          />
-        </Fragment>
-      )}
+      {addMore}
     </div>
   )
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

There's no need to open a drawer to select the only option available, in case there's only one block it will directly add it without having to do an extra step for the user.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
