### PR TITLE
chore: adds fallbackFileType functionality

### DIFF
--- a/packages/next/src/routes/rest/files/getFile.ts
+++ b/packages/next/src/routes/rest/files/getFile.ts
@@ -10,6 +10,7 @@ import { streamFile } from '../../../next-stream-file/index.js'
 import { headersWithCors } from '../../../utilities/headersWithCors.js'
 import { routeError } from '../routeError.js'
 import { checkFileAccess } from './checkFileAccess.js'
+import { getFileTypeFallback } from './getFileTypeFallback.js'
 
 // /:collectionSlug/file/:filename
 type Args = {
@@ -54,15 +55,15 @@ export const getFile = async ({ collection, filename, req }: Args): Promise<Resp
     const data = streamFile(filePath)
 
     const headers = new Headers({
-      'content-length': stats.size + '',
+      'Content-Length': stats.size + '',
     })
 
-    const fileTypeResult = await getFileType.fromFile(filePath)
-    if (fileTypeResult?.mime) headers.set('content-type', fileTypeResult.mime)
+    const fileTypeResult = (await getFileType.fromFile(filePath)) || getFileTypeFallback(filePath)
+    headers.set('Content-Type', fileTypeResult.mime)
 
     return new Response(data, {
       headers: headersWithCors({
-        headers: new Headers(),
+        headers,
         req,
       }),
       status: httpStatus.OK,

--- a/packages/next/src/routes/rest/files/getFileTypeFallback.ts
+++ b/packages/next/src/routes/rest/files/getFileTypeFallback.ts
@@ -12,7 +12,7 @@ const extensionMap: {
   html: 'text/html',
   js: 'application/javascript',
   json: 'application/json',
-  markdown: 'text/markdown',
+  md: 'text/markdown',
   svg: 'image/svg+xml',
   xml: 'application/xml',
   yml: 'application/x-yaml',

--- a/packages/next/src/routes/rest/files/getFileTypeFallback.ts
+++ b/packages/next/src/routes/rest/files/getFileTypeFallback.ts
@@ -1,0 +1,28 @@
+type ReturnType = {
+  ext: string
+  mime: string
+}
+
+const extensionMap: {
+  [ext: string]: string
+} = {
+  css: 'text/css',
+  csv: 'text/csv',
+  htm: 'text/html',
+  html: 'text/html',
+  js: 'application/javascript',
+  json: 'application/json',
+  markdown: 'text/markdown',
+  svg: 'image/svg+xml',
+  xml: 'application/xml',
+  yml: 'application/x-yaml',
+}
+
+export const getFileTypeFallback = (path: string): ReturnType => {
+  const ext = path.split('.').pop() || 'txt'
+
+  return {
+    ext,
+    mime: extensionMap[ext] || 'text/plain',
+  }
+}

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -244,12 +244,13 @@ describe('uploads', () => {
   test('should throw error when file is larger than the limit and abortOnLimit is true', async () => {
     await page.goto(mediaURL.create)
     await page.setInputFiles('input[type="file"]', path.resolve(dirname, './2mb.jpg'))
+    await expect(page.locator('.file-field__filename')).toHaveValue('2mb.jpg')
 
-    await wait(500) // TODO: Fix this
     await page.click('#action-save', { delay: 100 })
     await expect(page.locator('.Toastify .Toastify__toast--error')).toContainText(
       'File size limit has been reached',
     )
+    await wait(500) // TODO: Fix this
   })
 
   test('Should render adminThumbnail when using a function', async () => {


### PR DESCRIPTION
## Description

Sets up fallbackFileType functionality since [`file-type`](https://www.npmjs.com/package/file-type) does not handle text based files.

Fixes https://github.com/payloadcms/payload-3.0-demo/issues/132

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
