### PR TITLE
feat: Add IndentConverter and AlignConverter

### DIFF
--- a/packages/plugin-form-builder/src/utilities/lexical/converters/align.ts
+++ b/packages/plugin-form-builder/src/utilities/lexical/converters/align.ts
@@ -1,0 +1,47 @@
+import type { HTMLConverter } from '../types'
+
+import { convertLexicalNodesToHTML } from '../serializeLexical'
+
+type Converter = HTMLConverter<any>
+
+type ConverterFunctionParams = Parameters<Converter['converter']>[0]
+
+async function convertFunction({
+  converters,
+  node,
+  parent,
+  submissionData,
+}: ConverterFunctionParams): Promise<string> {
+  const filteredSelfConverters = converters.filter(
+    (converter) => converter.converter !== convertFunction,
+  )
+
+  let text = await convertLexicalNodesToHTML({
+    converters: filteredSelfConverters,
+    lexicalNodes: [node],
+    parent,
+    submissionData,
+  })
+
+  const styleArray = []
+
+  if (node.indent) {
+    styleArray.push('text-align: ' + node.format)
+  }
+
+  const firstTag = text.slice(0, text.indexOf('>') + 1)
+  if (styleArray.length > 0) {
+    if (firstTag.includes('style')) {
+      text = text.replace('style="', `style="${styleArray.join('; ')};`)
+    } else {
+      text = text.replace('>', ` style="${styleArray.join('; ')};">`)
+    }
+  }
+
+  return text
+}
+
+export const AlignHTMLConverter: Converter = {
+  converter: convertFunction,
+  nodeTypes: ['paragraph', 'heading', 'listitem', 'quote'],
+}

--- a/packages/plugin-form-builder/src/utilities/lexical/converters/indent.ts
+++ b/packages/plugin-form-builder/src/utilities/lexical/converters/indent.ts
@@ -1,0 +1,47 @@
+import type { HTMLConverter } from '../types'
+
+import { convertLexicalNodesToHTML } from '../serializeLexical'
+
+type Converter = HTMLConverter<any>
+
+type ConverterFunctionParams = Parameters<Converter['converter']>[0]
+
+async function convertFunction({
+  converters,
+  node,
+  parent,
+  submissionData,
+}: ConverterFunctionParams): Promise<string> {
+  const filteredSelfConverters = converters.filter(
+    (converter) => converter.converter !== convertFunction,
+  )
+
+  let text = await convertLexicalNodesToHTML({
+    converters: filteredSelfConverters,
+    lexicalNodes: [node],
+    parent,
+    submissionData,
+  })
+
+  const styleArray = []
+
+  if (node.indent) {
+    styleArray.push(`padding-inline-start: ${node.indent * 20}px`)
+  }
+
+  const firstTag = text.slice(0, text.indexOf('>') + 1)
+  if (styleArray.length > 0) {
+    if (firstTag.includes('style')) {
+      text = text.replace('style="', `style="${styleArray.join('; ')}`)
+    } else {
+      text = text.replace('>', ` style="${styleArray.join('; ')}">`)
+    }
+  }
+
+  return text
+}
+
+export const IndentHTMLConverter: Converter = {
+  converter: convertFunction,
+  nodeTypes: ['paragraph', 'heading', 'listitem', 'quote'],
+}

--- a/packages/plugin-form-builder/src/utilities/lexical/defaultConverters.ts
+++ b/packages/plugin-form-builder/src/utilities/lexical/defaultConverters.ts
@@ -1,6 +1,8 @@
 import type { HTMLConverter } from './types'
 
+import { AlignHTMLConverter } from './converters/align'
 import { HeadingHTMLConverter } from './converters/heading'
+import { IndentHTMLConverter } from './converters/indent'
 import { LinebreakHTMLConverter } from './converters/linebreak'
 import { LinkHTMLConverter } from './converters/link'
 import { ListHTMLConverter, ListItemHTMLConverter } from './converters/list'
@@ -9,6 +11,8 @@ import { QuoteHTMLConverter } from './converters/quote'
 import { TextHTMLConverter } from './converters/text'
 
 export const defaultHTMLConverters: HTMLConverter[] = [
+  AlignHTMLConverter,
+  IndentHTMLConverter,
   ParagraphHTMLConverter,
   TextHTMLConverter,
   LinebreakHTMLConverter,

--- a/packages/richtext-lexical/src/field/features/converters/html/converter/converters/align.ts
+++ b/packages/richtext-lexical/src/field/features/converters/html/converter/converters/align.ts
@@ -1,0 +1,45 @@
+import type { HTMLConverter } from '../types'
+
+import { convertLexicalNodesToHTML } from '../index'
+
+type Converter = HTMLConverter<any>
+
+type ConverterFunctionParams = Parameters<Converter['converter']>[0]
+
+async function convertFunction({
+  converters,
+  node,
+  parent,
+}: ConverterFunctionParams): Promise<string> {
+  const filteredSelfConverters = converters.filter(
+    (converter) => converter.converter !== convertFunction,
+  )
+
+  let text = await convertLexicalNodesToHTML({
+    converters: filteredSelfConverters,
+    lexicalNodes: [node],
+    parent,
+  })
+
+  const styleArray = []
+
+  if (node.indent) {
+    styleArray.push('text-align: ' + node.format)
+  }
+
+  const firstTag = text.slice(0, text.indexOf('>') + 1)
+  if (styleArray.length > 0) {
+    if (firstTag.includes('style')) {
+      text = text.replace('style="', `style="${styleArray.join('; ')};`)
+    } else {
+      text = text.replace('>', ` style="${styleArray.join('; ')};">`)
+    }
+  }
+
+  return text
+}
+
+export const AlignHTMLConverter: Converter = {
+  converter: convertFunction,
+  nodeTypes: ['paragraph', 'heading', 'listitem', 'quote'],
+}

--- a/packages/richtext-lexical/src/field/features/converters/html/converter/converters/indent.ts
+++ b/packages/richtext-lexical/src/field/features/converters/html/converter/converters/indent.ts
@@ -1,0 +1,45 @@
+import type { HTMLConverter } from '../types'
+
+import { convertLexicalNodesToHTML } from '../index'
+
+type Converter = HTMLConverter<any>
+
+type ConverterFunctionParams = Parameters<Converter['converter']>[0]
+
+async function convertFunction({
+  converters,
+  node,
+  parent,
+}: ConverterFunctionParams): Promise<string> {
+  const filteredSelfConverters = converters.filter(
+    (converter) => converter.converter !== convertFunction,
+  )
+
+  let text = await convertLexicalNodesToHTML({
+    converters: filteredSelfConverters,
+    lexicalNodes: [node],
+    parent,
+  })
+
+  const styleArray = []
+
+  if (node.indent) {
+    styleArray.push(`padding-inline-start: ${node.indent * 20}px`)
+  }
+
+  const firstTag = text.slice(0, text.indexOf('>') + 1)
+  if (styleArray.length > 0) {
+    if (firstTag.includes('style')) {
+      text = text.replace('style="', `style="${styleArray.join('; ')}`)
+    } else {
+      text = text.replace('>', ` style="${styleArray.join('; ')}">`)
+    }
+  }
+
+  return text
+}
+
+export const IndentHTMLConverter: Converter = {
+  converter: convertFunction,
+  nodeTypes: ['paragraph', 'heading', 'listitem', 'quote'],
+}

--- a/packages/richtext-lexical/src/field/features/converters/html/converter/defaultConverters.ts
+++ b/packages/richtext-lexical/src/field/features/converters/html/converter/defaultConverters.ts
@@ -1,10 +1,14 @@
 import type { HTMLConverter } from './types'
 
+import { AlignHTMLConverter } from './converters/align'
+import { IndentHTMLConverter } from './converters/indent'
 import { LinebreakHTMLConverter } from './converters/linebreak'
 import { ParagraphHTMLConverter } from './converters/paragraph'
 import { TextHTMLConverter } from './converters/text'
 
 export const defaultHTMLConverters: HTMLConverter[] = [
+  AlignHTMLConverter,
+  IndentHTMLConverter,
   ParagraphHTMLConverter,
   TextHTMLConverter,
   LinebreakHTMLConverter,


### PR DESCRIPTION
## Description

Enhance based on #5146.

Add IndentConverter and AlignConverter. But IndentFeature and AlignFeature is not Node-agonistic, so I added all feature available nodes(I think).

There is caution in two converter. It must be head of converter because find converter with `Array.find`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
