### PR TITLE
chore: converts dynamic imports to esm require

### DIFF
--- a/packages/db-mongodb/src/createMigration.ts
+++ b/packages/db-mongodb/src/createMigration.ts
@@ -2,13 +2,8 @@
 import type { CreateMigration } from 'payload/database'
 
 import fs from 'fs'
-import { createRequire } from 'module'
 import path from 'path'
 import { fileURLToPath } from 'url'
-
-// Needed for eval require statement
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const require = createRequire(import.meta.url)
 
 const migrationTemplate = (upSQL?: string, downSQL?: string) => `import {
   MigrateUpArgs,
@@ -50,7 +45,10 @@ export const createMigration: CreateMigration = async function createMigration({
 
     // Check if predefined migration exists
     if (fs.existsSync(cleanPath)) {
-      const { down, up } = await eval(`require(${cleanPath})`)
+      let migration = await eval(`${require ? 'require' : 'import'}(${cleanPath})`)
+      if ('default' in migration) migration = migration.default
+      const { down, up } = migration
+
       migrationFileContent = migrationTemplate(up, down)
     } else {
       payload.logger.error({

--- a/packages/db-mongodb/src/createMigration.ts
+++ b/packages/db-mongodb/src/createMigration.ts
@@ -2,8 +2,13 @@
 import type { CreateMigration } from 'payload/database'
 
 import fs from 'fs'
+import { createRequire } from 'module'
 import path from 'path'
 import { fileURLToPath } from 'url'
+
+// Needed for eval require statement
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const require = createRequire(import.meta.url)
 
 const migrationTemplate = (upSQL?: string, downSQL?: string) => `import {
   MigrateUpArgs,
@@ -45,7 +50,7 @@ export const createMigration: CreateMigration = async function createMigration({
 
     // Check if predefined migration exists
     if (fs.existsSync(cleanPath)) {
-      const { down, up } = await eval(`import(${cleanPath})`)
+      const { down, up } = await eval(`require(${cleanPath})`)
       migrationFileContent = migrationTemplate(up, down)
     } else {
       payload.logger.error({

--- a/packages/db-postgres/src/createMigration.ts
+++ b/packages/db-postgres/src/createMigration.ts
@@ -3,12 +3,9 @@ import type { DrizzleSnapshotJSON } from 'drizzle-kit/payload'
 import type { CreateMigration } from 'payload/database'
 
 import fs from 'fs'
-import { createRequire } from 'module'
 import prompts from 'prompts'
 
 import type { PostgresAdapter } from './types.js'
-
-const require = createRequire(import.meta.url)
 
 const migrationTemplate = (
   upSQL?: string,
@@ -63,7 +60,9 @@ export const createMigration: CreateMigration = async function createMigration(
     fs.mkdirSync(dir)
   }
 
-  const { generateDrizzleJson, generateMigration } = require('drizzle-kit/payload')
+  const { generateDrizzleJson, generateMigration } = require
+    ? require('drizzle-kit/payload')
+    : await import('drizzle-kit/payload')
 
   const [yyymmdd, hhmmss] = new Date().toISOString().split('T')
   const formattedDate = yyymmdd.replace(/\D/g, '')

--- a/packages/db-postgres/src/migrate.ts
+++ b/packages/db-postgres/src/migrate.ts
@@ -3,7 +3,6 @@ import type { Payload } from 'payload'
 import type { Migration } from 'payload/database'
 import type { PayloadRequest } from 'payload/types'
 
-import { createRequire } from 'module'
 import {
   commitTransaction,
   initTransaction,
@@ -17,8 +16,6 @@ import type { PostgresAdapter } from './types.js'
 import { createMigrationTable } from './utilities/createMigrationTable.js'
 import { migrationTableExists } from './utilities/migrationTableExists.js'
 import { parseError } from './utilities/parseError.js'
-
-const require = createRequire(import.meta.url)
 
 export async function migrate(this: PostgresAdapter): Promise<void> {
   const { payload } = this
@@ -85,7 +82,9 @@ export async function migrate(this: PostgresAdapter): Promise<void> {
 }
 
 async function runMigrationFile(payload: Payload, migration: Migration, batch: number) {
-  const { generateDrizzleJson } = require('drizzle-kit/payload')
+  const { generateDrizzleJson } = require
+    ? require('drizzle-kit/payload')
+    : await import('drizzle-kit/payload')
 
   const start = Date.now()
   const req = { payload } as PayloadRequest

--- a/packages/db-postgres/src/utilities/pushDevSchema.ts
+++ b/packages/db-postgres/src/utilities/pushDevSchema.ts
@@ -1,11 +1,8 @@
 import { eq } from 'drizzle-orm'
 import { numeric, timestamp, varchar } from 'drizzle-orm/pg-core'
-import { createRequire } from 'module'
 import prompts from 'prompts'
 
 import type { PostgresAdapter } from '../types.js'
-
-const require = createRequire(import.meta.url)
 
 /**
  * Pushes the development schema to the database using Drizzle.
@@ -14,7 +11,9 @@ const require = createRequire(import.meta.url)
  * @returns {Promise<void>} - A promise that resolves once the schema push is complete.
  */
 export const pushDevSchema = async (db: PostgresAdapter) => {
-  const { pushSchema } = require('drizzle-kit/payload')
+  const { pushSchema } = require
+    ? require('drizzle-kit/payload')
+    : await import('drizzle-kit/payload')
 
   // This will prompt if clarifications are needed for Drizzle to push new schema
   const { apply, hasDataLoss, statementsToExecute, warnings } = await pushSchema(

--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import minimist from 'minimist'
+import { createRequire } from 'module'
 
 import type { BinScript } from '../config/types.js'
 
@@ -8,10 +9,12 @@ import { generateTypes } from './generateTypes.js'
 import { loadEnv } from './loadEnv.js'
 import { migrate } from './migrate.js'
 
+const require = createRequire(import.meta.url)
+
 export const bin = async () => {
   loadEnv()
   const configPath = findConfig()
-  const configPromise = await import(configPath)
+  const configPromise = require(configPath)
   let config = await configPromise
   if (config.default) config = await config.default
 
@@ -24,7 +27,7 @@ export const bin = async () => {
 
   if (userBinScript) {
     try {
-      const script: BinScript = await import(userBinScript.scriptPath)
+      const script: BinScript = require(userBinScript.scriptPath)
       await script(config)
     } catch (err) {
       console.log(`Could not find associated bin script for the ${userBinScript.key} command`)

--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import minimist from 'minimist'
-import { createRequire } from 'module'
 
 import type { BinScript } from '../config/types.js'
 
@@ -9,12 +8,10 @@ import { generateTypes } from './generateTypes.js'
 import { loadEnv } from './loadEnv.js'
 import { migrate } from './migrate.js'
 
-const require = createRequire(import.meta.url)
-
 export const bin = async () => {
   loadEnv()
   const configPath = findConfig()
-  const configPromise = require(configPath)
+  const configPromise = await import(configPath)
   let config = await configPromise
   if (config.default) config = await config.default
 
@@ -27,7 +24,7 @@ export const bin = async () => {
 
   if (userBinScript) {
     try {
-      const script: BinScript = require(userBinScript.scriptPath)
+      const script: BinScript = await import(userBinScript.scriptPath)
       await script(config)
     } catch (err) {
       console.log(`Could not find associated bin script for the ${userBinScript.key} command`)

--- a/packages/payload/src/database/migrations/readMigrationFiles.ts
+++ b/packages/payload/src/database/migrations/readMigrationFiles.ts
@@ -1,13 +1,8 @@
 import fs from 'fs'
-import { createRequire } from 'module'
 import path from 'path'
 
 import type { Payload } from '../../index.js'
 import type { Migration } from '../types.js'
-
-// Needed for eval require statement
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const require = createRequire(import.meta.url)
 
 /**
  * Read the migration files from disk
@@ -41,7 +36,10 @@ export const readMigrationFiles = async ({
   return Promise.all(
     files.map(async (filePath) => {
       // eval used to circumvent errors bundling
-      const migration = await eval(`require('${filePath.replaceAll('\\', '/')}')`)
+      let migration = await eval(
+        `${require ? 'require' : 'import'}('${filePath.replaceAll('\\', '/')}')`,
+      )
+      if ('default' in migration) migration = migration.default
 
       const result: Migration = {
         name: path.basename(filePath).split('.')?.[0],

--- a/packages/payload/src/database/migrations/readMigrationFiles.ts
+++ b/packages/payload/src/database/migrations/readMigrationFiles.ts
@@ -1,8 +1,13 @@
 import fs from 'fs'
+import { createRequire } from 'module'
 import path from 'path'
 
 import type { Payload } from '../../index.js'
 import type { Migration } from '../types.js'
+
+// Needed for eval require statement
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const require = createRequire(import.meta.url)
 
 /**
  * Read the migration files from disk
@@ -36,7 +41,7 @@ export const readMigrationFiles = async ({
   return Promise.all(
     files.map(async (filePath) => {
       // eval used to circumvent errors bundling
-      const migration = await eval(`import('${filePath.replaceAll('\\', '/')}')`)
+      const migration = await eval(`require('${filePath.replaceAll('\\', '/')}')`)
 
       const result: Migration = {
         name: path.basename(filePath).split('.')?.[0],


### PR DESCRIPTION
## Description

Attempts to fix an issue where Jest integration tests were breaking when running into dynamic imports. Particularly in the database integration tests that were using `eval` to dynamically import.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.