### PR TITLE
fix(richtext-lexical): link html converter: serialize newTab to target="_blank"

### DIFF
--- a/packages/richtext-lexical/src/field/features/link/feature.server.ts
+++ b/packages/richtext-lexical/src/field/features/link/feature.server.ts
@@ -124,6 +124,7 @@ export const LinkFeature: FeatureProviderProviderServer<LinkFeatureServerProps, 
                   })
 
                   const rel: string = node.fields.newTab ? ' rel="noopener noreferrer"' : ''
+                  const target: string = node.fields.newTab ? ' target="_blank"' : ''
 
                   let href: string = node.fields.url
                   if (node.fields.linkType === 'internal') {
@@ -133,7 +134,7 @@ export const LinkFeature: FeatureProviderProviderServer<LinkFeatureServerProps, 
                         : node.fields.doc?.value?.id
                   }
 
-                  return `<a href="${href}"${rel}>${childrenText}</a>`
+                  return `<a href="${href}"${target}${rel}>${childrenText}</a>`
                 },
                 nodeTypes: [AutoLinkNode.getType()],
               },


### PR DESCRIPTION
Issue https://github.com/payloadcms/payload/issues/5256 re-appeared in Payload v.3.x-beta, this PR fixes it again.

## Type of Change:
- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
