### PR TITLE
fix: named tab being required in generated types without any required fields

### DIFF
--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -5,6 +5,7 @@ import { configToJSONSchema } from './configToJSONSchema.js'
 
 describe('configToJSONSchema', () => {
   it('should handle optional arrays with required fields', async () => {
+    // @ts-expect-error
     const config: Config = {
       collections: [
         {
@@ -54,6 +55,93 @@ describe('configToJSONSchema', () => {
         },
       },
       required: ['id'],
+      title: 'Test',
+      type: 'object',
+    })
+  })
+
+  it('should handle tabs and named tabs with required fields', async () => {
+    // @ts-expect-error
+    const config: Config = {
+      collections: [
+        {
+          fields: [
+            {
+              type: 'tabs',
+              tabs: [
+                {
+                  label: 'unnamedTab',
+                  fields: [
+                    {
+                      type: 'text',
+                      name: 'fieldInUnnamedTab',
+                    },
+                  ],
+                },
+                {
+                  label: 'namedTab',
+                  name: 'namedTab',
+                  fields: [
+                    {
+                      type: 'text',
+                      name: 'fieldInNamedTab',
+                    },
+                  ],
+                },
+                {
+                  label: 'namedTabWithRequired',
+                  name: 'namedTabWithRequired',
+                  fields: [
+                    {
+                      type: 'text',
+                      name: 'fieldInNamedTab',
+                      required: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          slug: 'test',
+          timestamps: false,
+        },
+      ],
+    }
+
+    const sanitizedConfig = await sanitizeConfig(config)
+    const schema = configToJSONSchema(sanitizedConfig, 'text')
+
+    expect(schema?.definitions?.test).toStrictEqual({
+      additionalProperties: false,
+      properties: {
+        id: {
+          type: 'string',
+        },
+        fieldInUnnamedTab: {
+          type: ['string', 'null'],
+        },
+        namedTab: {
+          additionalProperties: false,
+          type: 'object',
+          properties: {
+            fieldInNamedTab: {
+              type: ['string', 'null'],
+            },
+          },
+          required: [],
+        },
+        namedTabWithRequired: {
+          additionalProperties: false,
+          type: 'object',
+          properties: {
+            fieldInNamedTab: {
+              type: 'string',
+            },
+          },
+          required: ['fieldInNamedTab'],
+        },
+      },
+      required: ['id', 'namedTabWithRequired'],
       title: 'Test',
       type: 'object',
     })

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -466,7 +466,13 @@ export function fieldsToJSONSchema(
                   additionalProperties: false,
                   ...childSchema,
                 })
-                requiredFieldNames.add(tab.name)
+
+                // If the named tab has any required fields then we mark this as required otherwise it should be optional
+                const hasRequiredFields = tab.fields.some((subField) => fieldIsRequired(subField))
+
+                if (hasRequiredFields) {
+                  requiredFieldNames.add(tab.name)
+                }
               } else {
                 Object.entries(childSchema.properties).forEach(([propName, propSchema]) => {
                   fieldSchemas.set(propName, propSchema)


### PR DESCRIPTION
For this given config

```ts
{
  type: 'tabs',
  tabs: [
    {
      label: 'unnamedTab',
      fields: [
        {
          type: 'text',
          name: 'fieldInUnnamedTab',
        },
      ],
    },
    {
      label: 'namedTab',
      name: 'namedTab',
      fields: [
        {
          type: 'text',
          name: 'fieldInNamedTab',
        },
      ],
    },
    {
      label: 'namedTabWithRequired',
      name: 'namedTabWithRequired',
      fields: [
        {
          type: 'text',
          name: 'fieldInNamedTab',
          required: true,
        },
      ],
    },
  ],
},
```

The generated types should be

```ts
fieldInUnnamedTab?: string | null;
namedTab?: {
  fieldInNamedTab?: string | null;
};
namedTabWithRequired: {
  fieldInNamedTab: string;
};
```

Currently `namedTab` will be required as well without having any required fields, this fixes that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
