### PR TITLE
docs: updates comment in globals `afterChange` hook example

### DIFF
--- a/docs/hooks/globals.mdx
+++ b/docs/hooks/globals.mdx
@@ -79,7 +79,7 @@ import { GlobalAfterChangeHook } from 'payload/types'
 
 const afterChangeHook: GlobalAfterChangeHook = async ({
   doc, // full document data
-  previousDoc, // document data before updating the collection
+  previousDoc, // document data before updating the global
   req, // full express request
 }) => {
   return data


### PR DESCRIPTION
## Description

docs: updates comment in globals `afterChange` hook example to correctly use the term `global` instead of `collection`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
