### PR TITLE
fix: safely access cookie header for uploads

### DIFF
--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -25,7 +25,7 @@ export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promis
     const headers = uploadConfig.externalFileHeaderFilter
       ? uploadConfig.externalFileHeaderFilter(headersToObject(req.headers))
       : {
-          cookie: req.headers['cookie'],
+          cookie: req.headers?.['cookie'],
         }
 
     const res = await fetch(fileURL, {


### PR DESCRIPTION
## Description

Issue with editing and changing the crop or focal point of an image

`Error`:

```
ERROR (payload): FileRetrievalError: There was a problem while uploading the file. Cannot read properties of undefined (reading 'cookie')
    at generateFileData (/node_modules/payload/src/uploads/generateFileData.ts:86:15)
```
(`payload v2.16.1` and `plugin-cloud v3.0.1`)

Fix: add optional chaing to safely access `cookie` header when fetching image

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
