### PR TITLE
fix: cell component types

### DIFF
--- a/packages/payload/src/admin/components/views/collections/List/Cell/types.ts
+++ b/packages/payload/src/admin/components/views/collections/List/Cell/types.ts
@@ -14,10 +14,10 @@ export type Props = {
   }
 }
 
-export type CellComponentProps<Field = FieldAffectingData | UIField, Data = unknown> = Pick<
-  Props,
-  'collection' | 'rowData'
-> & {
+export type CellComponentProps<
+  Field = FieldAffectingData | UIField,
+  Data = unknown,
+> = Partial<Props> & {
   data: Data
   field: Field
 }


### PR DESCRIPTION
## Description

Closes #5923 

The cell component prop types are incomplete because we are currently using `Pick<>` to add `'collection' | 'rowData'` from the cell props, we should use `Partial<>` instead so any cell prop type can be accessed (but is not required).

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Chore (non-breaking change which does not add functionality)

## Checklist:

- [X] Existing test suite passes locally with my changes