### PR TITLE
chore(plugin-stripe): add types exports and rename types to be more consistent with other plugins

### DIFF
--- a/packages/plugin-stripe/package.json
+++ b/packages/plugin-stripe/package.json
@@ -26,14 +26,17 @@
       "import": "./src/index.ts",
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./*": {
+      "import": "./src/exports/*.ts",
+      "require": "./src/exports/*.ts",
+      "types": "./src/exports/*.ts"
     }
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "files": [
-    "dist",
-    "types.js",
-    "types.d.ts"
+    "dist"
   ],
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",

--- a/packages/plugin-stripe/src/admin.ts
+++ b/packages/plugin-stripe/src/admin.ts
@@ -1,20 +1,20 @@
 import type { Config } from 'payload/config'
 
-import type { SanitizedStripeConfig, StripeConfig } from './types.js'
+import type { PluginConfig, SanitizedPluginConfig } from './types.js'
 
 import { getFields } from './fields/getFields.js'
 
 export const stripePlugin =
-  (incomingStripeConfig: StripeConfig) =>
+  (incomingPluginConfig: PluginConfig) =>
   (config: Config): Config => {
     const { collections } = config
 
     // set config defaults here
-    const stripeConfig: SanitizedStripeConfig = {
-      ...incomingStripeConfig,
+    const pluginConfig: SanitizedPluginConfig = {
+      ...incomingPluginConfig,
       // TODO: in the next major version, default this to `false`
-      rest: incomingStripeConfig?.rest ?? true,
-      sync: incomingStripeConfig?.sync || [],
+      rest: incomingPluginConfig?.rest ?? true,
+      sync: incomingPluginConfig?.sync || [],
     }
 
     // NOTE: env variables are never passed to the client, but we need to know if `stripeSecretKey` is a test key
@@ -24,12 +24,12 @@ export const stripePlugin =
     return {
       ...config,
       collections: collections?.map((collection) => {
-        const syncConfig = stripeConfig.sync?.find((sync) => sync.collection === collection.slug)
+        const syncConfig = pluginConfig.sync?.find((sync) => sync.collection === collection.slug)
 
         if (syncConfig) {
           const fields = getFields({
             collection,
-            stripeConfig,
+            pluginConfig,
             syncConfig,
           })
           return {

--- a/packages/plugin-stripe/src/admin.ts
+++ b/packages/plugin-stripe/src/admin.ts
@@ -1,16 +1,16 @@
 import type { Config } from 'payload/config'
 
-import type { PluginConfig, SanitizedPluginConfig } from './types.js'
+import type { SanitizedStripePluginConfig, StripePluginConfig } from './types.js'
 
 import { getFields } from './fields/getFields.js'
 
 export const stripePlugin =
-  (incomingPluginConfig: PluginConfig) =>
+  (incomingPluginConfig: StripePluginConfig) =>
   (config: Config): Config => {
     const { collections } = config
 
     // set config defaults here
-    const pluginConfig: SanitizedPluginConfig = {
+    const pluginConfig: SanitizedStripePluginConfig = {
       ...incomingPluginConfig,
       // TODO: in the next major version, default this to `false`
       rest: incomingPluginConfig?.rest ?? true,

--- a/packages/plugin-stripe/src/exports/types.ts
+++ b/packages/plugin-stripe/src/exports/types.ts
@@ -1,0 +1,1 @@
+export type { FieldSyncConfig, StripeProxy, StripeWebhookHandler, SyncConfig } from '../types.js'

--- a/packages/plugin-stripe/src/exports/types.ts
+++ b/packages/plugin-stripe/src/exports/types.ts
@@ -1,1 +1,9 @@
-export type { FieldSyncConfig, StripeProxy, StripeWebhookHandler, SyncConfig } from '../types.js'
+export type {
+  FieldSyncConfig,
+  SanitizedStripePluginConfig,
+  StripePluginConfig,
+  StripeProxy,
+  StripeWebhookHandler,
+  StripeWebhookHandlers,
+  SyncConfig,
+} from '../types.js'

--- a/packages/plugin-stripe/src/fields/getFields.ts
+++ b/packages/plugin-stripe/src/fields/getFields.ts
@@ -1,12 +1,12 @@
 import type { CollectionConfig, Field } from 'payload/types'
 
-import type { SanitizedPluginConfig } from '../types.js'
+import type { SanitizedStripePluginConfig } from '../types.js'
 
 import { LinkToDoc } from '../ui/LinkToDoc.js'
 
 interface Args {
   collection: CollectionConfig
-  pluginConfig: SanitizedPluginConfig
+  pluginConfig: SanitizedStripePluginConfig
   syncConfig: {
     stripeResourceType: string
   }

--- a/packages/plugin-stripe/src/fields/getFields.ts
+++ b/packages/plugin-stripe/src/fields/getFields.ts
@@ -1,18 +1,18 @@
 import type { CollectionConfig, Field } from 'payload/types'
 
-import type { SanitizedStripeConfig } from '../types.js'
+import type { SanitizedPluginConfig } from '../types.js'
 
 import { LinkToDoc } from '../ui/LinkToDoc.js'
 
 interface Args {
   collection: CollectionConfig
-  stripeConfig: SanitizedStripeConfig
+  pluginConfig: SanitizedPluginConfig
   syncConfig: {
     stripeResourceType: string
   }
 }
 
-export const getFields = ({ collection, stripeConfig, syncConfig }: Args): Field[] => {
+export const getFields = ({ collection, pluginConfig, syncConfig }: Args): Field[] => {
   const stripeIDField: Field = {
     name: 'stripeID',
     type: 'text',
@@ -42,7 +42,7 @@ export const getFields = ({ collection, stripeConfig, syncConfig }: Args): Field
         Field: LinkToDoc,
       },
       custom: {
-        isTestKey: stripeConfig.isTestKey,
+        isTestKey: pluginConfig.isTestKey,
         nameOfIDField: 'stripeID',
         stripeResourceType: syncConfig.stripeResourceType,
       },

--- a/packages/plugin-stripe/src/hooks/createNewInStripe.ts
+++ b/packages/plugin-stripe/src/hooks/createNewInStripe.ts
@@ -3,7 +3,7 @@ import type { CollectionBeforeValidateHook, CollectionConfig } from 'payload/typ
 import { APIError } from 'payload/errors'
 import Stripe from 'stripe'
 
-import type { PluginConfig } from '../types.js'
+import type { StripePluginConfig } from '../types.js'
 
 import { deepen } from '../utilities/deepen.js'
 
@@ -21,7 +21,7 @@ type HookArgsWithCustomCollection = Omit<
 export type CollectionBeforeValidateHookWithArgs = (
   args: HookArgsWithCustomCollection & {
     collection?: CollectionConfig
-    pluginConfig?: PluginConfig
+    pluginConfig?: StripePluginConfig
   },
 ) => void
 

--- a/packages/plugin-stripe/src/hooks/createNewInStripe.ts
+++ b/packages/plugin-stripe/src/hooks/createNewInStripe.ts
@@ -3,7 +3,7 @@ import type { CollectionBeforeValidateHook, CollectionConfig } from 'payload/typ
 import { APIError } from 'payload/errors'
 import Stripe from 'stripe'
 
-import type { StripeConfig } from '../types.js'
+import type { PluginConfig } from '../types.js'
 
 import { deepen } from '../utilities/deepen.js'
 
@@ -21,14 +21,14 @@ type HookArgsWithCustomCollection = Omit<
 export type CollectionBeforeValidateHookWithArgs = (
   args: HookArgsWithCustomCollection & {
     collection?: CollectionConfig
-    stripeConfig?: StripeConfig
+    pluginConfig?: PluginConfig
   },
 ) => void
 
 export const createNewInStripe: CollectionBeforeValidateHookWithArgs = async (args) => {
-  const { collection, data, operation, req, stripeConfig } = args
+  const { collection, data, operation, pluginConfig, req } = args
 
-  const { logs, sync } = stripeConfig || {}
+  const { logs, sync } = pluginConfig || {}
 
   const payload = req?.payload
 

--- a/packages/plugin-stripe/src/hooks/deleteFromStripe.ts
+++ b/packages/plugin-stripe/src/hooks/deleteFromStripe.ts
@@ -3,7 +3,7 @@ import type { CollectionAfterDeleteHook, CollectionConfig } from 'payload/types'
 import { APIError } from 'payload/errors'
 import Stripe from 'stripe'
 
-import type { PluginConfig } from '../types.js'
+import type { StripePluginConfig } from '../types.js'
 
 const stripeSecretKey = process.env.STRIPE_SECRET_KEY
 // api version can only be the latest, stripe recommends ts ignoring it
@@ -16,7 +16,7 @@ type HookArgsWithCustomCollection = Omit<Parameters<CollectionAfterDeleteHook>[0
 export type CollectionAfterDeleteHookWithArgs = (
   args: HookArgsWithCustomCollection & {
     collection?: CollectionConfig
-    pluginConfig?: PluginConfig
+    pluginConfig?: StripePluginConfig
   },
 ) => void
 

--- a/packages/plugin-stripe/src/hooks/deleteFromStripe.ts
+++ b/packages/plugin-stripe/src/hooks/deleteFromStripe.ts
@@ -3,7 +3,7 @@ import type { CollectionAfterDeleteHook, CollectionConfig } from 'payload/types'
 import { APIError } from 'payload/errors'
 import Stripe from 'stripe'
 
-import type { StripeConfig } from '../types.js'
+import type { PluginConfig } from '../types.js'
 
 const stripeSecretKey = process.env.STRIPE_SECRET_KEY
 // api version can only be the latest, stripe recommends ts ignoring it
@@ -16,14 +16,14 @@ type HookArgsWithCustomCollection = Omit<Parameters<CollectionAfterDeleteHook>[0
 export type CollectionAfterDeleteHookWithArgs = (
   args: HookArgsWithCustomCollection & {
     collection?: CollectionConfig
-    stripeConfig?: StripeConfig
+    pluginConfig?: PluginConfig
   },
 ) => void
 
 export const deleteFromStripe: CollectionAfterDeleteHookWithArgs = async (args) => {
-  const { collection, doc, req, stripeConfig } = args
+  const { collection, doc, pluginConfig, req } = args
 
-  const { logs, sync } = stripeConfig || {}
+  const { logs, sync } = pluginConfig || {}
 
   const { payload } = req
   const { slug: collectionSlug } = collection || {}

--- a/packages/plugin-stripe/src/hooks/syncExistingWithStripe.ts
+++ b/packages/plugin-stripe/src/hooks/syncExistingWithStripe.ts
@@ -3,7 +3,7 @@ import type { CollectionBeforeChangeHook, CollectionConfig } from 'payload/types
 import { APIError } from 'payload/errors'
 import Stripe from 'stripe'
 
-import type { StripeConfig } from '../types.js'
+import type { PluginConfig } from '../types.js'
 
 import { deepen } from '../utilities/deepen.js'
 
@@ -21,14 +21,14 @@ type HookArgsWithCustomCollection = Omit<
 export type CollectionBeforeChangeHookWithArgs = (
   args: HookArgsWithCustomCollection & {
     collection?: CollectionConfig
-    stripeConfig?: StripeConfig
+    pluginConfig?: PluginConfig
   },
 ) => void
 
 export const syncExistingWithStripe: CollectionBeforeChangeHookWithArgs = async (args) => {
-  const { collection, data, operation, originalDoc, req, stripeConfig } = args
+  const { collection, data, operation, originalDoc, pluginConfig, req } = args
 
-  const { logs, sync } = stripeConfig || {}
+  const { logs, sync } = pluginConfig || {}
 
   const { payload } = req
 

--- a/packages/plugin-stripe/src/hooks/syncExistingWithStripe.ts
+++ b/packages/plugin-stripe/src/hooks/syncExistingWithStripe.ts
@@ -3,7 +3,7 @@ import type { CollectionBeforeChangeHook, CollectionConfig } from 'payload/types
 import { APIError } from 'payload/errors'
 import Stripe from 'stripe'
 
-import type { PluginConfig } from '../types.js'
+import type { StripePluginConfig } from '../types.js'
 
 import { deepen } from '../utilities/deepen.js'
 
@@ -21,7 +21,7 @@ type HookArgsWithCustomCollection = Omit<
 export type CollectionBeforeChangeHookWithArgs = (
   args: HookArgsWithCustomCollection & {
     collection?: CollectionConfig
-    pluginConfig?: PluginConfig
+    pluginConfig?: StripePluginConfig
   },
 ) => void
 

--- a/packages/plugin-stripe/src/index.ts
+++ b/packages/plugin-stripe/src/index.ts
@@ -1,6 +1,6 @@
 import type { Config, Endpoint } from 'payload/config'
 
-import type { SanitizedStripeConfig, StripeConfig } from './types.js'
+import type { PluginConfig, SanitizedPluginConfig } from './types.js'
 
 import { getFields } from './fields/getFields.js'
 import { createNewInStripe } from './hooks/createNewInStripe.js'
@@ -13,12 +13,12 @@ export { LinkToDoc } from './ui/LinkToDoc.js'
 export { stripeProxy } from './utilities/stripeProxy.js'
 
 export const stripePlugin =
-  (incomingStripeConfig: StripeConfig) =>
+  (incomingStripeConfig: PluginConfig) =>
   (config: Config): Config => {
     const { collections } = config
 
     // set config defaults here
-    const stripeConfig: SanitizedStripeConfig = {
+    const pluginConfig: SanitizedPluginConfig = {
       ...incomingStripeConfig,
       // TODO: in the next major version, default this to `false`
       rest: incomingStripeConfig?.rest ?? true,
@@ -35,8 +35,8 @@ export const stripePlugin =
         handler: async (req) => {
           const res = await stripeWebhooks({
             config,
+            pluginConfig,
             req,
-            stripeConfig,
           })
 
           return res
@@ -50,8 +50,8 @@ export const stripePlugin =
       endpoints.push({
         handler: async (req) => {
           const res = await stripeREST({
+            pluginConfig,
             req,
-            stripeConfig,
           })
 
           return res
@@ -66,12 +66,12 @@ export const stripePlugin =
       collections: collections?.map((collection) => {
         const { hooks: existingHooks } = collection
 
-        const syncConfig = stripeConfig.sync?.find((sync) => sync.collection === collection.slug)
+        const syncConfig = pluginConfig.sync?.find((sync) => sync.collection === collection.slug)
 
         if (syncConfig) {
           const fields = getFields({
             collection,
-            stripeConfig,
+            pluginConfig,
             syncConfig,
           })
           return {
@@ -85,7 +85,7 @@ export const stripePlugin =
                   deleteFromStripe({
                     ...args,
                     collection,
-                    stripeConfig,
+                    pluginConfig,
                   }),
               ],
               beforeChange: [
@@ -94,7 +94,7 @@ export const stripePlugin =
                   syncExistingWithStripe({
                     ...args,
                     collection,
-                    stripeConfig,
+                    pluginConfig,
                   }),
               ],
               beforeValidate: [
@@ -103,7 +103,7 @@ export const stripePlugin =
                   createNewInStripe({
                     ...args,
                     collection,
-                    stripeConfig,
+                    pluginConfig,
                   }),
               ],
             },

--- a/packages/plugin-stripe/src/index.ts
+++ b/packages/plugin-stripe/src/index.ts
@@ -1,6 +1,6 @@
 import type { Config, Endpoint } from 'payload/config'
 
-import type { PluginConfig, SanitizedPluginConfig } from './types.js'
+import type { SanitizedStripePluginConfig, StripePluginConfig } from './types.js'
 
 import { getFields } from './fields/getFields.js'
 import { createNewInStripe } from './hooks/createNewInStripe.js'
@@ -13,12 +13,12 @@ export { LinkToDoc } from './ui/LinkToDoc.js'
 export { stripeProxy } from './utilities/stripeProxy.js'
 
 export const stripePlugin =
-  (incomingStripeConfig: PluginConfig) =>
+  (incomingStripeConfig: StripePluginConfig) =>
   (config: Config): Config => {
     const { collections } = config
 
     // set config defaults here
-    const pluginConfig: SanitizedPluginConfig = {
+    const pluginConfig: SanitizedStripePluginConfig = {
       ...incomingStripeConfig,
       // TODO: in the next major version, default this to `false`
       rest: incomingStripeConfig?.rest ?? true,

--- a/packages/plugin-stripe/src/routes/rest.ts
+++ b/packages/plugin-stripe/src/routes/rest.ts
@@ -2,12 +2,12 @@ import type { PayloadRequestWithData } from 'payload/types'
 
 import { Forbidden } from 'payload/errors'
 
-import type { PluginConfig } from '../types.js'
+import type { StripePluginConfig } from '../types.js'
 
 import { stripeProxy } from '../utilities/stripeProxy.js'
 
 export const stripeREST = async (args: {
-  pluginConfig: PluginConfig
+  pluginConfig: StripePluginConfig
   req: PayloadRequestWithData
 }): Promise<any> => {
   let responseStatus = 200

--- a/packages/plugin-stripe/src/routes/rest.ts
+++ b/packages/plugin-stripe/src/routes/rest.ts
@@ -2,18 +2,18 @@ import type { PayloadRequestWithData } from 'payload/types'
 
 import { Forbidden } from 'payload/errors'
 
-import type { StripeConfig } from '../types.js'
+import type { PluginConfig } from '../types.js'
 
 import { stripeProxy } from '../utilities/stripeProxy.js'
 
 export const stripeREST = async (args: {
+  pluginConfig: PluginConfig
   req: PayloadRequestWithData
-  stripeConfig: StripeConfig
 }): Promise<any> => {
   let responseStatus = 200
   let responseJSON
 
-  const { req, stripeConfig } = args
+  const { pluginConfig, req } = args
 
   const {
     data: {
@@ -24,7 +24,7 @@ export const stripeREST = async (args: {
     user,
   } = req
 
-  const { stripeSecretKey } = stripeConfig
+  const { stripeSecretKey } = pluginConfig
 
   try {
     if (!user) {

--- a/packages/plugin-stripe/src/routes/webhooks.ts
+++ b/packages/plugin-stripe/src/routes/webhooks.ts
@@ -3,13 +3,13 @@ import type { PayloadRequestWithData } from 'payload/types'
 
 import Stripe from 'stripe'
 
-import type { PluginConfig } from '../types.js'
+import type { StripePluginConfig } from '../types.js'
 
 import { handleWebhooks } from '../webhooks/index.js'
 
 export const stripeWebhooks = async (args: {
   config: PayloadConfig
-  pluginConfig: PluginConfig
+  pluginConfig: StripePluginConfig
   req: PayloadRequestWithData
 }): Promise<any> => {
   const { config, pluginConfig, req } = args

--- a/packages/plugin-stripe/src/routes/webhooks.ts
+++ b/packages/plugin-stripe/src/routes/webhooks.ts
@@ -3,19 +3,19 @@ import type { PayloadRequestWithData } from 'payload/types'
 
 import Stripe from 'stripe'
 
-import type { StripeConfig } from '../types.js'
+import type { PluginConfig } from '../types.js'
 
 import { handleWebhooks } from '../webhooks/index.js'
 
 export const stripeWebhooks = async (args: {
   config: PayloadConfig
+  pluginConfig: PluginConfig
   req: PayloadRequestWithData
-  stripeConfig: StripeConfig
 }): Promise<any> => {
-  const { config, req, stripeConfig } = args
+  const { config, pluginConfig, req } = args
   let returnStatus = 200
 
-  const { stripeSecretKey, stripeWebhooksEndpointSecret, webhooks } = stripeConfig
+  const { stripeSecretKey, stripeWebhooksEndpointSecret, webhooks } = pluginConfig
 
   if (stripeWebhooksEndpointSecret) {
     const stripe = new Stripe(stripeSecretKey, {
@@ -46,8 +46,8 @@ export const stripeWebhooks = async (args: {
           config,
           event,
           payload: req.payload,
+          pluginConfig,
           stripe,
-          stripeConfig,
         })
 
         // Fire external webhook handlers if they exist
@@ -56,8 +56,8 @@ export const stripeWebhooks = async (args: {
             config,
             event,
             payload: req.payload,
+            pluginConfig,
             stripe,
-            stripeConfig,
           })
         }
 
@@ -68,8 +68,8 @@ export const stripeWebhooks = async (args: {
               config,
               event,
               payload: req.payload,
+              pluginConfig,
               stripe,
-              stripeConfig,
             })
           }
         }

--- a/packages/plugin-stripe/src/types.ts
+++ b/packages/plugin-stripe/src/types.ts
@@ -6,8 +6,8 @@ export type StripeWebhookHandler<T = any> = (args: {
   config: PayloadConfig
   event: T
   payload: Payload
+  pluginConfig?: PluginConfig
   stripe: Stripe
-  stripeConfig?: StripeConfig
 }) => void
 
 export interface StripeWebhookHandlers {
@@ -26,7 +26,7 @@ export interface SyncConfig {
   stripeResourceTypeSingular: 'customer' | 'product' // TODO: there must be a better way to do this
 }
 
-export interface StripeConfig {
+export interface PluginConfig {
   isTestKey?: boolean
   logs?: boolean
   // @deprecated this will default as `false` in the next major version release
@@ -37,7 +37,7 @@ export interface StripeConfig {
   webhooks?: StripeWebhookHandler | StripeWebhookHandlers
 }
 
-export type SanitizedStripeConfig = StripeConfig & {
+export type SanitizedPluginConfig = PluginConfig & {
   sync: SyncConfig[] // convert to required
 }
 

--- a/packages/plugin-stripe/src/types.ts
+++ b/packages/plugin-stripe/src/types.ts
@@ -6,27 +6,27 @@ export type StripeWebhookHandler<T = any> = (args: {
   config: PayloadConfig
   event: T
   payload: Payload
-  pluginConfig?: PluginConfig
+  pluginConfig?: StripePluginConfig
   stripe: Stripe
 }) => void
 
-export interface StripeWebhookHandlers {
+export type StripeWebhookHandlers = {
   [webhookName: string]: StripeWebhookHandler
 }
 
-export interface FieldSyncConfig {
+export type FieldSyncConfig = {
   fieldPath: string
   stripeProperty: string
 }
 
-export interface SyncConfig {
+export type SyncConfig = {
   collection: string
   fields: FieldSyncConfig[]
   stripeResourceType: 'customers' | 'products' // TODO: get this from Stripe types
   stripeResourceTypeSingular: 'customer' | 'product' // TODO: there must be a better way to do this
 }
 
-export interface PluginConfig {
+export type StripePluginConfig = {
   isTestKey?: boolean
   logs?: boolean
   // @deprecated this will default as `false` in the next major version release
@@ -37,7 +37,7 @@ export interface PluginConfig {
   webhooks?: StripeWebhookHandler | StripeWebhookHandlers
 }
 
-export type SanitizedPluginConfig = PluginConfig & {
+export type SanitizedStripePluginConfig = StripePluginConfig & {
   sync: SyncConfig[] // convert to required
 }
 

--- a/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
+++ b/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
@@ -1,20 +1,20 @@
 import { v4 as uuid } from 'uuid'
 
-import type { SanitizedStripeConfig, StripeWebhookHandler } from '../types.js'
+import type { SanitizedPluginConfig, StripeWebhookHandler } from '../types.js'
 
 import { deepen } from '../utilities/deepen.js'
 
 type HandleCreatedOrUpdated = (
   args: Parameters<StripeWebhookHandler>[0] & {
     resourceType: string
-    syncConfig: SanitizedStripeConfig['sync'][0]
+    syncConfig: SanitizedPluginConfig['sync'][0]
   },
 ) => void
 
 export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
-  const { config: payloadConfig, event, payload, resourceType, stripeConfig, syncConfig } = args
+  const { config: payloadConfig, event, payload, pluginConfig, resourceType, syncConfig } = args
 
-  const { logs } = stripeConfig || {}
+  const { logs } = pluginConfig || {}
 
   const stripeDoc: any = event?.data?.object || {}
 

--- a/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
+++ b/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
@@ -1,13 +1,13 @@
 import { v4 as uuid } from 'uuid'
 
-import type { SanitizedPluginConfig, StripeWebhookHandler } from '../types.js'
+import type { SanitizedStripePluginConfig, StripeWebhookHandler } from '../types.js'
 
 import { deepen } from '../utilities/deepen.js'
 
 type HandleCreatedOrUpdated = (
   args: Parameters<StripeWebhookHandler>[0] & {
     resourceType: string
-    syncConfig: SanitizedPluginConfig['sync'][0]
+    syncConfig: SanitizedStripePluginConfig['sync'][0]
   },
 ) => void
 

--- a/packages/plugin-stripe/src/webhooks/handleDeleted.ts
+++ b/packages/plugin-stripe/src/webhooks/handleDeleted.ts
@@ -1,9 +1,9 @@
-import type { SanitizedPluginConfig, StripeWebhookHandler } from '../types.js'
+import type { SanitizedStripePluginConfig, StripeWebhookHandler } from '../types.js'
 
 type HandleDeleted = (
   args: Parameters<StripeWebhookHandler>[0] & {
     resourceType: string
-    syncConfig: SanitizedPluginConfig['sync'][0]
+    syncConfig: SanitizedStripePluginConfig['sync'][0]
   },
 ) => void
 

--- a/packages/plugin-stripe/src/webhooks/handleDeleted.ts
+++ b/packages/plugin-stripe/src/webhooks/handleDeleted.ts
@@ -1,16 +1,16 @@
-import type { SanitizedStripeConfig, StripeWebhookHandler } from '../types.js'
+import type { SanitizedPluginConfig, StripeWebhookHandler } from '../types.js'
 
 type HandleDeleted = (
   args: Parameters<StripeWebhookHandler>[0] & {
     resourceType: string
-    syncConfig: SanitizedStripeConfig['sync'][0]
+    syncConfig: SanitizedPluginConfig['sync'][0]
   },
 ) => void
 
 export const handleDeleted: HandleDeleted = async (args) => {
-  const { event, payload, resourceType, stripeConfig, syncConfig } = args
+  const { event, payload, pluginConfig, resourceType, syncConfig } = args
 
-  const { logs } = stripeConfig || {}
+  const { logs } = pluginConfig || {}
 
   const collectionSlug = syncConfig?.collection
 

--- a/packages/plugin-stripe/src/webhooks/index.ts
+++ b/packages/plugin-stripe/src/webhooks/index.ts
@@ -4,9 +4,9 @@ import { handleCreatedOrUpdated } from './handleCreatedOrUpdated.js'
 import { handleDeleted } from './handleDeleted.js'
 
 export const handleWebhooks: StripeWebhookHandler = (args) => {
-  const { event, payload, stripeConfig } = args
+  const { event, payload, pluginConfig } = args
 
-  if (stripeConfig?.logs)
+  if (pluginConfig?.logs)
     payload.logger.info(`🪝 Received Stripe '${event.type}' webhook event with ID: '${event.id}'.`)
 
   // could also traverse into event.data.object.object to get the type, but that seems unreliable
@@ -14,7 +14,7 @@ export const handleWebhooks: StripeWebhookHandler = (args) => {
   const resourceType = event.type.split('.')[0]
   const method = event.type.split('.').pop()
 
-  const syncConfig = stripeConfig?.sync?.find(
+  const syncConfig = pluginConfig?.sync?.find(
     (sync) => sync.stripeResourceTypeSingular === resourceType,
   )
 
@@ -23,8 +23,8 @@ export const handleWebhooks: StripeWebhookHandler = (args) => {
       case 'created': {
         void handleCreatedOrUpdated({
           ...args,
+          pluginConfig,
           resourceType,
-          stripeConfig,
           syncConfig,
         })
         break
@@ -32,8 +32,8 @@ export const handleWebhooks: StripeWebhookHandler = (args) => {
       case 'updated': {
         void handleCreatedOrUpdated({
           ...args,
+          pluginConfig,
           resourceType,
-          stripeConfig,
           syncConfig,
         })
         break
@@ -41,8 +41,8 @@ export const handleWebhooks: StripeWebhookHandler = (args) => {
       case 'deleted': {
         void handleDeleted({
           ...args,
+          pluginConfig,
           resourceType,
-          stripeConfig,
           syncConfig,
         })
         break

--- a/packages/plugin-stripe/types.d.ts
+++ b/packages/plugin-stripe/types.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/types'

--- a/packages/plugin-stripe/types.js
+++ b/packages/plugin-stripe/types.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/types')


### PR DESCRIPTION
chore(plugin-stripe)!: add types exports and rename types to be more consistent with other plugins and what they mean

Closes https://github.com/payloadcms/payload/issues/6214

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

