### PR TITLE
chore(plugin-search): add types export and rename internal config

### DIFF
--- a/packages/plugin-search/package.json
+++ b/packages/plugin-search/package.json
@@ -23,14 +23,17 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./*": {
+      "import": "./src/exports/*.ts",
+      "require": "./src/exports/*.ts",
+      "types": "./src/exports/*.ts"
     }
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "files": [
-    "dist",
-    "types.js",
-    "types.d.ts"
+    "dist"
   ],
   "scripts": {
     "build": "pnpm build:swc && pnpm build:types",

--- a/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
@@ -1,6 +1,10 @@
 import type { CollectionAfterDeleteHook } from 'payload/types'
 
-const deleteFromSearch: CollectionAfterDeleteHook = async ({ doc, req: { payload }, req }) => {
+export const deleteFromSearch: CollectionAfterDeleteHook = async ({
+  doc,
+  req: { payload },
+  req,
+}) => {
   try {
     const searchDocQuery = await payload.find({
       collection: 'search',
@@ -28,5 +32,3 @@ const deleteFromSearch: CollectionAfterDeleteHook = async ({ doc, req: { payload
 
   return doc
 }
-
-export default deleteFromSearch

--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -1,19 +1,18 @@
-import type { DocToSync, SearchConfig, SyncWithSearch } from '../../types.js'
+import type { DocToSync, SyncWithSearch } from '../../types.js'
 
-const syncWithSearch: SyncWithSearch = async (args) => {
+export const syncWithSearch: SyncWithSearch = async (args) => {
   const {
     collection,
     doc,
     operation,
+    pluginConfig,
     req: { payload },
     req,
-    // @ts-expect-error
-    searchConfig,
   } = args
 
   const { id, _status: status, title } = doc || {}
 
-  const { beforeSync, defaultPriorities, deleteDrafts, syncDrafts } = searchConfig as SearchConfig // todo fix SyncWithSearch type, see note in ./types.ts
+  const { beforeSync, defaultPriorities, deleteDrafts, syncDrafts } = pluginConfig
 
   let dataToSave: DocToSync = {
     doc: {
@@ -159,5 +158,3 @@ const syncWithSearch: SyncWithSearch = async (args) => {
 
   return doc
 }
-
-export default syncWithSearch

--- a/packages/plugin-search/src/Search/index.ts
+++ b/packages/plugin-search/src/Search/index.ts
@@ -2,12 +2,12 @@ import type { CollectionConfig } from 'payload/types'
 
 import deepMerge from 'deepmerge'
 
-import type { SearchConfig } from '../types.js'
+import type { PluginConfig } from '../types.js'
 
 import { LinkToDoc } from './ui/index.js'
 
 // all settings can be overridden by the config
-export const generateSearchCollection = (searchConfig: SearchConfig): CollectionConfig =>
+export const generateSearchCollection = (pluginConfig: PluginConfig): CollectionConfig =>
   deepMerge(
     {
       slug: 'search',
@@ -46,7 +46,7 @@ export const generateSearchCollection = (searchConfig: SearchConfig): Collection
           },
           index: true,
           maxDepth: 0,
-          relationTo: searchConfig?.collections || [],
+          relationTo: pluginConfig?.collections || [],
           required: true,
         },
         {
@@ -65,5 +65,5 @@ export const generateSearchCollection = (searchConfig: SearchConfig): Collection
         singular: 'Search Result',
       },
     },
-    searchConfig?.searchOverrides || {},
+    pluginConfig?.searchOverrides || {},
   )

--- a/packages/plugin-search/src/exports/types.ts
+++ b/packages/plugin-search/src/exports/types.ts
@@ -1,0 +1,1 @@
+export type { BeforeSync, DocToSync } from '../types.js'

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -1,19 +1,19 @@
 import type { Config } from 'payload/config'
 
-import type { SearchConfig } from './types.js'
+import type { PluginConfig } from './types.js'
 
-import deleteFromSearch from './Search/hooks/deleteFromSearch.js'
-import syncWithSearch from './Search/hooks/syncWithSearch.js'
+import { deleteFromSearch } from './Search/hooks/deleteFromSearch.js'
+import { syncWithSearch } from './Search/hooks/syncWithSearch.js'
 import { generateSearchCollection } from './Search/index.js'
 
 export const searchPlugin =
-  (incomingSearchConfig: SearchConfig) =>
+  (incomingPluginConfig: PluginConfig) =>
   (config: Config): Config => {
     const { collections } = config
 
     if (collections) {
-      const searchConfig: SearchConfig = {
-        ...incomingSearchConfig,
+      const pluginConfig: PluginConfig = {
+        ...incomingPluginConfig,
         deleteDrafts: true,
         syncDrafts: false,
         // write any config defaults here
@@ -24,7 +24,7 @@ export const searchPlugin =
         ?.map((collection) => {
           const { hooks: existingHooks } = collection
 
-          const enabledCollections = searchConfig.collections || []
+          const enabledCollections = pluginConfig.collections || []
           const isEnabled = enabledCollections.indexOf(collection.slug) > -1
           if (isEnabled) {
             return {
@@ -37,7 +37,7 @@ export const searchPlugin =
                     await syncWithSearch({
                       ...args,
                       collection: collection.slug,
-                      searchConfig,
+                      pluginConfig,
                     })
                   },
                 ],
@@ -54,7 +54,7 @@ export const searchPlugin =
         ...config,
         collections: [
           ...(collectionsWithSearchHooks || []),
-          generateSearchCollection(searchConfig),
+          generateSearchCollection(pluginConfig),
         ],
       }
     }

--- a/packages/plugin-search/src/types.ts
+++ b/packages/plugin-search/src/types.ts
@@ -23,7 +23,7 @@ export type BeforeSync = (args: {
   searchDoc: DocToSync
 }) => DocToSync | Promise<DocToSync>
 
-export interface SearchConfig {
+export interface PluginConfig {
   beforeSync?: BeforeSync
   collections?: string[]
   defaultPriorities?: {
@@ -39,5 +39,6 @@ export interface SearchConfig {
 export type SyncWithSearch = (
   Args: Omit<Parameters<CollectionAfterChangeHook>[0], 'collection'> & {
     collection: string
+    pluginConfig: PluginConfig
   },
 ) => ReturnType<CollectionAfterChangeHook>

--- a/packages/plugin-search/types.d.ts
+++ b/packages/plugin-search/types.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/types'

--- a/packages/plugin-search/types.js
+++ b/packages/plugin-search/types.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/types')


### PR DESCRIPTION
Adds types export to search plugin and renames some internal variables to be more consistent with other plugins

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
