### PR TITLE
fix: add back explicit crop x and y values

### DIFF
--- a/packages/payload/src/admin/components/elements/EditUpload/index.tsx
+++ b/packages/payload/src/admin/components/elements/EditUpload/index.tsx
@@ -41,6 +41,8 @@ export const EditUpload: React.FC<{
     height: uploadEdits?.crop?.height || 100,
     unit: '%',
     width: uploadEdits?.crop?.width || 100,
+    x: uploadEdits?.crop?.x || 0,
+    y: uploadEdits?.crop?.y || 0,
   })
 
   const [focalPosition, setFocalPosition] = useState<{ x: number; y: number }>({


### PR DESCRIPTION
Cropping x and y values pulling from the UI were unintentionally removed in #6364 