### PR TITLE
fix(db-postgres): error on delete having where that require joins

### DIFF
--- a/packages/db-postgres/src/deleteOne.ts
+++ b/packages/db-postgres/src/deleteOne.ts
@@ -28,7 +28,7 @@ export const deleteOne: DeleteOne = async function deleteOne(
     where: whereArg,
   })
 
-  const selectDistinctResult = selectDistinct({
+  const selectDistinctResult = await selectDistinct({
     adapter: this,
     chainedMethods: [{ args: [1], method: 'limit' }],
     db,

--- a/packages/db-postgres/src/deleteOne.ts
+++ b/packages/db-postgres/src/deleteOne.ts
@@ -51,6 +51,8 @@ export const deleteOne: DeleteOne = async function deleteOne(
       tableName,
     })
 
+    findManyArgs.where = where
+
     docToDelete = await db.query[tableName].findFirst(findManyArgs)
   }
 

--- a/packages/db-postgres/src/deleteOne.ts
+++ b/packages/db-postgres/src/deleteOne.ts
@@ -1,47 +1,66 @@
 import type { DeleteOne } from 'payload/database'
 import type { PayloadRequest } from 'payload/types'
 
+import { eq } from 'drizzle-orm'
 import toSnakeCase from 'to-snake-case'
 
 import type { PostgresAdapter } from './types'
 
 import { buildFindManyArgs } from './find/buildFindManyArgs'
 import buildQuery from './queries/buildQuery'
+import { selectDistinct } from './queries/selectDistinct'
 import { transform } from './transform/read'
 
 export const deleteOne: DeleteOne = async function deleteOne(
   this: PostgresAdapter,
-  { collection, req = {} as PayloadRequest, where: incomingWhere },
+  { collection: collectionSlug, req = {} as PayloadRequest, where: whereArg },
 ) {
   const db = this.sessions[req.transactionID]?.db || this.drizzle
-  const collectionConfig = this.payload.collections[collection].config
-  const tableName = toSnakeCase(collection)
+  const collection = this.payload.collections[collectionSlug].config
+  const tableName = toSnakeCase(collectionSlug)
+  let docToDelete: Record<string, unknown>
 
-  const { where } = await buildQuery({
+  const { joinAliases, joins, selectFields, where } = await buildQuery({
     adapter: this,
-    fields: collectionConfig.fields,
+    fields: collection.fields,
+    locale: req.locale,
     tableName,
-    where: incomingWhere,
+    where: whereArg,
   })
 
-  const findManyArgs = buildFindManyArgs({
+  const selectDistinctResult = selectDistinct({
     adapter: this,
-    depth: 0,
-    fields: collectionConfig.fields,
+    chainedMethods: [{ args: [1], method: 'limit' }],
+    db,
+    joinAliases,
+    joins,
+    selectFields,
     tableName,
+    where,
   })
 
-  findManyArgs.where = where
+  if (selectDistinctResult?.[0]?.id) {
+    docToDelete = await db.query[tableName].findFirst({
+      where: eq(this.tables[tableName].id, selectDistinctResult[0].id),
+    })
+  } else {
+    const findManyArgs = buildFindManyArgs({
+      adapter: this,
+      depth: 0,
+      fields: collection.fields,
+      tableName,
+    })
 
-  const docToDelete = await db.query[tableName].findFirst(findManyArgs)
+    docToDelete = await db.query[tableName].findFirst(findManyArgs)
+  }
 
   const result = transform({
     config: this.payload.config,
     data: docToDelete,
-    fields: collectionConfig.fields,
+    fields: collection.fields,
   })
 
-  await db.delete(this.tables[tableName]).where(where)
+  await db.delete(this.tables[tableName]).where(eq(this.tables[tableName].id, docToDelete.id))
 
   return result
 }

--- a/packages/db-postgres/src/find/chainMethods.ts
+++ b/packages/db-postgres/src/find/chainMethods.ts
@@ -1,3 +1,5 @@
+import type { QueryPromise } from 'drizzle-orm'
+
 export type ChainedMethods = {
   args: unknown[]
   method: string
@@ -8,7 +10,7 @@ export type ChainedMethods = {
  * @param methods
  * @param query
  */
-const chainMethods = ({ methods, query }): Promise<unknown> => {
+const chainMethods = <T>({ methods, query }): QueryPromise<T> => {
   return methods.reduce((query, { args, method }) => {
     return query[method](...args)
   }, query)

--- a/packages/db-postgres/src/find/findMany.ts
+++ b/packages/db-postgres/src/find/findMany.ts
@@ -7,6 +7,7 @@ import type { PostgresAdapter } from '../types'
 import type { ChainedMethods } from './chainMethods'
 
 import buildQuery from '../queries/buildQuery'
+import { selectDistinct } from '../queries/selectDistinct'
 import { transform } from '../transform/read'
 import { buildFindManyArgs } from './buildFindManyArgs'
 import { chainMethods } from './chainMethods'
@@ -39,7 +40,6 @@ export const findMany = async function find({
   let hasPrevPage: boolean
   let hasNextPage: boolean
   let pagingCounter: number
-  let selectDistinctResult
 
   const { joinAliases, joins, orderBy, selectFields, where } = await buildQuery({
     adapter,
@@ -69,36 +69,21 @@ export const findMany = async function find({
     tableName,
   })
 
-  // only fetch IDs when a sort or where query is used that needs to be done on join tables, otherwise these can be done directly on the table in findMany
-  if (Object.keys(joins).length > 0 || joinAliases.length > 0) {
-    if (where) {
-      selectDistinctMethods.push({ args: [where], method: 'where' })
-    }
+  selectDistinctMethods.push({ args: [skip || (page - 1) * limit], method: 'offset' })
+  selectDistinctMethods.push({ args: [limit === 0 ? undefined : limit], method: 'limit' })
 
-    joinAliases.forEach(({ condition, table }) => {
-      selectDistinctMethods.push({
-        args: [table, condition],
-        method: 'leftJoin',
-      })
-    })
+  const selectDistinctResult = await selectDistinct({
+    adapter,
+    chainedMethods: selectDistinctMethods,
+    db,
+    joinAliases,
+    joins,
+    selectFields,
+    tableName,
+    where,
+  })
 
-    Object.entries(joins).forEach(([joinTable, condition]) => {
-      if (joinTable) {
-        selectDistinctMethods.push({
-          args: [adapter.tables[joinTable], condition],
-          method: 'leftJoin',
-        })
-      }
-    })
-
-    selectDistinctMethods.push({ args: [skip || (page - 1) * limit], method: 'offset' })
-    selectDistinctMethods.push({ args: [limit === 0 ? undefined : limit], method: 'limit' })
-
-    selectDistinctResult = await chainMethods({
-      methods: selectDistinctMethods,
-      query: db.selectDistinct(selectFields).from(table),
-    })
-
+  if (selectDistinctResult) {
     if (selectDistinctResult.length === 0) {
       return {
         docs: [],
@@ -112,13 +97,14 @@ export const findMany = async function find({
         totalDocs: 0,
         totalPages: 0,
       }
+    } else {
+      // set the id in an object for sorting later
+      selectDistinctResult.forEach(({ id }, i) => {
+        orderedIDMap[id] = i
+      })
+      orderedIDs = Object.keys(orderedIDMap)
+      findManyArgs.where = inArray(adapter.tables[tableName].id, orderedIDs)
     }
-    // set the id in an object for sorting later
-    selectDistinctResult.forEach(({ id }, i) => {
-      orderedIDMap[id as number | string] = i
-    })
-    orderedIDs = Object.keys(orderedIDMap)
-    findManyArgs.where = inArray(adapter.tables[tableName].id, orderedIDs)
   } else {
     findManyArgs.limit = limitArg === 0 ? undefined : limitArg
 

--- a/packages/db-postgres/src/queries/selectDistinct.ts
+++ b/packages/db-postgres/src/queries/selectDistinct.ts
@@ -1,0 +1,60 @@
+import type { QueryPromise, SQL } from 'drizzle-orm'
+
+import type { ChainedMethods } from '../find/chainMethods'
+import type { DrizzleDB, PostgresAdapter } from '../types'
+import type { BuildQueryJoinAliases, BuildQueryJoins } from './buildQuery'
+
+import { chainMethods } from '../find/chainMethods'
+import { type GenericColumn } from '../types'
+
+type Args = {
+  adapter: PostgresAdapter
+  chainedMethods?: ChainedMethods
+  db: DrizzleDB
+  joinAliases: BuildQueryJoinAliases
+  joins: BuildQueryJoins
+  selectFields: Record<string, GenericColumn>
+  tableName: string
+  where: SQL
+}
+
+/**
+ * Selects distinct records from a table only if there are joins that need to be used, otherwise return null
+ */
+export const selectDistinct = ({
+  adapter,
+  chainedMethods = [],
+  db,
+  joinAliases,
+  joins,
+  selectFields,
+  tableName,
+  where,
+}: Args): QueryPromise<Record<string, GenericColumn> & { id: number | string }[]> => {
+  if (Object.keys(joins).length > 0 || joinAliases.length > 0) {
+    if (where) {
+      chainedMethods.push({ args: [where], method: 'where' })
+    }
+
+    joinAliases.forEach(({ condition, table }) => {
+      chainedMethods.push({
+        args: [table, condition],
+        method: 'leftJoin',
+      })
+    })
+
+    Object.entries(joins).forEach(([joinTable, condition]) => {
+      if (joinTable) {
+        chainedMethods.push({
+          args: [adapter.tables[joinTable], condition],
+          method: 'leftJoin',
+        })
+      }
+    })
+
+    return chainMethods({
+      methods: chainedMethods,
+      query: db.selectDistinct(selectFields).from(adapter.tables[tableName]),
+    })
+  }
+}

--- a/packages/db-postgres/src/update.ts
+++ b/packages/db-postgres/src/update.ts
@@ -2,10 +2,10 @@ import type { UpdateOne } from 'payload/database'
 
 import toSnakeCase from 'to-snake-case'
 
-import type { ChainedMethods } from './find/chainMethods'
-import { chainMethods } from './find/chainMethods'
 import type { PostgresAdapter } from './types'
+
 import buildQuery from './queries/buildQuery'
+import { selectDistinct } from './queries/selectDistinct'
 import { upsertRow } from './upsertRow'
 
 export const updateOne: UpdateOne = async function updateOne(
@@ -16,6 +16,7 @@ export const updateOne: UpdateOne = async function updateOne(
   const collection = this.payload.collections[collectionSlug].config
   const tableName = toSnakeCase(collectionSlug)
   const whereToUse = whereArg || { id: { equals: id } }
+  let idToUpdate = id
 
   const { joinAliases, joins, selectFields, where } = await buildQuery({
     adapter: this,
@@ -25,42 +26,19 @@ export const updateOne: UpdateOne = async function updateOne(
     where: whereToUse,
   })
 
-  let idToUpdate = id
+  const selectDistinctResult = selectDistinct({
+    adapter: this,
+    chainedMethods: [{ args: [1], method: 'limit' }],
+    db,
+    joinAliases,
+    joins,
+    selectFields,
+    tableName,
+    where,
+  })
 
-  // only fetch IDs when a sort or where query is used that needs to be done on join tables, otherwise these can be done directly on the table in findMany
-  if (Object.keys(joins).length > 0 || joinAliases.length > 0) {
-    const selectDistinctMethods: ChainedMethods = []
-
-    if (where) {
-      selectDistinctMethods.push({ args: [where], method: 'where' })
-    }
-
-    joinAliases.forEach(({ condition, table }) => {
-      selectDistinctMethods.push({
-        args: [table, condition],
-        method: 'leftJoin',
-      })
-    })
-
-    Object.entries(joins).forEach(([joinTable, condition]) => {
-      if (joinTable) {
-        selectDistinctMethods.push({
-          args: [this.tables[joinTable], condition],
-          method: 'leftJoin',
-        })
-      }
-    })
-
-    selectDistinctMethods.push({ args: [1], method: 'limit' })
-
-    const selectDistinctResult = await chainMethods({
-      methods: selectDistinctMethods,
-      query: db.selectDistinct(selectFields).from(this.tables[tableName]),
-    })
-
-    if (selectDistinctResult?.[0]?.id) {
-      idToUpdate = selectDistinctResult?.[0]?.id
-    }
+  if (selectDistinctResult?.[0]?.id) {
+    idToUpdate = selectDistinctResult?.[0]?.id
   }
 
   const result = await upsertRow({
@@ -70,8 +48,8 @@ export const updateOne: UpdateOne = async function updateOne(
     db,
     fields: collection.fields,
     operation: 'update',
-    tableName: toSnakeCase(collectionSlug),
     req,
+    tableName: toSnakeCase(collectionSlug),
   })
 
   return result

--- a/packages/db-postgres/src/update.ts
+++ b/packages/db-postgres/src/update.ts
@@ -26,7 +26,7 @@ export const updateOne: UpdateOne = async function updateOne(
     where: whereToUse,
   })
 
-  const selectDistinctResult = selectDistinct({
+  const selectDistinctResult = await selectDistinct({
     adapter: this,
     chainedMethods: [{ args: [1], method: 'limit' }],
     db,


### PR DESCRIPTION
## Description

When using deleteOne with a complex query, the join tables would not be included in the query.

This change reduces code duplication with a new function for postgres selectDistinct and calls it from deleteOne, update, and findMany.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
