### PR TITLE
fix(alpha): number field with hasMany should accept array as defaultValue

### DIFF
--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -112,7 +112,13 @@ export const number = baseField.keys({
     placeholder: joi.string(),
     step: joi.number(),
   }),
-  defaultValue: joi.alternatives().try(joi.number(), joi.func()),
+  defaultValue: joi
+    .alternatives()
+    .try(
+      joi.number(),
+      joi.func(),
+      joi.array().when('hasMany', { not: true, then: joi.forbidden() }),
+    ),
   hasMany: joi.boolean().default(false),
   max: joi.number(),
   maxRows: joi.number().when('hasMany', { is: joi.not(true), then: joi.forbidden() }),


### PR DESCRIPTION
## Description

Number field should allow an array to be passed to `defaultValue` when `hasMany` is true.

Same change to 2.0 [here](https://github.com/payloadcms/payload/pull/5618).

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
