### PR TITLE
chore(ui): expose 'customClient' config to useFieldProps hook and move 'custom' to server only

### DIFF
--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -8,7 +8,7 @@ export type ServerOnlyFieldProperties =
   | 'editor' // This is a `richText` only property
   | 'filterOptions' // This is a `relationship` and `upload` only property
   | 'label'
-  | keyof Pick<FieldBase, 'access' | 'defaultValue' | 'hooks' | 'validate'>
+  | keyof Pick<FieldBase, 'access' | 'custom' | 'defaultValue' | 'hooks' | 'validate'>
 
 export type ServerOnlyFieldAdminProperties = keyof Pick<
   FieldBase['admin'],
@@ -30,6 +30,7 @@ export const createClientFieldConfig = ({
     'validate',
     'defaultValue',
     'label',
+    'custom',
     'filterOptions', // This is a `relationship` and `upload` only property
     'editor', // This is a `richText` only property
     // `fields`

--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -38,6 +38,7 @@ export const baseField = joi
     }),
     admin: baseAdminFields.default(),
     custom: joi.object().pattern(joi.string(), joi.any()),
+    customClient: joi.object().pattern(joi.string(), joi.any()),
     hidden: joi.boolean().default(false),
     hooks: joi
       .object()
@@ -520,6 +521,7 @@ export const ui = joi.object().keys({
     })
     .default(),
   custom: joi.object().pattern(joi.string(), joi.any()),
+  customClient: joi.object().pattern(joi.string(), joi.any()),
   label: joi.alternatives().try(joi.string(), joi.object().pattern(joi.string(), [joi.string()])),
 })
 

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -15,7 +15,6 @@ import type {
   RichTextAdapter,
   RowLabel,
 } from '../../admin/types.js'
-import type { User } from '../../auth/index.js'
 import type { SanitizedCollectionConfig, TypeWithID } from '../../collections/config/types.js'
 import type { CustomComponent, LabelFunction } from '../../config/types.js'
 import type { DBIdentifierName } from '../../database/types.js'
@@ -179,8 +178,12 @@ export interface FieldBase {
     update?: FieldAccess
   }
   admin?: Admin
-  /** Extension point to add your custom data. */
+  /** Extension point to add your custom data. Server only. */
   custom?: Record<string, any>
+  /**
+   * Extension point to add your custom data to the client bundle.
+   */
+  customClient?: Record<string, any>
   defaultValue?: any
   hidden?: boolean
   hooks?: {
@@ -425,8 +428,12 @@ export type UIField = {
     position?: string
     width?: string
   }
-  /** Extension point to add your custom data. */
+  /** Extension point to add your custom data. Server only. */
   custom?: Record<string, any>
+  /**
+   * Extension point to add your custom data to the client bundle.
+   */
+  customClient?: Record<string, any>
   label?: Record<string, string> | string
   name: string
   type: 'ui'

--- a/packages/ui/src/fields/shared/index.tsx
+++ b/packages/ui/src/fields/shared/index.tsx
@@ -17,6 +17,7 @@ export type FormFieldBase = {
   CustomError?: React.ReactNode
   CustomLabel?: React.ReactNode
   className?: string
+  custom?: Record<string, unknown>
   descriptionProps?: FieldDescriptionProps
   disabled?: boolean
   docPreferences?: DocumentPreferences

--- a/packages/ui/src/fields/shared/index.tsx
+++ b/packages/ui/src/fields/shared/index.tsx
@@ -17,7 +17,7 @@ export type FormFieldBase = {
   CustomError?: React.ReactNode
   CustomLabel?: React.ReactNode
   className?: string
-  custom?: Record<string, unknown>
+  customClient?: Record<string, any>
   descriptionProps?: FieldDescriptionProps
   disabled?: boolean
   docPreferences?: DocumentPreferences

--- a/packages/ui/src/forms/FieldPropsProvider/index.tsx
+++ b/packages/ui/src/forms/FieldPropsProvider/index.tsx
@@ -5,6 +5,7 @@ import type { FieldPermissions } from 'payload/types'
 import React from 'react'
 
 export type FieldPropsContextType = {
+  custom?: Record<string, unknown>
   indexPath?: string
   path: string
   permissions?: FieldPermissions
@@ -28,6 +29,7 @@ const FieldPropsContext = React.createContext<FieldPropsContextType>({
 
 export type Props = {
   children: React.ReactNode
+  custom?: Record<string, unknown>
   indexPath?: string
   path: string
   permissions?: FieldPermissions
@@ -42,6 +44,7 @@ export type Props = {
 export const FieldPropsProvider: React.FC<Props> = ({
   type,
   children,
+  custom,
   indexPath,
   path,
   permissions,
@@ -53,6 +56,7 @@ export const FieldPropsProvider: React.FC<Props> = ({
     <FieldPropsContext.Provider
       value={{
         type,
+        custom,
         indexPath,
         path,
         permissions,

--- a/packages/ui/src/forms/FieldPropsProvider/index.tsx
+++ b/packages/ui/src/forms/FieldPropsProvider/index.tsx
@@ -5,7 +5,7 @@ import type { FieldPermissions } from 'payload/types'
 import React from 'react'
 
 export type FieldPropsContextType = {
-  custom?: Record<string, unknown>
+  customClient?: Record<string, any>
   indexPath?: string
   path: string
   permissions?: FieldPermissions
@@ -29,7 +29,7 @@ const FieldPropsContext = React.createContext<FieldPropsContextType>({
 
 export type Props = {
   children: React.ReactNode
-  custom?: Record<string, unknown>
+  customClient?: Record<string, any>
   indexPath?: string
   path: string
   permissions?: FieldPermissions
@@ -44,7 +44,7 @@ export type Props = {
 export const FieldPropsProvider: React.FC<Props> = ({
   type,
   children,
-  custom,
+  customClient,
   indexPath,
   path,
   permissions,
@@ -56,7 +56,7 @@ export const FieldPropsProvider: React.FC<Props> = ({
     <FieldPropsContext.Provider
       value={{
         type,
-        custom,
+        customClient,
         indexPath,
         path,
         permissions,
@@ -71,6 +71,6 @@ export const FieldPropsProvider: React.FC<Props> = ({
 }
 
 export const useFieldProps = () => {
-  const path = React.useContext(FieldPropsContext)
-  return path
+  const props = React.useContext(FieldPropsContext)
+  return props
 }

--- a/packages/ui/src/forms/RenderFields/RenderField.tsx
+++ b/packages/ui/src/forms/RenderFields/RenderField.tsx
@@ -17,6 +17,7 @@ import { FieldPropsProvider, useFieldProps } from '../FieldPropsProvider/index.j
 
 type Props = {
   CustomField: MappedField['CustomField']
+  custom?: Record<string, unknown>
   disabled: boolean
   fieldComponentProps?: FieldComponentProps
   indexPath?: string
@@ -36,6 +37,7 @@ export const RenderField: React.FC<Props> = ({
   name,
   type,
   CustomField,
+  custom,
   disabled,
   fieldComponentProps,
   indexPath,
@@ -78,6 +80,7 @@ export const RenderField: React.FC<Props> = ({
 
   return (
     <FieldPropsProvider
+      custom={custom}
       indexPath={indexPath}
       path={path}
       permissions={permissions}

--- a/packages/ui/src/forms/RenderFields/RenderField.tsx
+++ b/packages/ui/src/forms/RenderFields/RenderField.tsx
@@ -17,7 +17,7 @@ import { FieldPropsProvider, useFieldProps } from '../FieldPropsProvider/index.j
 
 type Props = {
   CustomField: MappedField['CustomField']
-  custom?: Record<string, unknown>
+  customClient?: Record<string, any>
   disabled: boolean
   fieldComponentProps?: FieldComponentProps
   indexPath?: string
@@ -37,7 +37,7 @@ export const RenderField: React.FC<Props> = ({
   name,
   type,
   CustomField,
-  custom,
+  customClient,
   disabled,
   fieldComponentProps,
   indexPath,
@@ -80,7 +80,7 @@ export const RenderField: React.FC<Props> = ({
 
   return (
     <FieldPropsProvider
-      custom={custom}
+      customClient={customClient}
       indexPath={indexPath}
       path={path}
       permissions={permissions}

--- a/packages/ui/src/forms/RenderFields/index.tsx
+++ b/packages/ui/src/forms/RenderFields/index.tsx
@@ -60,6 +60,7 @@ export const RenderFields: React.FC<Props> = (props) => {
             const {
               type,
               CustomField,
+              custom,
               disabled,
               fieldComponentProps,
               fieldComponentProps: { readOnly },
@@ -71,6 +72,7 @@ export const RenderFields: React.FC<Props> = (props) => {
             return (
               <RenderField
                 CustomField={CustomField}
+                custom={custom}
                 disabled={disabled}
                 fieldComponentProps={fieldComponentProps}
                 indexPath={indexPath !== undefined ? `${indexPath}.${fieldIndex}` : `${fieldIndex}`}

--- a/packages/ui/src/forms/RenderFields/index.tsx
+++ b/packages/ui/src/forms/RenderFields/index.tsx
@@ -60,7 +60,7 @@ export const RenderFields: React.FC<Props> = (props) => {
             const {
               type,
               CustomField,
-              custom,
+              customClient,
               disabled,
               fieldComponentProps,
               fieldComponentProps: { readOnly },
@@ -72,7 +72,7 @@ export const RenderFields: React.FC<Props> = (props) => {
             return (
               <RenderField
                 CustomField={CustomField}
-                custom={custom}
+                customClient={customClient}
                 disabled={disabled}
                 fieldComponentProps={fieldComponentProps}
                 indexPath={indexPath !== undefined ? `${indexPath}.${fieldIndex}` : `${fieldIndex}`}

--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
@@ -195,7 +195,7 @@ export const mapFields = (args: {
           CustomDescription,
           CustomError,
           CustomLabel,
-          custom: field.custom,
+          customClient: field.customClient,
           descriptionProps,
           disabled: 'admin' in field && 'disabled' in field.admin ? field.admin?.disabled : false,
           errorProps,
@@ -750,7 +750,7 @@ export const mapFields = (args: {
             <WithServerSideProps Component={CustomFieldComponent} {...fieldComponentProps} />
           ) : undefined,
           cellComponentProps,
-          custom: field?.custom,
+          customClient: field?.customClient,
           disableBulkEdit:
             'admin' in field && 'disableBulkEdit' in field.admin && field.admin.disableBulkEdit,
           fieldComponentProps,

--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
@@ -17,12 +17,7 @@ import type {
 
 import { FieldDescription } from '@payloadcms/ui/forms/FieldDescription'
 import { fieldAffectsData, fieldIsPresentationalOnly } from 'payload/types'
-import {
-  isPlainFunction,
-  isReactClientComponent,
-  isReactComponent,
-  isReactServerComponent,
-} from 'payload/utilities'
+import { isPlainFunction, isReactComponent } from 'payload/utilities'
 import React, { Fragment } from 'react'
 
 import type { ArrayFieldProps } from '../../../fields/Array/index.js'
@@ -200,6 +195,7 @@ export const mapFields = (args: {
           CustomDescription,
           CustomError,
           CustomLabel,
+          custom: field.custom,
           descriptionProps,
           disabled: 'admin' in field && 'disabled' in field.admin ? field.admin?.disabled : false,
           errorProps,
@@ -754,6 +750,7 @@ export const mapFields = (args: {
             <WithServerSideProps Component={CustomFieldComponent} {...fieldComponentProps} />
           ) : undefined,
           cellComponentProps,
+          custom: field?.custom,
           disableBulkEdit:
             'admin' in field && 'disableBulkEdit' in field.admin && field.admin.disableBulkEdit,
           fieldComponentProps,

--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/types.ts
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/types.ts
@@ -68,7 +68,7 @@ export type MappedField = {
   CustomCell?: React.ReactNode
   CustomField?: React.ReactNode
   cellComponentProps: CellComponentProps
-  custom?: Record<string, unknown>
+  customClient?: Record<string, any>
   disableBulkEdit?: boolean
   disabled?: boolean
   fieldComponentProps: FieldComponentProps

--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/types.ts
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/types.ts
@@ -68,6 +68,7 @@ export type MappedField = {
   CustomCell?: React.ReactNode
   CustomField?: React.ReactNode
   cellComponentProps: CellComponentProps
+  custom?: Record<string, unknown>
   disableBulkEdit?: boolean
   disabled?: boolean
   fieldComponentProps: FieldComponentProps

--- a/test/fields/collections/UI/UICustomClient.tsx
+++ b/test/fields/collections/UI/UICustomClient.tsx
@@ -1,0 +1,9 @@
+'use client'
+import { useFieldProps } from '@payloadcms/ui/forms/FieldPropsProvider'
+import React from 'react'
+
+export const UICustomClient: React.FC = () => {
+  const { customClient, path } = useFieldProps()
+
+  return <div id={path}>{customClient?.customValue}</div>
+}

--- a/test/fields/collections/UI/index.ts
+++ b/test/fields/collections/UI/index.ts
@@ -1,0 +1,33 @@
+import type { CollectionConfig } from 'payload/types'
+
+import { UICustomClient } from './UICustomClient.js'
+import { uiFieldsSlug } from './shared.js'
+
+const UIFields: CollectionConfig = {
+  slug: uiFieldsSlug,
+  admin: {
+    useAsTitle: 'text',
+  },
+  defaultSort: 'id',
+  fields: [
+    {
+      name: 'text',
+      type: 'text',
+      required: true,
+    },
+    {
+      type: 'ui',
+      name: 'uiCustomClient',
+      admin: {
+        components: {
+          Field: UICustomClient,
+        },
+      },
+      customClient: {
+        customValue: `client-side-configuration`,
+      },
+    },
+  ],
+}
+
+export default UIFields

--- a/test/fields/collections/UI/shared.ts
+++ b/test/fields/collections/UI/shared.ts
@@ -1,0 +1,2 @@
+export const defaultText = 'default-text'
+export const uiFieldsSlug = 'ui-fields'

--- a/test/fields/config.ts
+++ b/test/fields/config.ts
@@ -22,6 +22,7 @@ import RowFields from './collections/Row/index.js'
 import SelectFields from './collections/Select/index.js'
 import TabsFields from './collections/Tabs/index.js'
 import TextFields from './collections/Text/index.js'
+import UIFields from './collections/UI/index.js'
 import Uploads from './collections/Upload/index.js'
 import Uploads2 from './collections/Upload2/index.js'
 import Uploads3 from './collections/Uploads3/index.js'
@@ -64,6 +65,7 @@ export const collectionSlugs: CollectionConfig[] = [
   SelectFields,
   TabsFields,
   TextFields,
+  UIFields,
   Uploads,
   Uploads2,
   Uploads3,

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -930,6 +930,22 @@ describe('fields', () => {
     })
   })
 
+  describe('ui', () => {
+    let url: AdminUrlUtil
+    beforeAll(() => {
+      url = new AdminUrlUtil(serverURL, 'ui-fields')
+    })
+
+    test('should show customClient configuration', async () => {
+      await page.goto(url.create)
+
+      const uiField = page.locator('#uiCustomClient')
+
+      await expect(uiField).toBeVisible()
+      await expect(uiField).toContainText('client-side-configuration')
+    })
+  })
+
   describe('conditional logic', () => {
     let url: AdminUrlUtil
     beforeAll(() => {

--- a/test/fields/seed.ts
+++ b/test/fields/seed.ts
@@ -43,6 +43,7 @@ import {
   selectFieldsSlug,
   tabsFieldsSlug,
   textFieldsSlug,
+  uiSlug,
   uploadsSlug,
   usersSlug,
 } from './slugs.js'
@@ -300,6 +301,13 @@ export const seed = async (_payload) => {
     data: numberDoc,
     depth: 0,
     overrideAccess: true,
+  })
+
+  await _payload.create({
+    collection: uiSlug,
+    data: {
+      text: 'text',
+    },
   })
 }
 

--- a/test/fields/slugs.ts
+++ b/test/fields/slugs.ts
@@ -1,28 +1,29 @@
-export const usersSlug = 'users' as const
-export const arrayFieldsSlug = 'array-fields' as const
-export const blockFieldsSlug = 'block-fields' as const
-export const checkboxFieldsSlug = 'checkbox-fields' as const
-export const codeFieldsSlug = 'code-fields' as const
-export const collapsibleFieldsSlug = 'collapsible-fields' as const
-export const conditionalLogicSlug = 'conditional-logic' as const
-export const dateFieldsSlug = 'date-fields' as const
-export const groupFieldsSlug = 'group-fields' as const
-export const indexedFieldsSlug = 'indexed-fields' as const
-export const jsonFieldsSlug = 'json-fields' as const
-export const lexicalFieldsSlug = 'lexical-fields' as const
-export const lexicalMigrateFieldsSlug = 'lexical-migrate-fields' as const
-export const numberFieldsSlug = 'number-fields' as const
-export const pointFieldsSlug = 'point-fields' as const
-export const radioFieldsSlug = 'radio-fields' as const
-export const relationshipFieldsSlug = 'relationship-fields' as const
-export const richTextFieldsSlug = 'rich-text-fields' as const
-export const rowFieldsSlug = 'row-fields' as const
-export const selectFieldsSlug = 'select-fields' as const
-export const tabsFieldsSlug = 'tabs-fields' as const
-export const textFieldsSlug = 'text-fields' as const
-export const uploadsSlug = 'uploads' as const
-export const uploads2Slug = 'uploads2' as const
-export const uploads3Slug = 'uploads3' as const
+export const usersSlug = 'users'
+export const arrayFieldsSlug = 'array-fields'
+export const blockFieldsSlug = 'block-fields'
+export const checkboxFieldsSlug = 'checkbox-fields'
+export const codeFieldsSlug = 'code-fields'
+export const collapsibleFieldsSlug = 'collapsible-fields'
+export const conditionalLogicSlug = 'conditional-logic'
+export const dateFieldsSlug = 'date-fields'
+export const groupFieldsSlug = 'group-fields'
+export const indexedFieldsSlug = 'indexed-fields'
+export const jsonFieldsSlug = 'json-fields'
+export const lexicalFieldsSlug = 'lexical-fields'
+export const lexicalMigrateFieldsSlug = 'lexical-migrate-fields'
+export const numberFieldsSlug = 'number-fields'
+export const pointFieldsSlug = 'point-fields'
+export const radioFieldsSlug = 'radio-fields'
+export const relationshipFieldsSlug = 'relationship-fields'
+export const richTextFieldsSlug = 'rich-text-fields'
+export const rowFieldsSlug = 'row-fields'
+export const selectFieldsSlug = 'select-fields'
+export const tabsFieldsSlug = 'tabs-fields'
+export const textFieldsSlug = 'text-fields'
+export const uploadsSlug = 'uploads'
+export const uploads2Slug = 'uploads2'
+export const uploads3Slug = 'uploads3'
+export const uiSlug = 'ui-fields'
 export const collectionSlugs = [
   usersSlug,
   arrayFieldsSlug,
@@ -46,6 +47,7 @@ export const collectionSlugs = [
   selectFieldsSlug,
   tabsFieldsSlug,
   textFieldsSlug,
+  uiSlug,
   uploadsSlug,
   uploads2Slug,
   uploads3Slug,


### PR DESCRIPTION
Moves `custom` to server only properties

Exposes the `customClient` config object to the useFieldProps, currently needed for the plugin-stripe to support contextual configuration

![image](https://github.com/payloadcms/payload/assets/35137243/c1c7616a-fc1a-4067-9670-9eaf49cdbe8c)

