### PR TITLE
fix(richtext-lexical): do not render uploads extra fields drawer if no extra fields are provided

### DIFF
--- a/packages/richtext-lexical/src/field/features/upload/component/index.tsx
+++ b/packages/richtext-lexical/src/field/features/upload/component/index.tsx
@@ -173,11 +173,13 @@ const Component: React.FC<ElementProps> = (props) => {
         </div>
       </div>
       {value?.id && <DocumentDrawer onSave={updateUpload} />}
-      <ExtraFieldsUploadDrawer
-        drawerSlug={drawerSlug}
-        relatedCollection={relatedCollection}
-        {...props}
-      />
+      {hasExtraFields ? (
+        <ExtraFieldsUploadDrawer
+          drawerSlug={drawerSlug}
+          relatedCollection={relatedCollection}
+          {...props}
+        />
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
## Description

This fixes a failed form state request error when upload nodes are added in your editor without any custom extra fields

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
