### PR TITLE
fix(next): issue with password and confirm password fields not being type of password

### DIFF
--- a/packages/next/src/views/CreateFirstUser/index.client.tsx
+++ b/packages/next/src/views/CreateFirstUser/index.client.tsx
@@ -14,7 +14,7 @@ export const CreateFirstUserFields: React.FC<{
 
   const fieldMap = getFieldMap({ collectionSlug: userSlug })
 
-  const newMap = createFirstUserFieldMap.map((field) => {
+  const firstUserFieldMapWithPasswordFields = createFirstUserFieldMap.map((field) => {
     if (field.name === 'password') {
       const type: keyof FieldTypes = 'password'
 
@@ -36,7 +36,7 @@ export const CreateFirstUserFields: React.FC<{
 
   return (
     <RenderFields
-      fieldMap={[...(newMap || []), ...(fieldMap || [])]}
+      fieldMap={[...(firstUserFieldMapWithPasswordFields || []), ...(fieldMap || [])]}
       operation="create"
       path=""
       readOnly={false}

--- a/packages/next/src/views/CreateFirstUser/index.client.tsx
+++ b/packages/next/src/views/CreateFirstUser/index.client.tsx
@@ -1,6 +1,5 @@
 'use client'
 import type { FieldMap } from '@payloadcms/ui/utilities/buildComponentMap'
-import type { FieldTypes } from 'payload/config'
 
 import { RenderFields } from '@payloadcms/ui/forms/RenderFields'
 import { useComponentMap } from '@payloadcms/ui/providers/ComponentMap'
@@ -14,29 +13,9 @@ export const CreateFirstUserFields: React.FC<{
 
   const fieldMap = getFieldMap({ collectionSlug: userSlug })
 
-  const firstUserFieldMapWithPasswordFields = createFirstUserFieldMap.map((field) => {
-    if (field.name === 'password') {
-      const type: keyof FieldTypes = 'password'
-
-      return {
-        ...field,
-        type,
-      }
-    }
-    if (field.name === 'confirm-password') {
-      const type: keyof FieldTypes = 'confirmPassword'
-
-      return {
-        ...field,
-        type,
-      }
-    }
-    return field
-  })
-
   return (
     <RenderFields
-      fieldMap={[...(firstUserFieldMapWithPasswordFields || []), ...(fieldMap || [])]}
+      fieldMap={[...(createFirstUserFieldMap || []), ...(fieldMap || [])]}
       operation="create"
       path=""
       readOnly={false}

--- a/packages/next/src/views/CreateFirstUser/index.client.tsx
+++ b/packages/next/src/views/CreateFirstUser/index.client.tsx
@@ -1,5 +1,6 @@
 'use client'
 import type { FieldMap } from '@payloadcms/ui/utilities/buildComponentMap'
+import type { FieldTypes } from 'payload/config'
 
 import { RenderFields } from '@payloadcms/ui/forms/RenderFields'
 import { useComponentMap } from '@payloadcms/ui/providers/ComponentMap'
@@ -13,9 +14,29 @@ export const CreateFirstUserFields: React.FC<{
 
   const fieldMap = getFieldMap({ collectionSlug: userSlug })
 
+  const newMap = createFirstUserFieldMap.map((field) => {
+    if (field.name === 'password') {
+      const type: keyof FieldTypes = 'password'
+
+      return {
+        ...field,
+        type,
+      }
+    }
+    if (field.name === 'confirm-password') {
+      const type: keyof FieldTypes = 'confirmPassword'
+
+      return {
+        ...field,
+        type,
+      }
+    }
+    return field
+  })
+
   return (
     <RenderFields
-      fieldMap={[...(fieldMap || []), ...(createFirstUserFieldMap || [])]}
+      fieldMap={[...(newMap || []), ...(fieldMap || [])]}
       operation="create"
       path=""
       readOnly={false}

--- a/packages/next/src/views/CreateFirstUser/index.tsx
+++ b/packages/next/src/views/CreateFirstUser/index.tsx
@@ -1,3 +1,4 @@
+import type { FieldTypes } from 'payload/config'
 import type { Field, WithServerSideProps as WithServerSidePropsType } from 'payload/types'
 import type { AdminViewProps } from 'payload/types'
 
@@ -61,6 +62,25 @@ export const CreateFirstUserView: React.FC<AdminViewProps> = async ({ initPageRe
     fieldSchema: fields,
     i18n,
     parentPath: userSlug,
+  }).map((field) => {
+    // Transform field types for the password and confirm-password fields
+    if (field.name === 'password') {
+      const type: keyof FieldTypes = 'password'
+
+      return {
+        ...field,
+        type,
+      }
+    }
+    if (field.name === 'confirm-password') {
+      const type: keyof FieldTypes = 'confirmPassword'
+
+      return {
+        ...field,
+        type,
+      }
+    }
+    return field
   })
 
   const formState = await buildStateFromSchema({


### PR DESCRIPTION
fix: issue with password and confirm password fields not being type of password


Previously the password and confirm password fields would end up being visible
![image](https://github.com/payloadcms/payload/assets/35137243/09b2af55-b953-4a01-b954-0323b6dbda12)
