### PR TITLE
fix: collection labels with locales not working when creating new doc

### DIFF
--- a/packages/payload/src/admin/components/elements/DocumentControls/index.tsx
+++ b/packages/payload/src/admin/components/elements/DocumentControls/index.tsx
@@ -5,6 +5,7 @@ import type { CollectionPermission, GlobalPermission } from '../../../../auth'
 import type { SanitizedCollectionConfig } from '../../../../collections/config/types'
 import type { SanitizedGlobalConfig } from '../../../../globals/config/types'
 
+import { getTranslation } from '../../../../utilities/getTranslation'
 import { formatDate } from '../../../utilities/formatDate'
 import { useConfig } from '../../utilities/Config'
 import { useDocumentInfo } from '../../utilities/DocumentInfo'
@@ -63,6 +64,12 @@ export const DocumentControls: React.FC<{
     collection && id && !disableActions && (hasCreatePermission || hasDeletePermission),
   )
 
+  const collectionLabel = () => {
+    const label = collection?.labels?.singular
+    if (!label) return t('document')
+    return typeof label === 'string' ? label : getTranslation(label, i18n)
+  }
+
   return (
     <Gutter className={baseClass}>
       <div className={`${baseClass}__wrapper`}>
@@ -71,12 +78,7 @@ export const DocumentControls: React.FC<{
             {collection && !isEditing && !isAccountView && (
               <li className={`${baseClass}__list-item`}>
                 <p className={`${baseClass}__value`}>
-                  {t('creatingNewLabel', {
-                    label:
-                      typeof collection?.labels?.singular === 'string'
-                        ? collection.labels.singular
-                        : t('document'),
-                  })}
+                  {t('creatingNewLabel', { label: collectionLabel() })}
                 </p>
               </li>
             )}


### PR DESCRIPTION
## Description

Closes #5992

When a collection has a label with more than one language, it is falling back to the default label _(document)_ when creating a new document. It should show the correct label for the current locale.
```ts
  labels: {
    singular: {
      de: 'test',
      en: 'post',
    },
  },
```

Before:
![Screenshot 2024-04-24 at 2 44 23 PM](https://github.com/payloadcms/payload/assets/67977755/5d02e28d-fb70-4bc2-a1f0-6e69e57f7e5e)

After:
![Screenshot 2024-04-24 at 2 43 52 PM](https://github.com/payloadcms/payload/assets/67977755/4dd01162-90e6-41fa-b4b4-11648d3d6cdf)


- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes