### PR TITLE
chore(ui): adds `customClient` to globals and collections config and moves `custom` to server only

### DIFF
--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -2,7 +2,7 @@ import type { LivePreviewConfig, ServerOnlyLivePreviewProperties } from '../../c
 
 export type ServerOnlyCollectionProperties = keyof Pick<
   SanitizedCollectionConfig,
-  'access' | 'endpoints' | 'hooks'
+  'access' | 'custom' | 'endpoints' | 'hooks'
 >
 
 export type ServerOnlyCollectionAdminProperties = keyof Pick<
@@ -44,6 +44,7 @@ export const createClientCollectionConfig = ({
     'hooks',
     'access',
     'endpoints',
+    'custom',
     // `upload`
     // `admin`
     // are all handled separately

--- a/packages/payload/src/collections/config/schema.ts
+++ b/packages/payload/src/collections/config/schema.ts
@@ -108,6 +108,7 @@ const collectionSchema = joi.object().keys({
     joi.boolean(),
   ),
   custom: joi.object().pattern(joi.string(), joi.any()),
+  customClient: joi.object().pattern(joi.string(), joi.any()),
   dbName: joi.alternatives().try(joi.string(), joi.func()),
   defaultSort: joi.string(),
   disableDuplicate: joi.bool(),

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -313,8 +313,10 @@ export type CollectionConfig = {
    * Use `true` to enable with default options
    */
   auth?: IncomingAuthType | boolean
-  /** Extension point to add your custom data. */
+  /** Extension point to add your custom data. Server only. */
   custom?: Record<string, any>
+  /** Extension point to add your custom data to the client side.*/
+  customClient?: Record<string, any>
   /**
    * Default field to sort by in collection list view
    */

--- a/packages/payload/src/globals/config/client.ts
+++ b/packages/payload/src/globals/config/client.ts
@@ -12,7 +12,7 @@ import { createClientFieldConfigs } from '../../fields/config/client.js'
 
 export type ServerOnlyGlobalProperties = keyof Pick<
   SanitizedGlobalConfig,
-  'access' | 'admin' | 'endpoints' | 'fields' | 'hooks'
+  'access' | 'admin' | 'custom' | 'endpoints' | 'fields' | 'hooks'
 >
 export type ServerOnlyGlobalAdminProperties = keyof Pick<
   SanitizedGlobalConfig['admin'],
@@ -46,6 +46,7 @@ export const createClientGlobalConfig = ({
     'hooks',
     'access',
     'endpoints',
+    'custom',
     // `admin` is handled separately
   ]
 

--- a/packages/payload/src/globals/config/schema.ts
+++ b/packages/payload/src/globals/config/schema.ts
@@ -49,6 +49,7 @@ const globalSchema = joi
       preview: joi.func(),
     }),
     custom: joi.object().pattern(joi.string(), joi.any()),
+    customClient: joi.object().pattern(joi.string(), joi.any()),
     dbName: joi.alternatives().try(joi.string(), joi.func()),
     endpoints: endpointsSchema,
     fields: joi.array(),

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -140,8 +140,10 @@ export type GlobalConfig = {
     update?: Access
   }
   admin?: GlobalAdminOptions
-  /** Extension point to add your custom data. */
+  /** Extension point to add your custom data. Server only. */
   custom?: Record<string, any>
+  /** Extension point to add your custom data to the client side.*/
+  customClient?: Record<string, any>
   /**
    * Customize the SQL table name
    */


### PR DESCRIPTION
chore: adds `customClient` to globals and collections config and moves `custom` to server only