### PR TITLE
fix(richtext-lexical): field required validation not working if content was removed manually

### DIFF
--- a/packages/richtext-lexical/src/populate/defaultValue.ts
+++ b/packages/richtext-lexical/src/populate/defaultValue.ts
@@ -30,23 +30,3 @@ export const defaultRichTextValue: SerializedEditorState = {
     version: 1,
   },
 }
-
-export const defaultRichTextValueV2: SerializedEditorState = {
-  root: {
-    type: 'root',
-    children: [
-      {
-        type: 'paragraph',
-        children: [],
-        direction: null,
-        format: '',
-        indent: 0,
-        version: 1,
-      } as SerializedParagraphNode,
-    ],
-    direction: null,
-    format: '',
-    indent: 0,
-    version: 1,
-  },
-}

--- a/packages/richtext-lexical/src/validate/index.ts
+++ b/packages/richtext-lexical/src/validate/index.ts
@@ -1,9 +1,8 @@
-import type { SerializedEditorState } from 'lexical'
+import type { SerializedEditorState, SerializedParagraphNode } from 'lexical'
 import type { RichTextField, Validate } from 'payload/types'
 
 import type { SanitizedServerEditorConfig } from '../field/lexical/config/types.js'
 
-import { defaultRichTextValue, defaultRichTextValueV2 } from '../populate/defaultValue.js'
 import { validateNodes } from './validateNodes.js'
 
 export const richTextValidateHOC = ({
@@ -21,13 +20,17 @@ export const richTextValidateHOC = ({
     } = options
 
     if (required) {
-      if (
-        !value ||
-        !value?.root?.children ||
-        !value?.root?.children?.length ||
-        JSON.stringify(value) === JSON.stringify(defaultRichTextValue) ||
-        JSON.stringify(value) === JSON.stringify(defaultRichTextValueV2)
-      ) {
+      const hasChildren = value?.root?.children?.length
+
+      const hasOnlyEmptyParagraph =
+        (value?.root?.children?.length === 1 &&
+          value?.root?.children[0]?.type === 'paragraph' &&
+          (value?.root?.children[0] as SerializedParagraphNode)?.children?.length === 0) ||
+        ((value?.root?.children[0] as SerializedParagraphNode)?.children?.length === 1 &&
+          (value?.root?.children[0] as SerializedParagraphNode)?.children[0]?.type === 'text' &&
+          (value?.root?.children[0] as SerializedParagraphNode)?.children[0]?.['text'] === '')
+
+      if (!hasChildren || hasOnlyEmptyParagraph) {
         return t('validation:required')
       }
     }


### PR DESCRIPTION
## Description

Previously, if you typed something in a required lexical field, save, remove everything and save again, it did not error.

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
