### PR TITLE
chore: fixes e2e running for windows

### DIFF
--- a/test/helpers/initPayloadE2E.ts
+++ b/test/helpers/initPayloadE2E.ts
@@ -19,7 +19,7 @@ type Result = {
 }
 
 export async function initPayloadE2E({ dirname }: Args): Promise<Result> {
-  const testSuiteName = dirname.split('/').pop()
+  const testSuiteName = path.basename(dirname)
   const { beforeTest } = await createTestHooks(testSuiteName)
   await beforeTest()
   await startMemoryDB()

--- a/test/helpers/initPayloadE2ENoConfig.ts
+++ b/test/helpers/initPayloadE2ENoConfig.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'http'
 import nextImport from 'next'
 import { spawn } from 'node:child_process'
-import { dirname, resolve } from 'path'
+import path, { dirname, resolve } from 'path'
 import { wait } from 'payload/utilities'
 import { parse } from 'url'
 import { fileURLToPath } from 'url'
@@ -30,7 +30,7 @@ export async function initPayloadE2ENoConfig<T extends GeneratedTypes<T>>({
   dirname,
   prebuild,
 }: Args): Promise<Result<T>> {
-  const testSuiteName = dirname.split('/').pop()
+  const testSuiteName = path.basename(dirname)
   const { beforeTest } = await createTestHooks(testSuiteName)
   await beforeTest()
 
@@ -87,6 +87,7 @@ export async function initPayloadE2ENoConfig<T extends GeneratedTypes<T>>({
       const parsedUrl = parse(req.url, true)
       await handle(req, res, parsedUrl)
     }).listen(port, () => {
+      console.log(`> Ready on http://localhost:${port}`)
       resolveServer()
     })
   })

--- a/test/helpers/initPayloadE2ENoConfig.ts
+++ b/test/helpers/initPayloadE2ENoConfig.ts
@@ -87,7 +87,6 @@ export async function initPayloadE2ENoConfig<T extends GeneratedTypes<T>>({
       const parsedUrl = parse(req.url, true)
       await handle(req, res, parsedUrl)
     }).listen(port, () => {
-      console.log(`> Ready on http://localhost:${port}`)
       resolveServer()
     })
   })


### PR DESCRIPTION
Corrects test suite name logic to not be dependenant on the '/' delimiter. E2E hasn't worked for beta branch before this.