### PR TITLE
fix: moves ts-essentials to prod deps

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -29,14 +29,14 @@
   },
   "dependencies": {
     "graphql-scalars": "1.22.2",
-    "pluralize": "8.0.0"
+    "pluralize": "8.0.0",
+    "ts-essentials": "7.0.3"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",
     "@types/pluralize": "^0.0.33",
     "graphql-http": "^1.22.0",
-    "payload": "workspace:*",
-    "ts-essentials": "7.0.3"
+    "payload": "workspace:*"
   },
   "peerDependencies": {
     "graphql": "^16.8.1",

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -115,6 +115,7 @@
     "sanitize-filename": "1.6.3",
     "scheduler": "0.23.0",
     "scmp": "2.1.0",
+    "ts-essentials": "7.0.3",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
@@ -158,8 +159,7 @@
     "passport-strategy": "1.0.0",
     "rimraf": "3.0.2",
     "serve-static": "1.15.0",
-    "sharp": "0.32.6",
-    "ts-essentials": "7.0.3"
+    "sharp": "0.32.6"
   },
   "peerDependencies": {
     "@swc/core": "^1.4.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,7 +170,7 @@ importers:
         version: 9.1.8
       next:
         specifier: ^14.3.0-canary.7
-        version: 14.3.0-canary.7(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 14.3.0-canary.7(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0)(react@18.2.0)(sass@1.74.1)
       node-mocks-http:
         specifier: ^1.14.1
         version: 1.14.1
@@ -535,6 +535,9 @@ importers:
       pluralize:
         specifier: 8.0.0
         version: 8.0.0
+      ts-essentials:
+        specifier: 7.0.3
+        version: 7.0.3(typescript@5.4.5)
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*
@@ -548,9 +551,6 @@ importers:
       payload:
         specifier: workspace:*
         version: link:../payload
-      ts-essentials:
-        specifier: 7.0.3
-        version: 7.0.3(typescript@5.4.5)
 
   packages/live-preview:
     devDependencies:
@@ -803,6 +803,9 @@ importers:
       scmp:
         specifier: 2.1.0
         version: 2.1.0
+      ts-essentials:
+        specifier: 7.0.3
+        version: 7.0.3(typescript@5.4.5)
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -930,9 +933,6 @@ importers:
       sharp:
         specifier: 0.32.6
         version: 0.32.6
-      ts-essentials:
-        specifier: 7.0.3
-        version: 7.0.3(typescript@5.4.5)
 
   packages/plugin-cloud:
     dependencies:
@@ -1485,7 +1485,7 @@ importers:
         version: 2.3.0
       next:
         specifier: ^14.3.0-canary.7
-        version: 14.3.0-canary.7(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 14.3.0-canary.7(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0)(react@18.2.0)(sass@1.74.1)
       object-to-formdata:
         specifier: 4.5.1
         version: 4.5.1
@@ -12354,48 +12354,6 @@ packages:
   /next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
-  /next@14.3.0-canary.7(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-loPrWTCvHvZgOy3rgL9+2WpxNDxlRNt462ihqm/DUuyK8LUZV1F4H920YTAu1wEiYC8RrpNUbpz8K7KRYAkQiA==}
-    engines: {node: '>=18.17.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
-      react: ^18.0.0
-      react-dom: ^18.0.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@playwright/test':
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 14.3.0-canary.7
-      '@playwright/test': 1.43.0
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001607
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.24.4)(react@18.2.0)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.3.0-canary.7
-      '@next/swc-darwin-x64': 14.3.0-canary.7
-      '@next/swc-linux-arm64-gnu': 14.3.0-canary.7
-      '@next/swc-linux-arm64-musl': 14.3.0-canary.7
-      '@next/swc-linux-x64-gnu': 14.3.0-canary.7
-      '@next/swc-linux-x64-musl': 14.3.0-canary.7
-      '@next/swc-win32-arm64-msvc': 14.3.0-canary.7
-      '@next/swc-win32-ia32-msvc': 14.3.0-canary.7
-      '@next/swc-win32-x64-msvc': 14.3.0-canary.7
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   /next@14.3.0-canary.7(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0)(react@18.2.0)(sass@1.74.1):
     resolution: {integrity: sha512-loPrWTCvHvZgOy3rgL9+2WpxNDxlRNt462ihqm/DUuyK8LUZV1F4H920YTAu1wEiYC8RrpNUbpz8K7KRYAkQiA==}
     engines: {node: '>=18.17.0'}
@@ -12438,7 +12396,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    dev: false
 
   /node-abi@3.57.0:
     resolution: {integrity: sha512-Dp+A9JWxRaKuHP35H77I4kCKesDy5HUDEmScia2FyncMTOXASMyg251F5PhFoDA5uqBrDDffiLpbqnrZmNXW+g==}
@@ -15683,7 +15640,6 @@ packages:
       typescript: 5.4.5
     dependencies:
       typescript: 5.4.5
-    dev: true
 
   /ts-jest@29.1.2(@babel/core@7.24.4)(esbuild@0.19.12)(jest@29.7.0)(typescript@5.4.5):
     resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}


### PR DESCRIPTION
## Description

Moves the ts-essentials pkg to prod dependency. Without it types were broken when using getPayload from an installed version of Payload.

[Discord Convo](https://discord.com/channels/967097582721572934/1234918974932779029)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
