### PR TITLE
fix(searchPlugin): ensure search updates are unique to collection

### DIFF
--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -76,6 +76,9 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
             'doc.value': {
               equals: id,
             },
+            'doc.relationTo': {
+              equals: collection,
+            },
           },
         })
 


### PR DESCRIPTION
## Description

Our app is using the `searchPlugin` with two different collections. We were having issues with search results disappearing randomly when we saved certain records.

After digging in, we found that the `syncWithSearch` hook is only searching for matching `search` records by `id`, not `relationTo`.

This resulted in the `syncWithSearch` hook incorrectly overwriting records in the wrong collection if they share the same ID. This patch resolves the issue.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
