### PR TITLE
fix: local req missing url headers

### DIFF
--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -51,7 +51,7 @@ const attachFakeURLProperties = (req: PayloadRequestWithData) => {
   // @ts-expect-error
   if (!req.origin) req.origin = getURLObject().origin
   // @ts-expect-error
-  if (!req?.url) req.url = getURLObject().url
+  if (!req?.url) req.url = getURLObject().href
 }
 
 type CreateLocalReq = (
@@ -84,6 +84,8 @@ export const createLocalReq: CreateLocalReq = async (
     }
   }
 
+  // @ts-expect-error
+  req.headers = req?.headers || new Headers()
   req.context = getRequestContext(req, context)
   req.payloadAPI = req?.payloadAPI || 'local'
   req.payload = payload

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -85,7 +85,7 @@ export const createLocalReq: CreateLocalReq = async (
   }
 
   // @ts-expect-error
-  req.headers = req?.headers || new Headers()
+  if (!req.headers) req.headers = new Headers()
   req.context = getRequestContext(req, context)
   req.payloadAPI = req?.payloadAPI || 'local'
   req.payload = payload

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -730,5 +730,25 @@ describe('Auth', () => {
 
       expect(authenticated.token).toBeTruthy()
     })
+
+    it('should forget and reset password', async () => {
+      const forgot = await payload.forgotPassword({
+        collection: 'users',
+        data: {
+          email: 'dev@payloadcms.com',
+        },
+      })
+
+      const reset = await payload.resetPassword({
+        collection: 'users',
+        overrideAccess: true,
+        data: {
+          password: 'test',
+          token: forgot,
+        },
+      })
+
+      expect(reset.user.email).toStrictEqual('dev@payloadcms.com')
+    })
   })
 })


### PR DESCRIPTION
`createLocalReq` was not filling `url` or `headers` properly.