### PR TITLE
fix: page metadata generation not working in turbopack

### DIFF
--- a/packages/next/src/utilities/meta.ts
+++ b/packages/next/src/utilities/meta.ts
@@ -30,14 +30,14 @@ export const meta = async (args: MetaConfig & { serverURL: string }): Promise<an
       type: 'image/png',
       rel: 'icon',
       sizes: '32x32',
-      url: payloadFaviconDark?.src,
+      url: typeof payloadFaviconDark === 'object' ? payloadFaviconDark?.src : payloadFaviconDark,
     },
     {
       type: 'image/png',
       media: '(prefers-color-scheme: dark)',
       rel: 'icon',
       sizes: '32x32',
-      url: payloadFaviconLight?.src,
+      url: typeof payloadFaviconLight === 'object' ? payloadFaviconLight?.src : payloadFaviconLight,
     },
   ]
 
@@ -79,7 +79,7 @@ export const meta = async (args: MetaConfig & { serverURL: string }): Promise<an
             {
               alt: ogTitle,
               height: 480,
-              url: staticOGImage.src,
+              url: typeof staticOGImage === 'object' ? staticOGImage?.src : staticOGImage,
               width: 640,
             },
           ],


### PR DESCRIPTION
## Description

In turbo, payloadFaviconDark is a string, not an object with src

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
