### PR TITLE
fix(create-payload-app): uses baseUrl for payload config path in tsconfig

### DIFF
--- a/packages/create-payload-app/src/lib/init-next.ts
+++ b/packages/create-payload-app/src/lib/init-next.ts
@@ -117,13 +117,17 @@ async function addPayloadConfigToTsConfig(projectDir: string, isSrcDir: boolean)
     warning(`Could not find tsconfig.json to add @payload-config path.`)
     return
   }
-
   const userTsConfigContent = await readFile(tsConfigPath, {
     encoding: 'utf8',
   })
   const userTsConfig = parse(userTsConfigContent) as {
     compilerOptions?: CompilerOptions
   }
+
+  const hasBaseUrl =
+    userTsConfig?.compilerOptions?.baseUrl && userTsConfig?.compilerOptions?.baseUrl !== '.'
+  const baseUrl = hasBaseUrl ? userTsConfig?.compilerOptions?.baseUrl : './'
+
   if (!userTsConfig.compilerOptions && !('extends' in userTsConfig)) {
     userTsConfig.compilerOptions = {}
   }
@@ -134,7 +138,7 @@ async function addPayloadConfigToTsConfig(projectDir: string, isSrcDir: boolean)
   ) {
     userTsConfig.compilerOptions.paths = {
       ...(userTsConfig.compilerOptions.paths || {}),
-      '@payload-config': [`./${isSrcDir ? 'src/' : ''}payload.config.ts`],
+      '@payload-config': [`${baseUrl}${isSrcDir ? 'src/' : ''}payload.config.ts`],
     }
     await writeFile(tsConfigPath, stringify(userTsConfig, null, 2), { encoding: 'utf8' })
   }


### PR DESCRIPTION
## Description

Closes #5812

The `payload.config` path added to the `tsconfig.json` file is incorrect when the user has `baseUrl` set.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes