### PR TITLE
fix(plugin-form-builder): hook overrides not working as intended

### DIFF
--- a/packages/plugin-form-builder/src/collections/FormSubmissions/index.ts
+++ b/packages/plugin-form-builder/src/collections/FormSubmissions/index.ts
@@ -91,12 +91,12 @@ export const generateSubmissionCollection = (formConfig: PluginConfig): Collecti
       ...(formConfig?.formSubmissionOverrides?.fields || []),
     ],
     hooks: {
+      ...(formConfig?.formSubmissionOverrides?.hooks || {}),
       beforeChange: [
         (data) => createCharge(data, formConfig),
         (data) => sendEmail(data, formConfig),
         ...(formConfig?.formSubmissionOverrides?.hooks?.beforeChange || []),
       ],
-      ...(formConfig?.formSubmissionOverrides?.hooks || {}),
     },
   }
 


### PR DESCRIPTION
## Description

Fixes issue when providing overrides for formSubmissions in form builder plugin

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
