### PR TITLE
fix: updates type name of `CustomPublishButtonProps` to `CustomPublishButtonType`

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -168,7 +168,7 @@ import * as React from 'react'
 import {
   CustomSaveButtonProps,
   CustomSaveDraftButtonProps,
-  CustomPublishButtonProps,
+  CustomPublishButtonType,
   CustomPreviewButtonProps,
 } from 'payload/types'
 
@@ -185,7 +185,7 @@ export const CustomSaveDraftButton: CustomSaveDraftButtonProps = ({
   return <DefaultButton label={label} disabled={disabled} saveDraft={saveDraft} />
 }
 
-export const CustomPublishButton: CustomPublishButtonProps = ({
+export const CustomPublishButton: CustomPublishButtonType = ({
   DefaultButton,
   disabled,
   label,

--- a/packages/payload/src/admin/components/elements/Publish/index.tsx
+++ b/packages/payload/src/admin/components/elements/Publish/index.tsx
@@ -9,7 +9,7 @@ import { useDocumentInfo } from '../../utilities/DocumentInfo'
 import { useLocale } from '../../utilities/Locale'
 import RenderCustomComponent from '../../utilities/RenderCustomComponent'
 
-export type CustomPublishButtonProps = React.ComponentType<
+export type CustomPublishButtonType = React.ComponentType<
   DefaultPublishButtonProps & {
     DefaultButton: React.ComponentType<DefaultPublishButtonProps>
   }
@@ -38,7 +38,7 @@ const DefaultPublishButton: React.FC<DefaultPublishButtonProps> = ({
 }
 
 type Props = {
-  CustomComponent?: CustomPublishButtonProps
+  CustomComponent?: CustomPublishButtonType
 }
 
 export const Publish: React.FC<Props> = ({ CustomComponent }) => {

--- a/packages/payload/src/admin/components/elements/Publish/index.tsx
+++ b/packages/payload/src/admin/components/elements/Publish/index.tsx
@@ -14,6 +14,11 @@ export type CustomPublishButtonType = React.ComponentType<
     DefaultButton: React.ComponentType<DefaultPublishButtonProps>
   }
 >
+/**
+ * @deprecated Use `CustomPublishButtonType` instead - renamed from `CustomPublishButtonProps`
+ */
+export type CustomPublishButtonProps = CustomPublishButtonType
+
 export type DefaultPublishButtonProps = {
   canPublish: boolean
   disabled: boolean

--- a/packages/payload/src/admin/components/elements/types.ts
+++ b/packages/payload/src/admin/components/elements/types.ts
@@ -1,4 +1,4 @@
 export type { CustomPreviewButtonProps } from './PreviewButton'
-export type { CustomPublishButtonType } from './Publish'
+export type { CustomPublishButtonProps, CustomPublishButtonType } from './Publish'
 export type { CustomSaveButtonProps } from './Save'
 export type { CustomSaveDraftButtonProps } from './SaveDraft'

--- a/packages/payload/src/admin/components/elements/types.ts
+++ b/packages/payload/src/admin/components/elements/types.ts
@@ -1,4 +1,4 @@
 export type { CustomPreviewButtonProps } from './PreviewButton'
-export type { CustomPublishButtonProps } from './Publish'
+export type { CustomPublishButtonType } from './Publish'
 export type { CustomSaveButtonProps } from './Save'
 export type { CustomSaveDraftButtonProps } from './SaveDraft'

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -6,7 +6,7 @@ import type { DeepRequired } from 'ts-essentials'
 import type { GeneratedTypes } from '../../'
 import type {
   CustomPreviewButtonProps,
-  CustomPublishButtonProps,
+  CustomPublishButtonType,
   CustomSaveButtonProps,
   CustomSaveDraftButtonProps,
 } from '../../admin/components/elements/types'
@@ -228,7 +228,7 @@ export type CollectionAdminOptions = {
        * Replaces the "Publish" button
        * + drafts must be enabled
        */
-      PublishButton?: CustomPublishButtonProps
+      PublishButton?: CustomPublishButtonType
       /**
        * Replaces the "Save" button
        * + drafts must be disabled

--- a/packages/payload/src/exports/types.ts
+++ b/packages/payload/src/exports/types.ts
@@ -18,6 +18,7 @@ export type { CellComponentProps } from '../admin/components/views/collections/L
 export { FileData, ImageSize, IncomingUploadType } from '../uploads/types'
 
 export type {
+  CustomPublishButtonProps,
   CustomPublishButtonType,
   CustomSaveButtonProps,
   CustomSaveDraftButtonProps,

--- a/packages/payload/src/exports/types.ts
+++ b/packages/payload/src/exports/types.ts
@@ -18,7 +18,7 @@ export type { CellComponentProps } from '../admin/components/views/collections/L
 export { FileData, ImageSize, IncomingUploadType } from '../uploads/types'
 
 export type {
-  CustomPublishButtonProps,
+  CustomPublishButtonType,
   CustomSaveButtonProps,
   CustomSaveDraftButtonProps,
 } from './../admin/components/elements/types'

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -3,7 +3,7 @@ import type { DeepRequired } from 'ts-essentials'
 
 import type {
   CustomPreviewButtonProps,
-  CustomPublishButtonProps,
+  CustomPublishButtonType,
   CustomSaveButtonProps,
   CustomSaveDraftButtonProps,
 } from '../../admin/components/elements/types'
@@ -86,7 +86,7 @@ export type GlobalAdminOptions = {
        * Replaces the "Publish" button
        * + drafts must be enabled
        */
-      PublishButton?: CustomPublishButtonProps
+      PublishButton?: CustomPublishButtonType
       /**
        * Replaces the "Save" button
        * + drafts must be disabled

--- a/test/versions/elements/CustomSaveButton/index.tsx
+++ b/test/versions/elements/CustomSaveButton/index.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 
-import type { CustomPublishButtonType } from '../../../../packages/payload/src/admin/components/elements/types'
+import type { CustomPublishButtonProps } from '../../../../packages/payload/src/admin/components/elements/types'
 
 // In your projects, you can import as follows:
-// import { CustomPublishButtonType } from 'payload/types';
+// import { CustomPublishButtonProps } from 'payload/types';
 
 import classes from './index.module.scss'
 
-export const CustomPublishButton: CustomPublishButtonType = ({ DefaultButton, ...rest }) => {
+export const CustomPublishButton: CustomPublishButtonProps = ({ DefaultButton, ...rest }) => {
   return (
     <div className={classes.customButton}>
       <DefaultButton {...rest} />

--- a/test/versions/elements/CustomSaveButton/index.tsx
+++ b/test/versions/elements/CustomSaveButton/index.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 
-import type { CustomPublishButtonProps } from '../../../../packages/payload/src/admin/components/elements/types'
+import type { CustomPublishButtonType } from '../../../../packages/payload/src/admin/components/elements/types'
 
 // In your projects, you can import as follows:
-// import { CustomPublishButtonProps } from 'payload/types';
+// import { CustomPublishButtonType } from 'payload/types';
 
 import classes from './index.module.scss'
 
-export const CustomPublishButton: CustomPublishButtonProps = ({ DefaultButton, ...rest }) => {
+export const CustomPublishButton: CustomPublishButtonType = ({ DefaultButton, ...rest }) => {
   return (
     <div className={classes.customButton}>
       <DefaultButton {...rest} />


### PR DESCRIPTION
## Description

`CustomPublishButtonProps` is being used to define a component type, not just the shape of props.

`React.ComponentType` is a utility type used in Typescript to denote a React component. The suffix `Props` typically implies a definition of props' shape rather than a component.

Fixes #5183 

Fix: updates type name of `CustomPublishButtonProps` to `CustomPublishButtonType` but keeps old `CustomPublishButtonProps` defined but mapped to `CustomPublishButtonType` in order to avoid a breaking change.

![Screenshot 2024-04-04 at 2 33 17 PM](https://github.com/payloadcms/payload/assets/35232443/f35e3d18-02a3-4ef6-bdbf-a58a99f522f7)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
