### PR TITLE
fix: issue of losing locale when switching tabs between API and edit views

### DIFF
--- a/packages/ui/src/elements/DocumentHeader/Tabs/Tab/TabLink.tsx
+++ b/packages/ui/src/elements/DocumentHeader/Tabs/Tab/TabLink.tsx
@@ -2,8 +2,10 @@
 import type { SanitizedConfig } from 'payload/types'
 
 import LinkImport from 'next/link.js'
-import { useParams, usePathname, useSearchParams } from 'next/navigation.js'
+import { useParams, usePathname } from 'next/navigation.js'
 import React from 'react'
+
+import { useSearchParams } from '../../../../providers/SearchParams/index.js'
 
 const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
 
@@ -26,8 +28,12 @@ export const DocumentTabLink: React.FC<{
   const pathname = usePathname()
   const params = useParams()
 
-  const searchParams = useSearchParams()
-  const locale = searchParams.get('locale')
+  const { searchParams } = useSearchParams()
+
+  const locale =
+    'locale' in searchParams && typeof searchParams.locale === 'string'
+      ? searchParams.locale
+      : undefined
 
   const [entityType, entitySlug, segmentThree, segmentFour, ...rest] = params.segments || []
   const isCollection = entityType === 'collections'

--- a/packages/ui/src/elements/DocumentHeader/Tabs/Tab/TabLink.tsx
+++ b/packages/ui/src/elements/DocumentHeader/Tabs/Tab/TabLink.tsx
@@ -2,7 +2,7 @@
 import type { SanitizedConfig } from 'payload/types'
 
 import LinkImport from 'next/link.js'
-import { useParams, usePathname } from 'next/navigation.js'
+import { useParams, usePathname, useSearchParams } from 'next/navigation.js'
 import React from 'react'
 
 const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
@@ -25,6 +25,10 @@ export const DocumentTabLink: React.FC<{
 }) => {
   const pathname = usePathname()
   const params = useParams()
+
+  const searchParams = useSearchParams()
+  const locale = searchParams.get('locale')
+
   const [entityType, entitySlug, segmentThree, segmentFour, ...rest] = params.segments || []
   const isCollection = entityType === 'collections'
   let docPath = `${adminRoute}/${isCollection ? 'collections' : 'globals'}/${entitySlug}`
@@ -34,6 +38,8 @@ export const DocumentTabLink: React.FC<{
   }
 
   const href = `${docPath}${hrefFromProps}`
+  // separated the two so it doesn't break checks against pathname
+  const hrefWithLocale = `${href}${locale ? `?locale=${locale}` : ''}`
 
   const isActive =
     (href === docPath && pathname === docPath) ||
@@ -44,7 +50,7 @@ export const DocumentTabLink: React.FC<{
     <li className={[baseClass, isActive && `${baseClass}--active`].filter(Boolean).join(' ')}>
       <Link
         className={`${baseClass}__link`}
-        href={!isActive || href !== pathname ? href : ''}
+        href={!isActive || href !== pathname ? hrefWithLocale : ''}
         {...(newTab && { rel: 'noopener noreferrer', target: '_blank' })}
         tabIndex={isActive ? -1 : 0}
       >


### PR DESCRIPTION
fixes the issue where your chosen locale would be reset to the default when switching between the top level tabs in document view