### PR TITLE
fix: logout-inactivity route was 404ing

### DIFF
--- a/packages/next/src/utilities/initPage.ts
+++ b/packages/next/src/utilities/initPage.ts
@@ -25,7 +25,15 @@ type Args = {
   searchParams: { [key: string]: string | string[] | undefined }
 }
 
-const authRoutes = ['/login', '/logout', '/create-first-user', '/forgot', '/reset', '/verify']
+const authRoutes = [
+  '/login',
+  '/logout',
+  '/create-first-user',
+  '/forgot',
+  '/reset',
+  '/verify',
+  '/logout-inactivity',
+]
 
 export const initPage = async ({
   config: configPromise,


### PR DESCRIPTION
`/admin/logout-inactivity` was incorrectly 404ing and redirecting the user to `/login` rather than displaying the desired state.