### PR TITLE
fix: undo changing baseBlockFields type to FieldWithRichTextRequiredEditor

### DIFF
--- a/packages/payload/src/fields/baseFields/baseBlockFields.ts
+++ b/packages/payload/src/fields/baseFields/baseBlockFields.ts
@@ -1,8 +1,8 @@
-import type { FieldWithRichTextRequiredEditor } from '../config/types.js'
+import type { Field } from '../config/types.js'
 
 import { baseIDField } from './baseIDField.js'
 
-export const baseBlockFields: FieldWithRichTextRequiredEditor[] = [
+export const baseBlockFields: Field[] = [
   baseIDField,
   {
     name: 'blockName',

--- a/packages/richtext-lexical/src/field/features/blocks/feature.server.ts
+++ b/packages/richtext-lexical/src/field/features/blocks/feature.server.ts
@@ -12,12 +12,12 @@ import { BlockNode } from './nodes/BlocksNode.js'
 import { blockPopulationPromiseHOC } from './populationPromise.js'
 import { blockValidationHOC } from './validate.js'
 
+export type LexicalBlock = Omit<Block, 'fields'> & {
+  fields: FieldWithRichTextRequiredEditor[]
+}
+
 export type BlocksFeatureProps = {
-  blocks: Array<
-    Omit<Block, 'fields'> & {
-      fields: FieldWithRichTextRequiredEditor[]
-    }
-  >
+  blocks: LexicalBlock[]
 }
 
 export const BlocksFeature: FeatureProviderProviderServer<

--- a/packages/richtext-lexical/src/field/features/blocks/feature.server.ts
+++ b/packages/richtext-lexical/src/field/features/blocks/feature.server.ts
@@ -32,7 +32,8 @@ export const BlocksFeature: FeatureProviderProviderServer<
 
       return {
         ...blockCopy,
-        fields: blockCopy.fields.concat(baseBlockFields),
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        fields: blockCopy.fields.concat(baseBlockFields as FieldWithRichTextRequiredEditor[]),
         labels: !blockCopy.labels ? formatLabels(blockCopy.slug) : blockCopy.labels,
       }
     })

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -212,7 +212,11 @@ export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapte
 
 export { AlignFeature } from './field/features/align/feature.server.js'
 export { BlockQuoteFeature } from './field/features/blockquote/feature.server.js'
-export { BlocksFeature, type BlocksFeatureProps } from './field/features/blocks/feature.server.js'
+export {
+  BlocksFeature,
+  type BlocksFeatureProps,
+  type LexicalBlock,
+} from './field/features/blocks/feature.server.js'
 export {
   $createBlockNode,
   $isBlockNode,

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -75,7 +75,7 @@ describe('admin', () => {
   beforeAll(async ({ browser }, testInfo) => {
     const prebuild = Boolean(process.env.CI)
 
-    if (prebuild) testInfo.setTimeout(testInfo.timeout * 2)
+    if (prebuild) testInfo.setTimeout(testInfo.timeout * 3)
 
     process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({

--- a/test/fields/collections/Lexical/blocks.ts
+++ b/test/fields/collections/Lexical/blocks.ts
@@ -1,4 +1,5 @@
-import type { ArrayField, Block } from 'payload/types'
+import type { LexicalBlock } from '@payloadcms/richtext-lexical'
+import type { ArrayField } from 'payload/types'
 
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 
@@ -29,7 +30,7 @@ export const BlockColumns = ({ name }: { name: string }): ArrayField => ({
     },
   ],
 })
-export const ConditionalLayoutBlock: Block = {
+export const ConditionalLayoutBlock: LexicalBlock = {
   fields: [
     {
       label: 'Layout',
@@ -73,7 +74,7 @@ export const ConditionalLayoutBlock: Block = {
   slug: 'conditionalLayout',
 }
 
-export const TextBlock: Block = {
+export const TextBlock: LexicalBlock = {
   fields: [
     {
       name: 'text',
@@ -84,7 +85,7 @@ export const TextBlock: Block = {
   slug: 'text',
 }
 
-export const RadioButtonsBlock: Block = {
+export const RadioButtonsBlock: LexicalBlock = {
   interfaceName: 'LexicalBlocksRadioButtonsBlock',
   fields: [
     {
@@ -109,7 +110,7 @@ export const RadioButtonsBlock: Block = {
   slug: 'radioButtons',
 }
 
-export const RichTextBlock: Block = {
+export const RichTextBlock: LexicalBlock = {
   fields: [
     {
       name: 'richText',
@@ -120,7 +121,7 @@ export const RichTextBlock: Block = {
   slug: 'richText',
 }
 
-export const UploadAndRichTextBlock: Block = {
+export const UploadAndRichTextBlock: LexicalBlock = {
   fields: [
     {
       name: 'upload',
@@ -137,7 +138,7 @@ export const UploadAndRichTextBlock: Block = {
   slug: 'uploadAndRichText',
 }
 
-export const RelationshipHasManyBlock: Block = {
+export const RelationshipHasManyBlock: LexicalBlock = {
   fields: [
     {
       name: 'rel',
@@ -149,7 +150,7 @@ export const RelationshipHasManyBlock: Block = {
   ],
   slug: 'relationshipHasManyBlock',
 }
-export const RelationshipBlock: Block = {
+export const RelationshipBlock: LexicalBlock = {
   fields: [
     {
       name: 'rel',
@@ -161,7 +162,7 @@ export const RelationshipBlock: Block = {
   slug: 'relationshipBlock',
 }
 
-export const SelectFieldBlock: Block = {
+export const SelectFieldBlock: LexicalBlock = {
   fields: [
     {
       name: 'select',
@@ -193,7 +194,7 @@ export const SelectFieldBlock: Block = {
   slug: 'select',
 }
 
-export const SubBlockBlock: Block = {
+export const SubBlockBlock: LexicalBlock = {
   slug: 'subBlock',
   fields: [
     {

--- a/test/fields/collections/RichText/blocks.ts
+++ b/test/fields/collections/RichText/blocks.ts
@@ -1,8 +1,8 @@
-import type { Block } from 'payload/types'
+import type { LexicalBlock } from '@payloadcms/richtext-lexical'
 
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 
-export const TextBlock: Block = {
+export const TextBlock: LexicalBlock = {
   fields: [
     {
       name: 'text',
@@ -13,7 +13,7 @@ export const TextBlock: Block = {
   slug: 'text',
 }
 
-export const UploadAndRichTextBlock: Block = {
+export const UploadAndRichTextBlock: LexicalBlock = {
   fields: [
     {
       name: 'upload',
@@ -30,7 +30,7 @@ export const UploadAndRichTextBlock: Block = {
   slug: 'uploadAndRichText',
 }
 
-export const RelationshipBlock: Block = {
+export const RelationshipBlock: LexicalBlock = {
   fields: [
     {
       name: 'rel',
@@ -42,7 +42,7 @@ export const RelationshipBlock: Block = {
   slug: 'relationshipBlock',
 }
 
-export const SelectFieldBlock: Block = {
+export const SelectFieldBlock: LexicalBlock = {
   fields: [
     {
       name: 'select',


### PR DESCRIPTION
## Description

Undoes part of #5699 as this causes other type errors within core. Instead, it adds a type assertion within lexical

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
