### PR TITLE
fix(translations): type StripCountVariants not working in TS strict mode

### DIFF
--- a/packages/translations/src/types.ts
+++ b/packages/translations/src/types.ts
@@ -79,7 +79,7 @@ export type NestedKeysStripped<T> = T extends object
   ? {
       [K in keyof T]-?: K extends string
         ? T[K] extends object
-          ? `${K}:${StripCountVariants<NestedKeysStripped<T[K]>>}` | null
+          ? `${K}:${NestedKeysStripped<T[K]>}`
           : `${StripCountVariants<K>}`
         : never
     }[keyof T]


### PR DESCRIPTION
## Description

This also removes the unnecessary StripCountVariants utility use for when NestedKeysStripped<T[K]> is an object

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
