### PR TITLE
fix: avoids getting and setting doc preferences when creating new

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Collapsible/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Collapsible/index.tsx
@@ -31,7 +31,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
   } = props
 
   const { getPreference, setPreference } = usePreferences()
-  const { id: docID, preferencesKey } = useDocumentInfo()
+  const { preferencesKey } = useDocumentInfo()
   const [collapsedOnMount, setCollapsedOnMount] = useState<boolean>()
   const fieldPreferencesKey = `collapsible-${indexPath.replace(/\./g, '__')}`
   const [errorCount, setErrorCount] = useState(0)
@@ -70,7 +70,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
   )
 
   useEffect(() => {
-    if (!docID) {
+    if (!preferencesKey) {
       setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
     }
 
@@ -87,7 +87,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
     }
 
     fetchInitialState()
-  }, [docID, getPreference, preferencesKey, fieldPreferencesKey, initCollapsed, path])
+  }, [getPreference, preferencesKey, fieldPreferencesKey, initCollapsed, path])
 
   if (typeof collapsedOnMount !== 'boolean') return null
 

--- a/packages/payload/src/admin/components/forms/field-types/Collapsible/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Collapsible/index.tsx
@@ -70,17 +70,17 @@ const CollapsibleField: React.FC<Props> = (props) => {
   )
 
   useEffect(() => {
-    if (!preferencesKey) {
-      setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
-    }
-
     const fetchInitialState = async () => {
-      const preferences = await getPreference(preferencesKey)
-      if (preferences) {
-        const initCollapsedFromPref = path
-          ? preferences?.fields?.[path]?.collapsed
-          : preferences?.fields?.[fieldPreferencesKey]?.collapsed
-        setCollapsedOnMount(Boolean(initCollapsedFromPref))
+      if (preferencesKey) {
+        const preferences = await getPreference(preferencesKey)
+        if (preferences) {
+          const initCollapsedFromPref = path
+            ? preferences?.fields?.[path]?.collapsed
+            : preferences?.fields?.[fieldPreferencesKey]?.collapsed
+          setCollapsedOnMount(Boolean(initCollapsedFromPref))
+        } else {
+          setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
+        }
       } else {
         setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
       }

--- a/packages/payload/src/admin/components/forms/field-types/Collapsible/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Collapsible/index.tsx
@@ -73,11 +73,12 @@ const CollapsibleField: React.FC<Props> = (props) => {
     const fetchInitialState = async () => {
       if (preferencesKey) {
         const preferences = await getPreference(preferencesKey)
-        if (preferences) {
-          const initCollapsedFromPref = path
-            ? preferences?.fields?.[path]?.collapsed
-            : preferences?.fields?.[fieldPreferencesKey]?.collapsed
-          setCollapsedOnMount(Boolean(initCollapsedFromPref))
+        const specificPreference = path
+          ? preferences?.fields?.[path]?.collapsed
+          : preferences?.fields?.[fieldPreferencesKey]?.collapsed
+
+        if (specificPreference !== undefined) {
+          setCollapsedOnMount(Boolean(specificPreference))
         } else {
           setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
         }
@@ -86,7 +87,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
       }
     }
 
-    fetchInitialState()
+    void fetchInitialState()
   }, [getPreference, preferencesKey, fieldPreferencesKey, initCollapsed, path])
 
   if (typeof collapsedOnMount !== 'boolean') return null

--- a/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
@@ -80,7 +80,7 @@ const TabsField: React.FC<Props> = (props) => {
   } = props
 
   const { getPreference, setPreference } = usePreferences()
-  const { id: docID, preferencesKey } = useDocumentInfo()
+  const { preferencesKey } = useDocumentInfo()
   const { i18n } = useTranslation()
 
   const { withinCollapsible } = useCollapsible()
@@ -88,20 +88,17 @@ const TabsField: React.FC<Props> = (props) => {
   const tabsPrefKey = `tabs-${indexPath}`
 
   useEffect(() => {
-    if (!docID) {
-      setActiveTabIndex(0)
-      return
+    if (preferencesKey) {
+      const getInitialPref = async () => {
+        const existingPreferences: DocumentPreferences = await getPreference(preferencesKey)
+        const initialIndex = path
+          ? existingPreferences?.fields?.[path]?.tabIndex
+          : existingPreferences?.fields?.[tabsPrefKey]?.tabIndex
+        setActiveTabIndex(initialIndex || 0)
+      }
+      void getInitialPref()
     }
-
-    const getInitialPref = async () => {
-      const existingPreferences: DocumentPreferences = await getPreference(preferencesKey)
-      const initialIndex = path
-        ? existingPreferences?.fields?.[path]?.tabIndex
-        : existingPreferences?.fields?.[tabsPrefKey]?.tabIndex
-      setActiveTabIndex(initialIndex || 0)
-    }
-    void getInitialPref()
-  }, [docID, path, indexPath, getPreference, preferencesKey, tabsPrefKey])
+  }, [path, indexPath, getPreference, preferencesKey, tabsPrefKey])
 
   const handleTabChange = useCallback(
     async (incomingTabIndex: number) => {


### PR DESCRIPTION
## Description

Fixes #5739 #5747 

fix: only call `getPreferences` & `setPreferences` if preferencesKey exists

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
