### PR TITLE
fix(db-postgres): extra version suffix added to table names

### DIFF
--- a/packages/db-postgres/src/schema/traverseFields.ts
+++ b/packages/db-postgres/src/schema/traverseFields.ts
@@ -228,7 +228,6 @@ export const traverseFields = ({
           prefix: `enum_${newTableName}_`,
           target: 'enumName',
           throwValidationError,
-          versions,
         })
 
         adapter.enums[enumName] = pgEnum(
@@ -249,7 +248,6 @@ export const traverseFields = ({
             parentTableName: newTableName,
             prefix: `${newTableName}_`,
             throwValidationError,
-            versions,
           })
           const baseColumns: Record<string, PgColumnBuilder> = {
             order: integer('order').notNull(),


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/5938

The custom table name feature accidentally included an extra addition of the versions suffix added to tables for select field enums and `hasMany` field tables relating to versions.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
