### PR TITLE
fix: wrong translation key being used as upload:Sizes instead of upload:sizes

### DIFF
--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -197,7 +197,7 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
           ],
           label: size.name,
         })),
-        label: ({ t }) => t('upload:Sizes'),
+        label: ({ t }) => t('upload:sizes'),
       },
     ])
   }

--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -244,6 +244,7 @@ export const clientTranslationKeys = [
   'upload:setCropArea',
   'upload:setFocalPoint',
   'upload:sizesFor',
+  'upload:sizes',
   'upload:width',
   'upload:fileName',
   'upload:fileSize',


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
