### PR TITLE
fix(next): ssr custom logout button and icon graphic and narrows client config type

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -688,11 +688,17 @@ export type SanitizedConfig = Omit<
   }
 }
 
-export type ClientConfig = Omit<SanitizedConfig, 'db' | 'endpoints'> & {
-  collections: (Omit<SanitizedCollectionConfig, 'access' | 'endpoints' | 'fields' | 'hooks'> & {
+export type ClientConfig = Omit<SanitizedConfig, 'admin' | 'db' | 'endpoints'> & {
+  admin: Omit<SanitizedConfig['admin'], 'components'>
+  collections: (Omit<
+    SanitizedCollectionConfig,
+    'access' | 'admin' | 'endpoints' | 'fields' | 'hooks'
+  > & {
+    admin: Omit<SanitizedCollectionConfig['admin'], 'components'>
     fields: ClientConfigField[]
   })[]
-  globals: (Omit<SanitizedGlobalConfig, 'access' | 'endpoints' | 'fields' | 'hooks'> & {
+  globals: (Omit<SanitizedGlobalConfig, 'access' | 'admin' | 'endpoints' | 'fields' | 'hooks'> & {
+    admin: Omit<SanitizedGlobalConfig['admin'], 'components'>
     fields: ClientConfigField[]
   })[]
 }

--- a/packages/ui/src/elements/Logout/index.tsx
+++ b/packages/ui/src/elements/Logout/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 import React, { Fragment } from 'react'
 
-import { RenderCustomComponent } from '../../elements/RenderCustomComponent/index.js'
 import { LogOut } from '../../icons/LogOut/index.js'
 import { useComponentMap } from '../../index.js'
 import { useConfig } from '../../providers/Config/index.js'

--- a/packages/ui/src/elements/Logout/index.tsx
+++ b/packages/ui/src/elements/Logout/index.tsx
@@ -1,8 +1,9 @@
 'use client'
-import React from 'react'
+import React, { Fragment } from 'react'
 
 import { RenderCustomComponent } from '../../elements/RenderCustomComponent/index.js'
 import { LogOut } from '../../icons/LogOut/index.js'
+import { useComponentMap } from '../../index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 
@@ -35,27 +36,18 @@ const DefaultLogout: React.FC<{
 }
 
 const Logout: React.FC<{
+  Link?: React.ComponentType
   tabIndex?: number
-}> = ({ tabIndex = 0 }) => {
+}> = ({ Link, tabIndex = 0 }) => {
   const {
-    admin: {
-      components: {
-        logout: { Button: CustomLogout } = {
-          Button: undefined,
-        },
-      } = {},
-    } = {},
-  } = useConfig()
+    componentMap: { LogoutButton: CustomLogout },
+  } = useComponentMap()
 
-  return (
-    <RenderCustomComponent
-      CustomComponent={CustomLogout}
-      DefaultComponent={DefaultLogout}
-      componentProps={{
-        tabIndex,
-      }}
-    />
-  )
+  if (CustomLogout) {
+    return <Fragment>{CustomLogout}</Fragment>
+  }
+
+  return <DefaultLogout Link={Link} tabIndex={tabIndex} />
 }
 
 export default Logout

--- a/packages/ui/src/graphics/Icon/index.tsx
+++ b/packages/ui/src/graphics/Icon/index.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 
-import { RenderCustomComponent } from '../../elements/RenderCustomComponent/index.js'
-import { useConfig } from '../../providers/Config/index.js'
+import { useComponentMap } from '../../index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 
 const css = `
@@ -44,16 +43,14 @@ const PayloadIcon: React.FC = () => {
 
 const Icon: React.FC = () => {
   const {
-    admin: {
-      components: {
-        graphics: { Icon: CustomIcon } = {
-          Icon: undefined,
-        },
-      } = {},
-    } = {},
-  } = useConfig()
+    componentMap: { Icon: CustomIcon },
+  } = useComponentMap()
 
-  return <RenderCustomComponent CustomComponent={CustomIcon} DefaultComponent={PayloadIcon} />
+  if (CustomIcon) {
+    return <Fragment>{CustomIcon}</Fragment>
+  }
+
+  return <PayloadIcon />
 }
 
 export default Icon

--- a/packages/ui/src/utilities/buildComponentMap/index.tsx
+++ b/packages/ui/src/utilities/buildComponentMap/index.tsx
@@ -181,8 +181,13 @@ export const buildComponentMap = (args: {
 
   const LogoutButton = LogoutButtonComponent ? <LogoutButtonComponent /> : null
 
+  const IconComponent = config.admin?.components?.graphics?.Icon
+
+  const Icon = IconComponent ? <IconComponent /> : null
+
   return {
     componentMap: {
+      Icon,
       LogoutButton,
       actions: config.admin?.components?.actions?.map((Component) => <Component />),
       collections,

--- a/packages/ui/src/utilities/buildComponentMap/index.tsx
+++ b/packages/ui/src/utilities/buildComponentMap/index.tsx
@@ -177,8 +177,13 @@ export const buildComponentMap = (args: {
     return <Component>{children}</Component>
   }
 
+  const LogoutButtonComponent = config.admin?.components?.logout?.Button
+
+  const LogoutButton = LogoutButtonComponent ? <LogoutButtonComponent /> : null
+
   return {
     componentMap: {
+      LogoutButton,
       actions: config.admin?.components?.actions?.map((Component) => <Component />),
       collections,
       globals,

--- a/packages/ui/src/utilities/buildComponentMap/types.ts
+++ b/packages/ui/src/utilities/buildComponentMap/types.ts
@@ -99,6 +99,7 @@ export type ConfigComponentMapBase = {
 }
 
 export type ComponentMap = {
+  Icon: React.ReactNode
   LogoutButton: React.ReactNode
   actions: React.ReactNode[]
   collections: {

--- a/packages/ui/src/utilities/buildComponentMap/types.ts
+++ b/packages/ui/src/utilities/buildComponentMap/types.ts
@@ -99,6 +99,7 @@ export type ConfigComponentMapBase = {
 }
 
 export type ComponentMap = {
+  LogoutButton: React.ReactNode
   actions: React.ReactNode[]
   collections: {
     [slug: SanitizedCollectionConfig['slug']]: CollectionComponentMap


### PR DESCRIPTION
## Description

Server renders custom logout button and custom icon graphic. Also narrows the `ClientConfig` type to strip out server-only properties that `createClientConfig` removes.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.