### PR TITLE
chore: version permissions

### DIFF
--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -60,6 +60,7 @@ export const Account: React.FC<AdminViewProps> = ({ initPageResult, params, sear
           config={payload.config}
           hideTabs
           i18n={i18n}
+          permissions={permissions}
         />
         <HydrateClientUser permissions={permissions} user={user} />
         <FormQueryParamsProvider

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -200,6 +200,7 @@ export const Document: React.FC<AdminViewProps> = async ({
           config={payload.config}
           globalConfig={globalConfig}
           i18n={i18n}
+          permissions={permissions}
         />
       )}
       <HydrateClientUser permissions={permissions} user={user} />

--- a/packages/payload/src/admin/elements/Tab.ts
+++ b/packages/payload/src/admin/elements/Tab.ts
@@ -1,5 +1,6 @@
 import type { I18n } from '@payloadcms/translations'
 
+import type { Permissions } from '../../auth/types.js'
 import type { SanitizedCollectionConfig } from '../../collections/config/types.js'
 import type { SanitizedConfig } from '../../config/types.js'
 import type { SanitizedGlobalConfig } from '../../globals/config/types.js'
@@ -10,12 +11,14 @@ export type DocumentTabProps = {
   config: SanitizedConfig
   globalConfig?: SanitizedGlobalConfig
   i18n: I18n
+  permissions: Permissions
 }
 
 export type DocumentTabCondition = (args: {
   collectionConfig: SanitizedCollectionConfig
   config: SanitizedConfig
   globalConfig: SanitizedGlobalConfig
+  permissions: Permissions
 }) => boolean
 
 // Everything is optional because we merge in the defaults

--- a/packages/ui/src/elements/DocumentHeader/Tabs/Tab/index.tsx
+++ b/packages/ui/src/elements/DocumentHeader/Tabs/Tab/index.tsx
@@ -20,6 +20,7 @@ export const DocumentTab: React.FC<DocumentTabProps & DocumentTabConfig> = (prop
     isActive: tabIsActive,
     label,
     newTab,
+    permissions,
   } = props
 
   const { routes } = config
@@ -43,7 +44,8 @@ export const DocumentTab: React.FC<DocumentTabProps & DocumentTabConfig> = (prop
   }
 
   const meetsCondition =
-    !condition || (condition && Boolean(condition({ collectionConfig, config, globalConfig })))
+    !condition ||
+    (condition && Boolean(condition({ collectionConfig, config, globalConfig, permissions })))
 
   if (meetsCondition) {
     const labelToRender =

--- a/packages/ui/src/elements/DocumentHeader/Tabs/index.tsx
+++ b/packages/ui/src/elements/DocumentHeader/Tabs/index.tsx
@@ -1,4 +1,5 @@
 import type { I18n } from '@payloadcms/translations'
+import type { Permissions } from 'payload/auth'
 import type {
   SanitizedCollectionConfig,
   SanitizedConfig,
@@ -22,8 +23,9 @@ export const DocumentTabs: React.FC<{
   config: SanitizedConfig
   globalConfig: SanitizedGlobalConfig
   i18n: I18n
+  permissions: Permissions
 }> = (props) => {
-  const { collectionConfig, config, globalConfig } = props
+  const { collectionConfig, config, globalConfig, permissions } = props
 
   const customViews = getCustomViews({ collectionConfig, globalConfig })
 
@@ -51,7 +53,8 @@ export const DocumentTabs: React.FC<{
 
                 const meetsCondition =
                   !condition ||
-                  (condition && Boolean(condition({ collectionConfig, config, globalConfig })))
+                  (condition &&
+                    Boolean(condition({ collectionConfig, config, globalConfig, permissions })))
 
                 if (meetsCondition) {
                   return (

--- a/packages/ui/src/elements/DocumentHeader/Tabs/tabs/index.tsx
+++ b/packages/ui/src/elements/DocumentHeader/Tabs/tabs/index.tsx
@@ -68,8 +68,13 @@ export const tabs: Record<
   },
   Versions: {
     Pill: VersionsPill,
-    condition: ({ collectionConfig, globalConfig }) =>
-      Boolean(collectionConfig?.versions || globalConfig?.versions),
+    condition: ({ collectionConfig, globalConfig, permissions }) =>
+      Boolean(
+        (collectionConfig?.versions &&
+          permissions?.collections?.[collectionConfig?.slug]?.readVersions?.permission) ||
+          (globalConfig?.versions &&
+            permissions?.globals?.[globalConfig?.slug]?.readVersions?.permission),
+      ),
     href: '/versions',
     label: ({ t }) => t('version:versions'),
     order: 200,

--- a/packages/ui/src/elements/DocumentHeader/index.tsx
+++ b/packages/ui/src/elements/DocumentHeader/index.tsx
@@ -1,4 +1,5 @@
 import type { I18n } from '@payloadcms/translations'
+import type { Permissions } from 'payload/auth'
 import type {
   SanitizedCollectionConfig,
   SanitizedConfig,
@@ -21,8 +22,10 @@ export const DocumentHeader: React.FC<{
   globalConfig?: SanitizedGlobalConfig
   hideTabs?: boolean
   i18n: I18n
+  permissions: Permissions
 }> = (props) => {
-  const { collectionConfig, config, customHeader, globalConfig, hideTabs, i18n } = props
+  const { collectionConfig, config, customHeader, globalConfig, hideTabs, i18n, permissions } =
+    props
 
   return (
     <Gutter className={baseClass}>
@@ -36,6 +39,7 @@ export const DocumentHeader: React.FC<{
               config={config}
               globalConfig={globalConfig}
               i18n={i18n}
+              permissions={permissions}
             />
           )}
         </Fragment>

--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -82,11 +82,11 @@ export const DocumentInfoProvider: React.FC<
   }
 
   const isEditing = Boolean(id)
+  const shouldFetchVersions = Boolean(versionsConfig && docPermissions?.readVersions?.permission)
 
   const getVersions = useCallback(async () => {
     let versionFetchURL
     let publishedFetchURL
-    const shouldFetchVersions = Boolean(versionsConfig)
     let unpublishedVersionJSON = null
     let versionJSON = null
     let shouldFetch = true
@@ -209,7 +209,7 @@ export const DocumentInfoProvider: React.FC<
       setVersions(versionJSON)
       setUnpublishedVersions(unpublishedVersionJSON)
     }
-  }, [i18n, globalSlug, collectionSlug, id, baseURL, locale, versionsConfig])
+  }, [i18n, globalSlug, collectionSlug, id, baseURL, locale, versionsConfig, shouldFetchVersions])
 
   const getDocPermissions = React.useCallback(async () => {
     let docAccessURL: string


### PR DESCRIPTION
## Description

Closes https://github.com/payloadcms/payload-3.0-demo/issues/146. Collections without version read access would still render their versions tab, ultimately leading the user to a 403. For the record, this is in fact the current behavior of 2.0. This is mostly a quality of life improvement. Permissions are now thread to each tab's condition function so that it can determine its own logic. Versions were also previously being requested (403ing) even though we already know whether they have read access to versions. Now, no versions are fetched unless needed.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.