### PR TITLE
fix: incorrect tooltip colors in light mode

### DIFF
--- a/packages/payload/src/admin/components/elements/Tooltip/index.scss
+++ b/packages/payload/src/admin/components/elements/Tooltip/index.scss
@@ -85,15 +85,15 @@
 
 html[data-theme='light'] {
   .tooltip {
-    background-color: var(--theme-error-250);
-    color: var(--theme-error-750);
+    background-color: var(--theme-elevation-100);
+    color: var(--theme-elevation-1000);
 
     &--position-top:after {
-      border-top-color: var(--theme-error-250);
+      border-top-color: var(--theme-elevation-100);
     }
 
     &--position-bottom:after {
-      border-bottom-color: var(--theme-error-250);
+      border-bottom-color: var(--theme-elevation-100);
     }
   }
 }


### PR DESCRIPTION
## Description

Light mode colors for the tooltip were using the incorrect set of colors. 

They were using the error state colors even for tooltips not for a field error state. This PR updates the light theme colors of the tooltip.

Fixes #5089 

`Before`:

![Screenshot 2024-04-03 at 12 40 00 PM](https://github.com/payloadcms/payload/assets/35232443/a208ea9c-563d-4706-aac0-ad69b1fa301c)

`After`:

![Screenshot 2024-04-03 at 12 39 23 PM](https://github.com/payloadcms/payload/assets/35232443/aa0dc5e7-4d70-4a11-b242-bfee365c9725)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
