### PR TITLE
fix: do not modify original collections array/obj when sanitizing config

### DIFF
--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -1,6 +1,7 @@
 import { en } from '@payloadcms/translations/languages/en'
 import merge from 'deepmerge'
 
+import type { SanitizedCollectionConfig } from '../collections/config/types.js'
 import type {
   Config,
   LocalizationConfigWithLabels,
@@ -94,8 +95,11 @@ export const sanitizeConfig = (incomingConfig: Config): SanitizedConfig => {
     ...(incomingConfig?.i18n ?? {}),
   }
 
-  configWithDefaults.collections.push(getPreferencesCollection(configWithDefaults))
-  configWithDefaults.collections.push(migrationsCollection)
+  config.collections = [
+    ...config.collections,
+    getPreferencesCollection(configWithDefaults) as SanitizedCollectionConfig,
+    migrationsCollection as SanitizedCollectionConfig,
+  ]
 
   config.collections = config.collections.map((collection) =>
     sanitizeCollection(configWithDefaults, collection),


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

Fixes:

- When instantiating payload more than once, fixes the `DuplicateCollection` error caused by adding the preferences and migrations collections to the original config collections object.

Explanation:

- Why instantiate payload more than once?  Because I'm using a reduced payload configuration for the local API (dev server performance, customized `@payloadcms/db-postgres` package). Why is this still occurring when using multiple configurations? Because my collections object is shared between configurations.


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
