### PR TITLE
fix: duplicate document multiple times in quick succession

### DIFF
--- a/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
+++ b/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
@@ -17,7 +17,7 @@ import './index.scss'
 
 const baseClass = 'duplicate'
 
-const Duplicate: React.FC<Props> = ({ id, collection, slug }) => {
+const Duplicate: React.FC<Props> = ({ id, slug, collection }) => {
   const { push } = useHistory()
   const modified = useFormModified()
   const { toggleModal } = useModal()
@@ -31,12 +31,15 @@ const Duplicate: React.FC<Props> = ({ id, collection, slug }) => {
     routes: { admin },
   } = useConfig()
   const [hasClicked, setHasClicked] = useState<boolean>(false)
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
   const { i18n, t } = useTranslation('general')
 
   const modalSlug = `duplicate-${id}`
 
   const handleClick = useCallback(
     async (override = false) => {
+      if (isSubmitting) return
+      setIsSubmitting(true)
       setHasClicked(true)
 
       if (modified && !override) {
@@ -144,6 +147,7 @@ const Duplicate: React.FC<Props> = ({ id, collection, slug }) => {
       }
 
       setModified(false)
+      setIsSubmitting(false)
 
       setTimeout(() => {
         push({
@@ -170,13 +174,17 @@ const Duplicate: React.FC<Props> = ({ id, collection, slug }) => {
   )
 
   const confirm = useCallback(async () => {
-    setHasClicked(false)
     await handleClick(true)
+    setHasClicked(false)
   }, [handleClick])
 
   return (
     <React.Fragment>
-      <PopupList.Button id="action-duplicate" onClick={() => handleClick(false)}>
+      <PopupList.Button
+        disabled={isSubmitting}
+        id="action-duplicate"
+        onClick={() => handleClick(false)}
+      >
         {t('duplicate')}
       </PopupList.Button>
       {modified && hasClicked && (

--- a/packages/payload/src/admin/components/elements/Popup/PopupButtonList/index.tsx
+++ b/packages/payload/src/admin/components/elements/Popup/PopupButtonList/index.tsx
@@ -27,6 +27,7 @@ type MenuButtonProps = {
   active?: boolean
   children: React.ReactNode
   className?: string
+  disabled?: boolean
   id?: string
   onClick?: () => void
   to?: LinkProps['to']
@@ -36,6 +37,7 @@ export const Button: React.FC<MenuButtonProps> = ({
   active,
   children,
   className,
+  disabled,
   onClick,
   to,
 }) => {
@@ -64,6 +66,7 @@ export const Button: React.FC<MenuButtonProps> = ({
     return (
       <button
         className={classes}
+        disabled={disabled}
         id={id}
         onClick={() => {
           if (onClick) {


### PR DESCRIPTION
## Description

`fix`: adds loading state to duplicate button that disables the duplicate button until document is successfully duplicated.

fixes #5465 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
