### PR TITLE
chore: reduce db io by optimizing internal calls

### DIFF
--- a/packages/payload/src/auth/strategies/apiKey.ts
+++ b/packages/payload/src/auth/strategies/apiKey.ts
@@ -37,7 +37,9 @@ export const APIKeyAuthentication =
         const userQuery = await payload.find({
           collection: collectionConfig.slug,
           depth: collectionConfig.auth.depth,
+          limit: 1,
           overrideAccess: true,
+          pagination: false,
           where,
         })
 

--- a/packages/payload/src/auth/strategies/local/incrementLoginAttempts.ts
+++ b/packages/payload/src/auth/strategies/local/incrementLoginAttempts.ts
@@ -31,6 +31,7 @@ export const incrementLoginAttempts = async ({
           lockUntil: null,
           loginAttempts: 1,
         },
+        depth: 0,
         req,
       })
     }
@@ -52,6 +53,7 @@ export const incrementLoginAttempts = async ({
     id: doc.id,
     collection: collection.slug,
     data,
+    depth: 0,
     req,
   })
 }

--- a/packages/payload/src/auth/strategies/local/register.ts
+++ b/packages/payload/src/auth/strategies/local/register.ts
@@ -23,6 +23,9 @@ export const registerLocalStrategy = async ({
   const existingUser = await payload.find({
     collection: collection.slug,
     depth: 0,
+    limit: 1,
+    pagination: false,
+    req,
     where: {
       email: {
         equals: doc.email,

--- a/packages/payload/src/auth/strategies/local/resetLoginAttempts.ts
+++ b/packages/payload/src/auth/strategies/local/resetLoginAttempts.ts
@@ -23,6 +23,7 @@ export const resetLoginAttempts = async ({
       lockUntil: null,
       loginAttempts: 0,
     },
+    depth: 0,
     overrideAccess: true,
     req,
   })

--- a/packages/payload/src/preferences/operations/findOne.ts
+++ b/packages/payload/src/preferences/operations/findOne.ts
@@ -8,6 +8,7 @@ async function findOne(
   const {
     key,
     req: { payload },
+    req,
     user,
   } = args
 
@@ -21,17 +22,11 @@ async function findOne(
     ],
   }
 
-  const { docs } = await payload.find({
+  return await payload.db.findOne({
     collection: 'payload-preferences',
-    depth: 0,
-    pagination: false,
-    user,
+    req,
     where,
   })
-
-  if (docs.length === 0) return null
-
-  return docs[0]
 }
 
 export default findOne

--- a/packages/payload/src/versions/drafts/replaceWithDraftIfAvailable.ts
+++ b/packages/payload/src/versions/drafts/replaceWithDraftIfAvailable.ts
@@ -65,6 +65,7 @@ const replaceWithDraftIfAvailable = async <T extends TypeWithID>({
     global: entity.slug,
     limit: 1,
     locale,
+    pagination: false,
     req,
     sort: '-updatedAt',
     where: combineQueries(queryToBuild, versionAccessResult),

--- a/packages/payload/src/versions/enforceMaxVersions.ts
+++ b/packages/payload/src/versions/enforceMaxVersions.ts
@@ -44,6 +44,7 @@ export const enforceMaxVersions = async ({
     } else if (global) {
       const query = await payload.db.findGlobalVersions({
         global: global.slug,
+        pagination: false,
         req,
         skip: max,
         sort: '-updatedAt',

--- a/packages/payload/src/versions/getLatestCollectionVersion.ts
+++ b/packages/payload/src/versions/getLatestCollectionVersion.ts
@@ -25,6 +25,8 @@ export const getLatestCollectionVersion = async <T extends TypeWithID = any>({
   if (config.versions?.drafts) {
     const { docs } = await payload.db.findVersions<T>({
       collection: config.slug,
+      limit: 1,
+      pagination: false,
       req,
       sort: '-updatedAt',
       where: { parent: { equals: id } },

--- a/packages/payload/src/versions/getLatestGlobalVersion.ts
+++ b/packages/payload/src/versions/getLatestGlobalVersion.ts
@@ -29,6 +29,7 @@ export const getLatestGlobalVersion = async ({
         global: slug,
         limit: 1,
         locale,
+        pagination: false,
         req,
         sort: '-updatedAt',
       })

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -40,6 +40,7 @@ export const saveVersion = async ({
       let docs
       const findVersionArgs = {
         limit: 1,
+        pagination: false,
         req,
         sort: '-updatedAt',
       }


### PR DESCRIPTION
I found some simple tweaks to reduce load on the db and server mostly with auth and versions.

- Adds `pagination: false` where possible
- Adds `limit: 1` when more docs are not needed
- Adds `depth: 0` when populations aren't needed
- Uses `payload.db.findOne` instead of `payload.find` for getting preferences