### PR TITLE
fix(db-mongodb): ignore end session errors

### DIFF
--- a/packages/db-mongodb/src/transactions/commitTransaction.ts
+++ b/packages/db-mongodb/src/transactions/commitTransaction.ts
@@ -6,6 +6,10 @@ export const commitTransaction: CommitTransaction = async function commitTransac
   }
 
   await this.sessions[id].commitTransaction()
-  await this.sessions[id].endSession()
+  try {
+    await this.sessions[id].endSession()
+  } catch (error) {
+    // ending sessions is only best effort and won't impact anything if it fails since the transaction was committed
+  }
   delete this.sessions[id]
 }


### PR DESCRIPTION
## Description

It is possible to have a race condition if a hook calls commitTransaction and then payload's own operation calls the same. This is only a problem because of the multiple awaits in commitTransaction. This will make it so any failing endSession calls for this or any other reason get swallowed.
