### PR TITLE
fix: only allow save after form is modified

### DIFF
--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -21,7 +21,7 @@ import { RenderTitle } from '../RenderTitle/index.js'
 import { baseClass } from './index.js'
 
 export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
-  id,
+  id: existingDocID,
   Header,
   collectionSlug,
   drawerSlug,
@@ -39,7 +39,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   const { closeModal, modalState, toggleModal } = useModal()
   const locale = useLocale()
   const { t } = useTranslation()
-  const [createdID, setCreatedID] = useState()
+  const [docID, setDocID] = useState(existingDocID)
   const [isOpen, setIsOpen] = useState(false)
   const [collectionConfig] = useRelatedCollections(collectionSlug)
   const { formQueryParams } = useFormQueryParams()
@@ -48,10 +48,12 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   const { componentMap } = useComponentMap()
 
   const { Edit } = componentMap[`${collectionSlug ? 'collections' : 'globals'}`][collectionSlug]
-  const isEditing = Boolean(id)
-  const apiURL = id ? `${serverURL}${apiRoute}/${collectionSlug}/${id}?locale=${locale.code}` : null
+  const isEditing = Boolean(docID)
+  const apiURL = docID
+    ? `${serverURL}${apiRoute}/${collectionSlug}/${docID}?locale=${locale.code}`
+    : null
   const action = `${serverURL}${apiRoute}/${collectionSlug}${
-    isEditing ? `/${id}` : ''
+    isEditing ? `/${docID}` : ''
   }?${formattedQueryParams}`
 
   useEffect(() => {
@@ -70,7 +72,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
 
   const onSave = useCallback<DocumentDrawerProps['onSave']>(
     (args) => {
-      setCreatedID(args.doc.id)
+      setDocID(args.doc.id)
       if (typeof onSaveFromProps === 'function') {
         void onSaveFromProps({
           ...args,
@@ -115,7 +117,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
       // Same reason as above. We need to fully-fetch the docPreferences from the server. This is done in DocumentInfoProvider if we set it to null here.
       hasSavePermission={null}
       // isLoading,
-      id={id || createdID}
+      id={docID}
       isEditing={isEditing}
       onLoadError={onLoadError}
       onSave={onSave}

--- a/packages/ui/src/elements/Save/index.tsx
+++ b/packages/ui/src/elements/Save/index.tsx
@@ -6,6 +6,7 @@ import { useForm, useFormModified } from '../../forms/Form/context.js'
 import { FormSubmit } from '../../forms/Submit/index.js'
 import { useHotkey } from '../../hooks/useHotkey.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
+import { useOperation } from '../../providers/Operation/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 
 export const DefaultSaveButton: React.FC<{ label?: string }> = ({ label: labelProp }) => {
@@ -15,9 +16,12 @@ export const DefaultSaveButton: React.FC<{ label?: string }> = ({ label: labelPr
   const label = labelProp || t('general:save')
   const ref = useRef<HTMLButtonElement>(null)
   const editDepth = useEditDepth()
+  const operation = useOperation()
+
+  const forceDisable = operation === 'update' && !modified
 
   useHotkey({ cmdCtrlKey: true, editDepth, keyCodes: ['s'] }, (e) => {
-    if (!modified) return
+    if (forceDisable) return
 
     e.preventDefault()
     e.stopPropagation()
@@ -29,7 +33,7 @@ export const DefaultSaveButton: React.FC<{ label?: string }> = ({ label: labelPr
   return (
     <FormSubmit
       buttonId="action-save"
-      disabled={!modified}
+      disabled={forceDisable}
       onClick={() => submit()}
       ref={ref}
       size="small"

--- a/packages/ui/src/elements/Save/index.tsx
+++ b/packages/ui/src/elements/Save/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef } from 'react'
 
-import { useForm } from '../../forms/Form/context.js'
+import { useForm, useFormModified } from '../../forms/Form/context.js'
 import { FormSubmit } from '../../forms/Submit/index.js'
 import { useHotkey } from '../../hooks/useHotkey.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
@@ -11,11 +11,14 @@ import { useTranslation } from '../../providers/Translation/index.js'
 export const DefaultSaveButton: React.FC<{ label?: string }> = ({ label: labelProp }) => {
   const { t } = useTranslation()
   const { submit } = useForm()
+  const modified = useFormModified()
   const label = labelProp || t('general:save')
   const ref = useRef<HTMLButtonElement>(null)
   const editDepth = useEditDepth()
 
   useHotkey({ cmdCtrlKey: true, editDepth, keyCodes: ['s'] }, (e) => {
+    if (!modified) return
+
     e.preventDefault()
     e.stopPropagation()
     if (ref?.current) {
@@ -26,6 +29,7 @@ export const DefaultSaveButton: React.FC<{ label?: string }> = ({ label: labelPr
   return (
     <FormSubmit
       buttonId="action-save"
+      disabled={!modified}
       onClick={() => submit()}
       ref={ref}
       size="small"

--- a/packages/ui/src/elements/SaveDraft/index.tsx
+++ b/packages/ui/src/elements/SaveDraft/index.tsx
@@ -9,6 +9,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
+import { useOperation } from '../../providers/Operation/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 
 const baseClass = 'save-draft'
@@ -25,8 +26,13 @@ const DefaultSaveDraftButton: React.FC = () => {
   const editDepth = useEditDepth()
   const { t } = useTranslation()
   const { submit } = useForm()
+  const operation = useOperation()
+
+  const forceDisable = operation === 'update' && !modified
 
   const saveDraft = useCallback(async () => {
+    if (forceDisable) return
+
     const search = `?locale=${locale}&depth=0&fallback-locale=null&draft=true`
     let action
     let method = 'POST'
@@ -48,12 +54,10 @@ const DefaultSaveDraftButton: React.FC = () => {
       },
       skipValidation: true,
     })
-  }, [submit, collectionSlug, globalSlug, serverURL, api, locale, id])
+  }, [submit, collectionSlug, globalSlug, serverURL, api, locale, id, forceDisable])
 
   useHotkey({ cmdCtrlKey: true, editDepth, keyCodes: ['s'] }, (e) => {
-    if (!modified) {
-      return
-    }
+    if (forceDisable) return
 
     e.preventDefault()
     e.stopPropagation()
@@ -67,7 +71,7 @@ const DefaultSaveDraftButton: React.FC = () => {
       buttonId="action-save-draft"
       buttonStyle="secondary"
       className={baseClass}
-      disabled={!modified}
+      disabled={forceDisable}
       onClick={saveDraft}
       ref={ref}
       size="small"

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -594,7 +594,7 @@ export const Form: React.FC<FormProps> = (props) => {
         >
           <SubmittedContext.Provider value={submitted}>
             <ProcessingContext.Provider value={processing}>
-              <ModifiedContext.Provider value={modified}>
+              <ModifiedContext.Provider value={operation === 'create' || modified}>
                 <FormFieldsContext.Provider value={fieldsReducer}>
                   {children}
                 </FormFieldsContext.Provider>

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -594,7 +594,7 @@ export const Form: React.FC<FormProps> = (props) => {
         >
           <SubmittedContext.Provider value={submitted}>
             <ProcessingContext.Provider value={processing}>
-              <ModifiedContext.Provider value={operation === 'create' || modified}>
+              <ModifiedContext.Provider value={modified}>
                 <FormFieldsContext.Provider value={fieldsReducer}>
                   {children}
                 </FormFieldsContext.Provider>

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -465,7 +465,6 @@ describe('admin', () => {
       await globalLabel.click()
       await checkPageTitle(page, label)
       await checkBreadcrumb(page, label)
-      await saveDocAndAssert(page)
     })
 
     test('global — should render slug in sentence case as fallback', async () => {

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -477,7 +477,6 @@ describe('admin', () => {
       await globalLabel.click()
       await checkPageTitle(page, label)
       await checkBreadcrumb(page, label)
-      await saveDocAndAssert(page)
     })
   })
 

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -438,8 +438,10 @@ describe('fields - relationship', () => {
     ).toHaveCount(1)
 
     // save the same document again to ensure the relationship field doesn't receive duplicative values
+    await drawerField.fill('Updated document')
     await saveButton.click()
-    await expect(page.locator('.Toastify')).toContainText('successfully')
+    await expect(page.locator('.Toastify')).toContainText('Updated successfully')
+    await page.locator('.doc-drawer__header-close').click()
     await expect(
       page.locator('#field-relationshipHasMany .value-container .rs__multi-value'),
     ).toHaveCount(1)

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -241,7 +241,6 @@ describe('Localization', () => {
       await openDocControls(page)
       await page.locator('#action-duplicate').click()
       await expect(page.locator('.id-label')).not.toContainText(originalID)
-      await page.locator('#action-save').click()
 
       // verify that the locale did copy
       await expect(page.locator('#field-title')).toHaveValue(englishTitle)

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -116,7 +116,6 @@ describe('Localization', () => {
 
       await fillValues({ description, title })
       await saveDocAndAssert(page)
-      await saveDocAndAssert(page)
 
       await expect(page.locator('#field-title')).toHaveValue(title)
       await expect(page.locator('#field-description')).toHaveValue(description)


### PR DESCRIPTION
## Description

Disallow saving if the form is being updated and has not been modified. 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
