### PR TITLE
fix(templates): adds back missing CSS import

### DIFF
--- a/templates/blank-3.0/src/app/(payload)/layout.tsx
+++ b/templates/blank-3.0/src/app/(payload)/layout.tsx
@@ -1,5 +1,6 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 import configPromise from '@payload-config'
+import '@payloadcms/next/css'
 import { RootLayout } from '@payloadcms/next/layouts'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import React from 'react'


### PR DESCRIPTION
## Description

This PR reverts back a change in layout.tsx [app/(payload)/layout.tsx] to include the CSS styles from payloadcms/next package.

Without this import, the styling is missing from admin.


![image](https://github.com/payloadcms/payload/assets/14984773/b1c3c3e8-7432-46ea-bf5e-b9f8fb7736a9)

## Accept Contributing

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)