### PR TITLE
 fix(ui): passes cellComponentProps through buildColumnState

### DIFF
--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -134,7 +134,7 @@ export const buildColumnState = (args: Args): Column[] => {
         accessor: name,
         active,
         cellProps: {
-          ...cellProps?.[index],
+          ...field.cellComponentProps,
           link: isFirstActiveColumn,
           relationTo:
             field.type === 'relationship' && 'relationTo' in field.fieldComponentProps

--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -135,6 +135,7 @@ export const buildColumnState = (args: Args): Column[] => {
         active,
         cellProps: {
           ...field.cellComponentProps,
+          ...cellProps?.[index],
           link: isFirstActiveColumn,
           relationTo:
             field.type === 'relationship' && 'relationTo' in field.fieldComponentProps


### PR DESCRIPTION
## Description

Fixes [beta-105](https://github.com/payloadcms/payload-3.0-demo/issues/105)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Existing test suite passes locally with my changes

Update: sorry i think i hurried, why we used this `cellProps[index]` in the first place? let me think
Update2: now i see, we are using it in ListDrawer for the first cell, so i guess that's right to pass both.