### PR TITLE
chore: return valid as true if no validation function provided

### DIFF
--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -9,7 +9,7 @@ import { FieldLabel } from '@payloadcms/ui/forms/FieldLabel'
 import { useFieldProps } from '@payloadcms/ui/forms/FieldPropsProvider'
 import { useField } from '@payloadcms/ui/forms/useField'
 import { withCondition } from '@payloadcms/ui/forms/withCondition'
-import React, { useCallback } from 'react'
+import React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import type { SanitizedClientEditorConfig } from './lexical/config/types.js'
@@ -47,23 +47,11 @@ const _RichText: React.FC<
     width,
   } = props
 
-  const memoizedValidate = useCallback(
-    (value, validationOptions) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...validationOptions, props, required })
-      }
-      return true
-    },
-    // Important: do not add props to the dependencies array.
-    // This would cause an infinite loop and endless re-rendering.
-    // Removing props from the dependencies array fixed this issue: https://github.com/payloadcms/payload/issues/3709
-    [validate, required],
-  )
   const { path: pathFromContext } = useFieldProps()
 
   const fieldType = useField<SerializedEditorState>({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const { initialValue, path, setValue, showError, value } = fieldType

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -52,6 +52,7 @@ const _RichText: React.FC<
       if (typeof validate === 'function') {
         return validate(value, { ...validationOptions, props, required })
       }
+      return true
     },
     // Important: do not add props to the dependencies array.
     // This would cause an infinite loop and endless re-rendering.
@@ -65,7 +66,7 @@ const _RichText: React.FC<
     validate: memoizedValidate,
   })
 
-  const { errorMessage, initialValue, path, schemaPath, setValue, showError, value } = fieldType
+  const { initialValue, path, setValue, showError, value } = fieldType
 
   const classes = [
     baseClass,

--- a/packages/richtext-slate/src/field/RichText.tsx
+++ b/packages/richtext-slate/src/field/RichText.tsx
@@ -99,6 +99,7 @@ const RichTextField: React.FC<
           required,
         })
       }
+      return true
     },
     [validate, required, i18n],
   )

--- a/packages/richtext-slate/src/field/RichText.tsx
+++ b/packages/richtext-slate/src/field/RichText.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { FormFieldBase } from '@payloadcms/ui/fields/shared'
-import type { ClientValidate, FieldBase } from 'payload/types'
+import type { FieldBase } from 'payload/types'
 import type { BaseEditor, BaseOperation } from 'slate'
 import type { HistoryEditor } from 'slate-history'
 import type { ReactEditor } from 'slate-react'
@@ -25,7 +25,6 @@ import type { ElementNode, RichTextPlugin, TextNode } from '../types.js'
 import type { EnabledFeatures } from './types.js'
 
 import { defaultRichTextValue } from '../data/defaultValue.js'
-import { richTextValidate } from '../data/validation.js'
 import { listTypes } from './elements/listTypes.js'
 import { hotkeys } from './hotkeys.js'
 import './index.scss'
@@ -77,7 +76,7 @@ const RichTextField: React.FC<
     readOnly,
     required,
     style,
-    validate = richTextValidate,
+    validate,
     width,
   } = props
 
@@ -88,27 +87,11 @@ const RichTextField: React.FC<
   const drawerDepth = useEditDepth()
   const drawerIsOpen = drawerDepth > 1
 
-  const memoizedValidate: ClientValidate = useCallback(
-    (value, validationOptions) => {
-      if (typeof validate === 'function') {
-        return validate(value, {
-          ...validationOptions,
-          req: {
-            t: i18n.t,
-          },
-          required,
-        })
-      }
-      return true
-    },
-    [validate, required, i18n],
-  )
-
   const { path: pathFromContext } = useFieldProps()
 
   const { initialValue, path, schemaPath, setValue, showError, value } = useField({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const editor = useMemo(() => {

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -99,20 +99,6 @@ export const _ArrayField: React.FC<ArrayFieldProps> = (props) => {
 
   const labels = getLabels(props)
 
-  const memoizedValidate = useCallback(
-    (value, options) => {
-      // alternative locales can be null
-      if (!editingDefaultLocale && value === null) {
-        return true
-      }
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, maxRows, minRows, required })
-      }
-      return true
-    },
-    [maxRows, minRows, required, validate, editingDefaultLocale],
-  )
-
   const { path: pathFromContext } = useFieldProps()
 
   const {
@@ -126,7 +112,7 @@ export const _ArrayField: React.FC<ArrayFieldProps> = (props) => {
   } = useField<number>({
     hasRows: true,
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const addRow = useCallback(

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -108,6 +108,7 @@ export const _ArrayField: React.FC<ArrayFieldProps> = (props) => {
       if (typeof validate === 'function') {
         return validate(value, { ...options, maxRows, minRows, required })
       }
+      return true
     },
     [maxRows, minRows, required, validate, editingDefaultLocale],
   )

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -100,20 +100,6 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
     return true
   })()
 
-  const memoizedValidate = useCallback(
-    (value, options) => {
-      // alternative locales can be null
-      if (!editingDefaultLocale && value === null) {
-        return true
-      }
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, maxRows, minRows, required })
-      }
-      return true
-    },
-    [maxRows, minRows, required, validate, editingDefaultLocale],
-  )
-
   const { path: pathFromContext } = useFieldProps()
 
   const {
@@ -128,7 +114,7 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
   } = useField<number>({
     hasRows: true,
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const addRow = useCallback(

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -109,6 +109,7 @@ const _BlocksField: React.FC<BlocksFieldProps> = (props) => {
       if (typeof validate === 'function') {
         return validate(value, { ...options, maxRows, minRows, required })
       }
+      return true
     },
     [maxRows, minRows, required, validate, editingDefaultLocale],
   )

--- a/packages/ui/src/fields/Checkbox/index.tsx
+++ b/packages/ui/src/fields/Checkbox/index.tsx
@@ -53,6 +53,7 @@ const CheckboxField: React.FC<CheckboxFieldProps> = (props) => {
       if (typeof validate === 'function') {
         return validate(value, { ...options, required })
       }
+      return true
     },
     [validate, required],
   )

--- a/packages/ui/src/fields/Checkbox/index.tsx
+++ b/packages/ui/src/fields/Checkbox/index.tsx
@@ -48,23 +48,13 @@ const CheckboxField: React.FC<CheckboxFieldProps> = (props) => {
 
   const { uuid } = useForm()
 
-  const memoizedValidate: ClientValidate = useCallback(
-    (value, options) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, required })
-      }
-      return true
-    },
-    [validate, required],
-  )
-
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
 
   const { path, setValue, showError, value } = useField({
     disableFormData,
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const onToggle = useCallback(() => {

--- a/packages/ui/src/fields/Code/index.tsx
+++ b/packages/ui/src/fields/Code/index.tsx
@@ -60,6 +60,7 @@ const CodeField: React.FC<CodeFieldProps> = (props) => {
       if (typeof validate === 'function') {
         return validate(value, { ...options, required })
       }
+      return true
     },
     [validate, required],
   )

--- a/packages/ui/src/fields/Code/index.tsx
+++ b/packages/ui/src/fields/Code/index.tsx
@@ -6,7 +6,7 @@ import { FieldDescription } from '@payloadcms/ui/forms/FieldDescription'
 import { FieldError } from '@payloadcms/ui/forms/FieldError'
 import { FieldLabel } from '@payloadcms/ui/forms/FieldLabel'
 import { useFieldProps } from '@payloadcms/ui/forms/FieldPropsProvider'
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import type { FormFieldBase } from '../shared/index.js'
 
@@ -55,22 +55,12 @@ const CodeField: React.FC<CodeFieldProps> = (props) => {
     width,
   } = props
 
-  const memoizedValidate = useCallback(
-    (value, options) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, required })
-      }
-      return true
-    },
-    [validate, required],
-  )
-
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
 
   const { path, setValue, showError, value } = useField({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   return (

--- a/packages/ui/src/fields/DateTime/index.tsx
+++ b/packages/ui/src/fields/DateTime/index.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable react/destructuring-assignment */
 'use client'
-import type { ClientValidate } from 'payload/types'
 
 import { getTranslation } from '@payloadcms/translations'
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import { DatePickerField } from '../../elements/DatePicker/index.js'
 import { FieldLabel } from '../../forms/FieldLabel/index.js'
@@ -58,21 +57,11 @@ const DateTimeField: React.FC<DateFieldProps> = (props) => {
 
   const { i18n } = useTranslation()
 
-  const memoizedValidate: ClientValidate = useCallback(
-    (value, options) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, required })
-      }
-      return true
-    },
-    [validate, required],
-  )
-
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
 
   const { path, setValue, showError, value } = useField<Date>({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const readOnly = readOnlyFromProps || readOnlyFromContext

--- a/packages/ui/src/fields/DateTime/index.tsx
+++ b/packages/ui/src/fields/DateTime/index.tsx
@@ -63,6 +63,7 @@ const DateTimeField: React.FC<DateFieldProps> = (props) => {
       if (typeof validate === 'function') {
         return validate(value, { ...options, required })
       }
+      return true
     },
     [validate, required],
   )

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -58,8 +58,10 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
 
   const memoizedValidate: ClientValidate = useCallback(
     (value, options) => {
-      if (typeof validate === 'function')
+      if (typeof validate === 'function') {
         return validate(value, { ...options, jsonError, required })
+      }
+      return true
     },
     [validate, required, jsonError],
   )

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { ClientValidate } from 'payload/types'
 
 import React, { useCallback, useEffect, useState } from 'react'
 
@@ -53,25 +52,14 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
   } = props
 
   const [stringValue, setStringValue] = useState<string>()
-  const [jsonError, setJsonError] = useState<string>()
   const [hasLoadedValue, setHasLoadedValue] = useState(false)
-
-  const memoizedValidate: ClientValidate = useCallback(
-    (value, options) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, jsonError, required })
-      }
-      return true
-    },
-    [validate, required, jsonError],
-  )
 
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
 
   const { initialValue, path, setValue, showError, value } = useField<string>({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const handleMount = useCallback(
@@ -100,10 +88,8 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
 
       try {
         setValue(val ? JSON.parse(val) : null)
-        setJsonError(undefined)
       } catch (e) {
         setValue(val ? val : null)
-        setJsonError(e)
       }
     },
     [readOnly, setValue, setStringValue],

--- a/packages/ui/src/fields/Number/index.tsx
+++ b/packages/ui/src/fields/Number/index.tsx
@@ -69,6 +69,7 @@ const NumberFieldComponent: React.FC<NumberFieldProps> = (props) => {
       if (typeof validate === 'function') {
         return validate(value, { ...options, max, min, required })
       }
+      return true
     },
     [validate, min, max, required],
   )

--- a/packages/ui/src/fields/Number/index.tsx
+++ b/packages/ui/src/fields/Number/index.tsx
@@ -64,22 +64,12 @@ const NumberFieldComponent: React.FC<NumberFieldProps> = (props) => {
 
   const { i18n, t } = useTranslation()
 
-  const memoizedValidate = useCallback(
-    (value, options) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, max, min, required })
-      }
-      return true
-    },
-    [validate, min, max, required],
-  )
-
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
 
   const { path, setValue, showError, value } = useField<number | number[]>({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const handleChange = useCallback(

--- a/packages/ui/src/fields/Password/index.tsx
+++ b/packages/ui/src/fields/Password/index.tsx
@@ -1,9 +1,9 @@
 'use client'
-import type { ClientValidate, Description, Validate } from 'payload/types'
+import type { Description, Validate } from 'payload/types'
 
 import { FieldError } from '@payloadcms/ui/forms/FieldError'
 import { FieldLabel } from '@payloadcms/ui/forms/FieldLabel'
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import type { FormFieldBase } from '../shared/index.js'
 
@@ -44,19 +44,9 @@ const PasswordField: React.FC<PasswordFieldProps> = (props) => {
     width,
   } = props
 
-  const memoizedValidate: ClientValidate = useCallback(
-    (value, options) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, required })
-      }
-      return true
-    },
-    [validate, required],
-  )
-
   const { formProcessing, path, setValue, showError, value } = useField({
     path: pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   return (

--- a/packages/ui/src/fields/Password/index.tsx
+++ b/packages/ui/src/fields/Password/index.tsx
@@ -49,6 +49,7 @@ const PasswordField: React.FC<PasswordFieldProps> = (props) => {
       if (typeof validate === 'function') {
         return validate(value, { ...options, required })
       }
+      return true
     },
     [validate, required],
   )

--- a/packages/ui/src/fields/Point/index.tsx
+++ b/packages/ui/src/fields/Point/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/destructuring-assignment */
 'use client'
-import type { ClientValidate, FieldBase } from 'payload/types'
+import type { FieldBase } from 'payload/types'
 
 import { getTranslation } from '@payloadcms/translations'
 import React, { useCallback } from 'react'
@@ -44,7 +44,6 @@ const PointField: React.FC<PointFieldProps> = (props) => {
     path: pathFromProps,
     placeholder,
     readOnly: readOnlyFromProps,
-    required,
     step,
     style,
     validate,
@@ -52,16 +51,6 @@ const PointField: React.FC<PointFieldProps> = (props) => {
   } = props
 
   const { i18n, t } = useTranslation()
-
-  const memoizedValidate: ClientValidate = useCallback(
-    (value, options) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, required })
-      }
-      return true
-    },
-    [validate, required],
-  )
 
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
@@ -73,7 +62,7 @@ const PointField: React.FC<PointFieldProps> = (props) => {
     value = [null, null],
   } = useField<[number, number]>({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const handleChange = useCallback(

--- a/packages/ui/src/fields/Point/index.tsx
+++ b/packages/ui/src/fields/Point/index.tsx
@@ -58,6 +58,7 @@ const PointField: React.FC<PointFieldProps> = (props) => {
       if (typeof validate === 'function') {
         return validate(value, { ...options, required })
       }
+      return true
     },
     [validate, required],
   )

--- a/packages/ui/src/fields/RadioGroup/index.tsx
+++ b/packages/ui/src/fields/RadioGroup/index.tsx
@@ -62,8 +62,10 @@ const RadioGroupField: React.FC<RadioFieldProps> = (props) => {
 
   const memoizedValidate = useCallback(
     (value, validationOptions) => {
-      if (typeof validate === 'function')
+      if (typeof validate === 'function') {
         return validate(value, { ...validationOptions, options, required })
+      }
+      return true
     },
     [validate, options, required],
   )

--- a/packages/ui/src/fields/RadioGroup/index.tsx
+++ b/packages/ui/src/fields/RadioGroup/index.tsx
@@ -4,7 +4,7 @@
 import type { FieldBase, Option } from 'payload/types'
 
 import { optionIsObject } from 'payload/types'
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import { FieldLabel } from '../../forms/FieldLabel/index.js'
 import { useForm } from '../../forms/Form/context.js'
@@ -60,16 +60,6 @@ const RadioGroupField: React.FC<RadioFieldProps> = (props) => {
 
   const { uuid } = useForm()
 
-  const memoizedValidate = useCallback(
-    (value, validationOptions) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...validationOptions, options, required })
-      }
-      return true
-    },
-    [validate, options, required],
-  )
-
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
 
@@ -80,7 +70,7 @@ const RadioGroupField: React.FC<RadioFieldProps> = (props) => {
     value: valueFromContext,
   } = useField<string>({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const value = valueFromContext || valueFromProps

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -89,6 +89,7 @@ const RelationshipField: React.FC<RelationshipFieldProps> = (props) => {
       if (typeof validate === 'function') {
         return validate(value, { ...validationOptions, required })
       }
+      return true
     },
     [validate, required],
   )

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -84,15 +84,6 @@ const RelationshipField: React.FC<RelationshipFieldProps> = (props) => {
   const menuIsOpen = useRef(false)
   const hasLoadedFirstPageRef = useRef(false)
 
-  const memoizedValidate = useCallback(
-    (value, validationOptions) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...validationOptions, required })
-      }
-      return true
-    },
-    [validate, required],
-  )
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
 
@@ -100,7 +91,7 @@ const RelationshipField: React.FC<RelationshipFieldProps> = (props) => {
     Value | Value[]
   >({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const valueRef = useRef(value)

--- a/packages/ui/src/fields/Select/index.tsx
+++ b/packages/ui/src/fields/Select/index.tsx
@@ -75,8 +75,10 @@ const SelectField: React.FC<SelectFieldProps> = (props) => {
 
   const memoizedValidate: ClientValidate = useCallback(
     (value, validationOptions) => {
-      if (typeof validate === 'function')
+      if (typeof validate === 'function') {
         return validate(value, { ...validationOptions, hasMany, options, required })
+      }
+      return true
     },
     [validate, required, hasMany, options],
   )

--- a/packages/ui/src/fields/Select/index.tsx
+++ b/packages/ui/src/fields/Select/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/destructuring-assignment */
 'use client'
-import type { ClientValidate, FieldBase, Option, OptionObject } from 'payload/types'
+import type { FieldBase, Option, OptionObject } from 'payload/types'
 
 import { getTranslation } from '@payloadcms/translations'
 import { FieldDescription } from '@payloadcms/ui/forms/FieldDescription'
@@ -73,22 +73,12 @@ const SelectField: React.FC<SelectFieldProps> = (props) => {
 
   const [options] = useState(formatOptions(optionsFromProps))
 
-  const memoizedValidate: ClientValidate = useCallback(
-    (value, validationOptions) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...validationOptions, hasMany, options, required })
-      }
-      return true
-    },
-    [validate, required, hasMany, options],
-  )
-
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
 
   const { path, setValue, showError, value } = useField({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   let valueToRender

--- a/packages/ui/src/fields/Text/index.tsx
+++ b/packages/ui/src/fields/Text/index.tsx
@@ -53,8 +53,10 @@ const TextField: React.FC<TextFieldProps> = (props) => {
 
   const memoizedValidate: ClientValidate = useCallback(
     (value, options) => {
-      if (typeof validate === 'function')
+      if (typeof validate === 'function') {
         return validate(value, { ...options, maxLength, minLength, required })
+      }
+      return true
     },
     [validate, minLength, maxLength, required],
   )

--- a/packages/ui/src/fields/Text/index.tsx
+++ b/packages/ui/src/fields/Text/index.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { ClientValidate } from 'payload/types'
 import type {} from 'payload/types'
 
 import { useFieldProps } from '@payloadcms/ui/forms/FieldPropsProvider'
@@ -33,9 +32,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
     inputRef,
     labelProps,
     localized,
-    maxLength,
     maxRows,
-    minLength,
     minRows,
     path: pathFromProps,
     placeholder,
@@ -51,22 +48,12 @@ const TextField: React.FC<TextFieldProps> = (props) => {
 
   const { localization: localizationConfig } = useConfig()
 
-  const memoizedValidate: ClientValidate = useCallback(
-    (value, options) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, maxLength, minLength, required })
-      }
-      return true
-    },
-    [validate, minLength, maxLength, required],
-  )
-
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
 
   const { formProcessing, path, setValue, showError, value } = useField({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   const renderRTL = isFieldRTL({

--- a/packages/ui/src/fields/Textarea/index.tsx
+++ b/packages/ui/src/fields/Textarea/index.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable react/destructuring-assignment */
 'use client'
-import type { ClientValidate } from 'payload/types'
-
 import { getTranslation } from '@payloadcms/translations'
 import { useFieldProps } from '@payloadcms/ui/forms/FieldPropsProvider'
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import type { TextAreaInputProps, TextareaFieldProps } from './types.js'
 
@@ -32,8 +30,6 @@ const TextareaField: React.FC<TextareaFieldProps> = (props) => {
     labelProps,
     locale,
     localized,
-    maxLength,
-    minLength,
     path: pathFromProps,
     placeholder,
     readOnly: readOnlyFromProps,
@@ -56,22 +52,12 @@ const TextareaField: React.FC<TextareaFieldProps> = (props) => {
     localizationConfig: localization || undefined,
   })
 
-  const memoizedValidate: ClientValidate = useCallback(
-    (value, options) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, maxLength, minLength, required })
-      }
-      return true
-    },
-    [validate, required, maxLength, minLength],
-  )
-
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
 
   const { path, setValue, showError, value } = useField<string>({
     path: pathFromContext || pathFromProps || name,
-    validate: memoizedValidate,
+    validate,
   })
 
   return (

--- a/packages/ui/src/fields/Textarea/index.tsx
+++ b/packages/ui/src/fields/Textarea/index.tsx
@@ -58,8 +58,10 @@ const TextareaField: React.FC<TextareaFieldProps> = (props) => {
 
   const memoizedValidate: ClientValidate = useCallback(
     (value, options) => {
-      if (typeof validate === 'function')
+      if (typeof validate === 'function') {
         return validate(value, { ...options, maxLength, minLength, required })
+      }
+      return true
     },
     [validate, required, maxLength, minLength],
   )

--- a/packages/ui/src/fields/Upload/index.tsx
+++ b/packages/ui/src/fields/Upload/index.tsx
@@ -46,6 +46,7 @@ const _Upload: React.FC<UploadFieldProps> = (props) => {
       if (typeof validate === 'function') {
         return validate(value, { ...options, required })
       }
+      return true
     },
     [validate, required],
   )

--- a/packages/ui/src/fields/Upload/index.tsx
+++ b/packages/ui/src/fields/Upload/index.tsx
@@ -41,22 +41,12 @@ const _Upload: React.FC<UploadFieldProps> = (props) => {
 
   const collection = collections.find((coll) => coll.slug === relationTo)
 
-  const memoizedValidate = useCallback(
-    (value, options) => {
-      if (typeof validate === 'function') {
-        return validate(value, { ...options, required })
-      }
-      return true
-    },
-    [validate, required],
-  )
-
   const { path: pathFromContext, readOnly: readOnlyFromContext } = useFieldProps()
   const readOnly = readOnlyFromProps || readOnlyFromContext
 
   const { filterOptions, path, setValue, showError, value } = useField<string>({
     path: pathFromContext || pathFromProps,
-    validate: memoizedValidate,
+    validate,
   })
 
   const onChange = useCallback(


### PR DESCRIPTION
## Description

Previously, if no validation function was passed in, many of these would return undefined when called. This causes issues inside the useField hook where it runs the validation function and `isValid` evaluates to `undefined`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
