### PR TITLE
chore: obliterate next cache before starting e2e/int/dev

### DIFF
--- a/test/testHooks.js
+++ b/test/testHooks.js
@@ -10,26 +10,23 @@ const dirname = path.dirname(filename)
 export const createTestHooks = async (testSuiteName = '_community') => {
   const tsConfigPath = path.resolve(dirname, '../tsconfig.json')
   const tsConfig = await json5.parse(await readFile(tsConfigPath, 'utf8'))
-  const originalPayloadConfigTsValue =
-    tsConfig.compilerOptions.paths['@payload-config'] ?? './_community/config.ts'
 
   return {
     /**
      * Clear next webpack cache and set '@payload-config' path in tsconfig.json
      */
     beforeTest: async () => {
-      // Delete next webpack cache
-      const nextWebpackCache = path.resolve(dirname, '../.next/cache/webpack')
-      if (existsSync(nextWebpackCache)) {
-        await rm(nextWebpackCache, { recursive: true })
+      // Delete entire .next cache folder
+      const nextCache = path.resolve(dirname, '../.next')
+      if (existsSync(nextCache)) {
+        await rm(nextCache, { recursive: true })
       }
 
       // Set '@payload-config' in tsconfig.json
       tsConfig.compilerOptions.paths['@payload-config'] = [`./test/${testSuiteName}/config.ts`]
       await writeFile(tsConfigPath, JSON.stringify(tsConfig, null, 2))
 
-      const PAYLOAD_CONFIG_PATH = path.resolve(testSuiteName, 'config')
-      process.env.PAYLOAD_CONFIG_PATH = PAYLOAD_CONFIG_PATH
+      process.env.PAYLOAD_CONFIG_PATH = path.resolve(testSuiteName, 'config')
     },
     /**
      * Reset the changes made to tsconfig.json


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
