### PR TITLE
fix(templates): updates payload app files

### DIFF
--- a/templates/blank-3.0/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/templates/blank-3.0/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next'
 
 import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
-import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
+import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
 type Args = {
   params: {
@@ -17,6 +17,6 @@ type Args = {
 export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
 
-export default Page
+export default NotFound

--- a/templates/blank-3.0/src/app/(payload)/api/[...slug]/route.ts
+++ b/templates/blank-3.0/src/app/(payload)/api/[...slug]/route.ts
@@ -1,9 +1,10 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY it because it could be re-written at any time. */
 import config from '@payload-config'
-import { REST_DELETE, REST_GET, REST_PATCH, REST_POST } from '@payloadcms/next/routes'
+import { REST_DELETE, REST_GET, REST_OPTIONS, REST_PATCH, REST_POST } from '@payloadcms/next/routes'
 
 export const GET = REST_GET(config)
 export const POST = REST_POST(config)
 export const DELETE = REST_DELETE(config)
 export const PATCH = REST_PATCH(config)
+export const OPTIONS = REST_OPTIONS(config)

--- a/templates/blank-3.0/src/app/(payload)/custom.scss
+++ b/templates/blank-3.0/src/app/(payload)/custom.scss
@@ -1,0 +1,8 @@
+#custom-css {
+  font-family: monospace;
+  background-image: url('/placeholder.png');
+}
+
+#custom-css::after {
+  content: 'custom-css';
+}

--- a/templates/blank-3.0/src/app/(payload)/custom.scss
+++ b/templates/blank-3.0/src/app/(payload)/custom.scss
@@ -1,8 +1,0 @@
-#custom-css {
-  font-family: monospace;
-  background-image: url('/placeholder.png');
-}
-
-#custom-css::after {
-  content: 'custom-css';
-}

--- a/templates/blank-3.0/src/app/(payload)/layout.tsx
+++ b/templates/blank-3.0/src/app/(payload)/layout.tsx
@@ -1,6 +1,5 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 import configPromise from '@payload-config'
-import '@payloadcms/next/css'
 import { RootLayout } from '@payloadcms/next/layouts'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import React from 'react'

--- a/templates/blank-3.0/src/app/(payload)/layout.tsx
+++ b/templates/blank-3.0/src/app/(payload)/layout.tsx
@@ -4,6 +4,8 @@ import { RootLayout } from '@payloadcms/next/layouts'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import React from 'react'
 
+import './custom.scss'
+
 type Args = {
   children: React.ReactNode
 }

--- a/templates/blank-3.0/src/app/(payload)/layout.tsx
+++ b/templates/blank-3.0/src/app/(payload)/layout.tsx
@@ -4,8 +4,6 @@ import { RootLayout } from '@payloadcms/next/layouts'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import React from 'react'
 
-import './custom.scss'
-
 type Args = {
   children: React.ReactNode
 }

--- a/templates/blank-3.0/src/app/my-route/route.ts
+++ b/templates/blank-3.0/src/app/my-route/route.ts
@@ -1,5 +1,14 @@
-export const GET = () => {
-  return Response.json({
-    hello: 'elliot',
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+
+export const GET = async () => {
+  const payload = await getPayload({
+    config: configPromise,
   })
+
+  const data = await payload.find({
+    collection: 'users',
+  })
+
+  return Response.json(data)
 }

--- a/templates/blank-3.0/src/app/my-route/route.ts
+++ b/templates/blank-3.0/src/app/my-route/route.ts
@@ -1,14 +1,5 @@
-import configPromise from '@payload-config'
-import { getPayload } from 'payload'
-
-export const GET = async () => {
-  const payload = await getPayload({
-    config: configPromise,
+export const GET = () => {
+  return Response.json({
+    hello: 'elliot',
   })
-
-  const data = await payload.find({
-    collection: 'users',
-  })
-
-  return Response.json(data)
 }


### PR DESCRIPTION
## Description

The app files copied over during installation via `create-payload-app@beta` are out of date. The `templates/blank-3.0` template needs to reflect exactly what is maintained in the root `app` dir. It has become out of sync some time ago, missing things like the not found page, CORS headers, etc.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.