### PR TITLE
fix: missing FormQueryParamsProvider in account view

### DIFF
--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -3,6 +3,7 @@ import type { Data, DocumentPreferences, ServerSideEditViewProps } from 'payload
 import {
   DocumentHeader,
   DocumentInfoProvider,
+  FormQueryParamsProvider,
   HydrateClientUser,
   RenderCustomComponent,
   buildStateFromSchema,
@@ -22,6 +23,7 @@ export { generateAccountMetadata } from './meta.js'
 export const Account: React.FC<AdminViewProps> = async ({ initPageResult, searchParams }) => {
   const {
     permissions,
+    locale,
     req: {
       i18n,
       payload,
@@ -118,13 +120,22 @@ export const Account: React.FC<AdminViewProps> = async ({ initPageResult, search
           i18n={i18n}
         />
         <HydrateClientUser permissions={permissions} user={user} />
-        <RenderCustomComponent
-          CustomComponent={
-            typeof CustomAccountComponent === 'function' ? CustomAccountComponent : undefined
-          }
-          DefaultComponent={EditView}
-          componentProps={serverSideProps}
-        />
+        <FormQueryParamsProvider
+          initialParams={{
+            depth: 0,
+            'fallback-locale': 'null',
+            locale: locale.code,
+            uploadEdits: undefined,
+          }}
+        >
+          <RenderCustomComponent
+            CustomComponent={
+              typeof CustomAccountComponent === 'function' ? CustomAccountComponent : undefined
+            }
+            DefaultComponent={EditView}
+            componentProps={serverSideProps}
+          />
+        </FormQueryParamsProvider>
       </DocumentInfoProvider>
     )
   }


### PR DESCRIPTION
## Description

Updating the current user's account on `/admin/account` causes the following error:

```
Unhandled Runtime Error
TypeError: dispatchFormQueryParams is not a function

Call Stack
dispatchFormQueryParams
node_modules/.pnpm/@payloadcms+next@3.0.0-alpha.34_@types+react@18.2.64_http-status@1.6.2_monaco-editor@0.46.0_n_n7tiwpnlqwhrajzmafbvh4ooai/node_modules/@payloadcms/next/dist/views/Edit/index.client.js (22:13)
onSaveFromContext
node_modules/.pnpm/@payloadcms+next@3.0.0-alpha.34_@types+react@18.2.64_http-status@1.6.2_monaco-editor@0.46.0_n_n7tiwpnlqwhrajzmafbvh4ooai/node_modules/@payloadcms/next/dist/views/Edit/Default/index.js (50:18)
onSuccess
node_modules/.pnpm/@payloadcms+ui@3.0.0-alpha.34_@types+react@18.2.64_monaco-editor@0.46.0_next@14.2.0-canary.7__tu76glckrdk3y2gcvr5mf4lzvq/node_modules/@payloadcms/ui/dist/forms/Form/index.js (181:54)
```

This PR wraps the `Account` view with the appropriate `FormQueryParamsProvider` to provide the view with the `dispatchFormQueryParams` function.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
