### PR TITLE
fix(richtext-lexical): type errors for FeatureProviderServer with typescript strict mode

### DIFF
--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -13,9 +13,9 @@ export type LexicalEditorProps = {
     | (({
         defaultFeatures,
       }: {
-        defaultFeatures: FeatureProviderServer<unknown, unknown>[]
-      }) => FeatureProviderServer<unknown, unknown>[])
-    | FeatureProviderServer<unknown, unknown>[]
+        defaultFeatures: FeatureProviderServer<any, any>[]
+      }) => FeatureProviderServer<any, any>[])
+    | FeatureProviderServer<any, any>[]
   lexical?: LexicalEditorConfig
 }
 


### PR DESCRIPTION
## Description

Fixes this:

![CleanShot 2024-04-28 at 17 05 52](https://github.com/payloadcms/payload/assets/70709113/8b5046f6-3f65-4742-a0d0-b5eb0069a97f)

![CleanShot 2024-04-28 at 17 06 03](https://github.com/payloadcms/payload/assets/70709113/8d17adce-35fb-497a-9a47-4c7a5f1c8a85)


- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
