### PR TITLE
fix(plugin-seo): image generation handler invalid response

### DIFF
--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -232,7 +232,7 @@ const seo =
             const args: Parameters<GenerateImage>[0] =
               req.data as unknown as Parameters<GenerateImage>[0]
             const result = pluginConfig.generateImage ? await pluginConfig.generateImage(args) : ''
-            return new Response(result, { status: 200 })
+            return new Response(JSON.stringify({ result }), { status: 200 })
           },
           method: 'post',
           path: '/plugin-seo/generate-image',

--- a/test/plugin-seo/collections/Pages.ts
+++ b/test/plugin-seo/collections/Pages.ts
@@ -28,6 +28,11 @@ export const Pages: CollectionConfig = {
               required: true,
             },
             {
+              name: 'photo',
+              type: 'upload',
+              relationTo: 'media',
+            },
+            {
               name: 'excerpt',
               label: 'Excerpt',
               type: 'text',

--- a/test/plugin-seo/config.ts
+++ b/test/plugin-seo/config.ts
@@ -57,6 +57,7 @@ export default buildConfigWithDefaults({
       ],
       generateDescription: ({ doc }: any) => doc?.excerpt?.value || 'generated description',
       generateTitle: (data: any) => `Website.com — ${data?.doc?.title?.value}`,
+      generateImage: (data: any) => data.doc?.photo?.value,
       generateURL: ({ doc, locale }: any) =>
         `https://yoursite.com/${locale ? locale + '/' : ''}${doc?.slug?.value || ''}`,
       tabbedUI: true,


### PR DESCRIPTION
## Description

Fixed invalid raw (non json) response in generate-image endpoint caused to not generating the meta image.

Honestly tried to add e2e test because we don't have it for image-gen, but it doesn't pass even without my changes neither on Windows PC or Macbook, saying: ```ERROR There was a problem while uploading the file.```.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Existing test suite passes locally with my changes
