### PR TITLE
fix: filter with ID not_in AND queries - postgres

### DIFF
--- a/packages/db-postgres/src/queries/parseParams.ts
+++ b/packages/db-postgres/src/queries/parseParams.ts
@@ -10,8 +10,8 @@ import type { GenericColumn, PostgresAdapter } from '../types'
 import type { BuildQueryJoinAliases, BuildQueryJoins } from './buildQuery'
 
 import { buildAndOrConditions } from './buildAndOrConditions'
-import { convertPathToJSONTraversal } from './createJSONQuery/convertPathToJSONTraversal'
 import { createJSONQuery } from './createJSONQuery'
+import { convertPathToJSONTraversal } from './createJSONQuery/convertPathToJSONTraversal'
 import { getTableColumnFromPath } from './getTableColumnFromPath'
 import { operatorMap } from './operatorMap'
 import { sanitizeQueryValue } from './sanitizeQueryValue'
@@ -195,10 +195,10 @@ export async function parseParams({
                   operator === 'not_in'
                 ) {
                   constraints.push(
-                    sql`${notInArray(table[columnName], queryValue)} OR
+                    sql`(${notInArray(table[columnName], queryValue)} OR
                     ${table[columnName]}
                     IS
-                    NULL`,
+                    NULL)`,
                   )
 
                   break

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -908,6 +908,29 @@ describe('Versions', () => {
 
       expect(byID.docs).toHaveLength(1)
     })
+
+    it('should be able to query by id AND any other field with draft=true', async () => {
+      const results = await payload.find({
+        collection: 'draft-posts',
+        draft: true,
+        where: {
+          and: [
+            {
+              id: {
+                not_in: '1',
+              },
+            },
+            {
+              title: {
+                like: 'Published',
+              },
+            },
+          ],
+        },
+      })
+
+      expect(results.docs).toHaveLength(1)
+    })
   })
 
   describe('Collections - GraphQL', () => {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -917,7 +917,7 @@ describe('Versions', () => {
           and: [
             {
               id: {
-                not_in: '1',
+                not_in: [1],
               },
             },
             {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -910,6 +910,13 @@ describe('Versions', () => {
     })
 
     it('should be able to query by id AND any other field with draft=true', async () => {
+      const allDocs = await payload.find({
+        collection: 'draft-posts',
+        draft: true,
+      })
+
+      expect(allDocs.docs.length).toBeGreaterThan(1)
+
       const results = await payload.find({
         collection: 'draft-posts',
         draft: true,
@@ -917,7 +924,7 @@ describe('Versions', () => {
           and: [
             {
               id: {
-                not_in: [1],
+                not_in: allDocs.docs[0].id,
               },
             },
             {


### PR DESCRIPTION
## Description

Fixes #5151 

`Issue`: With `Postgres`, when filtering by two queries with `AND`, if the first query involved `ID` and the `not_in` operator, the second query in the filter would never be evaluated.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
