### PR TITLE
fix: loader support for server-only

### DIFF
--- a/packages/payload/src/bin/loader/ignores.ts
+++ b/packages/payload/src/bin/loader/ignores.ts
@@ -1,0 +1,1 @@
+export const specifiersToIgnore = ['server-only']

--- a/packages/payload/src/bin/loader/index.ts
+++ b/packages/payload/src/bin/loader/index.ts
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL } from 'url'
 
 import { CLIENT_EXTENSIONS } from './clientExtensions.js'
 import { compile } from './compile.js'
+import { specifiersToIgnore } from './ignores.js'
 import { resolveOriginalPath } from './resolveOriginalPath.js'
 
 interface ResolveContext {
@@ -55,13 +56,15 @@ const TS_EXTENSIONS: string[] = [
 export const resolve: ResolveFn = async (specifier, context, nextResolve) => {
   const isTS = TS_EXTENSIONS.some((ext) => specifier.endsWith(ext))
   const isClient = CLIENT_EXTENSIONS.some((ext) => specifier.endsWith(ext))
+  const shouldIgnore = specifiersToIgnore.includes(specifier)
 
-  // If a client file is resolved, we'll set `format: client`
+  // If it's a client file, or a file to be ignored is resolved,
+  // we'll set `format: 'ignore'`
   // and short circuit, so the load step
   // will return source code of empty object
-  if (isClient) {
+  if (isClient || shouldIgnore) {
     return {
-      format: 'client',
+      format: 'ignore',
       shortCircuit: true,
       // No need to resolve the URL using nextResolve. We ignore client files anyway.
       // Additionally, nextResolve throws an error if the URL is a TS path, so we'd have to use TypeScript's resolveModuleName to resolve the URL, which is unnecessary
@@ -147,7 +150,7 @@ const swcOptions = {
   paths: undefined,
 }
 export const load: LoadFn = async (url, context, nextLoad) => {
-  if (context.format === 'client') {
+  if (context.format === 'ignore') {
     const rawSource = 'export default {}'
 
     return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1726,6 +1726,9 @@ importers:
       payload:
         specifier: workspace:*
         version: link:../packages/payload
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       tempy:
         specifier: ^1.0.1
         version: 1.0.1
@@ -14801,6 +14804,10 @@ packages:
       send: 0.18.0
     transitivePeerDependencies:
       - supports-color
+
+  /server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+    dev: true
 
   /set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}

--- a/test/loader/int.spec.ts
+++ b/test/loader/int.spec.ts
@@ -11,6 +11,11 @@ describe('Loader', () => {
     expect(code).toStrictEqual(0)
   })
 
+  it('should import server-only without breaking', async () => {
+    const code = await startChildProcess('./server-only-test.ts')
+    expect(code).toStrictEqual(0)
+  })
+
   it('should import configs that rely on custom components', async () => {
     const code = await startChildProcess('../admin/config.ts')
     expect(code).toStrictEqual(0)

--- a/test/loader/server-only-test.ts
+++ b/test/loader/server-only-test.ts
@@ -1,0 +1,3 @@
+import 'server-only'
+
+console.log('woo')

--- a/test/package.json
+++ b/test/package.json
@@ -48,6 +48,7 @@
     "execa": "5.1.1",
     "http-status": "1.6.2",
     "payload": "workspace:*",
+    "server-only": "^0.0.1",
     "tempy": "^1.0.1",
     "ts-essentials": "7.0.3",
     "typescript": "5.4.5",


### PR DESCRIPTION
## Description

Allows `server-only` to work within the Payload loader.

Fixes https://github.com/payloadcms/payload-3.0-demo/issues/218
