### PR TITLE
fix(graphql): threads through correct draft value for upload relations

### DIFF
--- a/packages/graphql/src/schema/buildObjectType.ts
+++ b/packages/graphql/src/schema/buildObjectType.ts
@@ -361,7 +361,7 @@ function buildObjectType({
           const locale = args.locale || context.req.locale
           const fallbackLocale = args.fallbackLocale || context.req.fallbackLocale
           let relatedCollectionSlug = field.relationTo
-          const draft = args.draft ?? context.req.query?.draft
+          const draft = Boolean(args.draft ?? context.req.query?.draft)
 
           if (hasManyValues) {
             const results = []
@@ -627,6 +627,7 @@ function buildObjectType({
           const locale = args.locale || context.req.locale
           const fallbackLocale = args.fallbackLocale || context.req.fallbackLocale
           const id = value
+          const draft = Boolean(args.draft ?? context.req.query?.draft)
 
           if (id) {
             const relatedDocument = await context.req.payloadDataLoader.load(
@@ -635,7 +636,7 @@ function buildObjectType({
                 currentDepth: 0,
                 depth: 0,
                 docID: id,
-                draft: false,
+                draft,
                 fallbackLocale,
                 locale,
                 overrideAccess: false,

--- a/test/collections-graphql/config.ts
+++ b/test/collections-graphql/config.ts
@@ -351,10 +351,26 @@ export default buildConfigWithDefaults({
           type: 'relationship',
           relationTo: 'cyclical-relationship',
         },
+        {
+          type: 'upload',
+          name: 'media',
+          relationTo: 'media',
+        },
       ],
       versions: {
         drafts: true,
       },
+    },
+    {
+      slug: 'media',
+      access: openAccess,
+      upload: true,
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+      ],
     },
   ],
   graphQL: {


### PR DESCRIPTION
## Description

Adds test and correctly threads draft arg through to upload resolvers in GraphQL

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
