### PR TITLE
fix: form-state issues

### DIFF
--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -16,6 +16,61 @@ const ObjectId = (ObjectIdImport.default ||
  */
 export function fieldReducer(state: FormState, action: FieldAction): FormState {
   switch (action.type) {
+    case 'REPLACE_STATE_NO_VALUES': {
+      Object.entries(state).forEach(([path, field]) => {
+        if (action.state[path]) {
+          if (
+            action.state[path].errorPaths === null ||
+            action.state[path].errorPaths === undefined
+          ) {
+            delete field.errorPaths
+          } else {
+            field.errorPaths = action.state[path].errorPaths
+          }
+          if (
+            action.state[path].errorMessage === null ||
+            action.state[path].errorMessage === undefined
+          ) {
+            delete field.errorMessage
+          } else {
+            field.errorMessage = action.state[path].errorMessage
+          }
+
+          if (action.state[path].valid === null || action.state[path].valid === undefined) {
+            delete field.valid
+          } else {
+            field.valid = action.state[path].valid
+          }
+
+          if (action.state[path].validate === null || action.state[path].validate === undefined) {
+            delete field.validate
+          } else {
+            field.validate = action.state[path].validate
+          }
+
+          if (
+            action.state[path].disableFormData === null ||
+            action.state[path].disableFormData === undefined
+          ) {
+            delete field.disableFormData
+          } else {
+            field.disableFormData = action.state[path].disableFormData
+          }
+
+          if (
+            action.state[path].passesCondition === null ||
+            action.state[path].passesCondition === undefined
+          ) {
+            delete field.passesCondition
+          } else {
+            field.passesCondition = action.state[path].passesCondition
+          }
+        }
+      })
+
+      return deepCopyObject(state)
+    }
+
     case 'REPLACE_STATE': {
       const newState = {}
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -549,7 +549,9 @@ export const Form: React.FC<FormProps> = (props) => {
       if (modified) void executeOnChange()
     },
     150,
-    [fields, dispatchFields, onChange],
+    // Make sure we trigger this whenever modified changes (not just when `fields` changes), otherwise we will miss merging server form state for the first form update/onChange. Here's why:
+    // `fields` updates before `modified`, because setModified is in a setTimeout. So on the first change, modified is false, so we don't trigger the effect even though we should.
+    [fields, dispatchFields, onChange, modified],
   )
 
   const actionString =

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -541,7 +541,7 @@ export const Form: React.FC<FormProps> = (props) => {
           const { changed, newState } = mergeServerFormState(fields || {}, revalidatedFormState)
 
           if (changed) {
-            dispatchFields({ type: 'REPLACE_STATE', optimize: false, state: newState })
+            dispatchFields({ type: 'REPLACE_STATE_NO_VALUES', state: newState })
           }
         }
       }

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -72,6 +72,12 @@ export type REPLACE_STATE = {
   type: 'REPLACE_STATE'
 }
 
+export type REPLACE_STATE_NO_VALUES = {
+  optimize?: boolean
+  state: FormState
+  type: 'REPLACE_STATE_NO_VALUES'
+}
+
 export type REMOVE = {
   path: string
   type: 'REMOVE'
@@ -148,6 +154,7 @@ export type FieldAction =
   | REMOVE_ROW
   | REPLACE_ROW
   | REPLACE_STATE
+  | REPLACE_STATE_NO_VALUES
   | SET_ALL_ROWS_COLLAPSED
   | SET_ROW_COLLAPSED
   | UPDATE

--- a/test/fields/lexical.e2e.spec.ts
+++ b/test/fields/lexical.e2e.spec.ts
@@ -718,7 +718,7 @@ describe('lexical', () => {
       await expect(nestedEditorParagraph).toHaveText('Some text below relationship node 12345')
     })
 
-    test.skip('should respect row removal in nested array field', async () => {
+    test('should respect row removal in nested array field', async () => {
       await navigateToLexicalFields()
       const richTextField = page.locator('.rich-text-lexical').nth(1) // second
       await richTextField.scrollIntoViewIfNeeded()


### PR DESCRIPTION
## Description

- Fixes  server form-state request wasn't triggered on first onChange 
- Fixes form-state request messing with value stuff (e.g. undoing new rows you create, new values etc.) if your network is slow OR if you are too fast:

https://github.com/payloadcms/payload/assets/70709113/47598b13-f6dc-4e4d-8d75-22f5040034df



- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
