### PR TITLE
feat: use filterOptions in list relationship filter

### DIFF
--- a/packages/payload/src/admin/components/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -1,3 +1,6 @@
+import type { Where } from 'payload/types'
+
+import qs from 'qs'
 import React, { useCallback, useEffect, useReducer, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -6,6 +9,7 @@ import type { Option } from '../../../ReactSelect/types'
 import type { GetResults, Props, ValueWithRelation } from './types'
 
 import useDebounce from '../../../../../hooks/useDebounce'
+import { useAuth } from '../../../../utilities/Auth'
 import { useConfig } from '../../../../utilities/Config'
 import ReactSelect from '../../../ReactSelect'
 import './index.scss'
@@ -16,7 +20,15 @@ const baseClass = 'condition-value-relationship'
 const maxResultsPerRequest = 10
 
 const RelationshipField: React.FC<Props> = (props) => {
-  const { admin: { isSortable } = {}, disabled, hasMany, onChange, relationTo, value } = props
+  const {
+    admin: { isSortable } = {},
+    disabled,
+    filterOptions,
+    hasMany,
+    onChange,
+    relationTo,
+    value,
+  } = props
 
   const {
     collections,
@@ -33,11 +45,12 @@ const RelationshipField: React.FC<Props> = (props) => {
   const [hasLoadedFirstOptions, setHasLoadedFirstOptions] = useState(false)
   const debouncedSearch = useDebounce(search, 300)
   const { i18n, t } = useTranslation('general')
+  const { user } = useAuth()
 
   const addOptions = useCallback(
     (data, relation) => {
       const collection = collections.find((coll) => coll.slug === relation)
-      dispatchOptions({ collection, data, hasMultipleRelations, i18n, relation, type: 'ADD' })
+      dispatchOptions({ type: 'ADD', collection, data, hasMultipleRelations, i18n, relation })
     },
     [collections, hasMultipleRelations, i18n],
   )
@@ -61,23 +74,63 @@ const RelationshipField: React.FC<Props> = (props) => {
       let resultsFetched = 0
 
       if (!errorLoading) {
-        relationsToFetch.reduce(async (priorRelation, relation) => {
+        void relationsToFetch.reduce(async (priorRelation, relation) => {
           await priorRelation
-
           if (resultsFetched < 10) {
+            const search: Record<string, unknown> & { where: Where } = {
+              depth: 0,
+              limit: maxResultsPerRequest,
+              page: lastLoadedPageToUse,
+              where: { and: [] },
+            }
             const collection = collections.find((coll) => coll.slug === relation)
             const fieldToSearch = collection?.admin?.useAsTitle || 'id'
-            const searchParam = searchArg ? `&where[${fieldToSearch}][like]=${searchArg}` : ''
-
-            const response = await fetch(
-              `${serverURL}${api}/${relation}?limit=${maxResultsPerRequest}&page=${lastLoadedPageToUse}&depth=0${searchParam}`,
-              {
-                credentials: 'include',
-                headers: {
-                  'Accept-Language': i18n.language,
+            // add search arg to where object
+            if (searchArg) {
+              search.where.and.push({
+                [fieldToSearch]: {
+                  like: searchArg,
                 },
+              })
+            }
+            // call the filterOptions function if it exists passing in the collection
+            if (filterOptions) {
+              const optionFilter =
+                typeof filterOptions === 'function'
+                  ? await filterOptions({
+                      id: undefined,
+                      data: {},
+                      relationTo: collection.slug,
+                      siblingData: {},
+                      user,
+                    })
+                  : filterOptions
+              if (typeof optionFilter === 'object') {
+                search.where.and.push(optionFilter)
+              }
+              if (optionFilter === false) {
+                // no options will be returned
+                setLastFullyLoadedRelation(relations.indexOf(relation))
+
+                // If there are more relations to search, need to reset lastLoadedPage to 1
+                // both locally within function and state
+                if (relations.indexOf(relation) + 1 < relations.length) {
+                  lastLoadedPageToUse = 1
+                }
+                return
+              }
+            }
+
+            if (search.where.and.length === 0) {
+              delete search.where
+            }
+
+            const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(search)}`, {
+              credentials: 'include',
+              headers: {
+                'Accept-Language': i18n.language,
               },
-            )
+            })
 
             if (response.ok) {
               const data: PaginatedDocs = await response.json()
@@ -103,7 +156,18 @@ const RelationshipField: React.FC<Props> = (props) => {
         }, Promise.resolve())
       }
     },
-    [i18n, relationTo, errorLoading, collections, serverURL, api, addOptions, t],
+    [
+      relationTo,
+      errorLoading,
+      collections,
+      filterOptions,
+      serverURL,
+      api,
+      i18n.language,
+      user,
+      addOptions,
+      t,
+    ],
   )
 
   const findOptionsByValue = useCallback((): Option | Option[] => {

--- a/packages/payload/src/admin/components/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -98,6 +98,9 @@ const RelationshipField: React.FC<Props> = (props) => {
               const optionFilter =
                 typeof filterOptions === 'function'
                   ? await filterOptions({
+                      // data and siblingData are empty since we cannot fetch with the values covering the
+                      // entire list this limitation means that filterOptions functions using a document's
+                      //  data are unsupported in the whereBuilder
                       id: undefined,
                       data: {},
                       relationTo: collection.slug,


### PR DESCRIPTION
## Description

This makes it so that the filterOptions are applied to the filter controls on the list view of a collection:
![image](https://github.com/payloadcms/payload/assets/6434612/d9ecbd63-9b26-4cbd-b168-83b755dbd29a)

Now any non-valid options will no longer appear in the search results.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
