### PR TITLE
feat(cpa): update existing payload installation

### DIFF
--- a/packages/create-payload-app/src/lib/get-package-manager.ts
+++ b/packages/create-payload-app/src/lib/get-package-manager.ts
@@ -1,0 +1,23 @@
+// @ts-expect-error no types
+import { detect } from 'detect-package-manager'
+
+import type { CliArgs, PackageManager } from '../types.js'
+
+export async function getPackageManager(
+  args: CliArgs,
+  projectDir: string,
+): Promise<PackageManager> {
+  let packageManager: PackageManager = 'npm'
+
+  if (args['--use-npm']) {
+    packageManager = 'npm'
+  } else if (args['--use-yarn']) {
+    packageManager = 'yarn'
+  } else if (args['--use-pnpm']) {
+    packageManager = 'pnpm'
+  } else {
+    const detected = await detect({ cwd: projectDir })
+    packageManager = detected || 'npm'
+  }
+  return packageManager
+}

--- a/packages/create-payload-app/src/lib/get-package-manager.ts
+++ b/packages/create-payload-app/src/lib/get-package-manager.ts
@@ -3,17 +3,24 @@ import { detect } from 'detect-package-manager'
 
 import type { CliArgs, PackageManager } from '../types.js'
 
-export async function getPackageManager(
-  args: CliArgs,
-  projectDir: string,
-): Promise<PackageManager> {
+export async function getPackageManager(args: {
+  cliArgs?: CliArgs
+  projectDir: string
+}): Promise<PackageManager> {
+  const { cliArgs, projectDir } = args
+
+  if (!cliArgs) {
+    const detected = await detect({ cwd: projectDir })
+    return detected || 'npm'
+  }
+
   let packageManager: PackageManager = 'npm'
 
-  if (args['--use-npm']) {
+  if (cliArgs['--use-npm']) {
     packageManager = 'npm'
-  } else if (args['--use-yarn']) {
+  } else if (cliArgs['--use-yarn']) {
     packageManager = 'yarn'
-  } else if (args['--use-pnpm']) {
+  } else if (cliArgs['--use-pnpm']) {
     packageManager = 'pnpm'
   } else {
     const detected = await detect({ cwd: projectDir })

--- a/packages/create-payload-app/src/lib/init-next.ts
+++ b/packages/create-payload-app/src/lib/init-next.ts
@@ -269,7 +269,6 @@ export async function getNextAppDetails(projectDir: string): Promise<NextAppDeta
     }
   }
 
-  // TODO: Check if Payload is already installed
   const packageObj = await fse.readJson(path.resolve(projectDir, 'package.json'))
   if (packageObj.dependencies?.payload) {
     return {
@@ -293,7 +292,7 @@ export async function getNextAppDetails(projectDir: string): Promise<NextAppDeta
     nextAppDir = undefined
   }
 
-  const configType = await getProjectType(projectDir, nextConfigPath)
+  const configType = getProjectType({ nextConfigPath, packageObj })
 
   const hasTopLevelLayout = nextAppDir
     ? fs.existsSync(path.resolve(nextAppDir, 'layout.tsx'))
@@ -302,7 +301,11 @@ export async function getNextAppDetails(projectDir: string): Promise<NextAppDeta
   return { hasTopLevelLayout, isSrcDir, nextAppDir, nextConfigPath, nextConfigType: configType }
 }
 
-async function getProjectType(projectDir: string, nextConfigPath: string): Promise<'cjs' | 'esm'> {
+function getProjectType(args: {
+  nextConfigPath: string
+  packageObj: Record<string, unknown>
+}): 'cjs' | 'esm' {
+  const { nextConfigPath, packageObj } = args
   if (nextConfigPath.endsWith('.mjs')) {
     return 'esm'
   }
@@ -310,7 +313,6 @@ async function getProjectType(projectDir: string, nextConfigPath: string): Promi
     return 'cjs'
   }
 
-  const packageObj = await fse.readJson(path.resolve(projectDir, 'package.json'))
   const packageJsonType = packageObj.type
   if (packageJsonType === 'module') {
     return 'esm'

--- a/packages/create-payload-app/src/lib/init-next.ts
+++ b/packages/create-payload-app/src/lib/init-next.ts
@@ -15,6 +15,7 @@ import type { CliArgs, DbType, NextAppDetails, NextConfigType, PackageManager } 
 import { copyRecursiveSync } from '../utils/copy-recursive-sync.js'
 import { debug as origDebug, warning } from '../utils/log.js'
 import { moveMessage } from '../utils/messages.js'
+import { installPackages } from './install-packages.js'
 import { wrapNextConfig } from './wrap-next-config.js'
 
 const readFile = promisify(fs.readFile)
@@ -229,29 +230,7 @@ async function installDeps(projectDir: string, packageManager: PackageManager, d
   // Match graphql version of @payloadcms/next
   packagesToInstall.push('graphql@^16.8.1')
 
-  let exitCode = 0
-  switch (packageManager) {
-    case 'npm': {
-      ;({ exitCode } = await execa('npm', ['install', '--save', ...packagesToInstall], {
-        cwd: projectDir,
-      }))
-      break
-    }
-    case 'yarn':
-    case 'pnpm': {
-      ;({ exitCode } = await execa(packageManager, ['add', ...packagesToInstall], {
-        cwd: projectDir,
-      }))
-      break
-    }
-    case 'bun': {
-      warning('Bun support is untested.')
-      ;({ exitCode } = await execa('bun', ['add', ...packagesToInstall], { cwd: projectDir }))
-      break
-    }
-  }
-
-  return { success: exitCode === 0 }
+  return await installPackages({ packageManager, packagesToInstall, projectDir })
 }
 
 export async function getNextAppDetails(projectDir: string): Promise<NextAppDetails> {

--- a/packages/create-payload-app/src/lib/install-packages.ts
+++ b/packages/create-payload-app/src/lib/install-packages.ts
@@ -1,0 +1,50 @@
+import execa from 'execa'
+
+import type { PackageManager } from '../types.js'
+
+import { error, warning } from '../utils/log.js'
+
+export async function installPackages(args: {
+  packageManager: PackageManager
+  packagesToInstall: string[]
+  projectDir: string
+}) {
+  const { packageManager, packagesToInstall, projectDir } = args
+
+  let exitCode = 0
+  let stdout = ''
+  let stderr = ''
+
+  switch (packageManager) {
+    case 'npm': {
+      ;({ exitCode, stderr, stdout } = await execa(
+        'npm',
+        ['install', '--save', ...packagesToInstall],
+        {
+          cwd: projectDir,
+        },
+      ))
+      break
+    }
+    case 'yarn':
+    case 'pnpm': {
+      ;({ exitCode, stderr, stdout } = await execa(packageManager, ['add', ...packagesToInstall], {
+        cwd: projectDir,
+      }))
+      break
+    }
+    case 'bun': {
+      warning('Bun support is untested.')
+      ;({ exitCode, stderr, stdout } = await execa('bun', ['add', ...packagesToInstall], {
+        cwd: projectDir,
+      }))
+      break
+    }
+  }
+
+  if (exitCode !== 0) {
+    error(`Unable to install packages. Error: ${stderr}`)
+  }
+
+  return { success: exitCode === 0 }
+}

--- a/packages/create-payload-app/src/lib/update-payload-in-project.ts
+++ b/packages/create-payload-app/src/lib/update-payload-in-project.ts
@@ -1,0 +1,112 @@
+// @ts-expect-error no types
+import { detect } from 'detect-package-manager'
+import execa from 'execa'
+import fse from 'fs-extra'
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+import type { NextAppDetails } from '../types.js'
+
+import { copyRecursiveSync } from '../utils/copy-recursive-sync.js'
+import { debug, info, warning } from '../utils/log.js'
+
+export async function updatePayloadInProject(
+  appDetails: NextAppDetails,
+): Promise<{ success: boolean }> {
+  if (!appDetails.nextConfigPath) return { success: false }
+
+  const projectDir = path.dirname(appDetails.nextConfigPath)
+
+  const packageObj = (await fse.readJson(path.resolve(projectDir, 'package.json'))) as {
+    dependencies?: Record<string, string>
+  }
+  if (!packageObj?.dependencies) {
+    throw new Error('No package.json found in this project')
+  }
+
+  const payloadVersion = packageObj.dependencies?.payload
+  if (!payloadVersion) {
+    throw new Error('Payload is not installed in this project')
+  }
+
+  const packageManager = await detect({ cwd: projectDir })
+
+  // Fetch latest Payload version from npm
+  const { exitCode: getLatestVersionExitCode, stdout: latestPayloadVersion } = await execa('npm', [
+    'show',
+    'payload@beta',
+    'version',
+  ])
+  if (getLatestVersionExitCode !== 0) {
+    throw new Error('Failed to fetch latest Payload version')
+  }
+
+  if (payloadVersion === latestPayloadVersion) {
+    throw new Error(`Payload v${payloadVersion} is already up to date.`)
+  }
+
+  // Update all existing Payload packages
+  const payloadPackages = Object.keys(packageObj.dependencies).filter((dep) =>
+    dep.startsWith('@payloadcms/'),
+  )
+  const packagesToUpdate = ['payload', ...payloadPackages].map(
+    (pkg) => `${pkg}@${latestPayloadVersion}`,
+  )
+
+  info(`Updating ${packagesToUpdate.length} Payload packages to v${latestPayloadVersion}...`)
+  debug(`Packages to update: ${packagesToUpdate.join(', ')}`)
+  debug(`Package Manager: ${packageManager}`)
+  debug(`Project directory: ${projectDir}`)
+
+  // Update all packages
+  let exitCode = 0
+  let stdout = ''
+  let stderr = ''
+  switch (packageManager) {
+    case 'npm': {
+      ;({ exitCode, stderr, stdout } = await execa(
+        'npm',
+        ['install', '--save', ...packagesToUpdate],
+        {
+          cwd: projectDir,
+        },
+      ))
+      break
+    }
+    case 'yarn':
+    case 'pnpm': {
+      debug(`args: ${[packageManager, 'add', ...packagesToUpdate].join(' ')}`)
+      ;({ exitCode, stderr, stdout } = await execa(packageManager, ['add', ...packagesToUpdate], {
+        cwd: projectDir,
+      }))
+      break
+    }
+    case 'bun': {
+      warning('Bun support is untested.')
+      ;({ exitCode } = await execa('bun', ['add', ...packagesToUpdate], { cwd: projectDir }))
+      break
+    }
+  }
+  debug(`Exit code: ${exitCode}`)
+  debug(`stdout: ${stdout}`)
+  debug(`stderr: ${stderr}`)
+
+  if (exitCode !== 0) {
+    throw new Error('Failed to update Payload packages')
+  }
+  info('Payload packages updated successfully.')
+
+  info(`Updating Payload Next.js files...`)
+  const templateFilesPath = dirname.endsWith('dist')
+    ? path.resolve(dirname, '../..', 'dist/template')
+    : path.resolve(dirname, '../../../../templates/blank-3.0')
+
+  const templateSrcDir = path.resolve(templateFilesPath ? '' : 'src')
+
+  copyRecursiveSync(templateSrcDir, path.dirname(dirname))
+
+  return { success: true }
+}

--- a/packages/create-payload-app/src/lib/update-payload-in-project.ts
+++ b/packages/create-payload-app/src/lib/update-payload-in-project.ts
@@ -104,9 +104,12 @@ export async function updatePayloadInProject(
     ? path.resolve(dirname, '../..', 'dist/template')
     : path.resolve(dirname, '../../../../templates/blank-3.0')
 
-  const templateSrcDir = path.resolve(templateFilesPath ? '' : 'src')
+  const templateSrcDir = path.resolve(templateFilesPath, 'src/app/(payload)')
 
-  copyRecursiveSync(templateSrcDir, path.dirname(dirname))
+  copyRecursiveSync(
+    templateSrcDir,
+    path.resolve(projectDir, appDetails.isSrcDir ? 'src/app' : 'app', '(payload)'),
+  )
 
   return { success: true }
 }

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -95,7 +95,7 @@ export class Main {
           message: chalk.bold(`Upgrade Payload in this project?`),
         })
 
-        if (p.isCancel(shouldUpdate) || !shouldUpdate) {
+        if (!p.isCancel(shouldUpdate) || shouldUpdate) {
           await updatePayloadInProject(nextAppDetails)
         }
 

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -89,14 +89,19 @@ export class Main {
 
       // Upgrade Payload in existing project
       if (isPayloadInstalled && nextConfigPath) {
-        p.log.warn(`Payload is already installed in this project.`)
+        p.log.warn(`Payload installation detected in current project.`)
         const shouldUpdate = await p.confirm({
           initialValue: false,
           message: chalk.bold(`Upgrade Payload in this project?`),
         })
 
         if (!p.isCancel(shouldUpdate) || shouldUpdate) {
-          await updatePayloadInProject(nextAppDetails)
+          const { message, success: updateSuccess } = await updatePayloadInProject(nextAppDetails)
+          if (updateSuccess) {
+            info(message)
+          } else {
+            error(message)
+          }
         }
 
         p.outro(feedbackOutro())
@@ -112,7 +117,7 @@ export class Main {
         ? path.dirname(nextConfigPath)
         : path.resolve(process.cwd(), slugify(projectName))
 
-      const packageManager = await getPackageManager(this.args, projectDir)
+      const packageManager = await getPackageManager({ cliArgs: this.args, projectDir })
 
       if (nextConfigPath) {
         p.log.step(

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -2,21 +2,21 @@ import * as p from '@clack/prompts'
 import slugify from '@sindresorhus/slugify'
 import arg from 'arg'
 import chalk from 'chalk'
-// @ts-expect-error no types
-import { detect } from 'detect-package-manager'
 import figures from 'figures'
 import path from 'path'
 
-import type { CliArgs, PackageManager } from './types.js'
+import type { CliArgs } from './types.js'
 
 import { configurePayloadConfig } from './lib/configure-payload-config.js'
 import { createProject } from './lib/create-project.js'
 import { generateSecret } from './lib/generate-secret.js'
+import { getPackageManager } from './lib/get-package-manager.js'
 import { getNextAppDetails, initNext } from './lib/init-next.js'
 import { parseProjectName } from './lib/parse-project-name.js'
 import { parseTemplate } from './lib/parse-template.js'
 import { selectDb } from './lib/select-db.js'
 import { getValidTemplates, validateTemplate } from './lib/templates.js'
+import { updatePayloadInProject } from './lib/update-payload-in-project.js'
 import { writeEnvFile } from './lib/write-env-file.js'
 import { error, info } from './utils/log.js'
 import {
@@ -85,7 +85,23 @@ export class Main {
 
       // Detect if inside Next.js project
       const nextAppDetails = await getNextAppDetails(process.cwd())
-      const { hasTopLevelLayout, nextAppDir, nextConfigPath } = nextAppDetails
+      const { hasTopLevelLayout, isPayloadInstalled, nextAppDir, nextConfigPath } = nextAppDetails
+
+      // Upgrade Payload in existing project
+      if (isPayloadInstalled && nextConfigPath) {
+        p.log.warn(`Payload is already installed in this project.`)
+        const shouldUpdate = await p.confirm({
+          initialValue: false,
+          message: chalk.bold(`Upgrade Payload in this project?`),
+        })
+
+        if (p.isCancel(shouldUpdate) || !shouldUpdate) {
+          await updatePayloadInProject(nextAppDetails)
+        }
+
+        p.outro(feedbackOutro())
+        process.exit(0)
+      }
 
       if (nextConfigPath) {
         this.args['--name'] = slugify(path.basename(path.dirname(nextConfigPath)))
@@ -211,20 +227,4 @@ export class Main {
       error(err instanceof Error ? err.message : 'An error occurred')
     }
   }
-}
-
-async function getPackageManager(args: CliArgs, projectDir: string): Promise<PackageManager> {
-  let packageManager: PackageManager = 'npm'
-
-  if (args['--use-npm']) {
-    packageManager = 'npm'
-  } else if (args['--use-yarn']) {
-    packageManager = 'yarn'
-  } else if (args['--use-pnpm']) {
-    packageManager = 'pnpm'
-  } else {
-    const detected = await detect({ cwd: projectDir })
-    packageManager = detected || 'npm'
-  }
-  return packageManager
 }

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -65,3 +65,14 @@ export type DbDetails = {
 }
 
 export type EditorType = 'lexical' | 'slate'
+
+export type NextAppDetails = {
+  hasTopLevelLayout: boolean
+  isPayloadInstalled?: boolean
+  isSrcDir: boolean
+  nextAppDir?: string
+  nextConfigPath?: string
+  nextConfigType?: NextConfigType
+}
+
+export type NextConfigType = 'cjs' | 'esm'


### PR DESCRIPTION
Updates create-payload-app to update an existing payload installation

- Detects existing Payload installation. Fixes #6517 
- If not latest, will install latest and grab the `(payload)` directory structure (ripped from `templates/blank-3.0`