### PR TITLE
fix(plugin-seo): add default empty endpoints array

### DIFF
--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -194,7 +194,7 @@ const seo =
           return collection
         }) || [],
       endpoints: [
-        ...config.endpoints,
+        ...(config.endpoints ?? []),
         {
           handler: async (req) => {
             const args: Parameters<GenerateTitle>[0] =


### PR DESCRIPTION
## Description

This PR adds an empty array as default for endpoints in the seo plugin config in the case that the user has not defined it already in their own config. This fixes an issue where the user gets the following error when using the seo plugin because the endpoints key is missing in their payload config:
`
⨯ Internal error: TypeError: config.endpoints is not iterable
    at eval (./node_modules/.pnpm/@payloadcms+plugin-seo@3.0.0-beta.10_@payloadcms+translations@3.0.0-beta.10_@payloadcms+ui@3._ml3lpt77zlmgnq5dsq5ypyhlaq/node_modules/@payloadcms/plugin-seo/dist/index.js:167:27)
    at eval (./node_modules/.pnpm/payload@3.0.0-beta.10_@swc+core@1.4.13_@swc+types@0.1.6/node_modules/payload/dist/config/build.js:15:20)
    at async buildConfig (./node_modules/.pnpm/payload@3.0.0-beta.10_@swc+core@1.4.13_@swc+types@0.1.6/node_modules/payload/dist/config/build.js:13:36)
`

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Existing test suite passes locally with my changes
