### PR TITLE
fix(plugin-cloud-storage)!: Pass filename to utility function getting file prefix

### DIFF
--- a/packages/plugin-cloud-storage/src/adapters/azure/staticHandler.ts
+++ b/packages/plugin-cloud-storage/src/adapters/azure/staticHandler.ts
@@ -14,11 +14,11 @@ interface Args {
 }
 
 export const getHandler = ({ collection, getStorageClient }: Args): StaticHandler => {
-  return async (req, { params }) => {
+  return async (req, { params: { filename } }) => {
     try {
-      const prefix = await getFilePrefix({ collection, req })
+      const prefix = await getFilePrefix({ collection, filename, req })
       const blockBlobClient = getStorageClient().getBlockBlobClient(
-        path.posix.join(prefix, params.filename),
+        path.posix.join(prefix, filename),
       )
 
       const { end, start } = await getRangeFromHeader(blockBlobClient, req.headers.get('range'))

--- a/packages/plugin-cloud-storage/src/adapters/gcs/staticHandler.ts
+++ b/packages/plugin-cloud-storage/src/adapters/gcs/staticHandler.ts
@@ -14,10 +14,10 @@ interface Args {
 }
 
 export const getHandler = ({ bucket, collection, getStorageClient }: Args): StaticHandler => {
-  return async (req, { params }) => {
+  return async (req, { params: { filename } }) => {
     try {
-      const prefix = await getFilePrefix({ collection, req })
-      const file = getStorageClient().bucket(bucket).file(path.posix.join(prefix, params.filename))
+      const prefix = await getFilePrefix({ collection, filename, req })
+      const file = getStorageClient().bucket(bucket).file(path.posix.join(prefix, filename))
 
       const [metadata] = await file.getMetadata()
 

--- a/packages/plugin-cloud-storage/src/adapters/s3/staticHandler.ts
+++ b/packages/plugin-cloud-storage/src/adapters/s3/staticHandler.ts
@@ -23,13 +23,13 @@ const streamToBuffer = async (readableStream) => {
 }
 
 export const getHandler = ({ bucket, collection, getStorageClient }: Args): StaticHandler => {
-  return async (req, { params }) => {
+  return async (req, { params: { filename } }) => {
     try {
-      const prefix = await getFilePrefix({ collection, req })
+      const prefix = await getFilePrefix({ collection, filename, req })
 
       const object = await getStorageClient().getObject({
         Bucket: bucket,
-        Key: path.posix.join(prefix, params.filename),
+        Key: path.posix.join(prefix, filename),
       })
 
       if (!object.Body) {

--- a/packages/plugin-cloud-storage/src/adapters/vercelBlob/staticHandler.ts
+++ b/packages/plugin-cloud-storage/src/adapters/vercelBlob/staticHandler.ts
@@ -17,7 +17,7 @@ export const getStaticHandler = (
 ): StaticHandler => {
   return async (req, { params: { filename } }) => {
     try {
-      const prefix = await getFilePrefix({ collection, req })
+      const prefix = await getFilePrefix({ collection, req, filename })
 
       const fileUrl = `${baseUrl}/${path.posix.join(prefix, filename)}`
 

--- a/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
@@ -3,13 +3,13 @@ import type { CollectionConfig, PayloadRequest, UploadConfig } from 'payload/typ
 export async function getFilePrefix({
   collection,
   req,
+  filename,
 }: {
   collection: CollectionConfig
   req: PayloadRequest
+  filename: string
 }): Promise<string> {
   const imageSizes = (collection?.upload as UploadConfig)?.imageSizes || []
-  const { routeParams } = req
-  const filename = routeParams['filename']
 
   const files = await req.payload.find({
     collection: collection.slug,


### PR DESCRIPTION
## Description

Route params are still being accessed the old way, causing filename to be undefined. This in turn results in no documents being found, and thus the prefix also not being found. Files are then fetched from cloud storage without the prefix, causing a 404.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
