### PR TITLE
chore: improve cookie helper functions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,13 @@
       "type": "node-terminal"
     },
     {
+      "command": "node --no-deprecation test/dev.js auth",
+      "cwd": "${workspaceFolder}",
+      "name": "Run Dev Auth",
+      "request": "launch",
+      "type": "node-terminal"
+    },
+    {
       "command": "pnpm run dev plugin-cloud-storage",
       "cwd": "${workspaceFolder}",
       "name": "Run Dev - plugin-cloud-storage",
@@ -69,35 +76,25 @@
       }
     },
     {
-      "command": "pnpm run dev versions",
+      "command": "node --no-deprecation test/dev.js versions",
       "cwd": "${workspaceFolder}",
       "name": "Run Dev Versions",
       "request": "launch",
       "type": "node-terminal"
     },
     {
-      "command": "pnpm run dev localization",
+      "command": "node --no-deprecation test/dev.js localization",
       "cwd": "${workspaceFolder}",
       "name": "Run Dev Localization",
       "request": "launch",
       "type": "node-terminal"
     },
     {
-      "command": "pnpm run dev uploads",
+      "command": "node --no-deprecation test/dev.js uploads",
       "cwd": "${workspaceFolder}",
       "name": "Run Dev Uploads",
       "request": "launch",
       "type": "node-terminal"
-    },
-    {
-      "command": "PAYLOAD_BUNDLER=vite pnpm run dev fields",
-      "cwd": "${workspaceFolder}",
-      "name": "Run Dev Fields (Vite)",
-      "request": "launch",
-      "type": "node-terminal",
-      "env": {
-        "NODE_ENV": "production"
-      }
     },
     {
       "command": "pnpm run test:int live-preview",

--- a/packages/payload/src/auth/cookies.ts
+++ b/packages/payload/src/auth/cookies.ts
@@ -106,7 +106,7 @@ export const generateCookie = <ReturnCookieAsString = boolean>(
     }
   }
 
-  return (returnCookieAsObject ? cookieString : cookieObject) as ReturnCookieAsString extends true
+  return (returnCookieAsObject ? cookieObject : cookieString) as ReturnCookieAsString extends true
     ? CookieObject
     : string
 }

--- a/packages/payload/src/auth/cookies.ts
+++ b/packages/payload/src/auth/cookies.ts
@@ -15,14 +15,14 @@ type CookieOptions = {
 }
 
 type CookieObject = {
-  Domain?: string
-  HttpOnly?: boolean
-  'Max-Age'?: number
-  Path?: string
-  SameSite?: 'Lax' | 'None' | 'Strict'
-  Secure?: boolean
+  domain?: string
   expires?: string
+  httpOnly?: boolean
+  maxAge?: number
   name: string
+  path?: string
+  sameSite?: 'Lax' | 'None' | 'Strict'
+  secure?: boolean
   value: string
 }
 
@@ -50,27 +50,61 @@ export const generateCookie = <ReturnCookieAsString = boolean>(
 
   const secure = secureArg || sameSite === 'None'
 
-  function buildResponse(propertyName, value: boolean | string) {
+  if (expires) {
     if (returnCookieAsObject) {
-      cookieString += `; ${propertyName}${typeof value === 'string' ? `=${value}` : ''}`
+      cookieObject.expires = expires.toUTCString()
     } else {
-      cookieObject[propertyName] = value
+      cookieString += `; Expires=${expires.toUTCString()}}`
     }
   }
 
-  if (expires) buildResponse('Expires', expires.toUTCString())
+  if (maxAge) {
+    if (returnCookieAsObject) {
+      cookieObject.maxAge = maxAge
+    } else {
+      cookieString += `; Max-Age=${maxAge.toString()}}`
+    }
+  }
 
-  if (maxAge) buildResponse('Max-Age', maxAge.toString())
+  if (domain) {
+    if (returnCookieAsObject) {
+      cookieObject.domain = domain
+    } else {
+      cookieString += `; Domain=${domain}}`
+    }
+  }
 
-  if (domain) buildResponse('Domain', domain)
+  if (path) {
+    if (returnCookieAsObject) {
+      cookieObject.path = path
+    } else {
+      cookieString += `; Path=${path}}`
+    }
+  }
 
-  if (path) buildResponse('Path', path)
+  if (secure) {
+    if (returnCookieAsObject) {
+      cookieObject.secure = secure
+    } else {
+      cookieString += `; Secure=${secure}}`
+    }
+  }
 
-  if (secure) buildResponse('Secure', secure)
+  if (httpOnly) {
+    if (returnCookieAsObject) {
+      cookieObject.httpOnly = httpOnly
+    } else {
+      cookieString += `; HttpOnly=${httpOnly}}`
+    }
+  }
 
-  if (httpOnly) buildResponse('HttpOnly', httpOnly)
-
-  if (sameSite) buildResponse('SameSite', sameSite)
+  if (sameSite) {
+    if (returnCookieAsObject) {
+      cookieObject.sameSite = sameSite
+    } else {
+      cookieString += `; SameSite=${sameSite}}`
+    }
+  }
 
   return (returnCookieAsObject ? cookieString : cookieObject) as ReturnCookieAsString extends true
     ? CookieObject
@@ -102,7 +136,7 @@ type GeneratePayloadCookieArgs = {
 export const generatePayloadCookie = <T extends GeneratePayloadCookieArgs>({
   collectionConfig,
   payload,
-  returnCookieAsObject = true,
+  returnCookieAsObject = false,
   token,
 }: T): T['returnCookieAsObject'] extends true ? CookieObject : string => {
   const sameSite =
@@ -128,7 +162,7 @@ export const generatePayloadCookie = <T extends GeneratePayloadCookieArgs>({
 export const generateExpiredPayloadCookie = <T extends Omit<GeneratePayloadCookieArgs, 'token'>>({
   collectionConfig,
   payload,
-  returnCookieAsObject = true,
+  returnCookieAsObject = false,
 }: T): T['returnCookieAsObject'] extends true ? CookieObject : string => {
   const sameSite =
     typeof collectionConfig.auth.cookies.sameSite === 'string'

--- a/packages/payload/src/auth/cookies.ts
+++ b/packages/payload/src/auth/cookies.ts
@@ -26,9 +26,9 @@ type CookieObject = {
   value: string
 }
 
-export const generateCookie = <ReturnCookieAsString = boolean>(
+export const generateCookie = <ReturnCookieAsObject = boolean>(
   args: CookieOptions,
-): ReturnCookieAsString extends true ? CookieObject : string => {
+): ReturnCookieAsObject extends true ? CookieObject : string => {
   const {
     name,
     domain,
@@ -54,7 +54,7 @@ export const generateCookie = <ReturnCookieAsString = boolean>(
     if (returnCookieAsObject) {
       cookieObject.expires = expires.toUTCString()
     } else {
-      cookieString += `; Expires=${expires.toUTCString()}}`
+      cookieString += `; Expires=${expires.toUTCString()}`
     }
   }
 
@@ -62,7 +62,7 @@ export const generateCookie = <ReturnCookieAsString = boolean>(
     if (returnCookieAsObject) {
       cookieObject.maxAge = maxAge
     } else {
-      cookieString += `; Max-Age=${maxAge.toString()}}`
+      cookieString += `; Max-Age=${maxAge.toString()}`
     }
   }
 
@@ -70,7 +70,7 @@ export const generateCookie = <ReturnCookieAsString = boolean>(
     if (returnCookieAsObject) {
       cookieObject.domain = domain
     } else {
-      cookieString += `; Domain=${domain}}`
+      cookieString += `; Domain=${domain}`
     }
   }
 
@@ -78,7 +78,7 @@ export const generateCookie = <ReturnCookieAsString = boolean>(
     if (returnCookieAsObject) {
       cookieObject.path = path
     } else {
-      cookieString += `; Path=${path}}`
+      cookieString += `; Path=${path}`
     }
   }
 
@@ -86,7 +86,7 @@ export const generateCookie = <ReturnCookieAsString = boolean>(
     if (returnCookieAsObject) {
       cookieObject.secure = secure
     } else {
-      cookieString += `; Secure=${secure}}`
+      cookieString += `; Secure=${secure}`
     }
   }
 
@@ -94,7 +94,7 @@ export const generateCookie = <ReturnCookieAsString = boolean>(
     if (returnCookieAsObject) {
       cookieObject.httpOnly = httpOnly
     } else {
-      cookieString += `; HttpOnly=${httpOnly}}`
+      cookieString += `; HttpOnly=${httpOnly}`
     }
   }
 
@@ -102,11 +102,11 @@ export const generateCookie = <ReturnCookieAsString = boolean>(
     if (returnCookieAsObject) {
       cookieObject.sameSite = sameSite
     } else {
-      cookieString += `; SameSite=${sameSite}}`
+      cookieString += `; SameSite=${sameSite}`
     }
   }
 
-  return (returnCookieAsObject ? cookieObject : cookieString) as ReturnCookieAsString extends true
+  return (returnCookieAsObject ? cookieObject : cookieString) as ReturnCookieAsObject extends true
     ? CookieObject
     : string
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload-3.0-demo/issues/101

Makes it easier to re-use our helper functions when working with Cookies and Next.js

You can now use `generatePayloadCookie` like so:
```ts
import { generatePayloadCookie } from 'payload/auth'

const result = await loginOperation({
  collection,
  data: {
    email: 'abc@test.com',
    password: 'password',
  },
  req,
})

// returns a cookie string
const cookie = generatePayloadCookie({
  collectionConfig: collection.config,
  payload: req.payload,
  token: result.token,
})

// returns a cookie object
const cookie = generatePayloadCookie({
  collectionConfig: collection.config,
  payload: req.payload,
  token: result.token,
  returnAsObject: true,
})
```

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
