### PR TITLE
Fixed Nested Docs URL conflicts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,21 +5,21 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     }
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     }
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     }
   },
   "[json]": {

--- a/examples/nested-docs/next-app/app/[...slug]/page.tsx
+++ b/examples/nested-docs/next-app/app/[...slug]/page.tsx
@@ -24,12 +24,12 @@ export default async function Page({ params }: PageParams) {
   let { slug } = params || {}
   if (!slug) slug = ['home']
 
-  const lastSlug = slug[slug.length - 1]
+  const fullPathSlug = slug.join('/');
 
   const page: Page = await fetch(
     `${
       process.env.NEXT_PUBLIC_PAYLOAD_URL
-    }/api/pages?where[slug][equals]=${lastSlug.toLowerCase()}&depth=1`,
+    }/api/pages?where[slug][equals]=${fullPathSlug.toLowerCase()}&depth=1`,
   )?.then(res => res.json()?.then(data => data.docs[0]))
 
   if (!page) {


### PR DESCRIPTION
## Description

The issue (ref #5879) existed due to the code was only considering the last part of the slug to fetch the page. ref `examples\nested-docs\next-app\app\[...slug]\page.tsx`

The fix was to use the full path of the slug to fetch the page.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
