### PR TITLE
fix(create-payload-app): Check package name for forbidden characters

### DIFF
--- a/packages/create-payload-app/package.json
+++ b/packages/create-payload-app/package.json
@@ -29,7 +29,8 @@
     "handlebars": "^4.7.7",
     "ora": "^5.1.0",
     "prompts": "^2.4.2",
-    "terminal-link": "^2.1.1"
+    "terminal-link": "^2.1.1",
+    "validate-npm-package-name": "^5.0.0"
   },
   "devDependencies": {
     "@types/command-exists": "^1.2.0",

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -13,6 +13,7 @@ import { getValidTemplates, validateTemplate } from './lib/templates'
 import { writeEnvFile } from './lib/write-env-file'
 import { success } from './utils/log'
 import { helpMessage, successMessage, welcomeMessage } from './utils/messages'
+import { checkAppName } from './utils/checkAppName'
 
 export class Main {
   args: CliArgs
@@ -64,6 +65,9 @@ export class Main {
 
       console.log(welcomeMessage)
       const projectName = await parseProjectName(this.args)
+
+      checkAppName(projectName)
+
       const validTemplates = getValidTemplates()
       const template = await parseTemplate(this.args, validTemplates)
 

--- a/packages/create-payload-app/src/utils/checkAppName.ts
+++ b/packages/create-payload-app/src/utils/checkAppName.ts
@@ -1,0 +1,24 @@
+import  validateProjectName from 'validate-npm-package-name'
+import chalk from 'chalk'
+
+
+export const checkAppName = (appName) => {
+  const validationResult = validateProjectName(appName);
+  if (!validationResult.validForNewPackages) {
+    console.error(
+      chalk.red(
+        `Cannot create a project named ${chalk.green(
+          `"${appName}"`
+        )} because of npm naming restrictions:\n`
+      )
+    );
+    [
+      ...(validationResult.errors || []),
+      ...(validationResult.warnings || []),
+    ].forEach(error => {
+      console.error(chalk.red(`  * ${error}`));
+    });
+    console.error(chalk.red('\nPlease choose a different project name.'));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Description

In this PR I've added a package that will be working as a name validator while creating new Payload app. Right now we doesn't validate name provided by the user, which is causing errors later in the installation process, and can lead to unexpected troubles.

Right now it will validate provided name, create a detailed output in console that will let user know what he did wrong, and how to fix it quickly on the beginning of the process.

This PR resolves problem stated in #5351 

I've created a whole new util for this case, as I know that we should add some things in the future. To be precise - checking if user provided a name that is used by any package that we are using in this template, e.g. 'payload', which can lead to process breaking loop.


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
