### PR TITLE
fix: postgres turbopack localized fields array

### DIFF
--- a/packages/db-postgres/src/schema/build.ts
+++ b/packages/db-postgres/src/schema/build.ts
@@ -66,13 +66,6 @@ export const buildTable = ({
   const columns: Record<string, PgColumnBuilder> = baseColumns
   const indexes: Record<string, (cols: GenericColumns) => IndexBuilder> = {}
 
-  let hasLocalizedField = false
-  let hasLocalizedRelationshipField = false
-  let hasManyTextField: 'index' | boolean = false
-  let hasManyNumberField: 'index' | boolean = false
-  let hasLocalizedManyTextField = false
-  let hasLocalizedManyNumberField = false
-
   const localesColumns: Record<string, PgColumnBuilder> = {}
   const localesIndexes: Record<string, (cols: GenericColumns) => IndexBuilder> = {}
   let localesTable: GenericTable | PgTableWithColumns<any>
@@ -89,7 +82,7 @@ export const buildTable = ({
 
   const idColType: IDType = setColumnID({ adapter, columns, fields })
 
-  ;({
+  const {
     hasLocalizedField,
     hasLocalizedManyNumberField,
     hasLocalizedManyTextField,
@@ -116,7 +109,7 @@ export const buildTable = ({
     rootTableIDColType: rootTableIDColType || idColType,
     rootTableName,
     versions,
-  }))
+  })
 
   if (timestamps) {
     columns.createdAt = timestamp('created_at', {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

Fixes:

- When using the payload local api in combination with postgres, turbopack (next dev --turbo) and a field of type array/block with localized children fields, fixes the error: `Error: cannot connect to Postgres. Details: Cannot read properties of undefined (reading 'Symbol(drizzle:Name)')`

Explanation: 

- Turbopack uses some sort of weird or incomplete static analysis, so the unusual implementation choice to reassign variables via parentheses enclosure (`packages/db-postgres/src/schema/build.ts`) causes those variables to never actually be reassigned, and consequently leads to missing table definitions. FYI: the debugger will register reassignments but if you `console.log` then the truth comes out.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
