### PR TITLE
feat: toggle sortable arrays and blocks

### DIFF
--- a/docs/fields/array.mdx
+++ b/docs/fields/array.mdx
@@ -59,6 +59,7 @@ properties:
 | Option                    | Description                                                                                                          |
 |---------------------------|----------------------------------------------------------------------------------------------------------------------|
 | **`initCollapsed`**       | Set the initial collapsed state                                                                                      |
+| **`disableSortable`**     | Disable order sorting                                                                                                |
 | **`components.RowLabel`** | Function or React component to be rendered as the label on the array row. Receives `({ data, index, path })` as args |
 
 ### Example

--- a/docs/fields/array.mdx
+++ b/docs/fields/array.mdx
@@ -59,7 +59,7 @@ properties:
 | Option                    | Description                                                                                                          |
 |---------------------------|----------------------------------------------------------------------------------------------------------------------|
 | **`initCollapsed`**       | Set the initial collapsed state                                                                                      |
-| **`disableSortable`**     | Disable order sorting                                                                                                |
+| **`isSortable`**          | Disable order sorting by setting this value to `false`                                                               |
 | **`components.RowLabel`** | Function or React component to be rendered as the label on the array row. Receives `({ data, index, path })` as args |
 
 ### Example

--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -58,7 +58,7 @@ properties:
 | Option              | Description                     |
 |---------------------|---------------------------------|
 | **`initCollapsed`** | Set the initial collapsed state |
-| **`disableSortable`** | Disable order sorting |
+| **`isSortable`** | Disable order sorting by setting this value to `false` |
 
 ### Block configs
 

--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -58,6 +58,7 @@ properties:
 | Option              | Description                     |
 |---------------------|---------------------------------|
 | **`initCollapsed`** | Set the initial collapsed state |
+| **`disableSortable`** | Disable order sorting |
 
 ### Block configs
 

--- a/packages/payload/src/admin/components/elements/ArrayAction/index.tsx
+++ b/packages/payload/src/admin/components/elements/ArrayAction/index.tsx
@@ -16,6 +16,7 @@ const baseClass = 'array-actions'
 
 export const ArrayAction: React.FC<Props> = ({
   addRow,
+  disableSortable,
   duplicateRow,
   hasMaxRows,
   index,
@@ -33,7 +34,7 @@ export const ArrayAction: React.FC<Props> = ({
       render={({ close }) => {
         return (
           <PopupList.ButtonGroup buttonSize="small">
-            {index !== 0 && (
+            {!disableSortable && index !== 0 && (
               <PopupList.Button
                 className={`${baseClass}__action ${baseClass}__move-up`}
                 onClick={() => {
@@ -47,7 +48,7 @@ export const ArrayAction: React.FC<Props> = ({
                 {t('moveUp')}
               </PopupList.Button>
             )}
-            {index < rowCount - 1 && (
+            {!disableSortable && index < rowCount - 1 && (
               <PopupList.Button
                 className={`${baseClass}__action`}
                 onClick={() => {

--- a/packages/payload/src/admin/components/elements/ArrayAction/index.tsx
+++ b/packages/payload/src/admin/components/elements/ArrayAction/index.tsx
@@ -16,10 +16,10 @@ const baseClass = 'array-actions'
 
 export const ArrayAction: React.FC<Props> = ({
   addRow,
-  disableSortable,
   duplicateRow,
   hasMaxRows,
   index,
+  isSortable,
   moveRow,
   removeRow,
   rowCount,
@@ -34,7 +34,7 @@ export const ArrayAction: React.FC<Props> = ({
       render={({ close }) => {
         return (
           <PopupList.ButtonGroup buttonSize="small">
-            {!disableSortable && index !== 0 && (
+            {isSortable && index !== 0 && (
               <PopupList.Button
                 className={`${baseClass}__action ${baseClass}__move-up`}
                 onClick={() => {
@@ -48,7 +48,7 @@ export const ArrayAction: React.FC<Props> = ({
                 {t('moveUp')}
               </PopupList.Button>
             )}
-            {!disableSortable && index < rowCount - 1 && (
+            {isSortable && index < rowCount - 1 && (
               <PopupList.Button
                 className={`${baseClass}__action`}
                 onClick={() => {

--- a/packages/payload/src/admin/components/elements/ArrayAction/types.ts
+++ b/packages/payload/src/admin/components/elements/ArrayAction/types.ts
@@ -1,9 +1,9 @@
 export type Props = {
   addRow: (current: number, blockType?: string) => void
-  disableSortable: boolean
   duplicateRow: (current: number) => void
   hasMaxRows: boolean
   index: number
+  isSortable: boolean
   moveRow: (from: number, to: number) => void
   removeRow: (index: number) => void
   rowCount: number

--- a/packages/payload/src/admin/components/elements/ArrayAction/types.ts
+++ b/packages/payload/src/admin/components/elements/ArrayAction/types.ts
@@ -1,5 +1,6 @@
 export type Props = {
   addRow: (current: number, blockType?: string) => void
+  disableSortable: boolean
   duplicateRow: (current: number) => void
   hasMaxRows: boolean
   index: number

--- a/packages/payload/src/admin/components/forms/field-types/Array/ArrayRow.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/ArrayRow.tsx
@@ -23,6 +23,7 @@ type ArrayRowProps = UseDraggableSortableReturn &
   Pick<Props, 'fieldTypes' | 'fields' | 'indexPath' | 'labels' | 'path' | 'permissions'> & {
     CustomRowLabel?: RowLabelType
     addRow: (rowIndex: number) => void
+    disableSortable: boolean
     duplicateRow: (rowIndex: number) => void
     forceRender?: boolean
     hasMaxRows?: boolean
@@ -38,6 +39,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
   CustomRowLabel,
   addRow,
   attributes,
+  disableSortable,
   duplicateRow,
   fieldTypes,
   fields,
@@ -91,6 +93,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
           !readOnly ? (
             <ArrayAction
               addRow={addRow}
+              disableSortable={disableSortable}
               duplicateRow={duplicateRow}
               hasMaxRows={hasMaxRows}
               index={rowIndex}

--- a/packages/payload/src/admin/components/forms/field-types/Array/ArrayRow.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/ArrayRow.tsx
@@ -23,10 +23,10 @@ type ArrayRowProps = UseDraggableSortableReturn &
   Pick<Props, 'fieldTypes' | 'fields' | 'indexPath' | 'labels' | 'path' | 'permissions'> & {
     CustomRowLabel?: RowLabelType
     addRow: (rowIndex: number) => void
-    disableSortable: boolean
     duplicateRow: (rowIndex: number) => void
     forceRender?: boolean
     hasMaxRows?: boolean
+    isSortable: boolean
     moveRow: (fromIndex: number, toIndex: number) => void
     readOnly?: boolean
     removeRow: (rowIndex: number) => void
@@ -39,13 +39,13 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
   CustomRowLabel,
   addRow,
   attributes,
-  disableSortable,
   duplicateRow,
   fieldTypes,
   fields,
   forceRender = false,
   hasMaxRows,
   indexPath,
+  isSortable,
   labels,
   listeners,
   moveRow,
@@ -93,10 +93,10 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
           !readOnly ? (
             <ArrayAction
               addRow={addRow}
-              disableSortable={disableSortable}
               duplicateRow={duplicateRow}
               hasMaxRows={hasMaxRows}
               index={rowIndex}
+              isSortable={isSortable}
               moveRow={moveRow}
               removeRow={removeRow}
               rowCount={rowCount}

--- a/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
@@ -29,7 +29,7 @@ const baseClass = 'array-field'
 const ArrayFieldType: React.FC<Props> = (props) => {
   const {
     name,
-    admin: { className, components, condition, description, readOnly },
+    admin: { className, components, condition, description, disableSortable = false, readOnly },
     fieldTypes,
     fields,
     forceRender = false,
@@ -227,7 +227,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
           onDragEnd={({ moveFromIndex, moveToIndex }) => moveRow(moveFromIndex, moveToIndex)}
         >
           {rows.map((row, i) => (
-            <DraggableSortableItem disabled={readOnly} id={row.id} key={row.id}>
+            <DraggableSortableItem disabled={readOnly || disableSortable} id={row.id} key={row.id}>
               {(draggableSortableItemProps) => (
                 <ArrayRow
                   {...draggableSortableItemProps}

--- a/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
@@ -29,7 +29,7 @@ const baseClass = 'array-field'
 const ArrayFieldType: React.FC<Props> = (props) => {
   const {
     name,
-    admin: { className, components, condition, description, disableSortable = false, readOnly },
+    admin: { className, components, condition, description, isSortable = true, readOnly },
     fieldTypes,
     fields,
     forceRender = false,
@@ -227,19 +227,19 @@ const ArrayFieldType: React.FC<Props> = (props) => {
           onDragEnd={({ moveFromIndex, moveToIndex }) => moveRow(moveFromIndex, moveToIndex)}
         >
           {rows.map((row, i) => (
-            <DraggableSortableItem disabled={readOnly || disableSortable} id={row.id} key={row.id}>
+            <DraggableSortableItem disabled={readOnly || !isSortable} id={row.id} key={row.id}>
               {(draggableSortableItemProps) => (
                 <ArrayRow
                   {...draggableSortableItemProps}
                   CustomRowLabel={CustomRowLabel}
                   addRow={addRow}
-                  disableSortable={disableSortable}
                   duplicateRow={duplicateRow}
                   fieldTypes={fieldTypes}
                   fields={fields}
                   forceRender={forceRender}
                   hasMaxRows={hasMaxRows}
                   indexPath={indexPath}
+                  isSortable={isSortable}
                   labels={labels}
                   moveRow={moveRow}
                   path={path}

--- a/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
@@ -113,7 +113,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
 
   const duplicateRow = useCallback(
     (rowIndex: number) => {
-      dispatchFields({ path, rowIndex, type: 'DUPLICATE_ROW' })
+      dispatchFields({ type: 'DUPLICATE_ROW', path, rowIndex })
       setModified(true)
 
       setTimeout(() => {
@@ -133,7 +133,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
 
   const moveRow = useCallback(
     (moveFromIndex: number, moveToIndex: number) => {
-      dispatchFields({ moveFromIndex, moveToIndex, path, type: 'MOVE_ROW' })
+      dispatchFields({ type: 'MOVE_ROW', moveFromIndex, moveToIndex, path })
       setModified(true)
     },
     [dispatchFields, path, setModified],
@@ -141,14 +141,14 @@ const ArrayFieldType: React.FC<Props> = (props) => {
 
   const toggleCollapseAll = useCallback(
     (collapsed: boolean) => {
-      dispatchFields({ collapsed, path, setDocFieldPreferences, type: 'SET_ALL_ROWS_COLLAPSED' })
+      dispatchFields({ type: 'SET_ALL_ROWS_COLLAPSED', collapsed, path, setDocFieldPreferences })
     },
     [dispatchFields, path, setDocFieldPreferences],
   )
 
   const setCollapse = useCallback(
     (rowID: string, collapsed: boolean) => {
-      dispatchFields({ collapsed, path, rowID, setDocFieldPreferences, type: 'SET_ROW_COLLAPSED' })
+      dispatchFields({ type: 'SET_ROW_COLLAPSED', collapsed, path, rowID, setDocFieldPreferences })
     },
     [dispatchFields, path, setDocFieldPreferences],
   )

--- a/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
@@ -233,6 +233,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
                   {...draggableSortableItemProps}
                   CustomRowLabel={CustomRowLabel}
                   addRow={addRow}
+                  disableSortable={disableSortable}
                   duplicateRow={duplicateRow}
                   fieldTypes={fieldTypes}
                   fields={fields}

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/BlockRow.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/BlockRow.tsx
@@ -23,10 +23,10 @@ type BlockFieldProps = UseDraggableSortableReturn &
   Pick<Props, 'blocks' | 'fieldTypes' | 'indexPath' | 'labels' | 'path' | 'permissions'> & {
     addRow: (rowIndex: number, blockType: string) => void
     blockToRender: Block
-    disableSortable?: boolean
     duplicateRow: (rowIndex: number) => void
     forceRender?: boolean
     hasMaxRows?: boolean
+    isSortable?: boolean
     moveRow: (fromIndex: number, toIndex: number) => void
     readOnly: boolean
     removeRow: (rowIndex: number) => void
@@ -40,12 +40,12 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
   attributes,
   blockToRender,
   blocks,
-  disableSortable,
   duplicateRow,
   fieldTypes,
   forceRender,
   hasMaxRows,
   indexPath,
+  isSortable,
   labels,
   listeners,
   moveRow,
@@ -90,9 +90,9 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
               addRow={addRow}
               blockType={row.blockType}
               blocks={blocks}
-              disableSortable={disableSortable}
               duplicateRow={duplicateRow}
               hasMaxRows={hasMaxRows}
+              isSortable={isSortable}
               labels={labels}
               moveRow={moveRow}
               removeRow={removeRow}

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/BlockRow.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/BlockRow.tsx
@@ -23,6 +23,7 @@ type BlockFieldProps = UseDraggableSortableReturn &
   Pick<Props, 'blocks' | 'fieldTypes' | 'indexPath' | 'labels' | 'path' | 'permissions'> & {
     addRow: (rowIndex: number, blockType: string) => void
     blockToRender: Block
+    disableSortable?: boolean
     duplicateRow: (rowIndex: number) => void
     forceRender?: boolean
     hasMaxRows?: boolean
@@ -39,6 +40,7 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
   attributes,
   blockToRender,
   blocks,
+  disableSortable,
   duplicateRow,
   fieldTypes,
   forceRender,
@@ -88,6 +90,7 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
               addRow={addRow}
               blockType={row.blockType}
               blocks={blocks}
+              disableSortable={disableSortable}
               duplicateRow={duplicateRow}
               hasMaxRows={hasMaxRows}
               labels={labels}

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/RowActions.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/RowActions.tsx
@@ -11,9 +11,9 @@ export const RowActions: React.FC<{
   addRow: (rowIndex: number, blockType: string) => void
   blockType: string
   blocks: Block[]
-  disableSortable?: boolean
   duplicateRow: (rowIndex: number, blockType: string) => void
   hasMaxRows?: boolean
+  isSortable?: boolean
   labels: Labels
   moveRow: (fromIndex: number, toIndex: number) => void
   removeRow: (rowIndex: number) => void
@@ -24,9 +24,9 @@ export const RowActions: React.FC<{
     addRow,
     blockType,
     blocks,
-    disableSortable,
     duplicateRow,
     hasMaxRows,
+    isSortable,
     labels,
     moveRow,
     removeRow,
@@ -58,10 +58,10 @@ export const RowActions: React.FC<{
           setIndexToAdd(index)
           openModal(drawerSlug)
         }}
-        disableSortable={disableSortable}
         duplicateRow={() => duplicateRow(rowIndex, blockType)}
         hasMaxRows={hasMaxRows}
         index={rowIndex}
+        isSortable={isSortable}
         moveRow={moveRow}
         removeRow={removeRow}
         rowCount={rowCount}

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/RowActions.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/RowActions.tsx
@@ -11,6 +11,7 @@ export const RowActions: React.FC<{
   addRow: (rowIndex: number, blockType: string) => void
   blockType: string
   blocks: Block[]
+  disableSortable?: boolean
   duplicateRow: (rowIndex: number, blockType: string) => void
   hasMaxRows?: boolean
   labels: Labels
@@ -23,6 +24,7 @@ export const RowActions: React.FC<{
     addRow,
     blockType,
     blocks,
+    disableSortable,
     duplicateRow,
     hasMaxRows,
     labels,
@@ -56,6 +58,7 @@ export const RowActions: React.FC<{
           setIndexToAdd(index)
           openModal(drawerSlug)
         }}
+        disableSortable={disableSortable}
         duplicateRow={() => duplicateRow(rowIndex, blockType)}
         hasMaxRows={hasMaxRows}
         index={rowIndex}

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -34,7 +34,7 @@ const BlocksField: React.FC<Props> = (props) => {
 
   const {
     name,
-    admin: { className, condition, description, readOnly },
+    admin: { className, condition, description, disableSortable = false, readOnly },
     blocks,
     fieldTypes,
     forceRender = false,
@@ -230,7 +230,11 @@ const BlocksField: React.FC<Props> = (props) => {
 
             if (blockToRender) {
               return (
-                <DraggableSortableItem disabled={readOnly} id={row.id} key={row.id}>
+                <DraggableSortableItem
+                  disabled={readOnly || disableSortable}
+                  id={row.id}
+                  key={row.id}
+                >
                   {(draggableSortableItemProps) => (
                     <BlockRow
                       {...draggableSortableItemProps}

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -241,6 +241,7 @@ const BlocksField: React.FC<Props> = (props) => {
                       addRow={addRow}
                       blockToRender={blockToRender}
                       blocks={blocks}
+                      disableSortable={disableSortable}
                       duplicateRow={duplicateRow}
                       fieldTypes={fieldTypes}
                       forceRender={forceRender}

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -34,7 +34,7 @@ const BlocksField: React.FC<Props> = (props) => {
 
   const {
     name,
-    admin: { className, condition, description, disableSortable = false, readOnly },
+    admin: { className, condition, description, isSortable = true, readOnly },
     blocks,
     fieldTypes,
     forceRender = false,
@@ -230,23 +230,19 @@ const BlocksField: React.FC<Props> = (props) => {
 
             if (blockToRender) {
               return (
-                <DraggableSortableItem
-                  disabled={readOnly || disableSortable}
-                  id={row.id}
-                  key={row.id}
-                >
+                <DraggableSortableItem disabled={readOnly || !isSortable} id={row.id} key={row.id}>
                   {(draggableSortableItemProps) => (
                     <BlockRow
                       {...draggableSortableItemProps}
                       addRow={addRow}
                       blockToRender={blockToRender}
                       blocks={blocks}
-                      disableSortable={disableSortable}
                       duplicateRow={duplicateRow}
                       fieldTypes={fieldTypes}
                       forceRender={forceRender}
                       hasMaxRows={hasMaxRows}
                       indexPath={indexPath}
+                      isSortable={isSortable}
                       labels={labels}
                       moveRow={moveRow}
                       path={path}

--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -311,6 +311,7 @@ export const array = baseField.keys({
           RowLabel: componentSchema,
         })
         .default({}),
+      disableSortable: joi.boolean(),
     })
     .default({}),
   dbName: joi.alternatives().try(joi.string(), joi.func()),
@@ -408,6 +409,11 @@ export const relationship = baseField.keys({
 export const blocks = baseField.keys({
   name: joi.string().required(),
   type: joi.string().valid('blocks').required(),
+  admin: baseAdminFields
+    .keys({
+      disableSortable: joi.boolean(),
+    })
+    .default({}),
   blocks: joi
     .array()
     .items(

--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -311,7 +311,7 @@ export const array = baseField.keys({
           RowLabel: componentSchema,
         })
         .default({}),
-      disableSortable: joi.boolean(),
+      isSortable: joi.boolean(),
     })
     .default({}),
   dbName: joi.alternatives().try(joi.string(), joi.func()),
@@ -411,7 +411,7 @@ export const blocks = baseField.keys({
   type: joi.string().valid('blocks').required(),
   admin: baseAdminFields
     .keys({
-      disableSortable: joi.boolean(),
+      isSortable: joi.boolean(),
     })
     .default({}),
   blocks: joi

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -563,6 +563,10 @@ export type ArrayField = FieldBase & {
     components?: {
       RowLabel?: RowLabel
     } & Admin['components']
+    /**
+     * Disable drag and drop array sorting
+     */
+    disableSortable?: boolean
     initCollapsed?: boolean | false
   }
   /**
@@ -630,6 +634,10 @@ export type Block = {
 
 export type BlockField = FieldBase & {
   admin?: Admin & {
+    /**
+     * Disable drag and drop array sorting
+     */
+    disableSortable?: boolean
     initCollapsed?: boolean | false
   }
   blocks: Block[]

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -563,11 +563,11 @@ export type ArrayField = FieldBase & {
     components?: {
       RowLabel?: RowLabel
     } & Admin['components']
+    initCollapsed?: boolean | false
     /**
      * Disable drag and drop sorting
      */
-    disableSortable?: boolean
-    initCollapsed?: boolean | false
+    isSortable?: boolean
   }
   /**
    * Customize the SQL table name
@@ -634,11 +634,11 @@ export type Block = {
 
 export type BlockField = FieldBase & {
   admin?: Admin & {
+    initCollapsed?: boolean | false
     /**
      * Disable drag and drop sorting
      */
-    disableSortable?: boolean
-    initCollapsed?: boolean | false
+    isSortable?: boolean
   }
   blocks: Block[]
   defaultValue?: unknown

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -564,7 +564,7 @@ export type ArrayField = FieldBase & {
       RowLabel?: RowLabel
     } & Admin['components']
     /**
-     * Disable drag and drop array sorting
+     * Disable drag and drop sorting
      */
     disableSortable?: boolean
     initCollapsed?: boolean | false
@@ -635,7 +635,7 @@ export type Block = {
 export type BlockField = FieldBase & {
   admin?: Admin & {
     /**
-     * Disable drag and drop array sorting
+     * Disable drag and drop sorting
      */
     disableSortable?: boolean
     initCollapsed?: boolean | false

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -18,6 +18,9 @@ const ArrayFields: CollectionConfig = {
     {
       name: 'items',
       defaultValue: arrayDefaultValue,
+      admin: {
+        disableSortable: true,
+      },
       fields: [
         {
           name: 'text',

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -159,7 +159,7 @@ const ArrayFields: CollectionConfig = {
       name: 'disableSortItems',
       defaultValue: arrayDefaultValue,
       admin: {
-        disableSortable: true,
+        isSortable: false,
       },
       fields: [
         {

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -18,9 +18,6 @@ const ArrayFields: CollectionConfig = {
     {
       name: 'items',
       defaultValue: arrayDefaultValue,
-      admin: {
-        disableSortable: true,
-      },
       fields: [
         {
           name: 'text',
@@ -156,6 +153,21 @@ const ArrayFields: CollectionConfig = {
         },
       ],
       minRows: 2,
+      type: 'array',
+    },
+    {
+      name: 'disableSortItems',
+      defaultValue: arrayDefaultValue,
+      admin: {
+        disableSortable: true,
+      },
+      fields: [
+        {
+          name: 'text',
+          required: true,
+          type: 'text',
+        },
+      ],
       type: 'array',
     },
   ],

--- a/test/fields/collections/Array/shared.ts
+++ b/test/fields/collections/Array/shared.ts
@@ -63,4 +63,15 @@ export const anotherArrayDoc: Partial<ArrayField> = {
       text: 'second row',
     },
   ],
+  disableSortItems: [
+    {
+      text: 'un-sortable item 1',
+    },
+    {
+      text: 'un-sortable item 2',
+    },
+    {
+      text: 'un-sortable item 3',
+    },
+  ],
 }

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -8,9 +8,6 @@ import { getBlocksFieldSeedData } from './shared'
 export const getBlocksField = (prefix?: string): BlockField => ({
   name: 'blocks',
   type: 'blocks',
-  admin: {
-    disableSortable: true,
-  },
   blocks: [
     {
       slug: prefix ? `${prefix}Content` : 'content',
@@ -45,9 +42,6 @@ export const getBlocksField = (prefix?: string): BlockField => ({
             {
               name: 'subBlocks',
               type: 'blocks',
-              admin: {
-                disableSortable: true,
-              },
               blocks: [
                 {
                   slug: 'text',
@@ -130,6 +124,7 @@ const BlockFields: CollectionConfig = {
       name: 'collapsedByDefaultBlocks',
       admin: {
         initCollapsed: true,
+        disableSortable: true,
       },
       localized: true,
     },
@@ -141,9 +136,6 @@ const BlockFields: CollectionConfig = {
     {
       name: 'i18nBlocks',
       type: 'blocks',
-      admin: {
-        disableSortable: true,
-      },
       blocks: [
         {
           slug: 'text',
@@ -186,9 +178,6 @@ const BlockFields: CollectionConfig = {
     {
       name: 'blocksWithSimilarConfigs',
       type: 'blocks',
-      admin: {
-        disableSortable: true,
-      },
       blocks: [
         {
           slug: 'block-a',
@@ -243,7 +232,6 @@ const BlockFields: CollectionConfig = {
       name: 'blocksWithSimilarGroup',
       type: 'blocks',
       admin: {
-        disableSortable: true,
         description:
           'The purpose of this field is to test validateExistingBlockIsIdentical works with similar blocks with group fields',
       },
@@ -284,9 +272,6 @@ const BlockFields: CollectionConfig = {
     {
       name: 'blocksWithMinRows',
       type: 'blocks',
-      admin: {
-        disableSortable: true,
-      },
       blocks: [
         {
           slug: 'block',
@@ -303,9 +288,6 @@ const BlockFields: CollectionConfig = {
     {
       name: 'customBlocks',
       type: 'blocks',
-      admin: {
-        disableSortable: true,
-      },
       blocks: [
         {
           slug: 'block-1',
@@ -330,9 +312,6 @@ const BlockFields: CollectionConfig = {
     {
       name: 'relationshipBlocks',
       type: 'blocks',
-      admin: {
-        disableSortable: true,
-      },
       blocks: [
         {
           slug: 'relationships',

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -124,7 +124,7 @@ const BlockFields: CollectionConfig = {
       name: 'collapsedByDefaultBlocks',
       admin: {
         initCollapsed: true,
-        disableSortable: true,
+        isSortable: false,
       },
       localized: true,
     },

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -8,6 +8,9 @@ import { getBlocksFieldSeedData } from './shared'
 export const getBlocksField = (prefix?: string): BlockField => ({
   name: 'blocks',
   type: 'blocks',
+  admin: {
+    disableSortable: true,
+  },
   blocks: [
     {
       slug: prefix ? `${prefix}Content` : 'content',
@@ -42,6 +45,9 @@ export const getBlocksField = (prefix?: string): BlockField => ({
             {
               name: 'subBlocks',
               type: 'blocks',
+              admin: {
+                disableSortable: true,
+              },
               blocks: [
                 {
                   slug: 'text',
@@ -135,6 +141,9 @@ const BlockFields: CollectionConfig = {
     {
       name: 'i18nBlocks',
       type: 'blocks',
+      admin: {
+        disableSortable: true,
+      },
       blocks: [
         {
           slug: 'text',
@@ -177,6 +186,9 @@ const BlockFields: CollectionConfig = {
     {
       name: 'blocksWithSimilarConfigs',
       type: 'blocks',
+      admin: {
+        disableSortable: true,
+      },
       blocks: [
         {
           slug: 'block-a',
@@ -231,6 +243,7 @@ const BlockFields: CollectionConfig = {
       name: 'blocksWithSimilarGroup',
       type: 'blocks',
       admin: {
+        disableSortable: true,
         description:
           'The purpose of this field is to test validateExistingBlockIsIdentical works with similar blocks with group fields',
       },
@@ -271,6 +284,9 @@ const BlockFields: CollectionConfig = {
     {
       name: 'blocksWithMinRows',
       type: 'blocks',
+      admin: {
+        disableSortable: true,
+      },
       blocks: [
         {
           slug: 'block',
@@ -287,6 +303,9 @@ const BlockFields: CollectionConfig = {
     {
       name: 'customBlocks',
       type: 'blocks',
+      admin: {
+        disableSortable: true,
+      },
       blocks: [
         {
           slug: 'block-1',
@@ -311,6 +330,9 @@ const BlockFields: CollectionConfig = {
     {
       name: 'relationshipBlocks',
       type: 'blocks',
+      admin: {
+        disableSortable: true,
+      },
       blocks: [
         {
           slug: 'relationships',

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -696,6 +696,12 @@ describe('fields', () => {
         })
       })
     })
+
+    test('should have disabled admin sorting', async () => {
+      await page.goto(url.create)
+      const field = page.locator('.array-actions__action-chevron')
+      expect(await field.count()).toEqual(0)
+    })
   })
 
   describe('array', () => {
@@ -714,6 +720,12 @@ describe('fields', () => {
       await page.goto(url.create)
       const field = page.locator('#field-readOnly__0__text')
       await expect(field).toHaveValue('defaultValue')
+    })
+
+    test('should have disabled admin sorting', async () => {
+      await page.goto(url.create)
+      const field = page.locator('.array-actions__action-chevron')
+      expect(await field.count()).toEqual(0)
     })
 
     test('should render RowLabel using a function', async () => {

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -699,7 +699,7 @@ describe('fields', () => {
 
     test('should have disabled admin sorting', async () => {
       await page.goto(url.create)
-      const field = page.locator('.array-actions__action-chevron')
+      const field = page.locator('#field-collapsedByDefaultBlocks .array-actions__action-chevron')
       expect(await field.count()).toEqual(0)
     })
   })
@@ -724,7 +724,7 @@ describe('fields', () => {
 
     test('should have disabled admin sorting', async () => {
       await page.goto(url.create)
-      const field = page.locator('.array-actions__action-chevron')
+      const field = page.locator('#field-disableSortItems .array-actions__action-chevron')
       expect(await field.count()).toEqual(0)
     })
 

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -265,6 +265,10 @@ export interface ArrayField {
         id?: string | null
       }[]
     | null
+  disableSortItems?: {
+    text: string
+    id?: string | null
+  }[]
   updatedAt: string
   createdAt: string
 }


### PR DESCRIPTION
## Description

Given arrays and Blocks can be sorted by admins, sorting should be able to be toggled in the config

## Example
Fields: `Array, Blocks`

```javascript
const Field: CollectionConfig = {
  admin: {
    isSortable: false
  }
}
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
