### PR TITLE
chore(plugin-seo): add translation file for Swedish, and missing key

### DIFF
--- a/packages/plugin-seo/src/translations/en.json
+++ b/packages/plugin-seo/src/translations/en.json
@@ -10,6 +10,7 @@
     "tooLong": "Too long",
     "tooShort": "Too short",
     "almostThere": "Almost there",
+    "missing": "Missing",
     "characterCount": "{{current}}/{{minLength}}-{{maxLength}} chars, ",
     "charactersToGo": "{{characters}} to go",
     "charactersLeftOver": "{{characters}} left over",

--- a/packages/plugin-seo/src/translations/es.json
+++ b/packages/plugin-seo/src/translations/es.json
@@ -10,6 +10,7 @@
     "tooLong": "Demasiado largo",
     "tooShort": "Demasiado corto",
     "almostThere": "Ya casi está",
+    "missing": "Missing",
     "characterCount": "{{current}}/{{minLength}}-{{maxLength}} letras, ",
     "charactersToGo": "{{characters}} letras sobrantes",
     "charactersLeftOver": "{{characters}} letras sobrantes",

--- a/packages/plugin-seo/src/translations/fa.json
+++ b/packages/plugin-seo/src/translations/fa.json
@@ -10,6 +10,7 @@
     "tooLong": "خیلی طولانی",
     "tooShort": "خیلی کوتاه",
     "almostThere": "چیزیی باقی نمونده",
+    "missing": "Missing",
     "characterCount": "{{current}}/{{minLength}}-{{maxLength}} کلمه، ",
     "charactersToGo": "{{characters}} باقی مانده",
     "charactersLeftOver": "{{characters}} باقی مانده",

--- a/packages/plugin-seo/src/translations/fr.json
+++ b/packages/plugin-seo/src/translations/fr.json
@@ -1,22 +1,23 @@
 {
-    "$schema": "./translation-schema.json",
-    "plugin-seo": {
-        "autoGenerate": "Auto-générer",
-        "imageAutoGenerationTip": "L'auto-génération récupérera l'image principale sélectionnée.",
-        "bestPractices": "bonnes pratiques",
-        "lengthTipTitle": "Ceci devrait contenir entre {{minLength}} et {{maxLength}} caractères. Pour obtenir de l'aide pour rédiger des titres meta de qualité, consultez les ",
-        "lengthTipDescription": "Ceci devrait contenir entre {{minLength}} et {{maxLength}} caractères. Pour obtenir de l'aide pour rédiger des descriptions meta de qualité, consultez les ",
-        "good": "Bien",
-        "tooLong": "Trop long",
-        "tooShort": "Trop court",
-        "almostThere": "On y est presque",
-        "characterCount": "{{current}}/{{minLength}}-{{maxLength}} caractères, ",
-        "charactersToGo": "{{characters}} à ajouter",
-        "charactersLeftOver": "{{characters}} restants",
-        "charactersTooMany": "{{characters}} en trop",
-        "noImage": "Pas d'image",
-        "checksPassing": "{{current}}/{{max}} vérifications réussies",
-        "preview": "Aperçu",
-        "previewDescription": "Les résultats exacts peuvent varier en fonction du contenu et de la pertinence de la recherche."
-    }
+  "$schema": "./translation-schema.json",
+  "plugin-seo": {
+    "autoGenerate": "Auto-générer",
+    "imageAutoGenerationTip": "L'auto-génération récupérera l'image principale sélectionnée.",
+    "bestPractices": "bonnes pratiques",
+    "lengthTipTitle": "Ceci devrait contenir entre {{minLength}} et {{maxLength}} caractères. Pour obtenir de l'aide pour rédiger des titres meta de qualité, consultez les ",
+    "lengthTipDescription": "Ceci devrait contenir entre {{minLength}} et {{maxLength}} caractères. Pour obtenir de l'aide pour rédiger des descriptions meta de qualité, consultez les ",
+    "good": "Bien",
+    "tooLong": "Trop long",
+    "tooShort": "Trop court",
+    "almostThere": "On y est presque",
+    "missing": "Missing",
+    "characterCount": "{{current}}/{{minLength}}-{{maxLength}} caractères, ",
+    "charactersToGo": "{{characters}} à ajouter",
+    "charactersLeftOver": "{{characters}} restants",
+    "charactersTooMany": "{{characters}} en trop",
+    "noImage": "Pas d'image",
+    "checksPassing": "{{current}}/{{max}} vérifications réussies",
+    "preview": "Aperçu",
+    "previewDescription": "Les résultats exacts peuvent varier en fonction du contenu et de la pertinence de la recherche."
+  }
 }

--- a/packages/plugin-seo/src/translations/index.ts
+++ b/packages/plugin-seo/src/translations/index.ts
@@ -4,6 +4,7 @@ import fa from './fa.json'
 import fr from './fr.json'
 import nb from './nb.json'
 import pl from './pl.json'
+import sv from './sv.json'
 import ua from './ua.json'
 
 export default {
@@ -13,5 +14,6 @@ export default {
   fr,
   nb,
   pl,
+  sv,
   ua,
 }

--- a/packages/plugin-seo/src/translations/nb.json
+++ b/packages/plugin-seo/src/translations/nb.json
@@ -10,6 +10,7 @@
     "tooLong": "For lang",
     "tooShort": "For kort",
     "almostThere": "Nesten der",
+    "missing": "Missing",
     "characterCount": "{{current}}/{{minLength}}-{{maxLength}} tegn, ",
     "charactersToGo": "{{characters}} igjen",
     "charactersLeftOver": "{{characters}} til overs",

--- a/packages/plugin-seo/src/translations/pl.json
+++ b/packages/plugin-seo/src/translations/pl.json
@@ -10,6 +10,7 @@
     "tooLong": "Zbyt długie",
     "tooShort": "Zbyt krótkie",
     "almostThere": "Prawie gotowe",
+    "missing": "Missing",
     "characterCount": "{{current}}/{{minLength}}-{{maxLength}} znaków, ",
     "charactersToGo": "pozostało {{characters}} znaków",
     "charactersLeftOver": "zostało {{characters}} znaków",

--- a/packages/plugin-seo/src/translations/sv.json
+++ b/packages/plugin-seo/src/translations/sv.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "./translation-schema.json",
+  "plugin-seo": {
+    "autoGenerate": "Autogenerera",
+    "imageAutoGenerationTip": "Autogenerering kommer att hämta den valda bilden.",
+    "bestPractices": "rekommenderade metoder och standarder",
+    "lengthTipTitle": "Bör vara mellan {{minLength}} och {{maxLength}} tecken lång. För hjälp med att skriva meta-titlar av hög kvalitet, se ",
+    "lengthTipDescription": "Bör vara mellan {{minLength}} och {{maxLength}} tecken lång. För hjälp med att skriva meta-beskrivningar av hög kvalitet, se ",
+    "good": "OK",
+    "tooLong": "För många tecken",
+    "tooShort": "För få tecken",
+    "almostThere": "Nästan där",
+    "missing": "Saknas",
+    "characterCount": "{{current}}/{{minLength}}-{{maxLength}} tecken, ",
+    "charactersToGo": "{{characters}} kvar",
+    "charactersLeftOver": "{{characters}} tecken över",
+    "charactersTooMany": "{{characters}} tecken för mycket",
+    "noImage": "Ingen bild",
+    "checksPassing": "{{current}}/{{max}} kontroller OK",
+    "preview": "Förhandsvisning",
+    "previewDescription": "Exakt hur resultat listas kan variera, beroende på innehåll och sökrelevans."
+  }
+}

--- a/packages/plugin-seo/src/translations/translation-schema.json
+++ b/packages/plugin-seo/src/translations/translation-schema.json
@@ -35,6 +35,9 @@
         "almostThere": {
           "type": "string"
         },
+        "missing": {
+          "type": "string"
+        },
         "characterCount": {
           "type": "string"
         },
@@ -70,6 +73,7 @@
         "tooLong",
         "tooShort",
         "almostThere",
+        "missing",
         "characterCount",
         "charactersToGo",
         "charactersLeftOver",

--- a/packages/plugin-seo/src/translations/ua.json
+++ b/packages/plugin-seo/src/translations/ua.json
@@ -2,6 +2,7 @@
   "$schema": "./translation-schema.json",
   "plugin-seo": {
     "almostThere": "Ще трошки",
+    "missing": "Missing",
     "autoGenerate": "Згенерувати",
     "bestPractices": "найкращі практики",
     "characterCount": "{{current}}/{{minLength}}-{{maxLength}} символів, ",

--- a/packages/plugin-seo/src/ui/LengthIndicator.tsx
+++ b/packages/plugin-seo/src/ui/LengthIndicator.tsx
@@ -25,7 +25,7 @@ export const LengthIndicator: React.FC<{
     const textLength = text?.length || 0
 
     if (textLength === 0) {
-      setLabel('Missing')
+      setLabel(t('missing'))
       setLabelStyle({
         backgroundColor: 'red',
         color: 'white',


### PR DESCRIPTION
## Description

Added translation file for Swedish, to support sv, when using plugin-seo.

Added translation key for label "Missing". Translation has been provided for Swedish, but set to "Missing" in all other translation files. The label "Missing" will be used as before, until proper translations are made available.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Chore (non-breaking change which does not add functionality)

## Checklist:

- [X] Existing test suite passes locally with my changes