### PR TITLE
fix: Error handling non-ASCII names when uploading files

### DIFF
--- a/packages/payload/src/express/middleware/index.ts
+++ b/packages/payload/src/express/middleware/index.ts
@@ -51,6 +51,7 @@ const middleware = (payload: Payload): any => {
     localizationMiddleware,
     express.json(payload.config.express.json),
     fileUpload({
+      defParamCharset: 'utf8',
       parseNested: true,
       ...payload.config.upload,
     }),


### PR DESCRIPTION
## Description

The current fileUpload method used by the Uploads cannot handle non-ascii characters in the file meta. This will cause the filename to be unreadable after uploading.
![msedge_ZKbTZNE19V](https://github.com/payloadcms/payload/assets/21760321/d4d49cbe-1324-4338-b09c-0bfbb6d83566)
![msedge_fQi89p0VT8](https://github.com/payloadcms/payload/assets/21760321/3c162372-2daf-409d-86ab-8bd83115ff03)
![msedge_ze6cSFw2OU](https://github.com/payloadcms/payload/assets/21760321/79b475de-dd20-4a9e-9c0e-c50d319d8d6e)

Expected:
![msedge_59k5K5qpY0](https://github.com/payloadcms/payload/assets/21760321/7a2e7522-2ab5-46be-97e0-9d9d73d0c763)
![msedge_Vplgdtp36D](https://github.com/payloadcms/payload/assets/21760321/b50b4921-8db9-45e3-9cc0-2fe7439a2351)

A default charset could solve this issue. [richardgirges/express-fileupload/issues/319](https://github.com/richardgirges/express-fileupload/issues/319)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

> payload.create in the test case cannot trigger this bug.

- [x] Existing test suite passes locally with my changes

## Alternative fix
Add `defParamCharset: 'utf8'` into buildConfig under payload.config.ts. This requires a documentation update.
```
upload: {
    defParamCharset: 'utf8',
  }
```