### PR TITLE
fix(next): incorrect access of select options in versions view

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Select/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Select/index.tsx
@@ -55,14 +55,16 @@ const Select: React.FC<
 
   if (version === comparison) placeholder = `[${i18n.t('general:noValue')}]`
 
+  const options = 'options' in field.fieldComponentProps && field.fieldComponentProps.options
+
   const comparisonToRender =
     typeof comparison !== 'undefined'
-      ? getTranslatedOptions(getOptionsToRender(comparison, field.options, field.hasMany), i18n)
+      ? getTranslatedOptions(getOptionsToRender(comparison, options, field.hasMany), i18n)
       : placeholder
 
   const versionToRender =
     typeof version !== 'undefined'
-      ? getTranslatedOptions(getOptionsToRender(version, field.options, field.hasMany), i18n)
+      ? getTranslatedOptions(getOptionsToRender(version, options, field.hasMany), i18n)
       : placeholder
 
   return (


### PR DESCRIPTION
## Description

Originally was trying to access options with `field.options` but needs to be `field.fieldComponentProps.options`

Fixes this [issue](https://github.com/payloadcms/payload-3.0-alpha-demo/issues/61) in `alpha demo repo`

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
