### PR TITLE
docs(plugin-cloud): Fix link to local-dev.md

### DIFF
--- a/packages/plugin-cloud-storage/README.md
+++ b/packages/plugin-cloud-storage/README.md
@@ -188,7 +188,7 @@ If this does not apply to you (your upload collection has `read: () => true` or 
 
 ## Local development
 
-For instructions regarding how to develop with this plugin locally, [click here](https://github.com/payloadcms/plugin-cloud-storage/blob/master/docs/local-dev.md).
+For instructions regarding how to develop with this plugin locally, [click here](https://github.com/payloadcms/payload/blob/main/packages/plugin-cloud-storage/docs/local-dev.md).
 
 ## Questions
 


### PR DESCRIPTION
## Description

Just a documentation update for the new link to local-dev.md for the cloud plugin.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] I have made corresponding changes to the documentation
