### PR TITLE
fix(db-postgres): use locales suffix

### DIFF
--- a/packages/db-postgres/src/find/buildFindManyArgs.ts
+++ b/packages/db-postgres/src/find/buildFindManyArgs.ts
@@ -53,7 +53,7 @@ export const buildFindManyArgs = ({
     }
   }
 
-  if (adapter.tables[`${tableName}_rels`]) {
+  if (adapter.tables[`${tableName}${adapter.relationshipsSuffix}`]) {
     result.with._rels = {
       columns: {
         id: false,
@@ -63,7 +63,7 @@ export const buildFindManyArgs = ({
     }
   }
 
-  if (adapter.tables[`${tableName}_locales`]) {
+  if (adapter.tables[`${tableName}${adapter.localesSuffix}`]) {
     result.with._locales = _locales
   }
 

--- a/packages/db-postgres/src/upsertRow/insertArrays.ts
+++ b/packages/db-postgres/src/upsertRow/insertArrays.ts
@@ -71,9 +71,9 @@ export const insertArrays = async ({ adapter, arrays, db, parentRows }: Args): P
     }
 
     // Insert locale rows
-    if (adapter.tables[`${tableName}_locales`] && row.locales.length > 0) {
+    if (adapter.tables[`${tableName}${adapter.localesSuffix}`] && row.locales.length > 0) {
       if (!row.locales[0]._parentID) {
-        row.locales = row.locales.map((localeRow, i) => {
+        row.locales = row.locales.map((localeRow) => {
           if (typeof localeRow._getParentID === 'function') {
             localeRow._parentID = localeRow._getParentID(insertedRows)
             delete localeRow._getParentID
@@ -81,7 +81,10 @@ export const insertArrays = async ({ adapter, arrays, db, parentRows }: Args): P
           return localeRow
         })
       }
-      await db.insert(adapter.tables[`${tableName}_locales`]).values(row.locales).returning()
+      await db
+        .insert(adapter.tables[`${tableName}${adapter.localesSuffix}`])
+        .values(row.locales)
+        .returning()
     }
 
     // If there are sub arrays, call this function recursively


### PR DESCRIPTION
In a few places we were not using localesSuffix and relationshipSuffix and instead only had the old hard-coded strings in place.