### PR TITLE
fix: versions not working when used on collections with custom IDs.

### DIFF
--- a/packages/db-mongodb/src/queries/buildSearchParams.ts
+++ b/packages/db-mongodb/src/queries/buildSearchParams.ts
@@ -56,9 +56,7 @@ export async function buildSearchParam({
   let hasCustomID = false
 
   if (sanitizedPath === '_id') {
-    const customIDfield = payload.collections[collectionSlug]?.config.fields.find(
-      (field) => fieldAffectsData(field) && field.name === 'id',
-    )
+    const customIDfield = fields.find((field) => fieldAffectsData(field) && field.name === 'id')
 
     let idFieldType: 'number' | 'text' = 'text'
 


### PR DESCRIPTION
## Description

Fix for issue [#5355](https://github.com/payloadcms/payload/issues/5355)

When building search params, we are checking to see if there is a custom ID field, this will be passed further down to the sanitize script. When trying to query for the ID of a version, this looks at the parent collection instead, and if that has a custom ID, it will assume the version has a custom ID and try to cast it accordingly. However, version IDs are ObjectIDs, and so the cast will fail and throw an error.

To fix, I have changed how **buildSearchParam** decides if this is a CustomID or not. It looks at the fields passed down from the invoking function, instead of going to the collection config. This makes it so when the query is for a version, it looks at the version's fields, instead of the collection's.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
