### PR TITLE
chore(deps): adjust node engines to account for node register requirement

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -171,7 +171,7 @@
     }
   },
   "engines": {
-    "node": ">=18.20.2"
+    "node": "^18.20.2 || >=20.6.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Description

`register` function is needed but only available in `>=20.6.0`. Adjusted node engines to accommodate.

https://nodejs.org/docs/latest-v20.x/api/module.html