### PR TITLE
fix(ui): uses correct save draft button label

### DIFF
--- a/packages/ui/src/elements/SaveDraft/index.tsx
+++ b/packages/ui/src/elements/SaveDraft/index.tsx
@@ -25,7 +25,6 @@ const DefaultSaveDraftButton: React.FC = () => {
   const editDepth = useEditDepth()
   const { t } = useTranslation()
   const { submit } = useForm()
-  const label = t('general:save')
 
   const saveDraft = useCallback(async () => {
     const search = `?locale=${locale}&depth=0&fallback-locale=null&draft=true`
@@ -74,7 +73,7 @@ const DefaultSaveDraftButton: React.FC = () => {
       size="small"
       type="button"
     >
-      {label}
+      {t('version:saveDraft')}
     </FormSubmit>
   )
 }


### PR DESCRIPTION
## Description

The `SaveDraft` component was rendering the "save" label instead of the "save draft" label as expected.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.