### PR TITLE
fix: regression of filterOptions using different transaction

### DIFF
--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -354,12 +354,12 @@ const validateFilterOptions: Validate<
               falseCollections.push(collection)
             }
 
-            // `req` omitted to prevent transaction errors from aborting the entire transaction
             const result = await payload.find({
               collection,
               depth: 0,
               limit: 0,
               pagination: false,
+              req,
               where: findWhere,
             })
 

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -1,4 +1,5 @@
 import type { Payload } from 'payload'
+import type { PayloadRequest } from 'payload/types'
 
 import { randomBytes } from 'crypto'
 
@@ -685,6 +686,35 @@ describe('Relationships', () => {
         })
         expect(count).toBe(1)
         expect(item.text).toBe('sub')
+      })
+    })
+  })
+
+  describe('Creating', () => {
+    describe('With transactions', () => {
+      it('should be able to create filtered relations within a transaction', async () => {
+        const req = {} as PayloadRequest
+        req.transactionID = await payload.db.beginTransaction?.()
+        const related = await payload.create({
+          collection: relationSlug,
+          data: {
+            name: 'parent',
+          },
+          req,
+        })
+        const withRelation = await payload.create({
+          collection: slug,
+          data: {
+            filteredRelation: related.id,
+          },
+          req,
+        })
+
+        if (req.transactionID) {
+          await payload.db.commitTransaction?.(req.transactionID)
+        }
+
+        expect(withRelation.filteredRelation.id).toEqual(related.id)
       })
     })
   })


### PR DESCRIPTION
Copy of PR to main: https://github.com/payloadcms/payload/pull/5169