### PR TITLE
fix: issue with dupplicate ':' in email links

### DIFF
--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -101,11 +101,11 @@ export const forgotPasswordOperation = async (incomingArgs: Arguments): Promise<
     })
 
     if (!disableEmail) {
-      const protocol = new URL(req.url).protocol
+      const protocol = new URL(req.url).protocol // includes the final :
       const serverURL =
         config.serverURL !== null && config.serverURL !== ''
           ? config.serverURL
-          : `${protocol}://${req.headers.get('host')}`
+          : `${protocol}//${req.headers.get('host')}`
 
       let html = `${req.t('authentication:youAreReceivingResetPassword')}
     <a href="${serverURL}${config.routes.admin}/reset/${token}">

--- a/packages/payload/src/auth/sendVerificationEmail.ts
+++ b/packages/payload/src/auth/sendVerificationEmail.ts
@@ -29,11 +29,11 @@ export async function sendVerificationEmail(args: Args): Promise<void> {
   } = args
 
   if (!disableEmail) {
-    const protocol = new URL(req.url).protocol
+    const protocol = new URL(req.url).protocol // includes the final :
     const serverURL =
       config.serverURL !== null && config.serverURL !== ''
         ? config.serverURL
-        : `${protocol}://${req.headers.get('host')}`
+        : `${protocol}//${req.headers.get('host')}`
 
     const verificationURL = `${serverURL}${config.routes.admin}/${collectionConfig.slug}/verify/${token}`
 


### PR DESCRIPTION
Fixes an issue with duplicate `:` in email links

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
