### PR TITLE
feat(db-postgres): Add multiple field sort by string

### DIFF
--- a/packages/db-mongodb/src/queries/buildSortParam.ts
+++ b/packages/db-mongodb/src/queries/buildSortParam.ts
@@ -28,7 +28,7 @@ export const buildSortParam = ({
 }: Args): PaginateOptions['sort'] => {
   let sortProperty: string
   let sortDirection: SortDirection = 'desc'
-  const isSortMultipleField = sort.includes(' ') ?? false
+  const isSortMultipleField = sort.includes(' ')
 
   if (isSortMultipleField) {
     const sortFields = sort.split(' ')

--- a/packages/db-mongodb/src/queries/buildSortParam.ts
+++ b/packages/db-mongodb/src/queries/buildSortParam.ts
@@ -8,7 +8,7 @@ type Args = {
   config: SanitizedConfig
   fields: Field[]
   locale: string
-  sort: string
+  sort: string | undefined
   timestamps: boolean
 }
 
@@ -30,7 +30,13 @@ export const buildSortParam = ({
   let sortDirection: SortDirection = 'desc'
   const isSortMultipleField = sort.includes(',')
 
-  if (isSortMultipleField) {
+  if (!sort) {
+    if (timestamps) {
+      sortProperty = 'createdAt'
+    } else {
+      sortProperty = '_id'
+    }
+  } else if (isSortMultipleField) {
     const sortFields = sort.split(',')
     return sortFields.reduce((acc, sortField) => {
       const isDesc = sortField.indexOf('-') === 0
@@ -48,14 +54,6 @@ export const buildSortParam = ({
       }
       return [...acc, `${isDesc ? '-' : ''}${currentSortProperty}`]
     }, [])
-  }
-
-  if (!sort) {
-    if (timestamps) {
-      sortProperty = 'createdAt'
-    } else {
-      sortProperty = '_id'
-    }
   } else if (sort.indexOf('-') === 0) {
     sortProperty = sort.substring(1)
   } else {

--- a/packages/db-mongodb/src/queries/buildSortParam.ts
+++ b/packages/db-mongodb/src/queries/buildSortParam.ts
@@ -28,10 +28,10 @@ export const buildSortParam = ({
 }: Args): PaginateOptions['sort'] => {
   let sortProperty: string
   let sortDirection: SortDirection = 'desc'
-  const isSortMultipleField = sort.includes(' ')
+  const isSortMultipleField = sort.includes(',')
 
   if (isSortMultipleField) {
-    const sortFields = sort.split(' ')
+    const sortFields = sort.split(',')
     return sortFields.reduce((acc, sortField) => {
       const isDesc = sortField.indexOf('-') === 0
       let currentSortProperty = sortField.replace(/^-/, '')

--- a/packages/db-mongodb/src/queries/buildSortParam.ts
+++ b/packages/db-mongodb/src/queries/buildSortParam.ts
@@ -28,6 +28,27 @@ export const buildSortParam = ({
 }: Args): PaginateOptions['sort'] => {
   let sortProperty: string
   let sortDirection: SortDirection = 'desc'
+  const isSortMultipleField = sort.includes(' ') ?? false
+
+  if (isSortMultipleField) {
+    const sortFields = sort.split(' ')
+    return sortFields.reduce((acc, sortField) => {
+      const isDesc = sortField.indexOf('-') === 0
+      let currentSortProperty = sortField.replace(/^-/, '')
+
+      if (currentSortProperty === 'id') {
+        currentSortProperty = '_id'
+      } else {
+        currentSortProperty = getLocalizedSortProperty({
+          config,
+          fields,
+          locale,
+          segments: currentSortProperty.split('.'),
+        })
+      }
+      return [...acc, `${isDesc ? '-' : ''}${currentSortProperty}`]
+    }, [])
+  }
 
   if (!sort) {
     if (timestamps) {

--- a/packages/db-postgres/src/find/findMany.ts
+++ b/packages/db-postgres/src/find/findMany.ts
@@ -55,9 +55,9 @@ export const findMany = async function find({
 
   const selectDistinctMethods: ChainedMethods = []
 
-  if (orderBy?.order && orderBy?.column) {
+  if (orderBy.length) {
     selectDistinctMethods.push({
-      args: [orderBy.order(orderBy.column)],
+      args: orderBy.map(({ column, order }) => order(column)),
       method: 'orderBy',
     })
   }
@@ -115,7 +115,7 @@ export const findMany = async function find({
     if (where) {
       findManyArgs.where = where
     }
-    findManyArgs.orderBy = orderBy.order(orderBy.column)
+    findManyArgs.orderBy = orderBy.map(({ column, order }) => order(column))
   }
 
   const findPromise = db.query[tableName].findMany(findManyArgs)

--- a/packages/db-postgres/src/queries/buildQuery.ts
+++ b/packages/db-postgres/src/queries/buildQuery.ts
@@ -52,7 +52,7 @@ const buildQuery = async function buildQuery({
   let orderBy: Result['orderBy'] = []
 
   if (sort) {
-    orderBy = sort.split(' ').map((sortString) => {
+    orderBy = sort.split(',').map((sortString) => {
       const sortPath = sortString.replace(/^-/, '')
       try {
         const { columnName: sortTableColumnName, table: sortTable } = getTableColumnFromPath({
@@ -68,8 +68,8 @@ const buildQuery = async function buildQuery({
           value: sortPath,
         })
         return {
-          order: sortString[0] === '-' ? desc : asc,
           column: sortTable?.[sortTableColumnName] ?? null,
+          order: sortString[0] === '-' ? desc : asc,
         }
       } catch (err) {
         // continue

--- a/packages/db-postgres/src/queries/buildQuery.ts
+++ b/packages/db-postgres/src/queries/buildQuery.ts
@@ -52,29 +52,32 @@ const buildQuery = async function buildQuery({
   let orderBy: Result['orderBy'] = []
 
   if (sort) {
-    orderBy = sort.split(',').map((sortString) => {
-      const sortPath = sortString.replace(/^-/, '')
-      try {
-        const { columnName: sortTableColumnName, table: sortTable } = getTableColumnFromPath({
-          adapter,
-          collectionPath: sortPath,
-          fields,
-          joinAliases,
-          joins,
-          locale,
-          pathSegments: sortPath.replace(/__/g, '.').split('.'),
-          selectFields,
-          tableName,
-          value: sortPath,
-        })
-        return {
-          column: sortTable?.[sortTableColumnName] ?? null,
-          order: sortString[0] === '-' ? desc : asc,
+    orderBy = sort
+      .split(',')
+      .map((sortString) => {
+        const sortPath = sortString.replace(/^-/, '')
+        try {
+          const { columnName: sortTableColumnName, table: sortTable } = getTableColumnFromPath({
+            adapter,
+            collectionPath: sortPath,
+            fields,
+            joinAliases,
+            joins,
+            locale,
+            pathSegments: sortPath.replace(/__/g, '.').split('.'),
+            selectFields,
+            tableName,
+            value: sortPath,
+          })
+          return {
+            column: sortTable?.[sortTableColumnName] ?? null,
+            order: sortString[0] === '-' ? desc : asc,
+          }
+        } catch (err) {
+          // continue
         }
-      } catch (err) {
-        // continue
-      }
-    })
+      })
+      .filter((sortInfo) => !!sortInfo)
   }
 
   if (!orderBy.length) {

--- a/packages/payload/src/versions/drafts/getQueryDraftsSort.ts
+++ b/packages/payload/src/versions/drafts/getQueryDraftsSort.ts
@@ -5,13 +5,16 @@
 export const getQueryDraftsSort = (sort: string): string => {
   if (!sort) return sort
 
-  let direction = ''
-  let orderBy = sort
-
-  if (sort[0] === '-') {
-    direction = '-'
-    orderBy = sort.substring(1)
-  }
-
-  return `${direction}version.${orderBy}`
+  return sort
+    .split(' ')
+    .map((sortString) => {
+      let direction = ''
+      let orderBy = sortString
+      if (sortString[0] === '-') {
+        direction = '-'
+        orderBy = sortString.substring(1)
+      }
+      return `${direction}version.${orderBy}`
+    })
+    .join(' ')
 }

--- a/packages/payload/src/versions/drafts/getQueryDraftsSort.ts
+++ b/packages/payload/src/versions/drafts/getQueryDraftsSort.ts
@@ -6,7 +6,7 @@ export const getQueryDraftsSort = (sort: string): string => {
   if (!sort) return sort
 
   return sort
-    .split(' ')
+    .split(',')
     .map((sortString) => {
       let direction = ''
       let orderBy = sortString
@@ -16,5 +16,5 @@ export const getQueryDraftsSort = (sort: string): string => {
       }
       return `${direction}version.${orderBy}`
     })
-    .join(' ')
+    .join(',')
 }


### PR DESCRIPTION
## Description

Related disscusion is #2089. For 1.x PR, #3236.

I added conditional logic for multiple field sort. sort string is implemented as comma format like [PR comment](https://github.com/payloadcms/payload/pull/3236#issuecomment-2067901468).

https://github.com/payloadcms/payload/blob/45b3f06e1b239623a8be5f73e0324aabccf244d6/packages/db-postgres/src/queries/buildQuery.ts#L98-L100

I wasn't sure what this code was doing, so I opened the PR as a draft.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
