### PR TITLE
fix: disable api key checkbox does not remove api key

### DIFF
--- a/packages/payload/src/admin/components/views/collections/Edit/Auth/APIKey.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Auth/APIKey.tsx
@@ -7,14 +7,14 @@ import CopyToClipboard from '../../../../elements/CopyToClipboard'
 import GenerateConfirmation from '../../../../elements/GenerateConfirmation'
 import { useFormFields } from '../../../../forms/Form/context'
 import Label from '../../../../forms/Label'
-import useField from '../../../../forms/useField'
 import { fieldBaseClass } from '../../../../forms/field-types/shared'
+import useField from '../../../../forms/useField'
 
 const path = 'apiKey'
 const baseClass = 'api-key'
 
-const APIKey: React.FC<{ readOnly?: boolean }> = ({ readOnly }) => {
-  const [initialAPIKey, setInitialAPIKey] = useState(null)
+const APIKey: React.FC<{ enabled: boolean; readOnly?: boolean }> = ({ enabled, readOnly }) => {
+  const [initialAPIKey] = useState(uuidv4())
   const [highlightedField, setHighlightedField] = useState(false)
   const { t } = useTranslation()
 
@@ -51,14 +51,13 @@ const APIKey: React.FC<{ readOnly?: boolean }> = ({ readOnly }) => {
   const { setValue, value } = fieldType
 
   useEffect(() => {
-    setInitialAPIKey(uuidv4())
-  }, [])
-
-  useEffect(() => {
-    if (!apiKeyValue) {
+    if (!apiKeyValue && enabled) {
       setValue(initialAPIKey)
     }
-  }, [apiKeyValue, setValue, initialAPIKey])
+    if (!enabled) {
+      setValue(null)
+    }
+  }, [apiKeyValue, enabled, setValue, initialAPIKey])
 
   useEffect(() => {
     if (highlightedField) {
@@ -67,6 +66,10 @@ const APIKey: React.FC<{ readOnly?: boolean }> = ({ readOnly }) => {
       }, 10000)
     }
   }, [highlightedField])
+
+  if (!enabled) {
+    return null
+  }
 
   return (
     <React.Fragment>

--- a/packages/payload/src/admin/components/views/collections/Edit/Auth/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Auth/index.tsx
@@ -145,7 +145,7 @@ const Auth: React.FC<Props> = (props) => {
       {useAPIKey && (
         <div className={`${baseClass}__api-key`}>
           <Checkbox admin={{ readOnly }} label={t('enableAPIKey')} name="enableAPIKey" />
-          {enableAPIKey?.value && <APIKey readOnly={readOnly} />}
+          <APIKey enabled={!!enableAPIKey?.value} readOnly={readOnly} />
         </div>
       )}
       {verify && <Checkbox admin={{ readOnly }} label={t('verified')} name="_verified" />}

--- a/packages/payload/src/auth/baseFields/apiKey.ts
+++ b/packages/payload/src/auth/baseFields/apiKey.ts
@@ -20,7 +20,6 @@ export default [
         Field: () => null,
       },
     },
-    defaultValue: false,
     label: labels['authentication:enableAPIKey'],
   },
   {
@@ -46,15 +45,18 @@ export default [
     hidden: true,
     hooks: {
       beforeValidate: [
-        async ({ data, req, value }) => {
+        ({ data, req, value }) => {
+          if (data.apiKey === false || data.apiKey === null) {
+            return null
+          }
+          if (data.enableAPIKey === false || data.enableAPIKey === null) {
+            return null
+          }
           if (data.apiKey) {
             return crypto
               .createHmac('sha1', req.payload.secret)
               .update(data.apiKey as string)
               .digest('hex')
-          }
-          if (data.enableAPIKey === false) {
-            return null
           }
           return value
         },

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test'
 
 import { expect, test } from '@playwright/test'
+import { v4 as uuid } from 'uuid'
 
 import payload from '../../packages/payload/src'
 import { initPageConsoleErrorCatch, login, saveDocAndAssert } from '../helpers'
@@ -82,6 +83,7 @@ describe('auth', () => {
       user = await payload.create({
         collection: apiKeysSlug,
         data: {
+          apiKey: uuid(),
           enableAPIKey: true,
         },
       })
@@ -117,7 +119,7 @@ describe('auth', () => {
       const response = await fetch(`${apiURL}/${apiKeysSlug}/me`, {
         headers: {
           ...headers,
-          Authorization: `${slug} API-Key ${user.apiKey}`,
+          Authorization: `${apiKeysSlug} API-Key ${user.apiKey}`,
         },
       }).then((res) => res.json())
 


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/5742

The checkbox to disable API Keys did not clear the `apiKey` from form state. The request on save after unchecking still had it.
![image](https://github.com/payloadcms/payload/assets/6434612/22224851-51c1-4820-a010-be25b892335b)

This change makes it so that apiKey is sent to the API as `null` so that it can be properly saved without a key.
The e2e test associated with the feature was passing because it didn't properly send the apiKey to test against in the /me route 🤦.

I've also changed the API Key index hook so that local operations passing data respect the request moving forward. The following scenarios will result in a usable API Key:
- `data: { apiKey: '0987654321 }'
- `data: { apiKey: '0987654321', enableAPIKey: true }`

Updates made with the following will prevent the API key auth strategy for the user:
- `data: { apiKey: '0987654321', enableAPIKey: false }
- `data: { apiKey: '0987654321', enableAPIKey: null }
- `data: { enableAPIKey: false }`
- `data: { enableAPIKey: null }`
- `data: { apiKey: false }`
- `data: { apiKey: null }`

End result:
![image](https://github.com/payloadcms/payload/assets/6434612/72e1bea3-e043-4f4a-b4c1-adc0b282e7fa)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
