### PR TITLE
fix: richtext-lexical i18n validate destructure of t

### DIFF
--- a/packages/richtext-lexical/src/validate/index.ts
+++ b/packages/richtext-lexical/src/validate/index.ts
@@ -16,7 +16,9 @@ export const richTextValidateHOC = ({
     options,
   ) => {
     const {
-      req: { t },
+      req: {
+        i18n: { t },
+      },
       required,
     } = options
 


### PR DESCRIPTION
## Description

@AlessioGr  - not 100% here, so feel free to kill this if incorrect, but I _think_ you need to destructure `t` in the validate function as:

```ts
const {
    req: {
      i18n: { t },
    },
    required,
  } = options
```

- [x ] I have read and understand the [CONTRIBUTING.md]

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
