### PR TITLE
fix(ui): sets proper id on publish button and updates custom button s…

### DIFF
--- a/packages/ui/src/elements/Publish/index.tsx
+++ b/packages/ui/src/elements/Publish/index.tsx
@@ -16,6 +16,7 @@ const DefaultPublishButton: React.FC = () => {
   const [hasPublishPermission, setHasPublishPermission] = React.useState(false)
   const { getData, submit } = useForm()
   const modified = useFormModified()
+
   const {
     routes: { api },
     serverURL,
@@ -78,7 +79,7 @@ const DefaultPublishButton: React.FC = () => {
 
   return (
     <FormSubmit
-      buttonId={id.toString()}
+      buttonId="action-save"
       disabled={!canPublish}
       onClick={publish}
       size="small"

--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/index.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/index.tsx
@@ -64,17 +64,17 @@ export const buildComponentMap = (args: {
 
     const afterListTable = collectionConfig?.admin?.components?.AfterListTable
 
-    const SaveButton = collectionConfig?.admin?.components?.edit?.SaveButton
-    const SaveButtonComponent = SaveButton ? <SaveButton /> : undefined
+    const SaveButtonComponent = collectionConfig?.admin?.components?.edit?.SaveButton
+    const SaveButton = SaveButtonComponent ? <SaveButtonComponent /> : undefined
 
-    const SaveDraftButton = collectionConfig?.admin?.components?.edit?.SaveDraftButton
-    const SaveDraftButtonComponent = SaveDraftButton ? <SaveDraftButton /> : undefined
+    const SaveDraftButtonComponent = collectionConfig?.admin?.components?.edit?.SaveDraftButton
+    const SaveDraftButton = SaveDraftButtonComponent ? <SaveDraftButtonComponent /> : undefined
 
-    /* const PreviewButton = collectionConfig?.admin?.components?.edit?.PreviewButton
-    const PreviewButtonComponent = PreviewButton ? <PreviewButton /> : undefined */
+    /* const PreviewButtonComponent = collectionConfig?.admin?.components?.edit?.PreviewButton
+    const PreviewButton = PreviewButtonComponent ? <PreviewButtonComponent /> : undefined */
 
-    const PublishButton = collectionConfig?.admin?.components?.edit?.PublishButton
-    const PublishButtonComponent = PublishButton ? <PublishButton /> : undefined
+    const PublishButtonComponent = collectionConfig?.admin?.components?.edit?.PublishButton
+    const PublishButton = PublishButtonComponent ? <PublishButtonComponent /> : undefined
 
     const BeforeList =
       (beforeList && Array.isArray(beforeList) && beforeList?.map((Component) => <Component />)) ||
@@ -111,10 +111,10 @@ export const buildComponentMap = (args: {
       BeforeListTable,
       Edit: <Edit collectionSlug={collectionConfig.slug} />,
       List: <List collectionSlug={collectionConfig.slug} />,
-      /* PreviewButton: PreviewButtonComponent, */
-      PublishButton: PublishButtonComponent,
-      SaveButton: SaveButtonComponent,
-      SaveDraftButton: SaveDraftButtonComponent,
+      /* PreviewButton, */
+      PublishButton,
+      SaveButton,
+      SaveDraftButton,
       actionsMap: mapActions({
         collectionConfig,
       }),


### PR DESCRIPTION
## Description

The `create` view was crashing on draft-enabled collections because the publish button was using an `id` derived from the document (`id.toString()`), even though the document does not exist yet. This uses the proper id "action-save" and also updates some semantics in the field map around custom buttons.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.