### PR TITLE
fix(next): properly renders document-level unauthorized view

### DIFF
--- a/packages/next/src/views/CreateFirstUser/index.tsx
+++ b/packages/next/src/views/CreateFirstUser/index.tsx
@@ -12,7 +12,7 @@ import './index.scss'
 
 export { generateCreateFirstUserMetadata } from './meta.js'
 
-export const CreateFirstUser: React.FC<AdminViewProps> = async ({ initPageResult }) => {
+export const CreateFirstUserView: React.FC<AdminViewProps> = async ({ initPageResult }) => {
   const {
     req,
     req: {

--- a/packages/next/src/views/Document/getViewsFromConfig.tsx
+++ b/packages/next/src/views/Document/getViewsFromConfig.tsx
@@ -10,7 +10,7 @@ import type {
 import { APIView as DefaultAPIView } from '../API/index.js'
 import { EditView as DefaultEditView } from '../Edit/index.js'
 import { LivePreviewView as DefaultLivePreviewView } from '../LivePreview/index.js'
-import { Unauthorized } from '../Unauthorized/index.js'
+import { UnauthorizedView } from '../Unauthorized/index.js'
 import { VersionView as DefaultVersionView } from '../Version/index.js'
 import { VersionsView as DefaultVersionsView } from '../Versions/index.js'
 import { getCustomViewByKey } from './getCustomViewByKey.js'
@@ -77,7 +77,7 @@ export const getViewsFromConfig = ({
                 CustomView = getCustomViewByKey(views, 'Default')
                 DefaultView = DefaultEditView
               } else {
-                ErrorView = Unauthorized
+                ErrorView = UnauthorizedView
               }
               break
             }
@@ -87,7 +87,7 @@ export const getViewsFromConfig = ({
                 CustomView = getCustomViewByKey(views, 'Default')
                 DefaultView = DefaultEditView
               } else {
-                ErrorView = Unauthorized
+                ErrorView = UnauthorizedView
               }
               break
             }
@@ -118,7 +118,7 @@ export const getViewsFromConfig = ({
                 CustomView = getCustomViewByKey(views, 'Versions')
                 DefaultView = DefaultVersionsView
               } else {
-                ErrorView = Unauthorized
+                ErrorView = UnauthorizedView
               }
               break
             }
@@ -150,7 +150,7 @@ export const getViewsFromConfig = ({
               CustomView = getCustomViewByKey(views, 'Version')
               DefaultView = DefaultVersionView
             } else {
-              ErrorView = Unauthorized
+              ErrorView = UnauthorizedView
             }
           } else {
             const baseRoute = [adminRoute, collectionEntity, collectionSlug, segment3]
@@ -191,7 +191,7 @@ export const getViewsFromConfig = ({
             CustomView = getCustomViewByKey(views, 'Default')
             DefaultView = DefaultEditView
           } else {
-            ErrorView = Unauthorized
+            ErrorView = UnauthorizedView
           }
           break
         }
@@ -219,7 +219,7 @@ export const getViewsFromConfig = ({
                 CustomView = getCustomViewByKey(views, 'Versions')
                 DefaultView = DefaultVersionsView
               } else {
-                ErrorView = Unauthorized
+                ErrorView = UnauthorizedView
               }
               break
             }
@@ -229,7 +229,7 @@ export const getViewsFromConfig = ({
                 CustomView = getCustomViewByKey(views, 'Default')
                 DefaultView = DefaultEditView
               } else {
-                ErrorView = Unauthorized
+                ErrorView = UnauthorizedView
               }
               break
             }
@@ -244,7 +244,7 @@ export const getViewsFromConfig = ({
               CustomView = getCustomViewByKey(views, 'Version')
               DefaultView = DefaultVersionView
             } else {
-              ErrorView = Unauthorized
+              ErrorView = UnauthorizedView
             }
           } else {
             const baseRoute = [adminRoute, 'globals', globalSlug].filter(Boolean).join('/')

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -15,6 +15,7 @@ import React from 'react'
 
 import type { GenerateEditViewMetadata } from './getMetaBySegment.js'
 
+import { NotFoundView } from '../NotFound/index.js'
 import { getMetaBySegment } from './getMetaBySegment.js'
 import { getViewsFromConfig } from './getViewsFromConfig.js'
 
@@ -106,12 +107,8 @@ export const Document: React.FC<AdminViewProps> = async ({
       ErrorView = collectionViews?.ErrorView
     }
 
-    if (!CustomView && !DefaultView && !ViewOverride) {
-      if (ErrorView) {
-        return <ErrorView initPageResult={initPageResult} searchParams={searchParams} />
-      }
-
-      notFound()
+    if (!CustomView && !DefaultView && !ViewOverride && !ErrorView) {
+      ErrorView = NotFoundView
     }
   }
 
@@ -143,12 +140,8 @@ export const Document: React.FC<AdminViewProps> = async ({
       DefaultView = globalViews?.DefaultView
       ErrorView = globalViews?.ErrorView
 
-      if (!CustomView && !DefaultView && !ViewOverride) {
-        if (ErrorView) {
-          return <ErrorView initPageResult={initPageResult} searchParams={searchParams} />
-        }
-
-        notFound()
+      if (!CustomView && !DefaultView && !ViewOverride && !ErrorView) {
+        ErrorView = NotFoundView
       }
     }
   }
@@ -219,11 +212,15 @@ export const Document: React.FC<AdminViewProps> = async ({
             uploadEdits: undefined,
           }}
         >
-          <RenderCustomComponent
-            CustomComponent={ViewOverride || CustomView}
-            DefaultComponent={DefaultView}
-            componentProps={viewComponentProps}
-          />
+          {ErrorView ? (
+            <ErrorView initPageResult={initPageResult} searchParams={searchParams} />
+          ) : (
+            <RenderCustomComponent
+              CustomComponent={ViewOverride || CustomView}
+              DefaultComponent={DefaultView}
+              componentProps={viewComponentProps}
+            />
+          )}
         </FormQueryParamsProvider>
       </EditDepthProvider>
     </DocumentInfoProvider>

--- a/packages/next/src/views/ForgotPassword/index.tsx
+++ b/packages/next/src/views/ForgotPassword/index.tsx
@@ -13,7 +13,7 @@ export { generateForgotPasswordMetadata } from './meta.js'
 const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
 export const forgotPasswordBaseClass = 'forgot-password'
 
-export const ForgotPassword: React.FC<AdminViewProps> = ({ initPageResult }) => {
+export const ForgotPasswordView: React.FC<AdminViewProps> = ({ initPageResult }) => {
   const {
     req: {
       i18n,

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -13,7 +13,7 @@ import React, { Fragment } from 'react'
 
 import type { DefaultListViewProps, ListPreferences } from './Default/types.js'
 
-import { Unauthorized } from '../Unauthorized/index.js'
+import { UnauthorizedView } from '../Unauthorized/index.js'
 import { DefaultListView } from './Default/index.js'
 
 export { generateListMetadata } from './meta.js'
@@ -35,7 +35,7 @@ export const ListView: React.FC<AdminViewProps> = async ({ initPageResult, searc
   const collectionSlug = collectionConfig?.slug
 
   if (!permissions?.collections?.[collectionSlug]?.read?.permission) {
-    return <Unauthorized initPageResult={initPageResult} searchParams={searchParams} />
+    return <UnauthorizedView initPageResult={initPageResult} searchParams={searchParams} />
   }
 
   let listPreferences: ListPreferences

--- a/packages/next/src/views/Login/index.tsx
+++ b/packages/next/src/views/Login/index.tsx
@@ -11,7 +11,7 @@ export { generateLoginMetadata } from './meta.js'
 
 export const loginBaseClass = 'login'
 
-export const Login: React.FC<AdminViewProps> = ({ initPageResult, searchParams }) => {
+export const LoginView: React.FC<AdminViewProps> = ({ initPageResult, searchParams }) => {
   const { req } = initPageResult
 
   const {

--- a/packages/next/src/views/Logout/index.tsx
+++ b/packages/next/src/views/Logout/index.tsx
@@ -10,7 +10,7 @@ const baseClass = 'logout'
 
 export { generateLogoutMetadata } from './meta.js'
 
-export const Logout: React.FC<
+export const LogoutView: React.FC<
   AdminViewProps & {
     inactivity?: boolean
   }
@@ -39,5 +39,5 @@ export const Logout: React.FC<
 }
 
 export const LogoutInactivity: React.FC<AdminViewProps> = (props) => {
-  return <Logout inactivity {...props} />
+  return <LogoutView inactivity {...props} />
 }

--- a/packages/next/src/views/NotFound/index.tsx
+++ b/packages/next/src/views/NotFound/index.tsx
@@ -1,6 +1,6 @@
 import type { I18n } from '@payloadcms/translations'
 import type { Metadata } from 'next'
-import type { SanitizedConfig } from 'payload/types'
+import type { AdminViewComponent, SanitizedConfig } from 'payload/types'
 
 import { getNextI18n } from '@payloadcms/next/utilities'
 import { HydrateClientUser } from '@payloadcms/ui/elements/HydrateClientUser'
@@ -64,4 +64,8 @@ export const NotFoundPage = async ({
       </DefaultTemplate>
     </Fragment>
   )
+}
+
+export const NotFoundView: AdminViewComponent = () => {
+  return <NotFoundClient marginTop="large" />
 }

--- a/packages/next/src/views/Root/getViewFromConfig.tsx
+++ b/packages/next/src/views/Root/getViewFromConfig.tsx
@@ -4,15 +4,15 @@ import type { AdminViewComponent } from 'payload/types'
 import type { initPage } from '../../utilities/initPage.js'
 
 import { Account } from '../Account/index.js'
-import { CreateFirstUser } from '../CreateFirstUser/index.js'
+import { CreateFirstUserView } from '../CreateFirstUser/index.js'
 import { Dashboard } from '../Dashboard/index.js'
 import { Document as DocumentView } from '../Document/index.js'
-import { ForgotPassword, forgotPasswordBaseClass } from '../ForgotPassword/index.js'
+import { ForgotPasswordView, forgotPasswordBaseClass } from '../ForgotPassword/index.js'
 import { ListView } from '../List/index.js'
-import { Login, loginBaseClass } from '../Login/index.js'
-import { Logout, LogoutInactivity } from '../Logout/index.js'
+import { LoginView, loginBaseClass } from '../Login/index.js'
+import { LogoutInactivity, LogoutView } from '../Logout/index.js'
 import { ResetPassword, resetPasswordBaseClass } from '../ResetPassword/index.js'
-import { Unauthorized } from '../Unauthorized/index.js'
+import { UnauthorizedView } from '../Unauthorized/index.js'
 import { Verify, verifyBaseClass } from '../Verify/index.js'
 import { getCustomViewByRoute } from './getCustomViewByRoute.js'
 
@@ -24,12 +24,12 @@ const baseClasses = {
 }
 
 const oneSegmentViews = {
-  'create-first-user': CreateFirstUser,
-  forgot: ForgotPassword,
-  login: Login,
-  logout: Logout,
+  'create-first-user': CreateFirstUserView,
+  forgot: ForgotPasswordView,
+  login: LoginView,
+  logout: LogoutView,
   'logout-inactivity': LogoutInactivity,
-  unauthorized: Unauthorized,
+  unauthorized: UnauthorizedView,
 }
 
 export const getViewFromConfig = ({

--- a/packages/next/src/views/Unauthorized/index.scss
+++ b/packages/next/src/views/Unauthorized/index.scss
@@ -1,0 +1,36 @@
+@import '../../scss/styles.scss';
+
+.unauthorized {
+  margin-top: var(--base);
+
+  & > * {
+    &:first-child {
+      margin-top: 0;
+    }
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__button {
+    margin: 0;
+  }
+
+  &--margin-top-large {
+    margin-top: calc(var(--base) * 2);
+  }
+
+  @include large-break {
+    &--margin-top-large {
+      margin-top: var(--base);
+    }
+  }
+
+  @include small-break {
+    margin-top: calc(var(--base) / 2);
+
+    &--margin-top-large {
+      margin-top: calc(var(--base) / 2);
+    }
+  }
+}

--- a/packages/next/src/views/Unauthorized/index.tsx
+++ b/packages/next/src/views/Unauthorized/index.tsx
@@ -5,11 +5,15 @@ import { Gutter } from '@payloadcms/ui/elements/Gutter'
 import LinkImport from 'next/link.js'
 import React from 'react'
 
+import './index.scss'
+
 const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
 
 export { generateUnauthorizedMetadata } from './meta.js'
 
-export const Unauthorized: AdminViewComponent = ({ initPageResult }) => {
+const baseClass = 'unauthorized'
+
+export const UnauthorizedView: AdminViewComponent = ({ initPageResult }) => {
   const {
     req: {
       i18n,
@@ -22,11 +26,10 @@ export const Unauthorized: AdminViewComponent = ({ initPageResult }) => {
   } = initPageResult
 
   return (
-    <Gutter className="unauthorized">
+    <Gutter className={baseClass}>
       <h2>{i18n.t('error:unauthorized')}</h2>
       <p>{i18n.t('error:notAllowedToAccessPage')}</p>
-      <br />
-      <Button Link={Link} el="link" to={logoutRoute}>
+      <Button Link={Link} className={`${baseClass}__button`} el="link" to={logoutRoute}>
         {i18n.t('authentication:logOut')}
       </Button>
     </Gutter>

--- a/packages/next/src/webpackEntry.ts
+++ b/packages/next/src/webpackEntry.ts
@@ -1,4 +1,4 @@
 export { RootLayout } from './layouts/Root/index.js'
 export { Dashboard as DashboardPage } from './views/Dashboard/index.js'
-export { Login } from './views/Login/index.js'
+export { LoginView } from './views/Login/index.js'
 export { RootPage } from './views/Root/index.js'

--- a/test/_community/collections/Posts/index.ts
+++ b/test/_community/collections/Posts/index.ts
@@ -9,9 +9,6 @@ export const PostsCollection: CollectionConfig = {
   admin: {
     useAsTitle: 'text',
   },
-  access: {
-    readVersions: () => false,
-  },
   fields: [
     {
       name: 'text',

--- a/test/_community/collections/Posts/index.ts
+++ b/test/_community/collections/Posts/index.ts
@@ -9,6 +9,9 @@ export const PostsCollection: CollectionConfig = {
   admin: {
     useAsTitle: 'text',
   },
+  access: {
+    readVersions: () => false,
+  },
   fields: [
     {
       name: 'text',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
     ],
     "paths": {
       "@payload-config": [
-        "./test/admin/config.ts"
+        "./test/_community/config.ts"
       ],
       "@payloadcms/live-preview": [
         "./packages/live-preview/src"


### PR DESCRIPTION
## Description

Closes https://github.com/payloadcms/payload-3.0-alpha-demo/issues/67. The document-level unauthorized view was completely overtaking the view, instead of rendering beneath the document tabs.

Also renames the `LoginView`, `LogoutView`, etc. for semantics.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.