### PR TITLE
fix(website template): archiveBlock being populated with draft items by default, causing an error for graphql in the frontend

### DIFF
--- a/templates/website/src/payload/hooks/populateArchiveBlock.ts
+++ b/templates/website/src/payload/hooks/populateArchiveBlock.ts
@@ -36,6 +36,9 @@ export const populateArchiveBlock: AfterReadHook = async ({ doc, context, req: {
                     },
                   }
                 : {}),
+              _status: {
+                equals: 'published',
+              },
             },
             sort: '-publishedAt',
           })

--- a/templates/website/src/payload/hooks/populateArchiveBlock.ts
+++ b/templates/website/src/payload/hooks/populateArchiveBlock.ts
@@ -1,10 +1,14 @@
 import type { AfterReadHook } from 'payload/dist/collections/config/types'
 
+import { adminsOrPublished } from '../access/adminsOrPublished'
 import type { Page, Post } from '../payload-types'
 
-export const populateArchiveBlock: AfterReadHook = async ({ doc, context, req: { payload } }) => {
+export const populateArchiveBlock: AfterReadHook = async ({ doc, context, req }) => {
   // pre-populate the archive block if `populateBy` is `collection`
   // then hydrate it on your front-end
+  const payload = req.payload
+  const adminOrPublishedResult = await adminsOrPublished({ req: req })
+  const adminOrPublishedQuery = adminOrPublishedResult
 
   const layoutWithArchive = await Promise.all(
     doc.layout.map(async block => {
@@ -36,9 +40,7 @@ export const populateArchiveBlock: AfterReadHook = async ({ doc, context, req: {
                     },
                   }
                 : {}),
-              _status: {
-                equals: 'published',
-              },
+              ...(typeof adminOrPublishedQuery === 'boolean' ? {} : adminOrPublishedQuery),
             },
             sort: '-publishedAt',
           })


### PR DESCRIPTION
Fixes archiveBlock being populated with draft items by default, causing an error for graphql in the frontend

closes https://github.com/payloadcms/payload/issues/5613

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
