### PR TITLE
fix: step-nav breadcrumbs ellipsis

### DIFF
--- a/packages/payload/src/admin/components/elements/StepNav/index.scss
+++ b/packages/payload/src/admin/components/elements/StepNav/index.scss
@@ -2,6 +2,7 @@
 
 .step-nav {
   display: flex;
+  align-items: center;
   gap: calc(var(--base) / 2);
 
   &::after {
@@ -56,8 +57,6 @@
   }
 
   span {
-    display: flex;
-    align-items: center;
     max-width: base(8);
     text-overflow: ellipsis;
     overflow: hidden;


### PR DESCRIPTION
## Description

Long titles in the `breadcrumbs` were not properly applying the `text-overflow: ellipsis` style.

`Before`:
![Screenshot 2024-05-13 at 3 18 58 PM](https://github.com/payloadcms/payload/assets/35232443/b4561e19-1d96-484d-aab5-896b99b69c18)

`After`:
![Screenshot 2024-05-13 at 3 18 25 PM](https://github.com/payloadcms/payload/assets/35232443/51176fe2-c80b-4438-a4b7-49957603221d)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
