### PR TITLE
Fix/graphql upload relations

### DIFF
--- a/packages/payload/src/graphql/schema/buildObjectType.ts
+++ b/packages/payload/src/graphql/schema/buildObjectType.ts
@@ -609,6 +609,7 @@ function buildObjectType({
           const locale = args.locale || context.req.locale
           const fallbackLocale = args.fallbackLocale || context.req.fallbackLocale
           const id = value
+          const draft = args.draft ?? context.req.query?.draft
 
           if (id) {
             const relatedDocument = await context.req.payloadDataLoader.load(
@@ -622,6 +623,7 @@ function buildObjectType({
                 fallbackLocale,
                 false,
                 false,
+                Boolean(draft),
               ]),
             )
 

--- a/test/collections-graphql/config.ts
+++ b/test/collections-graphql/config.ts
@@ -358,10 +358,26 @@ export default buildConfigWithDefaults({
           type: 'relationship',
           relationTo: ['cyclical-relationship'],
         },
+        {
+          type: 'upload',
+          name: 'media',
+          relationTo: 'media',
+        },
       ],
       versions: {
         drafts: true,
       },
+    },
+    {
+      slug: 'media',
+      access: openAccess,
+      upload: true,
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+      ],
     },
   ],
   graphQL: {

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -1,8 +1,10 @@
 import { GraphQLClient } from 'graphql-request'
+import path from 'path'
 
 import type { Post } from './payload-types'
 
 import payload from '../../packages/payload/src'
+import getFileByPath from '../../packages/payload/src/uploads/getFileByPath'
 import { mapAsync } from '../../packages/payload/src/utilities/mapAsync'
 import { initPayloadTest } from '../helpers/configHelpers'
 import { idToString } from '../helpers/idToString'
@@ -944,6 +946,40 @@ describe('collections-graphql', () => {
         const queriedDoc = response.CyclicalRelationships.docs[0]
         expect(queriedDoc.title).toEqual('2')
         expect(queriedDoc.relationToSelf.title).toEqual('1')
+      })
+
+      it('should query upload enabled docs', async () => {
+        const file = await getFileByPath(path.resolve(__dirname, '../uploads/test-image.jpg'))
+
+        const mediaDoc = await payload.create({
+          collection: 'media',
+          file,
+          data: {
+            title: 'example',
+          },
+        })
+
+        // doc with upload relation
+        const newDoc = await payload.create({
+          collection: 'cyclical-relationship',
+          data: {
+            media: mediaDoc.id,
+          },
+        })
+
+        const query = `{
+          CyclicalRelationship(id: "${newDoc.id}") {
+            media {
+              id
+              title
+            }
+          }
+        }`
+        const response = (await client.request(query)) as any
+
+        const queriedDoc = response.CyclicalRelationship
+        expect(queriedDoc.media.id).toEqual(mediaDoc.id)
+        expect(queriedDoc.media.title).toEqual('example')
       })
     })
   })

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -968,7 +968,9 @@ describe('collections-graphql', () => {
         })
 
         const query = `{
-          CyclicalRelationship(id: "${newDoc.id}") {
+          CyclicalRelationship(id: ${
+            typeof newDoc.id === 'number' ? newDoc.id : `"${newDoc.id}"`
+          }) {
             media {
               id
               title


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/6221

Fixes issue when querying upload relationship fields with GraphQL. The draft arg, from work done in [this PR](https://github.com/payloadcms/payload/pull/6141), was not being threaded through inside the upload resolver.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
