### PR TITLE
fix: Versions - make sure parent key is the same type as parent _id.

### DIFF
--- a/packages/db-mongodb/src/models/buildSchema.ts
+++ b/packages/db-mongodb/src/models/buildSchema.ts
@@ -55,6 +55,12 @@ type FieldSchemaGenerator = (
   buildSchemaOptions: BuildSchemaOptions,
 ) => void
 
+const idTypes = {
+  string: String,
+  number: Number,
+  objectid: Schema.Types.ObjectId,
+}
+
 const formatBaseSchema = (field: FieldAffectingData, buildSchemaOptions: BuildSchemaOptions) => {
   const { disableUnique, draftsEnabled, indexSortableFields } = buildSchemaOptions
   const schema: SchemaTypeOptions<unknown> = {
@@ -405,17 +411,17 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
             localeSchema = {
               ...formatBaseSchema(field, buildSchemaOptions),
               _id: false,
-              type: Schema.Types.Mixed,
+              type: idTypes[field.idType] || Schema.Types.Mixed,
               relationTo: { type: String, enum: field.relationTo },
               value: {
-                type: Schema.Types.Mixed,
+                type: idTypes[field.idType] || Schema.Types.Mixed,
                 refPath: `${field.name}.${locale}.relationTo`,
               },
             }
           } else {
             localeSchema = {
               ...formatBaseSchema(field, buildSchemaOptions),
-              type: Schema.Types.Mixed,
+              type: idTypes[field.idType] || Schema.Types.Mixed,
               ref: field.relationTo,
             }
           }
@@ -431,10 +437,10 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
       schemaToReturn = {
         ...formatBaseSchema(field, buildSchemaOptions),
         _id: false,
-        type: Schema.Types.Mixed,
+        type: idTypes[field.idType] || Schema.Types.Mixed,
         relationTo: { type: String, enum: field.relationTo },
         value: {
-          type: Schema.Types.Mixed,
+          type: idTypes[field.idType] || Schema.Types.Mixed,
           refPath: `${field.name}.relationTo`,
         },
       }
@@ -448,7 +454,7 @@ const fieldToSchemaMap: Record<string, FieldSchemaGenerator> = {
     } else {
       schemaToReturn = {
         ...formatBaseSchema(field, buildSchemaOptions),
-        type: Schema.Types.Mixed,
+        type: idTypes[field.idType] || Schema.Types.Mixed,
         ref: field.relationTo,
       }
 

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -515,12 +515,14 @@ export type PolymorphicRelationshipField = SharedRelationshipProperties & {
     }
   }
   relationTo: string[]
+  idType?: string
 }
 export type SingleRelationshipField = SharedRelationshipProperties & {
   admin?: RelationshipAdmin & {
     sortOptions?: string
   }
   relationTo: string
+  idType?: string
 }
 export type RelationshipField = PolymorphicRelationshipField | SingleRelationshipField
 

--- a/packages/payload/src/versions/buildCollectionFields.ts
+++ b/packages/payload/src/versions/buildCollectionFields.ts
@@ -8,6 +8,7 @@ export const buildVersionCollectionFields = (collection: SanitizedCollectionConf
       type: 'relationship',
       index: true,
       relationTo: collection.slug,
+      idType: collection.fields.find((field) => 'name' in field && field.name === 'id')?.type,
     },
     {
       name: 'version',


### PR DESCRIPTION
## Description

Fix for issue #6349 

When creating versions in mongodb, the type of the parent key needs to match the type of the _id of the parent. Otherwise you might end up with strings instead of numbers which will break the UI (seeing multiple versions when you shouldn't, not seeing the latest version, etc).

There are a few ways to solve this, however the most elegant I've found was to add support for an optional property to **relationship** fields, where we can manually specify the type of the **parent** key. I called this idType:

![Screenshot 2024-05-14 at 13 42 57](https://github.com/payloadcms/payload/assets/2424284/7a0bd93d-f283-4429-8d1b-ac3f1cecf93d)

Then, when building version collection fields, we can pass in the id type of the parent collection:

![Screenshot 2024-05-14 at 13 43 33](https://github.com/payloadcms/payload/assets/2424284/819a00e6-8989-445a-96f3-793f3be73f70)

Finally, when we build our schema we try for one of the allowed id types, falling back to the default Schema.Types.Mixed.

![Screenshot 2024-05-14 at 13 44 29](https://github.com/payloadcms/payload/assets/2424284/0a4c1ec4-02ff-4dd0-9714-5657068a6ba6)
![Screenshot 2024-05-14 at 13 45 19](https://github.com/payloadcms/payload/assets/2424284/36f4dd0d-8861-4da9-a51f-13e93354eab8)


Other ways to solve this would be quite hacky and prone to bugs down the line:
- In the relationship field schema generator, check whether this is the **parent** key of a version collection, then look at the parent collection and figure out the id type. - Quite bad
- In db-mongodb's init function, when we generate the versionSchema, check the parent collection and override the version's schema as needed. - Better but not really

The solution proposed uses payload's own API, it is clear and easy to understand, and opens the possibility of adding your own custom IDs in relationship fields - completely optional with no side effects.

Have not tested this bug on Postgres, however if this PR is accepted, it should be fairly simple for someone to use the idType property with similar logic in db-postgres.

I can make the required changes to the documentation if this is accepted. 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:
- [x] Existing test suite passes locally with my changes
