### PR TITLE
fix(ui): table cell links

### DIFF
--- a/packages/ui/src/elements/TableColumns/buildColumns.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumns.tsx
@@ -36,7 +36,7 @@ export const buildColumns = (args: {
     })
   }
 
-  let numberOfActiveColumns = 0
+  const activeColumnsIndices = []
 
   const sorted = sortedFieldMap.reduce((acc, field, index) => {
     const columnPreference = columnPreferences?.find(
@@ -49,13 +49,15 @@ export const buildColumns = (args: {
       active = columnPreference.active
     } else if (defaultColumns && Array.isArray(defaultColumns) && defaultColumns.length > 0) {
       active = defaultColumns.includes(field.name)
-    } else if (numberOfActiveColumns < 4) {
+    } else if (activeColumnsIndices.length < 4) {
       active = true
     }
 
-    if (active) {
-      numberOfActiveColumns += 1
+    if (active && !activeColumnsIndices.includes(index)) {
+      activeColumnsIndices.push(index)
     }
+
+    const isFirstActiveColumn = activeColumnsIndices[0] === index
 
     if (field) {
       const column: Column = {
@@ -64,7 +66,7 @@ export const buildColumns = (args: {
         active,
         cellProps: {
           ...cellProps?.[index],
-          link: (numberOfActiveColumns === 1 && active && enableRowSelections) || undefined,
+          link: isFirstActiveColumn,
         },
         components: {
           Cell: field.Cell,

--- a/packages/ui/src/elements/TableColumns/buildColumns.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumns.tsx
@@ -17,14 +17,7 @@ export const buildColumns = (args: {
   fieldMap: FieldMap
   useAsTitle: SanitizedCollectionConfig['admin']['useAsTitle']
 }): Column[] => {
-  const {
-    cellProps,
-    columnPreferences,
-    defaultColumns,
-    enableRowSelections,
-    fieldMap,
-    useAsTitle,
-  } = args
+  const { cellProps, columnPreferences, defaultColumns, enableRowSelections, fieldMap } = args
 
   let sortedFieldMap = fieldMap
 

--- a/packages/ui/src/elements/TableColumns/columnReducer.ts
+++ b/packages/ui/src/elements/TableColumns/columnReducer.ts
@@ -25,6 +25,8 @@ type MOVE = {
 export type Action = MOVE | SET | TOGGLE
 
 export const columnReducer = (state: Column[], action: Action): Column[] => {
+  let newState = [...state]
+
   switch (action.type) {
     case 'toggle': {
       const { column } = action.payload
@@ -40,20 +42,42 @@ export const columnReducer = (state: Column[], action: Action): Column[] => {
         return col
       })
 
-      return withToggledColumn
+      newState = withToggledColumn
+      break
     }
     case 'move': {
       const { fromIndex, toIndex } = action.payload
       const withMovedColumn = [...state]
       const [columnToMove] = withMovedColumn.splice(fromIndex, 1)
       withMovedColumn.splice(toIndex, 0, columnToMove)
-      return withMovedColumn
+      newState = withMovedColumn
+      break
     }
     case 'set': {
       const { columns } = action.payload
-      return columns
+      newState = columns
+      break
     }
     default:
-      return state
+      break
   }
+
+  // determine new `link` prop on only a single cell
+  // it needs to be the first active column, and nothing else
+
+  const withActive = newState.map((column, index) => {
+    if (column.active) {
+      return {
+        ...column,
+        cellProps: {
+          ...column.cellProps,
+          link: index === 0,
+        },
+      }
+    }
+
+    return column
+  }, [])
+
+  return withActive
 }

--- a/packages/ui/src/elements/TableColumns/columnReducer.ts
+++ b/packages/ui/src/elements/TableColumns/columnReducer.ts
@@ -69,13 +69,13 @@ export const columnReducer = (state: Column[], action: Action): Column[] => {
   })
 
   const withFirstLink = newState.map((column, index) => {
-    const isLink = column.active && firstActiveColumnIndex === index
+    const isFirstActiveColumn = column.active && firstActiveColumnIndex === index
 
     return {
       ...column,
       cellProps: {
         ...column.cellProps,
-        link: isLink,
+        link: isFirstActiveColumn,
       },
     }
   }, [])

--- a/packages/ui/src/elements/TableColumns/columnReducer.ts
+++ b/packages/ui/src/elements/TableColumns/columnReducer.ts
@@ -62,22 +62,23 @@ export const columnReducer = (state: Column[], action: Action): Column[] => {
       break
   }
 
-  // determine new `link` prop on only a single cell
-  // it needs to be the first active column, and nothing else
-
-  const withActive = newState.map((column, index) => {
-    if (column.active) {
-      return {
-        ...column,
-        cellProps: {
-          ...column.cellProps,
-          link: index === 0,
-        },
-      }
+  const firstActiveColumnIndex = newState.findIndex((column, index) => {
+    if (column.active && column.accessor !== '_select') {
+      return index
     }
+  })
 
-    return column
+  const withFirstLink = newState.map((column, index) => {
+    const isLink = column.active && firstActiveColumnIndex === index
+
+    return {
+      ...column,
+      cellProps: {
+        ...column.cellProps,
+        link: isLink,
+      },
+    }
   }, [])
 
-  return withActive
+  return withFirstLink
 }

--- a/packages/ui/src/elements/TableColumns/index.tsx
+++ b/packages/ui/src/elements/TableColumns/index.tsx
@@ -99,7 +99,7 @@ export const TableColumnsProvider: React.FC<{
       }
     }
 
-    sync()
+    void sync()
   }, [
     preferenceKey,
     getPreference,


### PR DESCRIPTION
## Description

Fixes table cell links in `alpha` where re-ordering or toggling columns could potentially lead to the linked cell to either move positions or be removed completely from the table, leading to unnavigable documents. The problem was that the link conditions were previously only running on the server to determine initial state. Now, every time the column state changes, the reducer recalculates which column should be the link for the row.

Related: https://github.com/payloadcms/payload-3.0-alpha-demo/issues/29

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.