### PR TITLE
fix: safely access cookie header for uploads

### DIFF
--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -20,7 +20,7 @@ export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promis
 
     const headers = uploadConfig.externalFileHeaderFilter
       ? uploadConfig.externalFileHeaderFilter(Object.fromEntries(new Headers(req.headers)))
-      : { cookie: req.headers.get('cookie') }
+      : { cookie: req.headers?.get('cookie') }
 
     const res = await fetch(fileURL, {
       credentials: 'include',


### PR DESCRIPTION
## Description

Issue with editing and changing the crop or focal point of an image

`fix`: adds optional chaining to safely access cookie header when fetching image

v2 PR [here](https://github.com/payloadcms/payload/pull/6367)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
