### PR TITLE
Replace FieldHook with FieldHookArgs in Typescript Section

### DIFF
--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -212,14 +212,14 @@ user-friendly.
 Payload exports a type for field hooks which can be accessed and used as follows:
 
 ```ts
-import type { FieldHook } from 'payload/types'
+import type { FieldHookArgs } from 'payload/types'
 
-// Field hook type is a generic that takes three arguments:
+// Field hook args type is a generic that takes three arguments:
 // 1: The document type
 // 2: The value type
 // 3: The sibling data type
 
-type ExampleFieldHook = FieldHook<ExampleDocumentType, string, SiblingDataType>
+type ExampleFieldHook = FieldHookArgs<ExampleDocumentType, string, SiblingDataType>
 
 const exampleFieldHook: ExampleFieldHook = (args) => {
   const {


### PR DESCRIPTION
Typescript documentation shows import and use of FieldHook type which I think is incorrect and should be FieldHookArgs

## Description

Documentation fix for typescript field hooks

- [X ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X ] Chore (non-breaking change which does not add functionality)

## Checklist:

- [X ] I have made corresponding changes to the documentation
