### PR TITLE
fix: resets pagination when search term changes in drawer list

### DIFF
--- a/packages/payload/src/admin/components/elements/ListDrawer/DrawerContent.tsx
+++ b/packages/payload/src/admin/components/elements/ListDrawer/DrawerContent.tsx
@@ -198,6 +198,10 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
     setPreference(preferenceKey, newPreferences, true)
   }, [sort, limit, setPreference, preferenceKey])
 
+  useEffect(() => {
+    setPage(1)
+  }, [search])
+
   const onCreateNew = useCallback(
     ({ doc }) => {
       if (typeof onSelect === 'function') {


### PR DESCRIPTION
## Description

fix: resets pagination to page 1 every time the search term changes

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
