### PR TITLE
fix: blocks non-admin users from admin access

### DIFF
--- a/packages/payload/src/auth/getAccessResults.ts
+++ b/packages/payload/src/auth/getAccessResults.ts
@@ -17,7 +17,7 @@ export async function getAccessResults({ req }: GetAccessResultsArgs): Promise<P
       ? payload.config.collections.find((collection) => collection.slug === user.collection)
       : null
 
-  if (userCollectionConfig) {
+  if (userCollectionConfig && payload.config.admin.user === user.collection) {
     results.canAccessAdmin = userCollectionConfig.access.admin
       ? await userCollectionConfig.access.admin({ req })
       : isLoggedIn

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -10,6 +10,7 @@ import {
   hiddenAccessSlug,
   hiddenFieldsSlug,
   noAdminAccessEmail,
+  nonAdminUserEmail,
   nonAdminUserSlug,
   readOnlyGlobalSlug,
   readOnlySlug,
@@ -494,9 +495,9 @@ export default buildConfigWithDefaults({
     })
 
     await payload.create({
-      collection: 'users',
+      collection: nonAdminUserSlug,
       data: {
-        email: nonAdminUserSlug,
+        email: nonAdminUserEmail,
         password: 'test',
       },
     })

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -10,6 +10,7 @@ import {
   hiddenAccessSlug,
   hiddenFieldsSlug,
   noAdminAccessEmail,
+  nonAdminUserSlug,
   readOnlyGlobalSlug,
   readOnlySlug,
   relyOnRequestHeadersSlug,
@@ -121,6 +122,11 @@ export default buildConfigWithDefaults({
           },
         },
       ],
+    },
+    {
+      slug: nonAdminUserSlug,
+      auth: true,
+      fields: [],
     },
     {
       slug,
@@ -483,6 +489,14 @@ export default buildConfigWithDefaults({
       collection: 'users',
       data: {
         email: noAdminAccessEmail,
+        password: 'test',
+      },
+    })
+
+    await payload.create({
+      collection: 'users',
+      data: {
+        email: nonAdminUserSlug,
         password: 'test',
       },
     })

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -363,11 +363,19 @@ describe('access control', () => {
     })
 
     await expect(page.locator('.next-error-h1')).toBeVisible()
+
+    // Log back in for the next test
+    await login({
+      page,
+      serverURL,
+      data: {
+        email: devUser.email,
+        password: devUser.password,
+      },
+    })
   })
 
   test('should block admin access to non-admin user', async () => {
-    // TODO: Need to authenticate the user outside of the login form and use _that_ token in the Playwright browser
-    // This is bc the logic form is specific to the `users` collection, and this test is for non-admin users
     const adminURL = `${serverURL}/admin`
     await page.goto(adminURL)
     await page.waitForURL(adminURL)

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -364,6 +364,9 @@ describe('access control', () => {
 
     await expect(page.locator('.next-error-h1')).toBeVisible()
 
+    await page.goto(`${serverURL}/admin/logout`)
+    await page.waitForURL(`${serverURL}/admin/logout`)
+
     // Log back in for the next test
     await login({
       page,

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -26,6 +26,7 @@ import { POLL_TOPASS_TIMEOUT } from '../playwright.config.js'
 import {
   docLevelAccessSlug,
   noAdminAccessEmail,
+  nonAdminUserEmail,
   readOnlyGlobalSlug,
   readOnlySlug,
   restrictedSlug,
@@ -340,7 +341,7 @@ describe('access control', () => {
     await expect(documentDrawer2.locator('#field-name')).toBeEnabled()
   })
 
-  test('should completely block admin access', async () => {
+  test('should block admin access to admin user', async () => {
     const adminURL = `${serverURL}/admin`
     await page.goto(adminURL)
     await page.waitForURL(adminURL)
@@ -355,6 +356,28 @@ describe('access control', () => {
       serverURL,
       data: {
         email: noAdminAccessEmail,
+        password: 'test',
+      },
+    })
+
+    await expect(page.locator('.next-error-h1')).toBeVisible()
+  })
+
+  test('should block admin access to non-admin user', async () => {
+    const adminURL = `${serverURL}/admin`
+    await page.goto(adminURL)
+    await page.waitForURL(adminURL)
+
+    await expect(page.locator('.dashboard')).toBeVisible()
+
+    await page.goto(`${serverURL}/admin/logout`)
+    await page.waitForURL(`${serverURL}/admin/logout`)
+
+    await login({
+      page,
+      serverURL,
+      data: {
+        email: nonAdminUserEmail,
         password: 'test',
       },
     })

--- a/test/access-control/shared.ts
+++ b/test/access-control/shared.ts
@@ -17,3 +17,7 @@ export const hiddenAccessSlug = 'hidden-access'
 export const hiddenAccessCountSlug = 'hidden-access-count'
 
 export const noAdminAccessEmail = 'no-admin-access@payloadcms.com'
+
+export const nonAdminUserEmail = 'non-admin-user@payloadcms.com'
+
+export const nonAdminUserSlug = 'non-admin-user'

--- a/test/helpers/sdk/index.ts
+++ b/test/helpers/sdk/index.ts
@@ -75,6 +75,7 @@ export class PayloadTestSDK<TGeneratedTypes extends GeneratedTypes<TGeneratedTyp
     jwt,
     ...args
   }: LoginArgs<TGeneratedTypes, T>) => {
+    console.log('login', args)
     return this.fetch<TGeneratedTypes['collections'][T]>({
       operation: 'login',
       args,

--- a/test/helpers/sdk/index.ts
+++ b/test/helpers/sdk/index.ts
@@ -75,7 +75,6 @@ export class PayloadTestSDK<TGeneratedTypes extends GeneratedTypes<TGeneratedTyp
     jwt,
     ...args
   }: LoginArgs<TGeneratedTypes, T>) => {
-    console.log('login', args)
     return this.fetch<TGeneratedTypes['collections'][T]>({
       operation: 'login',
       args,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
     ],
     "paths": {
       "@payload-config": [
-        "./test/_community/config.ts"
+        "./test/access-control/config.ts"
       ],
       "@payloadcms/live-preview": [
         "./packages/live-preview/src"


### PR DESCRIPTION
## Description

Closes https://github.com/payloadcms/payload-3.0-demo/issues/161. Non-admin users could access the admin panel. This was because of a fallback based on whether _any_ user is logged in. In 2.0, we solely relied on the `/me` operation to catch this instead of fully verifying that the authenticating user is in fact admin-enabled.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.