### PR TITLE
fix(ui): passes initCollapsed through collapsible field map

### DIFF
--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/mapFields.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/mapFields.tsx
@@ -352,6 +352,7 @@ export const mapFields = (args: {
                 parentPath: path,
                 readOnly: readOnlyOverride,
               }),
+              initCollapsed: field.admin?.initCollapsed,
               readOnly: field.admin?.readOnly,
               required: field.required,
               style: field.admin?.style,


### PR DESCRIPTION
## Description

Collapsible fields were not initializing as collapsed when set as `initCollapsed` in the field config—though the component was already setup to handle this.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.