### PR TITLE
chore(plugin-seo): add Ukrainian translations

### DIFF
--- a/packages/plugin-seo/src/translations/index.ts
+++ b/packages/plugin-seo/src/translations/index.ts
@@ -4,6 +4,7 @@ import fa from './fa.json'
 import fr from './fr.json'
 import nb from './nb.json'
 import pl from './pl.json'
+import uk from './uk.json'
 
 export default {
   en,
@@ -12,4 +13,5 @@ export default {
   fr,
   nb,
   pl,
+  uk,
 }

--- a/packages/plugin-seo/src/translations/uk.json
+++ b/packages/plugin-seo/src/translations/uk.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "./translation-schema.json",
+  "plugin-seo": {
+    "almostThere": "Ще трошки",
+    "autoGenerate": "Згенерувати",
+    "bestPractices": "найкращі практики",
+    "characterCount": "{{current}}/{{minLength}}-{{maxLength}} символів, ",
+    "charactersLeftOver": "залишилось {{characters}} символів",
+    "charactersToGo": " на {{characters}} символів коротше",
+    "charactersTooMany": "на {{characters}} символів довше",
+    "checksPassing": "{{current}}/{{max}} перевірок пройдено",
+    "good": "Чудово",
+    "imageAutoGenerationTip": "Автоматична генерація використає зображення з головного блоку",
+    "lengthTipDescription": "Має бути від {{minLength}} до {{maxLength}} символів. Щоб дізнатися, як писати якісні метаописи — перегляньте ",
+    "lengthTipTitle": "Має бути від {{minLength}} до {{maxLength}} символів. Щоб дізнатися, як писати якісні метазаголовки — перегляньте ",
+    "noImage": "Немає зображення",
+    "preview": "Попередній перегляд",
+    "previewDescription": "Реальне відображення може відрізнятися в залежності від вмісту та релевантності пошуку.",
+    "tooLong": "Задовгий",
+    "tooShort": "Закороткий"
+  }
+}


### PR DESCRIPTION
## Description

Add Ukrainian translation to the Payload SEO plugin.
The following changes don't require any additional test suite or docs changes

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
