### PR TITLE
chore: make migrations output to .mts instead of .ts files

### DIFF
--- a/packages/db-mongodb/src/createMigration.ts
+++ b/packages/db-mongodb/src/createMigration.ts
@@ -64,7 +64,9 @@ export const createMigration: CreateMigration = async function createMigration({
   const timestamp = `${formattedDate}_${formattedTime}`
 
   const formattedName = migrationName?.replace(/\W/g, '_')
-  const fileName = migrationName ? `${timestamp}_${formattedName}.ts` : `${timestamp}_migration.ts`
+  const fileName = migrationName
+    ? `${timestamp}_${formattedName}.mts`
+    : `${timestamp}_migration.mts`
   const filePath = `${dir}/${fileName}`
   fs.writeFileSync(filePath, migrationFileContent)
   payload.logger.info({ msg: `Migration created at ${filePath}` })

--- a/packages/db-postgres/src/createMigration.ts
+++ b/packages/db-postgres/src/createMigration.ts
@@ -123,7 +123,7 @@ export const createMigration: CreateMigration = async function createMigration(
 
   // write migration
   fs.writeFileSync(
-    `${filePath}.ts`,
+    `${filePath}.mts`,
     migrationTemplate(
       sqlStatementsUp.length ? sqlStatementsUp?.join('\n') : undefined,
       sqlStatementsDown.length ? sqlStatementsDown?.join('\n') : undefined,

--- a/packages/payload/src/database/migrations/createMigration.ts
+++ b/packages/payload/src/database/migrations/createMigration.ts
@@ -5,6 +5,7 @@ import type { CreateMigration } from '../types.js'
 
 import { migrationTemplate } from './migrationTemplate.js'
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export const createMigration: CreateMigration = async function createMigration({
   migrationName,
   payload,
@@ -21,7 +22,7 @@ export const createMigration: CreateMigration = async function createMigration({
   const timestamp = `${formattedDate}_${formattedTime}`
 
   const formattedName = migrationName.replace(/\W/g, '_')
-  const fileName = `${timestamp}_${formattedName}.ts`
+  const fileName = `${timestamp}_${formattedName}.mts`
   const filePath = `${dir}/${fileName}`
   fs.writeFileSync(filePath, migrationTemplate)
   payload.logger.info({ msg: `Migration created at ${filePath}` })

--- a/packages/payload/src/database/migrations/readMigrationFiles.ts
+++ b/packages/payload/src/database/migrations/readMigrationFiles.ts
@@ -27,7 +27,7 @@ export const readMigrationFiles = async ({
     .readdirSync(payload.db.migrationDir)
     .sort()
     .filter((f) => {
-      return f.endsWith('.ts') || f.endsWith('.js')
+      return f.endsWith('.mts') || f.endsWith('.mjs')
     })
     .map((file) => {
       return path.resolve(payload.db.migrationDir, file)


### PR DESCRIPTION
Changes the output file type of migrations from .ts to .mts files