### PR TITLE
feat: allow configuration for setting headers on external file fetch

### DIFF
--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -59,6 +59,7 @@ export const createClientCollectionConfig = ({
     sanitized.upload = { ...sanitized.upload }
     delete sanitized.upload.handlers
     delete sanitized.upload.adminThumbnail
+    delete sanitized.upload.externalFileHeaderFilter
   }
 
   if ('auth' in sanitized && typeof sanitized.auth === 'object') {

--- a/packages/payload/src/collections/config/schema.ts
+++ b/packages/payload/src/collections/config/schema.ts
@@ -154,6 +154,7 @@ const collectionSchema = joi.object().keys({
       adminThumbnail: joi.alternatives().try(joi.string(), componentSchema),
       crop: joi.bool(),
       disableLocalStorage: joi.bool(),
+      externalFileHeaderFilter: joi.func(),
       filesRequiredOnCreate: joi.bool(),
       focalPoint: joi.bool(),
       formatOptions: joi.object().keys({

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -70,7 +70,11 @@ export const generateFileData = async <T>({
         file = response
         overwriteExistingFiles = true
       } else if (filename && url) {
-        file = await getExternalFile({ data: data as FileData, req })
+        file = await getExternalFile({
+          data: data as FileData,
+          req,
+          uploadConfig: collectionConfig.upload,
+        })
         overwriteExistingFiles = true
       }
     } catch (err) {

--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -1,24 +1,30 @@
 import type { PayloadRequest } from '../types/index.ts'
-import type { File, FileData } from './types.js'
+import type { File, FileData, UploadConfig } from './types.js'
 
 import { APIError } from '../errors/index.js'
 
 type Args = {
   data: FileData
   req: PayloadRequest
+  uploadConfig: UploadConfig
 }
-export const getExternalFile = async ({ data, req }: Args): Promise<File> => {
+export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promise<File> => {
   const baseUrl = req.origin || `${req.protocol}://${req.host}`
   const { filename, url } = data
 
   if (typeof url === 'string') {
     const fileURL = `${baseUrl}${url}`
 
+    const headers = uploadConfig.externalFileHeaderFilter
+      ? uploadConfig.externalFileHeaderFilter(req.headers)
+      : {
+          Authorization: req.headers['authorization'],
+          cookie: req.headers['cookie'],
+        }
+
     const res = await fetch(fileURL, {
       credentials: 'include',
-      headers: {
-        ...req.headers,
-      },
+      headers,
       method: 'GET',
     })
 

--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -16,9 +16,8 @@ export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promis
     const fileURL = `${baseUrl}${url}`
 
     const headers = uploadConfig.externalFileHeaderFilter
-      ? uploadConfig.externalFileHeaderFilter(req.headers)
+      ? uploadConfig.externalFileHeaderFilter(Object.fromEntries(new Headers(req.headers)))
       : {
-          Authorization: req.headers['authorization'],
           cookie: req.headers['cookie'],
         }
 

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -83,7 +83,7 @@ export type UploadConfig = {
    *
    * Useful for adding custom headers to fetch from external providers.
    */
-  externalFileHeaderFilter?: (headers: Headers) => Headers
+  externalFileHeaderFilter?: (headers: Record<string, string>) => Record<string, string>
   filesRequiredOnCreate?: boolean
   focalPoint?: boolean
   /** Options for original upload file only. For sizes, set each formatOptions individually. */

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -78,6 +78,12 @@ export type UploadConfig = {
   adminThumbnail?: GetAdminThumbnail | string
   crop?: boolean
   disableLocalStorage?: boolean
+  /**
+   * Accepts existing headers and can filter/modify them.
+   *
+   * Useful for adding custom headers to fetch from external providers.
+   */
+  externalFileHeaderFilter?: (headers: Headers) => Headers
   filesRequiredOnCreate?: boolean
   focalPoint?: boolean
   /** Options for original upload file only. For sizes, set each formatOptions individually. */


### PR DESCRIPTION
## Description

Addresses https://github.com/payloadcms/payload/issues/5159

- Adds new `externalFileHeaderFilter` property to a collection's upload config that allows the user to filter headers however they wish.
- Fallback when not configured is now just cookie and authorization

An accompanying PR will be made against `main`