### PR TITLE
fix: hide unusable fields from collection filter select

### DIFF
--- a/packages/payload/src/admin/components/elements/WhereBuilder/index.tsx
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/index.tsx
@@ -32,34 +32,34 @@ const reduceFields = (fields, i18n) =>
       } else {
         operators = fieldTypes[field.type].operators
       }
-    }
 
-    const operatorKeys = new Set()
-    const filteredOperators = operators.reduce((acc, operator) => {
-      if (!operatorKeys.has(operator.value)) {
-        operatorKeys.add(operator.value)
-        return [
-          ...acc,
-          {
-            ...operator,
-            label: i18n.t(`operators:${operator.label}`),
-          },
-        ]
+      const operatorKeys = new Set()
+      const filteredOperators = operators.reduce((acc, operator) => {
+        if (!operatorKeys.has(operator.value)) {
+          operatorKeys.add(operator.value)
+          return [
+            ...acc,
+            {
+              ...operator,
+              label: i18n.t(`operators:${operator.label}`),
+            },
+          ]
+        }
+        return acc
+      }, [])
+
+      const formattedField = {
+        label: getTranslation(field.label || field.name, i18n),
+        value: field.name,
+        ...fieldTypes[field.type],
+        operators: filteredOperators,
+        props: {
+          ...field,
+        },
       }
-      return acc
-    }, [])
-
-    const formattedField = {
-      label: getTranslation(field.label || field.name, i18n),
-      value: field.name,
-      ...fieldTypes[field.type],
-      operators: filteredOperators,
-      props: {
-        ...field,
-      },
+      return [...reduced, formattedField]
     }
-
-    return [...reduced, formattedField]
+    return reduced
   }, [])
 
 /**


### PR DESCRIPTION
## Description

Closes #6097 

The collection filter UI should not return fields that cannot be filtered on.

No PR for 3.0 as this is already the default behavior.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes