### PR TITLE
fix: ensure file persists through form state changes

### DIFF
--- a/packages/next/src/routes/rest/buildFormState.ts
+++ b/packages/next/src/routes/rest/buildFormState.ts
@@ -187,6 +187,16 @@ export const buildFormState = async ({ req }: { req: PayloadRequest }) => {
       req,
     })
 
+    // Maintain form state of file
+    if (
+      collectionSlug &&
+      req.payload.collections[collectionSlug]?.config?.upload &&
+      formState &&
+      formState.file
+    ) {
+      result.file = formState.file
+    }
+
     return Response.json(result, {
       status: httpStatus.OK,
     })


### PR DESCRIPTION
Ensure file persists through form state changes. A file selected but not uploaded yet was being cleared if state changed.