### PR TITLE
fix(ui): step-nav breadcrumbs ellipsis

### DIFF
--- a/packages/ui/src/elements/StepNav/index.scss
+++ b/packages/ui/src/elements/StepNav/index.scss
@@ -2,6 +2,7 @@
 
 .step-nav {
   display: flex;
+  align-items: center;
   gap: calc(var(--base) / 2);
 
   &::after {
@@ -56,8 +57,6 @@
   }
 
   span {
-    display: flex;
-    align-items: center;
     max-width: base(8);
     text-overflow: ellipsis;
     overflow: hidden;


### PR DESCRIPTION
## Description

Fixes this [issue](https://github.com/payloadcms/payload-3.0-demo/issues/212) in 3.0 demo repo.

Long titles in the `breadcrumbs` were not properly applying the `text-overflow: ellipsis` style.

`Before`:
![Screenshot 2024-05-13 at 3 18 58 PM](https://github.com/payloadcms/payload/assets/35232443/4b4e9271-5a95-4be2-99bd-2e9b35c04b48)

`After`:
![Screenshot 2024-05-13 at 3 18 25 PM](https://github.com/payloadcms/payload/assets/35232443/b090c45c-811e-40be-b85b-bb21906f419c)



- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
