### PR TITLE
fix: skip validation for other locales when duplicating

### DIFF
--- a/packages/payload/src/collections/operations/duplicate.ts
+++ b/packages/payload/src/collections/operations/duplicate.ts
@@ -122,7 +122,15 @@ export const duplicateOperation = async <TSlug extends keyof GeneratedTypes['col
     let locales = [undefined]
 
     if (config.localization) {
-      locales = config.localization.locales.map(({ code }) => code)
+      // make sure the current request locale is the first locale to be handled to skip validation for other locales
+      locales = config.localization.locales.reduce(
+        (acc, { code }) => {
+          if (req.locale === code) return acc
+          acc.push(code)
+          return acc
+        },
+        [req.locale],
+      )
     }
 
     let result
@@ -221,7 +229,7 @@ export const duplicateOperation = async <TSlug extends keyof GeneratedTypes['col
         global: null,
         operation,
         req,
-        skipValidation: shouldSaveDraft,
+        skipValidation: shouldSaveDraft || operation === 'update',
       })
     }, Promise.resolve())
 

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -64,7 +64,7 @@ export const DuplicateDocument: React.FC<Props> = ({ id, slug, singularLabel }) 
           },
         })
         .then(async (res) => {
-          const { doc, message } = await res.json()
+          const { doc, errors, message } = await res.json()
           if (res.status < 400) {
             toast.success(
               message ||
@@ -77,7 +77,9 @@ export const DuplicateDocument: React.FC<Props> = ({ id, slug, singularLabel }) 
             router.push(`${admin}/collections/${slug}/${doc.id}?locale=${locale.code}`)
           } else {
             toast.error(
-              message || t('error:unspecific', { label: getTranslation(singularLabel, i18n) }),
+              errors?.[0].message ||
+                message ||
+                t('error:unspecific', { label: getTranslation(singularLabel, i18n) }),
               { autoClose: 5000 },
             )
           }

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -10,6 +10,7 @@ import { toast } from 'react-toastify'
 
 import { useForm, useFormModified } from '../../forms/Form/context.js'
 import { useConfig } from '../../providers/Config/index.js'
+import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { MinimalTemplate } from '../../templates/Minimal/index.js'
 import { requests } from '../../utilities/api.js'
@@ -31,6 +32,7 @@ export const DuplicateDocument: React.FC<Props> = ({ id, slug, singularLabel }) 
   const router = useRouter()
   const modified = useFormModified()
   const { toggleModal } = useModal()
+  const locale = useLocale()
   const { setModified } = useForm()
   const {
     routes: { api },
@@ -53,7 +55,7 @@ export const DuplicateDocument: React.FC<Props> = ({ id, slug, singularLabel }) 
         return
       }
       await requests
-        .post(`${serverURL}${api}/${slug}/${id}/duplicate`, {
+        .post(`${serverURL}${api}/${slug}/${id}/duplicate?locale=${locale.code}`, {
           body: JSON.stringify({}),
           headers: {
             'Accept-Language': i18n.language,
@@ -72,7 +74,7 @@ export const DuplicateDocument: React.FC<Props> = ({ id, slug, singularLabel }) 
               },
             )
             setModified(false)
-            router.push(`${admin}/collections/${slug}/${doc.id}`)
+            router.push(`${admin}/collections/${slug}/${doc.id}?locale=${locale.code}`)
           } else {
             toast.error(
               message || t('error:unspecific', { label: getTranslation(singularLabel, i18n) }),
@@ -82,6 +84,7 @@ export const DuplicateDocument: React.FC<Props> = ({ id, slug, singularLabel }) 
         })
     },
     [
+      locale,
       modified,
       serverURL,
       api,


### PR DESCRIPTION
These changes are all to improve duplicate document workflows.
- The current locale is now sent in the request and is the only one that will be validated, the other locales will now skip validation.
- The URL after duplicating now includes the current ?locale param so you don't end up back at the defaultLocale
- On error we show the validation error in a toast now:
![image](https://github.com/payloadcms/payload/assets/6434612/d9a5b099-0f90-437d-a02e-10326caa35d2)