### PR TITLE
chore(translations): ai translation script should use formal language

### DIFF
--- a/packages/translations/scripts/translateNewKeys/translateText.ts
+++ b/packages/translations/scripts/translateNewKeys/translateText.ts
@@ -12,7 +12,7 @@ export async function translateText(text: string, targetLang: string) {
       max_tokens: 150,
       messages: [
         {
-          content: `Only respond with the translation of the text you receive. The original language is English and the translation language is ${targetLang}. Only respond with the translation - do not say anything else. If you cannot translate the text, respond with "[SKIPPED]"`,
+          content: `Only respond with the translation of the text you receive. The original language is English and the translation language is ${targetLang}. Use formal and professional language. Only respond with the translation - do not say anything else. If you cannot translate the text, respond with "[SKIPPED]"`,
           role: 'system',
         },
         {


### PR DESCRIPTION
Added additional prompt to make sure the translation we receive is using formal language where it makes sense.

In the context of latin languages for example:
- Spanish: "tu" should be using "vos"
- French: "tu" should be using "votre"

These differences can affect verb conjugations and in these languages it comes across as less professional if informal language is used.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
