### PR TITLE
chore(plugin-stripe)!: disables rest proxy by default

### DIFF
--- a/docs/plugins/stripe.mdx
+++ b/docs/plugins/stripe.mdx
@@ -85,7 +85,7 @@ The following custom endpoints are automatically opened for you:
 
 ##### Stripe REST Proxy
 
-If `rest` is true, proxies the [Stripe REST API](https://stripe.com/docs/api) behind [Payload access control](https://payloadcms.com/docs/access-control/overview) and returns the result. If you need to proxy the API server-side, use the [stripeProxy](#node) function.
+If `rest` is true, proxies the [Stripe REST API](https://stripe.com/docs/api) behind [Payload access control](https://payloadcms.com/docs/access-control/overview) and returns the result. This flag should only be used for local development, see the security note below for more information.
 
 ```ts
 const res = await fetch(`/api/stripe/rest`, {
@@ -106,11 +106,19 @@ const res = await fetch(`/api/stripe/rest`, {
 })
 ```
 
+If you need to proxy the API server-side, use the [stripeProxy](#node) function.
+
 <Banner type="info">
   <strong>Note:</strong>
   <br />
   The `/api` part of these routes may be different based on the settings defined in your Payload
   config.
+</Banner>
+
+<Banner type="warning">
+  <strong>Warning:</strong>
+  <br />
+  Opening the REST proxy endpoint in production is a potential security risk. Authenticated users will have open access to the Stripe REST API. In production, open your own endpoint and use the [stripeProxy](#node) function to proxy the Stripe API server-side.
 </Banner>
 
 ## Webhooks

--- a/packages/plugin-stripe/src/index.ts
+++ b/packages/plugin-stripe/src/index.ts
@@ -20,8 +20,7 @@ export const stripePlugin =
     // set config defaults here
     const stripeConfig: SanitizedStripeConfig = {
       ...incomingStripeConfig,
-      // TODO: in the next major version, default this to `false`
-      rest: incomingStripeConfig?.rest ?? true,
+      rest: incomingStripeConfig?.rest ?? false,
       sync: incomingStripeConfig?.sync || [],
     }
 

--- a/packages/plugin-stripe/src/types.ts
+++ b/packages/plugin-stripe/src/types.ts
@@ -29,7 +29,7 @@ export interface SyncConfig {
 export interface StripeConfig {
   isTestKey?: boolean
   logs?: boolean
-  // @deprecated this will default as `false` in the next major version release
+  /** @default false */
   rest?: boolean
   stripeSecretKey: string
   stripeWebhooksEndpointSecret?: string


### PR DESCRIPTION
## Description

Disables the REST proxy by default. This has been a `TODO` item waiting on the next major version. See changes for full details.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.