### PR TITLE
fix: properly extracts fallbackLang

### DIFF
--- a/packages/next/src/utilities/getRequestLanguage.ts
+++ b/packages/next/src/utilities/getRequestLanguage.ts
@@ -14,25 +14,24 @@ type GetRequestLanguageArgs = {
 export const getRequestLanguage = ({
   config,
   cookies,
-  defaultLanguage = 'en',
   headers,
 }: GetRequestLanguageArgs): AcceptedLanguages => {
+  const supportedLanguageKeys = <AcceptedLanguages[]>Object.keys(config.i18n.supportedLanguages)
   const langCookie = cookies.get(`${config.cookiePrefix || 'payload'}-lng`)
-  const languageFromCookie = typeof langCookie === 'string' ? langCookie : langCookie?.value
+  const languageFromCookie: AcceptedLanguages = (
+    typeof langCookie === 'string' ? langCookie : langCookie?.value
+  ) as AcceptedLanguages
   const languageFromHeader = headers.get('Accept-Language')
     ? extractHeaderLanguage(headers.get('Accept-Language'))
     : undefined
-  const fallbackLang = config?.i18n?.fallbackLanguage || defaultLanguage
-
-  const supportedLanguageKeys = Object.keys(config?.i18n?.supportedLanguages || {})
 
   if (languageFromCookie && supportedLanguageKeys.includes(languageFromCookie)) {
-    return languageFromCookie as AcceptedLanguages
+    return languageFromCookie
   }
 
   if (languageFromHeader && supportedLanguageKeys.includes(languageFromHeader)) {
     return languageFromHeader
   }
 
-  return supportedLanguageKeys.includes(fallbackLang) ? (fallbackLang as AcceptedLanguages) : 'en'
+  return config.i18n.fallbackLanguage
 }

--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -28,6 +28,7 @@ export const defaults: Omit<Config, 'db' | 'editor' | 'secret'> = {
     maxComplexity: 1000,
   },
   hooks: {},
+  i18n: {},
   localization: false,
   maxDepth: 10,
   routes: {

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -1,3 +1,5 @@
+import type { AcceptedLanguages } from '@payloadcms/translations'
+
 import { en } from '@payloadcms/translations/languages/en'
 import merge from 'deepmerge'
 
@@ -88,14 +90,28 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
     }
   }
 
-  config.i18n = {
+  const i18nConfig: SanitizedConfig['i18n'] = {
     fallbackLanguage: 'en',
     supportedLanguages: {
       en,
     },
     translations: {},
-    ...(incomingConfig?.i18n ?? {}),
   }
+
+  if (incomingConfig?.i18n) {
+    i18nConfig.supportedLanguages =
+      incomingConfig.i18n?.supportedLanguages || i18nConfig.supportedLanguages
+
+    const supportedLangKeys = <AcceptedLanguages[]>Object.keys(i18nConfig.supportedLanguages)
+    const fallbackLang = incomingConfig.i18n?.fallbackLanguage || i18nConfig.fallbackLanguage
+
+    i18nConfig.fallbackLanguage = supportedLangKeys.includes(fallbackLang)
+      ? fallbackLang
+      : supportedLangKeys[0]
+    i18nConfig.translations = incomingConfig.i18n?.translations || i18nConfig.translations
+  }
+
+  config.i18n = i18nConfig
 
   configWithDefaults.collections.push(getPreferencesCollection(config as unknown as Config))
   configWithDefaults.collections.push(migrationsCollection)

--- a/packages/payload/src/translations/getLocalI18n.ts
+++ b/packages/payload/src/translations/getLocalI18n.ts
@@ -6,10 +6,10 @@ import type { SanitizedConfig } from '../config/types.js'
 
 export const getLocalI18n = async ({
   config,
-  language = 'en',
+  language,
 }: {
   config: SanitizedConfig
-  language?: AcceptedLanguages
+  language: AcceptedLanguages
 }) =>
   initI18n({
     config: config.i18n,

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -68,8 +68,6 @@ export const createLocalReq: CreateLocalReq = async (
   { context, fallbackLocale, locale: localeArg, req = {} as PayloadRequestWithData, user },
   payload,
 ) => {
-  const i18n = req?.i18n || (await getLocalI18n({ config: payload.config }))
-
   if (payload.config?.localization) {
     const locale = localeArg === '*' ? 'all' : localeArg
     const defaultLocale = payload.config.localization.defaultLocale
@@ -83,6 +81,10 @@ export const createLocalReq: CreateLocalReq = async (
       req.fallbackLocale = fallbackLocaleFromConfig || defaultLocale
     }
   }
+
+  const i18n =
+    req?.i18n ||
+    (await getLocalI18n({ config: payload.config, language: payload.config.i18n.fallbackLanguage }))
 
   // @ts-expect-error
   if (!req.headers) req.headers = new Headers()

--- a/packages/translations/src/types.ts
+++ b/packages/translations/src/types.ts
@@ -63,7 +63,7 @@ export type I18n = {
 }
 
 export type I18nOptions = {
-  fallbackLanguage?: string
+  fallbackLanguage?: AcceptedLanguages
   supportedLanguages?: SupportedLanguages
   translations?: Partial<{
     [key in AcceptedLanguages]?: Language['translations']
@@ -82,7 +82,7 @@ export type InitTFunction = (args: {
 export type InitI18n = (args: {
   config: I18nOptions
   context: 'api' | 'client'
-  language?: AcceptedLanguages
+  language: AcceptedLanguages
 }) => Promise<I18n>
 
 export type LanguagePreference = {

--- a/packages/translations/src/utilities/init.ts
+++ b/packages/translations/src/utilities/init.ts
@@ -164,7 +164,7 @@ function memoize(fn: (args: unknown) => Promise<I18n>, keys: string[]) {
 }
 
 export const initI18n: InitI18n = memoize(
-  async ({ config, context, language = 'en' }: Parameters<InitI18n>[0]) => {
+  async ({ config, context, language = config.fallbackLanguage }: Parameters<InitI18n>[0]) => {
     const translations = getTranslationsByContext(config.supportedLanguages[language], context)
 
     const { t, translations: mergedTranslations } = initTFunction({

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -166,7 +166,7 @@ export async function buildConfigWithDefaults(
     ...testConfig,
     i18n: {
       supportedLanguages: {
-        // en,
+        en,
         es,
         de,
       },

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -166,7 +166,7 @@ export async function buildConfigWithDefaults(
     ...testConfig,
     i18n: {
       supportedLanguages: {
-        en,
+        // en,
         es,
         de,
       },


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload-3.0-demo/issues/182

Language was defaulting to `en` in some places which caused issues when removing it from the config. The fallback locale is set in a proper manner now. This ensures the key is one of the supported languages allowing us to use it reliably.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
