### PR TITLE
feat!: removed getDataAndFile and getLocales from createPayloadRequest in favour of new utilities addDataAndFileToRequest and addLocalesToRequest

### DIFF
--- a/packages/next/src/exports/utilities.ts
+++ b/packages/next/src/exports/utilities.ts
@@ -1,3 +1,5 @@
+export { addDataAndFileToRequest } from '../utilities/addDataAndFileToRequest.js'
+export { addLocalesToRequest } from '../utilities/addLocalesToRequest.js'
 export { traverseFields } from '../utilities/buildFieldSchemaMap/traverseFields.js'
 export { createPayloadRequest } from '../utilities/createPayloadRequest.js'
 export { getNextRequestI18n } from '../utilities/getNextRequestI18n.js'

--- a/packages/next/src/routes/graphql/handler.ts
+++ b/packages/next/src/routes/graphql/handler.ts
@@ -5,7 +5,6 @@ import { configToSchema } from '@payloadcms/graphql'
 import { createHandler } from 'graphql-http/lib/use/fetch'
 import httpStatus from 'http-status'
 
-import { addDataAndFileToRequest } from '../../utilities/addDataAndFileToRequest.js'
 import { addLocalesToRequest } from '../../utilities/addLocalesToRequest.js'
 import { createPayloadRequest } from '../../utilities/createPayloadRequest.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'

--- a/packages/next/src/routes/graphql/handler.ts
+++ b/packages/next/src/routes/graphql/handler.ts
@@ -89,7 +89,7 @@ export const POST =
       request,
     })
 
-    addLocalesToRequest({ config: req.payload.config, request: req })
+    addLocalesToRequest({ request: req })
 
     const { schema, validationRules } = await getGraphql(config)
 

--- a/packages/next/src/routes/graphql/handler.ts
+++ b/packages/next/src/routes/graphql/handler.ts
@@ -5,6 +5,8 @@ import { configToSchema } from '@payloadcms/graphql'
 import { createHandler } from 'graphql-http/lib/use/fetch'
 import httpStatus from 'http-status'
 
+import { addDataAndFileToRequest } from '../../utilities/addDataAndFileToRequest.js'
+import { addLocalesToRequest } from '../../utilities/addLocalesToRequest.js'
 import { createPayloadRequest } from '../../utilities/createPayloadRequest.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
 
@@ -86,6 +88,9 @@ export const POST =
       config,
       request,
     })
+
+    addLocalesToRequest({ config: req.payload.config, request: req })
+
     const { schema, validationRules } = await getGraphql(config)
 
     const { payload } = req

--- a/packages/next/src/routes/graphql/playground.ts
+++ b/packages/next/src/routes/graphql/playground.ts
@@ -2,6 +2,7 @@ import type { SanitizedConfig } from 'payload/types'
 
 import { renderPlaygroundPage } from 'graphql-playground-html'
 
+import { addLocalesToRequest } from '../../utilities/addLocalesToRequest.js'
 import { createPayloadRequest } from '../../utilities/createPayloadRequest.js'
 
 export const GET = (config: Promise<SanitizedConfig>) => async (request: Request) => {
@@ -9,6 +10,8 @@ export const GET = (config: Promise<SanitizedConfig>) => async (request: Request
     config,
     request,
   })
+
+  addLocalesToRequest({ config: req.payload.config, request: req })
 
   if (
     (!req.payload.config.graphQL.disable &&

--- a/packages/next/src/routes/graphql/playground.ts
+++ b/packages/next/src/routes/graphql/playground.ts
@@ -11,7 +11,7 @@ export const GET = (config: Promise<SanitizedConfig>) => async (request: Request
     request,
   })
 
-  addLocalesToRequest({ config: req.payload.config, request: req })
+  addLocalesToRequest({ request: req })
 
   if (
     (!req.payload.config.graphQL.disable &&

--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -232,10 +232,12 @@ export const GET =
           entitySlug: slug1,
           payloadRequest: req,
         })
-        if (customEndpointResponse) return customEndpointResponse
-
-        await addDataAndFileToRequest({ request: req })
-        addLocalesToRequest({ request: req })
+        if (customEndpointResponse) {
+          return customEndpointResponse
+        } else {
+          await addDataAndFileToRequest({ request: req })
+          addLocalesToRequest({ request: req })
+        }
 
         switch (slug.length) {
           case 1:
@@ -293,10 +295,12 @@ export const GET =
           payloadRequest: req,
         })
 
-        if (customEndpointResponse) return customEndpointResponse
-
-        await addDataAndFileToRequest({ request: req })
-        addLocalesToRequest({ request: req })
+        if (customEndpointResponse) {
+          return customEndpointResponse
+        } else {
+          await addDataAndFileToRequest({ request: req })
+          addLocalesToRequest({ request: req })
+        }
 
         switch (slug.length) {
           case 2:
@@ -399,10 +403,12 @@ export const POST =
           payloadRequest: req,
         })
 
-        if (customEndpointResponse) return customEndpointResponse
-
-        await addDataAndFileToRequest({ request: req })
-        addLocalesToRequest({ request: req })
+        if (customEndpointResponse) {
+          return customEndpointResponse
+        } else {
+          await addDataAndFileToRequest({ request: req })
+          addLocalesToRequest({ request: req })
+        }
 
         switch (slug.length) {
           case 1:
@@ -453,10 +459,13 @@ export const POST =
           entitySlug: `${slug1}/${slug2}`,
           payloadRequest: req,
         })
-        if (customEndpointResponse) return customEndpointResponse
 
-        await addDataAndFileToRequest({ request: req })
-        addLocalesToRequest({ request: req })
+        if (customEndpointResponse) {
+          return customEndpointResponse
+        } else {
+          await addDataAndFileToRequest({ request: req })
+          addLocalesToRequest({ request: req })
+        }
 
         switch (slug.length) {
           case 2:
@@ -552,10 +561,12 @@ export const DELETE =
           entitySlug: slug1,
           payloadRequest: req,
         })
-        if (customEndpointResponse) return customEndpointResponse
-
-        await addDataAndFileToRequest({ request: req })
-        addLocalesToRequest({ request: req })
+        if (customEndpointResponse) {
+          return customEndpointResponse
+        } else {
+          await addDataAndFileToRequest({ request: req })
+          addLocalesToRequest({ request: req })
+        }
 
         switch (slug.length) {
           case 1:
@@ -628,10 +639,13 @@ export const PATCH =
           entitySlug: slug1,
           payloadRequest: req,
         })
-        if (customEndpointResponse) return customEndpointResponse
 
-        await addDataAndFileToRequest({ request: req })
-        addLocalesToRequest({ request: req })
+        if (customEndpointResponse) {
+          return customEndpointResponse
+        } else {
+          await addDataAndFileToRequest({ request: req })
+          addLocalesToRequest({ request: req })
+        }
 
         switch (slug.length) {
           case 1:

--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -234,8 +234,8 @@ export const GET =
         })
         if (customEndpointResponse) return customEndpointResponse
 
-        await addDataAndFileToRequest({ collection, config: req.payload.config, request: req })
-        addLocalesToRequest({ config: req.payload.config, request: req })
+        await addDataAndFileToRequest({ request: req })
+        addLocalesToRequest({ request: req })
 
         switch (slug.length) {
           case 1:
@@ -295,8 +295,8 @@ export const GET =
 
         if (customEndpointResponse) return customEndpointResponse
 
-        await addDataAndFileToRequest({ collection, config: await config, request: req })
-        addLocalesToRequest({ config: req.payload.config, request: req })
+        await addDataAndFileToRequest({ request: req })
+        addLocalesToRequest({ request: req })
 
         switch (slug.length) {
           case 2:
@@ -334,8 +334,8 @@ export const GET =
             break
         }
       } else if (slug.length === 1 && slug1 in endpoints.root.GET) {
-        await addDataAndFileToRequest({ collection, config: await config, request: req })
-        addLocalesToRequest({ config: req.payload.config, request: req })
+        await addDataAndFileToRequest({ request: req })
+        addLocalesToRequest({ request: req })
         res = await endpoints.root.GET[slug1]({ req })
       }
 
@@ -401,8 +401,8 @@ export const POST =
 
         if (customEndpointResponse) return customEndpointResponse
 
-        await addDataAndFileToRequest({ collection, config: await config, request: req })
-        addLocalesToRequest({ config: req.payload.config, request: req })
+        await addDataAndFileToRequest({ request: req })
+        addLocalesToRequest({ request: req })
 
         switch (slug.length) {
           case 1:
@@ -455,8 +455,8 @@ export const POST =
         })
         if (customEndpointResponse) return customEndpointResponse
 
-        await addDataAndFileToRequest({ collection, config: await config, request: req })
-        addLocalesToRequest({ config: req.payload.config, request: req })
+        await addDataAndFileToRequest({ request: req })
+        addLocalesToRequest({ request: req })
 
         switch (slug.length) {
           case 2:
@@ -488,8 +488,8 @@ export const POST =
             res = new Response('Route Not Found', { status: 404 })
         }
       } else if (slug.length === 1 && slug1 in endpoints.root.POST) {
-        await addDataAndFileToRequest({ collection, config: await config, request: req })
-        addLocalesToRequest({ config: req.payload.config, request: req })
+        await addDataAndFileToRequest({ request: req })
+        addLocalesToRequest({ request: req })
         res = await endpoints.root.POST[slug1]({ req })
       }
 
@@ -554,8 +554,8 @@ export const DELETE =
         })
         if (customEndpointResponse) return customEndpointResponse
 
-        await addDataAndFileToRequest({ collection, config: await config, request: req })
-        addLocalesToRequest({ config: req.payload.config, request: req })
+        await addDataAndFileToRequest({ request: req })
+        addLocalesToRequest({ request: req })
 
         switch (slug.length) {
           case 1:
@@ -630,8 +630,8 @@ export const PATCH =
         })
         if (customEndpointResponse) return customEndpointResponse
 
-        await addDataAndFileToRequest({ collection, config: await config, request: req })
-        addLocalesToRequest({ config: req.payload.config, request: req })
+        await addDataAndFileToRequest({ request: req })
+        addLocalesToRequest({ request: req })
 
         switch (slug.length) {
           case 1:

--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -11,6 +11,8 @@ import type {
   GlobalRouteHandlerWithID,
 } from './types.js'
 
+import { addDataAndFileToRequest } from '../../utilities/addDataAndFileToRequest.js'
+import { addLocalesToRequest } from '../../utilities/addLocalesToRequest.js'
 import { createPayloadRequest } from '../../utilities/createPayloadRequest.js'
 import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { access } from './auth/access.js'
@@ -232,6 +234,9 @@ export const GET =
         })
         if (customEndpointResponse) return customEndpointResponse
 
+        await addDataAndFileToRequest({ collection, config: req.payload.config, request: req })
+        addLocalesToRequest({ config: req.payload.config, request: req })
+
         switch (slug.length) {
           case 1:
             // /:collection
@@ -290,6 +295,9 @@ export const GET =
 
         if (customEndpointResponse) return customEndpointResponse
 
+        await addDataAndFileToRequest({ collection, config: await config, request: req })
+        addLocalesToRequest({ config: req.payload.config, request: req })
+
         switch (slug.length) {
           case 2:
             // /globals/:slug
@@ -326,6 +334,8 @@ export const GET =
             break
         }
       } else if (slug.length === 1 && slug1 in endpoints.root.GET) {
+        await addDataAndFileToRequest({ collection, config: await config, request: req })
+        addLocalesToRequest({ config: req.payload.config, request: req })
         res = await endpoints.root.GET[slug1]({ req })
       }
 
@@ -391,6 +401,9 @@ export const POST =
 
         if (customEndpointResponse) return customEndpointResponse
 
+        await addDataAndFileToRequest({ collection, config: await config, request: req })
+        addLocalesToRequest({ config: req.payload.config, request: req })
+
         switch (slug.length) {
           case 1:
             // /:collection
@@ -442,6 +455,9 @@ export const POST =
         })
         if (customEndpointResponse) return customEndpointResponse
 
+        await addDataAndFileToRequest({ collection, config: await config, request: req })
+        addLocalesToRequest({ config: req.payload.config, request: req })
+
         switch (slug.length) {
           case 2:
             // /globals/:slug
@@ -472,6 +488,8 @@ export const POST =
             res = new Response('Route Not Found', { status: 404 })
         }
       } else if (slug.length === 1 && slug1 in endpoints.root.POST) {
+        await addDataAndFileToRequest({ collection, config: await config, request: req })
+        addLocalesToRequest({ config: req.payload.config, request: req })
         res = await endpoints.root.POST[slug1]({ req })
       }
 
@@ -535,6 +553,9 @@ export const DELETE =
           payloadRequest: req,
         })
         if (customEndpointResponse) return customEndpointResponse
+
+        await addDataAndFileToRequest({ collection, config: await config, request: req })
+        addLocalesToRequest({ config: req.payload.config, request: req })
 
         switch (slug.length) {
           case 1:
@@ -608,6 +629,9 @@ export const PATCH =
           payloadRequest: req,
         })
         if (customEndpointResponse) return customEndpointResponse
+
+        await addDataAndFileToRequest({ collection, config: await config, request: req })
+        addLocalesToRequest({ config: req.payload.config, request: req })
 
         switch (slug.length) {
           case 1:

--- a/packages/next/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/next/src/utilities/addDataAndFileToRequest.ts
@@ -1,28 +1,18 @@
-import type {
-  Collection,
-  CustomPayloadRequest,
-  PayloadRequest,
-  SanitizedConfig,
-} from 'payload/types'
+import type { CustomPayloadRequest, PayloadRequest } from 'payload/types'
 
 import type { NextFileUploadOptions } from '../next-fileupload/index.js'
 
 import { nextFileUpload } from '../next-fileupload/index.js'
 
-type AddDataAndFileToRequest = (args: {
-  collection: Collection
-  config: SanitizedConfig
-  request: PayloadRequest
-}) => Promise<void>
+type AddDataAndFileToRequest = (args: { request: PayloadRequest }) => Promise<void>
 
 /**
  * Mutates the Request to contain 'data' and 'file' if present
  */
 export const addDataAndFileToRequest: AddDataAndFileToRequest = async ({
-  collection,
-  config,
   request: incomingRequest,
 }) => {
+  const config = incomingRequest.payload.config
   let data: Record<string, any> | undefined = undefined
   let file: CustomPayloadRequest['file'] = undefined
 
@@ -61,7 +51,7 @@ export const addDataAndFileToRequest: AddDataAndFileToRequest = async ({
           throw new Error(error.message)
         }
 
-        if (collection?.config?.upload && files?.file) {
+        if (files?.file) {
           file = files.file
         }
 

--- a/packages/next/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/next/src/utilities/addDataAndFileToRequest.ts
@@ -1,0 +1,80 @@
+import type {
+  Collection,
+  CustomPayloadRequest,
+  PayloadRequest,
+  SanitizedConfig,
+} from 'payload/types'
+
+import type { NextFileUploadOptions } from '../next-fileupload/index.js'
+
+import { nextFileUpload } from '../next-fileupload/index.js'
+
+type AddDataAndFileToRequest = (args: {
+  collection: Collection
+  config: SanitizedConfig
+  request: PayloadRequest
+}) => Promise<void>
+
+/**
+ * Mutates the Request to contain 'data' and 'file' if present
+ */
+export const addDataAndFileToRequest: AddDataAndFileToRequest = async ({
+  collection,
+  config,
+  request: incomingRequest,
+}) => {
+  let data: Record<string, any> | undefined = undefined
+  let file: CustomPayloadRequest['file'] = undefined
+
+  if (
+    incomingRequest.method &&
+    ['PATCH', 'POST', 'PUT'].includes(incomingRequest.method.toUpperCase()) &&
+    incomingRequest.body
+  ) {
+    // @ts-expect-error todo: fix type
+    const request = new Request(incomingRequest)
+    const [contentType] = (request.headers.get('Content-Type') || '').split(';')
+
+    if (contentType === 'application/json') {
+      const bodyByteSize = parseInt(request.headers.get('Content-Length') || '0', 10)
+      const upperByteLimit =
+        typeof config.upload?.limits?.fieldSize === 'number'
+          ? config.upload.limits.fields
+          : undefined
+      if ((upperByteLimit && bodyByteSize <= upperByteLimit) || upperByteLimit === undefined) {
+        try {
+          data = await request.json()
+        } catch (error) {
+          data = {}
+        }
+      } else {
+        throw new Error('Request body size exceeds the limit')
+      }
+    } else {
+      if (request.headers.has('Content-Length') && request.headers.get('Content-Length') !== '0') {
+        const { error, fields, files } = await nextFileUpload({
+          options: config.upload as NextFileUploadOptions,
+          request,
+        })
+
+        if (error) {
+          throw new Error(error.message)
+        }
+
+        if (collection?.config?.upload && files?.file) {
+          file = files.file
+        }
+
+        if (fields?._payload && typeof fields._payload === 'string') {
+          data = JSON.parse(fields._payload)
+        }
+      }
+    }
+  }
+
+  if (data) {
+    incomingRequest.data = data
+    incomingRequest.json = () => Promise.resolve(data)
+  }
+  if (file) incomingRequest.file = file
+}

--- a/packages/next/src/utilities/addLocalesToRequest.ts
+++ b/packages/next/src/utilities/addLocalesToRequest.ts
@@ -1,15 +1,17 @@
-import type { PayloadRequest, SanitizedConfig } from 'payload/types'
+import type { PayloadRequest } from 'payload/types'
 
 type AddLocalesToRequestArgs = {
-  config: SanitizedConfig
   request: PayloadRequest
 }
 
 /**
  * Mutates the Request to contain 'locale' and 'fallbackLocale' based on data or searchParams
  */
-export function addLocalesToRequest({ config, request }: AddLocalesToRequestArgs): void {
-  const { data } = request
+export function addLocalesToRequest({ request }: AddLocalesToRequestArgs): void {
+  const {
+    data,
+    payload: { config },
+  } = request
   const { localization } = config
   const urlProperties = new URL(request.url)
   const { searchParams } = urlProperties

--- a/packages/next/src/utilities/addLocalesToRequest.ts
+++ b/packages/next/src/utilities/addLocalesToRequest.ts
@@ -1,0 +1,43 @@
+import type { PayloadRequest, SanitizedConfig } from 'payload/types'
+
+type AddLocalesToRequestArgs = {
+  config: SanitizedConfig
+  request: PayloadRequest
+}
+
+/**
+ * Mutates the Request to contain 'locale' and 'fallbackLocale' based on data or searchParams
+ */
+export function addLocalesToRequest({ config, request }: AddLocalesToRequestArgs): void {
+  const { data } = request
+  const { localization } = config
+  const urlProperties = new URL(request.url)
+  const { searchParams } = urlProperties
+
+  let locale = searchParams.get('locale')
+  let fallbackLocale = searchParams.get('fallback-locale')
+
+  if (data) {
+    if (data?.locale && typeof data.locale === 'string') {
+      locale = data.locale
+    }
+    if (data?.['fallback-locale'] && typeof data?.['fallback-locale'] === 'string') {
+      fallbackLocale = data['fallback-locale']
+    }
+  }
+
+  if (fallbackLocale === 'none') {
+    fallbackLocale = 'null'
+  } else if (localization && !localization.localeCodes.includes(fallbackLocale)) {
+    fallbackLocale = localization.defaultLocale
+  }
+
+  if (locale === '*') {
+    locale = 'all'
+  } else if (localization && !localization.localeCodes.includes(locale)) {
+    locale = localization.defaultLocale
+  }
+
+  if (locale) request.locale = locale
+  if (fallbackLocale) request.fallbackLocale = fallbackLocale
+}

--- a/packages/next/src/utilities/createPayloadRequest.ts
+++ b/packages/next/src/utilities/createPayloadRequest.ts
@@ -12,10 +12,8 @@ import { getDataLoader } from 'payload/utilities'
 import qs from 'qs'
 import { URL } from 'url'
 
-import { getDataAndFile } from './getDataAndFile.js'
 import { getPayloadHMR } from './getPayloadHMR.js'
 import { getRequestLanguage } from './getRequestLanguage.js'
-import { getRequestLocales } from './getRequestLocales.js'
 
 type Args = {
   config: Promise<SanitizedConfig> | SanitizedConfig
@@ -41,29 +39,13 @@ export const createPayloadRequest = async ({
   }
 
   const urlProperties = new URL(request.url)
-  const { pathname, searchParams } = urlProperties
+  const { pathname } = urlProperties
 
   const isGraphQL =
     !config.graphQL.disable && pathname === `${config.routes.api}${config.routes.graphQL}`
 
-  const { data, file } = await getDataAndFile({
-    collection,
-    config,
-    request,
-  })
-
   let requestFallbackLocale
   let requestLocale
-
-  if (config.localization) {
-    const locales = getRequestLocales({
-      data,
-      localization: config.localization,
-      searchParams,
-    })
-    requestLocale = locales.locale
-    requestFallbackLocale = locales.fallbackLocale
-  }
 
   const language = getRequestLanguage({
     config,
@@ -79,9 +61,7 @@ export const createPayloadRequest = async ({
 
   const customRequest: CustomPayloadRequest = {
     context: {},
-    data,
     fallbackLocale: requestFallbackLocale,
-    file,
     hash: urlProperties.hash,
     host: urlProperties.host,
     href: urlProperties.href,
@@ -112,7 +92,6 @@ export const createPayloadRequest = async ({
 
   const req: PayloadRequest = Object.assign(request, customRequest)
 
-  if (data) req.json = () => Promise.resolve(data)
   req.payloadDataLoader = getDataLoader(req)
 
   req.user = await executeAuthStrategies({

--- a/packages/next/src/utilities/createPayloadRequest.ts
+++ b/packages/next/src/utilities/createPayloadRequest.ts
@@ -44,9 +44,6 @@ export const createPayloadRequest = async ({
   const isGraphQL =
     !config.graphQL.disable && pathname === `${config.routes.api}${config.routes.graphQL}`
 
-  let requestFallbackLocale
-  let requestLocale
-
   const language = getRequestLanguage({
     config,
     cookies,
@@ -61,12 +58,10 @@ export const createPayloadRequest = async ({
 
   const customRequest: CustomPayloadRequest = {
     context: {},
-    fallbackLocale: requestFallbackLocale,
     hash: urlProperties.hash,
     host: urlProperties.host,
     href: urlProperties.href,
     i18n,
-    locale: requestLocale,
     origin: urlProperties.origin,
     pathname: urlProperties.pathname,
     payload,

--- a/packages/payload/src/preferences/requestHandlers/delete.ts
+++ b/packages/payload/src/preferences/requestHandlers/delete.ts
@@ -5,6 +5,7 @@ import type { PayloadHandler } from '../../config/types.js'
 import deleteOperation from '../operations/delete.js'
 
 export const deleteHandler: PayloadHandler = async (req): Promise<Response> => {
+  req.data = await req.json()
   const result = await deleteOperation({
     key: req.routeParams?.key as string,
     req,

--- a/packages/payload/src/preferences/requestHandlers/delete.ts
+++ b/packages/payload/src/preferences/requestHandlers/delete.ts
@@ -5,7 +5,19 @@ import type { PayloadHandler } from '../../config/types.js'
 import deleteOperation from '../operations/delete.js'
 
 export const deleteHandler: PayloadHandler = async (req): Promise<Response> => {
-  req.data = await req.json()
+  let data
+
+  try {
+    data = await req.json()
+  } catch (error) {
+    data = {}
+  }
+
+  if (data) {
+    req.data = data
+    req.json = () => Promise.resolve(data)
+  }
+
   const result = await deleteOperation({
     key: req.routeParams?.key as string,
     req,

--- a/packages/payload/src/preferences/requestHandlers/delete.ts
+++ b/packages/payload/src/preferences/requestHandlers/delete.ts
@@ -5,6 +5,8 @@ import type { PayloadHandler } from '../../config/types.js'
 import deleteOperation from '../operations/delete.js'
 
 export const deleteHandler: PayloadHandler = async (req): Promise<Response> => {
+  // We cannot import the addDataAndFileToRequest utility here from the 'next' package because of dependency issues
+  // However that utility should be used where possible instead of manually appending the data
   let data
 
   try {

--- a/packages/payload/src/preferences/requestHandlers/findOne.ts
+++ b/packages/payload/src/preferences/requestHandlers/findOne.ts
@@ -5,6 +5,8 @@ import type { PayloadHandler } from '../../config/types.js'
 import findOne from '../operations/findOne.js'
 
 export const findByIDHandler: PayloadHandler = async (req): Promise<Response> => {
+  // We cannot import the addDataAndFileToRequest utility here from the 'next' package because of dependency issues
+  // However that utility should be used where possible instead of manually appending the data
   let data
 
   try {

--- a/packages/payload/src/preferences/requestHandlers/findOne.ts
+++ b/packages/payload/src/preferences/requestHandlers/findOne.ts
@@ -5,6 +5,7 @@ import type { PayloadHandler } from '../../config/types.js'
 import findOne from '../operations/findOne.js'
 
 export const findByIDHandler: PayloadHandler = async (req): Promise<Response> => {
+  req.data = await req.json()
   const result = await findOne({
     key: req.routeParams?.key as string,
     req,

--- a/packages/payload/src/preferences/requestHandlers/findOne.ts
+++ b/packages/payload/src/preferences/requestHandlers/findOne.ts
@@ -5,7 +5,19 @@ import type { PayloadHandler } from '../../config/types.js'
 import findOne from '../operations/findOne.js'
 
 export const findByIDHandler: PayloadHandler = async (req): Promise<Response> => {
-  req.data = await req.json()
+  let data
+
+  try {
+    data = await req.json()
+  } catch (error) {
+    data = {}
+  }
+
+  if (data) {
+    req.data = data
+    req.json = () => Promise.resolve(data)
+  }
+
   const result = await findOne({
     key: req.routeParams?.key as string,
     req,

--- a/packages/payload/src/preferences/requestHandlers/update.ts
+++ b/packages/payload/src/preferences/requestHandlers/update.ts
@@ -5,6 +5,7 @@ import type { PayloadHandler } from '../../config/types.js'
 import update from '../operations/update.js'
 
 export const updateHandler: PayloadHandler = async (req) => {
+  req.data = await req.json()
   const payloadRequest = req
 
   const doc = await update({

--- a/packages/payload/src/preferences/requestHandlers/update.ts
+++ b/packages/payload/src/preferences/requestHandlers/update.ts
@@ -5,6 +5,8 @@ import type { PayloadHandler } from '../../config/types.js'
 import update from '../operations/update.js'
 
 export const updateHandler: PayloadHandler = async (req) => {
+  // We cannot import the addDataAndFileToRequest utility here from the 'next' package because of dependency issues
+  // However that utility should be used where possible instead of manually appending the data
   let data
 
   try {

--- a/packages/payload/src/preferences/requestHandlers/update.ts
+++ b/packages/payload/src/preferences/requestHandlers/update.ts
@@ -5,7 +5,19 @@ import type { PayloadHandler } from '../../config/types.js'
 import update from '../operations/update.js'
 
 export const updateHandler: PayloadHandler = async (req) => {
-  req.data = await req.json()
+  let data
+
+  try {
+    data = await req.json()
+  } catch (error) {
+    data = {}
+  }
+
+  if (data) {
+    req.data = data
+    req.json = () => Promise.resolve(data)
+  }
+
   const payloadRequest = req
 
   const doc = await update({

--- a/packages/plugin-seo/package.json
+++ b/packages/plugin-seo/package.json
@@ -44,6 +44,7 @@
     "payload": "workspace:*",
     "@payloadcms/translations": "workspace:*",
     "@payloadcms/ui": "workspace:*",
+    "@payloadcms/next": "workspace:*",
     "react": "^18.0.0"
   },
   "exports": {

--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -1,6 +1,7 @@
 import type { Config } from 'payload/config'
 import type { Field, GroupField, TabsField, TextField } from 'payload/types'
 
+import { addDataAndFileToRequest } from '@payloadcms/next/utilities'
 import { deepMerge } from 'payload/utilities'
 import React from 'react'
 
@@ -197,6 +198,7 @@ const seo =
         ...(config.endpoints ?? []),
         {
           handler: async (req) => {
+            await addDataAndFileToRequest({ request: req })
             const args: Parameters<GenerateTitle>[0] =
               req.data as unknown as Parameters<GenerateTitle>[0]
             const result = pluginConfig.generateTitle ? await pluginConfig.generateTitle(args) : ''
@@ -207,6 +209,7 @@ const seo =
         },
         {
           handler: async (req) => {
+            await addDataAndFileToRequest({ request: req })
             const args: Parameters<GenerateDescription>[0] =
               req.data as unknown as Parameters<GenerateDescription>[0]
             const result = pluginConfig.generateDescription
@@ -219,6 +222,7 @@ const seo =
         },
         {
           handler: async (req) => {
+            await addDataAndFileToRequest({ request: req })
             const args: Parameters<GenerateURL>[0] =
               req.data as unknown as Parameters<GenerateURL>[0]
             const result = pluginConfig.generateURL ? await pluginConfig.generateURL(args) : ''
@@ -229,6 +233,7 @@ const seo =
         },
         {
           handler: async (req) => {
+            await addDataAndFileToRequest({ request: req })
             const args: Parameters<GenerateImage>[0] =
               req.data as unknown as Parameters<GenerateImage>[0]
             const result = pluginConfig.generateImage ? await pluginConfig.generateImage(args) : ''

--- a/packages/plugin-seo/tsconfig.json
+++ b/packages/plugin-seo/tsconfig.json
@@ -20,5 +20,5 @@
     "src/**/*.spec.tsx"
   ],
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "src/**/*.json"],
-  "references": [{ "path": "../payload" }, { "path": "../ui" }]
+  "references": [{ "path": "../payload" }, { "path": "../ui" }, { "path": "../next" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1179,6 +1179,9 @@ importers:
       '@payloadcms/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config-payload
+      '@payloadcms/next':
+        specifier: workspace:*
+        version: link:../next
       '@payloadcms/translations':
         specifier: workspace:*
         version: link:../translations

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -60,7 +60,7 @@ import { fileURLToPath } from 'url'
 
 import type { PayloadTestSDK } from '../helpers/sdk/index.js'
 
-import { reInitializeDB } from '../helpers/reInit.js'
+import { reInitializeDB } from '../helpers/reInitializeDB.js'
 import { POLL_TOPASS_TIMEOUT } from '../playwright.config.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)

--- a/test/endpoints/endpoints/collections.ts
+++ b/test/endpoints/endpoints/collections.ts
@@ -27,7 +27,17 @@ export const collectionEndpoints: CollectionConfig['endpoints'] = [
   {
     path: '/whoami',
     method: 'post',
-    handler: (req) => {
+    handler: async (req) => {
+      let data
+
+      try {
+        data = await req.json()
+      } catch (error) {
+        data = {}
+      }
+
+      if (data) req.data = data
+
       return Response.json({
         name: req.data.name,
         age: req.data.age,

--- a/test/fields/collections/Array/e2e.spec.ts
+++ b/test/fields/collections/Array/e2e.spec.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../helpers.js'
 import { AdminUrlUtil } from '../../../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../../../helpers/initPayloadE2ENoConfig.js'
-import { reInitializeDB } from '../../../helpers/reInit.js'
+import { reInitializeDB } from '../../../helpers/reInitializeDB.js'
 import { RESTClient } from '../../../helpers/rest.js'
 
 const filename = fileURLToPath(import.meta.url)

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../helpers.js'
 import { AdminUrlUtil } from '../../../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../../../helpers/initPayloadE2ENoConfig.js'
-import { reInitializeDB } from '../../../helpers/reInit.js'
+import { reInitializeDB } from '../../../helpers/reInitializeDB.js'
 import { RESTClient } from '../../../helpers/rest.js'
 
 const filename = fileURLToPath(import.meta.url)

--- a/test/fields/collections/Lexical/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e.spec.ts
@@ -5,7 +5,7 @@ import type { SerializedEditorState, SerializedParagraphNode, SerializedTextNode
 
 import { expect, test } from '@playwright/test'
 import { initPayloadE2ENoConfig } from 'helpers/initPayloadE2ENoConfig.js'
-import { reInitializeDB } from 'helpers/reInit.js'
+import { reInitializeDB } from 'helpers/reInitializeDB.js'
 import path from 'path'
 import { wait } from 'payload/utilities'
 import { fileURLToPath } from 'url'

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../helpers.js'
 import { AdminUrlUtil } from '../../../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../../../helpers/initPayloadE2ENoConfig.js'
-import { reInitializeDB } from '../../../helpers/reInit.js'
+import { reInitializeDB } from '../../../helpers/reInitializeDB.js'
 import { RESTClient } from '../../../helpers/rest.js'
 import { POLL_TOPASS_TIMEOUT } from '../../../playwright.config.js'
 import { relationshipFieldsSlug, textFieldsSlug } from '../../slugs.js'

--- a/test/fields/collections/RichText/e2e.spec.ts
+++ b/test/fields/collections/RichText/e2e.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../helpers.js'
 import { AdminUrlUtil } from '../../../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../../../helpers/initPayloadE2ENoConfig.js'
-import { reInitializeDB } from '../../../helpers/reInit.js'
+import { reInitializeDB } from '../../../helpers/reInitializeDB.js'
 import { RESTClient } from '../../../helpers/rest.js'
 
 const filename = fileURLToPath(import.meta.url)

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
-import { reInitializeDB } from '../helpers/reInit.js'
+import { reInitializeDB } from '../helpers/reInitializeDB.js'
 import { RESTClient } from '../helpers/rest.js'
 import { POLL_TOPASS_TIMEOUT } from '../playwright.config.js'
 import { jsonDoc } from './collections/JSON/shared.js'

--- a/test/helpers/reInit.ts
+++ b/test/helpers/reInit.ts
@@ -1,12 +1,16 @@
 import type { Endpoint } from 'payload/config'
 import type { PayloadRequest } from 'payload/types'
 
+import { addDataAndFileToRequest, addLocalesToRequest } from '@payloadcms/next/utilities'
 import httpStatus from 'http-status'
 
 import { seedDB } from './seed.js'
 
-const handler = async ({ data, payload }: PayloadRequest) => {
+const handler = async (req: PayloadRequest) => {
   process.env.SEED_IN_CONFIG_ONINIT = 'true'
+  await addDataAndFileToRequest({ request: req })
+  addLocalesToRequest({ request: req })
+  const { data, payload } = req
 
   try {
     await seedDB({

--- a/test/helpers/reInit.ts
+++ b/test/helpers/reInit.ts
@@ -4,6 +4,7 @@ import type { PayloadRequest } from 'payload/types'
 import { addDataAndFileToRequest, addLocalesToRequest } from '@payloadcms/next/utilities'
 import httpStatus from 'http-status'
 
+import { path } from './reInitializeDB.js'
 import { seedDB } from './seed.js'
 
 const handler = async (req: PayloadRequest) => {
@@ -37,31 +38,8 @@ const handler = async (req: PayloadRequest) => {
   }
 }
 
-const path = '/re-initialize'
-
 export const reInitEndpoint: Endpoint = {
   path,
   method: 'post',
   handler,
-}
-
-export const reInitializeDB = async ({
-  serverURL,
-  snapshotKey,
-  uploadsDir,
-}: {
-  serverURL: string
-  snapshotKey: string
-  uploadsDir?: string
-}) => {
-  await fetch(`${serverURL}/api${path}`, {
-    method: 'post',
-    body: JSON.stringify({
-      snapshotKey,
-      uploadsDir,
-    }),
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
 }

--- a/test/helpers/reInitializeDB.ts
+++ b/test/helpers/reInitializeDB.ts
@@ -1,0 +1,22 @@
+export const path = '/re-initialize'
+
+export const reInitializeDB = async ({
+  serverURL,
+  snapshotKey,
+  uploadsDir,
+}: {
+  serverURL: string
+  snapshotKey: string
+  uploadsDir?: string
+}) => {
+  await fetch(`${serverURL}/api${path}`, {
+    method: 'post',
+    body: JSON.stringify({
+      snapshotKey,
+      uploadsDir,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}

--- a/test/helpers/sdk/endpoint.ts
+++ b/test/helpers/sdk/endpoint.ts
@@ -1,8 +1,13 @@
 import type { Endpoint, PayloadHandler } from 'payload/config'
 
+import { addDataAndFileToRequest, addLocalesToRequest } from '@payloadcms/next/utilities'
 import httpStatus from 'http-status'
 
-export const handler: PayloadHandler = async ({ payload, data, user }) => {
+export const handler: PayloadHandler = async (req) => {
+  await addDataAndFileToRequest({ request: req })
+  addLocalesToRequest({ request: req })
+
+  const { data, payload, user } = req
   const operation = String(data.operation)
 
   if (typeof payload[operation] === 'function') {

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -43,7 +43,7 @@ import {
 } from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
-import { reInitializeDB } from '../helpers/reInit.js'
+import { reInitializeDB } from '../helpers/reInitializeDB.js'
 import { POLL_TOPASS_TIMEOUT } from '../playwright.config.js'
 import { titleToDelete } from './shared.js'
 import {


### PR DESCRIPTION
feat!: removed getDataAndFile and getLocales from createPayloadRequest in favour of new utilities addDataAndFileToRequest and addLocalesToRequest


- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Breaking change:

Custom handlers will no longer resolve `data`, `locale` and `fallbackLocale` for you. Instead you can use our provided utilities from the `next` package

```ts
// ❌ Before
{
  path: '/whoami/:parameter',
  method: 'post',
  handler: async (req) => {
    return Response.json({
      name: req.data.name, // data will be undefined
      // locales will be undefined
      fallbackLocale: req.fallbackLocale,
      locale: req.locale,
    })
  }
} 

// ✅ After
import { addDataAndFileToRequest } from '@payloadcms/next/utilities'
import { addLocalesToRequest } from '@payloadcms/next/utilities'

{
  path: '/whoami/:parameter',
  method: 'post',
  handler: async (req) => {
    // mutates req, must be awaited
    await addDataAndFileToRequest(req)
    
    // mutates req
    addLocalesToRequest(req)
	  
    return Response.json({
      name: req.data.name, // data is now available
      fallbackLocale: req.fallbackLocale, // locales available
      locale: req.locale,
    })
  }
} 
```
