### PR TITLE
chore: Exclude all *.js dotfiles from publish

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -220,6 +220,7 @@
     "*.scss",
     "*.js",
     "*.d.ts",
+    "!.*.js",
     "!jest.config.js",
     "!jest.components.config.js"
   ],


### PR DESCRIPTION
## Description

Currently the published `payload` package contains the `.eslintrc.js` and `.release-it.js` files, which I don't believe is intentional. (See top of the file listing here for example: https://www.npmjs.com/package/payload?activeTab=code).
So this PR updates to exclude all dotfiles with *.js extensions from publish.


Cleaning this up will:

 * Shave a tiny bit off the package
 * Prevent (very) hypothetical cases where any secrets in a `.*.js` file could be accidentally published (NOTE: definitely not a current security issue, and maybe this scenario is a bit of a stretch, no one uses e.g. .env.js files)
 * Fix issue I'm seeing when editing a Payload app using the Zed editor
    * (This happens when viewing type definitions for Payload exports, e.g. by right-clicking a type imported from Payload in a project source file - the editor tries to lint upon opening the Payload source file. I wouldn't be surprised if some other tools act this way if they detect presence of an ESLint config in the dependency module, though bet most skip linting inside `node_modules`).

<img width="466" alt="Screenshot 2024-03-04 at 10 28 43 AM" src="https://github.com/payloadcms/payload/assets/237410/9374ece9-86ea-4e4f-b450-8975e3ec49ad">
  
- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

Because this affects only package publish configuration, the usual checklist does not apply. But I diffed the output of `pnpm publish --dry-run` before and after to confirm that this removes the `.eslintrc.js` and `.release-it.js` from the published package and has no other effect.