### PR TITLE
fix: correctly sets headers on external file fetch

### DIFF
--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -32,9 +32,7 @@ export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promis
 
     const res = await fetch(fileURL, {
       credentials: 'include',
-      headers: {
-        headers,
-      },
+      headers,
       method: 'GET',
     })
 


### PR DESCRIPTION
## Description

Headers were not being set correctly when fetching an external file.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
