### PR TITLE
fix(database): parallel transactions overwriting ids

### DIFF
--- a/packages/payload/src/utilities/initTransaction.ts
+++ b/packages/payload/src/utilities/initTransaction.ts
@@ -17,13 +17,14 @@ export async function initTransaction(req: PayloadRequest): Promise<boolean> {
   }
   if (typeof payload.db.beginTransaction === 'function') {
     // create a new transaction
-    req.transactionIDPromise = payload.db.beginTransaction().then((transactionID) => {
-      if (transactionID) {
+    req.transactionIDPromise = payload.db.beginTransaction().then((newTransactionID) => {
+      if (newTransactionID && !req.transactionID && !req.transactionIDPromise) {
         req.transactionID = transactionID
       }
       delete req.transactionIDPromise
     })
     await req.transactionIDPromise
+
     return !!req.transactionID
   }
   return false


### PR DESCRIPTION
## Description

Fixes an issue when running payload operations in parallel like: await promise.all([payload.find, payload.find]).

The problem:

- Transaction 1
  - No transactionID, call beginTransaction()
  - ❌ When it returns an ID, set the ID on the req
  - ✅ When it returns an ID, check the req again for an ID or an IDPromise before setting a new one
- Transaction 2
  - No transactionID, call beginTransaction()
  - ❌ When it returns an ID, set the ID on the req
  - ✅ When it returns an ID, check the req again for an ID or an IDPromise before setting a new one
When the promises would come back, the second one would overwrite the previous one. They should be on the same transaction under the same request. We needed to check the req after we began the transaction and ensure another one was not set while we were creating a new one.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
