### PR TITLE
chore:(i18n): adds translation for document/s key

### DIFF
--- a/packages/next/src/views/Edit/Default/index.tsx
+++ b/packages/next/src/views/Edit/Default/index.tsx
@@ -14,13 +14,13 @@ import { useDocumentInfo } from '@payloadcms/ui/providers/DocumentInfo'
 import { useEditDepth } from '@payloadcms/ui/providers/EditDepth'
 import { useFormQueryParams } from '@payloadcms/ui/providers/FormQueryParams'
 import { OperationProvider } from '@payloadcms/ui/providers/Operation'
+import { useTranslation } from '@payloadcms/ui/providers/Translation'
 import { getFormState } from '@payloadcms/ui/utilities/getFormState'
 import { useRouter } from 'next/navigation.js'
 import { useSearchParams } from 'next/navigation.js'
 import React, { Fragment, useCallback } from 'react'
 
 import { LeaveWithoutSaving } from '../../../elements/LeaveWithoutSaving/index.js'
-// import { getTranslation } from '@payloadcms/translations'
 import { Auth } from './Auth/index.js'
 import { SetDocumentStepNav } from './SetDocumentStepNav/index.js'
 import { SetDocumentTitle } from './SetDocumentTitle/index.js'
@@ -63,6 +63,8 @@ export const DefaultEditView: React.FC = () => {
   const params = useSearchParams()
   const depth = useEditDepth()
   const { reportUpdate } = useDocumentEvents()
+
+  const { i18n } = useTranslation()
 
   const {
     admin: { user: userSlug },
@@ -196,7 +198,7 @@ export const DefaultEditView: React.FC = () => {
             name={`collection-edit--${
               typeof collectionConfig?.labels?.singular === 'string'
                 ? collectionConfig.labels.singular
-                : 'document'
+                : i18n.t('general:document')
             }`}
             type="withoutNav"
           />

--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -120,6 +120,8 @@ export const clientTranslationKeys = [
   'general:deleting',
   'general:descending',
   'general:deselectAllRows',
+  'general:document',
+  'general:documents',
   'general:duplicate',
   'general:duplicateWithoutSaving',
   'general:edit',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -190,6 +190,8 @@ export const ar: Language = {
       deleting: 'يتمّ الحذف...',
       descending: 'تنازلي',
       deselectAllRows: 'إلغاء تحديد جميع الصفوف',
+      document: 'وثيقة',
+      documents: 'وثائق',
       duplicate: 'استنساخ',
       duplicateWithoutSaving: 'استنساخ بدون حفظ التغييرات',
       edit: 'تعديل',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -192,6 +192,8 @@ export const az: Language = {
       deleting: 'Silinir...',
       descending: 'Azalan',
       deselectAllRows: 'Bütün sıraları seçimi ləğv edin',
+      document: 'Sənəd',
+      documents: 'Sənədlər',
       duplicate: 'Dublikat',
       duplicateWithoutSaving: 'Dəyişiklikləri saxlamadan dublikatla',
       edit: 'Redaktə et',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -190,6 +190,8 @@ export const bg: Language = {
       deleting: 'Изтриване...',
       descending: 'Низходящо',
       deselectAllRows: 'Деселектирай всички редове',
+      document: 'Документ',
+      documents: 'Документи',
       duplicate: 'Дупликирай',
       duplicateWithoutSaving: 'Дупликирай без да запазваш промените',
       edit: 'Редактирай',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -191,6 +191,8 @@ export const cs: Language = {
       deleting: 'Odstraňování...',
       descending: 'Sestupně',
       deselectAllRows: 'Zrušte výběr všech řádků',
+      document: 'Dokument',
+      documents: 'Dokumenty',
       duplicate: 'Duplikovat',
       duplicateWithoutSaving: 'Duplikovat bez uložení změn',
       edit: 'Upravit',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -194,6 +194,8 @@ export const de: Language = {
       deleting: 'Lösche...',
       descending: 'Absteigend',
       deselectAllRows: 'Alle Zeilen abwählen',
+      document: 'Dokument',
+      documents: 'Dokumente',
       duplicate: 'Duplizieren',
       duplicateWithoutSaving: 'Dupliziere ohne Änderungen zu speichern',
       edit: 'Bearbeiten',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -191,6 +191,8 @@ export const en: Language = {
       deleting: 'Deleting...',
       descending: 'Descending',
       deselectAllRows: 'Deselect all rows',
+      document: 'Document',
+      documents: 'Documents',
       duplicate: 'Duplicate',
       duplicateWithoutSaving: 'Duplicate without saving changes',
       edit: 'Edit',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -193,6 +193,8 @@ export const es: Language = {
       deleting: 'Eliminando...',
       descending: 'Descendente',
       deselectAllRows: 'Deselecciona todas las filas',
+      document: 'Documento',
+      documents: 'Documentos',
       duplicate: 'Duplicar',
       duplicateWithoutSaving: 'Duplicar sin guardar cambios',
       edit: 'Editar',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -191,6 +191,8 @@ export const fa: Language = {
       deleting: 'در حال حذف...',
       descending: 'رو به پایین',
       deselectAllRows: 'تمام سطرها را از انتخاب خارج کنید',
+      document: 'سند',
+      documents: 'اسناد',
       duplicate: 'تکراری',
       duplicateWithoutSaving: 'رونوشت بدون ذخیره کردن تغییرات',
       edit: 'نگارش',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -197,6 +197,8 @@ export const fr: Language = {
       deleting: 'Suppression en cours...',
       descending: 'Descendant(e)',
       deselectAllRows: 'Désélectionner toutes les lignes',
+      document: 'Document',
+      documents: 'Documents',
       duplicate: 'Dupliquer',
       duplicateWithoutSaving: 'Dupliquer sans enregistrer les modifications',
       edit: 'Éditer',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -191,6 +191,8 @@ export const hr: Language = {
       deleting: 'Brisanje...',
       descending: 'Silazno',
       deselectAllRows: 'Odznači sve redove',
+      document: 'Dokument',
+      documents: 'Dokumenti',
       duplicate: 'Duplikat',
       duplicateWithoutSaving: 'Dupliciraj bez spremanja promjena',
       edit: 'Uredi',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -193,6 +193,8 @@ export const hu: Language = {
       deleting: 'Törlés...',
       descending: 'Csökkenő',
       deselectAllRows: 'Jelölje ki az összes sort',
+      document: 'Dokumentum',
+      documents: 'Dokumentumok',
       duplicate: 'Duplikálás',
       duplicateWithoutSaving: 'Duplikálás a módosítások mentése nélkül',
       edit: 'Szerkesztés',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -193,6 +193,8 @@ export const it: Language = {
       deleting: 'Sto eliminando...',
       descending: 'Decrescente',
       deselectAllRows: 'Deseleziona tutte le righe',
+      document: 'Documento',
+      documents: 'Documenti',
       duplicate: 'Duplica',
       duplicateWithoutSaving: 'Duplica senza salvare le modifiche',
       edit: 'Modificare',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -191,6 +191,8 @@ export const ja: Language = {
       deleting: '削除しています...',
       descending: '降順',
       deselectAllRows: 'すべての行の選択を解除します',
+      document: 'ドキュメント',
+      documents: 'ドキュメント',
       duplicate: '複製',
       duplicateWithoutSaving: '変更を保存せずに複製',
       edit: '編集',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -191,6 +191,8 @@ export const ko: Language = {
       deleting: '삭제 중...',
       descending: '내림차순',
       deselectAllRows: '모든 행 선택 해제',
+      document: '문서',
+      documents: '문서들',
       duplicate: '복제',
       duplicateWithoutSaving: '변경 사항 저장 없이 복제',
       edit: '수정',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -193,6 +193,8 @@ export const my: Language = {
       deleting: 'ဖျက်နေဆဲ ...',
       descending: 'ဆင်းသက်လာသည်။',
       deselectAllRows: 'အားလုံးကို မရွေးနိုင်ပါ',
+      document: 'စာရွက်စာတမ်း',
+      documents: 'စာရွက်စာတမ်းများ',
       duplicate: 'ပုံတူပွားမည်။',
       duplicateWithoutSaving: 'သေချာပါပြီ။',
       edit: 'တည်းဖြတ်ပါ။',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -191,6 +191,8 @@ export const nb: Language = {
       deleting: 'Sletter...',
       descending: 'Synkende',
       deselectAllRows: 'Fjern markeringen fra alle rader',
+      document: 'Dokument',
+      documents: 'Dokumenter',
       duplicate: 'Dupliser',
       duplicateWithoutSaving: 'Dupliser uten å lagre endringer',
       edit: 'Redigere',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -193,6 +193,8 @@ export const nl: Language = {
       deleting: 'Verwijderen...',
       descending: 'Aflopend',
       deselectAllRows: 'Deselecteer alle rijen',
+      document: 'Document',
+      documents: 'Documenten',
       duplicate: 'Dupliceren',
       duplicateWithoutSaving: 'Dupliceren zonder wijzigingen te bewaren',
       edit: 'Bewerk',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -193,6 +193,8 @@ export const pl: Language = {
       deleting: 'Usuwanie...',
       descending: 'Malejąco',
       deselectAllRows: 'Odznacz wszystkie wiersze',
+      document: 'Dokument',
+      documents: 'Dokumenty',
       duplicate: 'Zduplikuj',
       duplicateWithoutSaving: 'Zduplikuj bez zapisywania zmian',
       edit: 'Edytuj',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -192,6 +192,8 @@ export const pt: Language = {
       deleting: 'Excluindo...',
       descending: 'Decrescente',
       deselectAllRows: 'Desmarcar todas as linhas',
+      document: 'Documento',
+      documents: 'Documentos',
       duplicate: 'Duplicar',
       duplicateWithoutSaving: 'Duplicar sem salvar alterações',
       edit: 'Editar',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -194,6 +194,8 @@ export const ro: Language = {
       deleting: 'Deleting...',
       descending: 'Descendentă',
       deselectAllRows: 'Deselectează toate rândurile',
+      document: 'Document',
+      documents: 'Documente',
       duplicate: 'Duplicați',
       duplicateWithoutSaving: 'Duplicați fără salvarea modificărilor',
       edit: 'Editează',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -190,6 +190,8 @@ export const rs: Language = {
       deleting: 'Брисање...',
       descending: 'Опадајуће',
       deselectAllRows: 'Деселектујте све редове',
+      document: 'Dokument',
+      documents: 'Dokumenti',
       duplicate: 'Дупликат',
       duplicateWithoutSaving: 'Понови без чувања промена',
       edit: 'Уреди',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -190,6 +190,8 @@ export const rsLatin: Language = {
       deleting: 'Brisanje...',
       descending: 'Opadajuće',
       deselectAllRows: 'Deselektujte sve redove',
+      document: 'Dokument',
+      documents: 'Dokumenti',
       duplicate: 'Duplikat',
       duplicateWithoutSaving: 'Ponovi bez čuvanja promena',
       edit: 'Uredi',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -193,6 +193,8 @@ export const ru: Language = {
       deleting: 'Удаление...',
       descending: 'Уменьшение',
       deselectAllRows: 'Снять выделение со всех строк',
+      document: 'Документ',
+      documents: 'Документы',
       duplicate: 'Дублировать',
       duplicateWithoutSaving: 'Дублирование без сохранения изменений',
       edit: 'Редактировать',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -192,6 +192,8 @@ export const sv: Language = {
       deleting: 'Tar bort...',
       descending: 'Fallande',
       deselectAllRows: 'Avmarkera alla rader',
+      document: 'Dokument',
+      documents: 'Dokument',
       duplicate: 'Duplicera',
       duplicateWithoutSaving: 'Duplicera utan att spara ändringar',
       edit: 'Redigera',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -187,6 +187,8 @@ export const th: Language = {
       deleting: 'กำลังลบ...',
       descending: 'มากไปน้อย',
       deselectAllRows: 'ยกเลิกการเลือกทุกแถว',
+      document: 'เอกสาร',
+      documents: 'เอกสาร',
       duplicate: 'สำเนา',
       duplicateWithoutSaving: 'สำเนาโดยไม่บันทึกการแก้ไข',
       edit: 'แก้ไข',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -194,6 +194,8 @@ export const tr: Language = {
       deleting: 'Siliniyor...',
       descending: 'Azalan',
       deselectAllRows: 'Tüm satırların seçimini kaldır',
+      document: 'Belge',
+      documents: 'Belgeler',
       duplicate: 'Çoğalt',
       duplicateWithoutSaving: 'Ayarları kaydetmeden çoğalt',
       edit: 'Düzenle',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -33,7 +33,8 @@ export const uk: Language = {
       lockUntil: 'Заблокувати до',
       logBackIn: 'Увійти знову',
       logOut: 'Вийти',
-      loggedIn: 'Щоб увйти в систему з іншого облікового запису, спочатку <0>вийдіть з системи</0>.',
+      loggedIn:
+        'Щоб увйти в систему з іншого облікового запису, спочатку <0>вийдіть з системи</0>.',
       loggedInChangePassword:
         'Щоб змінити ваш пароль, перейдіть до <0>сторінки облікового запису</0> і змініть ваш пароль.',
       loggedOutInactivity: 'Ви вийшли з системи через бездіяльність.',
@@ -41,7 +42,8 @@ export const uk: Language = {
       login: 'Увійти',
       loginAttempts: 'Спроби входу',
       loginUser: 'Вхід користувача в систему',
-      loginWithAnotherUser: 'Щоб увйти в систему з іншого облікового запису, спочатку <0>вийдіть з системи</0>.',
+      loginWithAnotherUser:
+        'Щоб увйти в систему з іншого облікового запису, спочатку <0>вийдіть з системи</0>.',
       logout: 'Вийти',
       logoutUser: 'Вийти з системи',
       newAPIKeyGenerated: 'Новий API ключ згенеровано.',
@@ -191,6 +193,8 @@ export const uk: Language = {
       deleting: 'Видалення...',
       descending: 'В порядку спадання',
       deselectAllRows: 'Скасувати вибір всіх рядків',
+      document: 'Документ',
+      documents: 'Документи',
       duplicate: 'Дублювати',
       duplicateWithoutSaving: 'Дублювання без збереження змін',
       edit: 'Редагувати',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -190,6 +190,8 @@ export const vi: Language = {
       deleting: 'Đang xóa...',
       descending: 'Xếp theo thứ tự giảm dần',
       deselectAllRows: 'Bỏ chọn tất cả các hàng',
+      document: 'Tài liệu',
+      documents: 'Tài liệu',
       duplicate: 'Tạo bản sao',
       duplicateWithoutSaving: 'Không lưu dữ liệu và tạo bản sao',
       edit: 'Chỉnh sửa',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -185,6 +185,8 @@ export const zh: Language = {
       deleting: '删除中...',
       descending: '降序',
       deselectAllRows: '取消选择所有行',
+      document: '文件',
+      documents: '文件',
       duplicate: '重复',
       duplicateWithoutSaving: '重复而不保存更改。',
       edit: '编辑',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -185,6 +185,8 @@ export const zhTw: Language = {
       deleting: '刪除中...',
       descending: '降冪',
       deselectAllRows: '取消選擇全部',
+      document: '文件',
+      documents: '文件',
       duplicate: '複製',
       duplicateWithoutSaving: '複製而不儲存變更。',
       edit: '編輯',

--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -84,7 +84,7 @@ export const DocumentControls: React.FC<{
                     label:
                       typeof collectionConfig?.labels?.singular === 'string'
                         ? collectionConfig.labels.singular
-                        : 'document',
+                        : i18n.t('general:document'),
                   })}
                 </p>
               </li>


### PR DESCRIPTION
## Description

Adds translation keys for `document` and uses it for the `create new [collection label]` fallback.

**Duplicate PR for 2.0 [here](https://github.com/payloadcms/payload/pull/5889)**.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Chore (non-breaking change which does not add functionality)

## Checklist:

- [X] Existing test suite passes locally with my changes