### PR TITLE
fix(plugin-seo): incorrect styling of field labels

### DIFF
--- a/packages/plugin-seo/src/fields/MetaDescription.tsx
+++ b/packages/plugin-seo/src/fields/MetaDescription.tsx
@@ -77,17 +77,6 @@ export const MetaDescription: React.FC<MetaDescriptionProps> = (props) => {
       >
         <div className="plugin-seo__field">
           {CustomLabel !== undefined ? CustomLabel : <FieldLabel {...(labelProps || {})} />}
-          {required && (
-            <span
-              style={{
-                color: 'var(--theme-error-500)',
-                marginLeft: '5px',
-              }}
-            >
-              *
-            </span>
-          )}
-
           {hasGenerateDescriptionFn && (
             <React.Fragment>
               &nbsp; &mdash; &nbsp;

--- a/packages/plugin-seo/src/fields/MetaDescription.tsx
+++ b/packages/plugin-seo/src/fields/MetaDescription.tsx
@@ -76,7 +76,7 @@ export const MetaDescription: React.FC<MetaDescriptionProps> = (props) => {
         }}
       >
         <div className="plugin-seo__field">
-          {CustomLabel !== undefined ? CustomLabel : <FieldLabel {...(labelProps || {})} />}
+          <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
           {hasGenerateDescriptionFn && (
             <React.Fragment>
               &nbsp; &mdash; &nbsp;

--- a/packages/plugin-seo/src/fields/MetaImage.tsx
+++ b/packages/plugin-seo/src/fields/MetaImage.tsx
@@ -78,16 +78,6 @@ export const MetaImage: React.FC<MetaImageProps> = (props) => {
       >
         <div className="plugin-seo__field">
           {CustomLabel !== undefined ? CustomLabel : <FieldLabel {...(labelProps || {})} />}
-          {required && (
-            <span
-              style={{
-                color: 'var(--theme-error-500)',
-                marginLeft: '5px',
-              }}
-            >
-              *
-            </span>
-          )}
           {hasGenerateImageFn && (
             <React.Fragment>
               &nbsp; &mdash; &nbsp;

--- a/packages/plugin-seo/src/fields/MetaImage.tsx
+++ b/packages/plugin-seo/src/fields/MetaImage.tsx
@@ -77,7 +77,7 @@ export const MetaImage: React.FC<MetaImageProps> = (props) => {
         }}
       >
         <div className="plugin-seo__field">
-          {CustomLabel !== undefined ? CustomLabel : <FieldLabel {...(labelProps || {})} />}
+          <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
           {hasGenerateImageFn && (
             <React.Fragment>
               &nbsp; &mdash; &nbsp;

--- a/packages/plugin-seo/src/fields/MetaTitle.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle.tsx
@@ -78,16 +78,6 @@ export const MetaTitle: React.FC<MetaTitleProps> = (props) => {
       >
         <div className="plugin-seo__field">
           {CustomLabel !== undefined ? CustomLabel : <FieldLabel {...(labelProps || {})} />}
-          {required && (
-            <span
-              style={{
-                color: 'var(--theme-error-500)',
-                marginLeft: '5px',
-              }}
-            >
-              *
-            </span>
-          )}
           {hasGenerateTitleFn && (
             <React.Fragment>
               &nbsp; &mdash; &nbsp;

--- a/packages/plugin-seo/src/fields/MetaTitle.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle.tsx
@@ -77,7 +77,7 @@ export const MetaTitle: React.FC<MetaTitleProps> = (props) => {
         }}
       >
         <div className="plugin-seo__field">
-          {CustomLabel !== undefined ? CustomLabel : <FieldLabel {...(labelProps || {})} />}
+          <FieldLabel CustomLabel={CustomLabel} {...(labelProps || {})} />
           {hasGenerateTitleFn && (
             <React.Fragment>
               &nbsp; &mdash; &nbsp;

--- a/packages/plugin-seo/src/fields/index.scss
+++ b/packages/plugin-seo/src/fields/index.scss
@@ -1,5 +1,5 @@
 .plugin-seo__field {
   .field-label {
-    display: inline;
+    display: inline!important;
   }
 }


### PR DESCRIPTION
## Description

The default `@payloadcms/ui/forms` FieldLabel component is styled with the "*" required indicator by default (when the field is required) as seen [here](https://github.com/payloadcms/payload/blob/2722d2f5ce48544c2a468fead49e0d17314d45f2/packages/ui/src/forms/FieldLabel/index.tsx#L33), but the seo-plugin also has its own `required` indicator, leading to the ui bug seen in the screenshot below:
<img width="825" alt="Bildschirmfoto 2024-04-14 um 11 57 43" src="https://github.com/payloadcms/payload/assets/89917778/d949bdac-63c7-48a3-bee0-97df442ec9a9">

This PR removes the indicator element from the seo-plugin fields to fix this issue.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Existing test suite passes locally with my changes

