### PR TITLE
feat(next)!: cjs support

### DIFF
--- a/packages/create-payload-app/src/lib/wrap-next-config.spec.ts
+++ b/packages/create-payload-app/src/lib/wrap-next-config.spec.ts
@@ -1,61 +1,133 @@
-import { parseAndModifyConfigContent, withPayloadImportStatement } from './wrap-next-config.js'
+import { parseAndModifyConfigContent, withPayloadStatement } from './wrap-next-config.js'
 import * as p from '@clack/prompts'
 
-const defaultNextConfig = `/** @type {import('next').NextConfig} */
+const esmConfigs = {
+  defaultNextConfig: `/** @type {import('next').NextConfig} */
 const nextConfig = {};
-
 export default nextConfig;
-`
-
-const nextConfigWithFunc = `const nextConfig = {
-  // Your Next.js config here
-}
-
-export default someFunc(nextConfig)
-`
-const nextConfigWithFuncMultiline = `const nextConfig = {
-  // Your Next.js config here
-}
-
+`,
+  nextConfigWithFunc: `const nextConfig = {};
+export default someFunc(nextConfig);
+`,
+  nextConfigWithFuncMultiline: `const nextConfig = {};;
 export default someFunc(
   nextConfig
-)
-`
-
-const nextConfigExportNamedDefault = `const nextConfig = {
-  // Your Next.js config here
+);
+`,
+  nextConfigExportNamedDefault: `const nextConfig = {};
+const wrapped = someFunc(asdf);
+export { wrapped as default };
+`,
 }
-const wrapped = someFunc(asdf)
-export { wrapped as default }
-`
+
+const cjsConfigs = {
+  defaultNextConfig: `
+  /** @type {import('next').NextConfig} */
+const nextConfig = {};
+module.exports = nextConfig;
+`,
+  anonConfig: `module.exports = {};`,
+  nextConfigWithFunc: `const nextConfig = {};
+module.exports = someFunc(nextConfig);
+`,
+  nextConfigWithFuncMultiline: `const nextConfig = {};
+module.exports = someFunc(
+  nextConfig
+);
+`,
+  nextConfigExportNamedDefault: `const nextConfig = {};
+const wrapped = someFunc(asdf);
+module.exports = wrapped;
+`,
+}
 
 describe('parseAndInsertWithPayload', () => {
-  it('should parse the default next config', () => {
-    const { modifiedConfigContent } = parseAndModifyConfigContent(defaultNextConfig)
-    expect(modifiedConfigContent).toContain(withPayloadImportStatement)
-    expect(modifiedConfigContent).toContain('withPayload(nextConfig)')
+  describe('esm', () => {
+    const configType = 'esm'
+    const importStatement = withPayloadStatement[configType]
+    it('should parse the default next config', () => {
+      const { modifiedConfigContent } = parseAndModifyConfigContent(
+        esmConfigs.defaultNextConfig,
+        configType,
+      )
+      expect(modifiedConfigContent).toContain(importStatement)
+      expect(modifiedConfigContent).toContain('withPayload(nextConfig)')
+    })
+    it('should parse the config with a function', () => {
+      const { modifiedConfigContent } = parseAndModifyConfigContent(
+        esmConfigs.nextConfigWithFunc,
+        configType,
+      )
+      expect(modifiedConfigContent).toContain('withPayload(someFunc(nextConfig))')
+    })
+
+    it('should parse the config with a function on a new line', () => {
+      const { modifiedConfigContent } = parseAndModifyConfigContent(
+        esmConfigs.nextConfigWithFuncMultiline,
+        configType,
+      )
+      expect(modifiedConfigContent).toContain(importStatement)
+      expect(modifiedConfigContent).toMatch(/withPayload\(someFunc\(\n  nextConfig\n\)\)/)
+    })
+
+    // Unsupported: export { wrapped as default }
+    it('should give warning with a named export as default', () => {
+      const warnLogSpy = jest.spyOn(p.log, 'warn').mockImplementation(() => {})
+
+      const { modifiedConfigContent, success } = parseAndModifyConfigContent(
+        esmConfigs.nextConfigExportNamedDefault,
+        configType,
+      )
+      expect(modifiedConfigContent).toContain(importStatement)
+      expect(success).toBe(false)
+
+      expect(warnLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Could not automatically wrap'),
+      )
+    })
   })
-  it('should parse the config with a function', () => {
-    const { modifiedConfigContent } = parseAndModifyConfigContent(nextConfigWithFunc)
-    expect(modifiedConfigContent).toContain('withPayload(someFunc(nextConfig))')
-  })
 
-  it('should parse the config with a function on a new line', () => {
-    const { modifiedConfigContent } = parseAndModifyConfigContent(nextConfigWithFuncMultiline)
-    expect(modifiedConfigContent).toContain(withPayloadImportStatement)
-    expect(modifiedConfigContent).toMatch(/withPayload\(someFunc\(\n  nextConfig\n\)\)/)
-  })
-
-  // Unsupported: export { wrapped as default }
-  it('should give warning with a named export as default', () => {
-    const warnLogSpy = jest.spyOn(p.log, 'warn').mockImplementation(() => {})
-
-    const { modifiedConfigContent, success } = parseAndModifyConfigContent(
-      nextConfigExportNamedDefault,
-    )
-    expect(modifiedConfigContent).toContain(withPayloadImportStatement)
-    expect(success).toBe(false)
-
-    expect(warnLogSpy).toHaveBeenCalledWith(expect.stringContaining('Could not automatically wrap'))
+  describe('cjs', () => {
+    const configType = 'cjs'
+    const requireStatement = withPayloadStatement[configType]
+    it('should parse the default next config', () => {
+      const { modifiedConfigContent } = parseAndModifyConfigContent(
+        cjsConfigs.defaultNextConfig,
+        configType,
+      )
+      expect(modifiedConfigContent).toContain(requireStatement)
+      expect(modifiedConfigContent).toContain('withPayload(nextConfig)')
+    })
+    it('should parse anonymous default config', () => {
+      const { modifiedConfigContent } = parseAndModifyConfigContent(
+        cjsConfigs.anonConfig,
+        configType,
+      )
+      expect(modifiedConfigContent).toContain(requireStatement)
+      expect(modifiedConfigContent).toContain('withPayload({})')
+    })
+    it('should parse the config with a function', () => {
+      const { modifiedConfigContent } = parseAndModifyConfigContent(
+        cjsConfigs.nextConfigWithFunc,
+        configType,
+      )
+      expect(modifiedConfigContent).toContain('withPayload(someFunc(nextConfig))')
+    })
+    it('should parse the config with a function on a new line', () => {
+      const { modifiedConfigContent } = parseAndModifyConfigContent(
+        cjsConfigs.nextConfigWithFuncMultiline,
+        configType,
+      )
+      expect(modifiedConfigContent).toContain(requireStatement)
+      expect(modifiedConfigContent).toMatch(/withPayload\(someFunc\(\n  nextConfig\n\)\)/)
+    })
+    it('should parse the config with a named export as default', () => {
+      const { modifiedConfigContent } = parseAndModifyConfigContent(
+        cjsConfigs.nextConfigExportNamedDefault,
+        configType,
+      )
+      expect(modifiedConfigContent).toContain(requireStatement)
+      expect(modifiedConfigContent).toContain('withPayload(wrapped)')
+    })
   })
 })

--- a/packages/next/.swcrc-cjs
+++ b/packages/next/.swcrc-cjs
@@ -6,10 +6,10 @@
     "parser": {
       "syntax": "typescript",
       "tsx": true,
-      "dts": true,
-    },
+      "dts": true
+    }
   },
   "module": {
-    "type": "commonjs",
-  },
+    "type": "commonjs"
+  }
 }

--- a/packages/next/.swcrc-cjs
+++ b/packages/next/.swcrc-cjs
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/swcrc",
+  "sourceMaps": true,
+  "jsc": {
+    "target": "esnext",
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "dts": true,
+    },
+  },
+  "module": {
+    "type": "commonjs",
+  },
+}

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -11,8 +11,8 @@
     "directory": "packages/next"
   },
   "scripts": {
-    "build:cjs": "swc ./src/withPayload.js -d ./dist/cjs --config-file .swcrc-cjs",
-    "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types && pnpm build:webpack && rm dist/prod/index.js",
+    "build:cjs": "swc ./src/withPayload.js -o ./dist/cjs/withPayload.cjs --config-file .swcrc-cjs",
+    "build": "pnpm copyfiles && pnpm build:swc && p build:cjs && pnpm build:types && pnpm build:webpack && rm dist/prod/index.js",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "build:webpack": "webpack --config webpack.config.js",
@@ -27,6 +27,10 @@
       "import": "./src/index.js",
       "require": "./src/index.js",
       "types": "./src/index.js"
+    },
+    "./withPayload": {
+      "import": "./src/withPayload.js",
+      "require": "./src/withPayload.js"
     },
     "./*": {
       "import": "./src/exports/*.ts",
@@ -87,7 +91,7 @@
       },
       "./withPayload": {
         "import": "./dist/withPayload.js",
-        "require": "./dist/cjs/withPayload.js"
+        "require": "./dist/cjs/withPayload.cjs"
       },
       "./*": {
         "import": "./dist/exports/*.js",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build:cjs": "swc ./src/withPayload.js -o ./dist/cjs/withPayload.cjs --config-file .swcrc-cjs",
-    "build": "pnpm copyfiles && pnpm build:swc && p build:cjs && pnpm build:types && pnpm build:webpack && rm dist/prod/index.js",
+    "build": "pnpm copyfiles && pnpm build:swc && pnpm build:cjs && pnpm build:types && pnpm build:webpack && rm dist/prod/index.js",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "build:webpack": "webpack --config webpack.config.js",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -11,6 +11,7 @@
     "directory": "packages/next"
   },
   "scripts": {
+    "build:cjs": "swc ./src/withPayload.js -d ./dist/cjs --config-file .swcrc-cjs",
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types && pnpm build:webpack && rm dist/prod/index.js",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
@@ -84,9 +85,9 @@
         "require": "./dist/prod/styles.css",
         "default": "./dist/prod/styles.css"
       },
-      ".": {
-        "import": "./dist/index.js",
-        "require": "./dist/index.js"
+      "./withPayload": {
+        "import": "./dist/withPayload.js",
+        "require": "./dist/cjs/withPayload.js"
       },
       "./*": {
         "import": "./dist/exports/*.js",

--- a/packages/next/tsconfig.cjs.json
+++ b/packages/next/tsconfig.cjs.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "composite": true, // Required for references to work
+    "noEmit": false /* Do not emit outputs. */,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/cjs" /* Specify an output folder for all emitted files. */,
+    "rootDir": "./src" /* Specify the root folder within your source files. */,
+    "sourceMap": true
+  },
+  "include": ["src/withPayload.js" /* Include the withPayload.js file in the build */]
+}

--- a/templates/blank-3.0/next.config.mjs
+++ b/templates/blank-3.0/next.config.mjs
@@ -1,4 +1,4 @@
-import { withPayload } from '@payloadcms/next'
+import { withPayload } from '@payloadcms/next/withPayload'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/templates/blank-3.0/package.json
+++ b/templates/blank-3.0/package.json
@@ -16,13 +16,13 @@
     "node": ">=18.19.0"
   },
   "dependencies": {
-    "@payloadcms/db-mongodb": "alpha",
-    "@payloadcms/next": "alpha",
-    "@payloadcms/plugin-cloud": "alpha",
-    "@payloadcms/richtext-lexical": "alpha",
+    "@payloadcms/db-mongodb": "beta",
+    "@payloadcms/next": "beta",
+    "@payloadcms/plugin-cloud": "beta",
+    "@payloadcms/richtext-lexical": "beta",
     "cross-env": "^7.0.3",
     "next": "14.2.0-canary.23",
-    "payload": "alpha",
+    "payload": "beta",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sharp": "0.32.6"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
     ],
     "paths": {
       "@payload-config": [
-        "./test/fields/config.ts"
+        "./test/_community/config.ts"
       ],
       "@payloadcms/live-preview": [
         "./packages/live-preview/src"


### PR DESCRIPTION
BREAKING CHANGE:

This moves `withPayload` from `@payloadcms/next` to `@payloadcms/next/withPayload`

- Adds support for CJS projects via `exports` `require`