### PR TITLE
chore: attempts to dynamically load config for getPayloadHMR

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+/* Our app sits here to not cause any conflicts with payload's root layout  */
+const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}
+
+export default Layout

--- a/app/(app)/server-component-test/page.tsx
+++ b/app/(app)/server-component-test/page.tsx
@@ -1,0 +1,16 @@
+import { getPayloadHMR } from '@payloadcms/next'
+import React from 'react'
+
+const Page = async () => {
+  const payload = await getPayloadHMR({ disableOnInit: true })
+  const url = payload.getAdminURL()
+
+  return (
+    <article className={['container'].filter(Boolean).join(' ')}>
+      <h1>Payload 3.0</h1>
+      <p>The admin panel is running at {url}</p>
+    </article>
+  )
+}
+
+export default Page

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,12 @@ const withBundleAnalyzer = bundleAnalyzer({
 // eslint-disable-next-line no-restricted-exports
 export default withBundleAnalyzer(
   withPayload({
+    experimental: {
+      serverComponentsExternalPackages: [
+        './packages/config-loader/src/index.ts',
+        '@payloadcms/config-loader',
+      ],
+    },
     reactStrictMode: false,
     eslint: {
       ignoreDuringBuilds: true,

--- a/packages/config-loader/.eslintignore
+++ b/packages/config-loader/.eslintignore
@@ -1,0 +1,11 @@
+.tmp
+**/.git
+**/.hg
+**/.pnp.*
+**/.svn
+**/.yarn/**
+**/build
+**/dist/**
+**/node_modules
+**/temp
+bin

--- a/packages/config-loader/.prettierignore
+++ b/packages/config-loader/.prettierignore
@@ -1,0 +1,12 @@
+.tmp
+**/.git
+**/.hg
+**/.pnp.*
+**/.svn
+**/.yarn/**
+**/build
+**/dist/**
+**/node_modules
+**/temp
+**/docs/**
+tsconfig.json

--- a/packages/config-loader/.swcrc
+++ b/packages/config-loader/.swcrc
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/swcrc",
+  "sourceMaps": true,
+  "jsc": {
+    "target": "esnext",
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "dts": true
+    },
+    "experimental": {
+      "plugins": [
+        [
+          "swc-plugin-transform-remove-imports",
+          {
+            "test": "\\.(scss|css)$"
+          }
+        ]
+      ]
+    }
+  },
+  "module": {
+    "type": "commonjs"
+  }
+}

--- a/packages/config-loader/README.md
+++ b/packages/config-loader/README.md
@@ -1,0 +1,7 @@
+# Payload Config Loader
+
+This package is used within `@payloadcms/next` in order to load the config within Next.js server components and not have any of the config's code leak into the client-side JS bundle. It is included within the Next.js config's `serverComponentsExternalPackages` property so as to not be included in the bundle.
+
+Without this approach, all client components referenced via the `payload.config.ts` file will be included into the client-side JS if the Payload Local API is used in a server component.
+
+The package is transpiled to CommonJS because when Next.js detects a package as `serverComponentsExternalPackages`, the package is `require`d rather than imported with ESM.

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@payloadcms/config-loader",
+  "version": "3.0.0-beta.10",
+  "type": "module",
+  "homepage": "https://payloadcms.com",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/payloadcms/payload.git",
+    "directory": "packages/config-loader"
+  },
+  "scripts": {
+    "build": "pnpm build:swc && pnpm build:types",
+    "build:swc": "swc ./src -d ./dist --config-file .swcrc",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "clean": "rimraf {dist,*.tsbuildinfo}",
+    "prepublishOnly": "pnpm clean && pnpm turbo build"
+  },
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "require": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "import": "./dist/index.js",
+        "require": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      }
+    },
+    "registry": "https://registry.npmjs.org/"
+  },
+  "devDependencies": {
+    "@payloadcms/eslint-config": "workspace:*",
+    "payload": "workspace:*"
+  },
+  "peerDependencies": {
+    "find-up": "4.1.0",
+    "get-tsconfig": "^4.7.2",
+    "payload": "workspace:*"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/config-loader/src/index.ts
+++ b/packages/config-loader/src/index.ts
@@ -1,0 +1,9 @@
+import type { SanitizedConfig } from 'payload/types'
+
+import { findConfig } from './find.js'
+
+export const loadConfig = async (): Promise<SanitizedConfig> => {
+  const configPath = findConfig()
+  const configPromise = await import(configPath)
+  return configPromise?.default || configPromise
+}

--- a/packages/config-loader/tsconfig.json
+++ b/packages/config-loader/tsconfig.json
@@ -18,13 +18,8 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
-    "src/withPayload.js" /* Include the withPayload.js file in the build */
   ],
   "references": [
-    { "path": "../config-loader" },
     { "path": "../payload" },
-    { "path": "../ui" },
-    { "path": "../translations" },
-    { "path": "../graphql" }
   ]
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^14.1.0",
+    "@payloadcms/config-loader": "workspace:*",
     "@payloadcms/eslint-config": "workspace:*",
     "@types/react": "18.2.74",
     "@types/react-dom": "18.2.24",
@@ -97,6 +98,11 @@
         "import": "./dist/exports/*.js",
         "require": "./dist/exports/*.js",
         "types": "./dist/exports/*.d.ts"
+      },
+      ".": {
+        "import": "./dist/exports/index.js",
+        "require": "./dist/exports/index.js",
+        "types": "./dist/exports/index.d.ts"
       }
     },
     "registry": "https://registry.npmjs.org/"

--- a/packages/next/src/exports/index.ts
+++ b/packages/next/src/exports/index.ts
@@ -1,0 +1,1 @@
+export { getPayloadHMR } from '../utilities/getPayloadHMR.js'

--- a/packages/next/src/utilities/getPayloadHMR.ts
+++ b/packages/next/src/utilities/getPayloadHMR.ts
@@ -1,6 +1,7 @@
 import type { GeneratedTypes, Payload } from 'payload'
 import type { InitOptions } from 'payload/config'
 
+import { loadConfig } from '@payloadcms/config-loader'
 import { BasePayload } from 'payload'
 import WebSocket from 'ws'
 
@@ -15,15 +16,15 @@ if (!cached) {
   cached = global._payload = { payload: null, promise: null, reload: false }
 }
 
-export const getPayloadHMR = async (options: InitOptions): Promise<Payload> => {
-  if (!options?.config) {
-    throw new Error('Error: the payload config is required for getPayload to work.')
+export const getPayloadHMR = async (incomingOptions?: Partial<InitOptions>): Promise<Payload> => {
+  const options: InitOptions = {
+    ...(incomingOptions || {}),
+    config: incomingOptions?.config || loadConfig(),
   }
 
   if (cached.payload) {
-    const config = await options.config // TODO: check if we can move this inside the cached.reload === true condition
-
     if (cached.reload === true) {
+      const config = await options.config
       let resolve
 
       cached.reload = new Promise((res) => (resolve = res))

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -23,6 +23,7 @@ export const withPayload = (nextConfig = {}) => {
         'libsql',
         'pino',
         'pino-pretty',
+        '@payloadcms/config-loader',
       ],
     },
     webpack: (webpackConfig, webpackOptions) => {

--- a/packages/payload/src/exports/node.ts
+++ b/packages/payload/src/exports/node.ts
@@ -1,2 +1,3 @@
 export { generateTypes } from '../bin/generateTypes.js'
+export { findConfig } from '../config/find.js'
 export { importConfig, importWithoutClientFiles } from '../utilities/importWithoutClientFiles.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,22 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
 
+  packages/config-loader:
+    dependencies:
+      find-up:
+        specifier: 4.1.0
+        version: 4.1.0
+      get-tsconfig:
+        specifier: ^4.7.2
+        version: 4.7.3
+    devDependencies:
+      '@payloadcms/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config-payload
+      payload:
+        specifier: workspace:*
+        version: link:../payload
+
   packages/create-payload-app:
     dependencies:
       '@clack/prompts':
@@ -652,6 +668,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^14.1.0
         version: 14.1.4
+      '@payloadcms/config-loader':
+        specifier: workspace:*
+        version: link:../config-loader
       '@payloadcms/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config-payload

--- a/test/testHooks.js
+++ b/test/testHooks.js
@@ -26,7 +26,7 @@ export const createTestHooks = async (testSuiteName = '_community') => {
       tsConfig.compilerOptions.paths['@payload-config'] = [`./test/${testSuiteName}/config.ts`]
       await writeFile(tsConfigPath, JSON.stringify(tsConfig, null, 2))
 
-      process.env.PAYLOAD_CONFIG_PATH = path.resolve(testSuiteName, 'config')
+      process.env.PAYLOAD_CONFIG_PATH = path.resolve(`./test/${testSuiteName}/config.ts`)
     },
     /**
      * Reset the changes made to tsconfig.json

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,7 +85,7 @@
         "./packages/next/src/exports/*.ts"
       ],
       "@payloadcms/next": [
-        "./packages/next/src/exports/*"
+        "./packages/next/src/exports/index.ts"
       ]
     }
   },


### PR DESCRIPTION
Attempts to expose a utility that loads the config within a package that is marked as `serverComponentsExternalPackages`, so we can avoid having any of the config's client components included in the client-side JS bundle that Next.js produces.

Related issue:
https://github.com/vercel/next.js/issues/50285