### PR TITLE
chore: sets bg on templates

### DIFF
--- a/packages/ui/src/templates/Default/index.scss
+++ b/packages/ui/src/templates/Default/index.scss
@@ -1,8 +1,10 @@
 @import '../../scss/styles.scss';
 
 .template-default {
-  [dir='rtl']
-  &__nav-toggler-wrapper {
+  background-color: var(--theme-bg);
+  color: var(--theme-text);
+
+  [dir='rtl'] &__nav-toggler-wrapper {
     left: unset;
     right: 0;
   }

--- a/packages/ui/src/templates/Minimal/index.scss
+++ b/packages/ui/src/templates/Minimal/index.scss
@@ -9,6 +9,8 @@
   margin-left: auto;
   margin-right: auto;
   min-height: 100%;
+  background-color: var(--theme-bg-color);
+  color: var(--theme-text);
 
   &--width-normal {
     .template-minimal__wrap {


### PR DESCRIPTION
## Description

Related issue: https://github.com/payloadcms/payload-3.0-alpha-demo/issues/13#event-12066591216

Scopes bg and text colors to templates. Fixes an issue where NextJS default project styles were appearing in the payload admin panel.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
