### PR TITLE
feat: add option to customize template in custom admin views config

### DIFF
--- a/packages/next/src/views/Root/getCustomViewByRoute.tsx
+++ b/packages/next/src/views/Root/getCustomViewByRoute.tsx
@@ -8,7 +8,11 @@ export const getCustomViewByRoute = ({
 }: {
   config: SanitizedConfig
   currentRoute: string
-}): AdminViewComponent => {
+}): {
+  ViewToRender: AdminViewComponent
+  templateClassname?: string
+  templateType: 'default' | 'minimal' | 'none'
+} | null => {
   const {
     admin: {
       components: { views },
@@ -33,5 +37,11 @@ export const getCustomViewByRoute = ({
       }
     })?.[1]
 
-  return typeof foundViewConfig === 'object' ? foundViewConfig.Component : null
+  return typeof foundViewConfig === 'object'
+    ? {
+        ViewToRender: foundViewConfig.Component,
+        templateClassname: foundViewConfig.templateClass,
+        templateType: foundViewConfig.templateType,
+      }
+    : null
 }

--- a/packages/next/src/views/Root/getViewFromConfig.tsx
+++ b/packages/next/src/views/Root/getViewFromConfig.tsx
@@ -50,11 +50,11 @@ export const getViewFromConfig = ({
   DefaultView: AdminViewComponent
   initPageOptions: Parameters<typeof initPage>[0]
   templateClassName: string
-  templateType: 'default' | 'minimal'
+  templateType: 'default' | 'minimal' | 'none'
 } => {
   let ViewToRender: AdminViewComponent = null
   let templateClassName: string
-  let templateType: 'default' | 'minimal' = 'minimal'
+  let templateType: 'default' | 'minimal' | 'none' = 'minimal'
 
   const initPageOptions: Parameters<typeof initPage>[0] = {
     config,
@@ -152,7 +152,10 @@ export const getViewFromConfig = ({
   }
 
   if (!ViewToRender) {
-    ViewToRender = getCustomViewByRoute({ config, currentRoute })
+    const result = getCustomViewByRoute({ config, currentRoute })
+    templateType = result?.templateType
+    templateClassName = result?.templateClassname
+    ViewToRender = result?.ViewToRender
   }
 
   return {

--- a/packages/next/src/views/Root/index.tsx
+++ b/packages/next/src/views/Root/index.tsx
@@ -83,11 +83,16 @@ export const RootPage = async ({
 
   return (
     <Fragment>
+      {templateType === 'none' && RenderedView}
       {templateType === 'minimal' && (
         <MinimalTemplate className={templateClassName}>{RenderedView}</MinimalTemplate>
       )}
       {templateType === 'default' && (
-        <DefaultTemplate config={config} visibleEntities={initPageResult.visibleEntities}>
+        <DefaultTemplate
+          className={templateClassName}
+          config={config}
+          visibleEntities={initPageResult.visibleEntities}
+        >
           {RenderedView}
         </DefaultTemplate>
       )}

--- a/packages/payload/src/admin/views/types.ts
+++ b/packages/payload/src/admin/views/types.ts
@@ -13,6 +13,9 @@ export type AdminViewConfig = {
   path: string
   sensitive?: boolean
   strict?: boolean
+  templateClass?: string
+  /** @default 'none' */
+  templateType?: 'default' | 'minimal' | 'none'
 }
 
 export type AdminViewProps = {

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -1,6 +1,7 @@
 import { en } from '@payloadcms/translations/languages/en'
 import merge from 'deepmerge'
 
+import type { AdminView } from '../admin/views/types.js'
 import type {
   Config,
   LocalizationConfigWithLabels,
@@ -37,6 +38,13 @@ const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig>
       `${sanitizedConfig.admin.user} is not a valid admin user collection`,
     )
   }
+
+  if (sanitizedConfig?.admin?.components?.views)
+    Object.entries(sanitizedConfig.admin.components.views).forEach(([_key, view]) => {
+      if (typeof view === 'function' || view.templateType) return
+
+      view.templateType = 'none'
+    })
 
   return sanitizedConfig as Partial<SanitizedConfig>
 }

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -1,7 +1,6 @@
 import { en } from '@payloadcms/translations/languages/en'
 import merge from 'deepmerge'
 
-import type { AdminView } from '../admin/views/types.js'
 import type {
   Config,
   LocalizationConfigWithLabels,

--- a/test/admin/components/views/CustomDefault/index.tsx
+++ b/test/admin/components/views/CustomDefault/index.tsx
@@ -7,6 +7,8 @@ import type { AdminViewProps } from '../../../../../packages/payload/types.js'
 
 const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
 
+import type { InitPageResult } from 'payload/types'
+
 import { Button } from '@payloadcms/ui/elements/Button'
 import { SetStepNav } from '@payloadcms/ui/elements/StepNav'
 
@@ -14,7 +16,11 @@ import { customViewPath } from '../../../shared.js'
 import './index.scss'
 const baseClass = 'custom-default-view'
 
-export const CustomDefaultView: React.FC<AdminViewProps> = ({ initPageResult }) => {
+export const CustomDefaultView: React.FC<AdminViewProps> = ({
+  initPageResult,
+}: {
+  initPageResult: InitPageResult
+}) => {
   const {
     permissions,
     req: {
@@ -36,7 +42,7 @@ export const CustomDefaultView: React.FC<AdminViewProps> = ({ initPageResult }) 
   }
 
   return (
-    <DefaultTemplate config={config} i18n={i18n} permissions={permissions} user={user}>
+    <div>
       <SetStepNav
         nav={[
           {
@@ -71,6 +77,6 @@ export const CustomDefaultView: React.FC<AdminViewProps> = ({ initPageResult }) 
           </Button>
         </div>
       </div>
-    </DefaultTemplate>
+    </div>
   )
 }

--- a/test/admin/components/views/CustomDefault/index.tsx
+++ b/test/admin/components/views/CustomDefault/index.tsx
@@ -1,9 +1,8 @@
-import { DefaultTemplate } from '@payloadcms/ui/templates/Default'
+import { HydrateClientUser } from '@payloadcms/ui/elements/HydrateClientUser'
 import LinkImport from 'next/link.js'
 import { redirect } from 'next/navigation.js'
+import { type AdminViewProps } from 'payload/types'
 import React from 'react'
-
-import type { AdminViewProps } from '../../../../../packages/payload/types.js'
 
 const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
 
@@ -24,9 +23,7 @@ export const CustomDefaultView: React.FC<AdminViewProps> = ({
   const {
     permissions,
     req: {
-      i18n,
       payload: {
-        config,
         config: {
           routes: { admin: adminRoute },
         },
@@ -43,38 +40,41 @@ export const CustomDefaultView: React.FC<AdminViewProps> = ({
 
   return (
     <div>
-      <SetStepNav
-        nav={[
-          {
-            label: 'Custom Admin View with Default Template',
-          },
-        ]}
-      />
-      <div
-        className={`${baseClass}__content`}
-        style={{
-          paddingLeft: 'var(--gutter-h)',
-          paddingRight: 'var(--gutter-h)',
-        }}
-      >
-        <h1>Custom Admin View</h1>
-        <p>
-          Here is a custom admin view that was added in the Payload config. It uses the Default
-          Template, so the sidebar is rendered.
-        </p>
-        <div className="custom-view__controls">
-          <Button Link={Link} buttonStyle="secondary" el="link" to={`${adminRoute}`}>
-            Go to Dashboard
-          </Button>
-          &nbsp; &nbsp; &nbsp;
-          <Button
-            Link={Link}
-            buttonStyle="secondary"
-            el="link"
-            to={`${adminRoute}/${customViewPath}`}
-          >
-            Go to Custom View
-          </Button>
+      <HydrateClientUser permissions={permissions} user={user} />
+      <div>
+        <SetStepNav
+          nav={[
+            {
+              label: 'Custom Admin View with Default Template',
+            },
+          ]}
+        />
+        <div
+          className={`${baseClass}__content`}
+          style={{
+            paddingLeft: 'var(--gutter-h)',
+            paddingRight: 'var(--gutter-h)',
+          }}
+        >
+          <h1>Custom Admin View</h1>
+          <p>
+            Here is a custom admin view that was added in the Payload config. It uses the Default
+            Template, so the sidebar is rendered.
+          </p>
+          <div className="custom-view__controls">
+            <Button Link={Link} buttonStyle="secondary" el="link" to={`${adminRoute}`}>
+              Go to Dashboard
+            </Button>
+            &nbsp; &nbsp; &nbsp;
+            <Button
+              Link={Link}
+              buttonStyle="secondary"
+              el="link"
+              to={`${adminRoute}/${customViewPath}`}
+            >
+              Go to Custom View
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/test/admin/components/views/CustomMinimal/index.tsx
+++ b/test/admin/components/views/CustomMinimal/index.tsx
@@ -11,7 +11,6 @@ const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.
 // import { useConfig } from 'payload/components/utilities';
 
 import { Button } from '@payloadcms/ui/elements/Button'
-import { MinimalTemplate } from '@payloadcms/ui/templates/Minimal'
 
 import type { AdminViewProps } from '../../../../../packages/payload/types.js'
 
@@ -32,7 +31,7 @@ export const CustomMinimalView: React.FC<AdminViewProps> = ({ initPageResult }) 
   } = initPageResult
 
   return (
-    <MinimalTemplate className={baseClass}>
+    <div className={baseClass}>
       <div className={`${baseClass}__content`}>
         <h1>Custom Admin View</h1>
         <p>Here is a custom admin view that was added in the Payload config.</p>
@@ -53,6 +52,6 @@ export const CustomMinimalView: React.FC<AdminViewProps> = ({ initPageResult }) 
           </div>
         </div>
       </div>
-    </MinimalTemplate>
+    </div>
   )
 }

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -33,7 +33,15 @@ import { GlobalGroup1B } from './globals/Group1B.js'
 import { GlobalHidden } from './globals/Hidden.js'
 import { GlobalNoApiView } from './globals/NoApiView.js'
 import { seed } from './seed.js'
-import { customNestedViewPath, customParamViewPath, customViewPath } from './shared.js'
+import {
+  customDefaultViewClass,
+  customDefaultViewPath,
+  customMinimalViewClass,
+  customMinimalViewPath,
+  customNestedViewPath,
+  customParamViewPath,
+  customViewPath,
+} from './shared.js'
 
 export default buildConfigWithDefaults({
   admin: {
@@ -51,11 +59,15 @@ export default buildConfigWithDefaults({
         // Account: CustomAccountView,
         CustomDefaultView: {
           Component: CustomDefaultView,
-          path: '/custom-default-view',
+          path: customDefaultViewPath,
+          templateType: 'default',
+          templateClass: customDefaultViewClass,
         },
         CustomMinimalView: {
           Component: CustomMinimalView,
-          path: '/custom-minimal-view',
+          path: customMinimalViewPath,
+          templateType: 'minimal',
+          templateClass: customMinimalViewClass,
         },
         CustomNestedView: {
           Component: CustomNestedView,

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -23,7 +23,11 @@ import {
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
 import {
+  customDefaultViewClass,
+  customDefaultViewPath,
   customEditLabel,
+  customMinimalViewClass,
+  customMinimalViewPath,
   customNestedTabViewPath,
   customNestedTabViewTitle,
   customNestedViewPath,
@@ -218,10 +222,12 @@ describe('admin', () => {
   })
 
   describe('custom views', () => {
-    test('root — should render custom view', async () => {
+    test('root — should render custom view without template', async () => {
       await page.goto(`${serverURL}/admin${customViewPath}`)
       await page.waitForURL(`**/admin${customViewPath}`)
       await expect(page.locator('h1#custom-view-title')).toContainText(customViewTitle)
+      await expect(page.locator('.template-default')).toBeHidden()
+      await expect(page.locator('.template-minimal')).toBeHidden()
     })
 
     test('root — should render custom nested view', async () => {
@@ -230,6 +236,18 @@ describe('admin', () => {
       const pathname = new URL(pageURL).pathname
       expect(pathname).toEqual(`/admin${customNestedViewPath}`)
       await expect(page.locator('h1#custom-view-title')).toContainText(customNestedViewTitle)
+    })
+
+    test('root - should render custom view with default template and custom class', async () => {
+      await page.goto(`${serverURL}/admin${customDefaultViewPath}`)
+      await expect(page.locator(`.template-default.${customDefaultViewClass}`)).toBeVisible()
+      await expect(page.locator('.template-minimal')).toBeHidden()
+    })
+
+    test('root - should render custom view with minimal template and custom class', async () => {
+      await page.goto(`${serverURL}/admin${customMinimalViewPath}`)
+      await expect(page.locator(`.template-minimal.${customMinimalViewClass}`)).toBeVisible()
+      await expect(page.locator('.template-default')).toBeHidden()
     })
 
     test('collection - should render custom tab view', async () => {

--- a/test/admin/shared.ts
+++ b/test/admin/shared.ts
@@ -6,6 +6,14 @@ export const customViewPath = '/custom-view'
 
 export const customParamViewPathBase = '/custom-param'
 
+export const customDefaultViewPath = '/custom-default-view'
+
+export const customDefaultViewClass = 'custom-default-view'
+
+export const customMinimalViewPath = '/custom-minimal-view'
+
+export const customMinimalViewClass = 'custom-minimal-view'
+
 export const customParamViewPath = `${customParamViewPathBase}/:id`
 
 export const customViewTitle = 'Custom View'


### PR DESCRIPTION
## Description
Currently a custom views in beta are wrapped with the Minimal template by default and you can't remove it and neither change it to the Default template. Because of this i can't migrate the views in my application from 2.0 to 3.0 (in 2.0 we were importing templates directly, but i guess this way could be better as less boilerplate)
Adds also abillity to apply classname to the template
Included e2e
change requires to update the doc but currently the doc mentions react-router so i think it's not updated to beta at this point.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
