### PR TITLE
chore: adjusts forgot pw email template

### DIFF
--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -108,9 +108,7 @@ export const forgotPasswordOperation = async (incomingArgs: Arguments): Promise<
           : `${protocol}//${req.headers.get('host')}`
 
       let html = `${req.t('authentication:youAreReceivingResetPassword')}
-    <a href="${serverURL}${config.routes.admin}/reset/${token}">
-     ${serverURL}${config.routes.admin}/reset/${token}
-    </a>
+    <a href="${serverURL}${config.routes.admin}/reset/${token}">${serverURL}${config.routes.admin}/reset/${token}</a>
     ${req.t('authentication:youDidNotRequestPassword')}`
 
       if (typeof collectionConfig.auth.forgotPassword.generateEmailHTML === 'function') {


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload-3.0-demo/issues/167

Addresses an issue where the development forgot pw emails displayed in the terminal would route incorrectly. 

This is not a real issue, it just has to do with how the generated html looks in the terminal. To work around this I placed the anchor tags on the same line as the label. But when using an actual email client, everything functions the same as before.

For example, the terminal would display the two links shown below. Both are able to be CMD+clicked, but the second one (red arrow) was appending a `\n` newline character from the html.

![CleanShot 2024-05-04 at 1  19 06](https://github.com/payloadcms/payload/assets/30633324/66104b7c-2898-46e9-a3aa-99b2149e25e3)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

