### PR TITLE
docs: updates rate limit default from `90000` to `900000`

### DIFF
--- a/docs/production/preventing-abuse.mdx
+++ b/docs/production/preventing-abuse.mdx
@@ -20,7 +20,7 @@ To prevent DDoS, brute-force, and similar attacks, you can set IP-based rate lim
 
 | Option           | Description                                                                                                             |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| **`window`**     | Time in milliseconds to track requests per IP. Defaults to `90000` (15 minutes).                                        |
+| **`window`**     | Time in milliseconds to track requests per IP. Defaults to `900000` (15 minutes).                                        |
 | **`max`**        | Number of requests served from a single IP before limiting. Defaults to `500`.                                          |
 | **`skip`**       | Express middleware function that can return true (or promise resulting in true) that will bypass limit.                 |
 | **`trustProxy`** | True or false, to enable to allow requests to pass through a proxy such as a load balancer or an `nginx` reverse proxy. |


### PR DESCRIPTION
## Description

docs: the [Preventing Production API Abuse](https://payloadcms.com/docs/production/preventing-abuse#rate-limiting-requests) page in the docs was showing 90000ms as the default rate limit but it is actually supposed to be 900000ms.

Closes #5260 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
