### PR TITLE
fix: simplifies field error path calculation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -220,7 +220,7 @@ jobs:
           - access-control
           # - admin
           - auth
-          # - field-error-states
+          - field-error-states
           # - fields-relationship
           # - fields
           - fields/lexical

--- a/packages/payload/src/admin/forms/Form.ts
+++ b/packages/payload/src/admin/forms/Form.ts
@@ -8,7 +8,6 @@ export type Data = {
 export type Row = {
   blockType?: string
   collapsed?: boolean
-  errorPaths?: string[]
   id: string
 }
 

--- a/packages/payload/src/admin/forms/Label.ts
+++ b/packages/payload/src/admin/forms/Label.ts
@@ -1,5 +1,6 @@
 export type LabelProps = {
   CustomLabel?: React.ReactNode
+  as?: 'label' | 'span'
   htmlFor?: string
   label?: Record<string, string> | false | string
   required?: boolean

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -229,7 +229,7 @@ const validateArrayLength = (
 ) => {
   const { maxRows, minRows, required, t } = options
 
-  const arrayLength = Array.isArray(value) ? value.length : 0
+  const arrayLength = Array.isArray(value) ? value.length : value || 0
 
   if (!required && arrayLength === 0) return true
 

--- a/packages/ui/src/fields/Array/ArrayRow.tsx
+++ b/packages/ui/src/fields/Array/ArrayRow.tsx
@@ -22,6 +22,7 @@ type ArrayRowProps = UseDraggableSortableReturn & {
   CustomRowLabel?: React.ReactNode
   addRow: (rowIndex: number) => void
   duplicateRow: (rowIndex: number) => void
+  errorCount: number
   fieldMap: FieldMap
   forceRender?: boolean
   hasMaxRows?: boolean
@@ -35,6 +36,7 @@ type ArrayRowProps = UseDraggableSortableReturn & {
   row: Row
   rowCount: number
   rowIndex: number
+  schemaPath: string
   setCollapse: (rowID: string, collapsed: boolean) => void
 }
 
@@ -43,6 +45,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
   addRow,
   attributes,
   duplicateRow,
+  errorCount,
   fieldMap,
   forceRender = false,
   hasMaxRows,
@@ -57,6 +60,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
   row,
   rowCount,
   rowIndex,
+  schemaPath,
   setCollapse,
   setNodeRef,
   transform,
@@ -70,7 +74,6 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
     '0',
   )}`
 
-  const errorCount = row.errorPaths?.length
   const fieldHasErrors = errorCount > 0 && hasSubmitted
 
   const classNames = [
@@ -134,7 +137,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
           path={path}
           permissions={permissions?.fields}
           readOnly={readOnly}
-          schemaPath={parentPath}
+          schemaPath={schemaPath}
         />
       </Collapsible>
     </div>

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -112,6 +112,7 @@ export const _ArrayField: React.FC<ArrayFieldProps> = (props) => {
   const { path: pathFromContext } = useFieldProps()
 
   const {
+    errorPaths,
     path,
     rows = [],
     schemaPath,
@@ -180,10 +181,8 @@ export const _ArrayField: React.FC<ArrayFieldProps> = (props) => {
 
   const hasMaxRows = maxRows && rows.length >= maxRows
 
-  const fieldErrorCount =
-    rows.reduce((total, row) => total + (row?.errorPaths?.length || 0), 0) + (valid ? 0 : 1)
-
-  const fieldHasErrors = submitted && fieldErrorCount > 0
+  const fieldErrorCount = errorPaths.length
+  const fieldHasErrors = submitted && errorPaths.length > 0
 
   const showRequired = readOnly && rows.length === 0
   const showMinRows = rows.length < minRows || (required && rows.length === 0)
@@ -209,7 +208,7 @@ export const _ArrayField: React.FC<ArrayFieldProps> = (props) => {
         <div className={`${baseClass}__header-wrap`}>
           <div className={`${baseClass}__header-content`}>
             <h3 className={`${baseClass}__title`}>
-              <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+              <FieldLabel CustomLabel={CustomLabel} as="span" unstyled {...(labelProps || {})} />
             </h3>
             {fieldHasErrors && fieldErrorCount > 0 && (
               <ErrorPill count={fieldErrorCount} i18n={i18n} withMessage />
@@ -247,32 +246,39 @@ export const _ArrayField: React.FC<ArrayFieldProps> = (props) => {
           ids={rows.map((row) => row.id)}
           onDragEnd={({ moveFromIndex, moveToIndex }) => moveRow(moveFromIndex, moveToIndex)}
         >
-          {rows.map((row, i) => (
-            <DraggableSortableItem disabled={readOnly} id={row.id} key={row.id}>
-              {(draggableSortableItemProps) => (
-                <ArrayRow
-                  {...draggableSortableItemProps}
-                  CustomRowLabel={CustomRowLabel}
-                  addRow={addRow}
-                  duplicateRow={duplicateRow}
-                  fieldMap={fieldMap}
-                  forceRender={forceRender}
-                  hasMaxRows={hasMaxRows}
-                  indexPath={indexPath}
-                  labels={labels}
-                  moveRow={moveRow}
-                  path={path}
-                  permissions={permissions}
-                  readOnly={readOnly}
-                  removeRow={removeRow}
-                  row={row}
-                  rowCount={rows.length}
-                  rowIndex={i}
-                  setCollapse={setCollapse}
-                />
-              )}
-            </DraggableSortableItem>
-          ))}
+          {rows.map((row, i) => {
+            const rowErrorCount = errorPaths?.filter((errorPath) =>
+              errorPath.startsWith(`${path}.${i}.`),
+            ).length
+            return (
+              <DraggableSortableItem disabled={readOnly} id={row.id} key={row.id}>
+                {(draggableSortableItemProps) => (
+                  <ArrayRow
+                    {...draggableSortableItemProps}
+                    CustomRowLabel={CustomRowLabel}
+                    addRow={addRow}
+                    duplicateRow={duplicateRow}
+                    errorCount={rowErrorCount}
+                    fieldMap={fieldMap}
+                    forceRender={forceRender}
+                    hasMaxRows={hasMaxRows}
+                    indexPath={indexPath}
+                    labels={labels}
+                    moveRow={moveRow}
+                    path={path}
+                    permissions={permissions}
+                    readOnly={readOnly}
+                    removeRow={removeRow}
+                    row={row}
+                    rowCount={rows.length}
+                    rowIndex={i}
+                    schemaPath={schemaPath}
+                    setCollapse={setCollapse}
+                  />
+                )}
+              </DraggableSortableItem>
+            )
+          })}
           {!valid && (
             <React.Fragment>
               {showRequired && (

--- a/packages/ui/src/fields/Blocks/BlockRow.tsx
+++ b/packages/ui/src/fields/Blocks/BlockRow.tsx
@@ -24,6 +24,7 @@ type BlockFieldProps = UseDraggableSortableReturn & {
   block: ReducedBlock
   blocks: ReducedBlock[]
   duplicateRow: (rowIndex: number) => void
+  errorCount: number
   forceRender?: boolean
   hasMaxRows?: boolean
   indexPath: string
@@ -46,6 +47,7 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
   block,
   blocks,
   duplicateRow,
+  errorCount,
   forceRender,
   hasMaxRows,
   labels,
@@ -67,8 +69,7 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
   const { i18n } = useTranslation()
   const hasSubmitted = useFormSubmitted()
 
-  const errorCount = row.errorPaths?.length
-  const fieldHasErrors = errorCount > 0 && hasSubmitted
+  const fieldHasErrors = hasSubmitted && errorCount > 0
 
   const classNames = [
     `${baseClass}__row`,

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -113,6 +113,7 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
   const { path: pathFromContext } = useFieldProps()
 
   const {
+    errorPaths,
     path,
     permissions,
     rows = [],
@@ -192,7 +193,7 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
 
   const hasMaxRows = maxRows && rows.length >= maxRows
 
-  const fieldErrorCount = rows.reduce((total, row) => total + (row?.errorPaths?.length || 0), 0)
+  const fieldErrorCount = errorPaths.length
   const fieldHasErrors = submitted && fieldErrorCount + (valid ? 0 : 1) > 0
 
   const showMinRows = rows.length < minRows || (required && rows.length === 0)
@@ -219,7 +220,7 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
         <div className={`${baseClass}__header-wrap`}>
           <div className={`${baseClass}__heading-with-error`}>
             <h3>
-              <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+              <FieldLabel CustomLabel={CustomLabel} as="span" unstyled {...(labelProps || {})} />
             </h3>
             {fieldHasErrors && fieldErrorCount > 0 && (
               <ErrorPill count={fieldErrorCount} i18n={i18n} withMessage />
@@ -262,6 +263,9 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
             const blockToRender = blocks.find((block) => block.slug === blockType)
 
             if (blockToRender) {
+              const rowErrorCount = errorPaths.filter((errorPath) =>
+                errorPath.startsWith(`${path}.${i}`),
+              ).length
               return (
                 <DraggableSortableItem disabled={readOnly} id={row.id} key={row.id}>
                   {(draggableSortableItemProps) => (
@@ -271,6 +275,7 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
                       block={blockToRender}
                       blocks={blocks}
                       duplicateRow={duplicateRow}
+                      errorCount={rowErrorCount}
                       forceRender={forceRender}
                       hasMaxRows={hasMaxRows}
                       indexPath={indexPath}

--- a/packages/ui/src/fields/Collapsible/index.tsx
+++ b/packages/ui/src/fields/Collapsible/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { DocumentPreferences, FieldBase, RowLabel as RowLabelType } from 'payload/types'
+import type { DocumentPreferences, FieldBase } from 'payload/types'
 
 import React, { Fragment, useCallback, useEffect, useState } from 'react'
 

--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -12,8 +12,9 @@ import type { FormFieldBase } from '../shared/index.js'
 import { useCollapsible } from '../../elements/Collapsible/provider.js'
 import { ErrorPill } from '../../elements/ErrorPill/index.js'
 import { useFieldProps } from '../../forms/FieldPropsProvider/index.js'
+import { useFormSubmitted } from '../../forms/Form/context.js'
 import { RenderFields } from '../../forms/RenderFields/index.js'
-import { WatchChildErrors } from '../../forms/WatchChildErrors/index.js'
+import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { useRow } from '../Row/provider.js'
@@ -53,14 +54,15 @@ const GroupField: React.FC<GroupFieldProps> = (props) => {
   const isWithinGroup = useGroup()
   const isWithinRow = useRow()
   const isWithinTab = useTabs()
-  const [errorCount, setErrorCount] = React.useState(undefined)
-  const fieldHasErrors = errorCount > 0
+  const { errorPaths } = useField({ path })
+  const submitted = useFormSubmitted()
+  const errorCount = errorPaths.length
+  const fieldHasErrors = submitted && errorCount > 0
 
   const isTopLevel = !(isWithinCollapsible || isWithinGroup || isWithinRow)
 
   return (
     <Fragment>
-      <WatchChildErrors fieldMap={fieldMap} path={path} setErrorCount={setErrorCount} />
       <div
         className={[
           fieldBaseClass,

--- a/packages/ui/src/forms/FieldLabel/index.tsx
+++ b/packages/ui/src/forms/FieldLabel/index.tsx
@@ -12,6 +12,7 @@ import './index.scss'
 
 const DefaultFieldLabel: React.FC<LabelProps> = (props) => {
   const {
+    as: Element = 'label',
     htmlFor: htmlForFromProps,
     label: labelFromProps,
     required = false,
@@ -26,10 +27,10 @@ const DefaultFieldLabel: React.FC<LabelProps> = (props) => {
 
   if (labelFromProps) {
     return (
-      <label className={`field-label ${unstyled ? 'unstyled' : ''}`} htmlFor={htmlFor}>
+      <Element className={`field-label ${unstyled ? 'unstyled' : ''}`} htmlFor={htmlFor}>
         {getTranslation(labelFromProps, i18n)}
         {required && !unstyled && <span className="required">*</span>}
-      </label>
+      </Element>
     )
   }
 

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -52,30 +52,6 @@ export const mergeServerFormState = (
         }
       })
 
-      /**
-       * Handle rows
-       */
-      if (Array.isArray(newFieldState.rows) && newFieldState?.rows.length) {
-        let i = 0
-        for (const row of newFieldState.rows) {
-          const incomingRow = incomingState[path]?.rows?.[i]
-          if (incomingRow) {
-            const errorPathsRowResult = mergeErrorPaths(
-              row.errorPaths,
-              incomingRow.errorPaths as unknown as string[],
-            )
-            if (errorPathsRowResult.result) {
-              if (errorPathsResult.changed) {
-                changed = true
-              }
-              incomingRow.errorPaths = errorPathsRowResult.result
-            }
-          }
-
-          i++
-        }
-      }
-
       // Conditions don't work if we don't memcopy the new state, as the object references would otherwise be the same
       newState[path] = { ...newFieldState }
     })

--- a/packages/ui/src/forms/buildStateFromSchema/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/buildStateFromSchema/addFieldStatePromise.ts
@@ -113,7 +113,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       value: data?.[field.name],
     })
 
-    if (data) {
+    if (data?.[field.name]) {
       data[field.name] = valueWithDefault
     }
 

--- a/packages/ui/src/forms/buildStateFromSchema/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/buildStateFromSchema/addFieldStatePromise.ts
@@ -24,7 +24,6 @@ export type AddFieldStatePromiseArgs = {
    */
   anyParentLocalized?: boolean
   data: Data
-  errorPaths: string[]
   field: NonPresentationalField
   fieldIndex: number
   /**
@@ -77,7 +76,6 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
     addErrorPathToParent: addErrorPathToParentArg,
     anyParentLocalized = false,
     data,
-    errorPaths: parentErrorPaths = [],
     field,
     filter,
     forceFullValue = false,
@@ -187,7 +185,6 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
                 addErrorPathToParent,
                 anyParentLocalized: field.localized || anyParentLocalized,
                 data: row,
-                errorPaths: fieldState.errorPaths,
                 fields: field.fields,
                 filter,
                 forceFullValue,
@@ -213,7 +210,6 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
                 collapsedRowIDs === undefined
                   ? field.admin.initCollapsed
                   : collapsedRowIDs.includes(row.id),
-              errorPaths: fieldState.errorPaths,
             })
 
             return acc
@@ -301,7 +297,6 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
                   addErrorPathToParent,
                   anyParentLocalized: field.localized || anyParentLocalized,
                   data: row,
-                  errorPaths: fieldState.errorPaths,
                   fields: block.fields,
                   filter,
                   forceFullValue,
@@ -328,7 +323,6 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
                   collapsedRowIDs === undefined
                     ? field.admin.initCollapsed
                     : collapsedRowIDs.includes(row.id),
-                errorPaths: fieldState.errorPaths,
               })
             }
 
@@ -371,7 +365,6 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
           addErrorPathToParent,
           anyParentLocalized: field.localized || anyParentLocalized,
           data: data?.[field.name] || {},
-          errorPaths: parentErrorPaths,
           fields: field.fields,
           filter,
           forceFullValue,
@@ -508,7 +501,6 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       addErrorPathToParent: addErrorPathToParentArg,
       anyParentLocalized: field.localized || anyParentLocalized,
       data,
-      errorPaths: parentErrorPaths,
       fields: field.fields,
       filter,
       forceFullValue,
@@ -532,7 +524,6 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
         addErrorPathToParent: addErrorPathToParentArg,
         anyParentLocalized: tab.localized || anyParentLocalized,
         data: tabHasName(tab) ? data?.[tab.name] : data,
-        errorPaths: parentErrorPaths,
         fields: tab.fields,
         filter,
         forceFullValue,

--- a/packages/ui/src/forms/buildStateFromSchema/index.tsx
+++ b/packages/ui/src/forms/buildStateFromSchema/index.tsx
@@ -39,6 +39,7 @@ export const buildStateFromSchema = async (args: Args): Promise<FormState> => {
 
     await iterateFields({
       id,
+      addErrorPathToParent: null,
       data: fullData,
       errorPaths: [],
       fields: fieldSchema,

--- a/packages/ui/src/forms/buildStateFromSchema/index.tsx
+++ b/packages/ui/src/forms/buildStateFromSchema/index.tsx
@@ -41,7 +41,6 @@ export const buildStateFromSchema = async (args: Args): Promise<FormState> => {
       id,
       addErrorPathToParent: null,
       data: fullData,
-      errorPaths: [],
       fields: fieldSchema,
       fullData,
       operation,

--- a/packages/ui/src/forms/buildStateFromSchema/iterateFields.ts
+++ b/packages/ui/src/forms/buildStateFromSchema/iterateFields.ts
@@ -13,7 +13,6 @@ type Args = {
    */
   anyParentLocalized?: boolean
   data: Data
-  errorPaths: string[]
   fields: FieldSchema[]
   filter?: (args: AddFieldStatePromiseArgs) => boolean
   /**
@@ -62,7 +61,6 @@ export const iterateFields = async ({
   addErrorPathToParent: addErrorPathToParentArg,
   anyParentLocalized = false,
   data,
-  errorPaths,
   fields,
   filter,
   forceFullValue = false,
@@ -97,7 +95,6 @@ export const iterateFields = async ({
           addErrorPathToParent: addErrorPathToParentArg,
           anyParentLocalized,
           data,
-          errorPaths,
           field,
           fieldIndex,
           filter,

--- a/packages/ui/src/forms/buildStateFromSchema/iterateFields.ts
+++ b/packages/ui/src/forms/buildStateFromSchema/iterateFields.ts
@@ -1,10 +1,4 @@
-import type {
-  Data,
-  Field as FieldSchema,
-  FormField,
-  FormState,
-  PayloadRequest,
-} from 'payload/types'
+import type { Data, Field as FieldSchema, FormState, PayloadRequest } from 'payload/types'
 
 import { fieldIsPresentationalOnly } from 'payload/types'
 
@@ -86,17 +80,6 @@ export const iterateFields = async ({
 }: Args): Promise<void> => {
   const promises = []
 
-  const addErrorPathToParent = (fieldPath: string) => (errorPath: string) => {
-    if (typeof addErrorPathToParentArg === 'function') {
-      addErrorPathToParentArg(errorPath)
-    }
-
-    if (state?.[fieldPath]?.errorPaths && !state[fieldPath].errorPaths.includes(errorPath)) {
-      state[fieldPath].errorPaths.push(errorPath)
-      state[fieldPath].valid = false
-    }
-  }
-
   fields.forEach((field, fieldIndex) => {
     if (!fieldIsPresentationalOnly(field) && !field?.admin?.disabled) {
       let passesCondition = true
@@ -108,23 +91,10 @@ export const iterateFields = async ({
         )
       }
 
-      const fieldState: FormField = {
-        errorPaths: [],
-        fieldSchema: includeSchema ? field : undefined,
-        initialValue: undefined,
-        passesCondition,
-        valid: true,
-        value: undefined,
-      }
-
-      const fieldName = 'name' in field ? field.name : ''
-      const fieldPath = path ? `${path}${fieldName || ''}` : fieldName
-      if (fieldName) state[fieldPath] = state?.[fieldPath] || fieldState
-
       promises.push(
         addFieldStatePromise({
           id,
-          addErrorPathToParent: addErrorPathToParent(fieldPath),
+          addErrorPathToParent: addErrorPathToParentArg,
           anyParentLocalized,
           data,
           errorPaths,

--- a/packages/ui/src/forms/useField/index.tsx
+++ b/packages/ui/src/forms/useField/index.tsx
@@ -105,6 +105,7 @@ export const useField = <T,>(options: Options): FieldType<T> => {
   const result: FieldType<T> = useMemo(
     () => ({
       errorMessage: field?.errorMessage,
+      errorPaths: field?.errorPaths || [],
       filterOptions,
       formProcessing: processing,
       formSubmitted: submitted,
@@ -123,6 +124,7 @@ export const useField = <T,>(options: Options): FieldType<T> => {
       field?.errorMessage,
       field?.rows,
       field?.valid,
+      field?.errorPaths,
       processing,
       setValue,
       showError,

--- a/packages/ui/src/forms/useField/types.ts
+++ b/packages/ui/src/forms/useField/types.ts
@@ -12,6 +12,7 @@ export type Options = {
 
 export type FieldType<T> = {
   errorMessage?: string
+  errorPaths?: string[]
   filterOptions?: FilterOptionsResult
   formProcessing: boolean
   formSubmitted: boolean


### PR DESCRIPTION
## Description

Adjusts how errorPaths are determined. `buildStateFromSchema` now hoists all child errorPaths up to _all_ parents up a chain. Removes reliance on WatchChildErrors where possible.

I left Collapsibles and Tabs alone because they are possibly unnamed.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.
