### PR TITLE
test(versions): replaces outdated CustomPublishButtonProps type

### DIFF
--- a/test/versions/elements/CustomSaveButton/index.tsx
+++ b/test/versions/elements/CustomSaveButton/index.tsx
@@ -1,12 +1,12 @@
 'use client'
-import type { CustomPublishButtonProps } from 'payload/types'
+import type { CustomPublishButton as CustomPublishButtonType } from 'payload/types'
 
 import { DefaultPublishButton } from '@payloadcms/ui/elements/Publish'
 import * as React from 'react'
 
 import classes from './index.module.scss'
 
-export const CustomPublishButton: CustomPublishButtonProps = () => {
+export const CustomPublishButton: CustomPublishButtonType = () => {
   return (
     <div className={classes.customButton}>
       <DefaultPublishButton />


### PR DESCRIPTION
## Description

`fix`: updates incorrect `CustomPublishButton` type in versions test suite from `CustomPublishButtonProps` to `CustomPublishButtonType`

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
