### PR TITLE
fix: hide drag handles when `admin.isSortable: false`

### DIFF
--- a/docs/fields/array.mdx
+++ b/docs/fields/array.mdx
@@ -59,7 +59,7 @@ properties:
 | Option                    | Description                                                                                                          |
 |---------------------------|----------------------------------------------------------------------------------------------------------------------|
 | **`initCollapsed`**       | Set the initial collapsed state                                                                                      |
-| **`isSortable`**          | Disable order sorting by setting this value to `false`                                                               |
+| **`isSortable`**          | Disable array order sorting by setting this value to `false`                                                               |
 | **`components.RowLabel`** | Function or React component to be rendered as the label on the array row. Receives `({ data, index, path })` as args |
 
 ### Example

--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -58,7 +58,7 @@ properties:
 | Option              | Description                     |
 |---------------------|---------------------------------|
 | **`initCollapsed`** | Set the initial collapsed state |
-| **`isSortable`** | Disable order sorting by setting this value to `false` |
+| **`isSortable`** | Disable block order sorting by setting this value to `false` |
 
 ### Block configs
 

--- a/packages/payload/src/admin/components/forms/field-types/Array/ArrayRow.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/ArrayRow.tsx
@@ -106,11 +106,15 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
         className={classNames}
         collapsed={row.collapsed}
         collapsibleStyle={fieldHasErrors ? 'error' : 'default'}
-        dragHandleProps={{
-          id: row.id,
-          attributes,
-          listeners,
-        }}
+        dragHandleProps={
+          isSortable
+            ? {
+                id: row.id,
+                attributes,
+                listeners,
+              }
+            : undefined
+        }
         header={
           <div className={`${baseClass}__row-header`}>
             <RowLabel

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/BlockRow.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/BlockRow.tsx
@@ -104,11 +104,15 @@ export const BlockRow: React.FC<BlockFieldProps> = ({
         className={classNames}
         collapsed={row.collapsed}
         collapsibleStyle={fieldHasErrors ? 'error' : 'default'}
-        dragHandleProps={{
-          id: row.id,
-          attributes,
-          listeners,
-        }}
+        dragHandleProps={
+          isSortable
+            ? {
+                id: row.id,
+                attributes,
+                listeners,
+              }
+            : undefined
+        }
         header={
           <div className={`${baseClass}__block-header`}>
             <span className={`${baseClass}__block-number`}>

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -156,7 +156,7 @@ const ArrayFields: CollectionConfig = {
       type: 'array',
     },
     {
-      name: 'disableSortItems',
+      name: 'disableSort',
       defaultValue: arrayDefaultValue,
       admin: {
         isSortable: false,

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -124,6 +124,13 @@ const BlockFields: CollectionConfig = {
       name: 'collapsedByDefaultBlocks',
       admin: {
         initCollapsed: true,
+      },
+      localized: true,
+    },
+    {
+      ...getBlocksField('localized'),
+      name: 'disableSort',
+      admin: {
         isSortable: false,
       },
       localized: true,

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -765,10 +765,22 @@ describe('fields', () => {
       })
     })
 
-    test('should have disabled admin sorting', async () => {
-      await page.goto(url.create)
-      const field = page.locator('#field-collapsedByDefaultBlocks .array-actions__action-chevron')
-      expect(await field.count()).toEqual(0)
+    describe('admin.isSortable: false', () => {
+      beforeAll(async () => {
+        await page.goto(url.create)
+      })
+
+      test('the move action should be hidden', async () => {
+        await expect(
+          page.locator('#field-collapsedByDefaultBlocks .array-actions__action-chevron'),
+        ).toHaveCount(0)
+      })
+
+      test('the drag handle should be hidden', async () => {
+        await expect(
+          page.locator('#field-collapsedByDefaultBlocks .collapsible__drag'),
+        ).toHaveCount(0)
+      })
     })
   })
 
@@ -788,12 +800,6 @@ describe('fields', () => {
       await page.goto(url.create)
       const field = page.locator('#field-readOnly__0__text')
       await expect(field).toHaveValue('defaultValue')
-    })
-
-    test('should have disabled admin sorting', async () => {
-      await page.goto(url.create)
-      const field = page.locator('#field-disableSortItems .array-actions__action-chevron')
-      expect(await field.count()).toEqual(0)
     })
 
     test('should render RowLabel using a function', async () => {
@@ -918,6 +924,23 @@ describe('fields', () => {
         ).toHaveValue(`${assertGroupText3} duplicate`)
       })
     })
+
+    describe('admin.isSortable: false', () => {
+      beforeAll(async () => {
+        await page.goto(url.create)
+      })
+
+      test('the move action should be hidden', async () => {
+        const locator = await expect(
+          page.locator('#field-disableSortItems .array-actions__action-chevron'),
+        ).toHaveCount(0)
+      })
+
+      test('the drag handle should be hidden', async () => {
+        await expect(page.locator('#field-disableSortItems .collapsible__drag')).toHaveCount(0)
+      })
+    })
+
     test('should bulk update', async () => {
       await Promise.all([
         payload.create({

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -771,15 +771,13 @@ describe('fields', () => {
       })
 
       test('the move action should be hidden', async () => {
-        await expect(
-          page.locator('#field-collapsedByDefaultBlocks .array-actions__action-chevron'),
-        ).toHaveCount(0)
+        await expect(page.locator('#field-disableSort .array-actions__action-chevron')).toHaveCount(
+          0,
+        )
       })
 
       test('the drag handle should be hidden', async () => {
-        await expect(
-          page.locator('#field-collapsedByDefaultBlocks .collapsible__drag'),
-        ).toHaveCount(0)
+        await expect(page.locator('#field-disableSort .collapsible__drag')).toHaveCount(0)
       })
     })
   })
@@ -931,13 +929,13 @@ describe('fields', () => {
       })
 
       test('the move action should be hidden', async () => {
-        const locator = await expect(
-          page.locator('#field-disableSortItems .array-actions__action-chevron'),
-        ).toHaveCount(0)
+        await expect(page.locator('#field-disableSort .array-actions__action-chevron')).toHaveCount(
+          0,
+        )
       })
 
       test('the drag handle should be hidden', async () => {
-        await expect(page.locator('#field-disableSortItems .collapsible__drag')).toHaveCount(0)
+        await expect(page.locator('#field-disableSort .collapsible__drag')).toHaveCount(0)
       })
     })
 


### PR DESCRIPTION
## Description

The ability to disable sorting in array and block fields was added recently with https://github.com/payloadcms/payload/pull/5962.

However, the drag handles are still visible and look interactive on hover:

<img width="967" alt="image" src="https://github.com/payloadcms/payload/assets/208149/93ac9049-1050-4714-9275-15b0a727b27d">


This PR hides the drag handles in array and block fields when `admin.isSortable: false`.

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] ~I have made corresponding changes to the documentation~
