### PR TITLE
fix: properly handle drafts in bulk update

### DIFF
--- a/packages/payload/src/admin/components/elements/EditMany/index.tsx
+++ b/packages/payload/src/admin/components/elements/EditMany/index.tsx
@@ -83,7 +83,7 @@ const SaveDraft: React.FC<{ action: string; disabled: boolean }> = ({ action, di
   )
 }
 const EditMany: React.FC<Props> = (props) => {
-  const { collection: { fields, labels: { plural }, slug } = {}, collection, resetParams } = props
+  const { collection: { slug, fields, labels: { plural } } = {}, collection, resetParams } = props
 
   const { permissions } = useAuth()
   const { closeModal } = useModal()
@@ -148,11 +148,11 @@ const EditMany: React.FC<Props> = (props) => {
                         {collection.versions ? (
                           <React.Fragment>
                             <Publish
-                              action={`${serverURL}${api}/${slug}${getQueryParams()}`}
+                              action={`${serverURL}${api}/${slug}${getQueryParams()}&draft=true`}
                               disabled={selected.length === 0}
                             />
                             <SaveDraft
-                              action={`${serverURL}${api}/${slug}${getQueryParams()}`}
+                              action={`${serverURL}${api}/${slug}${getQueryParams()}&draft=true`}
                               disabled={selected.length === 0}
                             />
                           </React.Fragment>

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -268,7 +268,8 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
           global: null,
           operation: 'update',
           req,
-          skipValidation: data._status !== 'published',
+          skipValidation:
+            Boolean(collectionConfig.versions?.drafts) && data._status !== 'published',
         })
 
         // /////////////////////////////////////

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -268,7 +268,7 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
           global: null,
           operation: 'update',
           req,
-          skipValidation: shouldSaveDraft || data._status === 'draft',
+          skipValidation: data._status !== 'published',
         })
 
         // /////////////////////////////////////

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -297,7 +297,6 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
               ...result,
               createdAt: doc.createdAt,
             },
-            draft: shouldSaveDraft,
             payload,
             req,
           })

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -241,7 +241,7 @@ async function updateByID<TSlug extends keyof GeneratedTypes['collections']>(
       global: null,
       operation: 'update',
       req,
-      skipValidation: shouldSaveDraft || data._status === 'draft',
+      skipValidation: Boolean(collectionConfig.versions?.drafts) && data._status !== 'published',
     })
 
     // /////////////////////////////////////

--- a/packages/payload/src/versions/getLatestCollectionVersion.ts
+++ b/packages/payload/src/versions/getLatestCollectionVersion.ts
@@ -26,6 +26,8 @@ export const getLatestCollectionVersion = async <T extends TypeWithID = any>({
   if (config.versions?.drafts) {
     const { docs } = await payload.db.findVersions<T>({
       collection: config.slug,
+      limit: 1,
+      pagination: false,
       req,
       sort: '-updatedAt',
       where: { parent: { equals: id } },

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -19,7 +19,6 @@
  *    - tabs
  *    - text
  *    - richtext
- *  - restore version
  *  - specify locales to show
  */
 

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -471,6 +471,47 @@ describe('Versions', () => {
         expect(draftPost.title.es).toBe(spanishTitle)
       })
     })
+
+    describe('Update Many', () => {
+      it('should update many using drafts', async () => {
+        const doc = await payload.create({
+          collection: draftCollectionSlug,
+          data: {
+            title: 'initial value',
+            description: 'description to bulk update',
+            _status: 'published',
+          },
+        })
+
+        await payload.update({
+          collection: draftCollectionSlug,
+          id: doc.id,
+          draft: true,
+          data: {
+            title: 'updated title',
+          },
+        })
+
+        const updated = await payload.update({
+          collection: draftCollectionSlug,
+          data: {
+            description: 'updated description',
+          },
+          draft: true,
+          where: {
+            id: {
+              in: [doc.id],
+            },
+          },
+        })
+
+        const updatedDoc = updated.docs?.[0]
+
+        expect(updatedDoc.description).toStrictEqual('updated description')
+        expect(updatedDoc.title).toStrictEqual('updated title') // probably will fail
+      })
+    })
+
     describe('Delete', () => {
       let postToDelete
       beforeEach(async () => {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -472,7 +472,7 @@ describe('Versions', () => {
         expect(draftPost.title.es).toBe(spanishTitle)
       })
 
-      it('should validate publishing without the draft arg', async () => {
+      it('should validate when publishing with the draft arg', async () => {
         // no title (not valid for publishing)
         const doc = await payload.create({
           collection: draftCollectionSlug,


### PR DESCRIPTION
## Description

Fixes #5834 

Latest draft was not being used in bulk update if versions were enabled due to an extra condition.