### PR TITLE
fix: passes number type limit arg to find on the list view

### DIFF
--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -87,7 +87,7 @@ export const ListView: React.FC<AdminViewProps> = async ({ initPageResult, searc
       },
     })
     const limit = isNumber(query?.limit)
-      ? query.limit
+      ? Number(query.limit)
       : listPreferences?.limit || collectionConfig.admin.pagination.defaultLimit
     const sort =
       query?.sort && typeof query.sort === 'string'

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -78,7 +78,7 @@ export const ListView: React.FC<AdminViewProps> = async ({ initPageResult, searc
       CustomListView = CustomList.Component
     }
 
-    const page = isNumber(query?.page) ? query.page : 0
+    const page = isNumber(query?.page) ? Number(query.page) : 0
     const whereQuery = mergeListSearchAndWhere({
       collectionConfig,
       query: {


### PR DESCRIPTION
## Description
Closes: [beta-#85](https://github.com/payloadcms/payload-3.0-demo/issues/85)
It was missing because [db-postgres/find/findMany/line-153](https://github.com/payloadcms/payload/blob/73c76cab771f812f47aa702ab74ba776478834da/packages/db-postgres/src/find/findMany.ts#L153) checks for typeof of `limit` that should be `number`, but we were passing `query.limit` which is string.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Existing test suite passes locally with my changes
