### PR TITLE
fix: passes parent id instead of incoming id to saveVersion

### DIFF
--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -154,7 +154,7 @@ export const saveVersion = async ({
   createdVersion.updatedAt = result.updatedAt
 
   createdVersion = sanitizeInternalFields(createdVersion)
-  createdVersion.id = id
+  createdVersion.id = result.parent
 
   return createdVersion
 }


### PR DESCRIPTION
## Description

`fix`: passes parent id instead of incoming id to saveVersion

There were instances where the incoming ID would be the incorrect type (I.e `string` instead of `number`) - `postgres` & `plugin-search`

v2 merged PR [here](https://github.com/payloadcms/payload/pull/5831)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
