### PR TITLE
test(uploads): remove all process.cwd() usage

### DIFF
--- a/test/uploads/collections/Upload1/index.ts
+++ b/test/uploads/collections/Upload1/index.ts
@@ -1,11 +1,14 @@
 import type { CollectionConfig } from 'payload/types'
 
+import { fileURLToPath } from 'node:url'
 import path from 'path'
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 
 export const Uploads1: CollectionConfig = {
   slug: 'uploads-1',
   upload: {
-    staticDir: path.resolve(process.cwd(), 'test/uploads/collections/Upload1/uploads'),
+    staticDir: path.resolve(dirname, 'uploads'),
   },
   fields: [
     {

--- a/test/uploads/collections/Upload2/index.ts
+++ b/test/uploads/collections/Upload2/index.ts
@@ -1,11 +1,14 @@
 import type { CollectionConfig } from 'payload/types'
 
+import { fileURLToPath } from 'node:url'
 import path from 'path'
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 
 export const Uploads2: CollectionConfig = {
   slug: 'uploads-2',
   upload: {
-    staticDir: path.resolve(process.cwd(), 'test/uploads/collections/Upload2/uploads'),
+    staticDir: path.resolve(dirname, 'uploads'),
   },
   admin: {
     enableRichTextRelationship: false,
@@ -21,5 +24,3 @@ export const Uploads2: CollectionConfig = {
 export const uploadsDoc = {
   text: 'An upload here',
 }
-
-export default Uploads2

--- a/test/uploads/collections/admin-thumbnail/index.ts
+++ b/test/uploads/collections/admin-thumbnail/index.ts
@@ -1,13 +1,16 @@
 import type { CollectionConfig } from 'payload/types'
 
+import { fileURLToPath } from 'node:url'
 import path from 'path'
 
 import { RegisterAdminThumbnailFn } from './RegisterThumbnailFn.js'
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 
 export const AdminThumbnailCol: CollectionConfig = {
   slug: 'admin-thumbnail',
   upload: {
-    staticDir: path.resolve(process.cwd(), 'test/uploads/media'),
+    staticDir: path.resolve(dirname, '../../media'),
     adminThumbnail: RegisterAdminThumbnailFn,
   },
   fields: [],

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -6,7 +6,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import removeFiles from '../helpers/removeFiles.js'
 import { Uploads1 } from './collections/Upload1/index.js'
-import Uploads2 from './collections/Upload2/index.js'
+import { Uploads2 } from './collections/Upload2/index.js'
 import { AdminThumbnailCol } from './collections/admin-thumbnail/index.js'
 import {
   audioSlug,
@@ -441,7 +441,10 @@ export default buildConfigWithDefaults({
           type: 'text',
         },
       ],
-      upload: true,
+      upload: {
+        staticDir: path.resolve(dirname, `./${versionSlug}`),
+        filesRequiredOnCreate: true,
+      },
       versions: {
         drafts: true,
       },


### PR DESCRIPTION
## Description

Removes all `process.cwd()` usage from uploads suite. This was causing issues with creating uploads in odd directories depending on where the test was triggered from.
