### PR TITLE
chore(eslint): add add no-jsx-import-statements custom rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,6 +4,13 @@ module.exports = {
   ignorePatterns: ['README.md', 'packages/**/*.spec.ts'],
   overrides: [
     {
+      files: ['packages/**'],
+      plugins: ['payload'],
+      rules: {
+        'payload/no-jsx-import-statements': 'warn',
+      },
+    },
+    {
       files: ['scripts/**'],
       rules: {
         '@typescript-eslint/no-unused-vars': 'off',

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "dotenv": "8.6.0",
     "drizzle-kit": "0.20.14-1f2c838",
     "drizzle-orm": "0.29.4",
+    "eslint-plugin-payload": "workspace:*",
     "escape-html": "^1.0.3",
     "execa": "5.1.1",
     "form-data": "3.0.1",

--- a/packages/eslint-plugin-payload/customRules/no-jsx-import-statements.js
+++ b/packages/eslint-plugin-payload/customRules/no-jsx-import-statements.js
@@ -1,0 +1,28 @@
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow imports from .jsx extensions',
+    },
+    fixable: 'code',
+    schema: [],
+  },
+  create: function (context) {
+    return {
+      ImportDeclaration(node) {
+        const importPath = node.source.value
+
+        if (!importPath.endsWith('.jsx')) return
+
+        context.report({
+          node: node.source,
+          message: 'JSX imports are invalid. Use .js instead.',
+          fix: (fixer) => {
+            return fixer.removeRange([node.source.range[1] - 2, node.source.range[1] - 1])
+          },
+        })
+      },
+    }
+  },
+}

--- a/packages/eslint-plugin-payload/customRules/no-non-retryable-assertions.js
+++ b/packages/eslint-plugin-payload/customRules/no-non-retryable-assertions.js
@@ -1,3 +1,4 @@
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-payload/customRules/no-relative-monorepo-imports.js
+++ b/packages/eslint-plugin-payload/customRules/no-relative-monorepo-imports.js
@@ -1,3 +1,4 @@
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/packages/eslint-plugin-payload/index.js
+++ b/packages/eslint-plugin-payload/index.js
@@ -1,6 +1,7 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   rules: {
+    'no-jsx-import-statements': require('./customRules/no-jsx-import-statements'),
     'no-non-retryable-assertions': require('./customRules/no-non-retryable-assertions'),
     'no-relative-monorepo-imports': require('./customRules/no-relative-monorepo-imports'),
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
+      eslint-plugin-payload:
+        specifier: workspace:*
+        version: link:packages/eslint-plugin-payload
       execa:
         specifier: 5.1.1
         version: 5.1.1

--- a/test/.eslintrc.cjs
+++ b/test/.eslintrc.cjs
@@ -42,7 +42,7 @@ module.exports = {
     {
       files: ['**/*.int.spec.ts', '**/int.spec.ts'],
       rules: {
-         'payload/no-relative-monorepo-imports': 'error',
+        'payload/no-relative-monorepo-imports': 'error',
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-unsafe-assignment': 'off',
         '@typescript-eslint/no-use-before-define': 'off',


### PR DESCRIPTION
## Description

Adds new eslint rule to disallow `.jsx` extensions from being imported from. IDE's will suggest this, but it will break on build.

This rule will error, but it also has a fixer that is run on save.
