### PR TITLE
fix(db-postgres): postgres version id bug

### DIFF
--- a/packages/db-postgres/src/createVersion.ts
+++ b/packages/db-postgres/src/createVersion.ts
@@ -25,13 +25,16 @@ export async function createVersion<T extends TypeWithID>(
 
   const tableName = this.tableNameMap.get(`_${defaultTableName}${this.versionsSuffix}`)
 
+  const version = { ...versionData }
+  if (version.id) delete version.id
+
   const result = await upsertRow<TypeWithVersion<T>>({
     adapter: this,
     data: {
       autosave,
       latest: true,
       parent,
-      version: versionData,
+      version,
     },
     db,
     fields: buildVersionCollectionFields(collection),

--- a/packages/db-postgres/src/schema/traverseFields.ts
+++ b/packages/db-postgres/src/schema/traverseFields.ts
@@ -250,7 +250,6 @@ export const traverseFields = ({
             parentTableName: newTableName,
             prefix: `${newTableName}_`,
             throwValidationError,
-            versionsCustomName: versions,
           })
           const baseColumns: Record<string, PgColumnBuilder> = {
             order: integer('order').notNull(),


### PR DESCRIPTION
## Description

Fixes an issue where `id`s were passed into `createVersion` data, which were incorrectly being used to create nested table rows like `hasMany` select fields.