### PR TITLE
chore(ui): pass localized to baseFieldProps

### DIFF
--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
@@ -597,6 +597,7 @@ export const mapFields = (args: {
               )
             }
 
+            fieldComponentProps = richTextField
             break
           }
           case 'row': {

--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
@@ -598,6 +598,7 @@ export const mapFields = (args: {
             }
 
             fieldComponentProps = richTextField
+
             break
           }
           case 'row': {

--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
@@ -205,6 +205,7 @@ export const mapFields = (args: {
           disabled: 'admin' in field && 'disabled' in field.admin ? field.admin?.disabled : false,
           errorProps,
           labelProps,
+          localized: 'localized' in field ? field.localized : undefined,
           path,
           required: 'required' in field ? field.required : undefined,
         }
@@ -595,8 +596,6 @@ export const mapFields = (args: {
                 <WithServerSideProps Component={RichTextCellComponent} />
               )
             }
-
-            fieldComponentProps = richTextField
 
             break
           }


### PR DESCRIPTION
## Description

Currently `fieldComponentProps` object doesn't contain `localized`, although by typescript it should.
I'm bulding a plugin that requires this prop and although i'm able to get it from `fields` in the config and passing it to a custom `Field` component, it doesn't work with `richText` field type as you can't make it custom.

actually was able to find a workound with passing `admin.custom` instead, but still feels like it was forgotten

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
