### PR TITLE
fix(richtext-lexical): checklist html converter incorrectly outputting children (#5570)

### DIFF
--- a/packages/plugin-form-builder/src/utilities/lexical/converters/list.ts
+++ b/packages/plugin-form-builder/src/utilities/lexical/converters/list.ts
@@ -40,7 +40,7 @@ export const ListItemHTMLConverter: HTMLConverter<any> = {
           tabIndex=${-1}
           value=${node?.value}
       >
-          {serializedChildren}
+          ${childrenText}
           </li>`
     } else {
       return `<li value=${node?.value}>${childrenText}</li>`

--- a/packages/richtext-lexical/src/field/features/lists/htmlConverter.ts
+++ b/packages/richtext-lexical/src/field/features/lists/htmlConverter.ts
@@ -46,7 +46,7 @@ export const ListItemHTMLConverter: HTMLConverter<SerializedListItemNode> = {
           tabIndex=${-1}
           value=${node?.value}
       >
-          {serializedChildren}
+          ${childrenText}
           </li>`
     } else {
       return `<li value=${node?.value}>${childrenText}</li>`


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
