### PR TITLE
chore(translations): NL mistranslation of crop from "gewas" to "bijsnijden"

### DIFF
--- a/packages/payload/src/translations/nl.json
+++ b/packages/payload/src/translations/nl.json
@@ -274,7 +274,7 @@
     "near": "nabij"
   },
   "upload": {
-    "crop": "Gewas",
+    "crop": "Bijsnijden",
     "cropToolDescription": "Sleep de hoeken van het geselecteerde gebied, teken een nieuw gebied of pas de waarden hieronder aan.",
     "dragAndDrop": "Sleep een bestand",
     "dragAndDropHere": "of sleep een bestand naar hier",
@@ -289,7 +289,7 @@
     "previewSizes": "Voorbeeldgroottes",
     "selectCollectionToBrowse": "Selecteer een collectie om door te bladeren",
     "selectFile": "Selecteer een bestand",
-    "setCropArea": "Stel oogstgebied in",
+    "setCropArea": "Stel bijsnijdgebied in",
     "setFocalPoint": "Stel het brandpunt in",
     "sizes": "Groottes",
     "sizesFor": "Maten voor {{label}}",


### PR DESCRIPTION
## Description

There is a small error with regards to the cropping of images where the translation in dutch actually refers to crops you find on agricultural lands. I've corrected the mistake using the term "bijsnijden" which sort of literally translates to "re-cut".

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
