### PR TITLE
chore!: update plugin exports to be named and consistent

### DIFF
--- a/packages/plugin-cloud-storage/src/index.ts
+++ b/packages/plugin-cloud-storage/src/index.ts
@@ -1,1 +1,1 @@
-export { cloudStorage } from './plugin.js'
+export { cloudStoragePlugin } from './plugin.js'

--- a/packages/plugin-cloud-storage/src/plugin.ts
+++ b/packages/plugin-cloud-storage/src/plugin.ts
@@ -15,7 +15,7 @@ import { getBeforeChangeHook } from './hooks/beforeChange.js'
 
 // Optionally, the adapter can specify any Webpack config overrides if they are necessary.
 
-export const cloudStorage =
+export const cloudStoragePlugin =
   (pluginOptions: PluginOptions) =>
   (incomingConfig: Config): Config => {
     const { collections: allCollectionOptions, enabled } = pluginOptions

--- a/packages/plugin-cloud/src/index.ts
+++ b/packages/plugin-cloud/src/index.ts
@@ -1,3 +1,3 @@
-export { payloadCloud } from './plugin.js'
+export { payloadCloudPlugin } from './plugin.js'
 export { createKey } from './utilities/createKey.js'
 export { getStorageClient } from './utilities/getStorageClient.js'

--- a/packages/plugin-cloud/src/plugin.spec.ts
+++ b/packages/plugin-cloud/src/plugin.spec.ts
@@ -4,7 +4,7 @@ import type { Payload } from 'payload'
 import nodemailer from 'nodemailer'
 import { defaults } from 'payload/config'
 
-import { payloadCloud } from './plugin.js'
+import { payloadCloudPlugin } from './plugin.js'
 import { nodemailerAdapter } from '@payloadcms/email-nodemailer'
 
 const mockedPayload: Payload = jest.fn() as unknown as Payload
@@ -34,7 +34,7 @@ describe('plugin', () => {
   describe('not in Payload Cloud', () => {
     // eslint-disable-next-line jest/expect-expect
     it('should return unmodified config', async () => {
-      const plugin = payloadCloud()
+      const plugin = payloadCloudPlugin()
       const config = await plugin(createConfig())
 
       assertNoCloudStorage(config)
@@ -52,7 +52,7 @@ describe('plugin', () => {
     describe('storage', () => {
       // eslint-disable-next-line jest/expect-expect
       it('should default to using payload cloud storage', async () => {
-        const plugin = payloadCloud()
+        const plugin = payloadCloudPlugin()
         const config = await plugin(createConfig())
 
         assertCloudStorage(config)
@@ -60,7 +60,7 @@ describe('plugin', () => {
 
       // eslint-disable-next-line jest/expect-expect
       it('should allow opt-out', async () => {
-        const plugin = payloadCloud({ storage: false })
+        const plugin = payloadCloudPlugin({ storage: false })
         const config = await plugin(createConfig())
 
         assertNoCloudStorage(config)
@@ -70,7 +70,7 @@ describe('plugin', () => {
     describe('email', () => {
       // eslint-disable-next-line jest/expect-expect
       it('should default to using payload cloud email', async () => {
-        const plugin = payloadCloud()
+        const plugin = payloadCloudPlugin()
         const config = await plugin(createConfig())
 
         expect(createTransportSpy).toHaveBeenCalledWith(
@@ -82,7 +82,7 @@ describe('plugin', () => {
 
       // eslint-disable-next-line jest/expect-expect
       it('should allow opt-out', async () => {
-        const plugin = payloadCloud({ email: false })
+        const plugin = payloadCloudPlugin({ email: false })
         const config = await plugin(createConfig())
 
         expect(config.email).toBeUndefined()
@@ -93,7 +93,7 @@ describe('plugin', () => {
         delete process.env.PAYLOAD_CLOUD_EMAIL_API_KEY
         delete process.env.PAYLOAD_CLOUD_DEFAULT_DOMAIN
 
-        const plugin = payloadCloud()
+        const plugin = payloadCloudPlugin()
         const config = await plugin(createConfig())
 
         expect(config.email).toBeUndefined()
@@ -120,7 +120,7 @@ describe('plugin', () => {
           }),
         })
 
-        const plugin = payloadCloud()
+        const plugin = payloadCloudPlugin()
         const config = await plugin(configWithTransport)
 
         expect(logSpy).toHaveBeenCalledWith(
@@ -141,7 +141,7 @@ describe('plugin', () => {
           }),
         })
 
-        const plugin = payloadCloud()
+        const plugin = payloadCloudPlugin()
         const config = await plugin(configWithPartialEmail)
         const emailConfig = config.email as Awaited<ReturnType<typeof nodemailerAdapter>>
 

--- a/packages/plugin-cloud/src/plugin.ts
+++ b/packages/plugin-cloud/src/plugin.ts
@@ -11,7 +11,7 @@ import {
 } from './hooks/uploadCache.js'
 import { getStaticHandler } from './staticHandler.js'
 
-export const payloadCloud =
+export const payloadCloudPlugin =
   (pluginOptions?: PluginOptions) =>
   async (incomingConfig: Config): Promise<Config> => {
     let config = { ...incomingConfig }

--- a/packages/plugin-form-builder/src/index.ts
+++ b/packages/plugin-form-builder/src/index.ts
@@ -8,7 +8,7 @@ import { generateFormCollection } from './collections/Forms/index.js'
 export { fields } from './collections/Forms/fields.js'
 export { getPaymentTotal } from './utilities/getPaymentTotal.js'
 
-const FormBuilder =
+export const formBuilderPlugin =
   (incomingFormConfig: PluginConfig) =>
   (config: Config): Config => {
     const formConfig: PluginConfig = {
@@ -51,5 +51,3 @@ const FormBuilder =
       ],
     }
   }
-
-export default FormBuilder

--- a/packages/plugin-nested-docs/src/index.ts
+++ b/packages/plugin-nested-docs/src/index.ts
@@ -12,7 +12,7 @@ import { populateBreadcrumbs } from './utilities/populateBreadcrumbs.js'
 
 export { createBreadcrumbsField, createParentField }
 
-export const nestedDocs =
+export const nestedDocsPlugin =
   (pluginConfig: PluginConfig): Plugin =>
   (config) => ({
     ...config,

--- a/packages/plugin-redirects/src/index.ts
+++ b/packages/plugin-redirects/src/index.ts
@@ -4,7 +4,7 @@ import type { PluginConfig } from './types.js'
 
 import deepMerge from './deepMerge.js'
 
-const redirects =
+export const redirectsPlugin =
   (pluginConfig: PluginConfig) =>
   (incomingConfig: Config): Config => ({
     ...incomingConfig,
@@ -78,5 +78,3 @@ const redirects =
       ),
     ],
   })
-
-export { redirects }

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -6,7 +6,7 @@ import deleteFromSearch from './Search/hooks/deleteFromSearch.js'
 import syncWithSearch from './Search/hooks/syncWithSearch.js'
 import { generateSearchCollection } from './Search/index.js'
 
-const Search =
+export const searchPlugin =
   (incomingSearchConfig: SearchConfig) =>
   (config: Config): Config => {
     const { collections } = config
@@ -61,5 +61,3 @@ const Search =
 
     return config
   }
-
-export default Search

--- a/packages/plugin-sentry/src/index.ts
+++ b/packages/plugin-sentry/src/index.ts
@@ -1,2 +1,2 @@
-export { sentry } from './plugin'
-export type { PluginOptions } from './types'
+export { sentryPlugin } from './plugin.js'
+export type { PluginOptions } from './types.js'

--- a/packages/plugin-sentry/src/plugin.spec.ts
+++ b/packages/plugin-sentry/src/plugin.spec.ts
@@ -1,32 +1,32 @@
 import type { Config } from 'payload/config'
 import { defaults } from 'payload/config'
 
-import { sentry } from './plugin'
+import { sentryPlugin } from './plugin'
 
 describe('plugin', () => {
   it('should run the plugin', () => {
-    const plugin = sentry({ enabled: true, dsn: 'asdf' })
+    const plugin = sentryPlugin({ enabled: true, dsn: 'asdf' })
     const config = plugin(createConfig())
 
     assertPluginRan(config)
   })
 
   it('should default enable: true', () => {
-    const plugin = sentry({ dsn: 'asdf' })
+    const plugin = sentryPlugin({ dsn: 'asdf' })
     const config = plugin(createConfig())
 
     assertPluginRan(config)
   })
 
   it('should not run if dsn is not provided', () => {
-    const plugin = sentry({ enabled: true, dsn: null })
+    const plugin = sentryPlugin({ enabled: true, dsn: null })
     const config = plugin(createConfig())
 
     assertPluginDidNotRun(config)
   })
 
   it('should respect enabled: false', () => {
-    const plugin = sentry({ enabled: false, dsn: null })
+    const plugin = sentryPlugin({ enabled: false, dsn: null })
     const config = plugin(createConfig())
 
     assertPluginDidNotRun(config)

--- a/packages/plugin-sentry/src/plugin.ts
+++ b/packages/plugin-sentry/src/plugin.ts
@@ -6,7 +6,7 @@ import type { PluginOptions } from './types.js'
 import { captureException } from './captureException.js'
 import { startSentry } from './startSentry.js'
 
-export const sentry =
+export const sentryPlugin =
   (pluginOptions: PluginOptions) =>
   (incomingConfig: Config): Config => {
     const config = { ...incomingConfig }

--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -20,7 +20,7 @@ import { translations } from './translations/index.js'
 import { Overview } from './ui/Overview.js'
 import { Preview } from './ui/Preview.js'
 
-const seo =
+export const seoPlugin =
   (pluginConfig: PluginConfig) =>
   (config: Config): Config => {
     const seoFields: GroupField[] = [
@@ -297,5 +297,3 @@ const seo =
       },
     }
   }
-
-export { seo }

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -8,7 +8,7 @@ import type {
 import type { Config, Plugin } from 'payload/config'
 
 import { BlobServiceClient } from '@azure/storage-blob'
-import { cloudStorage } from '@payloadcms/plugin-cloud-storage'
+import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
 
 import { getGenerateURL } from './generateURL.js'
 import { getHandleDelete } from './handleDelete.js'
@@ -94,7 +94,7 @@ export const azureStorage: AzureStoragePlugin =
       }),
     }
 
-    return cloudStorage({
+    return cloudStoragePlugin({
       collections: collectionsWithAdapter,
     })(config)
   }

--- a/packages/storage-gcs/src/index.ts
+++ b/packages/storage-gcs/src/index.ts
@@ -8,7 +8,7 @@ import type {
 import type { Config, Plugin } from 'payload/config'
 
 import { Storage } from '@google-cloud/storage'
-import { cloudStorage } from '@payloadcms/plugin-cloud-storage'
+import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
 
 import { getGenerateURL } from './generateURL.js'
 import { getHandleDelete } from './handleDelete.js'
@@ -84,7 +84,7 @@ export const gcsStorage: GcsStoragePlugin =
       }),
     }
 
-    return cloudStorage({
+    return cloudStoragePlugin({
       collections: collectionsWithAdapter,
     })(config)
   }

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -7,7 +7,7 @@ import type {
 import type { Config, Plugin } from 'payload/config'
 
 import * as AWS from '@aws-sdk/client-s3'
-import { cloudStorage } from '@payloadcms/plugin-cloud-storage'
+import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
 
 import { getGenerateURL } from './generateURL.js'
 import { getHandleDelete } from './handleDelete.js'
@@ -97,7 +97,7 @@ export const s3Storage: S3StoragePlugin =
       }),
     }
 
-    return cloudStorage({
+    return cloudStoragePlugin({
       collections: collectionsWithAdapter,
     })(config)
   }

--- a/packages/storage-vercel-blob/src/index.ts
+++ b/packages/storage-vercel-blob/src/index.ts
@@ -5,7 +5,7 @@ import type {
 import type { Adapter, GeneratedAdapter } from '@payloadcms/plugin-cloud-storage/types'
 import type { Config, Plugin } from 'payload/config'
 
-import { cloudStorage } from '@payloadcms/plugin-cloud-storage'
+import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
 
 import { getGenerateUrl } from './generateURL.js'
 import { getHandleDelete } from './handleDelete.js'
@@ -125,7 +125,7 @@ export const vercelBlobStorage: VercelBlobStoragePlugin =
       }),
     }
 
-    return cloudStorage({
+    return cloudStoragePlugin({
       collections: collectionsWithAdapter,
     })(config)
   }

--- a/test/plugin-cloud-storage/config.ts
+++ b/test/plugin-cloud-storage/config.ts
@@ -1,6 +1,6 @@
 import type { Adapter } from '@payloadcms/plugin-cloud-storage/types'
 
-import { cloudStorage } from '@payloadcms/plugin-cloud-storage'
+import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
 import { azureBlobStorageAdapter } from '@payloadcms/plugin-cloud-storage/azure'
 import { gcsAdapter } from '@payloadcms/plugin-cloud-storage/gcs'
 import { s3Adapter } from '@payloadcms/plugin-cloud-storage/s3'
@@ -122,7 +122,7 @@ export default buildConfigWithDefaults({
     )
   },
   plugins: [
-    cloudStorage({
+    cloudStoragePlugin({
       collections: {
         [mediaSlug]: {
           adapter,

--- a/test/plugin-cloud/config.ts
+++ b/test/plugin-cloud/config.ts
@@ -1,4 +1,4 @@
-import { payloadCloud } from '@payloadcms/plugin-cloud'
+import { payloadCloudPlugin } from '@payloadcms/plugin-cloud'
 import dotenv from 'dotenv'
 import path from 'path'
 
@@ -23,6 +23,6 @@ export default buildConfigWithDefaults({
       },
     })
   },
-  plugins: [payloadCloud()],
+  plugins: [payloadCloudPlugin()],
   serverURL: process.env.PAYLOAD_PUBLIC_SERVER_URL,
 })

--- a/test/plugin-form-builder/config.ts
+++ b/test/plugin-form-builder/config.ts
@@ -1,6 +1,6 @@
 import type { Block } from 'payload/types'
 
-import formBuilder, { fields as formFields } from '@payloadcms/plugin-form-builder'
+import { formBuilderPlugin, fields as formFields } from '@payloadcms/plugin-form-builder'
 import { slateEditor } from '@payloadcms/richtext-slate'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
@@ -43,7 +43,7 @@ export default buildConfigWithDefaults({
     await seed(payload)
   },
   plugins: [
-    formBuilder({
+    formBuilderPlugin({
       // handlePayment: handleFormPayments,
       // beforeEmail: prepareFormEmails,
       fields: {

--- a/test/plugin-nested-docs/config.ts
+++ b/test/plugin-nested-docs/config.ts
@@ -1,4 +1,4 @@
-import { nestedDocs } from '@payloadcms/plugin-nested-docs'
+import { nestedDocsPlugin } from '@payloadcms/plugin-nested-docs'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
@@ -26,12 +26,12 @@ export default buildConfigWithDefaults({
     await seed(payload)
   },
   plugins: [
-    nestedDocs({
+    nestedDocsPlugin({
       collections: ['pages'],
       generateLabel: (_, doc) => doc.title as string,
       generateURL: (docs) => docs.reduce((url, doc) => `${url}/${doc.slug}`, ''),
     }),
-    nestedDocs({
+    nestedDocsPlugin({
       breadcrumbsFieldSlug: 'categorization',
       collections: ['categories'],
       generateLabel: (_, doc) => doc.name as string,

--- a/test/plugin-redirects/config.ts
+++ b/test/plugin-redirects/config.ts
@@ -1,4 +1,4 @@
-import { redirects } from '@payloadcms/plugin-redirects'
+import { redirectsPlugin } from '@payloadcms/plugin-redirects'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
@@ -25,7 +25,7 @@ export default buildConfigWithDefaults({
     await seed(payload)
   },
   plugins: [
-    redirects({
+    redirectsPlugin({
       collections: ['pages'],
     }),
   ],

--- a/test/plugin-search/config.ts
+++ b/test/plugin-search/config.ts
@@ -1,4 +1,4 @@
-import searchPlugin from '@payloadcms/plugin-search'
+import { searchPlugin } from '@payloadcms/plugin-search'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'

--- a/test/plugin-sentry/config.ts
+++ b/test/plugin-sentry/config.ts
@@ -1,4 +1,4 @@
-import { sentry } from '@payloadcms/plugin-sentry'
+import { sentryPlugin } from '@payloadcms/plugin-sentry'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
@@ -24,7 +24,7 @@ export default buildConfigWithDefaults({
     })
   },
   plugins: [
-    sentry({
+    sentryPlugin({
       dsn: 'https://61edebe5ee6d4d38a9d6459c7323d777@o4505289711681536.ingest.sentry.io/4505357688242176',
       options: {
         captureErrors: [400, 403, 404],

--- a/test/plugin-seo/config.ts
+++ b/test/plugin-seo/config.ts
@@ -1,4 +1,4 @@
-import { seo } from '@payloadcms/plugin-seo'
+import { seoPlugin } from '@payloadcms/plugin-seo'
 import { en } from '@payloadcms/translations/languages/en'
 import { es } from '@payloadcms/translations/languages/es'
 
@@ -41,7 +41,7 @@ export default buildConfigWithDefaults({
     await seed(payload)
   },
   plugins: [
-    seo({
+    seoPlugin({
       collections: ['pages'],
       fieldOverrides: {
         title: {


### PR DESCRIPTION
**BREAKING CHANGE**: All plugins have been updated to use named exports and the names have been updated to be consistent.

```ts
// before
import { cloudStorage } from '@payloadcms/plugin-cloud-storage'
// current
import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'

// before
import { payloadCloud } from '@payloadcms/plugin-cloud'
// current
import { payloadCloudPlugin } from '@payloadcms/plugin-cloud'

// before
import formBuilder from '@payloadcms/plugin-form-builder'
// current
import { formBuilderPlugin } from '@payloadcms/plugin-form-builder'

// before
import { nestedDocs } from '@payloadcms/plugin-nested-docs'
// current
import { nestedDocsPlugin } from '@payloadcms/plugin-nested-docs'

// before
import { redirects } from '@payloadcms/plugin-redirects'
// current
import { redirectsPlugin } from '@payloadcms/plugin-redirects'

// before
import search from '@payloadcms/plugin-search'
// current
import { searchPlugin } from '@payloadcms/plugin-search'

// before
import { sentry } from '@payloadcms/plugin-sentry'
// current
import { sentryPlugin } from '@payloadcms/plugin-sentry'

// before
import { seo } from '@payloadcms/plugin-seo'
// current
import { seoPlugin } from '@payloadcms/plugin-seo'
```


## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

