### PR TITLE
fix(db-postgres): too many clients already, cannot read properties 'transaction' of undefined

### DIFF
--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -61,11 +61,12 @@ export const connect: Connect = async function connect(
   }
 
   try {
-    this.pool = new pg.Pool(this.poolOptions)
-    await connectWithReconnect({ adapter: this, payload: this.payload })
+    if (!this.pool) {
+      this.pool = new pg.Pool(this.poolOptions)
+      await connectWithReconnect({ adapter: this, payload: this.payload })
+    }
 
     const logger = this.logger || false
-
     this.drizzle = drizzle(this.pool, { logger, schema: this.schema })
 
     if (!hotReload) {
@@ -82,16 +83,18 @@ export const connect: Connect = async function connect(
     }
   } catch (err) {
     this.payload.logger.error(`Error: cannot connect to Postgres. Details: ${err.message}`, err)
+    if (typeof this.rejectInitializing === 'function') this.rejectInitializing()
     process.exit(1)
   }
 
   // Only push schema if not in production
   if (
-    process.env.NODE_ENV === 'production' ||
-    process.env.PAYLOAD_MIGRATING === 'true' ||
-    this.push === false
-  )
-    return
+    process.env.NODE_ENV !== 'production' &&
+    process.env.PAYLOAD_MIGRATING !== 'true' &&
+    this.push !== false
+  ) {
+    await pushDevSchema(this)
+  }
 
-  await pushDevSchema(this)
+  if (typeof this.resolveInitializing === 'function') this.resolveInitializing()
 }

--- a/packages/db-postgres/src/destroy.ts
+++ b/packages/db-postgres/src/destroy.ts
@@ -10,4 +10,8 @@ export const destroy: Destroy = async function destroy(this: PostgresAdapter) {
   this.relations = {}
   this.fieldConstraints = {}
   this.drizzle = undefined
+  this.initializing = new Promise((res, rej) => {
+    this.resolveInitializing = res
+    this.rejectInitializing = rej
+  })
 }

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -49,6 +49,13 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
 
   function adapter({ payload }: { payload: Payload }) {
     const migrationDir = findMigrationDir(args.migrationDir)
+    let resolveInitializing
+    let rejectInitializing
+
+    const initializing = new Promise<void>((res, rej) => {
+      resolveInitializing = res
+      rejectInitializing = rej
+    })
 
     return createDatabaseAdapter<PostgresAdapter>({
       name: 'postgres',
@@ -56,6 +63,7 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       enums: {},
       fieldConstraints: {},
       idType: postgresIDType,
+      initializing,
       localesSuffix: args.localesSuffix || '_locales',
       logger: args.logger,
       pgSchema: undefined,
@@ -101,6 +109,8 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       migrationDir,
       payload,
       queryDrafts,
+      rejectInitializing,
+      resolveInitializing,
       rollbackTransaction,
       updateGlobal,
       updateGlobalVersion,

--- a/packages/db-postgres/src/transactions/beginTransaction.ts
+++ b/packages/db-postgres/src/transactions/beginTransaction.ts
@@ -17,6 +17,11 @@ export const beginTransaction: BeginTransaction = async function beginTransactio
 
     let transactionReady: () => void
 
+    // Await initialization here
+    // Prevent race conditions where the adapter may be
+    // re-initializing, and `this.drizzle` is potentially undefined
+    await this.initializing
+
     // Drizzle only exposes a transactions API that is sufficient if you
     // can directly pass around the `tx` argument. But our operations are spread
     // over many files and we don't want to pass the `tx` around like that,

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -69,14 +69,17 @@ export type PostgresAdapter = BaseDatabaseAdapter & {
    */
   fieldConstraints: Record<string, Record<string, string>>
   idType: Args['idType']
+  initializing: Promise<void>
   localesSuffix?: string
   logger: DrizzleConfig['logger']
   pgSchema?: { table: PgTableFn } | PgSchema
   pool: Pool
   poolOptions: Args['pool']
   push: boolean
+  rejectInitializing: () => void
   relations: Record<string, GenericRelation>
   relationshipsSuffix?: string
+  resolveInitializing: () => void
   schema: Record<string, GenericEnum | GenericRelation | GenericTable>
   schemaName?: Args['schemaName']
   sessions: {


### PR DESCRIPTION
## Description

This PR aims to solve a few misc. issues related to Postgres and HMR.

First, we may have been creating a new connection each time HMR fired. We now re-use existing connections so that connection pools aren't exhausted.

Second, we now track Drizzle initialization across multiple invocations, so that if HMR is triggered, but there was already an operation in flight, Payload will wait for initialization before beginning a new transaction.