### PR TITLE
fix(richtext-lexical): floating toolbar caret positioned incorrectly for some line heights

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/plugins/FloatingSelectToolbar/index.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/FloatingSelectToolbar/index.tsx
@@ -114,36 +114,36 @@ function FloatingSelectToolbar({
   anchorElem: HTMLElement
   editor: LexicalEditor
 }): React.ReactNode {
-  const popupCharStylesEditorRef = useRef<HTMLDivElement | null>(null)
+  const floatingToolbarRef = useRef<HTMLDivElement | null>(null)
   const caretRef = useRef<HTMLDivElement | null>(null)
 
   const { editorConfig } = useEditorConfigContext()
 
   const closeFloatingToolbar = useCallback(() => {
-    if (popupCharStylesEditorRef?.current) {
-      const isOpacityZero = popupCharStylesEditorRef.current.style.opacity === '0'
-      const isPointerEventsNone = popupCharStylesEditorRef.current.style.pointerEvents === 'none'
+    if (floatingToolbarRef?.current) {
+      const isOpacityZero = floatingToolbarRef.current.style.opacity === '0'
+      const isPointerEventsNone = floatingToolbarRef.current.style.pointerEvents === 'none'
 
       if (!isOpacityZero) {
-        popupCharStylesEditorRef.current.style.opacity = '0'
+        floatingToolbarRef.current.style.opacity = '0'
       }
       if (!isPointerEventsNone) {
-        popupCharStylesEditorRef.current.style.pointerEvents = 'none'
+        floatingToolbarRef.current.style.pointerEvents = 'none'
       }
     }
-  }, [popupCharStylesEditorRef])
+  }, [floatingToolbarRef])
 
   const mouseMoveListener = useCallback(
     (e: MouseEvent) => {
-      if (popupCharStylesEditorRef?.current && (e.buttons === 1 || e.buttons === 3)) {
-        const isOpacityZero = popupCharStylesEditorRef.current.style.opacity === '0'
-        const isPointerEventsNone = popupCharStylesEditorRef.current.style.pointerEvents === 'none'
+      if (floatingToolbarRef?.current && (e.buttons === 1 || e.buttons === 3)) {
+        const isOpacityZero = floatingToolbarRef.current.style.opacity === '0'
+        const isPointerEventsNone = floatingToolbarRef.current.style.pointerEvents === 'none'
         if (!isOpacityZero || !isPointerEventsNone) {
           // Check if the mouse is not over the popup
           const x = e.clientX
           const y = e.clientY
           const elementUnderMouse = document.elementFromPoint(x, y)
-          if (!popupCharStylesEditorRef.current.contains(elementUnderMouse)) {
+          if (!floatingToolbarRef.current.contains(elementUnderMouse)) {
             // Mouse is not over the target element => not a normal click, but probably a drag
             closeFloatingToolbar()
           }
@@ -154,15 +154,15 @@ function FloatingSelectToolbar({
   )
 
   const mouseUpListener = useCallback(() => {
-    if (popupCharStylesEditorRef?.current) {
-      if (popupCharStylesEditorRef.current.style.opacity !== '1') {
-        popupCharStylesEditorRef.current.style.opacity = '1'
+    if (floatingToolbarRef?.current) {
+      if (floatingToolbarRef.current.style.opacity !== '1') {
+        floatingToolbarRef.current.style.opacity = '1'
       }
-      if (popupCharStylesEditorRef.current.style.pointerEvents !== 'auto') {
-        popupCharStylesEditorRef.current.style.pointerEvents = 'auto'
+      if (floatingToolbarRef.current.style.pointerEvents !== 'auto') {
+        floatingToolbarRef.current.style.pointerEvents = 'auto'
       }
     }
-  }, [popupCharStylesEditorRef])
+  }, [floatingToolbarRef])
 
   useEffect(() => {
     document.addEventListener('mousemove', mouseMoveListener)
@@ -172,15 +172,14 @@ function FloatingSelectToolbar({
       document.removeEventListener('mousemove', mouseMoveListener)
       document.removeEventListener('mouseup', mouseUpListener)
     }
-  }, [popupCharStylesEditorRef, mouseMoveListener, mouseUpListener])
+  }, [floatingToolbarRef, mouseMoveListener, mouseUpListener])
 
   const updateTextFormatFloatingToolbar = useCallback(() => {
     const selection = $getSelection()
 
-    const popupCharStylesEditorElem = popupCharStylesEditorRef.current
     const nativeSelection = window.getSelection()
 
-    if (popupCharStylesEditorElem === null) {
+    if (floatingToolbarRef.current === null) {
       return
     }
 
@@ -194,17 +193,25 @@ function FloatingSelectToolbar({
     ) {
       const rangeRect = getDOMRangeRect(nativeSelection, rootElement)
 
-      setFloatingElemPosition(rangeRect, popupCharStylesEditorElem, anchorElem, 'center')
+      // Position floating toolbar
+      const offsetIfFlipped = setFloatingElemPosition(
+        rangeRect, // selection to position around
+        floatingToolbarRef.current, // what to position
+        anchorElem, // anchor elem
+        'center',
+      )
 
+      // Position caret
       if (caretRef.current) {
         setFloatingElemPosition(
           rangeRect, // selection to position around
           caretRef.current, // what to position
-          popupCharStylesEditorElem, // anchor elem
+          floatingToolbarRef.current, // anchor elem
           'center',
           10,
           5,
           true,
+          offsetIfFlipped,
         )
       }
     }
@@ -255,7 +262,7 @@ function FloatingSelectToolbar({
   }, [editor, updateTextFormatFloatingToolbar])
 
   return (
-    <div className="floating-select-toolbar-popup" ref={popupCharStylesEditorRef}>
+    <div className="floating-select-toolbar-popup" ref={floatingToolbarRef}>
       <div className="caret" ref={caretRef} />
       {editor.isEditable() && (
         <React.Fragment>

--- a/packages/richtext-lexical/src/field/lexical/utils/setFloatingElemPosition.ts
+++ b/packages/richtext-lexical/src/field/lexical/utils/setFloatingElemPosition.ts
@@ -2,6 +2,9 @@ const VERTICAL_GAP = 10
 const HORIZONTAL_OFFSET = 5
 
 // TODO: needs refactoring
+// This is supposed to position the floatingElem based on the parent (anchorElem) and the target (targetRect) which is usually the selected text.
+// So basically, it positions the floatingElem either below or above the target (targetRect) and aligns it to the left or center of the target (targetRect).
+// This is used for positioning the floating toolbar (anchor: richtext editor) and its caret (anchor: floating toolbar)
 export function setFloatingElemPosition(
   targetRect: ClientRect | null,
   floatingElem: HTMLElement,

--- a/packages/richtext-lexical/src/field/lexical/utils/setFloatingElemPosition.ts
+++ b/packages/richtext-lexical/src/field/lexical/utils/setFloatingElemPosition.ts
@@ -1,9 +1,7 @@
 const VERTICAL_GAP = 10
 const HORIZONTAL_OFFSET = 5
 
-// TODO: This works fine with some dirty fixes (looking at you, specialHandlingForCaret). But this definitely needs refactoring and documentation, to be easier to understand and maintain.
-// This is supposed to position the floatingElem based on the parent (anchorElem) and the target (targetRect) which is usually the selected text.
-// So basically, it positions the floatingElem either below or above the target (targetRect) and aligns it to the left or center of the target (targetRect).
+// TODO: needs refactoring
 export function setFloatingElemPosition(
   targetRect: ClientRect | null,
   floatingElem: HTMLElement,
@@ -12,7 +10,9 @@ export function setFloatingElemPosition(
   verticalGap: number = VERTICAL_GAP,
   horizontalOffset: number = HORIZONTAL_OFFSET,
   specialHandlingForCaret = false,
-): void {
+  anchorFlippedOffset = 0, // Offset which was added to the anchor (for caret, floating toolbar) if it was flipped
+): number {
+  // Returns the top offset if the target was flipped
   const scrollerElem = anchorElem.parentElement
 
   if (targetRect === null || scrollerElem == null) {
@@ -33,8 +33,11 @@ export function setFloatingElemPosition(
     left = targetRect.left + targetRect.width / 2 - floatingElemRect.width / 2
   }
 
-  if (top < editorScrollerRect.top) {
-    top += floatingElemRect.height + targetRect.height + verticalGap * 2
+  let addedToTop = 0
+  if (top < editorScrollerRect.top && !specialHandlingForCaret) {
+    addedToTop = floatingElemRect.height + targetRect.height + verticalGap * 2
+
+    top += addedToTop
   }
 
   if (horizontalPosition === 'center') {
@@ -49,22 +52,21 @@ export function setFloatingElemPosition(
     }
   }
 
-  top -= anchorElementRect.top
   left -= anchorElementRect.left
 
   floatingElem.style.opacity = '1'
 
-  if (specialHandlingForCaret && top == 0 /* 0 Happens when selecting 1st line */) {
-    top -= 44 // Especially this arbitrary number needs refactoring (this is for the caret)
-    // rotate too
-    floatingElem.style.transform = `translate(${left}px, ${top}px) rotate(180deg)`
-  } else if (
-    specialHandlingForCaret &&
-    top === -63 /* -63 Happens when selecting 2nd line in multi-line paragraph */
-  ) {
-    top += 18 // Especially this arbitrary number needs refactoring (this is for the caret)
+  if (specialHandlingForCaret && anchorFlippedOffset !== 0) {
+    // Floating select toolbar was flipped (positioned below text rather than above). Thus, the caret now needs to be positioned
+    // on the other side and rotated.
+    top -= anchorElementRect.bottom - anchorFlippedOffset + floatingElemRect.height - 3
+    // top += anchorFlippedOffset - anchorElementRect.height - floatingElemRect.height + 2
     floatingElem.style.transform = `translate(${left}px, ${top}px) rotate(180deg)`
   } else {
+    top -= anchorElementRect.top
+
     floatingElem.style.transform = `translate(${left}px, ${top}px)`
   }
+
+  return addedToTop
 }


### PR DESCRIPTION
## Description

This optimizes the logic for handling caret positioning if the floating toolbar is flipped (which usually happens for the first 1-2 lines) and cleans it up.

Fixes #6139 

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
