### PR TITLE
fix: min/max attributes missing from number input

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Number/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Number/index.tsx
@@ -166,6 +166,8 @@ const NumberField: React.FC<Props> = (props) => {
           <input
             disabled={readOnly}
             id={`field-${path.replace(/\./g, '__')}`}
+            max={max}
+            min={min}
             name={path}
             onChange={handleChange}
             onWheel={(e) => {


### PR DESCRIPTION
## Description
This PR fixes #5763 issue. 
min/max values were not properly passed to an input element, which results in a bug that will let users set values that exceeds set limits.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
