### PR TITLE
fix: always re-fetch document data whenever dependencies change

### DIFF
--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -92,46 +92,40 @@ export const DocumentInfoProvider: React.FC<
   // no need to an additional requests when creating new documents
   const isEditing = Boolean(id)
 
-  const shouldLoadData = !hasInitializedState.current && !!(globalSlug || id)
-
   const [{ data, isError, isLoading: isLoadingDocument }] = usePayloadAPI(
-    shouldLoadData
-      ? `${baseURL}/${globalSlug ? 'globals/' : ''}${slug}${collectionSlug ? `/${id}` : ''}`
-      : null,
+    `${baseURL}/${globalSlug ? 'globals/' : ''}${slug}${collectionSlug ? `/${id}` : ''}`,
     { initialParams: { depth: 0, draft: 'true', 'fallback-locale': 'null' } },
   )
 
   useEffect(() => {
-    if (!hasInitializedState.current && (data || !shouldLoadData)) {
-      const getInitialState = async () => {
-        let docPreferences: DocumentPreferences = { fields: {} }
+    const getInitialState = async () => {
+      let docPreferences: DocumentPreferences = { fields: {} }
 
-        if (id) {
-          docPreferences = await getPreference(
-            `${id ? 'collection' : 'global'}-${collectionSlug}-${id}`,
-          )
-        }
-
-        const result = await getFormState({
-          apiRoute: api,
-          body: {
-            id,
-            collectionSlug,
-            data: data || {},
-            docPreferences,
-            globalSlug,
-            operation: isEditing ? 'update' : 'create',
-            schemaPath: collectionSlug || globalSlug,
-          },
-          serverURL,
-        })
-
-        setInitialState(result)
-        hasInitializedState.current = true
+      if (id) {
+        docPreferences = await getPreference(
+          `${id ? 'collection' : 'global'}-${collectionSlug}-${id}`,
+        )
       }
 
-      void getInitialState()
+      const result = await getFormState({
+        apiRoute: api,
+        body: {
+          id,
+          collectionSlug,
+          data: data || {},
+          docPreferences,
+          globalSlug,
+          operation: isEditing ? 'update' : 'create',
+          schemaPath: collectionSlug || globalSlug,
+        },
+        serverURL,
+      })
+
+      setInitialState(result)
+      hasInitializedState.current = true
     }
+
+    void getInitialState()
   }, [api, data, isEditing, collectionSlug, serverURL, id, getPreference, globalSlug])
 
   /**


### PR DESCRIPTION
## Description

Fixes document data not updating after changing locales

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
