### PR TITLE
fix: `date` field sets random milliseconds

### DIFF
--- a/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
+++ b/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
@@ -54,9 +54,12 @@ const DateTime: React.FC<Props> = (props) => {
 
   const onChange = (incomingDate: Date) => {
     const newDate = incomingDate
-    if (newDate instanceof Date && ['dayOnly', 'default', 'monthOnly'].includes(pickerAppearance)) {
-      const tzOffset = incomingDate.getTimezoneOffset() / 60
-      newDate.setHours(12 - tzOffset, 0)
+    if (newDate instanceof Date) {
+      newDate.setMilliseconds(0)
+      if (['dayOnly', 'default', 'monthOnly'].includes(pickerAppearance)) {
+        const tzOffset = incomingDate.getTimezoneOffset() / 60
+        newDate.setHours(12 - tzOffset, 0)
+      }
     }
     if (typeof onChangeFromProps === 'function') onChangeFromProps(newDate)
   }


### PR DESCRIPTION
## Description

Fixes #6108 

`fix`: sets milliseconds to 0 on new dates

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
