### PR TITLE
fix: sanitizes fields in default edit view for drawer content

### DIFF
--- a/packages/payload/src/admin/components/views/collections/Edit/Default/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { FieldTypes } from '../../../../forms/field-types'
@@ -12,6 +12,7 @@ import Meta from '../../../../utilities/Meta'
 import Auth from '../Auth'
 import { SetStepNav } from '../SetStepNav'
 import { Upload } from '../Upload'
+import formatFields from '../formatFields'
 import './index.scss'
 
 const baseClass = 'collection-default-edit'
@@ -37,7 +38,9 @@ export const DefaultCollectionEdit: React.FC<
     permissions,
   } = props
 
-  const { auth, fields, upload } = collection
+  const { auth, upload } = collection
+
+  const [fields] = useState(() => formatFields(collection, isEditing))
 
   const operation = isEditing ? 'update' : 'create'
 


### PR DESCRIPTION
## Description

Fixes #6076 

`Issue`: Custom ID field was coming through when editing a doc from within the relationship edit drawer view.

`Fix`: Sanitizes fields with `formatFields` in default edit view (used in Drawer component) to properly remove custom ID field from showing in the drawer edit view.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
