### PR TITLE
fix(db-postgres): issue querying by localised relationship not respecting locale as constraint

### DIFF
--- a/test/relationships/config.ts
+++ b/test/relationships/config.ts
@@ -37,6 +37,7 @@ const collectionWithName = (collectionSlug: string): CollectionConfig => {
 }
 
 export const slug = 'posts'
+export const slugWithLocalizedRel = 'postsLocalized'
 export const relationSlug = 'relation'
 export const defaultAccessRelSlug = 'strict-access'
 export const chainedRelSlug = 'chained'
@@ -46,6 +47,10 @@ export const polymorphicRelationshipsSlug = 'polymorphic-relationships'
 export const treeSlug = 'tree'
 
 export default buildConfigWithDefaults({
+  localization: {
+    locales: ['en', 'de'],
+    defaultLocale: 'en',
+  },
   collections: [
     {
       slug,
@@ -105,6 +110,23 @@ export default buildConfigWithDefaults({
               not_equals: true,
             },
           },
+        },
+      ],
+    },
+    {
+      slug: slugWithLocalizedRel,
+      access: openAccess,
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+        // Relationship
+        {
+          name: 'relationField',
+          type: 'relationship',
+          relationTo: relationSlug,
+          localized: true,
         },
       ],
     },
@@ -273,6 +295,13 @@ export default buildConfigWithDefaults({
       collection: relationSlug,
       data: {
         name: 'name',
+      },
+    })
+
+    const rel2 = await payload.create({
+      collection: relationSlug,
+      data: {
+        name: 'another name',
       },
     })
 

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -461,7 +461,7 @@ describe('Relationships', () => {
           })
         })
         it('should find two docs for german locale', async () => {
-          const { docs, totalDocs } = await payload.find<PostsLocalized>({
+          const { docs } = await payload.find<PostsLocalized>({
             collection: slugWithLocalizedRel,
             locale: 'de',
             where: {
@@ -471,11 +471,13 @@ describe('Relationships', () => {
             },
           })
 
-          expect(totalDocs).toEqual(2)
+          const mappedIds = docs.map((doc) => doc?.id)
+          expect(mappedIds).toContain(localizedPost1.id)
+          expect(mappedIds).toContain(localizedPost2.id)
         })
 
         it("shouldn't find a relationship query outside of the specified locale", async () => {
-          const { docs, totalDocs } = await payload.find<PostsLocalized>({
+          const { docs } = await payload.find<PostsLocalized>({
             collection: slugWithLocalizedRel,
             locale: 'en',
             where: {
@@ -485,7 +487,7 @@ describe('Relationships', () => {
             },
           })
 
-          expect(totalDocs).toEqual(0)
+          expect(docs.map((doc) => doc?.id)).not.toContain(localizedPost2.id)
         })
       })
     })

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -9,6 +9,7 @@ import type {
   Post,
   Relation,
 } from './payload-types'
+import type { PostsLocalized } from './payload-types'
 
 import payload from '../../packages/payload/src'
 import { devUser } from '../credentials'
@@ -21,6 +22,7 @@ import config, {
   defaultAccessRelSlug,
   relationSlug,
   slug,
+  slugWithLocalizedRel,
   treeSlug,
 } from './config'
 
@@ -407,6 +409,83 @@ describe('Relationships', () => {
           expect(doc?.maxDepthRelation).not.toHaveProperty('name')
           // should not affect other fields
           expect(doc?.relationField).toMatchObject({ id: relation.id, name: relation.name })
+        })
+      })
+
+      describe('with localization', () => {
+        let relation1: Relation
+        let relation2: Relation
+        let localizedPost1: PostsLocalized
+        let localizedPost2: PostsLocalized
+
+        beforeAll(async () => {
+          relation1 = await payload.create<Relation>({
+            collection: relationSlug,
+            data: {
+              name: 'english',
+            },
+          })
+
+          relation2 = await payload.create<Relation>({
+            collection: relationSlug,
+            data: {
+              name: 'german',
+            },
+          })
+
+          localizedPost1 = await payload.create<'postsLocalized'>({
+            collection: slugWithLocalizedRel,
+            data: {
+              title: 'english',
+              relationField: relation1.id,
+            },
+            locale: 'en',
+          })
+
+          await payload.update({
+            id: localizedPost1.id,
+            collection: slugWithLocalizedRel,
+            locale: 'de',
+            data: {
+              relationField: relation2.id,
+            },
+          })
+
+          localizedPost2 = await payload.create({
+            collection: slugWithLocalizedRel,
+            data: {
+              title: 'german',
+              relationField: relation2.id,
+            },
+            locale: 'de',
+          })
+        })
+        it('should find two docs for german locale', async () => {
+          const { docs, totalDocs } = await payload.find<PostsLocalized>({
+            collection: slugWithLocalizedRel,
+            locale: 'de',
+            where: {
+              relationField: {
+                equals: relation2.id,
+              },
+            },
+          })
+
+          expect(totalDocs).toEqual(2)
+        })
+
+        it("shouldn't find a relationship query outside of the specified locale", async () => {
+          const { docs, totalDocs } = await payload.find<PostsLocalized>({
+            collection: slugWithLocalizedRel,
+            locale: 'en',
+            where: {
+              relationField: {
+                equals: relation2.id,
+              },
+            },
+          })
+
+          expect(totalDocs).toEqual(0)
         })
       })
     })

--- a/test/relationships/payload-types.ts
+++ b/test/relationships/payload-types.ts
@@ -9,6 +9,7 @@ export interface Config {
   collections: {
     posts: Post
     relation: Relation
+    postsLocalized: PostsLocalized
     'strict-access': StrictAccess
     'chained-relation': ChainedRelation
     'custom-id-relation': CustomIdRelation
@@ -32,6 +33,13 @@ export interface Post {
   customIdRelation?: string | CustomIdRelation
   customIdNumberRelation?: number | CustomIdNumberRelation
   filteredRelation?: string | Relation
+  updatedAt: string
+  createdAt: string
+}
+export interface PostsLocalized {
+  id: string
+  title?: string | null
+  relationField?: (string | null) | Relation
   updatedAt: string
   createdAt: string
 }


### PR DESCRIPTION
## Description

Fixes an issue where if you queried docs by a localised relationship field it wouldn't respect the locale set in the query

Closes https://github.com/payloadcms/payload/issues/5579

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
