### PR TITLE
fix: add named export for Payload class in commonjs

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -30,6 +30,8 @@ const payload = new Payload()
 
 export default payload
 module.exports = payload
+exports = module.exports
+exports.Payload = Payload
 
 type GeneratedTypes = {
   collections: {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

Currently payload only exports payload instance but not the class for commonjs, this PR fixes this issue.

Without this change, `import { Payload } from 'payload'` gives undefined.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
