### PR TITLE
fix: add fallback for minRows

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
@@ -35,11 +35,11 @@ const ArrayFieldType: React.FC<Props> = (props) => {
     forceRender = false,
     indexPath,
     localized,
+    required,
+    minRows = required ? 1 : 0,
     maxRows,
-    minRows,
     path: pathFromProps,
     permissions,
-    required,
     validate = array,
   } = props
 
@@ -265,7 +265,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
                   {t('validation:requiresAtLeast', {
                     count: minRows,
                     label:
-                      getTranslation(minRows ? labels.plural : labels.singular, i18n) ||
+                      getTranslation(minRows > 1 ? labels.plural : labels.singular, i18n) ||
                       t(minRows > 1 ? 'general:row' : 'general:rows'),
                   })}
                 </Banner>


### PR DESCRIPTION
## Description

Given a collection config that looks like this:

```ts
export const Example: CollectionConfig = {
    slug: "example",
    fields: [
        {
            name: 'gallery',
            label: 'Gallery',
            type: 'array',
            required: true,
            fields: [
                {
                    name: 'image',
                    label: 'Image',
                    type: 'upload',
                    relationTo: 'media',
                    required: true,
                }
            ],
        },
    ],
}
```
I noticed this bug in the admin panel.

![image](https://github.com/payloadcms/payload/assets/18399089/4b358b92-1c95-4ec3-b570-2236c163517c)


Hopefully this should fix it!

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
