### PR TITLE
chore: adds Norwegian translation to plugin-seo

### DIFF
--- a/packages/plugin-seo/src/translations/index.ts
+++ b/packages/plugin-seo/src/translations/index.ts
@@ -99,6 +99,31 @@ export const translations = {
       tooShort: 'Trop court',
     },
   },
+  nb: {
+    $schema: './translation-schema.json',
+    'plugin-seo': {
+      almostThere: 'Nesten der',
+      autoGenerate: 'Auto-generer',
+      bestPractices: 'beste praksis',
+      characterCount: '{{current}}/{{minLength}}-{{maxLength}} tegn, ',
+      charactersLeftOver: '{{characters}} til overs',
+      charactersToGo: '{{characters}} igjen',
+      charactersTooMany: '{{characters}} for mange',
+      checksPassing: '{{current}}/{{max}} sjekker bestått',
+      good: 'Bra',
+      imageAutoGenerationTip: 'Auto-generering vil hente det valgte hero-bildet.',
+      lengthTipDescription:
+        'Dette bør være mellom {{minLength}} og {{maxLength}} tegn. For hjelp til å skrive beskrivelser av god kvalitet, se ',
+      lengthTipTitle:
+        'Dette bør være mellom {{minLength}} og {{maxLength}} tegn. For hjelp til å skrive metatitler av god kvalitet, se ',
+      noImage: 'Bilde mangler',
+      preview: 'Forhåndsvisning',
+      previewDescription:
+        'Eksakte resultatoppføringer kan variere basert på innhold og søke relevans.',
+      tooLong: 'For lang',
+      tooShort: 'For kort',
+    },
+  },
   pl: {
     $schema: './translation-schema.json',
     'plugin-seo': {


### PR DESCRIPTION
## Description

Duplicate [PR](https://github.com/payloadcms/payload/pull/5621) for  **alpha** - adds Norwegian translation to `plugin-seo`.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Chore (non-breaking change which does not add functionality)

## Checklist:

- [X] Existing test suite passes locally with my changes