### PR TITLE
fix(ui): places id field last in field map and prevents render

### DIFF
--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/mapFields.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/mapFields.tsx
@@ -727,9 +727,10 @@ export const mapFields = (args: {
 
   if (!disableAddingID && !hasID) {
     // TODO: For all fields (not just this one) we need to add the name to both .fieldComponentProps.name AND .name. This can probably be improved
-    result.unshift({
+    result.push({
       name: 'id',
       type: 'text',
+      CustomField: null,
       cellComponentProps: {
         name: 'id',
       },


### PR DESCRIPTION
## Description

fix: appends hidden fields to the end of the component map instead of at the beginning to prevent the `indexPath` of certain fields i.e. `Collapsibles` to start with an index of `1` instead of `0`.

Prior to this change, hidden fields would be rendered at the start of the component map array and take the index `0` spot.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
