### PR TITLE
fix: validate user slug is an auth-enabled collection

### DIFF
--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -32,7 +32,10 @@ const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig>
     }
   }
 
-  if (!sanitizedConfig.collections.find(({ slug }) => slug === sanitizedConfig.admin.user)) {
+  const userCollection = sanitizedConfig.collections.find(
+    ({ slug }) => slug === sanitizedConfig.admin.user,
+  )
+  if (!userCollection || !userCollection.auth) {
     throw new InvalidConfiguration(
       `${sanitizedConfig.admin.user} is not a valid admin user collection`,
     )


### PR DESCRIPTION
## Description

Validate user slug is an auth-enabled collection. Previously, a collection could be passed that was not auth-enabled.

Closes https://github.com/payloadcms/payload-3.0-demo/issues/115.