### PR TITLE
chore: upload ci test

### DIFF
--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -253,7 +253,6 @@ describe('uploads', () => {
   })
 
   test('Should render adminThumbnail when using a function', async () => {
-    await page.reload() // Flakey test, it likely has to do with the test that comes before it. Trace viewer is not helpful when it fails.
     await page.goto(adminThumbnailFunctionURL.list)
     await page.waitForURL(adminThumbnailFunctionURL.list)
 

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -250,6 +250,10 @@ describe('uploads', () => {
     await expect(page.locator('.Toastify .Toastify__toast--error')).toContainText(
       'File size limit has been reached',
     )
+
+    // Works around Playwright issue. Future `page.goto` calls hanging.
+    // Behavior has to do with a Next Layout stylesheet Request never responding.
+    await wait(5000) // do not remove
   })
 
   test('Should render adminThumbnail when using a function', async () => {


### PR DESCRIPTION
## Description

To reproduce the issue, you would need to remove the `wait` and run the debugger with these 4 tests selected:

![CleanShot 2024-04-25 at 11  13 38](https://github.com/payloadcms/payload/assets/30633324/2937a53b-a302-46d8-a41d-eea3df7fe457)

Everything works when you do this locally, even when performing the task _very quickly_.

It looks like Playwright is hanging when attempting to serve a specific layout.css file **_only_** after attempting to upload a file that triggers an, expected (and handled), 413 Response.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)