### PR TITLE
fix: loader throwing errors for client files imported using TS paths

### DIFF
--- a/packages/payload/src/bin/loader/index.ts
+++ b/packages/payload/src/bin/loader/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { getTsconfig } from 'get-tsconfig'
-import path from 'path'
 import ts from 'typescript'
 import { fileURLToPath, pathToFileURL } from 'url'
 
@@ -61,12 +60,12 @@ export const resolve: ResolveFn = async (specifier, context, nextResolve) => {
   // and short circuit, so the load step
   // will return source code of empty object
   if (isClient) {
-    const nextResult = await nextResolve(specifier, context, nextResolve)
-
     return {
       format: 'client',
       shortCircuit: true,
-      url: nextResult.url,
+      // No need to resolve the URL using nextResolve. We ignore client files anyway.
+      // Additionally, nextResolve throws an error if the URL is a TS path, so we'd have to use TypeScript's resolveModuleName to resolve the URL, which is unnecessary
+      url: 'file:///',
     }
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload-3.0-demo/issues/215

imports like import LogoSVG from '@/components/logo.svg' did not make it to the TS module resolution, due to the early isClient check.

And the isClient check only uses node module resolution (using nextResolves) which throws an error here.

This removes module resolution completely, as we "ignore" client files anyways. Should also help improve performance, and we do not have to fall back to ts module resolution for client files that way, which would be unnecessary