### PR TITLE
Fix - Bested async virtual fields

### DIFF
--- a/packages/payload/src/fields/hooks/afterRead/index.ts
+++ b/packages/payload/src/fields/hooks/afterRead/index.ts
@@ -70,8 +70,12 @@ export async function afterRead<T = any>(args: Args): Promise<T> {
     siblingDoc: doc,
   })
 
-  await Promise.all(fieldPromises)
-  await Promise.all(populationPromises)
+  while (fieldPromises.length > 0 || populationPromises.length > 0) {
+    const allPromises = [...fieldPromises, ...populationPromises]
+    fieldPromises.splice(0)
+    populationPromises.splice(0)
+    await Promise.all(allPromises)
+  }
 
   return doc
 }

--- a/test/hooks/collections/NestedAfterReadHooks/index.ts
+++ b/test/hooks/collections/NestedAfterReadHooks/index.ts
@@ -1,3 +1,4 @@
+import wait from '../../../../packages/payload/src/utilities/wait'
 import type { CollectionConfig } from '../../../../packages/payload/src/collections/config/types'
 
 import { relationsSlug } from '../Relations'
@@ -62,6 +63,40 @@ const NestedAfterReadHooks: CollectionConfig = {
               name: 'shouldPopulate',
               type: 'relationship',
               relationTo: relationsSlug,
+            },
+            {
+              name: 'blocks',
+              type: 'blocks',
+              defaultValue: [{ blockType: 'blockWithVirtualRelationField' }],
+              blocks: [
+                {
+                  slug: 'blockWithVirtualRelationField',
+                  fields: [
+                    {
+                      name: 'shouldPopulateVirtual',
+                      type: 'relationship',
+                      relationTo: relationsSlug,
+                      hasMany: true,
+                      hooks: {
+                        beforeChange: [
+                          ({ siblingData }) => {
+                            delete siblingData.shouldPopulateVirtual
+                          },
+                        ],
+                        afterRead: [
+                          async ({ req }) => {
+                            await wait(200)
+                            const { docs } = await req.payload.find({
+                              collection: relationsSlug,
+                            })
+                            return docs
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
             },
           ],
         },

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -131,6 +131,31 @@ describe('Hooks', () => {
       expect(document.group.array[0].afterRead).toEqual(generatedAfterReadText)
     })
 
+    it('should retrieve data generated with afterRead hook from async virtual field in nested field structures', async () => {
+      const relation = await payload.create({
+        collection: relationsSlug,
+        data: {
+          title: 'Hello',
+        },
+      })
+
+      const document: NestedAfterReadHook = await payload.create({
+        collection: nestedAfterReadHooksSlug,
+        data: {
+          group: { array: [{ input: 'input' }] },
+          text: 'ok',
+        },
+      })
+
+      const retrievedDoc = await payload.findByID({
+        id: document.id,
+        collection: nestedAfterReadHooksSlug,
+        depth: 1,
+      })
+
+      expect(retrievedDoc.group.subGroup.blocks[0].shouldPopulateVirtual[0]).toEqual(relation)
+    })
+
     it('should populate related docs within nested field structures', async () => {
       const relation = await payload.create({
         collection: relationsSlug,


### PR DESCRIPTION
## Description

Related issue: https://github.com/payloadcms/payload/issues/5505

Because of how async traversal is done, nested virtual async fields push their promises too late, which results in these promises being ignored.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
