### PR TITLE
fix(db-postgres): row table names were not being built properly

### DIFF
--- a/packages/db-postgres/src/schema/traverseFields.ts
+++ b/packages/db-postgres/src/schema/traverseFields.ts
@@ -657,7 +657,7 @@ export const traverseFields = ({
           indexes,
           localesColumns,
           localesIndexes,
-          newTableName: parentTableName,
+          newTableName,
           parentTableName,
           relationsToBuild,
           relationships,

--- a/test/fields/collections/Tabs/index.ts
+++ b/test/fields/collections/Tabs/index.ts
@@ -142,6 +142,21 @@ const TabsFields: CollectionConfig = {
               type: 'text',
               defaultValue: namedTabDefaultValue,
             },
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'arrayInRow',
+                  type: 'array',
+                  fields: [
+                    {
+                      name: 'textInArrayInRow',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
           ],
         },
         {

--- a/test/fields/collections/Tabs/shared.ts
+++ b/test/fields/collections/Tabs/shared.ts
@@ -35,6 +35,11 @@ export const tabsDoc: Partial<TabsField> = {
       },
     ],
     text: namedTabText,
+    arrayInRow: [
+      {
+        text: "Hello, I'm some text in an array in a row",
+      },
+    ],
   },
   localizedTab: {
     text: localizedTextValue,

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1084,6 +1084,10 @@ export interface TabsField {
     }[]
     text?: string | null
     defaultValue?: string | null
+    arrayInRow?: {
+      text: string
+      id?: string | null
+    }[]
   }
   namedTabWithDefaultValue: {
     defaultValue?: string | null


### PR DESCRIPTION
## Description

Fix: row table names were not being built properly

Fixes [#130](https://github.com/payloadcms/payload-3.0-demo/issues/130) in 3.0 demo

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
