### PR TITLE
fix(next): removes `global` slug from `collectionSlug` prop in `SetStepNav`

### DIFF
--- a/packages/next/src/views/Versions/index.tsx
+++ b/packages/next/src/views/Versions/index.tsx
@@ -101,7 +101,7 @@ export const VersionsView: EditViewComponent = async (props) => {
   return (
     <React.Fragment>
       <SetStepNav
-        collectionSlug={collectionConfig?.slug || globalConfig?.slug}
+        collectionSlug={collectionConfig?.slug}
         globalSlug={globalConfig?.slug}
         id={id}
         pluralLabel={collectionConfig?.labels?.plural || globalConfig?.label}


### PR DESCRIPTION
## Description

Fixes this [issue](https://github.com/payloadcms/payload-3.0-alpha-demo/issues/68) in `alpa demo repo`

The `global` slug was being passed as a `collectionSlug` prop in the `SetStepNav` component. Just needed to be removed.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
