### PR TITLE
fix(ui): document drawer permissions

### DIFF
--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -14,6 +14,7 @@ import { FieldPathProvider, useFieldPath } from '../../forms/FieldPathProvider/i
 import { useRelatedCollections } from '../../forms/fields/Relationship/AddNew/useRelatedCollections.js'
 import usePayloadAPI from '../../hooks/usePayloadAPI.js'
 import { X } from '../../icons/X/index.js'
+import { useAuth } from '../../index.js'
 import { useComponentMap } from '../../providers/ComponentMapProvider/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { DocumentInfoProvider } from '../../providers/DocumentInfo/index.js'
@@ -52,7 +53,7 @@ const Content: React.FC<DocumentDrawerProps> = ({
   const { formQueryParams } = useFormQueryParams()
   const formattedQueryParams = queryString.stringify(formQueryParams)
 
-  const { fields: fieldsFromConfig } = collectionConfig
+  const { permissions } = useAuth()
 
   const { schemaPath } = useFieldPath()
 
@@ -120,6 +121,8 @@ const Content: React.FC<DocumentDrawerProps> = ({
     return <LoadingOverlay />
   }
 
+  const docPermissions = permissions?.collections[collectionSlug]
+
   return (
     <DocumentInfoProvider
       BeforeDocument={
@@ -151,11 +154,12 @@ const Content: React.FC<DocumentDrawerProps> = ({
       collectionSlug={collectionConfig.slug}
       disableActions
       disableLeaveWithoutSaving
+      docPermissions={docPermissions}
+      hasSavePermission={docPermissions?.update?.permission}
       // isLoading,
       id={id}
       initialData={data}
       initialState={initialState}
-      // hasSavePermission={hasSavePermission}
       isEditing={isEditing}
       // me: true,
       onSave={onSave}
@@ -175,7 +179,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = (props) => {
   const [id, setId] = useState<null | number | string>(idFromProps)
 
   const onSave = useCallback<DocumentDrawerProps['onSave']>(
-    async (args) => {
+    (args) => {
       setId(args.doc.id)
 
       if (typeof onSaveFromProps === 'function') {

--- a/packages/ui/src/forms/fields/Relationship/AddNew/index.tsx
+++ b/packages/ui/src/forms/fields/Relationship/AddNew/index.tsx
@@ -10,12 +10,11 @@ import type { Props } from './types.js'
 
 import { Button } from '../../../../elements/Button/index.js'
 import { useDocumentDrawer } from '../../../../elements/DocumentDrawer/index.js'
-import Popup from '../../../../elements/Popup/index.js'
 import * as PopupList from '../../../../elements/Popup/PopupButtonList/index.js'
+import Popup from '../../../../elements/Popup/index.js'
 import { Tooltip } from '../../../../elements/Tooltip/index.js'
 import { Plus } from '../../../../icons/Plus/index.js'
 import { useAuth } from '../../../../providers/Auth/index.js'
-import { useConfig } from '../../../../providers/Config/index.js'
 import { useTranslation } from '../../../../providers/Translation/index.js'
 import './index.scss'
 import { useRelatedCollections } from './useRelatedCollections.js'
@@ -23,7 +22,7 @@ import { useRelatedCollections } from './useRelatedCollections.js'
 const baseClass = 'relationship-add-new'
 
 export const AddNewRelation: React.FC<Props> = ({
-  dispatchOptions,
+  // dispatchOptions,
   hasMany,
   path,
   relationTo,
@@ -41,7 +40,6 @@ export const AddNewRelation: React.FC<Props> = ({
   const [popupOpen, setPopupOpen] = useState(false)
   const { i18n, t } = useTranslation()
   const [showTooltip, setShowTooltip] = useState(false)
-  const config = useConfig()
 
   const [DocumentDrawer, DocumentDrawerToggler, { isDrawerOpen, toggleDrawer }] = useDocumentDrawer(
     {
@@ -87,7 +85,7 @@ export const AddNewRelation: React.FC<Props> = ({
         setSelectedCollection(undefined)
       }
     },
-    [relationTo, collectionConfig, dispatchOptions, i18n, hasMany, setValue, value, config],
+    [relationTo, collectionConfig, hasMany, setValue, value],
   )
 
   const onPopupToggle = useCallback((state) => {

--- a/test/_community/collections/Posts/index.ts
+++ b/test/_community/collections/Posts/index.ts
@@ -21,6 +21,11 @@ export const PostsCollection: CollectionConfig = {
       type: 'richText',
     },
     {
+      name: 'relationship',
+      type: 'relationship',
+      relationTo: ['posts'],
+    },
+    {
       name: 'associatedMedia',
       access: {
         create: () => true,


### PR DESCRIPTION
## Description

Properly threads permissions of related documents through the document info provider. This was causing the document drawer to render without save controls. Original report: https://github.com/payloadcms/payload-3.0-alpha-demo/issues/17

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.