### PR TITLE
fix: generate types loads config twice

### DIFF
--- a/packages/payload/src/bin/generateTypes.ts
+++ b/packages/payload/src/bin/generateTypes.ts
@@ -9,15 +9,16 @@ import Logger from '../utilities/logger'
 
 export async function generateTypes(): Promise<void> {
   const logger = Logger()
-  const config = await loadConfig()
-  const outputFile = process.env.PAYLOAD_TS_OUTPUT_PATH || config.typescript.outputFile
-
-  await payload.init({
+  
+  const instance = await payload.init({
     disableDBConnect: true,
     disableOnInit: true,
     local: true,
     secret: '--unused--',
   })
+  
+  const config = instance.config
+  const outputFile = process.env.PAYLOAD_TS_OUTPUT_PATH || config.typescript.outputFile
 
   logger.info('Compiling TS types for Collections and Globals...')
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

The `generate:types` command loads the config twice, which causes the performance to be slower.  
(All collections and globals have to be validated twice, which can take long with a large config.)

This PR updates the `generate:types` command, so it only loads the config once.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
