### PR TITLE
chore: adjust headersWithCors for req without payload

### DIFF
--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -187,7 +187,7 @@ export const OPTIONS =
       return routeError({
         config,
         err: error,
-        req,
+        req: req || request,
       })
     }
   }
@@ -347,7 +347,7 @@ export const GET =
         collection,
         config,
         err: error,
-        req,
+        req: req || request,
       })
     }
   }
@@ -493,7 +493,7 @@ export const POST =
         collection,
         config,
         err: error,
-        req,
+        req: req || request,
       })
     }
   }
@@ -566,7 +566,7 @@ export const DELETE =
         collection,
         config,
         err: error,
-        req,
+        req: req || request,
       })
     }
   }
@@ -639,7 +639,7 @@ export const PATCH =
         collection,
         config,
         err: error,
-        req,
+        req: req || request,
       })
     }
   }

--- a/packages/next/src/routes/rest/routeError.ts
+++ b/packages/next/src/routes/rest/routeError.ts
@@ -82,11 +82,6 @@ export const routeError = async ({
 }) => {
   let payload = req?.payload
 
-  const headers = headersWithCors({
-    headers: new Headers(),
-    req,
-  })
-
   if (!payload) {
     try {
       payload = await getPayloadHMR({ config: configArg })
@@ -95,10 +90,16 @@ export const routeError = async ({
         {
           message: 'There was an error initializing Payload',
         },
-        { headers, status: httpStatus.INTERNAL_SERVER_ERROR },
+        { status: httpStatus.INTERNAL_SERVER_ERROR },
       )
     }
   }
+
+  req.payload = payload
+  const headers = headersWithCors({
+    headers: new Headers(),
+    req,
+  })
 
   const { config, logger } = payload
 

--- a/packages/next/src/routes/rest/routeError.ts
+++ b/packages/next/src/routes/rest/routeError.ts
@@ -78,7 +78,7 @@ export const routeError = async ({
   collection?: Collection
   config: Promise<SanitizedConfig> | SanitizedConfig
   err: APIError
-  req: PayloadRequest
+  req: Partial<PayloadRequest>
 }) => {
   let payload = req?.payload
 
@@ -123,7 +123,7 @@ export const routeError = async ({
     ;({ response, status } = collection.config.hooks.afterError(
       err,
       response,
-      req.context,
+      req?.context,
       collection.config,
     ) || { response, status })
   }
@@ -132,7 +132,7 @@ export const routeError = async ({
     ;({ response, status } = config.hooks.afterError(
       err,
       response,
-      req.context,
+      req?.context,
       collection?.config,
     ) || {
       response,

--- a/packages/next/src/utilities/headersWithCors.ts
+++ b/packages/next/src/utilities/headersWithCors.ts
@@ -2,11 +2,11 @@ import type { PayloadRequest } from 'payload/types'
 
 type CorsArgs = {
   headers: Headers
-  req: PayloadRequest
+  req: Partial<PayloadRequest>
 }
 export const headersWithCors = ({ headers, req }: CorsArgs): Headers => {
   const cors = req?.payload.config.cors
-  const requestOrigin = req.headers.get('Origin')
+  const requestOrigin = req?.headers.get('Origin')
 
   if (cors) {
     headers.set('Access-Control-Allow-Methods', 'PUT, PATCH, POST, GET, DELETE, OPTIONS')

--- a/packages/next/src/utilities/headersWithCors.ts
+++ b/packages/next/src/utilities/headersWithCors.ts
@@ -5,7 +5,7 @@ type CorsArgs = {
   req: PayloadRequest
 }
 export const headersWithCors = ({ headers, req }: CorsArgs): Headers => {
-  const cors = req.payload.config.cors
+  const cors = req?.payload.config.cors
   const requestOrigin = req.headers.get('Origin')
 
   if (cors) {

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -253,6 +253,7 @@ describe('fields - relationship', () => {
   })
 
   async function runFilterOptionsTest(fieldName: string) {
+    await page.reload()
     await page.goto(url.edit(docWithExistingRelations.id))
 
     // fill the first relation field

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
     ],
     "paths": {
       "@payload-config": [
-        "./test/_community/config.ts"
+        "./test/fields-relationship/config.ts"
       ],
       "@payloadcms/live-preview": [
         "./packages/live-preview/src"


### PR DESCRIPTION
## Description

Fixes an issue where some req's would hit headersWithCors but not have payload on the request.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
