### PR TITLE
fix(richtext-lexical): properly center add- and drag-block handles

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/AddBlockHandlePlugin/index.scss
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/AddBlockHandlePlugin/index.scss
@@ -3,7 +3,7 @@
 .add-block-menu {
   all: unset; // reset all default button styles
   border-radius: 4px;
-  padding: 0px;
+  padding: 0;
   cursor: pointer;
   opacity: 0;
   position: absolute;
@@ -23,8 +23,6 @@
     height: 24px;
     opacity: 0.3;
     background-image: url(../../../ui/icons/Add/index.svg);
-    background-position-y: 2.5px;
-    background-position-x: 0px;
   }
 
   html[data-theme='dark'] & {

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.scss
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.scss
@@ -2,7 +2,7 @@
 
 .draggable-block-menu {
   border-radius: 4px;
-  padding: 0px;
+  padding: 0;
   cursor: grab;
   opacity: 0;
   position: absolute;

--- a/packages/richtext-lexical/src/field/lexical/ui/icons/Add/index.svg
+++ b/packages/richtext-lexical/src/field/lexical/ui/icons/Add/index.svg
@@ -1,4 +1,4 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M6 10H14" stroke="#000000" />
-    <path d="M10 14L10 6" stroke="#000000" />
+<svg width="18" height="24" viewBox="0 0 18 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M5,12h8" stroke="#000000" />
+    <path d="M9,16V8" stroke="#000000" />
 </svg>

--- a/packages/richtext-lexical/src/field/lexical/ui/icons/DraggableBlock/index.svg
+++ b/packages/richtext-lexical/src/field/lexical/ui/icons/DraggableBlock/index.svg
@@ -1,9 +1,9 @@
-<svg width="19" height="26" viewBox="0 0 19 26" fill="#000000"
+<svg width="18" height="24" viewBox="0 0 18 24" fill="#000000"
     xmlns="http://www.w3.org/2000/svg">
-    <circle cx="7.375" cy="9" r="1" fill="#000000" />
-    <circle cx="11.375" cy="9" r="1" fill="#000000" />
-    <circle cx="7.375" cy="13" r="1" fill="#000000" />
-    <circle cx="11.375" cy="13" r="1" fill="#000000" />
-    <circle cx="7.375" cy="17" r="1" fill="#000000" />
-    <circle cx="11.375" cy="17" r="1" fill="#000000" />
+    <circle cx="7" cy="8" r="1"/>
+    <circle cx="11" cy="8" r="1"/>
+    <circle cx="7" cy="12" r="1"/>
+    <circle cx="11" cy="12" r="1"/>
+    <circle cx="7" cy="16" r="1"/>
+    <circle cx="11" cy="16" r="1"/>
 </svg>


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
