### PR TITLE
feat: store focal point on uploads

### DIFF
--- a/packages/payload/src/admin/components/elements/EditUpload/index.tsx
+++ b/packages/payload/src/admin/components/elements/EditUpload/index.tsx
@@ -32,7 +32,7 @@ export const EditUpload: React.FC<{
   imageCacheTag?: string
   showCrop?: boolean
   showFocalPoint?: boolean
-}> = ({ fileName, fileSrc, imageCacheTag, showCrop, showFocalPoint }) => {
+}> = ({ doc, fileName, fileSrc, imageCacheTag, showCrop, showFocalPoint }) => {
   const { closeModal } = useModal()
   const { t } = useTranslation(['general', 'upload'])
   const { formQueryParams, setFormQueryParams } = useFormQueryParams()
@@ -41,14 +41,13 @@ export const EditUpload: React.FC<{
     height: uploadEdits?.crop?.height || 100,
     unit: '%',
     width: uploadEdits?.crop?.width || 100,
-    x: uploadEdits?.crop?.x || 0,
-    y: uploadEdits?.crop?.y || 0,
   })
 
-  const [pointPosition, setPointPosition] = useState<{ x: number; y: number }>({
-    x: uploadEdits?.focalPoint?.x || 50,
-    y: uploadEdits?.focalPoint?.y || 50,
+  const [focalPosition, setFocalPosition] = useState<{ x: number; y: number }>({
+    x: uploadEdits?.focalPoint?.x || doc.focalX || 50,
+    y: uploadEdits?.focalPoint?.y || doc.focalY || 50,
   })
+
   const [checkBounds, setCheckBounds] = useState<boolean>(false)
   const [originalHeight, setOriginalHeight] = useState<number>(0)
   const [originalWidth, setOriginalWidth] = useState<number>(0)
@@ -72,10 +71,16 @@ export const EditUpload: React.FC<{
     })
   }
 
-  const fineTuneFocalPoint = ({ coordinate, value }: { coordinate: 'x' | 'y'; value: string }) => {
+  const fineTuneFocalPosition = ({
+    coordinate,
+    value,
+  }: {
+    coordinate: 'x' | 'y'
+    value: string
+  }) => {
     const intValue = parseInt(value)
     if (intValue >= 0 && intValue <= 100) {
-      setPointPosition((prevPosition) => ({ ...prevPosition, [coordinate]: intValue }))
+      setFocalPosition((prevPosition) => ({ ...prevPosition, [coordinate]: intValue }))
     }
   }
 
@@ -84,14 +89,14 @@ export const EditUpload: React.FC<{
       ...formQueryParams,
       uploadEdits: {
         crop: crop || undefined,
-        focalPoint: pointPosition ? pointPosition : undefined,
+        focalPoint: focalPosition ? focalPosition : undefined,
       },
     })
     closeModal(editDrawerSlug)
   }
 
   const onDragEnd = React.useCallback(({ x, y }) => {
-    setPointPosition({ x, y })
+    setFocalPosition({ x, y })
     setCheckBounds(false)
   }, [])
 
@@ -104,7 +109,7 @@ export const EditUpload: React.FC<{
       ((boundsRect.left - containerRect.left + boundsRect.width / 2) / containerRect.width) * 100
     const yCenter =
       ((boundsRect.top - containerRect.top + boundsRect.height / 2) / containerRect.height) * 100
-    setPointPosition({ x: xCenter, y: yCenter })
+    setFocalPosition({ x: xCenter, y: yCenter })
   }
 
   const fileSrcToUse = imageCacheTag ? `${fileSrc}?${imageCacheTag}` : fileSrc
@@ -180,7 +185,7 @@ export const EditUpload: React.FC<{
                 checkBounds={showCrop ? checkBounds : false}
                 className={`${baseClass}__focalPoint`}
                 containerRef={focalWrapRef}
-                initialPosition={pointPosition}
+                initialPosition={focalPosition}
                 onDragEnd={onDragEnd}
                 setCheckBounds={showCrop ? setCheckBounds : false}
               >
@@ -251,13 +256,13 @@ export const EditUpload: React.FC<{
                 <div className={`${baseClass}__inputsWrap`}>
                   <Input
                     name="X %"
-                    onChange={(value) => fineTuneFocalPoint({ coordinate: 'x', value })}
-                    value={pointPosition.x.toFixed(0)}
+                    onChange={(value) => fineTuneFocalPosition({ coordinate: 'x', value })}
+                    value={focalPosition.x.toFixed(0)}
                   />
                   <Input
                     name="Y %"
-                    onChange={(value) => fineTuneFocalPoint({ coordinate: 'y', value })}
-                    value={pointPosition.y.toFixed(0)}
+                    onChange={(value) => fineTuneFocalPosition({ coordinate: 'y', value })}
+                    value={focalPosition.y.toFixed(0)}
                   />
                 </div>
               </div>

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -130,6 +130,7 @@ async function create<TSlug extends keyof GeneratedTypes['collections']>(
       collection,
       config,
       data,
+      operation: 'create',
       overwriteExistingFiles,
       req,
       throwOnMissingFile:

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -157,6 +157,7 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
       collection,
       config,
       data: bulkUpdateData,
+      operation: 'update',
       overwriteExistingFiles,
       req,
       throwOnMissingFile: false,

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -148,6 +148,7 @@ async function updateByID<TSlug extends keyof GeneratedTypes['collections']>(
       collection,
       config,
       data,
+      operation: 'update',
       overwriteExistingFiles,
       req,
       throwOnMissingFile: false,

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -149,6 +149,7 @@ async function updateByID<TSlug extends keyof GeneratedTypes['collections']>(
       config,
       data,
       operation: 'update',
+      originalDoc,
       overwriteExistingFiles,
       req,
       throwOnMissingFile: false,

--- a/packages/payload/src/uploads/cropImage.ts
+++ b/packages/payload/src/uploads/cropImage.ts
@@ -1,6 +1,7 @@
 import sharp from 'sharp'
 
-export const percentToPixel = (value, dimension) => {
+export const percentToPixel = (value: string, dimension: number): number => {
+  if (!value) return 0
   return Math.floor((parseFloat(value) / 100) * dimension)
 }
 
@@ -8,7 +9,7 @@ export default async function cropImage({ cropData, dimensions, file }) {
   try {
     const { height, width, x, y } = cropData
 
-    const formattedCropData = {
+    const formattedCropData: sharp.Region = {
       height: percentToPixel(height, dimensions.height),
       left: percentToPixel(x, dimensions.width),
       top: percentToPixel(y, dimensions.height),

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -236,7 +236,7 @@ export const generateFileData = async <T>({
 
     if (Array.isArray(imageSizes) && fileSupportsResize) {
       req.payloadUploadSizes = {}
-      const { sizeData, sizesToSave } = await resizeAndTransformImageSizes({
+      const { focalPoint, sizeData, sizesToSave } = await resizeAndTransformImageSizes({
         config: collectionConfig,
         dimensions: !cropData
           ? dimensions
@@ -253,10 +253,12 @@ export const generateFileData = async <T>({
       })
 
       fileData.sizes = sizeData
+      fileData.focalX = focalPoint?.x
+      fileData.focalY = focalPoint?.y
       filesToSave.push(...sizesToSave)
     }
   } catch (err) {
-    console.error(err)
+    req.payload.logger.error({ err, msg: 'Error uploading file' })
     throw new FileUploadError(req.t)
   }
 

--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -86,16 +86,6 @@ const getBaseUploadFields = ({ collection, config }: Options): Field[] => {
     unique: true,
   }
 
-  const focalPointFields: Field[] = ['focalX', 'focalY'].map((name) => {
-    return {
-      name,
-      type: 'number',
-      admin: {
-        hidden: true,
-      },
-    }
-  })
-
   let uploadFields: Field[] = [
     {
       ...url,
@@ -125,9 +115,26 @@ const getBaseUploadFields = ({ collection, config }: Options): Field[] => {
     mimeType.validate = mimeTypeValidator(uploadOptions.mimeTypes)
   }
 
+  // Add focal point fields if not disabled
+  if (
+    uploadOptions.focalPoint !== false &&
+    (uploadOptions.imageSizes || uploadOptions.resizeOptions)
+  ) {
+    uploadFields = uploadFields.concat(
+      ['focalX', 'focalY'].map((name) => {
+        return {
+          name,
+          type: 'number',
+          admin: {
+            hidden: true,
+          },
+        }
+      }),
+    )
+  }
+
   if (uploadOptions.imageSizes) {
     uploadFields = uploadFields.concat([
-      ...focalPointFields,
       {
         name: 'sizes',
         type: 'group',
@@ -174,10 +181,6 @@ const getBaseUploadFields = ({ collection, config }: Options): Field[] => {
         label: labels['upload:sizes'],
       },
     ])
-  }
-
-  if (uploadOptions.resizeOptions) {
-    uploadFields = uploadFields.concat(focalPointFields)
   }
 
   return uploadFields

--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -25,56 +25,57 @@ const getBaseUploadFields = ({ collection, config }: Options): Field[] => {
 
   const mimeType: Field = {
     name: 'mimeType',
+    type: 'text',
     admin: {
       hidden: true,
       readOnly: true,
     },
     label: 'MIME Type',
-    type: 'text',
   }
 
   const url: Field = {
     name: 'url',
+    type: 'text',
     admin: {
       hidden: true,
       readOnly: true,
     },
     label: 'URL',
-    type: 'text',
   }
 
   const width: Field = {
     name: 'width',
+    type: 'number',
     admin: {
       hidden: true,
       readOnly: true,
     },
     label: labels['upload:width'],
-    type: 'number',
   }
 
   const height: Field = {
     name: 'height',
+    type: 'number',
     admin: {
       hidden: true,
       readOnly: true,
     },
     label: labels['upload:height'],
-    type: 'number',
   }
 
   const filesize: Field = {
     name: 'filesize',
+    type: 'number',
     admin: {
       hidden: true,
       readOnly: true,
     },
     label: labels['upload:fileSize'],
-    type: 'number',
   }
 
   const filename: Field = {
     name: 'filename',
+    type: 'text',
     admin: {
       disableBulkEdit: true,
       hidden: true,
@@ -82,9 +83,18 @@ const getBaseUploadFields = ({ collection, config }: Options): Field[] => {
     },
     index: true,
     label: labels['upload:fileName'],
-    type: 'text',
     unique: true,
   }
+
+  const focalPointFields: Field[] = ['focalX', 'focalY'].map((name) => {
+    return {
+      name,
+      type: 'number',
+      admin: {
+        hidden: true,
+      },
+    }
+  })
 
   let uploadFields: Field[] = [
     {
@@ -117,13 +127,16 @@ const getBaseUploadFields = ({ collection, config }: Options): Field[] => {
 
   if (uploadOptions.imageSizes) {
     uploadFields = uploadFields.concat([
+      ...focalPointFields,
       {
         name: 'sizes',
+        type: 'group',
         admin: {
           hidden: true,
         },
         fields: uploadOptions.imageSizes.map((size) => ({
           name: size.name,
+          type: 'group',
           admin: {
             hidden: true,
           },
@@ -157,13 +170,16 @@ const getBaseUploadFields = ({ collection, config }: Options): Field[] => {
             },
           ],
           label: size.name,
-          type: 'group',
         })),
-        label: labels['upload:Sizes'],
-        type: 'group',
+        label: labels['upload:sizes'],
       },
     ])
   }
+
+  if (uploadOptions.resizeOptions) {
+    uploadFields = uploadFields.concat(focalPointFields)
+  }
+
   return uploadFields
 }
 

--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -232,7 +232,8 @@ export default async function resizeAndTransformImageSizes({
   savedFilename,
   staticPath,
 }: ResizeArgs): Promise<ImageSizesResult> {
-  const { imageSizes } = config.upload
+  const { focalPoint: focalPointEnabled = true, imageSizes } = config.upload
+
   // Noting to resize here so return as early as possible
   if (!imageSizes) return { sizeData: {}, sizesToSave: [] }
 
@@ -363,6 +364,6 @@ export default async function resizeAndTransformImageSizes({
       acc.sizesToSave.push(...result.sizesToSave)
       return acc
     },
-    { focalPoint, sizeData: {}, sizesToSave: [] },
+    { ...(focalPointEnabled && { focalPoint }), sizeData: {}, sizesToSave: [] },
   )
 }

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -125,3 +125,16 @@ export type FileToSave = {
   buffer: Buffer
   path: string
 }
+
+export type UploadEdits = {
+  crop?: {
+    height?: number
+    width?: number
+    x?: number
+    y?: number
+  }
+  focalPoint?: {
+    x?: number
+    y?: number
+  }
+}

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -5,8 +5,6 @@ import type { ResizeOptions, Sharp } from 'sharp'
 export type FileSize = {
   filename: null | string
   filesize: null | number
-  focalX?: number
-  focalY?: number
   height: null | number
   mimeType: null | string
   width: null | number

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import type express from 'express'
 import type serveStatic from 'serve-static'
 import type { ResizeOptions, Sharp } from 'sharp'
@@ -6,6 +5,8 @@ import type { ResizeOptions, Sharp } from 'sharp'
 export type FileSize = {
   filename: null | string
   filesize: null | number
+  focalX?: number
+  focalY?: number
   height: null | number
   mimeType: null | string
   width: null | number
@@ -18,6 +19,8 @@ export type FileSizes = {
 export type FileData = {
   filename: string
   filesize: number
+  focalX?: number
+  focalY?: number
   height: number
   mimeType: string
   sizes: FileSizes

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -7,7 +7,16 @@ import removeFiles from '../helpers/removeFiles'
 import { Uploads1 } from './collections/Upload1'
 import Uploads2 from './collections/Upload2'
 import AdminThumbnailCol from './collections/admin-thumbnail'
-import { audioSlug, enlargeSlug, mediaSlug, reduceSlug, relationSlug, versionSlug } from './shared'
+import {
+  audioSlug,
+  cropOnlySlug,
+  enlargeSlug,
+  focalOnlySlug,
+  mediaSlug,
+  reduceSlug,
+  relationSlug,
+  versionSlug,
+} from './shared'
 
 const mockModulePath = path.resolve(__dirname, './mocks/mockFSModule.js')
 
@@ -136,7 +145,7 @@ export default buildConfigWithDefaults({
       },
     },
     {
-      slug: 'crop-only',
+      slug: cropOnlySlug,
       fields: [],
       upload: {
         focalPoint: false,
@@ -163,7 +172,7 @@ export default buildConfigWithDefaults({
       },
     },
     {
-      slug: 'focal-only',
+      slug: focalOnlySlug,
       fields: [],
       upload: {
         crop: false,

--- a/test/uploads/payload-types.ts
+++ b/test/uploads/payload-types.ts
@@ -47,6 +47,8 @@ export interface Media {
   filesize?: number
   width?: number
   height?: number
+  focalX?: number
+  focalY?: number
   sizes?: {
     maintainedAspectRatio?: {
       url?: string

--- a/test/uploads/shared.ts
+++ b/test/uploads/shared.ts
@@ -1,13 +1,9 @@
-export const mediaSlug = 'media'
-
-export const relationSlug = 'relation'
-
-export const audioSlug = 'audio'
-
-export const enlargeSlug = 'enlarge'
-
-export const reduceSlug = 'reduce'
-
 export const adminThumbnailSlug = 'admin-thumbnail'
-
+export const audioSlug = 'audio'
+export const cropOnlySlug = 'crop-only'
+export const enlargeSlug = 'enlarge'
+export const focalOnlySlug = 'focal-only'
+export const mediaSlug = 'media'
+export const reduceSlug = 'reduce'
+export const relationSlug = 'relation'
 export const versionSlug = 'versions'


### PR DESCRIPTION
Store focal point data on uploads as `focalX` and `focalY`

Addresses https://github.com/payloadcms/payload/discussions/4082