### PR TITLE
fix: checks for undefined properties in mergeServerFormState

### DIFF
--- a/changelog.config.js
+++ b/changelog.config.js
@@ -8,10 +8,10 @@ module.exports = {
     preset: {
       name: 'conventionalcommits',
       types: [
-        { section: 'Features', type: 'feat' },
-        { section: 'Features', type: 'feature' },
-        { section: 'Bug Fixes', type: 'fix' },
-        { section: 'Documentation', type: 'docs' },
+        { type: 'feat', section: 'Features' },
+        { type: 'feature', section: 'Features' },
+        { type: 'fix', section: 'Bug Fixes' },
+        { type: 'docs', section: 'Documentation' },
       ],
     },
   },

--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
-import { URL } from 'url'
 import httpStatus from 'http-status'
+import { URL } from 'url'
 
 import type { Collection } from '../../collections/config/types.js'
 import type { PayloadRequest } from '../../types/index.js'

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -84,7 +84,7 @@ export const loginOperation = async <TSlug extends keyof GeneratedTypes['collect
 
     const email = unsanitizedEmail ? unsanitizedEmail.toLowerCase().trim() : null
 
-    let user = await payload.db.findOne<any>({
+    let user = await payload.db.findOne<User>({
       collection: collectionConfig.slug,
       req,
       where: { email: { equals: email.toLowerCase() } },
@@ -94,7 +94,7 @@ export const loginOperation = async <TSlug extends keyof GeneratedTypes['collect
       throw new AuthenticationError(req.t)
     }
 
-    if (user && isLocked(user.lockUntil)) {
+    if (user && isLocked(user.lockUntil as number)) {
       throw new LockedAuth(req.t)
     }
 

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -11,13 +11,15 @@ export const mergeServerFormState = (
   let changed = false
 
   Object.entries(newState).forEach(([path, newFieldState]) => {
-    newFieldState.initialValue = oldState[path]?.initialValue
-    newFieldState.value = oldState[path].value
+    if (oldState[path]) {
+      newFieldState.initialValue = oldState[path].initialValue
+      newFieldState.value = oldState[path].value
+    }
 
     const oldErrorPaths: string[] = []
     const newErrorPaths: string[] = []
 
-    if (oldState[path].errorPaths instanceof Set) {
+    if (oldState[path] && oldState[path].errorPaths instanceof Set) {
       oldState[path].errorPaths.forEach((path) => oldErrorPaths.push(path))
     }
 
@@ -34,7 +36,7 @@ export const mergeServerFormState = (
     }
 
     propsToCheck.forEach((prop) => {
-      if (newFieldState[prop] != oldState[path][prop]) {
+      if (oldState[path] && newFieldState[prop] != oldState[path][prop]) {
         changed = true
       }
     })


### PR DESCRIPTION
## Description
Fix TypeError: Added checks for undefined properties in mergeServerFormState
![2024-03-09 07-37-43](https://github.com/payloadcms/payload/assets/84094431/2b1989ca-4ec1-491b-a35b-e8089afd1f09)

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
