### PR TITLE
chore: loosen type for ClientTranslationsObject to improve TS performance

### DIFF
--- a/packages/translations/src/types.ts
+++ b/packages/translations/src/types.ts
@@ -110,6 +110,10 @@ export type DefaultTranslationKeys = NestedKeysStripped<DefaultTranslationsObjec
 export type ClientTranslationKeys<TExtraProps = (typeof clientTranslationKeys)[number]> =
   TExtraProps
 
+// Use GenericTranslationsObject instead of reconstructing the object from the client keys. This is because reconstructing the object is
+// A) Expensive on performance.
+// B) Not important to be typed specifically for the client translations. We really only care about the client translation keys to be typed.
+// C) Inaccurate. Client keys which previously had _many, _one or other suffixes have been removed and cannot be reconstructed
 export type ClientTranslationsObject = GenericTranslationsObject //ReconstructObjectFromTranslationKeys<ClientTranslationKeys>
 
 export type TFunction<TTranslationKeys = DefaultTranslationKeys> = (

--- a/packages/translations/src/types.ts
+++ b/packages/translations/src/types.ts
@@ -110,7 +110,7 @@ export type DefaultTranslationKeys = NestedKeysStripped<DefaultTranslationsObjec
 export type ClientTranslationKeys<TExtraProps = (typeof clientTranslationKeys)[number]> =
   TExtraProps
 
-export type ClientTranslationsObject = ReconstructObjectFromTranslationKeys<ClientTranslationKeys>
+export type ClientTranslationsObject = GenericTranslationsObject //ReconstructObjectFromTranslationKeys<ClientTranslationKeys>
 
 export type TFunction<TTranslationKeys = DefaultTranslationKeys> = (
   key: TTranslationKeys,


### PR DESCRIPTION
## Description

Use GenericTranslationsObject instead of reconstructing the object from the client keys. This is because reconstructing the object is
A) Expensive on performance.
B) Not important to be typed specifically for the client translations. We really only care about the client translation keys to be typed.
C) Inaccurate. Client keys which previously had _many, _one or other suffixes have been removed and cannot be reconstructed

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
