### PR TITLE
fix(tests): passing upload field e2e

### DIFF
--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -1882,7 +1882,7 @@ describe('fields', () => {
       await uploadImage()
       await expect(page.locator('.file-field .file-details img')).toHaveAttribute(
         'src',
-        '/uploads/payload-1.jpg',
+        '/api/uploads/file/payload-1.jpg',
       )
     })
 
@@ -1900,13 +1900,13 @@ describe('fields', () => {
       // Assert that the media field has the png upload
       await expect(
         page.locator('.field-type.upload .file-details .file-meta__url a'),
-      ).toHaveAttribute('href', '/uploads/payload-1.png')
+      ).toHaveAttribute('href', '/api/uploads/file/payload-1.png')
       await expect(
         page.locator('.field-type.upload .file-details .file-meta__url a'),
       ).toContainText('payload-1.png')
       await expect(page.locator('.field-type.upload .file-details img')).toHaveAttribute(
         'src',
-        '/uploads/payload-1.png',
+        '/api/uploads/file/payload-1.png',
       )
       await page.locator('#action-save').click()
       await wait(200)


### PR DESCRIPTION
## Description

Passing e2e tests for the upload field

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.
