### PR TITLE
fix(next): do not require handlers, attempt to read filesystem or throw

### DIFF
--- a/packages/next/src/routes/rest/files/getFile.ts
+++ b/packages/next/src/routes/rest/files/getFile.ts
@@ -25,13 +25,6 @@ export const getFile = async ({ collection, filename, req }: Args): Promise<Resp
       )
     }
 
-    if (collection.config.upload.disableLocalStorage && !collection.config.upload.handlers) {
-      throw new APIError(
-        `This collection has local storage disabled: ${collection.config.slug}`,
-        httpStatus.BAD_REQUEST,
-      )
-    }
-
     await checkFileAccess({
       collection,
       filename,
@@ -49,7 +42,7 @@ export const getFile = async ({ collection, filename, req }: Args): Promise<Resp
         })
       }
 
-      return response
+      if (response instanceof Response) return response
     }
 
     const fileDir = collection.config.upload?.staticDir || collection.config.slug
@@ -70,11 +63,11 @@ export const getFile = async ({ collection, filename, req }: Args): Promise<Resp
       headers,
       status: httpStatus.OK,
     })
-  } catch (error) {
+  } catch (err) {
     return routeError({
       collection,
       config: req.payload.config,
-      err: error,
+      err,
       req,
     })
   }


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload-3.0-demo/issues/92

Removes the requirement to provide a handler even if you disable local storage. Instead it will try handlers if they exist and fallback to attempting to read from the filesystem, throwing an error if it cannot find it.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
