### PR TITLE
fix: default baseUrl in loader if not set

### DIFF
--- a/packages/payload/src/bin/loader/index.ts
+++ b/packages/payload/src/bin/loader/index.ts
@@ -26,6 +26,11 @@ type ResolveFn = (...args: Required<ResolveArgs>) => Promise<ResolveResult>
 const locatedConfig = getTsconfig()
 const tsconfig = locatedConfig.config.compilerOptions as unknown as ts.CompilerOptions
 
+// Ensure baseUrl is set in order to support paths
+if (!tsconfig.baseUrl) {
+  tsconfig.baseUrl = '.'
+}
+
 // Don't resolve d.ts files, because we aren't type-checking
 tsconfig.noDtsResolution = true
 tsconfig.module = ts.ModuleKind.ESNext


### PR DESCRIPTION
Set `baseUrl` in loader if user does not have it set in their tsconfig.

Would throw this error if not:

```
> cross-env NODE_OPTIONS=--no-deprecation payload "generate:types"


node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^
Error: Debug Failure. Encountered 'paths' without a 'baseUrl', config file, or host 'getCurrentDirectory'.
```