### PR TITLE
fix(richtext-lexical): Blocks: do not include empty arrays in form state

### DIFF
--- a/packages/richtext-lexical/src/field/features/blocks/component/FormSavePlugin.tsx
+++ b/packages/richtext-lexical/src/field/features/blocks/component/FormSavePlugin.tsx
@@ -6,6 +6,8 @@ import { useAllFormFields } from '@payloadcms/ui/forms/Form'
 import { reduceFieldsToValues } from '@payloadcms/ui/utilities/reduceFieldsToValues'
 import { useEffect } from 'react'
 
+import { removeEmptyArrayValues } from './removeEmptyArrayValues.js'
+
 type Props = {
   onChange?: ({
     fullFieldsWithValues,
@@ -19,7 +21,9 @@ type Props = {
 export const FormSavePlugin: React.FC<Props> = (props) => {
   const { onChange } = props
 
-  const [fields, dispatchFields] = useAllFormFields()
+  const [_fields] = useAllFormFields()
+
+  const fields = removeEmptyArrayValues({ fields: _fields })
 
   // Pass in fields, and indicate if you'd like to "unflatten" field data.
   // The result below will reflect the data stored in the form at the given time

--- a/packages/richtext-lexical/src/field/features/blocks/component/index.tsx
+++ b/packages/richtext-lexical/src/field/features/blocks/component/index.tsx
@@ -24,6 +24,7 @@ import type { BlocksFeatureClientProps } from '../feature.client.js'
 import { useEditorConfigContext } from '../../../lexical/config/client/EditorConfigProvider.js'
 import { BlockContent } from './BlockContent.js'
 import './index.scss'
+import { removeEmptyArrayValues } from './removeEmptyArrayValues.js'
 
 type Props = {
   blockFieldWrapperName: string
@@ -75,7 +76,7 @@ export const BlockComponent: React.FC<Props> = (props) => {
 
       if (state) {
         setInitialState({
-          ...state,
+          ...removeEmptyArrayValues({ fields: state }),
           blockName: {
             initialValue: '',
             passesCondition: true,

--- a/packages/richtext-lexical/src/field/features/blocks/component/removeEmptyArrayValues.ts
+++ b/packages/richtext-lexical/src/field/features/blocks/component/removeEmptyArrayValues.ts
@@ -1,0 +1,17 @@
+import type { FormState } from 'payload/types'
+
+/**
+ * By default, if an array field is empty, it will be included in the form state with a value of 0.
+ * We do not need this behavior here, By setting `disableFormData` to true, we can prevent the field from being included in the form state
+ * like that.
+ * @param fields form state
+ */
+export function removeEmptyArrayValues({ fields }: { fields: FormState }): FormState {
+  for (const key in fields) {
+    const field = fields[key]
+    if (Array.isArray(field.rows) && 'value' in field) {
+      field.disableFormData = true
+    }
+  }
+  return fields
+}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
