### PR TITLE
fix: requests without Content-Type failing

### DIFF
--- a/packages/next/src/utilities/getDataAndFile.ts
+++ b/packages/next/src/utilities/getDataAndFile.ts
@@ -15,7 +15,7 @@ export const getDataAndFile: GetDataAndFile = async ({ collection, config, reque
   let file: CustomPayloadRequest['file'] = undefined
 
   if (['PATCH', 'POST', 'PUT'].includes(request.method.toUpperCase()) && request.body) {
-    const [contentType] = request.headers.get('Content-Type').split(';')
+    const [contentType] = (request.headers.get('Content-Type') || '').split(';')
 
     if (contentType === 'application/json') {
       data = await request.json()

--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -145,12 +145,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     [serverURL, api, userSlug, i18n, redirectToInactivityRoute, setTokenAndExpiration],
   )
 
-  const logOut = useCallback(() => {
+  const logOut = useCallback(async () => {
     setUser(null)
     revokeTokenAndExpire()
     try {
-      // TODO: I dont think errors from unawaited promises can be caught
-      requests.post(`${serverURL}${api}/${userSlug}/logout`)
+      await requests.post(`${serverURL}${api}/${userSlug}/logout`)
     } catch (e) {
       toast.error(`Logging out failed: ${e.message}`)
     }


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload-3.0-alpha-demo/issues/3

Requests without Content-Type were failing because the getFileAndData was reading the header, assuming it was always present.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
