### PR TITLE
fix(ui): properly initializes collapsible context

### DIFF
--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -639,12 +639,12 @@ export const CustomArrayManager = () => {
 
 The `useCollapsible` hook allows you to control parent collapsibles:
 
-| Property                | Description                                                                                                  |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------ | --- |
-| **`collapsed`**         | State of the collapsible. `true` if open, `false` if collapsed                                               |
-| **`isVisible`**         | If nested, determine if the nearest collapsible is visible. `true` if no parent is closed, `false` otherwise |
-| **`toggle`**            | Toggles the state of the nearest collapsible                                                                 |
-| **`withinCollapsible`** | Determine when you are within another collaspible                                                            |     |
+| Property                  | Description                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ | --- |
+| **`isCollapsed`**         | State of the collapsible. `true` if open, `false` if collapsed                                               |
+| **`isVisible`**           | If nested, determine if the nearest collapsible is visible. `true` if no parent is closed, `false` otherwise |
+| **`toggle`**              | Toggles the state of the nearest collapsible                                                                 |
+| **`isWithinCollapsible`** | Determine when you are within another collaspible                                                            |     |
 
 **Example:**
 
@@ -654,10 +654,11 @@ import React from 'react'
 import { useCollapsible } from 'payload/components/utilities'
 
 const CustomComponent: React.FC = () => {
-  const { collapsed, toggle } = useCollapsible()
+  const { isCollapsed, toggle } = useCollapsible()
+
   return (
     <div>
-      <p className="field-type">I am {collapsed ? 'closed' : 'open'}</p>
+      <p className="field-type">I am {isCollapsed ? 'closed' : 'open'}</p>
       <button onClick={toggle} type="button">
         Toggle
       </button>

--- a/packages/payload/node.d.ts
+++ b/packages/payload/node.d.ts
@@ -1,4 +1,5 @@
-export { getFileByPath } from './dist/uploads/getFileByPath.js';
-export { importConfig } from './dist/utilities/importConfig.js';
-export { importWithoutClientFiles } from './dist/utilities/importWithoutClientFiles.js';
+export {
+  importConfig,
+  importWithoutClientFiles,
+} from './dist/utilities/importWithoutClientFiles.js'
 //# sourceMappingURL=node.d.ts.map

--- a/packages/payload/node.js
+++ b/packages/payload/node.js
@@ -1,5 +1,6 @@
-export { getFileByPath } from './dist/uploads/getFileByPath.js';
-export { importConfig } from './dist/utilities/importConfig.js';
-export { importWithoutClientFiles } from './dist/utilities/importWithoutClientFiles.js';
+export {
+  importConfig,
+  importWithoutClientFiles,
+} from './dist/utilities/importWithoutClientFiles.js'
 
 //# sourceMappingURL=node.js.map

--- a/packages/richtext-lexical/src/field/features/blocks/component/BlockContent.tsx
+++ b/packages/richtext-lexical/src/field/features/blocks/component/BlockContent.tsx
@@ -66,7 +66,7 @@ export const BlockContent: React.FC<Props> = (props) => {
   // is important to consider for the data path used in setDocFieldPreferences
   const { getDocPreferences, setDocFieldPreferences } = useDocumentInfo()
 
-  const [collapsed, setCollapsed] = React.useState<boolean>(() => {
+  const [isCollapsed, setIsCollapsed] = React.useState<boolean>(() => {
     let initialState = false
 
     void getDocPreferences().then((currentDocPreferences) => {
@@ -76,7 +76,7 @@ export const BlockContent: React.FC<Props> = (props) => {
 
       if (collapsedArray && collapsedArray.includes(formData.id)) {
         initialState = true
-        setCollapsed(true)
+        setIsCollapsed(true)
       }
     })
     return initialState
@@ -196,7 +196,6 @@ export const BlockContent: React.FC<Props> = (props) => {
     <React.Fragment>
       <Collapsible
         className={classNames}
-        collapsed={collapsed}
         collapsibleStyle={fieldHasErrors ? 'error' : 'default'}
         header={
           <div className={`${baseClass}__block-header`}>
@@ -228,10 +227,11 @@ export const BlockContent: React.FC<Props> = (props) => {
             )}
           </div>
         }
+        isCollapsed={isCollapsed}
         key={0}
-        onToggle={(collapsed) => {
-          onCollapsedChange(collapsed)
-          setCollapsed(collapsed)
+        onToggle={(incomingCollapsedState) => {
+          onCollapsedChange(incomingCollapsedState)
+          setIsCollapsed(incomingCollapsedState)
         }}
       >
         <RenderFields

--- a/packages/ui/src/elements/Collapsible/index.tsx
+++ b/packages/ui/src/elements/Collapsible/index.tsx
@@ -21,11 +21,11 @@ export type Props = {
   actions?: React.ReactNode
   children: React.ReactNode
   className?: string
-  collapsed?: boolean
   collapsibleStyle?: 'default' | 'error'
   dragHandleProps?: DragHandleProps
   header?: React.ReactNode
   initCollapsed?: boolean
+  isCollapsed?: boolean
   onToggle?: (collapsed: boolean) => void
 }
 
@@ -33,24 +33,24 @@ export const Collapsible: React.FC<Props> = ({
   actions,
   children,
   className,
-  collapsed: collapsedFromProps,
   collapsibleStyle = 'default',
   dragHandleProps,
   header,
   initCollapsed,
+  isCollapsed: collapsedFromProps,
   onToggle,
 }) => {
   const [collapsedLocal, setCollapsedLocal] = useState(Boolean(initCollapsed))
   const [hoveringToggle, setHoveringToggle] = useState(false)
-  const { withinCollapsible } = useCollapsible()
+  const { isWithinCollapsible } = useCollapsible()
   const { t } = useTranslation()
 
-  const collapsed = typeof collapsedFromProps === 'boolean' ? collapsedFromProps : collapsedLocal
+  const isCollapsed = typeof collapsedFromProps === 'boolean' ? collapsedFromProps : collapsedLocal
 
   const toggleCollapsible = React.useCallback(() => {
-    if (typeof onToggle === 'function') onToggle(!collapsed)
-    setCollapsedLocal(!collapsed)
-  }, [onToggle, collapsed])
+    if (typeof onToggle === 'function') onToggle(!isCollapsed)
+    setCollapsedLocal(!isCollapsed)
+  }, [onToggle, isCollapsed])
 
   return (
     <div
@@ -58,15 +58,15 @@ export const Collapsible: React.FC<Props> = ({
         baseClass,
         className,
         dragHandleProps && `${baseClass}--has-drag-handle`,
-        collapsed && `${baseClass}--collapsed`,
-        withinCollapsible && `${baseClass}--nested`,
+        isCollapsed && `${baseClass}--collapsed`,
+        isWithinCollapsible && `${baseClass}--nested`,
         hoveringToggle && `${baseClass}--hovered`,
         `${baseClass}--style-${collapsibleStyle}`,
       ]
         .filter(Boolean)
         .join(' ')}
     >
-      <CollapsibleProvider collapsed={collapsed} toggle={toggleCollapsible}>
+      <CollapsibleProvider isCollapsed={isCollapsed} toggle={toggleCollapsible}>
         <div
           className={`${baseClass}__toggle-wrap`}
           onMouseEnter={() => setHoveringToggle(true)}
@@ -84,7 +84,7 @@ export const Collapsible: React.FC<Props> = ({
           <button
             className={[
               `${baseClass}__toggle`,
-              `${baseClass}__toggle--${collapsed ? 'collapsed' : 'open'}`,
+              `${baseClass}__toggle--${isCollapsed ? 'collapsed' : 'open'}`,
             ]
               .filter(Boolean)
               .join(' ')}
@@ -108,11 +108,11 @@ export const Collapsible: React.FC<Props> = ({
           <div className={`${baseClass}__actions-wrap`}>
             {actions && <div className={`${baseClass}__actions`}>{actions}</div>}
             <div className={`${baseClass}__indicator`}>
-              <Chevron direction={!collapsed ? 'up' : undefined} />
+              <Chevron direction={!isCollapsed ? 'up' : undefined} />
             </div>
           </div>
         </div>
-        <AnimateHeight duration={200} height={collapsed ? 0 : 'auto'}>
+        <AnimateHeight duration={200} height={isCollapsed ? 0 : 'auto'}>
           <div className={`${baseClass}__content`}>{children}</div>
         </AnimateHeight>
       </CollapsibleProvider>

--- a/packages/ui/src/elements/Collapsible/provider.tsx
+++ b/packages/ui/src/elements/Collapsible/provider.tsx
@@ -2,34 +2,36 @@
 import React, { createContext, useContext } from 'react'
 
 type ContextType = {
-  collapsed: boolean
+  isCollapsed: boolean
   isVisible: boolean
+  isWithinCollapsible: boolean
   toggle: () => void
-  withinCollapsible: boolean
 }
+
 const Context = createContext({
-  collapsed: false,
-  isVisible: true,
+  isCollapsed: undefined,
+  isVisible: undefined,
+  isWithinCollapsible: undefined,
   toggle: () => {},
-  withinCollapsible: true,
-})
+} as ContextType)
 
 export const CollapsibleProvider: React.FC<{
   children?: React.ReactNode
-  collapsed?: boolean
+  isCollapsed?: boolean
+  isWithinCollapsible?: boolean
   toggle: () => void
-  withinCollapsible?: boolean
-}> = ({ children, collapsed, toggle, withinCollapsible = true }) => {
-  const { collapsed: parentIsCollapsed, isVisible } = useCollapsible()
+}> = ({ children, isCollapsed, isWithinCollapsible = true, toggle }) => {
+  const { isCollapsed: parentIsCollapsed, isVisible } = useCollapsible()
 
   const contextValue = React.useMemo((): ContextType => {
     return {
-      collapsed: Boolean(collapsed),
+      isCollapsed,
       isVisible: isVisible && !parentIsCollapsed,
+      isWithinCollapsible,
       toggle,
-      withinCollapsible,
     }
-  }, [collapsed, withinCollapsible, toggle, parentIsCollapsed, isVisible])
+  }, [isCollapsed, isWithinCollapsible, toggle, parentIsCollapsed, isVisible])
+
   return <Context.Provider value={contextValue}>{children}</Context.Provider>
 }
 

--- a/packages/ui/src/fields/Array/ArrayRow.tsx
+++ b/packages/ui/src/fields/Array/ArrayRow.tsx
@@ -107,7 +107,6 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
           ) : undefined
         }
         className={classNames}
-        collapsed={row.collapsed}
         collapsibleStyle={fieldHasErrors ? 'error' : 'default'}
         dragHandleProps={{
           id: row.id,
@@ -126,6 +125,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
             {fieldHasErrors && <ErrorPill count={errorCount} i18n={i18n} withMessage />}
           </div>
         }
+        isCollapsed={row.collapsed}
         onToggle={(collapsed) => setCollapse(row.id, collapsed)}
       >
         <RenderFields

--- a/packages/ui/src/fields/Blocks/BlockRow.tsx
+++ b/packages/ui/src/fields/Blocks/BlockRow.tsx
@@ -106,7 +106,6 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
           ) : undefined
         }
         className={classNames}
-        collapsed={row.collapsed}
         collapsibleStyle={fieldHasErrors ? 'error' : 'default'}
         dragHandleProps={{
           id: row.id,
@@ -128,6 +127,7 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
             {fieldHasErrors && <ErrorPill count={errorCount} i18n={i18n} withMessage />}
           </div>
         }
+        isCollapsed={row.collapsed}
         key={row.id}
         onToggle={(collapsed) => setCollapse(row.id, collapsed)}
       >

--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -51,7 +51,7 @@ const GroupField: React.FC<GroupFieldProps> = (props) => {
 
   const { path, permissions, readOnly: readOnlyFromContext, schemaPath } = useFieldProps()
   const { i18n } = useTranslation()
-  const isWithinCollapsible = useCollapsible()
+  const { isWithinCollapsible } = useCollapsible()
   const isWithinGroup = useGroup()
   const isWithinRow = useRow()
   const isWithinTab = useTabs()

--- a/packages/ui/src/fields/Tabs/index.tsx
+++ b/packages/ui/src/fields/Tabs/index.tsx
@@ -59,9 +59,11 @@ const TabsField: React.FC<TabsFieldProps> = (props) => {
   const { getPreference, setPreference } = usePreferences()
   const { preferencesKey } = useDocumentInfo()
   const { i18n } = useTranslation()
-  const isWithinCollapsible = useCollapsible()
+  const collapsible = useCollapsible()
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0)
   const tabsPrefKey = `tabs-${indexPath}`
+
+  const isWithinCollapsible = collapsible.isWithinCollapsible
 
   useEffect(() => {
     const getInitialPref = async () => {

--- a/packages/ui/src/fields/Tabs/index.tsx
+++ b/packages/ui/src/fields/Tabs/index.tsx
@@ -59,11 +59,9 @@ const TabsField: React.FC<TabsFieldProps> = (props) => {
   const { getPreference, setPreference } = usePreferences()
   const { preferencesKey } = useDocumentInfo()
   const { i18n } = useTranslation()
-  const collapsible = useCollapsible()
+  const { isWithinCollapsible } = useCollapsible()
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0)
   const tabsPrefKey = `tabs-${indexPath}`
-
-  const isWithinCollapsible = collapsible.isWithinCollapsible
 
   useEffect(() => {
     const getInitialPref = async () => {


### PR DESCRIPTION
## Description

Collapsibles were broken in a couple ways:
1. Collapsible context has changed—it used to return a simple boolean and now it returns an object, but the consuming components were not updated to reflect this change.
2. The collapsible context was being "newed" up with an initial state of `isWithinCollapsible: true`. This meant that simply calling the `useCollapsible` hook would return `true`, even if no collapsible context provider was found up the tree. To fix this we could either initialize the entire context as `null` (but this would means consuming components would not be able to safely destructure properties) or simply initialize the individual properties as `undefined` (which is what I've done).

These two bugs led to incorrect classnames being applies to various fields that watch for the presence of a collapsible, like tabs, blocks, etc. The context properties themselves have also been slightly modified for parity with other naming conventions throughout the application: `collapsed` is now `isCollapsed`, and `withinCollapsible` is now `isWithinCollapsible`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.