### PR TITLE
fix: optionally types req in auth operation

### DIFF
--- a/packages/payload/src/auth/operations/auth.ts
+++ b/packages/payload/src/auth/operations/auth.ts
@@ -19,7 +19,7 @@ export type AuthResult = {
   user: User | null
 }
 
-export const auth = async (args: AuthArgs): Promise<AuthResult> => {
+export const auth = async (args: Required<AuthArgs>): Promise<AuthResult> => {
   const { headers } = args
   const req = args.req as PayloadRequest
   const { payload } = req

--- a/packages/payload/src/auth/operations/auth.ts
+++ b/packages/payload/src/auth/operations/auth.ts
@@ -10,7 +10,7 @@ import { getAccessResults } from '../getAccessResults.js'
 
 export type AuthArgs = {
   headers: Request['headers']
-  req: Omit<PayloadRequest, 'user'>
+  req?: Omit<PayloadRequest, 'user'>
 }
 
 export type AuthResult = {


### PR DESCRIPTION
## Description

The `payload.auth` method automatically threads `payload` through to the `auth` operation, as well as automatically creates a "local" req if none were provided via options. This means that calling `payload.auth` does not require its `req` argument, although it was typed that way. Just need to make `req` optional.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.