### PR TITLE
db-postgres: abort migration when one migration fails

### DIFF
--- a/packages/db-postgres/src/migrate.ts
+++ b/packages/db-postgres/src/migrate.ts
@@ -110,5 +110,6 @@ async function runMigrationFile(payload: Payload, migration: Migration, batch: n
       err,
       msg: parseError(err, `Error running migration ${migration.name}`),
     })
+    throw err
   }
 }


### PR DESCRIPTION
## Description

Related: https://github.com/payloadcms/payload/discussions/4322

The base migration method aborts when one migration fails.
https://github.com/payloadcms/payload/blob/main/packages/payload/src/database/migrations/migrate.ts#L50

So it's desirable that the db-postgres adapter's migration method has the same behavior.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Existing test suite passes locally with my changes