### PR TITLE
chore: fixes cannot destructure property 'schema'  issue

### DIFF
--- a/packages/next/src/routes/graphql/handler.ts
+++ b/packages/next/src/routes/graphql/handler.ts
@@ -63,11 +63,10 @@ export const getGraphql = async (config: Promise<SanitizedConfig> | SanitizedCon
   }
 
   if (!cached.promise) {
-    // eslint-disable-next-line no-async-promise-executor
-    cached.promise = new Promise(async (resolve) => {
-      const resolvedConfig = await config
+    const resolvedConfig = await config
+    cached.promise = new Promise((resolve) => {
       const schema = configToSchema(resolvedConfig)
-      resolve(schema)
+      resolve(cached.graphql || schema)
     })
   }
 


### PR DESCRIPTION
## Description

Fixes issue where console would output: 
```
 ○ Compiling /api/graphql ...
 ✓ Compiled /api/graphql in 5.3s (6101 modules)
 ⨯ TypeError: Cannot destructure property 'schema' of '(intermediate value)' as it is null.
```

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
