### PR TITLE
fix: checkbox icon-opacity on hover bleeding into all svgs inside field

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Checkbox/index.scss
+++ b/packages/payload/src/admin/components/forms/field-types/Checkbox/index.scss
@@ -92,8 +92,10 @@
     &:hover {
       cursor: pointer;
 
-      svg {
-        opacity: 0.2;
+      .checkbox-input__icon {
+        svg {
+          opacity: 0.2;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

I ran into this issue when adding an extra icon to the checkbox label by using a custom Label component that uses the default Label.

The style fixed in this PR was targeting all svgs inside the label and therefore reducing the opacity of the additional icon.

The fix simply wraps the `svg` selector into an additional `.checkbox-input__icon` selector, like it is already done in the rest of the file.

### Demo of the Issue

https://github.com/payloadcms/payload/assets/208149/acee830d-495d-4f0c-a457-5385cdc78814

### The existing checkbox works exactly as before:

Before: 

https://github.com/payloadcms/payload/assets/208149/ab9ca65a-af40-434a-aef5-b1c693729daf

After:

https://github.com/payloadcms/payload/assets/208149/205791a3-9d8f-4271-a3b2-8f1b34dbc079




  - [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Existing test suite passes locally with my changes
- [ ] ~I have made corresponding changes to the documentation~
