### PR TITLE
fix(test): reverts to original selector in array bulk update test to pass test

### DIFF
--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -916,7 +916,7 @@ describe('fields', () => {
       await addRowButton.click()
       await wait(200)
 
-      const targetInput = page.locator('#field-items__2__text')
+      const targetInput = page.locator('#field-items__0__text')
 
       await expect(targetInput).toBeVisible()
 


### PR DESCRIPTION
## Description

Reverts selector in array bulk update to original selector to pass test. It was previously updated due to unfinished / broken labels but this has since been rectified. 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
