### PR TITLE
fix: incorrect `localesNotSaved` translation

### DIFF
--- a/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
+++ b/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
@@ -139,7 +139,7 @@ const Duplicate: React.FC<Props> = ({ id, slug, collection }) => {
       if (localeErrors.length > 0) {
         toast.error(
           `
-          ${t('error:localesNotSaved', { count: localeErrors.length })}
+          ${t('error:localesNotSaved_other', { count: localeErrors.length })}
           ${localeErrors.join(', ')}
           `,
           { autoClose: 5000 },


### PR DESCRIPTION
## Description

Duplicate localized field toast error message was using the incorrect translation.

Before: `localesNotSaved`

After: `localesNotSaved_other`

Fixes #5993

![Screenshot 2024-04-24 at 9 14 34 AM](https://github.com/payloadcms/payload/assets/35232443/c7e75c3b-8cce-45ca-bcb8-88fd919609bd)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] Existing test suite passes locally with my changes
