### PR TITLE
feat(richtext-lexical)!: change link fields handling

### DIFF
--- a/packages/richtext-lexical/src/field/features/link/drawer/baseFields.ts
+++ b/packages/richtext-lexical/src/field/features/link/drawer/baseFields.ts
@@ -32,7 +32,7 @@ export const getBaseFields = (
       .map(({ slug }) => slug)
   }
 
-  const baseFields = [
+  const baseFields: Field[] = [
     {
       name: 'text',
       type: 'text',
@@ -40,63 +40,49 @@ export const getBaseFields = (
       required: true,
     },
     {
-      name: 'fields',
-      type: 'group',
+      name: 'linkType',
+      type: 'radio',
       admin: {
-        style: {
-          borderBottom: 0,
-          borderTop: 0,
-          margin: 0,
-          padding: 0,
-        },
+        description: ({ t }) => t('fields:chooseBetweenCustomTextOrDocument'),
       },
-      fields: [
+      defaultValue: 'custom',
+      label: ({ t }) => t('fields:linkType'),
+      options: [
         {
-          name: 'linkType',
-          type: 'radio',
-          admin: {
-            description: ({ t }) => t('fields:chooseBetweenCustomTextOrDocument'),
-          },
-          defaultValue: 'custom',
-          label: ({ t }) => t('fields:linkType'),
-          options: [
-            {
-              label: ({ t }) => t('fields:customURL'),
-              value: 'custom',
-            },
-          ],
-          required: true,
+          label: ({ t }) => t('fields:customURL'),
+          value: 'custom',
         },
-        {
-          name: 'url',
-          type: 'text',
-          label: ({ t }) => t('fields:enterURL'),
-          required: true,
-          validate: (value: string) => {
-            if (!validateUrl(value)) {
-              return 'Invalid URL'
-            }
-          },
-        },
-      ] as Field[],
+      ],
+      required: true,
+    } as RadioField,
+    {
+      name: 'url',
+      type: 'text',
+      label: ({ t }) => t('fields:enterURL'),
+      required: true,
+      validate: (value: string) => {
+        if (!validateUrl(value)) {
+          return 'Invalid URL'
+        }
+      },
     },
   ]
 
   // Only display internal link-specific fields / options / conditions if there are enabled relations
   if (enabledRelations?.length) {
-    ;(baseFields[1].fields[0] as RadioField).options.push({
+    ;(baseFields[1] as RadioField).options.push({
       label: ({ t }) => t('fields:internalLink'),
       value: 'internal',
     })
-    ;(baseFields[1].fields[1] as TextField).admin = {
-      condition: ({ fields }) => fields?.linkType !== 'internal',
+    ;(baseFields[2] as TextField).admin = {
+      condition: ({ linkType }) => linkType !== 'internal',
     }
 
-    baseFields[1].fields.push({
+    baseFields.push({
       name: 'doc',
       admin: {
-        condition: ({ fields }) => {
-          return fields?.linkType === 'internal'
+        condition: ({ linkType }) => {
+          return linkType === 'internal'
         },
       },
       // when admin.hidden is a function we need to dynamically call hidden with the user to know if the collection should be shown
@@ -116,7 +102,7 @@ export const getBaseFields = (
     })
   }
 
-  baseFields[1].fields.push({
+  baseFields.push({
     name: 'newTab',
     type: 'checkbox',
     label: ({ t }) => t('fields:openInNewTab'),

--- a/packages/richtext-lexical/src/field/features/link/drawer/types.ts
+++ b/packages/richtext-lexical/src/field/features/link/drawer/types.ts
@@ -1,9 +1,9 @@
 import type { FormState } from 'payload/types'
 
-import type { LinkPayload } from '../plugins/floatingLinkEditor/types.js'
+import type { LinkFields } from '../nodes/types.js'
 
 export interface Props {
   drawerSlug: string
   handleModalSubmit: (fields: FormState, data: Record<string, unknown>) => void
-  stateData?: LinkPayload
+  stateData?: LinkFields & { text: string }
 }

--- a/packages/richtext-lexical/src/field/features/link/plugins/floatingLinkEditor/index.scss
+++ b/packages/richtext-lexical/src/field/features/link/plugins/floatingLinkEditor/index.scss
@@ -36,12 +36,20 @@ html[data-theme='light'] {
     position: relative;
     font-family: var(--font-body);
 
+    &__label-pure {
+      color: var(--color-base-1000);
+      margin-right: 15px;
+      display: block;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
     a {
       text-decoration: none;
       display: block;
       white-space: nowrap;
       overflow: hidden;
-      margin-right: 30px;
+      margin-right: 15px;
       text-overflow: ellipsis;
       color: var(--color-blue-600);
       border-bottom: 1px dotted;

--- a/packages/richtext-lexical/src/field/features/link/plugins/floatingLinkEditor/utilities.ts
+++ b/packages/richtext-lexical/src/field/features/link/plugins/floatingLinkEditor/utilities.ts
@@ -1,12 +1,11 @@
 import type { SanitizedConfig } from 'payload/config'
-import type { Field, FieldWithRichTextRequiredEditor, GroupField } from 'payload/types'
+import type { FieldWithRichTextRequiredEditor } from 'payload/types'
 
 import { getBaseFields } from '../../drawer/baseFields.js'
 
 /**
  * This function is run to enrich the basefields which every link has with potential, custom user-added fields.
  */
-// eslint-disable-next-line @typescript-eslint/require-await
 export function transformExtraFields(
   customFieldSchema:
     | ((args: {
@@ -17,50 +16,22 @@ export function transformExtraFields(
   config: SanitizedConfig,
   enabledCollections?: false | string[],
   disabledCollections?: false | string[],
-): Field[] {
+): FieldWithRichTextRequiredEditor[] {
   const baseFields: FieldWithRichTextRequiredEditor[] = getBaseFields(
     config,
     enabledCollections,
     disabledCollections,
   )
 
-  const fields =
-    typeof customFieldSchema === 'function'
-      ? customFieldSchema({ config, defaultFields: baseFields })
-      : baseFields
+  let fields: FieldWithRichTextRequiredEditor[]
 
-  // Wrap fields which are not part of the base schema in a group named 'fields' - otherwise they will be rendered but not saved
-  const extraFields = []
-  for (let i = fields.length - 1; i >= 0; i--) {
-    const field = fields[i]
-
-    if ('name' in field) {
-      if (
-        !baseFields.find((baseField) => !('name' in baseField) || baseField.name === field.name)
-      ) {
-        if (field.name !== 'fields' && field.type !== 'group') {
-          extraFields.push(field)
-          // Remove from fields from now, as they need to be part of the fields group below
-          fields.splice(fields.indexOf(field), 1)
-        }
-      }
-    }
+  if (typeof customFieldSchema === 'function') {
+    fields = customFieldSchema({ config, defaultFields: baseFields })
+  } else if (Array.isArray(customFieldSchema)) {
+    fields = customFieldSchema
+  } else {
+    fields = baseFields
   }
 
-  if (Array.isArray(customFieldSchema) || fields.length > 0) {
-    // find field with name 'fields' and add the extra fields to it
-    const fieldsField: GroupField = fields.find(
-      (field) => field.type === 'group' && field.name === 'fields',
-    ) as GroupField
-    if (!fieldsField) {
-      throw new Error(
-        'Could not find field with name "fields". This is required to add fields to the link field.',
-      )
-    }
-    fieldsField.fields = Array.isArray(fieldsField.fields) ? fieldsField.fields : []
-    fieldsField.fields.push(
-      ...(Array.isArray(customFieldSchema) ? customFieldSchema.concat(extraFields) : extraFields),
-    )
-  }
   return fields
 }

--- a/packages/richtext-lexical/src/field/features/link/populationPromise.ts
+++ b/packages/richtext-lexical/src/field/features/link/populationPromise.ts
@@ -32,9 +32,7 @@ export const linkPopulationPromiseHOC = (
       recurseNestedFields({
         context,
         currentDepth,
-        data: {
-          fields: node.fields,
-        },
+        data: node.fields,
         depth,
         editorPopulationPromises,
         fieldPromises,
@@ -45,9 +43,7 @@ export const linkPopulationPromiseHOC = (
         populationPromises,
         req,
         showHiddenFields,
-        siblingDoc: {
-          fields: node.fields,
-        },
+        siblingDoc: node.fields,
       })
     }
   }

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -82,7 +82,8 @@ export async function buildConfigWithDefaults(
         ParagraphFeature(),
         RelationshipFeature(),
         LinkFeature({
-          fields: [
+          fields: ({ defaultFields }) => [
+            ...defaultFields,
             {
               name: 'description',
               type: 'text',

--- a/test/fields/collections/Lexical/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e.spec.ts
@@ -520,7 +520,7 @@ describe('lexical', () => {
       const drawerContent = page.locator('.drawer__content').first()
       await expect(drawerContent).toBeVisible()
 
-      const urlField = drawerContent.locator('input#field-fields__url').first()
+      const urlField = drawerContent.locator('input#field-url').first()
       await expect(urlField).toBeVisible()
       // Fill with https://www.payloadcms.com
       await urlField.fill('https://www.payloadcms.com')

--- a/test/fields/collections/Lexical/index.ts
+++ b/test/fields/collections/Lexical/index.ts
@@ -72,7 +72,8 @@ export const LexicalFields: CollectionConfig = {
           TreeViewFeature(),
           //HTMLConverterFeature(),
           LinkFeature({
-            fields: [
+            fields: ({ defaultFields }) => [
+              ...defaultFields,
               {
                 name: 'rel',
                 label: 'Rel Attribute',

--- a/test/fields/collections/LexicalMigrate/index.ts
+++ b/test/fields/collections/LexicalMigrate/index.ts
@@ -39,7 +39,8 @@ export const LexicalMigrateFields: CollectionConfig = {
           TreeViewFeature(),
           HTMLConverterFeature(),
           LinkFeature({
-            fields: [
+            fields: ({ defaultFields }) => [
+              ...defaultFields,
               {
                 name: 'rel',
                 label: 'Rel Attribute',
@@ -79,7 +80,8 @@ export const LexicalMigrateFields: CollectionConfig = {
           TreeViewFeature(),
           HTMLConverterFeature(),
           LinkFeature({
-            fields: [
+            fields: ({ defaultFields }) => [
+              ...defaultFields,
               {
                 name: 'rel',
                 label: 'Rel Attribute',

--- a/test/fields/collections/RichText/index.ts
+++ b/test/fields/collections/RichText/index.ts
@@ -38,7 +38,8 @@ const RichTextFields: CollectionConfig = {
           TreeViewFeature(),
           HTMLConverterFeature({}),
           LinkFeature({
-            fields: [
+            fields: ({ defaultFields }) => [
+              ...defaultFields,
               {
                 name: 'rel',
                 label: 'Rel Attribute',


### PR DESCRIPTION
## Description

**BREAKING:**
- Drawer fields are no longer wrapped in a `fields` group. This might be breaking if you depend on them being in a field group in any way - potentially if you use custom link fields. This does not change how the data is saved
- If you pass in an array of custom fields to the link feature, those were previously added to the base fields. Now, they completely replace the base fields for consistency. If you want to ADD fields to the base fields now, you will have to pass in a function and spread `defaultFields` - similar to how adding your own features to lexical works

**Example Migration for ADDING fields to the link base fields:**

**Previous:**
```ts
 LinkFeature({
    fields: [
      {
        name: 'rel',
        label: 'Rel Attribute',
        type: 'select',
        hasMany: true,
        options: ['noopener', 'noreferrer', 'nofollow'],
        admin: {
          description:
            'The rel attribute defines the relationship between a linked resource and the current document. This is a custom link field.',
        },
      },
    ],
  }),
```

**Now:**
```ts
 LinkFeature({
    fields: ({ defaultFields }) => [
      ...defaultFields,
      {
        name: 'rel',
        label: 'Rel Attribute',
        type: 'select',
        hasMany: true,
        options: ['noopener', 'noreferrer', 'nofollow'],
        admin: {
          description:
            'The rel attribute defines the relationship between a linked resource and the current document. This is a custom link field.',
        },
      },
    ],
  }),

```
This PR also allows the link feature to function even with no fields added. And if you add a label or url field, those are now used as the floating link popup label / link. This allows you to technically use the link feature to save any kind of arbitrary data.

Example:

![image](https://github.com/payloadcms/payload/assets/70709113/99f34c61-0a1b-4f61-bdbb-cbd3ed17b7ee)
![image](https://github.com/payloadcms/payload/assets/70709113/260b5591-c31d-4e75-8a67-780b96c2d992)

Once hooks are supported, those label and url fields could be made hidden, virtual fields. Oh the possibilities!

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
