### PR TITLE
chore: type locale from localization config on the payload request

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -484,6 +484,7 @@ type GeneratedTypes = {
   globals: {
     [slug: number | string | symbol]: GlobalTypeWithID & Record<string, unknown>
   }
+  locale: null | string
   user: TypeWithID & Record<string, unknown> & { collection: string }
 }
 

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -42,7 +42,7 @@ export type CustomPayloadRequest<U = unknown> = {
    * The requested locale if specified
    * Only available for localized collections
    */
-  locale?: string
+  locale?: GeneratedTypes['locale']
   /**
    * The payload object
    */

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -67,6 +67,25 @@ function generateEntitySchemas(
   }
 }
 
+function generateLocaleEntitySchemas(localization: SanitizedConfig['localization']): JSONSchema4 {
+  if (localization && 'locales' in localization && localization?.locales) {
+    const localesFromConfig = localization?.locales
+
+    const locales = [...localesFromConfig].map((locale) => {
+      return locale.code
+    }, [])
+
+    return {
+      type: 'string',
+      enum: locales,
+    }
+  }
+
+  return {
+    type: 'null',
+  }
+}
+
 function generateAuthEntitySchemas(entities: SanitizedCollectionConfig[]): JSONSchema4 {
   const properties: JSONSchema4[] = [...entities]
     .filter(({ auth }) => Boolean(auth))
@@ -577,9 +596,10 @@ export function configToJSONSchema(
     properties: {
       collections: generateEntitySchemas(config.collections || []),
       globals: generateEntitySchemas(config.globals || []),
+      locale: generateLocaleEntitySchemas(config.localization),
       user: generateAuthEntitySchemas(config.collections),
     },
-    required: ['user', 'collections', 'globals'],
+    required: ['user', 'locale', 'collections', 'globals'],
     title: 'Config',
   }
 }


### PR DESCRIPTION
Adds `locale` type as an enum to the config

![image](https://github.com/payloadcms/payload/assets/35137243/58c21ab2-3c1d-42ef-90c8-e9ab7f289e81)

```ts
export interface Config {
  locale: 'en' | 'es' | 'pt' | 'ar';
  collections: {
    users: User;
    'localized-posts': LocalizedPost;
    'array-fields': ArrayField;
    'localized-required': LocalizedRequired;
    'with-localized-relationship': WithLocalizedRelationship;
    'relationship-localized': RelationshipLocalized;
    dummy: Dummy;
    nested: Nested;
    'localized-sort': LocalizedSort;
    'payload-preferences': PayloadPreference;
    'payload-migrations': PayloadMigration;
  };
  globals: {
    'global-array': GlobalArray;
  };
  user: User & {
    collection: 'users';
  };
}
```