### PR TITLE
fix(next): live preview url

### DIFF
--- a/packages/next/src/views/LivePreview/index.tsx
+++ b/packages/next/src/views/LivePreview/index.tsx
@@ -56,7 +56,6 @@ export const LivePreviewView: EditViewComponent = async (props) => {
       ? await livePreviewConfig.url({
           data,
           documentInfo: {}, // TODO: recreate this object server-side, see `useDocumentInfo`
-          // @ts-expect-error
           locale,
         })
       : livePreviewConfig?.url

--- a/packages/next/src/views/LivePreview/index.tsx
+++ b/packages/next/src/views/LivePreview/index.tsx
@@ -1,6 +1,7 @@
 import type { LivePreviewConfig } from 'payload/config'
 import type { EditViewComponent, TypeWithID } from 'payload/types'
 
+import { notFound } from 'next/navigation.js'
 import React from 'react'
 
 import { LivePreviewClient } from './index.client.js'
@@ -25,23 +26,27 @@ export const LivePreviewView: EditViewComponent = async (props) => {
 
   let data: TypeWithID
 
-  if (collectionConfig) {
-    data = await initPageResult.req.payload.findByID({
-      id: docID,
-      collection: collectionConfig.slug,
-      depth: 0,
-      draft: true,
-      fallbackLocale: null,
-    })
-  }
+  try {
+    if (collectionConfig) {
+      data = await initPageResult.req.payload.findByID({
+        id: docID,
+        collection: collectionConfig.slug,
+        depth: 0,
+        draft: true,
+        fallbackLocale: null,
+      })
+    }
 
-  if (globalConfig) {
-    data = await initPageResult.req.payload.findGlobal({
-      slug: globalConfig.slug,
-      depth: 0,
-      draft: true,
-      fallbackLocale: null,
-    })
+    if (globalConfig) {
+      data = await initPageResult.req.payload.findGlobal({
+        slug: globalConfig.slug,
+        depth: 0,
+        draft: true,
+        fallbackLocale: null,
+      })
+    }
+  } catch (error) {
+    notFound()
   }
 
   let livePreviewConfig: LivePreviewConfig = topLevelLivePreviewConfig
@@ -77,6 +82,7 @@ export const LivePreviewView: EditViewComponent = async (props) => {
           data,
           globalConfig,
           locale,
+          payload: initPageResult.req.payload,
         })
       : livePreviewConfig?.url
 

--- a/packages/payload/src/admin/views/types.ts
+++ b/packages/payload/src/admin/views/types.ts
@@ -2,6 +2,7 @@ import type { Translations } from '@payloadcms/translations'
 
 import type { Permissions } from '../../auth/index.js'
 import type { SanitizedCollectionConfig } from '../../collections/config/types.js'
+import type { Locale } from '../../config/types.js'
 import type { SanitizedGlobalConfig } from '../../globals/config/types.js'
 import type { PayloadRequest } from '../../types/index.js'
 

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -63,8 +63,9 @@ export type LivePreviewConfig = {
    */
   url?:
     | ((args: {
+        collectionConfig?: SanitizedCollectionConfig
         data: Record<string, any>
-        documentInfo: any // TODO: remove or populate this
+        globalConfig?: SanitizedGlobalConfig
         locale: Locale
       }) => Promise<string> | string)
     | string

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -67,6 +67,7 @@ export type LivePreviewConfig = {
         data: Record<string, any>
         globalConfig?: SanitizedGlobalConfig
         locale: Locale
+        payload: Payload
       }) => Promise<string> | string)
     | string
 }

--- a/test/live-preview/seed/tenant-1.ts
+++ b/test/live-preview/seed/tenant-1.ts
@@ -2,5 +2,5 @@ import type { Tenant } from '../payload-types.js'
 
 export const tenant1: Omit<Tenant, 'createdAt' | 'id' | 'updatedAt'> = {
   title: 'Tenant 1',
-  clientURL: 'http://localhost:3001',
+  clientURL: 'http://localhost:3000',
 }

--- a/test/live-preview/seed/tenant-2.ts
+++ b/test/live-preview/seed/tenant-2.ts
@@ -2,5 +2,5 @@ import type { Tenant } from '../payload-types.js'
 
 export const tenant2: Omit<Tenant, 'createdAt' | 'id' | 'updatedAt'> = {
   title: 'Tenant 2',
-  clientURL: 'http://localhost:3002',
+  clientURL: 'http://localhost:3001',
 }

--- a/test/live-preview/utilities/formatLivePreviewURL.ts
+++ b/test/live-preview/utilities/formatLivePreviewURL.ts
@@ -1,4 +1,9 @@
-export const formatLivePreviewURL = async ({ data, documentInfo }) => {
+import type { LivePreviewConfig } from 'payload/config'
+
+export const formatLivePreviewURL: LivePreviewConfig['url'] = async ({
+  data,
+  collectionConfig,
+}) => {
   let baseURL = 'http://localhost:3000/live-preview'
 
   // You can run async requests here, if needed
@@ -21,6 +26,6 @@ export const formatLivePreviewURL = async ({ data, documentInfo }) => {
   // I.e. append '/posts' to the URL if the document is a post
   // You can also do this on individual collection or global config, if preferred
   return `${baseURL}${
-    documentInfo?.slug && documentInfo.slug !== 'pages' ? `/${documentInfo.slug}` : ''
+    collectionConfig && collectionConfig.slug !== 'pages' ? `/${collectionConfig.slug}` : ''
   }${data?.slug && data.slug !== 'home' ? `/${data.slug}` : ''}`
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
     ],
     "paths": {
       "@payload-config": [
-        "./test/_community/config.ts"
+        "./test/live-preview/config.ts"
       ],
       "@payloadcms/live-preview": [
         "./packages/live-preview/src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
     ],
     "paths": {
       "@payload-config": [
-        "./test/fields/config.ts"
+        "./test/_community/config.ts"
       ],
       "@payloadcms/live-preview": [
         "./packages/live-preview/src"


### PR DESCRIPTION
## Description

Closes https://github.com/payloadcms/payload-3.0-alpha-demo/issues/63. This is a breaking change. The args of the `livePreview.url` function have changed. It no longer receives `documentInfo` as an arg, and instead, now has `collectionConfig` and `globalConfig`. `data` was also missing, but has been brought back.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.