### PR TITLE
fix: bulk publish

### DIFF
--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -276,7 +276,7 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
         // Update
         // /////////////////////////////////////
 
-        if (!shouldSaveDraft) {
+        if (!shouldSaveDraft || data._status === 'published') {
           result = await req.payload.db.updateOne({
             id,
             collection: collectionConfig.slug,

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -262,7 +262,7 @@ async function updateByID<TSlug extends keyof GeneratedTypes['collections']>(
     // Update
     // /////////////////////////////////////
 
-    if (!shouldSaveDraft) {
+    if (!shouldSaveDraft || data._status === 'published') {
       result = await req.payload.db.updateOne({
         id,
         collection: collectionConfig.slug,

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -529,9 +529,11 @@ describe('Versions', () => {
           },
         })
 
+        // bulk publish
         const updated = await payload.update({
           collection: draftCollectionSlug,
           data: {
+            _status: 'published',
             description: 'updated description',
           },
           draft: true,
@@ -544,8 +546,20 @@ describe('Versions', () => {
 
         const updatedDoc = updated.docs?.[0]
 
+        // get the published doc
+        const findResult = await payload.find({
+          collection: draftCollectionSlug,
+          where: {
+            id: { equals: doc.id },
+          },
+        })
+
+        const findDoc = findResult.docs?.[0]
+
         expect(updatedDoc.description).toStrictEqual('updated description')
-        expect(updatedDoc.title).toStrictEqual('updated title') // probably will fail
+        expect(updatedDoc.title).toStrictEqual('updated title')
+        expect(findDoc.title).toStrictEqual('updated title')
+        expect(findDoc.description).toStrictEqual('updated description')
       })
     })
 

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -437,6 +437,7 @@ describe('Versions', () => {
           collection,
           data: {
             title: patchedTitle,
+            _status: 'draft',
           },
           draft: true,
           locale: 'en',
@@ -450,6 +451,7 @@ describe('Versions', () => {
           collection,
           data: {
             title: spanishTitle,
+            _status: 'draft',
           },
           draft: true,
           locale: 'es',
@@ -1250,6 +1252,7 @@ describe('Versions', () => {
         await payload.updateGlobal({
           slug: globalSlug,
           data: {
+            _status: 'draft',
             title: updatedTitle2,
           },
           draft: true,
@@ -1259,6 +1262,7 @@ describe('Versions', () => {
         await payload.updateGlobal({
           slug: globalSlug,
           data: {
+            _status: 'draft',
             title: updatedTitle2,
           },
           draft: true,


### PR DESCRIPTION
## Description

Some tests had to be changed in order to match the intended functionality of how drafts and `_status`. This may seem unexpected at first. The issue is that the `draft` arg alone is not sufficient in telling Payload's update and updateByID operations that you are saving as a draft.

Note: you may need to improve any payload local API calls to include `_status: 'published'` or `_status: 'draft'`. Previously a document saved with `draft: true` would not make write to the collection even if `_status: 'published'` was in the data of the request.

fixes #5977 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
