### PR TITLE
fix(next): does not wrap custom views with template

### DIFF
--- a/packages/next/src/views/Root/getViewFromConfig.tsx
+++ b/packages/next/src/views/Root/getViewFromConfig.tsx
@@ -61,7 +61,7 @@ export const getViewFromConfig = ({
 } => {
   let ViewToRender: AdminViewComponent = null
   let templateClassName: string
-  let templateType: 'default' | 'minimal' = 'minimal'
+  let templateType: 'default' | 'minimal' | undefined
 
   const initPageOptions: Parameters<typeof initPage>[0] = {
     config,

--- a/packages/next/src/views/Root/index.tsx
+++ b/packages/next/src/views/Root/index.tsx
@@ -86,6 +86,7 @@ export const RootPage = async ({
 
   return (
     <Fragment>
+      {!templateType && <Fragment>{RenderedView}</Fragment>}
       {templateType === 'minimal' && (
         <MinimalTemplate className={templateClassName}>{RenderedView}</MinimalTemplate>
       )}


### PR DESCRIPTION
## Description

Closes https://github.com/payloadcms/payload-3.0-demo/issues/216. Custom views were being wrapped with `MinimalTemplate` by default. Custom views are responsible for importing and rendering their own templates.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
