### PR TITLE
fix bug with forEach reference in uploads

### DIFF
--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -55,7 +55,7 @@ export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promis
 
 function headersToObject(headers) {
   const headersObj = {}
-  headers.forEach((value, key) => {
+  Object.entries(headers).forEach(([key, value]) => {
     // If the header value is an array, join its elements into a single string
     if (Array.isArray(value)) {
       headersObj[key] = value.join(', ')


### PR DESCRIPTION
## Description

fixes remaining bug in editing uploads as described in https://github.com/payloadcms/payload/issues/5159. Bug was introduced in https://github.com/payloadcms/payload/pull/5862

Currently getting error when attempting to edit an upload:

```text
TypeError: headers.forEach is not a function
    at uploadConfig (/Users/benebsworth/projects/shorted/cms/node_modules/payload/src/uploads/getExternalFile.ts:59:5)
    at getExternalFile
...
```

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works (manually tested with locally applied patch)
- [x] Existing test suite passes locally with my changes
