### PR TITLE
fix: breadcrumbs on live preview tab

### DIFF
--- a/packages/next/src/views/LivePreview/index.client.tsx
+++ b/packages/next/src/views/LivePreview/index.client.tsx
@@ -145,6 +145,8 @@ const PreviewView: React.FC<Props> = ({
             globalLabel={globalConfig?.label}
             globalSlug={globalSlug}
             id={id}
+            pluralLabel={collectionConfig ? collectionConfig?.labels?.plural : undefined}
+            useAsTitle={collectionConfig ? collectionConfig?.admin?.useAsTitle : undefined}
             view={t('general:livePreview')}
           />
           <SetDocumentTitle


### PR DESCRIPTION
closes https://github.com/payloadcms/payload-3.0-alpha-demo/issues/59