### PR TITLE
fix: allow focal point when no sizes defined

### DIFF
--- a/packages/payload/src/admin/components/views/collections/Edit/Upload/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Upload/index.tsx
@@ -116,10 +116,12 @@ export const Upload: React.FC<Props> = (props) => {
 
   const hasImageSizes = collection?.upload?.imageSizes?.length > 0
   const hasResizeOptions = Boolean(collection?.upload?.resizeOptions)
+  // Explicitly check if set to true, default is undefined
+  const focalPointEnabled = collection?.upload?.focalPoint === true
 
   const { collection: { upload: { crop: showCrop = true, focalPoint = true } } = {} } = props
 
-  const showFocalPoint = focalPoint && (hasImageSizes || hasResizeOptions)
+  const showFocalPoint = focalPoint && (hasImageSizes || hasResizeOptions || focalPointEnabled)
 
   const lastSubmittedTime = submitted ? new Date().toISOString() : null
 

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -66,8 +66,15 @@ export const generateFileData = async <T>({
     req,
   })
 
-  const { disableLocalStorage, formatOptions, imageSizes, resizeOptions, staticDir, trimOptions } =
-    collectionConfig.upload
+  const {
+    disableLocalStorage,
+    focalPoint: focalPointEnabled,
+    formatOptions,
+    imageSizes,
+    resizeOptions,
+    staticDir,
+    trimOptions,
+  } = collectionConfig.upload
 
   let staticPath = staticDir
   if (staticDir.indexOf('/') !== 0) {
@@ -244,7 +251,7 @@ export const generateFileData = async <T>({
       }
     }
 
-    if (Array.isArray(imageSizes) && fileSupportsResize) {
+    if (fileSupportsResize && (Array.isArray(imageSizes) || focalPointEnabled !== false)) {
       req.payloadUploadSizes = {}
       const { focalPoint, sizeData, sizesToSave } = await resizeAndTransformImageSizes({
         config: collectionConfig,

--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -117,8 +117,9 @@ const getBaseUploadFields = ({ collection, config }: Options): Field[] => {
 
   // Add focal point fields if not disabled
   if (
-    uploadOptions.focalPoint !== false &&
-    (uploadOptions.imageSizes || uploadOptions.resizeOptions)
+    uploadOptions.focalPoint !== false ||
+    uploadOptions.imageSizes ||
+    uploadOptions.resizeOptions
   ) {
     uploadFields = uploadFields.concat(
       ['focalX', 'focalY'].map((name) => {

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -199,6 +199,17 @@ export default buildConfigWithDefaults({
       },
     },
     {
+      slug: 'focal-no-sizes',
+      fields: [],
+      upload: {
+        crop: false,
+        focalPoint: true,
+        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
+        staticDir: './focal-no-sizes',
+        staticURL: '/focal-no-sizes',
+      },
+    },
+    {
       slug: mediaSlug,
       fields: [],
       upload: {


### PR DESCRIPTION
Allow focal points to be saved even when no imageSizes are defined. Expands upon #6364 .