### PR TITLE
Release live-preview in beta

### DIFF
--- a/packages/live-preview-react/package.json
+++ b/packages/live-preview-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/live-preview-react",
-  "version": "0.2.0",
+  "version": "3.0.0-beta.18",
   "description": "The official live preview React SDK for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {
@@ -31,7 +31,7 @@
     "prepublishOnly": "pnpm clean && pnpm turbo build"
   },
   "dependencies": {
-    "@payloadcms/live-preview": "workspace:^0.x"
+    "@payloadcms/live-preview": "workspace:*"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",

--- a/packages/live-preview-vue/.swcrc
+++ b/packages/live-preview-vue/.swcrc
@@ -10,6 +10,6 @@
     }
   },
   "module": {
-    "type": "commonjs"
+    "type": "es6"
   }
 }

--- a/packages/live-preview-vue/package.json
+++ b/packages/live-preview-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/live-preview-vue",
-  "version": "0.1.0",
+  "version": "3.0.0-beta.18",
   "description": "The official live preview Vue SDK for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {
@@ -31,7 +31,7 @@
     "prepublishOnly": "pnpm clean && pnpm turbo build"
   },
   "dependencies": {
-    "@payloadcms/live-preview": "workspace:^0.x"
+    "@payloadcms/live-preview": "workspace:*"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payloadcms/live-preview",
-  "version": "0.2.2",
+  "version": "3.0.0-beta.18",
   "description": "The official live preview JavaScript SDK for Payload",
   "homepage": "https://payloadcms.com",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,7 +579,7 @@ importers:
   packages/live-preview-react:
     dependencies:
       '@payloadcms/live-preview':
-        specifier: workspace:^0.x
+        specifier: workspace:*
         version: link:../live-preview
       react:
         specifier: ^18.2.0
@@ -598,7 +598,7 @@ importers:
   packages/live-preview-vue:
     dependencies:
       '@payloadcms/live-preview':
-        specifier: workspace:^0.x
+        specifier: workspace:*
         version: link:../live-preview
     devDependencies:
       '@payloadcms/eslint-config':


### PR DESCRIPTION
## Description

This PR will allow live-preview to be released alongside other betas. Currently, they are stuck on version 0.*, making them unusable in beta as the old plugins still use CommonJS.

I'm not sure that this PR will work, but I hope it provides a foundation so we can get live preview working in 3.0.0 betas. Thanks!

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
