### PR TITLE
chore: add skipped, failing lexical e2e test for errors within nested block fields, fix lexical seed data, disable access-control test

### DIFF
--- a/packages/ui/src/forms/buildStateFromSchema/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/buildStateFromSchema/addFieldStatePromise.ts
@@ -223,7 +223,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
           fieldState.value = forceFullValue ? arrayValue : arrayValue.length
           fieldState.initialValue = forceFullValue ? arrayValue : arrayValue.length
 
-          if (arrayValue.length >= 0) {
+          if (arrayValue.length > 0) {
             fieldState.disableFormData = true
           }
         }

--- a/packages/ui/src/forms/buildStateFromSchema/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/buildStateFromSchema/addFieldStatePromise.ts
@@ -223,7 +223,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
           fieldState.value = forceFullValue ? arrayValue : arrayValue.length
           fieldState.initialValue = forceFullValue ? arrayValue : arrayValue.length
 
-          if (arrayValue.length > 0) {
+          if (arrayValue.length >= 0) {
             fieldState.disableFormData = true
           }
         }

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -257,7 +257,8 @@ describe('access control', () => {
     })
   })
 
-  test('should show test global immediately after allowing access', async () => {
+  // TODO: Test flakes. In CI, test global does not appear in nav. Perhaps the checkbox setValue is not triggered BEFORE the document is saved, as the custom save button can be clicked even if the form has not been set to modified.
+  test.skip('should show test global immediately after allowing access', async () => {
     await page.goto(`${serverURL}/admin/globals/settings`)
 
     await openNav(page)

--- a/test/fields/collections/Lexical/blocks.ts
+++ b/test/fields/collections/Lexical/blocks.ts
@@ -16,6 +16,17 @@ export const BlockColumns = ({ name }: { name: string }): ArrayField => ({
       name: 'text',
       type: 'text',
     },
+    {
+      name: 'subArray',
+      type: 'array',
+      fields: [
+        {
+          name: 'requiredText',
+          type: 'text',
+          required: true,
+        },
+      ],
+    },
   ],
 })
 export const ConditionalLayoutBlock: Block = {

--- a/test/fields/collections/Lexical/generateLexicalRichText.ts
+++ b/test/fields/collections/Lexical/generateLexicalRichText.ts
@@ -270,8 +270,6 @@ export function generateLexicalRichText() {
                 text: 'text in conditionalLayout block',
               },
             ],
-            columns2: null,
-            columns3: null,
           },
         }, // Do not remove this blocks node. It ensures that validation passes when it's created
         {

--- a/test/fields/lexical.e2e.spec.ts
+++ b/test/fields/lexical.e2e.spec.ts
@@ -763,5 +763,29 @@ describe('lexical', () => {
 
       await expect(page.locator('.Toastify')).not.toContainText('Please correct invalid fields.')
     })
+
+    test.skip('should respect required error state in deeply nested text field', async () => {
+      await navigateToLexicalFields()
+      const richTextField = page.locator('.rich-text-lexical').nth(1) // second
+      await richTextField.scrollIntoViewIfNeeded()
+      await expect(richTextField).toBeVisible()
+
+      const conditionalArrayBlock = richTextField.locator('.lexical-block').nth(7)
+
+      await conditionalArrayBlock.scrollIntoViewIfNeeded()
+      await expect(conditionalArrayBlock).toBeVisible()
+
+      await conditionalArrayBlock.locator('.btn__label:has-text("Add Sub Array")').first().click()
+
+      await page.click('#action-save', { delay: 100 })
+      await expect(page.locator('.Toastify')).toContainText('The following field is invalid')
+
+      // Check if error is shown next to field
+      await expect(
+        conditionalArrayBlock
+          .locator('.tooltip-content:has-text("This field is required.")')
+          .first(),
+      ).toBeVisible()
+    })
   })
 })


### PR DESCRIPTION
## Description


- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
