### PR TITLE
docs: correct small typo

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -657,7 +657,7 @@ As your admin customizations gets more complex you may want to share state betwe
 
 ### Styling Custom Components
 
-Payload exports its SCSS variables and mixins for reuse in your own custom components. This is helpful in cases where you might want to style a custom input similarly to Payload's built-ini styling, so it blends more thoroughly into the existing admin UI.
+Payload exports its SCSS variables and mixins for reuse in your own custom components. This is helpful in cases where you might want to style a custom input similarly to Payload's built-in styling, so it blends more thoroughly into the existing admin UI.
 
 To make use of Payload SCSS variables / mixins to use directly in your own components, you can import them as follows:
 


### PR DESCRIPTION
## Description

Corrected a typo in the admin components documentation ("_built-ini_ styles")
- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
