### PR TITLE
Allow providing `config` option to remove the need for a `payload.config.ts` file

### DIFF
--- a/packages/payload/src/payload.ts
+++ b/packages/payload/src/payload.ts
@@ -323,15 +323,23 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
 
     if (options.config) {
       this.config = await options.config
-      const configPath = findConfig()
 
-      this.config = {
-        ...this.config,
-        paths: {
-          config: configPath,
-          configDir: path.dirname(configPath),
-          rawConfig: configPath,
-        },
+      try {
+        const configPath = findConfig()
+
+        this.config = {
+          ...this.config,
+          paths: {
+            config: configPath,
+            configDir: path.dirname(configPath),
+            rawConfig: configPath,
+          },
+        }
+      } catch (error) {
+        // only throw the config not found error when the config was not passed
+        if (!this.config) {
+          throw error;
+        }
       }
     } else {
       // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require


### PR DESCRIPTION
## Description

Currently, payload breaks when it cannot find a file named `payload.config.ts` for the config options, even though it supports a `config` option in `payload.init`.

Despite the `config` being passed as an option, payload will still require another file named `payload.config.ts`, erroring out if it can't find the file.

This issue is very noticeable in serverless environments, as those usually bundle everything into one JS file, and as such you can't include other files (easily).

fix #5282

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
