### PR TITLE
Fix setting lastFullyLoadedRelation

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -140,7 +140,7 @@ const Relationship: React.FC<Props> = (props) => {
           await priorRelation
 
           if (relationFilterOption === false) {
-            setLastFullyLoadedRelation(relations.indexOf(relation))
+            setLastFullyLoadedRelation(hasMultipleRelations ? relations.indexOf(relation) : -1)
             return Promise.resolve()
           }
 
@@ -205,7 +205,7 @@ const Relationship: React.FC<Props> = (props) => {
               })
 
               if (!data.nextPage) {
-                setLastFullyLoadedRelation(relations.indexOf(relation))
+                setLastFullyLoadedRelation(hasMultipleRelations ? relations.indexOf(relation) : -1)
               }
 
               if (data.docs.length > 0) {
@@ -221,7 +221,7 @@ const Relationship: React.FC<Props> = (props) => {
                 })
               }
             } else if (response.status === 403) {
-              setLastFullyLoadedRelation(relations.indexOf(relation))
+              setLastFullyLoadedRelation(hasMultipleRelations ? relations.indexOf(relation) : -1)
               dispatchOptions({
                 type: 'ADD',
                 collection,
@@ -245,15 +245,16 @@ const Relationship: React.FC<Props> = (props) => {
       relationTo,
       hasMany,
       errorLoading,
+      filterOptionsResult,
       search,
       lastLoadedPage,
+      hasMultipleRelations,
       collections,
       locale,
-      filterOptionsResult,
       serverURL,
-      sortOptions,
       api,
       i18n,
+      sortOptions,
       config,
       t,
     ],


### PR DESCRIPTION
## Description

fix setting the lastFullyLoadedRelation after search clear when there is only one relationTo in the array.
RE: #5696 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
