### PR TITLE
fix: imports from exports dir

### DIFF
--- a/packages/live-preview-react/package.json
+++ b/packages/live-preview-react/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "homepage": "https://payloadcms.com",
   "author": "Payload CMS, Inc.",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "type": "module",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "homepage": "https://payloadcms.com",
   "author": "Payload CMS, Inc.",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "type": "module",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0-alpha.49",
   "description": "Node, React and MongoDB Headless CMS and Application Framework",
   "license": "MIT",
-  "main": "./src/index.js",
+  "main": "./src/index.ts",
   "types": "./src/index.ts",
   "type": "module",
   "bin": {

--- a/packages/payload/src/auth/executeAccess.ts
+++ b/packages/payload/src/auth/executeAccess.ts
@@ -1,5 +1,5 @@
 import type { Access, AccessResult } from '../config/types.js'
-import type { PayloadRequest } from '../exports/types.js'
+import type { PayloadRequest } from '../types/index.js'
 
 import { Forbidden } from '../errors/index.js'
 

--- a/packages/payload/src/auth/strategies/apiKey.ts
+++ b/packages/payload/src/auth/strategies/apiKey.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto'
 
 import type { SanitizedCollectionConfig } from '../../collections/config/types.js'
-import type { Where } from '../../exports/types.js'
+import type { Where } from '../../types/index.js'
 import type { AuthStrategyFunction, User } from '../index.js'
 
 export const APIKeyAuthentication =

--- a/packages/payload/src/bin/migrate.ts
+++ b/packages/payload/src/bin/migrate.ts
@@ -1,6 +1,6 @@
 import type { ParsedArgs } from 'minimist'
 
-import type { SanitizedConfig } from '../exports/types.js'
+import type { SanitizedConfig } from '../config/types.js'
 
 import payload from '../index.js'
 import { prettySyncLoggerDestination } from '../utilities/logger.js'

--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -1,5 +1,4 @@
 import type { LivePreviewConfig, ServerOnlyLivePreviewProperties } from '../../config/types.js'
-import type { SanitizedCollectionConfig } from '../../exports/types.js'
 
 export type ServerOnlyCollectionProperties = keyof Pick<
   SanitizedCollectionConfig,
@@ -25,6 +24,7 @@ export type ClientCollectionConfig = Omit<
 }
 
 import type { ClientFieldConfig } from '../../fields/config/client.js'
+import type { SanitizedCollectionConfig } from './types.js'
 
 import { createClientFieldConfigs } from '../../fields/config/client.js'
 

--- a/packages/payload/src/collections/operations/utils.ts
+++ b/packages/payload/src/collections/operations/utils.ts
@@ -1,7 +1,7 @@
 import type { forgotPasswordOperation } from '../../auth/operations/forgotPassword.js'
 import type { loginOperation } from '../../auth/operations/login.js'
 import type { refreshOperation } from '../../auth/operations/refresh.js'
-import type { PayloadRequest } from '../../exports/types.js'
+import type { PayloadRequest } from '../../types/index.js'
 import type { AfterOperationHook, SanitizedCollectionConfig, TypeWithID } from '../config/types.js'
 import type { createOperation } from './create.js'
 import type { deleteOperation } from './delete.js'

--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -1,6 +1,7 @@
 import type { ClientCollectionConfig } from '../collections/config/client.js'
-import type { SanitizedCollectionConfig, SanitizedGlobalConfig } from '../exports/types.js'
+import type { SanitizedCollectionConfig } from '../collections/config/types.js'
 import type { ClientGlobalConfig } from '../globals/config/client.js'
+import type { SanitizedGlobalConfig } from '../globals/config/types.js'
 import type {
   LivePreviewConfig,
   SanitizedConfig,

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -1,4 +1,5 @@
-import type { RichTextAdapter, Where } from '../exports/types.js'
+import type { RichTextAdapter } from '../admin/types.js'
+import type { Where } from '../types/index.js'
 import type {
   ArrayField,
   BlockField,

--- a/packages/payload/src/preferences/requestHandlers/delete.ts
+++ b/packages/payload/src/preferences/requestHandlers/delete.ts
@@ -1,6 +1,6 @@
 import httpStatus from 'http-status'
 
-import type { PayloadHandler } from '../../exports/config.js'
+import type { PayloadHandler } from '../../config/types.js'
 
 import deleteOperation from '../operations/delete.js'
 

--- a/packages/payload/src/preferences/requestHandlers/findOne.ts
+++ b/packages/payload/src/preferences/requestHandlers/findOne.ts
@@ -1,6 +1,6 @@
 import httpStatus from 'http-status'
 
-import type { PayloadHandler } from '../../exports/config.js'
+import type { PayloadHandler } from '../../config/types.js'
 
 import findOne from '../operations/findOne.js'
 

--- a/packages/payload/src/preferences/requestHandlers/update.ts
+++ b/packages/payload/src/preferences/requestHandlers/update.ts
@@ -1,6 +1,6 @@
 import httpStatus from 'http-status'
 
-import type { PayloadHandler } from '../../exports/config.js'
+import type { PayloadHandler } from '../../config/types.js'
 
 import update from '../operations/update.js'
 

--- a/packages/payload/src/translations/getLocalI18n.ts
+++ b/packages/payload/src/translations/getLocalI18n.ts
@@ -1,9 +1,9 @@
 import { initI18n } from '@payloadcms/translations'
 import { translations } from '@payloadcms/translations/api'
 
-import type { SanitizedConfig } from '../exports/types.js'
+import type { SanitizedConfig } from '../config/types.js'
 
-export const getLocalI18n = async ({
+export const getLocalI18n = ({
   config,
   language = 'en',
 }: {

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -68,7 +68,7 @@ export const createLocalReq: CreateLocalReq = async (
   { context, fallbackLocale, locale: localeArg, req = {} as PayloadRequest, user },
   payload,
 ) => {
-  const i18n = req?.i18n || (await getLocalI18n({ config: payload.config }))
+  const i18n = req?.i18n || getLocalI18n({ config: payload.config })
 
   if (payload.config?.localization) {
     const locale = localeArg === '*' ? 'all' : localeArg

--- a/packages/payload/src/utilities/fieldSchemaToJSON.ts
+++ b/packages/payload/src/utilities/fieldSchemaToJSON.ts
@@ -1,4 +1,4 @@
-import type { FieldTypes } from '../exports/config.js'
+import type { FieldTypes } from '../admin/forms/FieldTypes.js'
 import type { ClientFieldConfig } from '../fields/config/client.js'
 
 export type FieldSchemaJSON = {

--- a/packages/plugin-nested-docs/package.json
+++ b/packages/plugin-nested-docs/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "homepage": "https://payloadcms.com",
   "author": "Payload CMS, Inc.",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "type": "module",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",

--- a/packages/plugin-search/package.json
+++ b/packages/plugin-search/package.json
@@ -4,8 +4,8 @@
   "homepage:": "https://payloadcms.com",
   "repository": "git@github.com:payloadcms/plugin-search.git",
   "description": "Search plugin for Payload",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "type": "module",
   "scripts": {
     "build": "pnpm build:swc && pnpm build:types",

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "homepage": "https://payloadcms.com",
   "author": "Payload CMS, Inc.",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "type": "module",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types && tsx ../../scripts/exportPointerFiles.ts ../packages/richtext-lexical dist/exports",

--- a/packages/richtext-lexical/src/field/features/converters/html/field/index.ts
+++ b/packages/richtext-lexical/src/field/features/converters/html/field/index.ts
@@ -1,8 +1,8 @@
 import type { SerializedEditorState } from 'lexical'
 import type { Field, RichTextField, TextField } from 'payload/types'
 
-import type { LexicalRichTextAdapter, SanitizedServerEditorConfig } from '../../../../../index.js'
-import type { AdapterProps } from '../../../../../types.js'
+import type { AdapterProps, LexicalRichTextAdapter } from '../../../../../types.js'
+import type { SanitizedServerEditorConfig } from '../../../../lexical/config/types.js'
 import type { HTMLConverter } from '../converter/types.js'
 import type { HTMLConverterFeatureProps } from '../feature.server.js'
 

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -1,14 +1,12 @@
 import type { JSONSchema4 } from 'json-schema'
-import type { SerializedEditorState } from 'lexical'
 import type { EditorConfig as LexicalEditorConfig } from 'lexical/LexicalEditor.js'
-import type { RichTextAdapter } from 'payload/types'
 
 import { withMergedProps } from '@payloadcms/ui/elements/withMergedProps'
 import { withNullableJSONSchemaType } from 'payload/utilities'
 
 import type { FeatureProviderServer, ResolvedServerFeatureMap } from './field/features/types.js'
 import type { SanitizedServerEditorConfig } from './field/lexical/config/types.js'
-import type { AdapterProps } from './types.js'
+import type { AdapterProps, LexicalEditorProps, LexicalRichTextAdapter } from './types.js'
 
 import { RichTextCell } from './cell/index.js'
 import { RichTextField } from './field/index.js'
@@ -24,22 +22,6 @@ import { getGenerateComponentMap } from './generateComponentMap.js'
 import { getGenerateSchemaMap } from './generateSchemaMap.js'
 import { richTextRelationshipPromise } from './populate/richTextRelationshipPromise.js'
 import { richTextValidateHOC } from './validate/index.js'
-
-export type LexicalEditorProps = {
-  features?:
-    | (({
-        defaultFeatures,
-      }: {
-        defaultFeatures: FeatureProviderServer<unknown, unknown>[]
-      }) => FeatureProviderServer<unknown, unknown>[])
-    | FeatureProviderServer<unknown, unknown>[]
-  lexical?: LexicalEditorConfig
-}
-
-// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-export type LexicalRichTextAdapter = RichTextAdapter<SerializedEditorState, AdapterProps, any> & {
-  editorConfig: SanitizedServerEditorConfig
-}
 
 export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapter {
   let resolvedFeatureMap: ResolvedServerFeatureMap = null
@@ -254,8 +236,10 @@ export {
   HTMLConverterFeature,
   type HTMLConverterFeatureProps,
 } from './field/features/converters/html/feature.server.js'
-export { consolidateHTMLConverters } from './field/features/converters/html/field/index.js'
-export { lexicalHTML } from './field/features/converters/html/field/index.js'
+export {
+  consolidateHTMLConverters,
+  lexicalHTML,
+} from './field/features/converters/html/field/index.js'
 export { createClientComponent } from './field/features/createClientComponent.js'
 export { TestRecorderFeature } from './field/features/debug/testrecorder/feature.server.js'
 export { TreeViewFeature } from './field/features/debug/treeview/feature.server.js'
@@ -431,3 +415,5 @@ export {
 } from './field/lexical/utils/swipe.js'
 export { sanitizeUrl, validateUrl } from './field/lexical/utils/url.js'
 export { defaultRichTextValue } from './populate/defaultValue.js'
+
+export type { LexicalEditorProps, LexicalRichTextAdapter } from './types.js'

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -1,10 +1,28 @@
 import type { SerializedEditorState } from 'lexical'
+import type { EditorConfig as LexicalEditorConfig } from 'lexical/LexicalEditor.js'
 import type { FieldPermissions } from 'payload/auth'
 import type { FieldTypes } from 'payload/config'
-import type { RichTextFieldProps } from 'payload/types'
+import type { RichTextAdapter, RichTextFieldProps } from 'payload/types'
 import type React from 'react'
 
+import type { FeatureProviderServer } from './field/features/types.js'
 import type { SanitizedServerEditorConfig } from './field/lexical/config/types.js'
+
+export type LexicalEditorProps = {
+  features?:
+    | (({
+        defaultFeatures,
+      }: {
+        defaultFeatures: FeatureProviderServer<unknown, unknown>[]
+      }) => FeatureProviderServer<unknown, unknown>[])
+    | FeatureProviderServer<unknown, unknown>[]
+  lexical?: LexicalEditorConfig
+}
+
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+export type LexicalRichTextAdapter = RichTextAdapter<SerializedEditorState, AdapterProps, any> & {
+  editorConfig: SanitizedServerEditorConfig
+}
 
 export type FieldProps = RichTextFieldProps<SerializedEditorState, AdapterProps, AdapterProps> & {
   fieldTypes: FieldTypes

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@payloadcms/translations",
   "version": "3.0.0-alpha.49",
-  "main": "./dist/exports/index.ts",
-  "types": "./dist/types.d.ts",
+  "main": "./src/exports/index.ts",
+  "types": "./src/types.ts",
   "type": "module",
   "scripts": {
     "build:types": "tsc --outDir dist",


### PR DESCRIPTION
## Description

- Payload and richtext-lexical had internal references to its own `exports/*` directory. This was causing issues when reference from the test directory.
- Also fixed some `main` package.json values to be `src/index.ts`