### PR TITLE
fix(ui): avoids getting and setting doc preferences when creating new

### DIFF
--- a/packages/ui/src/fields/Collapsible/index.tsx
+++ b/packages/ui/src/fields/Collapsible/index.tsx
@@ -67,40 +67,46 @@ const CollapsibleField: React.FC<CollapsibleFieldProps> = (props) => {
     async (newCollapsedState: boolean) => {
       const existingPreferences: DocumentPreferences = await getPreference(preferencesKey)
 
-      void setPreference(preferencesKey, {
-        ...existingPreferences,
-        ...(path
-          ? {
-              fields: {
-                ...(existingPreferences?.fields || {}),
-                [path]: {
-                  ...existingPreferences?.fields?.[path],
-                  collapsed: newCollapsedState,
+      if (preferencesKey) {
+        void setPreference(preferencesKey, {
+          ...existingPreferences,
+          ...(path
+            ? {
+                fields: {
+                  ...(existingPreferences?.fields || {}),
+                  [path]: {
+                    ...existingPreferences?.fields?.[path],
+                    collapsed: newCollapsedState,
+                  },
                 },
-              },
-            }
-          : {
-              fields: {
-                ...(existingPreferences?.fields || {}),
-                [fieldPreferencesKey]: {
-                  ...existingPreferences?.fields?.[fieldPreferencesKey],
-                  collapsed: newCollapsedState,
+              }
+            : {
+                fields: {
+                  ...(existingPreferences?.fields || {}),
+                  [fieldPreferencesKey]: {
+                    ...existingPreferences?.fields?.[fieldPreferencesKey],
+                    collapsed: newCollapsedState,
+                  },
                 },
-              },
-            }),
-      })
+              }),
+        })
+      }
     },
     [preferencesKey, fieldPreferencesKey, getPreference, setPreference, path],
   )
 
   useEffect(() => {
     const fetchInitialState = async () => {
-      const preferences = await getPreference(preferencesKey)
-      if (preferences) {
-        const initCollapsedFromPref = path
-          ? preferences?.fields?.[path]?.collapsed
-          : preferences?.fields?.[fieldPreferencesKey]?.collapsed
-        setCollapsedOnMount(Boolean(initCollapsedFromPref))
+      if (preferencesKey) {
+        const preferences = await getPreference(preferencesKey)
+        if (preferences) {
+          const initCollapsedFromPref = path
+            ? preferences?.fields?.[path]?.collapsed
+            : preferences?.fields?.[fieldPreferencesKey]?.collapsed
+          setCollapsedOnMount(Boolean(initCollapsedFromPref))
+        } else {
+          setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
+        }
       } else {
         setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
       }

--- a/packages/ui/src/fields/Collapsible/index.tsx
+++ b/packages/ui/src/fields/Collapsible/index.tsx
@@ -99,11 +99,12 @@ const CollapsibleField: React.FC<CollapsibleFieldProps> = (props) => {
     const fetchInitialState = async () => {
       if (preferencesKey) {
         const preferences = await getPreference(preferencesKey)
-        if (preferences) {
-          const initCollapsedFromPref = path
-            ? preferences?.fields?.[path]?.collapsed
-            : preferences?.fields?.[fieldPreferencesKey]?.collapsed
-          setCollapsedOnMount(Boolean(initCollapsedFromPref))
+        const specificPreference = path
+          ? preferences?.fields?.[path]?.collapsed
+          : preferences?.fields?.[fieldPreferencesKey]?.collapsed
+
+        if (specificPreference !== undefined) {
+          setCollapsedOnMount(Boolean(specificPreference))
         } else {
           setCollapsedOnMount(typeof initCollapsed === 'boolean' ? initCollapsed : false)
         }

--- a/packages/ui/src/fields/Tabs/index.tsx
+++ b/packages/ui/src/fields/Tabs/index.tsx
@@ -64,14 +64,16 @@ const TabsField: React.FC<TabsFieldProps> = (props) => {
   const tabsPrefKey = `tabs-${indexPath}`
 
   useEffect(() => {
-    const getInitialPref = async () => {
-      const existingPreferences: DocumentPreferences = await getPreference(preferencesKey)
-      const initialIndex = path
-        ? existingPreferences?.fields?.[path]?.tabIndex
-        : existingPreferences?.fields?.[tabsPrefKey]?.tabIndex
-      setActiveTabIndex(initialIndex || 0)
+    if (preferencesKey) {
+      const getInitialPref = async () => {
+        const existingPreferences: DocumentPreferences = await getPreference(preferencesKey)
+        const initialIndex = path
+          ? existingPreferences?.fields?.[path]?.tabIndex
+          : existingPreferences?.fields?.[tabsPrefKey]?.tabIndex
+        setActiveTabIndex(initialIndex || 0)
+      }
+      void getInitialPref()
     }
-    void getInitialPref()
   }, [path, getPreference, preferencesKey, tabsPrefKey])
 
   const handleTabChange = useCallback(
@@ -80,28 +82,30 @@ const TabsField: React.FC<TabsFieldProps> = (props) => {
 
       const existingPreferences: DocumentPreferences = await getPreference(preferencesKey)
 
-      void setPreference(preferencesKey, {
-        ...existingPreferences,
-        ...(path
-          ? {
-              fields: {
-                ...(existingPreferences?.fields || {}),
-                [path]: {
-                  ...existingPreferences?.fields?.[path],
-                  tabIndex: incomingTabIndex,
+      if (preferencesKey) {
+        void setPreference(preferencesKey, {
+          ...existingPreferences,
+          ...(path
+            ? {
+                fields: {
+                  ...(existingPreferences?.fields || {}),
+                  [path]: {
+                    ...existingPreferences?.fields?.[path],
+                    tabIndex: incomingTabIndex,
+                  },
                 },
-              },
-            }
-          : {
-              fields: {
-                ...existingPreferences?.fields,
-                [tabsPrefKey]: {
-                  ...existingPreferences?.fields?.[tabsPrefKey],
-                  tabIndex: incomingTabIndex,
+              }
+            : {
+                fields: {
+                  ...existingPreferences?.fields,
+                  [tabsPrefKey]: {
+                    ...existingPreferences?.fields?.[tabsPrefKey],
+                    tabIndex: incomingTabIndex,
+                  },
                 },
-              },
-            }),
-      })
+              }),
+        })
+      }
     },
     [preferencesKey, getPreference, setPreference, path, tabsPrefKey],
   )


### PR DESCRIPTION
## Description

fix: only call `getPreferences` & `setPreferences` if preferencesKey exists

`v2` [PR](https://github.com/payloadcms/payload/pull/5757)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
