### PR TITLE
feat(richtext-lexical): add rootFeatures prop to lexicalEditor

### DIFF
--- a/packages/richtext-lexical/src/field/lexical/config/server/default.ts
+++ b/packages/richtext-lexical/src/field/lexical/config/server/default.ts
@@ -21,7 +21,6 @@ import { OrderedListFeature } from '../../../features/lists/orderedList/feature.
 import { UnorderedListFeature } from '../../../features/lists/unorderedList/feature.server.js'
 import { ParagraphFeature } from '../../../features/paragraph/feature.server.js'
 import { RelationshipFeature } from '../../../features/relationship/feature.server.js'
-import { FixedToolbarFeature } from '../../../features/toolbars/fixed/feature.server.js'
 import { InlineToolbarFeature } from '../../../features/toolbars/inline/feature.server.js'
 import { UploadFeature } from '../../../features/upload/feature.server.js'
 import { LexicalEditorTheme } from '../../theme/EditorTheme.js'

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -11,8 +11,14 @@ export type LexicalEditorProps = {
   features?:
     | (({
         defaultFeatures,
+        rootFeatures,
       }: {
         defaultFeatures: FeatureProviderServer<any, any>[]
+        /**
+         * The features that are enabled in the root richText editor (the one defined in the payload.config.ts).
+         * If this is the root richText editor, or if the root richText editor is not a lexical editor, this will be an empty array.
+         */
+        rootFeatures: FeatureProviderServer<any, any>[]
       }) => FeatureProviderServer<any, any>[])
     | FeatureProviderServer<any, any>[]
   lexical?: LexicalEditorConfig
@@ -20,6 +26,7 @@ export type LexicalEditorProps = {
 
 export type LexicalRichTextAdapter = RichTextAdapter<SerializedEditorState, AdapterProps, any> & {
   editorConfig: SanitizedServerEditorConfig
+  features: FeatureProviderServer<any, any>[]
 }
 
 export type LexicalRichTextAdapterProvider =

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -13,10 +13,29 @@ export type LexicalEditorProps = {
         defaultFeatures,
         rootFeatures,
       }: {
+        /**
+         * This opinionated array contains all "recommended" default features.
+         *
+         * @Example
+         *
+         * ```ts
+         *  editor: lexicalEditor({
+         *    features: ({ defaultFeatures }) => [...defaultFeatures, FixedToolbarFeature()],
+         *  })
+         *  ```
+         */
         defaultFeatures: FeatureProviderServer<any, any>[]
         /**
-         * The features that are enabled in the root richText editor (the one defined in the payload.config.ts).
-         * If this is the root richText editor, or if the root richText editor is not a lexical editor, this will be an empty array.
+         * This array contains all features that are enabled in the root richText editor (the one defined in the payload.config.ts).
+         * If this field is the root richText editor, or if the root richText editor is not a lexical editor, this array will be empty
+         *
+         * @Example
+         *
+         * ```ts
+         *  editor: lexicalEditor({
+         *    features: ({ rootFeatures }) => [...rootFeatures, FixedToolbarFeature()],
+         *  })
+         *  ```
          */
         rootFeatures: FeatureProviderServer<any, any>[]
       }) => FeatureProviderServer<any, any>[])


### PR DESCRIPTION
## Description

Example:

```ts
fields: [
 {
      name: 'richTextDefault',
      type: 'richText',
    },
    {
      name: 'richText',
      type: 'richText',
      editor: lexicalEditor({
        features: ({ rootFeatures, defaultFeatures }) => [...rootFeatures, ItalicFeature()],
      }),
    },
]
```

Root editor (payload.config.ts):
```ts
 editor: lexicalEditor({
    features: [ParagraphFeature(), BoldFeature(), InlineToolbarFeature()],
  }),
```

richText will now have all features the root editor has, and the ItalicFeature.


- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
