### PR TITLE
fix(ui): radio field map

### DIFF
--- a/packages/payload/src/admin/RichText.ts
+++ b/packages/payload/src/admin/RichText.ts
@@ -3,7 +3,6 @@ import type { JSONSchema4 } from 'json-schema'
 import type { SanitizedConfig } from '../config/types.js'
 import type { Field, RichTextField, Validate } from '../fields/config/types.js'
 import type { PayloadRequest, RequestContext } from '../types/index.js'
-import type { CellComponentProps } from './elements/Cell.js'
 
 export type RichTextFieldProps<
   Value extends object,

--- a/packages/richtext-lexical/src/generateComponentMap.tsx
+++ b/packages/richtext-lexical/src/generateComponentMap.tsx
@@ -1,7 +1,6 @@
-import type { RichTextAdapter } from 'payload/types'
-
 import { mapFields } from '@payloadcms/ui/utilities'
 import { sanitizeFields } from 'payload/config'
+import { type RichTextAdapter } from 'payload/types'
 import React from 'react'
 
 import type { ResolvedServerFeatureMap } from './field/features/types.js'
@@ -45,6 +44,7 @@ export const getGenerateComponentMap =
 
             for (const componentKey in components) {
               const Component = components[componentKey]
+
               if (Component) {
                 componentMap.set(
                   `feature.${featureKey}.components.${componentKey}`,

--- a/packages/ui/src/forms/fields/RichText/types.ts
+++ b/packages/ui/src/forms/fields/RichText/types.ts
@@ -3,5 +3,7 @@ import type { MappedField } from '@payloadcms/ui'
 import type { FormFieldBase } from '../shared.js'
 
 export type RichTextFieldProps = FormFieldBase & {
+  name: string
   richTextComponentMap?: Map<string, MappedField[] | React.ReactNode>
+  width?: string
 }

--- a/packages/ui/src/utilities/buildComponentMap/mapFields.tsx
+++ b/packages/ui/src/utilities/buildComponentMap/mapFields.tsx
@@ -16,6 +16,7 @@ import type { GroupFieldProps } from '../../forms/fields/Group/types.js'
 import type { JSONFieldProps } from '../../forms/fields/JSON/types.js'
 import type { NumberFieldProps } from '../../forms/fields/Number/types.js'
 import type { PointFieldProps } from '../../forms/fields/Point/types.js'
+import type { RadioFieldProps } from '../../forms/fields/RadioGroup/types.js'
 import type { RelationshipFieldProps } from '../../forms/fields/Relationship/types.js'
 import type { RichTextFieldProps } from '../../forms/fields/RichText/types.js'
 import type { RowFieldProps } from '../../forms/fields/Row/types.js'
@@ -459,6 +460,22 @@ export const mapFields = (args: {
             }
 
             fieldComponentProps = relationshipField
+            break
+          }
+          case 'radio': {
+            const radioField: RadioFieldProps = {
+              ...baseFieldProps,
+              name: field.name,
+              className: field.admin?.className,
+              disabled: field.admin?.disabled,
+              options: field.options,
+              readOnly: field.admin?.readOnly,
+              required: field.required,
+              style: field.admin?.style,
+              width: field.admin?.width,
+            }
+
+            fieldComponentProps = radioField
             break
           }
           case 'richText': {

--- a/packages/ui/src/utilities/buildComponentMap/mapFields.tsx
+++ b/packages/ui/src/utilities/buildComponentMap/mapFields.tsx
@@ -17,6 +17,7 @@ import type { JSONFieldProps } from '../../forms/fields/JSON/types.js'
 import type { NumberFieldProps } from '../../forms/fields/Number/types.js'
 import type { PointFieldProps } from '../../forms/fields/Point/types.js'
 import type { RelationshipFieldProps } from '../../forms/fields/Relationship/types.js'
+import type { RichTextFieldProps } from '../../forms/fields/RichText/types.js'
 import type { RowFieldProps } from '../../forms/fields/Row/types.js'
 import type { SelectFieldProps } from '../../forms/fields/Select/types.js'
 import type { TabsFieldProps } from '../../forms/fields/Tabs/types.js'
@@ -461,7 +462,7 @@ export const mapFields = (args: {
             break
           }
           case 'richText': {
-            const richTextField = {
+            const richTextField: RichTextFieldProps = {
               ...baseFieldProps,
               name: field.name,
               className: field.admin?.className,
@@ -472,15 +473,12 @@ export const mapFields = (args: {
               width: field.admin?.width,
             }
 
-            fieldComponentProps = richTextField
-
             const RichTextFieldComponent = field.editor.FieldComponent
             const RichTextCellComponent = field.editor.CellComponent
 
             if (typeof field.editor.generateComponentMap === 'function') {
               const result = field.editor.generateComponentMap({ config, schemaPath: path })
-              // @ts-expect-error-next-line // TODO: the `richTextComponentMap` is not found on the union type
-              fieldComponentProps.richTextComponentMap = result
+              richTextField.richTextComponentMap = result
               cellComponentProps.richTextComponentMap = result
             }
 
@@ -491,6 +489,8 @@ export const mapFields = (args: {
             if (RichTextCellComponent) {
               cellComponentProps.CellComponentOverride = <RichTextCellComponent />
             }
+
+            fieldComponentProps = richTextField
 
             break
           }

--- a/packages/ui/src/utilities/buildComponentMap/types.ts
+++ b/packages/ui/src/utilities/buildComponentMap/types.ts
@@ -18,6 +18,7 @@ import type { JSONFieldProps } from '../../forms/fields/JSON/types.js'
 import type { NumberFieldProps } from '../../forms/fields/Number/types.js'
 import type { PointFieldProps } from '../../forms/fields/Point/types.js'
 import type { RelationshipFieldProps } from '../../forms/fields/Relationship/types.js'
+import type { RichTextFieldProps } from '../../forms/fields/RichText/types.js'
 import type { RowFieldProps } from '../../forms/fields/Row/types.js'
 import type { SelectFieldProps } from '../../forms/fields/Select/types.js'
 import type { TabsFieldProps } from '../../forms/fields/Tabs/types.js'
@@ -52,6 +53,7 @@ export type FieldComponentProps =
   | NumberFieldProps
   | PointFieldProps
   | RelationshipFieldProps
+  | RichTextFieldProps
   | RowFieldProps
   | SelectFieldProps
   | TabsFieldProps


### PR DESCRIPTION
## Description

Radio fields were missing in the component map. This led to runtime JS errors when attempting to render radio fields, such as a Lexical rich text link. This PR also properly types rich text fields in the component map, removing the need for `@ts-expect-error`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.