### PR TITLE
fix(ui): adds support for direct field label props

### DIFF
--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -210,7 +210,12 @@ export const _ArrayField: React.FC<ArrayFieldProps> = (props) => {
         <div className={`${baseClass}__header-wrap`}>
           <div className={`${baseClass}__header-content`}>
             <h3 className={`${baseClass}__title`}>
-              <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+              <FieldLabel
+                CustomLabel={CustomLabel}
+                label={label}
+                required={required}
+                {...(labelProps || {})}
+              />
             </h3>
             {fieldHasErrors && fieldErrorCount > 0 && (
               <ErrorPill count={fieldErrorCount} i18n={i18n} withMessage />

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -58,6 +58,7 @@ export const _ArrayField: React.FC<ArrayFieldProps> = (props) => {
     errorProps,
     fieldMap,
     forceRender = false,
+    label,
     labelProps,
     localized,
     maxRows,
@@ -202,14 +203,14 @@ export const _ArrayField: React.FC<ArrayFieldProps> = (props) => {
     >
       {showError && (
         <div className={`${baseClass}__error-wrap`}>
-          <FieldError CustomError={CustomError} {...(errorProps || {})} />
+          <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
         </div>
       )}
       <header className={`${baseClass}__header`}>
         <div className={`${baseClass}__header-wrap`}>
           <div className={`${baseClass}__header-content`}>
             <h3 className={`${baseClass}__title`}>
-              <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+              <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
             </h3>
             {fieldHasErrors && fieldErrorCount > 0 && (
               <ErrorPill count={fieldErrorCount} i18n={i18n} withMessage />

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -220,7 +220,12 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
         <div className={`${baseClass}__header-wrap`}>
           <div className={`${baseClass}__heading-with-error`}>
             <h3>
-              <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+              <FieldLabel
+                CustomLabel={CustomLabel}
+                label={label}
+                required={required}
+                {...(labelProps || {})}
+              />
             </h3>
             {fieldHasErrors && fieldErrorCount > 0 && (
               <ErrorPill count={fieldErrorCount} i18n={i18n} withMessage />

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -62,6 +62,7 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
     descriptionProps,
     errorProps,
     forceRender = false,
+    label,
     labelProps,
     labels: labelsFromProps,
     localized,
@@ -212,14 +213,14 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
     >
       {showError && (
         <div className={`${baseClass}__error-wrap`}>
-          <FieldError CustomError={CustomError} {...(errorProps || {})} />
+          <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
         </div>
       )}
       <header className={`${baseClass}__header`}>
         <div className={`${baseClass}__header-wrap`}>
           <div className={`${baseClass}__heading-with-error`}>
             <h3>
-              <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+              <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
             </h3>
             {fieldHasErrors && fieldErrorCount > 0 && (
               <ErrorPill count={fieldErrorCount} i18n={i18n} withMessage />

--- a/packages/ui/src/fields/Checkbox/Input.tsx
+++ b/packages/ui/src/fields/Checkbox/Input.tsx
@@ -76,7 +76,12 @@ export const CheckboxInput: React.FC<Props> = ({
         </span>
         {AfterInput}
       </div>
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
     </div>
   )
 }

--- a/packages/ui/src/fields/Checkbox/Input.tsx
+++ b/packages/ui/src/fields/Checkbox/Input.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { LabelProps } from 'payload/types'
+import type { FieldBase, LabelProps } from 'payload/types'
 
 import { FieldLabel } from '@payloadcms/ui/forms/FieldLabel'
 import React from 'react'
@@ -15,6 +15,7 @@ type Props = {
   className?: string
   id?: string
   inputRef?: React.RefObject<HTMLInputElement>
+  label?: FieldBase['label']
   labelProps?: LabelProps
   name?: string
   onToggle: (event: React.ChangeEvent<HTMLInputElement>) => void
@@ -34,6 +35,7 @@ export const CheckboxInput: React.FC<Props> = ({
   checked,
   className,
   inputRef,
+  label,
   labelProps,
   onToggle,
   partialChecked,
@@ -74,7 +76,7 @@ export const CheckboxInput: React.FC<Props> = ({
         </span>
         {AfterInput}
       </div>
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
     </div>
   )
 }

--- a/packages/ui/src/fields/Checkbox/index.tsx
+++ b/packages/ui/src/fields/Checkbox/index.tsx
@@ -34,6 +34,7 @@ const CheckboxField: React.FC<CheckboxFieldProps> = (props) => {
     descriptionProps,
     disableFormData,
     errorProps,
+    label,
     labelProps,
     onChange: onChangeFromProps,
     partialChecked,
@@ -93,7 +94,7 @@ const CheckboxField: React.FC<CheckboxFieldProps> = (props) => {
       }}
     >
       <div className={`${baseClass}__error-wrap`}>
-        <FieldError CustomError={CustomError} {...(errorProps || {})} />
+        <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
       </div>
       <CheckboxInput
         AfterInput={AfterInput}
@@ -102,6 +103,7 @@ const CheckboxField: React.FC<CheckboxFieldProps> = (props) => {
         checked={checked}
         id={fieldID}
         inputRef={null}
+        label={label}
         labelProps={labelProps}
         name={path}
         onToggle={onToggle}

--- a/packages/ui/src/fields/Code/index.tsx
+++ b/packages/ui/src/fields/Code/index.tsx
@@ -44,6 +44,7 @@ const CodeField: React.FC<CodeFieldProps> = (props) => {
     descriptionProps,
     editorOptions = {},
     errorProps,
+    label,
     labelProps,
     language = 'javascript',
     path: pathFromProps,
@@ -65,7 +66,7 @@ const CodeField: React.FC<CodeFieldProps> = (props) => {
 
   const { path: pathFromContext } = useFieldProps()
 
-  const { setValue, showError, value } = useField({
+  const { path, setValue, showError, value } = useField({
     path: pathFromContext || pathFromProps || name,
     validate: memoizedValidate,
   })
@@ -86,8 +87,8 @@ const CodeField: React.FC<CodeFieldProps> = (props) => {
         width,
       }}
     >
-      <FieldError CustomError={CustomError} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+      <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
       <div>
         {BeforeInput}
         <CodeEditor

--- a/packages/ui/src/fields/Code/index.tsx
+++ b/packages/ui/src/fields/Code/index.tsx
@@ -88,7 +88,12 @@ const CodeField: React.FC<CodeFieldProps> = (props) => {
       }}
     >
       <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       <div>
         {BeforeInput}
         <CodeEditor

--- a/packages/ui/src/fields/DateTime/index.tsx
+++ b/packages/ui/src/fields/DateTime/index.tsx
@@ -90,9 +90,9 @@ const DateTimeField: React.FC<DateFieldProps> = (props) => {
       }}
     >
       <div className={`${baseClass}__error-wrap`}>
-        <FieldError CustomError={CustomError} {...(errorProps || {})} />
+        <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
       </div>
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
       <div className={`${baseClass}__input-wrapper`} id={`field-${path.replace(/\./g, '__')}`}>
         {BeforeInput}
         <DatePickerField

--- a/packages/ui/src/fields/DateTime/index.tsx
+++ b/packages/ui/src/fields/DateTime/index.tsx
@@ -93,7 +93,12 @@ const DateTimeField: React.FC<DateFieldProps> = (props) => {
       <div className={`${baseClass}__error-wrap`}>
         <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
       </div>
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       <div className={`${baseClass}__input-wrapper`} id={`field-${path.replace(/\./g, '__')}`}>
         {BeforeInput}
         <DatePickerField

--- a/packages/ui/src/fields/DateTime/index.tsx
+++ b/packages/ui/src/fields/DateTime/index.tsx
@@ -45,6 +45,7 @@ const DateTimeField: React.FC<DateFieldProps> = (props) => {
     date: datePickerProps,
     descriptionProps,
     errorProps,
+    label,
     labelProps,
     path: pathFromProps,
     placeholder,

--- a/packages/ui/src/fields/Email/index.tsx
+++ b/packages/ui/src/fields/Email/index.tsx
@@ -78,7 +78,12 @@ const EmailField: React.FC<EmailFieldProps> = (props) => {
       }}
     >
       <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       <div>
         {BeforeInput}
         <input

--- a/packages/ui/src/fields/Email/index.tsx
+++ b/packages/ui/src/fields/Email/index.tsx
@@ -38,6 +38,7 @@ const EmailField: React.FC<EmailFieldProps> = (props) => {
     className,
     descriptionProps,
     errorProps,
+    label,
     labelProps,
     path: pathFromProps,
     placeholder,
@@ -76,8 +77,8 @@ const EmailField: React.FC<EmailFieldProps> = (props) => {
         width,
       }}
     >
-      <FieldError CustomError={CustomError} {...(errorProps || { path })} />
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || { path })} />
+      <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
       <div>
         {BeforeInput}
         <input

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -110,7 +110,12 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
       }}
     >
       <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       <div>
         {BeforeInput}
         <CodeEditor

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -40,6 +40,7 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
     descriptionProps,
     editorOptions,
     errorProps,
+    label,
     labelProps,
     path: pathFromProps,
     readOnly,
@@ -63,13 +64,7 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
 
   const { path: pathFromContext } = useFieldProps()
 
-  const {
-    initialValue,
-    // path,
-    setValue,
-    showError,
-    value,
-  } = useField<string>({
+  const { initialValue, path, setValue, showError, value } = useField<string>({
     path: pathFromContext || pathFromProps || name,
     validate: memoizedValidate,
   })
@@ -114,8 +109,8 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
         width,
       }}
     >
-      <FieldError CustomError={CustomError} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+      <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
       <div>
         {BeforeInput}
         <CodeEditor

--- a/packages/ui/src/fields/Number/index.tsx
+++ b/packages/ui/src/fields/Number/index.tsx
@@ -46,6 +46,7 @@ const NumberFieldComponent: React.FC<NumberFieldProps> = (props) => {
     descriptionProps,
     errorProps,
     hasMany = false,
+    label,
     labelProps,
     max = Infinity,
     maxRows = Infinity,
@@ -154,8 +155,8 @@ const NumberFieldComponent: React.FC<NumberFieldProps> = (props) => {
         width,
       }}
     >
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
-      <FieldError CustomError={CustomError} {...(errorProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
       {hasMany ? (
         <ReactSelect
           className={`field-${path.replace(/\./g, '__')}`}

--- a/packages/ui/src/fields/Number/index.tsx
+++ b/packages/ui/src/fields/Number/index.tsx
@@ -155,7 +155,12 @@ const NumberFieldComponent: React.FC<NumberFieldProps> = (props) => {
         width,
       }}
     >
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
       {hasMany ? (
         <ReactSelect

--- a/packages/ui/src/fields/Password/index.tsx
+++ b/packages/ui/src/fields/Password/index.tsx
@@ -35,6 +35,7 @@ const PasswordField: React.FC<PasswordFieldProps> = (props) => {
     className,
     disabled,
     errorProps,
+    label,
     labelProps,
     path: pathFromProps,
     required,
@@ -67,8 +68,8 @@ const PasswordField: React.FC<PasswordFieldProps> = (props) => {
         width,
       }}
     >
-      <FieldError CustomError={CustomError} {...(errorProps || { path })} />
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || { path })} />
+      <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
       <input
         autoComplete={autoComplete}
         disabled={formProcessing || disabled}

--- a/packages/ui/src/fields/Password/index.tsx
+++ b/packages/ui/src/fields/Password/index.tsx
@@ -69,7 +69,12 @@ const PasswordField: React.FC<PasswordFieldProps> = (props) => {
       }}
     >
       <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       <input
         autoComplete={autoComplete}
         disabled={formProcessing || disabled}

--- a/packages/ui/src/fields/Point/index.tsx
+++ b/packages/ui/src/fields/Point/index.tsx
@@ -112,7 +112,7 @@ const PointField: React.FC<PointFieldProps> = (props) => {
         width,
       }}
     >
-      <FieldError CustomError={CustomError} {...(errorProps || {})} />
+      <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
       <ul className={`${baseClass}__wrap`}>
         <li>
           {CustomLabel !== undefined ? (

--- a/packages/ui/src/fields/RadioGroup/index.tsx
+++ b/packages/ui/src/fields/RadioGroup/index.tsx
@@ -44,6 +44,7 @@ const RadioGroupField: React.FC<RadioFieldProps> = (props) => {
     className,
     descriptionProps,
     errorProps,
+    label,
     labelProps,
     layout = 'horizontal',
     onChange: onChangeFromProps,
@@ -99,9 +100,9 @@ const RadioGroupField: React.FC<RadioFieldProps> = (props) => {
       }}
     >
       <div className={`${baseClass}__error-wrap`}>
-        <FieldError CustomError={CustomError} {...(errorProps || {})} />
+        <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
       </div>
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
       <ul className={`${baseClass}--group`} id={`field-${path.replace(/\./g, '__')}`}>
         {options.map((option) => {
           let optionValue = ''

--- a/packages/ui/src/fields/RadioGroup/index.tsx
+++ b/packages/ui/src/fields/RadioGroup/index.tsx
@@ -102,7 +102,12 @@ const RadioGroupField: React.FC<RadioFieldProps> = (props) => {
       <div className={`${baseClass}__error-wrap`}>
         <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
       </div>
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       <ul className={`${baseClass}--group`} id={`field-${path.replace(/\./g, '__')}`}>
         {options.map((option) => {
           let optionValue = ''

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -49,6 +49,7 @@ const RelationshipField: React.FC<RelationshipFieldProps> = (props) => {
     errorProps,
     hasMany,
     isSortable = true,
+    label,
     labelProps,
     path: pathFromProps,
     readOnly,
@@ -442,8 +443,8 @@ const RelationshipField: React.FC<RelationshipFieldProps> = (props) => {
         width,
       }}
     >
-      <FieldError CustomError={CustomError} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+      <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
       {!errorLoading && (
         <div className={`${baseClass}__wrap`}>
           <ReactSelect

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -444,7 +444,12 @@ const RelationshipField: React.FC<RelationshipFieldProps> = (props) => {
       }}
     >
       <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       {!errorLoading && (
         <div className={`${baseClass}__wrap`}>
           <ReactSelect

--- a/packages/ui/src/fields/Select/index.tsx
+++ b/packages/ui/src/fields/Select/index.tsx
@@ -57,6 +57,7 @@ const SelectField: React.FC<SelectFieldProps> = (props) => {
     hasMany = false,
     isClearable = true,
     isSortable = true,
+    label,
     labelProps,
     onChange: onChangeFromProps,
     options: optionsFromProps = [],
@@ -148,8 +149,8 @@ const SelectField: React.FC<SelectFieldProps> = (props) => {
         width,
       }}
     >
-      <FieldError CustomError={CustomError} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+      <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
       <div>
         {BeforeInput}
         <ReactSelect

--- a/packages/ui/src/fields/Select/index.tsx
+++ b/packages/ui/src/fields/Select/index.tsx
@@ -150,7 +150,12 @@ const SelectField: React.FC<SelectFieldProps> = (props) => {
       }}
     >
       <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       <div>
         {BeforeInput}
         <ReactSelect

--- a/packages/ui/src/fields/Text/Input.tsx
+++ b/packages/ui/src/fields/Text/Input.tsx
@@ -24,6 +24,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     errorProps,
     hasMany,
     inputRef,
+    label,
     labelProps,
     maxRows,
     onChange,
@@ -58,8 +59,8 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
         width,
       }}
     >
-      <FieldError CustomError={CustomError} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+      <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
       {hasMany ? (
         <ReactSelect
           className={`field-${path.replace(/\./g, '__')}`}

--- a/packages/ui/src/fields/Text/Input.tsx
+++ b/packages/ui/src/fields/Text/Input.tsx
@@ -32,6 +32,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     path,
     placeholder,
     readOnly,
+    required,
     rtl,
     showError,
     style,
@@ -60,7 +61,12 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
       }}
     >
       <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       {hasMany ? (
         <ReactSelect
           className={`field-${path.replace(/\./g, '__')}`}

--- a/packages/ui/src/fields/Textarea/Input.tsx
+++ b/packages/ui/src/fields/Textarea/Input.tsx
@@ -27,6 +27,7 @@ export const TextareaInput: React.FC<TextAreaInputProps> = (props) => {
     path,
     placeholder,
     readOnly,
+    required,
     rows,
     rtl,
     showError,
@@ -54,7 +55,12 @@ export const TextareaInput: React.FC<TextAreaInputProps> = (props) => {
       }}
     >
       <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+      <FieldLabel
+        CustomLabel={CustomLabel}
+        label={label}
+        required={required}
+        {...(labelProps || {})}
+      />
       {BeforeInput}
       <label className="textarea-outer" htmlFor={`field-${path.replace(/\./g, '__')}`}>
         <div className="textarea-inner">

--- a/packages/ui/src/fields/Textarea/Input.tsx
+++ b/packages/ui/src/fields/Textarea/Input.tsx
@@ -21,6 +21,7 @@ export const TextareaInput: React.FC<TextAreaInputProps> = (props) => {
     className,
     descriptionProps,
     errorProps,
+    label,
     labelProps,
     onChange,
     path,
@@ -52,8 +53,8 @@ export const TextareaInput: React.FC<TextAreaInputProps> = (props) => {
         width,
       }}
     >
-      <FieldError CustomError={CustomError} {...(errorProps || {})} />
-      <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+      <FieldError CustomError={CustomError} path={path} {...(errorProps || {})} />
+      <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
       {BeforeInput}
       <label className="textarea-outer" htmlFor={`field-${path.replace(/\./g, '__')}`}>
         <div className="textarea-inner">

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -44,6 +44,7 @@ export const UploadInput: React.FC<UploadInputProps> = (props) => {
     descriptionProps,
     errorProps,
     filterOptions,
+    label,
     labelProps,
     onChange,
     readOnly,
@@ -132,7 +133,7 @@ export const UploadInput: React.FC<UploadInputProps> = (props) => {
         }}
       >
         <FieldError CustomError={CustomError} {...(errorProps || {})} />
-        <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
+        <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
         {collection?.upload && (
           <React.Fragment>
             {file && !missingFile && (

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -49,6 +49,7 @@ export const UploadInput: React.FC<UploadInputProps> = (props) => {
     onChange,
     readOnly,
     relationTo,
+    required,
     serverURL,
     showError,
     style,
@@ -133,7 +134,12 @@ export const UploadInput: React.FC<UploadInputProps> = (props) => {
         }}
       >
         <FieldError CustomError={CustomError} {...(errorProps || {})} />
-        <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
+        <FieldLabel
+          CustomLabel={CustomLabel}
+          label={label}
+          required={required}
+          {...(labelProps || {})}
+        />
         {collection?.upload && (
           <React.Fragment>
             {file && !missingFile && (

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -168,13 +168,7 @@ export function buildConfigWithDefaults(testConfig?: Partial<Config>): Promise<S
   }
 
   config.admin = {
-    autoLogin:
-      process.env.PAYLOAD_PUBLIC_DISABLE_AUTO_LOGIN === 'true'
-        ? false
-        : {
-            email: 'dev@payloadcms.com',
-            password: 'test',
-          },
+    autoLogin: process.env.PAYLOAD_PUBLIC_DISABLE_AUTO_LOGIN === 'true' ? false : false,
     ...(config.admin || {}),
   }
 

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -168,7 +168,13 @@ export function buildConfigWithDefaults(testConfig?: Partial<Config>): Promise<S
   }
 
   config.admin = {
-    autoLogin: process.env.PAYLOAD_PUBLIC_DISABLE_AUTO_LOGIN === 'true' ? false : false,
+    autoLogin:
+      process.env.PAYLOAD_PUBLIC_DISABLE_AUTO_LOGIN === 'true'
+        ? false
+        : {
+            email: 'dev@payloadcms.com',
+            password: 'test',
+          },
     ...(config.admin || {}),
   }
 


### PR DESCRIPTION
## Description

Supports direct field label props, i.e. `label`, `required`, etc. Fields that are rendered outside of `RenderFields`, i.e. login form, account auth, etc., need to be able to pass these as props to `FieldLabel` directly.  This is because there is no field props context in cases like these.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.