### PR TITLE
chore(plugin-nested-docs): update nested docs plugin exports and moved away from default exports

### DIFF
--- a/packages/plugin-nested-docs/src/fields/breadcrumbs.ts
+++ b/packages/plugin-nested-docs/src/fields/breadcrumbs.ts
@@ -45,5 +45,3 @@ export const createBreadcrumbsField = (
     ...(overrides?.fields || []),
   ],
 })
-
-export default createBreadcrumbsField

--- a/packages/plugin-nested-docs/src/fields/parent.ts
+++ b/packages/plugin-nested-docs/src/fields/parent.ts
@@ -20,5 +20,3 @@ export const createParentField = (
   relationTo,
   ...(overrides || {}),
 })
-
-export default createParentField

--- a/packages/plugin-nested-docs/src/fields/parentFilterOptions.ts
+++ b/packages/plugin-nested-docs/src/fields/parentFilterOptions.ts
@@ -12,5 +12,3 @@ export const parentFilterOptions: (breadcrumbsFieldSlug?: string) => FilterOptio
 
     return null
   }
-
-export default parentFilterOptions

--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -2,7 +2,7 @@ import type { CollectionAfterChangeHook, CollectionConfig, PayloadRequest } from
 
 import type { PluginConfig } from '../types.js'
 
-import populateBreadcrumbs from '../utilities/populateBreadcrumbs.js'
+import { populateBreadcrumbs } from '../utilities/populateBreadcrumbs.js'
 
 type ResaveArgs = {
   collection: CollectionConfig
@@ -65,7 +65,7 @@ const resave = async ({ collection, doc, draft, pluginConfig, req }: ResaveArgs)
   }
 }
 
-const resaveChildren =
+export const resaveChildren =
   (pluginConfig: PluginConfig, collection: CollectionConfig): CollectionAfterChangeHook =>
   async ({ doc, req }) => {
     await resave({
@@ -88,4 +88,3 @@ const resaveChildren =
 
     return undefined
   }
-export default resaveChildren

--- a/packages/plugin-nested-docs/src/hooks/resaveSelfAfterCreate.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveSelfAfterCreate.ts
@@ -5,7 +5,7 @@ import type { PluginConfig } from '../types.js'
 // This hook automatically re-saves a document after it is created
 // so that we can build its breadcrumbs with the newly created document's ID.
 
-const resaveSelfAfterCreate =
+export const resaveSelfAfterCreate =
   (pluginConfig: PluginConfig, collection: CollectionConfig): CollectionAfterChangeHook =>
   async ({ doc, operation, req }) => {
     const { locale, payload } = req
@@ -52,5 +52,3 @@ const resaveSelfAfterCreate =
 
     return undefined
   }
-
-export default resaveSelfAfterCreate

--- a/packages/plugin-nested-docs/src/index.ts
+++ b/packages/plugin-nested-docs/src/index.ts
@@ -3,14 +3,16 @@ import type { SingleRelationshipField } from 'payload/types'
 
 import type { PluginConfig } from './types.js'
 
-import createBreadcrumbsField from './fields/breadcrumbs.js'
-import createParentField from './fields/parent.js'
-import parentFilterOptions from './fields/parentFilterOptions.js'
-import resaveChildren from './hooks/resaveChildren.js'
-import resaveSelfAfterCreate from './hooks/resaveSelfAfterCreate.js'
-import populateBreadcrumbs from './utilities/populateBreadcrumbs.js'
+import { createBreadcrumbsField } from './fields/breadcrumbs.js'
+import { createParentField } from './fields/parent.js'
+import { parentFilterOptions } from './fields/parentFilterOptions.js'
+import { resaveChildren } from './hooks/resaveChildren.js'
+import { resaveSelfAfterCreate } from './hooks/resaveSelfAfterCreate.js'
+import { populateBreadcrumbs } from './utilities/populateBreadcrumbs.js'
 
-const nestedDocs =
+export { createBreadcrumbsField, createParentField }
+
+export const nestedDocs =
   (pluginConfig: PluginConfig): Plugin =>
   (config) => ({
     ...config,
@@ -67,5 +69,3 @@ const nestedDocs =
       return collection
     }),
   })
-
-export default nestedDocs

--- a/packages/plugin-nested-docs/src/utilities/formatBreadcrumb.ts
+++ b/packages/plugin-nested-docs/src/utilities/formatBreadcrumb.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from 'payload/types'
 
 import type { Breadcrumb, PluginConfig } from '../types.js'
 
-const formatBreadcrumb = (
+export const formatBreadcrumb = (
   pluginConfig: PluginConfig,
   collection: CollectionConfig,
   docs: Array<Record<string, unknown>>,
@@ -29,5 +29,3 @@ const formatBreadcrumb = (
     url,
   }
 }
-
-export default formatBreadcrumb

--- a/packages/plugin-nested-docs/src/utilities/getParents.ts
+++ b/packages/plugin-nested-docs/src/utilities/getParents.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from 'payload/types'
 
 import type { PluginConfig } from '../types.js'
 
-const getParents = async (
+export const getParents = async (
   req: any,
   pluginConfig: PluginConfig,
   collection: CollectionConfig,
@@ -44,5 +44,3 @@ const getParents = async (
 
   return docs
 }
-
-export default getParents

--- a/packages/plugin-nested-docs/src/utilities/populateBreadcrumbs.ts
+++ b/packages/plugin-nested-docs/src/utilities/populateBreadcrumbs.ts
@@ -2,10 +2,10 @@ import type { CollectionConfig } from 'payload/types'
 
 import type { PluginConfig } from '../types.js'
 
-import formatBreadcrumb from './formatBreadcrumb.js'
-import getParents from './getParents.js'
+import { formatBreadcrumb } from './formatBreadcrumb.js'
+import { getParents } from './getParents.js'
 
-const populateBreadcrumbs = async (
+export const populateBreadcrumbs = async (
   req: any,
   pluginConfig: PluginConfig,
   collection: CollectionConfig,
@@ -40,5 +40,3 @@ const populateBreadcrumbs = async (
     [pluginConfig?.breadcrumbsFieldSlug || 'breadcrumbs']: breadcrumbs,
   }
 }
-
-export default populateBreadcrumbs

--- a/test/plugin-nested-docs/collections/Categories.ts
+++ b/test/plugin-nested-docs/collections/Categories.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from 'payload/types'
 
-import { createBreadcrumbsField } from '../../../packages/plugin-nested-docs/src/fields/breadcrumbs.js'
-import createParentField from '../../../packages/plugin-nested-docs/src/fields/parent.js'
+import { createBreadcrumbsField } from '@payloadcms/plugin-nested-docs'
+import { createParentField } from '@payloadcms/plugin-nested-docs'
 
 export const Categories: CollectionConfig = {
   access: {

--- a/test/plugin-nested-docs/collections/Pages.ts
+++ b/test/plugin-nested-docs/collections/Pages.ts
@@ -1,7 +1,6 @@
-// const payload = require('payload');
 import type { CollectionConfig } from 'payload/types'
 
-import populateFullTitle from './populateFullTitle.js'
+import { populateFullTitle } from './populateFullTitle.js'
 
 export const Pages: CollectionConfig = {
   slug: 'pages',

--- a/test/plugin-nested-docs/collections/populateFullTitle.ts
+++ b/test/plugin-nested-docs/collections/populateFullTitle.ts
@@ -11,7 +11,5 @@ export const generateFullTitle = (breadcrumbs: Array<{ label: string }>): string
   return undefined
 }
 
-const populateFullTitle: FieldHook = ({ data, originalDoc }) =>
+export const populateFullTitle: FieldHook = ({ data, originalDoc }) =>
   generateFullTitle(data?.breadcrumbs || originalDoc?.breadcrumbs)
-
-export default populateFullTitle

--- a/test/plugin-nested-docs/config.ts
+++ b/test/plugin-nested-docs/config.ts
@@ -1,4 +1,4 @@
-import nestedDocs from '@payloadcms/plugin-nested-docs'
+import { nestedDocs } from '@payloadcms/plugin-nested-docs'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'


### PR DESCRIPTION
Fixes an issue where the field functions from the plugins are not exported as expected and moved the exports away from using default exports

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] Existing test suite passes locally with my changes
