### PR TITLE
feat(cpa): detect next app

### DIFF
--- a/packages/create-payload-app/jest.config.js
+++ b/packages/create-payload-app/jest.config.js
@@ -1,11 +1,32 @@
-import baseConfig from '../../jest.config.js'
+// import baseConfig from '../../jest.config.js'
 
-/** @type {import('@jest/types').Config} */
+// /** @type {import('@jest/types').Config} */
+// const customJestConfig = {
+//   ...baseConfig,
+//   setupFilesAfterEnv: null,
+//   testMatch: ['**/src/**/?(*.)+(spec|test|it-test).[tj]s?(x)'],
+//   testTimeout: 20000,
+// }
+
+// export default customJestConfig
+
+/** @type {import('jest').Config} */
 const customJestConfig = {
-  ...baseConfig,
-  setupFilesAfterEnv: null,
-  testMatch: ['**/src/**/?(*.)+(spec|test|it-test).[tj]s?(x)'],
-  testTimeout: 20000,
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '\\.(css|scss)$': '<rootDir>/helpers/mocks/emptyModule.js',
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+      '<rootDir>/test/helpers/mocks/fileMock.js',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/**/*spec.ts'],
+  testTimeout: 90000,
+  transform: {
+    '^.+\\.(t|j)sx?$': ['@swc/jest'],
+  },
+  verbose: true,
 }
 
 export default customJestConfig

--- a/packages/create-payload-app/package.json
+++ b/packages/create-payload-app/package.json
@@ -21,6 +21,7 @@
     "bin"
   ],
   "dependencies": {
+    "@clack/prompts": "^0.7.0",
     "@sindresorhus/slugify": "^1.1.0",
     "arg": "^5.0.0",
     "chalk": "^4.1.0",
@@ -33,9 +34,6 @@
     "figures": "^3.2.0",
     "fs-extra": "^9.0.1",
     "globby": "11.1.0",
-    "handlebars": "^4.7.7",
-    "ora": "^5.1.0",
-    "prompts": "^2.4.2",
     "terminal-link": "^2.1.1"
   },
   "devDependencies": {
@@ -44,8 +42,7 @@
     "@types/esprima": "^4.0.6",
     "@types/fs-extra": "^9.0.12",
     "@types/jest": "^27.0.3",
-    "@types/node": "^16.6.2",
-    "@types/prompts": "^2.4.1"
+    "@types/node": "^16.6.2"
   },
   "exports": {
     "./commands": {

--- a/packages/create-payload-app/package.json
+++ b/packages/create-payload-app/package.json
@@ -7,9 +7,9 @@
     "create-payload-app": "bin/cli.js"
   },
   "scripts": {
-    "build": "pnpm copyfiles && pnpm typecheck && pnpm build:swc",
+    "build": "pnpm pack-template-files && pnpm typecheck && pnpm build:swc",
     "typecheck": "tsc",
-    "copyfiles": "copyfiles -u 2 \"../../app/(payload)/**\" \"dist\"",
+    "pack-template-files": "tsx src/scripts/pack-template-files.ts",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc",
     "clean": "rimraf {dist,*.tsbuildinfo}",
     "test": "jest",

--- a/packages/create-payload-app/src/lib/create-project.ts
+++ b/packages/create-payload-app/src/lib/create-project.ts
@@ -1,15 +1,14 @@
+import * as p from '@clack/prompts'
 import chalk from 'chalk'
 import degit from 'degit'
 import execa from 'execa'
 import fse from 'fs-extra'
 import { fileURLToPath } from 'node:url'
-import ora from 'ora'
 import path from 'path'
 
 import type { CliArgs, DbDetails, PackageManager, ProjectTemplate } from '../types.js'
 
-import { log } from '../utils/log.js'
-import { debug, error, success, warning } from '../utils/log.js'
+import { debug, error, warning } from '../utils/log.js'
 import { configurePayloadConfig } from './configure-payload-config.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -61,13 +60,11 @@ export async function createProject(args: {
   const { cliArgs, dbDetails, packageManager, projectDir, projectName, template } = args
 
   if (cliArgs['--dry-run']) {
-    log(`\n  Dry run: Creating project in ${chalk.green(projectDir)}\n`)
+    debug(`Dry run: Creating project in ${chalk.green(projectDir)}`)
     return
   }
 
   await createOrFindProjectDir(projectDir)
-
-  log(`\n  Creating project in ${chalk.green(projectDir)}\n`)
 
   if (cliArgs['--local-template']) {
     // Copy template from local path. For development purposes.
@@ -87,9 +84,11 @@ export async function createProject(args: {
     await emitter.clone(projectDir)
   }
 
-  const spinner = ora('Checking latest Payload version...').start()
+  const spinner = p.spinner()
+  spinner.start('Checking latest Payload version...')
 
   await updatePackageJSON({ projectDir, projectName })
+  spinner.message('Configuring Payload...')
   await configurePayloadConfig({ dbDetails, projectDirOrConfigPath: { projectDir } })
 
   // Remove yarn.lock file. This is only desired in Payload Cloud.
@@ -99,18 +98,16 @@ export async function createProject(args: {
   }
 
   if (!cliArgs['--no-deps']) {
-    spinner.text = 'Installing dependencies...'
+    spinner.message('Installing dependencies...')
     const result = await installDeps({ cliArgs, packageManager, projectDir })
     spinner.stop()
-    spinner.clear()
     if (result) {
-      success('Dependencies installed')
+      spinner.stop('Dependencies installed')
     } else {
-      error('Error installing dependencies')
+      spinner.stop('Error installing dependencies', 1)
     }
   } else {
-    spinner.stop()
-    spinner.clear()
+    spinner.stop('Dependency installation skipped')
   }
 }
 

--- a/packages/create-payload-app/src/lib/create-project.ts
+++ b/packages/create-payload-app/src/lib/create-project.ts
@@ -90,7 +90,7 @@ export async function createProject(args: {
   const spinner = ora('Checking latest Payload version...').start()
 
   await updatePackageJSON({ projectDir, projectName })
-  await configurePayloadConfig({ dbDetails, projectDir })
+  await configurePayloadConfig({ dbDetails, projectDirOrConfigPath: { projectDir } })
 
   // Remove yarn.lock file. This is only desired in Payload Cloud.
   const lockPath = path.resolve(projectDir, 'yarn.lock')
@@ -125,6 +125,6 @@ export async function updatePackageJSON(args: {
     packageObj.name = projectName
     await fse.writeJson(packageJsonPath, packageObj, { spaces: 2 })
   } catch (err: unknown) {
-    warning('Unable to update name in package.json')
+    warning(`Unable to update name in package.json. ${err instanceof Error ? err.message : ''}`)
   }
 }

--- a/packages/create-payload-app/src/lib/create-project.ts
+++ b/packages/create-payload-app/src/lib/create-project.ts
@@ -8,6 +8,7 @@ import path from 'path'
 
 import type { CliArgs, DbDetails, PackageManager, ProjectTemplate } from '../types.js'
 
+import { log } from '../utils/log.js'
 import { debug, error, success, warning } from '../utils/log.js'
 import { configurePayloadConfig } from './configure-payload-config.js'
 
@@ -60,13 +61,13 @@ export async function createProject(args: {
   const { cliArgs, dbDetails, packageManager, projectDir, projectName, template } = args
 
   if (cliArgs['--dry-run']) {
-    console.log(`\n  Dry run: Creating project in ${chalk.green(projectDir)}\n`)
+    log(`\n  Dry run: Creating project in ${chalk.green(projectDir)}\n`)
     return
   }
 
   await createOrFindProjectDir(projectDir)
 
-  console.log(`\n  Creating project in ${chalk.green(projectDir)}\n`)
+  log(`\n  Creating project in ${chalk.green(projectDir)}\n`)
 
   if (cliArgs['--local-template']) {
     // Copy template from local path. For development purposes.

--- a/packages/create-payload-app/src/lib/init-next.ts
+++ b/packages/create-payload-app/src/lib/init-next.ts
@@ -1,13 +1,13 @@
 import type { CompilerOptions } from 'typescript'
 
-import chalk from 'chalk'
 import { parse, stringify } from 'comment-json'
 import execa from 'execa'
 import fs from 'fs'
-import fse from 'fs-extra'
 import globby from 'globby'
 import path from 'path'
 import { promisify } from 'util'
+
+import { log } from '../utils/log.js'
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
 
@@ -50,7 +50,7 @@ export async function initNext(args: InitNextArgs): Promise<InitNextResult> {
   const layoutPath = path.resolve(nextAppDir, 'layout.tsx')
   if (fs.existsSync(layoutPath)) {
     // Output directions for user to move all files from app to top-level directory named `(name)`
-    console.log(moveMessage({ nextAppDir, projectDir }))
+    log(moveMessage({ nextAppDir, projectDir }))
     return { reason: 'Found existing layout.tsx in app directory', success: false }
   }
 

--- a/packages/create-payload-app/src/lib/parse-project-name.ts
+++ b/packages/create-payload-app/src/lib/parse-project-name.ts
@@ -1,4 +1,4 @@
-import prompts from 'prompts'
+import * as p from '@clack/prompts'
 
 import type { CliArgs } from '../types.js'
 
@@ -6,19 +6,14 @@ export async function parseProjectName(args: CliArgs): Promise<string> {
   if (args['--name']) return args['--name']
   if (args._[0]) return args._[0]
 
-  const response = await prompts(
-    {
-      name: 'value',
-      type: 'text',
-      message: 'Project name?',
-      validate: (value: string) => !!value.length,
+  const projectName = await p.text({
+    message: 'Project name?',
+    validate: (value) => {
+      if (!value) return 'Please enter a project name.'
     },
-    {
-      onCancel: () => {
-        process.exit(0)
-      },
-    },
-  )
-
-  return response.value
+  })
+  if (p.isCancel(projectName)) {
+    process.exit(0)
+  }
+  return projectName
 }

--- a/packages/create-payload-app/src/lib/parse-project-name.ts
+++ b/packages/create-payload-app/src/lib/parse-project-name.ts
@@ -3,7 +3,6 @@ import prompts from 'prompts'
 import type { CliArgs } from '../types.js'
 
 export async function parseProjectName(args: CliArgs): Promise<string> {
-  if (args['--init-next']) return '.'
   if (args['--name']) return args['--name']
   if (args._[0]) return args._[0]
 

--- a/packages/create-payload-app/src/lib/parse-template.ts
+++ b/packages/create-payload-app/src/lib/parse-template.ts
@@ -1,11 +1,11 @@
-import prompts from 'prompts'
+import * as p from '@clack/prompts'
 
 import type { CliArgs, ProjectTemplate } from '../types.js'
 
 export async function parseTemplate(
   args: CliArgs,
   validTemplates: ProjectTemplate[],
-): Promise<ProjectTemplate> {
+): Promise<ProjectTemplate | undefined> {
   if (args['--template']) {
     const templateName = args['--template']
     const template = validTemplates.find((t) => t.name === templateName)
@@ -13,29 +13,20 @@ export async function parseTemplate(
     return template
   }
 
-  const response = await prompts(
-    {
-      name: 'value',
-      type: 'select',
-      choices: validTemplates.map((p) => {
-        return {
-          description: p.description,
-          title: p.name,
-          value: p.name,
-        }
-      }),
-      message: 'Choose project template',
-      validate: (value: string) => !!value.length,
-    },
-    {
-      onCancel: () => {
-        process.exit(0)
-      },
-    },
-  )
+  const response = await p.select<{ label: string; value: string }[], string>({
+    message: 'Choose project template',
+    options: validTemplates.map((p) => {
+      return {
+        label: p.name,
+        value: p.name,
+      }
+    }),
+  })
+  if (p.isCancel(response)) {
+    process.exit(0)
+  }
 
-  const template = validTemplates.find((t) => t.name === response.value)
-  if (!template) throw new Error('Template is undefined')
+  const template = validTemplates.find((t) => t.name === response)
 
   return template
 }

--- a/packages/create-payload-app/src/lib/wrap-next-config.spec.ts
+++ b/packages/create-payload-app/src/lib/wrap-next-config.spec.ts
@@ -1,4 +1,4 @@
-import { parseAndInsertWithPayload, withPayloadImportStatement } from './wrap-next-config.js'
+import { parseAndModifyConfigContent, withPayloadImportStatement } from './wrap-next-config.js'
 
 const defaultNextConfig = `/** @type {import('next').NextConfig} */
 const nextConfig = {};
@@ -30,25 +30,27 @@ export { wrapped as default }
 
 describe('parseAndInsertWithPayload', () => {
   it('should parse the default next config', () => {
-    const { modifiedConfigContent } = parseAndInsertWithPayload(defaultNextConfig)
+    const { modifiedConfigContent } = parseAndModifyConfigContent(defaultNextConfig)
     expect(modifiedConfigContent).toContain(withPayloadImportStatement)
     expect(modifiedConfigContent).toContain('withPayload(nextConfig)')
   })
   it('should parse the config with a function', () => {
-    const { modifiedConfigContent } = parseAndInsertWithPayload(nextConfigWithFunc)
+    const { modifiedConfigContent } = parseAndModifyConfigContent(nextConfigWithFunc)
     expect(modifiedConfigContent).toContain('withPayload(someFunc(nextConfig))')
   })
 
   it('should parse the config with a function on a new line', () => {
-    const { modifiedConfigContent } = parseAndInsertWithPayload(nextConfigWithFuncMultiline)
+    const { modifiedConfigContent } = parseAndModifyConfigContent(nextConfigWithFuncMultiline)
     expect(modifiedConfigContent).toContain(withPayloadImportStatement)
     expect(modifiedConfigContent).toMatch(/withPayload\(someFunc\(\n  nextConfig\n\)\)/)
   })
 
   // Unsupported: export { wrapped as default }
   it('should give warning with a named export as default', () => {
-    const { modifiedConfigContent, error } = parseAndInsertWithPayload(nextConfigExportNamedDefault)
+    const { modifiedConfigContent, success } = parseAndModifyConfigContent(
+      nextConfigExportNamedDefault,
+    )
     expect(modifiedConfigContent).toContain(withPayloadImportStatement)
-    expect(error).toBeTruthy()
+    expect(success).toBe(false)
   })
 })

--- a/packages/create-payload-app/src/lib/wrap-next-config.spec.ts
+++ b/packages/create-payload-app/src/lib/wrap-next-config.spec.ts
@@ -1,4 +1,5 @@
 import { parseAndModifyConfigContent, withPayloadImportStatement } from './wrap-next-config.js'
+import * as p from '@clack/prompts'
 
 const defaultNextConfig = `/** @type {import('next').NextConfig} */
 const nextConfig = {};
@@ -47,7 +48,7 @@ describe('parseAndInsertWithPayload', () => {
 
   // Unsupported: export { wrapped as default }
   it('should give warning with a named export as default', () => {
-    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const warnLogSpy = jest.spyOn(p.log, 'warn').mockImplementation(() => {})
 
     const { modifiedConfigContent, success } = parseAndModifyConfigContent(
       nextConfigExportNamedDefault,
@@ -55,8 +56,6 @@ describe('parseAndInsertWithPayload', () => {
     expect(modifiedConfigContent).toContain(withPayloadImportStatement)
     expect(success).toBe(false)
 
-    expect(consoleLogSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Could not automatically wrap'),
-    )
+    expect(warnLogSpy).toHaveBeenCalledWith(expect.stringContaining('Could not automatically wrap'))
   })
 })

--- a/packages/create-payload-app/src/lib/wrap-next-config.spec.ts
+++ b/packages/create-payload-app/src/lib/wrap-next-config.spec.ts
@@ -47,10 +47,16 @@ describe('parseAndInsertWithPayload', () => {
 
   // Unsupported: export { wrapped as default }
   it('should give warning with a named export as default', () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
     const { modifiedConfigContent, success } = parseAndModifyConfigContent(
       nextConfigExportNamedDefault,
     )
     expect(modifiedConfigContent).toContain(withPayloadImportStatement)
     expect(success).toBe(false)
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Could not automatically wrap'),
+    )
   })
 })

--- a/packages/create-payload-app/src/lib/wrap-next-config.ts
+++ b/packages/create-payload-app/src/lib/wrap-next-config.ts
@@ -1,28 +1,29 @@
+import chalk from 'chalk'
 import { parseModule } from 'esprima'
 import fs from 'fs'
-import globby from 'globby'
-import path from 'path'
+
+import { warning } from '../utils/log.js'
 
 export const withPayloadImportStatement = `import { withPayload } from '@payloadcms/next'\n`
 
-export const wrapNextConfig = async (args: { projectDir: string }): Promise<void> => {
-  const foundConfig = (await globby('next.config.*js', { cwd: args.projectDir }))?.[0]
+export const wrapNextConfig = (args: { nextConfigPath: string }) => {
+  const { nextConfigPath } = args
+  const configContent = fs.readFileSync(nextConfigPath, 'utf8')
+  const { modifiedConfigContent: newConfig, success } = parseAndModifyConfigContent(configContent)
 
-  if (!foundConfig) {
-    throw new Error(`No Next config found at ${args.projectDir}`)
+  if (!success) {
+    return
   }
-  const configPath = path.resolve(args.projectDir, foundConfig)
-  const configContent = fs.readFileSync(configPath, 'utf8')
-  const { error, modifiedConfigContent: newConfig } = parseAndInsertWithPayload(configContent)
-  if (error) {
-    console.warn(error)
-  }
-  fs.writeFileSync(configPath, newConfig)
+
+  fs.writeFileSync(nextConfigPath, newConfig)
 }
 
-export function parseAndInsertWithPayload(content: string): {
-  error?: string
+/**
+ * Parses config content with AST and wraps it with withPayload function
+ */
+export function parseAndModifyConfigContent(content: string): {
   modifiedConfigContent: string
+  success: boolean
 } {
   content = withPayloadImportStatement + content
   const ast = parseModule(content, { loc: true })
@@ -43,7 +44,7 @@ export function parseAndInsertWithPayload(content: string): {
       content,
       exportDefaultDeclaration.declaration?.loc,
     )
-    return { modifiedConfigContent }
+    return { modifiedConfigContent, success: true }
   } else if (exportNamedDeclaration) {
     const exportSpecifier = exportNamedDeclaration.specifiers.find(
       (s) =>
@@ -54,16 +55,42 @@ export function parseAndInsertWithPayload(content: string): {
     )
 
     if (exportSpecifier) {
-      // TODO: Improve with this example and/or link to docs
+      warning('Could not automatically wrap next.config.js with withPayload.')
+      warning('Automatic wrapping of named exports as default not supported yet.')
+
+      warnUserWrapNotSuccessful()
       return {
-        error: `Automatic wrapping of named exports as default not supported yet.
-  Please manually wrap your Next config with the withPayload function`,
         modifiedConfigContent: content,
+        success: false,
       }
     }
   } else {
-    throw new Error('Could not automatically wrap next.config.js with withPayload')
+    warning('Could not automatically wrap next.config.js with withPayload.')
+    warnUserWrapNotSuccessful()
+    return {
+      modifiedConfigContent: content,
+      success: false,
+    }
   }
+}
+
+function warnUserWrapNotSuccessful() {
+  // Output directions for user to update next.config.js
+  const withPayloadMessage = `
+
+  ${chalk.bold(`Please manually wrap your existing next.config.js with the withPayload function. Here is an example:`)}
+
+  import withPayload from '@payloadcms/next/withPayload'
+
+  const nextConfig = {
+    // Your Next.js config here
+  }
+
+  export default withPayload(nextConfig)
+
+`
+
+  console.log(withPayloadMessage)
 }
 
 type Directive = {

--- a/packages/create-payload-app/src/lib/wrap-next-config.ts
+++ b/packages/create-payload-app/src/lib/wrap-next-config.ts
@@ -3,6 +3,7 @@ import { parseModule } from 'esprima'
 import fs from 'fs'
 
 import { warning } from '../utils/log.js'
+import { log } from '../utils/log.js'
 
 export const withPayloadImportStatement = `import { withPayload } from '@payloadcms/next'\n`
 
@@ -90,7 +91,7 @@ function warnUserWrapNotSuccessful() {
 
 `
 
-  console.log(withPayloadMessage)
+  log(withPayloadMessage)
 }
 
 type Directive = {

--- a/packages/create-payload-app/src/lib/write-env-file.ts
+++ b/packages/create-payload-app/src/lib/write-env-file.ts
@@ -1,10 +1,9 @@
-import chalk from 'chalk'
 import fs from 'fs-extra'
 import path from 'path'
 
 import type { CliArgs, ProjectTemplate } from '../types.js'
 
-import { error, success } from '../utils/log.js'
+import { debug, error } from '../utils/log.js'
 
 /** Parse and swap .env.example values and write .env */
 export async function writeEnvFile(args: {
@@ -17,7 +16,7 @@ export async function writeEnvFile(args: {
   const { cliArgs, databaseUri, payloadSecret, projectDir, template } = args
 
   if (cliArgs['--dry-run']) {
-    success(`DRY RUN: .env file created`)
+    debug(`DRY RUN: .env file created`)
     return
   }
 
@@ -51,8 +50,6 @@ export async function writeEnvFile(args: {
       const content = `MONGODB_URI=${databaseUri}\nPAYLOAD_SECRET=${payloadSecret}`
       await fs.outputFile(`${projectDir}/.env`, content)
     }
-
-    success('.env file created')
   } catch (err: unknown) {
     error('Unable to write .env file')
     if (err instanceof Error) {

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import slugify from '@sindresorhus/slugify'
 import arg from 'arg'
 import { detect } from 'detect-package-manager'
@@ -15,7 +14,7 @@ import { parseTemplate } from './lib/parse-template.js'
 import { selectDb } from './lib/select-db.js'
 import { getValidTemplates, validateTemplate } from './lib/templates.js'
 import { writeEnvFile } from './lib/write-env-file.js'
-import { debug, error, success } from './utils/log.js'
+import { debug, error, log, success } from './utils/log.js'
 import { helpMessage, successMessage, welcomeMessage } from './utils/messages.js'
 
 export class Main {
@@ -66,10 +65,10 @@ export class Main {
 
     try {
       if (this.args['--help']) {
-        console.log(helpMessage())
+        log(helpMessage())
         process.exit(0)
       }
-      console.log(welcomeMessage)
+      log(welcomeMessage)
 
       // Detect if inside Next.js project
       const foundConfig = (
@@ -108,7 +107,7 @@ export class Main {
       if (templateArg) {
         const valid = validateTemplate(templateArg)
         if (!valid) {
-          console.log(helpMessage())
+          log(helpMessage())
           process.exit(1)
         }
       }
@@ -150,9 +149,9 @@ export class Main {
       }
 
       success('Payload project successfully created')
-      console.log(successMessage(projectDir, packageManager))
-    } catch (error: unknown) {
-      console.log(error)
+      log(successMessage(projectDir, packageManager))
+    } catch (err: unknown) {
+      error(err instanceof Error ? err.message : 'An error occurred')
     }
   }
 }

--- a/packages/create-payload-app/src/scripts/pack-template-files.ts
+++ b/packages/create-payload-app/src/scripts/pack-template-files.ts
@@ -1,0 +1,35 @@
+import fs from 'fs'
+import fsp from 'fs/promises'
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+main()
+
+/**
+ * Copy the necessary template files from `templates/blank-3.0` to `dist/template`
+ *
+ * Eventually, this should be replaced with using tar.x to stream from the git repo
+ */
+
+async function main() {
+  const root = path.resolve(dirname, '../../../../')
+  const outputPath = path.resolve(dirname, '../../dist/template')
+  const sourceTemplatePath = path.resolve(root, 'templates/blank-3.0')
+
+  if (!fs.existsSync(sourceTemplatePath)) {
+    throw new Error(`Source path does not exist: ${sourceTemplatePath}`)
+  }
+
+  if (!fs.existsSync(outputPath)) {
+    fs.mkdirSync(outputPath, { recursive: true })
+  }
+
+  // Copy the src directory from `templates/blank-3.0` to `dist`
+  const srcPath = path.resolve(sourceTemplatePath, 'src')
+  const distSrcPath = path.resolve(outputPath, 'src')
+  // Copy entire file structure from src to dist
+  await fsp.cp(srcPath, distSrcPath, { recursive: true })
+}

--- a/packages/create-payload-app/src/utils/log.ts
+++ b/packages/create-payload-app/src/utils/log.ts
@@ -1,34 +1,23 @@
 /* eslint-disable no-console */
+import * as p from '@clack/prompts'
 import chalk from 'chalk'
-import figures from 'figures'
-
-export const success = (message: string): void => {
-  console.log(`${chalk.green(figures.tick)} ${chalk.bold(message)}`)
-}
 
 export const warning = (message: string): void => {
-  console.log(chalk.yellow('? ') + chalk.bold(message))
+  p.log.warn(chalk.yellow('? ') + chalk.bold(message))
 }
 
-export const info = (message: string, paddingTop?: number): void => {
-  console.log(
-    `${'\n'.repeat(paddingTop || 0)}${chalk.green(figures.pointerSmall)} ${chalk.bold(message)}`,
-  )
+export const info = (message: string): void => {
+  p.log.step(chalk.bold(message))
 }
 
 export const error = (message: string): void => {
-  console.log(`${chalk.red(figures.cross)} ${chalk.bold(message)}`)
+  p.log.error(chalk.bold(message))
 }
 
 export const debug = (message: string): void => {
-  console.log(
-    `${chalk.gray(figures.pointerSmall)} ${chalk.bgGray('[DEBUG]')} ${chalk.gray(message)}`,
-  )
+  p.log.step(`${chalk.bgGray('[DEBUG]')} ${chalk.gray(message)}`)
 }
 
-/**
- * console.log passthrough
- */
 export const log = (message: string): void => {
-  console.log(message)
+  p.log.message(message)
 }

--- a/packages/create-payload-app/src/utils/log.ts
+++ b/packages/create-payload-app/src/utils/log.ts
@@ -25,3 +25,10 @@ export const debug = (message: string): void => {
     `${chalk.gray(figures.pointerSmall)} ${chalk.bgGray('[DEBUG]')} ${chalk.gray(message)}`,
   )
 }
+
+/**
+ * console.log passthrough
+ */
+export const log = (message: string): void => {
+  console.log(message)
+}

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -1,13 +1,14 @@
+/* eslint-disable no-console */
 import chalk from 'chalk'
-import figures from 'figures'
 import path from 'path'
 import terminalLink from 'terminal-link'
 
 import type { ProjectTemplate } from '../types.js'
+import type { PackageManager } from '../types.js'
 
 import { getValidTemplates } from '../lib/templates.js'
 
-const header = (message: string): string => `${chalk.yellow(figures.star)} ${chalk.bold(message)}`
+const header = (message: string): string => chalk.bold(message)
 
 export const welcomeMessage = chalk`
   {green Welcome to Payload. Let's create a project! }
@@ -15,14 +16,14 @@ export const welcomeMessage = chalk`
 
 const spacer = ' '.repeat(8)
 
-export function helpMessage(): string {
+export function helpMessage(): void {
   const validTemplates = getValidTemplates()
-  return chalk`
+  console.log(chalk`
   {bold USAGE}
 
       {dim $} {bold npx create-payload-app}
       {dim $} {bold npx create-payload-app} my-project
-      {dim $} {bold npx create-payload-app} -n my-project -t blog
+      {dim $} {bold npx create-payload-app} -n my-project -t template-name
 
   {bold OPTIONS}
 
@@ -36,7 +37,7 @@ export function helpMessage(): string {
       --use-pnpm                    Use pnpm to install dependencies
       --no-deps                     Do not install any dependencies
       -h                            Show help
-`
+`)
 }
 
 function formatTemplates(templates: ProjectTemplate[]) {
@@ -45,57 +46,56 @@ function formatTemplates(templates: ProjectTemplate[]) {
     .join(`\n${spacer}`)}`
 }
 
-export function successMessage(projectDir: string, packageManager: string): string {
+export function successMessage(projectDir: string, packageManager: PackageManager): string {
+  const relativePath = path.relative(process.cwd(), projectDir)
   return `
-  ${header('Launch Application:')}
+${header('Launch Application:')}
 
-    - cd ${projectDir}
-    - ${
-      packageManager === 'yarn' ? 'yarn' : 'npm run'
-    } dev or follow directions in ${createTerminalLink(
-      'README.md',
-      `file://${path.resolve(projectDir, 'README.md')}`,
-    )}
+  - cd ./${relativePath}
+  - ${
+    packageManager === 'npm' ? 'npm run' : packageManager
+  } dev or follow directions in ${createTerminalLink(
+    'README.md',
+    `file://${path.resolve(projectDir, 'README.md')}`,
+  )}
 
-  ${header('Documentation:')}
+${header('Documentation:')}
 
-    - ${createTerminalLink(
-      'Getting Started',
-      'https://payloadcms.com/docs/getting-started/what-is-payload',
-    )}
-    - ${createTerminalLink('Configuration', 'https://payloadcms.com/docs/configuration/overview')}
+  - ${createTerminalLink(
+    'Getting Started',
+    'https://payloadcms.com/docs/getting-started/what-is-payload',
+  )}
+  - ${createTerminalLink('Configuration', 'https://payloadcms.com/docs/configuration/overview')}
 
 `
 }
 
 export function successfulNextInit(): string {
-  return `
-  ${header('Successful Payload Installation!')}
-
-  ${header('Documentation:')}
-
-    - ${createTerminalLink(
-      'Getting Started',
-      'https://payloadcms.com/docs/getting-started/what-is-payload',
-    )}
-    - ${createTerminalLink('Configuration', 'https://payloadcms.com/docs/configuration/overview')}
+  return `- ${createTerminalLink(
+    'Getting Started',
+    'https://payloadcms.com/docs/getting-started/what-is-payload',
+  )}
+- ${createTerminalLink('Configuration', 'https://payloadcms.com/docs/configuration/overview')}
 `
 }
 
 export function moveMessage(args: { nextAppDir: string; projectDir: string }): string {
+  const relativePath = path.relative(process.cwd(), args.nextAppDir)
   return `
-  ${header('Next Steps:')}
+${header('Next Steps:')}
 
-  Payload does not support a top-level layout.tsx file in your Next.js app directory.
+Payload does not support a top-level layout.tsx file in your Next.js app directory.
 
-  ${chalk.bold('To continue:')}
+${chalk.bold('To continue:')}
 
-    - Move all files from ${args.nextAppDir} to a top-level directory named ${chalk.bold(
-      '(app)',
-    )} or similar.
+Move all files from ./${relativePath} to a named directory such as ${chalk.bold('(app)')}
 
-    Once moved, rerun the create-payload-app command again.
+Once moved, rerun the create-payload-app command again.
 `
+}
+
+export function feedbackOutro(): string {
+  return `${chalk.bgCyan(chalk.black(' Have feedback? '))} Visit ${createTerminalLink('GitHub', 'https://github.com/payloadcms/payload')}`
 }
 
 // Create terminalLink with fallback for unsupported terminals

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -68,6 +68,20 @@ export function successMessage(projectDir: string, packageManager: string): stri
 `
 }
 
+export function successfulNextInit(): string {
+  return `
+  ${header('Successful Payload Installation!')}
+
+  ${header('Documentation:')}
+
+    - ${createTerminalLink(
+      'Getting Started',
+      'https://payloadcms.com/docs/getting-started/what-is-payload',
+    )}
+    - ${createTerminalLink('Configuration', 'https://payloadcms.com/docs/configuration/overview')}
+`
+}
+
 export function moveMessage(args: { nextAppDir: string; projectDir: string }): string {
   return `
   ${header('Next Steps:')}
@@ -77,7 +91,7 @@ export function moveMessage(args: { nextAppDir: string; projectDir: string }): s
   ${chalk.bold('To continue:')}
 
     - Move all files from ${args.nextAppDir} to a top-level directory named ${chalk.bold(
-      '(name)',
+      '(app)',
     )} or similar.
 
     Once moved, rerun the create-payload-app command again.

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -68,6 +68,22 @@ export function successMessage(projectDir: string, packageManager: string): stri
 `
 }
 
+export function moveMessage(args: { nextAppDir: string; projectDir: string }): string {
+  return `
+  ${header('Next Steps:')}
+
+  Payload does not support a top-level layout.tsx file in your Next.js app directory.
+
+  ${chalk.bold('To continue:')}
+
+    - Move all files from ${args.nextAppDir} to a top-level directory named ${chalk.bold(
+      '(name)',
+    )} or similar.
+
+    Once moved, rerun the create-payload-app command again.
+`
+}
+
 // Create terminalLink with fallback for unsupported terminals
 function createTerminalLink(text: string, url: string) {
   return terminalLink(text, url, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,6 +295,9 @@ importers:
 
   packages/create-payload-app:
     dependencies:
+      '@clack/prompts':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@sindresorhus/slugify':
         specifier: ^1.1.0
         version: 1.1.2
@@ -331,15 +334,6 @@ importers:
       globby:
         specifier: 11.1.0
         version: 11.1.0
-      handlebars:
-        specifier: ^4.7.7
-        version: 4.7.8
-      ora:
-        specifier: ^5.1.0
-        version: 5.4.1
-      prompts:
-        specifier: ^2.4.2
-        version: 2.4.2
       terminal-link:
         specifier: ^2.1.1
         version: 2.1.1
@@ -362,9 +356,6 @@ importers:
       '@types/node':
         specifier: ^16.6.2
         version: 16.18.85
-      '@types/prompts':
-        specifier: ^2.4.1
-        version: 2.4.9
 
   packages/db-mongodb:
     dependencies:
@@ -2744,6 +2735,23 @@ packages:
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  /@clack/core@0.3.4:
+    resolution: {integrity: sha512-H4hxZDXgHtWTwV3RAVenqcC4VbJZNegbBjlPvzOzCouXtS2y3sDvlO3IsbrPNWuLWPPlYVYPghQdSF64683Ldw==}
+    dependencies:
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+
+  /@clack/prompts@0.7.0:
+    resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
+    dependencies:
+      '@clack/core': 0.3.4
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+    bundledDependencies:
+      - is-unicode-supported
 
   /@cspotcode/source-map-support@0.8.1:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7451,6 +7459,7 @@ packages:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    dev: true
 
   /body-parser@1.20.1:
     resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
@@ -7790,6 +7799,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       restore-cursor: 3.1.0
+    dev: true
 
   /cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
@@ -7801,6 +7811,7 @@ packages:
   /cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+    dev: true
 
   /cli-truncate@3.1.0:
     resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
@@ -7852,6 +7863,7 @@ packages:
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+    dev: true
 
   /clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
@@ -8738,6 +8750,7 @@ packages:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
     dependencies:
       clone: 1.0.4
+    dev: true
 
   /defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
@@ -10725,6 +10738,7 @@ packages:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.17.4
+    dev: true
 
   /hanji@0.0.5:
     resolution: {integrity: sha512-Abxw1Lq+TnYiL4BueXqMau222fPSPMFtya8HdpWsz/xVAhifXou71mPh/kY2+08RgFcVccjG3uZHs6K5HAe3zw==}
@@ -11234,6 +11248,7 @@ packages:
   /is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
+    dev: true
 
   /is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
@@ -11366,6 +11381,7 @@ packages:
   /is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+    dev: true
 
   /is-unicode-supported@1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
@@ -12595,6 +12611,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+    dev: true
 
   /log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
@@ -13060,6 +13077,7 @@ packages:
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+    dev: true
 
   /netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
@@ -13489,6 +13507,7 @@ packages:
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
+    dev: true
 
   /ora@8.0.1:
     resolution: {integrity: sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==}
@@ -15472,6 +15491,7 @@ packages:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
+    dev: true
 
   /restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
@@ -17014,6 +17034,7 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true
+    dev: true
     optional: true
 
   /unbox-primitive@1.0.2:
@@ -17242,6 +17263,7 @@ packages:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
     dependencies:
       defaults: 1.0.4
+    dev: true
 
   /web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}

--- a/templates/blank-3.0/src/payload.config.ts
+++ b/templates/blank-3.0/src/payload.config.ts
@@ -1,12 +1,12 @@
 import { mongooseAdapter } from '@payloadcms/db-mongodb' // database-adapter-import
-import { payloadCloud } from '@payloadcms/plugin-cloud'
+// import { payloadCloud } from '@payloadcms/plugin-cloud'
 import { lexicalEditor } from '@payloadcms/richtext-lexical' // editor-import
 import path from 'path'
 import { buildConfig } from 'payload/config'
-import sharp from 'sharp'
+// import sharp from 'sharp'
 import { fileURLToPath } from 'url'
 
-import { Users } from './src/collections/Users'
+import { Users } from './collections/Users'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -17,7 +17,7 @@ export default buildConfig({
   },
   collections: [Users],
   editor: lexicalEditor({}),
-  plugins: [payloadCloud()],
+  // plugins: [payloadCloud()], // TODO: Re-enable when cloud supports 3.0
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),
@@ -33,5 +33,6 @@ export default buildConfig({
 
   // This is temporary - we may make an adapter pattern
   // for this before reaching 3.0 stable
-  sharp,
+
+  // sharp,
 })

--- a/templates/blank-3.0/tsconfig.json
+++ b/templates/blank-3.0/tsconfig.json
@@ -20,7 +20,7 @@
     ],
     "paths": {
       "@/*": ["./src/*"],
-      "@payload-config": ["./payload.config.ts"]
+      "@payload-config": ["./src/payload.config.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/test/create-payload-app/int.spec.ts
+++ b/test/create-payload-app/int.spec.ts
@@ -67,6 +67,7 @@ describe('create-payload-app', () => {
         '--debug': true,
         projectDir,
         nextConfigPath: path.resolve(projectDir, 'next.config.mjs'),
+        dbType: 'mongodb',
         useDistFiles: true, // create-payload-app/dist/app/(payload)
         packageManager: 'pnpm',
       })
@@ -91,6 +92,7 @@ describe('create-payload-app', () => {
         '--debug': true,
         projectDir,
         nextConfigPath: path.resolve(projectDir, 'next.config.mjs'),
+        dbType: 'mongodb',
         useDistFiles: true, // create-payload-app/dist/app/(payload)
         packageManager: 'pnpm',
       })


### PR DESCRIPTION
## Description

Rework flow to detect if run within an Next.js app

If detected:

- Check if top-level `layout.tsx` exists, warn that this is not compatible and give instructions, then exit.
- Creates `(payload)` directory into app dir (from blank-3.0 template, packaged into cpa for now)
- Creates `payload.config.ts` in src dir
- Installs necessary dependencies using detected package manager
- Reworks CLI UI to use `clack`
