### PR TITLE
fix: missing translation key for richtext fields

### DIFF
--- a/packages/translations/src/_generatedFiles_/client/ar.js
+++ b/packages/translations/src/_generatedFiles_/client/ar.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} و {{count}} أخرى',
     labelRelationship: '{{label}} علاقة',
     latitude: 'خطّ العرض',
+    linkedTo: 'تمّ الرّبط ل <0>{{label}}</0>',
     longitude: 'خطّ الطّول',
     passwordsDoNotMatch: 'كلمة المرور غير مطابقة.',
     removeRelationship: 'حذف العلاقة',

--- a/packages/translations/src/_generatedFiles_/client/az.js
+++ b/packages/translations/src/_generatedFiles_/client/az.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} və daha {{count}} nəfər',
     labelRelationship: '{{label}} Relationship',
     latitude: 'Enlik',
+    linkedTo: '<0>{{label}}</0> ilə əlaqəli',
     longitude: 'Uzunluq',
     passwordsDoNotMatch: 'Şifrələr uyğun gəlmir.',
     removeRelationship: 'Relationship sil',

--- a/packages/translations/src/_generatedFiles_/client/bg.js
+++ b/packages/translations/src/_generatedFiles_/client/bg.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} и {{count}} повече',
     labelRelationship: '{{label}} връзка',
     latitude: 'Географска ширина',
+    linkedTo: 'Свързано с <0>{{label}}</0>',
     longitude: 'Географска дължина',
     passwordsDoNotMatch: 'Паролите не са еднакви.',
     removeRelationship: 'Премахни отношение',

--- a/packages/translations/src/_generatedFiles_/client/cs.js
+++ b/packages/translations/src/_generatedFiles_/client/cs.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} a {{count}} dalších',
     labelRelationship: 'Vztah {{label}}',
     latitude: 'Zeměpisná šířka',
+    linkedTo: 'Odkaz na <0>{{label}}</0>',
     longitude: 'Zeměpisná délka',
     passwordsDoNotMatch: 'Hesla se neshodují.',
     removeRelationship: 'Odstranit vztah',

--- a/packages/translations/src/_generatedFiles_/client/de.js
+++ b/packages/translations/src/_generatedFiles_/client/de.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} und {{count}} mehr',
     labelRelationship: '{{label}} Verknüpfung',
     latitude: 'Breitengrad',
+    linkedTo: 'Verweist auf <0>{{label}}</0>',
     longitude: 'Längengrad',
     passwordsDoNotMatch: 'Passwörter stimmen nicht überein.',
     removeRelationship: 'Beziehung Entfernen',

--- a/packages/translations/src/_generatedFiles_/client/en.js
+++ b/packages/translations/src/_generatedFiles_/client/en.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} and {{count}} more',
     labelRelationship: '{{label}} Relationship',
     latitude: 'Latitude',
+    linkedTo: 'Linked to <0>{{label}}</0>',
     longitude: 'Longitude',
     passwordsDoNotMatch: 'Passwords do not match.',
     removeRelationship: 'Remove Relationship',

--- a/packages/translations/src/_generatedFiles_/client/es.js
+++ b/packages/translations/src/_generatedFiles_/client/es.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} y {{count}} más',
     labelRelationship: 'Relación de {{label}}',
     latitude: 'Latitud',
+    linkedTo: 'Enlazado a <0>{{label}}</0>',
     longitude: 'Longitud',
     passwordsDoNotMatch: 'Las contraseñas no coinciden.',
     removeRelationship: 'Eliminar relación',

--- a/packages/translations/src/_generatedFiles_/client/fa.js
+++ b/packages/translations/src/_generatedFiles_/client/fa.js
@@ -72,6 +72,7 @@ export default {
     itemsAndMore: '{{items}} و {{count}} بیش‌تر',
     labelRelationship: '{{label}} پیوستگی',
     latitude: 'عرض جغرافیایی',
+    linkedTo: 'مرتبط با <0>{{label}}</0>',
     longitude: 'طول جغرافیایی',
     passwordsDoNotMatch: 'گذرواژه‌های وارد شده مطابقت ندارند.',
     removeRelationship: 'حذف پیوستگی',

--- a/packages/translations/src/_generatedFiles_/client/fr.js
+++ b/packages/translations/src/_generatedFiles_/client/fr.js
@@ -74,6 +74,7 @@ export default {
     itemsAndMore: '{{items}} et {{count}} de plus',
     labelRelationship: 'Relation de ou du {{label}} ',
     latitude: 'Latitude',
+    linkedTo: 'Lié à <0>{{label}}</0>',
     longitude: 'Longitude',
     passwordsDoNotMatch: 'Les mots de passe ne correspondent pas.',
     removeRelationship: 'Supprimer la relation',

--- a/packages/translations/src/_generatedFiles_/client/hr.js
+++ b/packages/translations/src/_generatedFiles_/client/hr.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} i {{count}} više',
     labelRelationship: '{{label}} veza',
     latitude: 'Zemljopisna širina',
+    linkedTo: 'Povezabi sa <0>{{label}}</0>',
     longitude: 'Zemljopisna dužina',
     passwordsDoNotMatch: 'Lozinke nisu iste.',
     removeRelationship: 'Ukloni vezu',

--- a/packages/translations/src/_generatedFiles_/client/hu.js
+++ b/packages/translations/src/_generatedFiles_/client/hu.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} és további {{count}}',
     labelRelationship: '{{label}} Kapcsolat',
     latitude: 'Szélesség',
+    linkedTo: 'Kapcsolódik a <0>{{label}}</0>',
     longitude: 'Hosszúság',
     passwordsDoNotMatch: 'A jelszavak nem egyeznek.',
     removeRelationship: 'Kapcsolat eltávolítása',

--- a/packages/translations/src/_generatedFiles_/client/it.js
+++ b/packages/translations/src/_generatedFiles_/client/it.js
@@ -75,6 +75,7 @@ export default {
     itemsAndMore: '{{items}} e altri {{count}}',
     labelRelationship: 'Relazione {{label}}',
     latitude: 'Latitudine',
+    linkedTo: 'Collegato a <0>{{label}}</0>',
     longitude: 'Longitudine',
     passwordsDoNotMatch: 'Le password non corrispondono.',
     removeRelationship: 'Rimuovi Relazione',

--- a/packages/translations/src/_generatedFiles_/client/ja.js
+++ b/packages/translations/src/_generatedFiles_/client/ja.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} 他{{count}}件',
     labelRelationship: '{{label}} リレーションシップ',
     latitude: '緯度',
+    linkedTo: '<0>{{label}}</0> にリンク',
     longitude: '経度',
     passwordsDoNotMatch: 'パスワードが一致しません',
     removeRelationship: '関係を削除',

--- a/packages/translations/src/_generatedFiles_/client/ko.js
+++ b/packages/translations/src/_generatedFiles_/client/ko.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} 및 {{count}}개 더',
     labelRelationship: '{{label}} 관계',
     latitude: '위도',
+    linkedTo: '<0>{{label}}</0>에 연결됨',
     longitude: '경도',
     passwordsDoNotMatch: '비밀번호가 일치하지 않습니다.',
     removeRelationship: '관계 제거',

--- a/packages/translations/src/_generatedFiles_/client/my.js
+++ b/packages/translations/src/_generatedFiles_/client/my.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} နှင့် နောက်ထပ် {{count}} ခု',
     labelRelationship: '{{label}} Relationship',
     latitude: 'vĩ độ',
+    linkedTo: '<0>{{label}}</0> ချိတ်ဆက်ထားသည်။',
     longitude: 'လောင်ဂျီကျု',
     passwordsDoNotMatch: 'စကားဝှက်များနှင့် မကိုက်ညီပါ။',
     removeRelationship: 'ဆက်ဆံရေးကို ဖယ်ရှားပါ။',

--- a/packages/translations/src/_generatedFiles_/client/nb.js
+++ b/packages/translations/src/_generatedFiles_/client/nb.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} og {{count}} flere',
     labelRelationship: '{{label}}-relasjon',
     latitude: 'Breddegrad',
+    linkedTo: 'Lenket til <0>{{label}}</0>',
     longitude: 'Lengdegrad',
     passwordsDoNotMatch: 'Passordene er ikke like.',
     removeRelationship: 'Fjern Forhold',

--- a/packages/translations/src/_generatedFiles_/client/nl.js
+++ b/packages/translations/src/_generatedFiles_/client/nl.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} en {{count}} meer',
     labelRelationship: '{{label}} relatie',
     latitude: 'Breedtegraad',
+    linkedTo: 'Gekoppeld aan aan <0>{{label}}</0>',
     longitude: 'Lengtegraad',
     passwordsDoNotMatch: 'Wachtwoorden komen niet overeen.',
     removeRelationship: 'Relatie Verwijderen',

--- a/packages/translations/src/_generatedFiles_/client/pl.js
+++ b/packages/translations/src/_generatedFiles_/client/pl.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} i {{count}} więcej',
     labelRelationship: 'Relacja {{label}}',
     latitude: 'Szerokość',
+    linkedTo: 'Połączony z <0>{{label}}</0>',
     longitude: 'Długość geograficzna',
     passwordsDoNotMatch: 'Hasła nie pasują',
     removeRelationship: 'Usuń Relację',

--- a/packages/translations/src/_generatedFiles_/client/pt.js
+++ b/packages/translations/src/_generatedFiles_/client/pt.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} e mais {{count}}',
     labelRelationship: 'Relacionado a {{label}}',
     latitude: 'Latitude',
+    linkedTo: 'Ligado a <0>{{label}}</0>',
     longitude: 'Longitude',
     passwordsDoNotMatch: 'Senhas não coincidem.',
     removeRelationship: 'Remover Relacionamento',

--- a/packages/translations/src/_generatedFiles_/client/ro.js
+++ b/packages/translations/src/_generatedFiles_/client/ro.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} şi {{count}} mai multe',
     labelRelationship: 'Relația cu {{label}}',
     latitude: 'Latitudine',
+    linkedTo: 'Legat de <0>{{label}}</0>',
     longitude: 'Longitudine',
     passwordsDoNotMatch: 'Parolele nu corespund.',
     removeRelationship: 'Eliminați relația',

--- a/packages/translations/src/_generatedFiles_/client/rs-latin.js
+++ b/packages/translations/src/_generatedFiles_/client/rs-latin.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} i {{count}} više',
     labelRelationship: '{{label}} veza',
     latitude: 'Geografska širina',
+    linkedTo: 'Povezani sa <0>{{label}}</0>',
     longitude: 'Geografska dužina',
     passwordsDoNotMatch: 'Lozinke nisu iste.',
     removeRelationship: 'Ukloni vezu',

--- a/packages/translations/src/_generatedFiles_/client/rs.js
+++ b/packages/translations/src/_generatedFiles_/client/rs.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} и {{count}} више',
     labelRelationship: '{{label}} веза',
     latitude: 'Географска ширина',
+    linkedTo: 'Повезани са <0>{{label}}</0>',
     longitude: 'Географска дужина',
     passwordsDoNotMatch: 'Лозинке нису исте.',
     removeRelationship: 'Уклони везу',

--- a/packages/translations/src/_generatedFiles_/client/ru.js
+++ b/packages/translations/src/_generatedFiles_/client/ru.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} и ещё {{count}}',
     labelRelationship: '{{label}} Отношения',
     latitude: 'Широта',
+    linkedTo: 'Связано с <0>{{label}}</0>',
     longitude: 'Долгота',
     passwordsDoNotMatch: 'Пароли не совпадают.',
     removeRelationship: 'Удалить связь',

--- a/packages/translations/src/_generatedFiles_/client/sv.js
+++ b/packages/translations/src/_generatedFiles_/client/sv.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} och {{count}} mer',
     labelRelationship: '{{label}} Relation',
     latitude: 'Latitud',
+    linkedTo: 'Länkad till <0>{{label}}</0>',
     longitude: 'Longitud',
     passwordsDoNotMatch: 'Lösenorden matchar inte.',
     removeRelationship: 'Ta Bort Relation',

--- a/packages/translations/src/_generatedFiles_/client/th.js
+++ b/packages/translations/src/_generatedFiles_/client/th.js
@@ -72,6 +72,7 @@ export default {
     itemsAndMore: '{{items}} และเพิ่มเติมอีก {{count}}',
     labelRelationship: 'ความสัมพันธ์กับ {{label}}',
     latitude: 'ละติจูด',
+    linkedTo: 'เชื่อมกับ <0>{{label}}</0> สำเร็จ',
     longitude: 'ลองติจูด',
     passwordsDoNotMatch: 'รหัสผ่านไม่ตรงกัน',
     removeRelationship: 'ลบความสัมพันธ์',

--- a/packages/translations/src/_generatedFiles_/client/tr.js
+++ b/packages/translations/src/_generatedFiles_/client/tr.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} and {{count}} more',
     labelRelationship: '{{label}} Relationship',
     latitude: 'Enlem',
+    linkedTo: '<0>label</0> için bağlantı verildi',
     longitude: 'Boylam',
     passwordsDoNotMatch: 'Parolalar eşleşmiyor.',
     removeRelationship: 'İlişkiyi Kaldır',

--- a/packages/translations/src/_generatedFiles_/client/ua.js
+++ b/packages/translations/src/_generatedFiles_/client/ua.js
@@ -73,6 +73,7 @@ export default {
     itemsAndMore: '{{items}} і ще {{count}}',
     labelRelationship: "{{label}} Зв'язок",
     latitude: 'Широта',
+    linkedTo: "Зв'язано з <0>{{label}}</0>",
     longitude: 'Довгота',
     passwordsDoNotMatch: 'Паролі не співпадають.',
     removeRelationship: "Видалити зв'язок",

--- a/packages/translations/src/_generatedFiles_/client/vi.js
+++ b/packages/translations/src/_generatedFiles_/client/vi.js
@@ -72,6 +72,7 @@ export default {
     itemsAndMore: '{{items}} và {{count}} món nữa',
     labelRelationship: 'Mối quan hệ của {{label}} (Relationship)',
     latitude: 'Vĩ độ',
+    linkedTo: 'Được nối với <0>{{label}}</0>',
     longitude: 'Kinh độ',
     passwordsDoNotMatch: 'Mật khẩu không trùng.',
     removeRelationship: 'Xóa Mối quan hệ',

--- a/packages/translations/src/_generatedFiles_/client/zh-tw.js
+++ b/packages/translations/src/_generatedFiles_/client/zh-tw.js
@@ -72,6 +72,7 @@ export default {
     itemsAndMore: '{{items}} 個，還有 {{count}} 個',
     labelRelationship: '{{label}}關聯',
     latitude: '緯度',
+    linkedTo: '連結到<0>{{label}}</0>',
     longitude: '經度',
     passwordsDoNotMatch: '密碼不匹配。',
     removeRelationship: '移除關聯',

--- a/packages/translations/src/_generatedFiles_/client/zh.js
+++ b/packages/translations/src/_generatedFiles_/client/zh.js
@@ -72,6 +72,7 @@ export default {
     itemsAndMore: '{{items}}和{{count}}更多',
     labelRelationship: '{{label}}关系',
     latitude: '纬度',
+    linkedTo: '链接到<0>{{label}}</0>',
     longitude: '经度',
     passwordsDoNotMatch: '密码不匹配。',
     removeRelationship: '移除关系',

--- a/packages/translations/writeTranslationFiles.ts
+++ b/packages/translations/writeTranslationFiles.ts
@@ -162,6 +162,7 @@ const clientTranslationKeys = [
   'fields:itemsAndMore',
   'fields:labelRelationship',
   'fields:latitude',
+  'fields:linkedTo',
   'fields:longitude',
   'fields:passwordsDoNotMatch',
   'fields:removeRelationship',


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
