### PR TITLE
fix: missing date locales

### DIFF
--- a/packages/payload/src/admin/utilities/formatDate/getSupportedDateLocale.ts
+++ b/packages/payload/src/admin/utilities/formatDate/getSupportedDateLocale.ts
@@ -1,9 +1,34 @@
 export const getSupportedDateLocale = (locale = 'enUS'): string => {
+  // Need to match our translation locales with the local codes of 'date-fns/locale to support date locales
   const formattedLocales = {
+    ar: 'ar',
+    az: 'az',
+    bg: 'bg',
+    cs: 'cs',
+    de: 'de',
     en: 'enUS',
+    es: 'es',
+    fa: 'faIR',
+    fr: 'fr',
+    hr: 'hr',
+    hu: 'hu',
+    it: 'it',
+    ja: 'ja',
+    ko: 'ko',
     my: 'enUS', // Burmese is not currently supported
+    nb: 'nb',
+    nl: 'nl',
+    pl: 'pl',
+    pt: 'pt',
+    ro: 'ro',
+    ru: 'ru',
+    sv: 'sv',
+    th: 'th',
+    tr: 'tr',
     ua: 'uk',
+    vi: 'vi',
     zh: 'zhCN',
+    zhTw: 'zhTW',
   }
 
   return formattedLocales[locale] || locale


### PR DESCRIPTION
## Description

Prior to this update, we had only a few locales defined for date locales because at the time those were the only translation locales Payload supported.

Fix: adds our updated translation locales with matching date locale codes from `date-fns/locale` package.

Fixes #5442 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
