### PR TITLE
fix(ui): resets filter state on navigation change

### DIFF
--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -3,7 +3,7 @@ import type { ClientCollectionConfig, FieldAffectingData, Where } from 'payload/
 
 import * as facelessUIImport from '@faceless-ui/window-info'
 import { getTranslation } from '@payloadcms/translations'
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import AnimateHeightImport from 'react-animate-height'
 
 const AnimateHeight = (AnimateHeightImport.default ||
@@ -59,10 +59,21 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
     breakpoints: { s: smallBreak },
   } = useWindowInfo()
 
+  const hasWhereParam = useRef<boolean>(Boolean(searchParams?.where))
+
   const shouldInitializeWhereOpened = validateWhereQuery(searchParams?.where)
   const [visibleDrawer, setVisibleDrawer] = useState<'columns' | 'sort' | 'where'>(
     shouldInitializeWhereOpened ? 'where' : undefined,
   )
+
+  useEffect(() => {
+    if (hasWhereParam.current && !searchParams?.where) {
+      setVisibleDrawer(undefined)
+      hasWhereParam.current = false
+    } else if (searchParams?.where) {
+      hasWhereParam.current = true
+    }
+  }, [setVisibleDrawer, searchParams?.where])
 
   return (
     <div className={baseClass}>
@@ -156,6 +167,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
         <WhereBuilder
           collectionPluralLabel={collectionConfig?.labels?.plural}
           collectionSlug={collectionConfig.slug}
+          key={String(hasWhereParam.current && !searchParams?.where)}
         />
       </AnimateHeight>
       {enableSort && (

--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientCollectionConfig, FieldAffectingData, Where } from 'payload/types'
+import type { ClientCollectionConfig, Where } from 'payload/types'
 
 import * as facelessUIImport from '@faceless-ui/window-info'
 import { getTranslation } from '@payloadcms/translations'
@@ -59,7 +59,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
     breakpoints: { s: smallBreak },
   } = useWindowInfo()
 
-  const hasWhereParam = useRef<boolean>(Boolean(searchParams?.where))
+  const hasWhereParam = useRef(Boolean(searchParams?.where))
 
   const shouldInitializeWhereOpened = validateWhereQuery(searchParams?.where)
   const [visibleDrawer, setVisibleDrawer] = useState<'columns' | 'sort' | 'where'>(


### PR DESCRIPTION
## Description

`V2` PR [here](https://github.com/payloadcms/payload/pull/6169)

Navigating from a route like `/admin/collections/post?limit=10&where=` to `/admin/collections/post` would not properly reset the WhereFilter.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes