### PR TITLE
fix(db-postgres): uuid custom db name

### DIFF
--- a/packages/db-postgres/src/createVersion.ts
+++ b/packages/db-postgres/src/createVersion.ts
@@ -45,8 +45,7 @@ export async function createVersion<T extends TypeWithID>(
 
   const table = this.tables[tableName]
 
-  const relationshipsTable =
-    this.tables[`_${defaultTableName}${this.versionsSuffix}${this.relationshipsSuffix}`]
+  const relationshipsTable = this.tables[`${tableName}${this.relationshipsSuffix}`]
 
   if (collection.versions.drafts) {
     await db.execute(sql`

--- a/test/database/config.ts
+++ b/test/database/config.ts
@@ -134,7 +134,9 @@ export default buildConfigWithDefaults({
           ],
         },
       ],
-      versions: true,
+      versions: {
+        drafts: true,
+      },
     },
   ],
   globals: [


### PR DESCRIPTION
## Description

Fixes an issue with creating versions when using custom DB names, `uuid`, and drafts.

v3 PR [here](https://github.com/payloadcms/payload/pull/6408)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
