### PR TITLE
fix: incorrect tooltip colors in light mode

### DIFF
--- a/packages/ui/src/elements/Tooltip/index.scss
+++ b/packages/ui/src/elements/Tooltip/index.scss
@@ -85,15 +85,15 @@
 
 html[data-theme='light'] {
   .tooltip {
-    background-color: var(--theme-error-250);
-    color: var(--theme-error-750);
+    background-color: var(--theme-elevation-100);
+    color: var(--theme-elevation-1000);
 
     &--position-top:after {
-      border-top-color: var(--theme-error-250);
+      border-top-color: var(--theme-elevation-100);
     }
 
     &--position-bottom:after {
-      border-bottom-color: var(--theme-error-250);
+      border-bottom-color: var(--theme-elevation-100);
     }
   }
 }


### PR DESCRIPTION
## Description

Light mode colors for the tooltip were using the incorrect set of colors.

They were using the error state colors even for tooltips not for a field error state. This PR updates the light theme colors of the tooltip.

This replicates #5632 for `alpha`

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
