### PR TITLE
feat: store focal point on uploads

### DIFF
--- a/packages/next/src/fetchAPI-multipart/index.ts
+++ b/packages/next/src/fetchAPI-multipart/index.ts
@@ -152,7 +152,7 @@ type FetchAPIFileUpload = (args: {
   request: Request
 }) => Promise<FetchAPIFileUploadResponse>
 export const fetchAPIFileUpload: FetchAPIFileUpload = async ({ options, request }) => {
-  const uploadOptions = { ...DEFAULT_OPTIONS, ...options }
+  const uploadOptions: FetchAPIFileUploadOptions = { ...DEFAULT_OPTIONS, ...options }
   if (!isEligibleRequest(request)) {
     debugLog(uploadOptions, 'Request is not eligible for file upload!')
     return {

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -121,6 +121,7 @@ export const createOperation = async <TSlug extends keyof GeneratedTypes['collec
       collection,
       config,
       data,
+      operation: 'create',
       overwriteExistingFiles,
       req,
       throwOnMissingFile:

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -156,6 +156,7 @@ export const updateOperation = async <TSlug extends keyof GeneratedTypes['collec
       collection,
       config,
       data: bulkUpdateData,
+      operation: 'update',
       overwriteExistingFiles,
       req,
       throwOnMissingFile: false,

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -147,6 +147,7 @@ export const updateByIDOperation = async <TSlug extends keyof GeneratedTypes['co
       collection,
       config,
       data,
+      operation: 'update',
       overwriteExistingFiles,
       req,
       throwOnMissingFile: false,

--- a/packages/payload/src/exports/utilities.ts
+++ b/packages/payload/src/exports/utilities.ts
@@ -12,7 +12,7 @@ export { traverseFields as beforeValidateTraverseFields } from '../fields/hooks/
 
 export { formatFilesize } from '../uploads/formatFilesize.js'
 
-export { default as isImage } from '../uploads/isImage.js'
+export { isImage } from '../uploads/isImage.js'
 
 export { combineMerge } from '../utilities/combineMerge.js'
 export {

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -7,19 +7,6 @@ import type { GeneratedTypes } from '../index.js'
 import type { validOperators } from './constants.js'
 export type { Payload as Payload } from '../index.js'
 
-export type UploadEdits = {
-  crop?: {
-    height?: number
-    width?: number
-    x?: number
-    y?: number
-  }
-  focalPoint?: {
-    x?: number
-    y?: number
-  }
-}
-
 export type CustomPayloadRequestProperties = {
   context: RequestContext
   /** The locale that should be used for a field when it is not translated to the requested locale */

--- a/packages/payload/src/uploads/canResizeImage.ts
+++ b/packages/payload/src/uploads/canResizeImage.ts
@@ -1,3 +1,3 @@
-export default function canResizeImage(mimeType: string): boolean {
+export function canResizeImage(mimeType: string): boolean {
   return ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/tiff'].indexOf(mimeType) > -1
 }

--- a/packages/payload/src/uploads/cropImage.ts
+++ b/packages/payload/src/uploads/cropImage.ts
@@ -2,7 +2,7 @@ export const percentToPixel = (value, dimension) => {
   return Math.floor((parseFloat(value) / 100) * dimension)
 }
 
-export default async function cropImage({ cropData, dimensions, file, sharp }) {
+export async function cropImage({ cropData, dimensions, file, sharp }) {
   try {
     const { height, width, x, y } = cropData
 

--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -149,6 +149,25 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
     height,
   ]
 
+  // Add focal point fields if not disabled
+  if (
+    uploadOptions.focalPoint !== false ||
+    uploadOptions.imageSizes ||
+    uploadOptions.resizeOptions
+  ) {
+    uploadFields = uploadFields.concat(
+      ['focalX', 'focalY'].map((name) => {
+        return {
+          name,
+          type: 'number',
+          admin: {
+            hidden: true,
+          },
+        }
+      }),
+    )
+  }
+
   if (uploadOptions.mimeTypes) {
     mimeType.validate = mimeTypeValidator(uploadOptions.mimeTypes)
   }

--- a/packages/payload/src/uploads/getSafeFilename.ts
+++ b/packages/payload/src/uploads/getSafeFilename.ts
@@ -29,7 +29,7 @@ type Args = {
   staticPath: string
 }
 
-async function getSafeFileName({
+export async function getSafeFileName({
   collectionSlug,
   desiredFilename,
   req,
@@ -51,5 +51,3 @@ async function getSafeFileName({
   }
   return modifiedFilename
 }
-
-export default getSafeFileName

--- a/packages/payload/src/uploads/isImage.ts
+++ b/packages/payload/src/uploads/isImage.ts
@@ -1,4 +1,4 @@
-export default function isImage(mimeType: string): boolean {
+export function isImage(mimeType: string): boolean {
   return (
     ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml', 'image/webp', 'image/avif'].indexOf(
       mimeType,

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -18,6 +18,8 @@ export type FileSizes = {
 export type FileData = {
   filename: string
   filesize: number
+  focalX?: number
+  focalY?: number
   height: number
   mimeType: string
   sizes: FileSizes
@@ -116,4 +118,17 @@ export type File = {
 export type FileToSave = {
   buffer: Buffer
   path: string
+}
+
+export type UploadEdits = {
+  crop?: {
+    height?: number
+    width?: number
+    x?: number
+    y?: number
+  }
+  focalPoint?: {
+    x?: number
+    y?: number
+  }
 }

--- a/packages/ui/src/elements/EditUpload/index.tsx
+++ b/packages/ui/src/elements/EditUpload/index.tsx
@@ -32,13 +32,12 @@ type FocalPosition = {
 }
 
 export type EditUploadProps = {
-  doc?: Data
   fileName: string
   fileSrc: string
   imageCacheTag?: string
   initialCrop?: CropType
   initialFocalPoint?: FocalPosition
-  onSave?: ({ crop, pointPosition }: { crop: CropType; pointPosition: FocalPosition }) => void
+  onSave?: ({ crop, focalPosition }: { crop: CropType; focalPosition: FocalPosition }) => void
   showCrop?: boolean
   showFocalPoint?: boolean
 }
@@ -49,11 +48,6 @@ const defaultCrop: CropType = {
   width: 100,
   x: 0,
   y: 0,
-}
-
-const defaultPointPosition: FocalPosition = {
-  x: 50,
-  y: 50,
 }
 
 export const EditUpload: React.FC<EditUploadProps> = ({
@@ -76,8 +70,15 @@ export const EditUpload: React.FC<EditUploadProps> = ({
     ...initialCrop,
   }))
 
-  const [pointPosition, setPointPosition] = useState<FocalPosition>(() => ({
-    ...defaultPointPosition,
+  const defaultFocalPosition: FocalPosition = {
+    x: 50,
+    y: 50,
+  }
+
+  console.log({ initialFocalPoint })
+
+  const [focalPosition, setFocalPosition] = useState<FocalPosition>(() => ({
+    ...defaultFocalPosition,
     ...initialFocalPoint,
   }))
   const [checkBounds, setCheckBounds] = useState<boolean>(false)
@@ -103,10 +104,16 @@ export const EditUpload: React.FC<EditUploadProps> = ({
     })
   }
 
-  const fineTuneFocalPoint = ({ coordinate, value }: { coordinate: 'x' | 'y'; value: string }) => {
+  const fineTuneFocalPosition = ({
+    coordinate,
+    value,
+  }: {
+    coordinate: 'x' | 'y'
+    value: string
+  }) => {
     const intValue = parseInt(value)
     if (intValue >= 0 && intValue <= 100) {
-      setPointPosition((prevPosition) => ({ ...prevPosition, [coordinate]: intValue }))
+      setFocalPosition((prevPosition) => ({ ...prevPosition, [coordinate]: intValue }))
     }
   }
 
@@ -114,13 +121,13 @@ export const EditUpload: React.FC<EditUploadProps> = ({
     if (typeof onSave === 'function')
       onSave({
         crop,
-        pointPosition,
+        focalPosition,
       })
     closeModal(editDrawerSlug)
   }
 
   const onDragEnd = React.useCallback(({ x, y }) => {
-    setPointPosition({ x, y })
+    setFocalPosition({ x, y })
     setCheckBounds(false)
   }, [])
 
@@ -133,7 +140,7 @@ export const EditUpload: React.FC<EditUploadProps> = ({
       ((boundsRect.left - containerRect.left + boundsRect.width / 2) / containerRect.width) * 100
     const yCenter =
       ((boundsRect.top - containerRect.top + boundsRect.height / 2) / containerRect.height) * 100
-    setPointPosition({ x: xCenter, y: yCenter })
+    setFocalPosition({ x: xCenter, y: yCenter })
   }
 
   const fileSrcToUse = imageCacheTag ? `${fileSrc}?${imageCacheTag}` : fileSrc
@@ -209,7 +216,7 @@ export const EditUpload: React.FC<EditUploadProps> = ({
                 checkBounds={showCrop ? checkBounds : false}
                 className={`${baseClass}__focalPoint`}
                 containerRef={focalWrapRef}
-                initialPosition={pointPosition}
+                initialPosition={focalPosition}
                 onDragEnd={onDragEnd}
                 setCheckBounds={showCrop ? setCheckBounds : false}
               >
@@ -280,13 +287,13 @@ export const EditUpload: React.FC<EditUploadProps> = ({
                 <div className={`${baseClass}__inputsWrap`}>
                   <Input
                     name="X %"
-                    onChange={(value) => fineTuneFocalPoint({ coordinate: 'x', value })}
-                    value={pointPosition.x.toFixed(0)}
+                    onChange={(value) => fineTuneFocalPosition({ coordinate: 'x', value })}
+                    value={focalPosition.x.toFixed(0)}
                   />
                   <Input
                     name="Y %"
-                    onChange={(value) => fineTuneFocalPoint({ coordinate: 'y', value })}
-                    value={pointPosition.y.toFixed(0)}
+                    onChange={(value) => fineTuneFocalPosition({ coordinate: 'y', value })}
+                    value={focalPosition.y.toFixed(0)}
                   />
                 </div>
               </div>

--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -101,7 +101,7 @@ export const Upload: React.FC<UploadProps> = (props) => {
   }, [setValue])
 
   const onEditsSave = React.useCallback(
-    ({ crop, pointPosition }) => {
+    ({ crop, focalPosition }) => {
       setCrop({
         x: crop.x || 0,
         y: crop.y || 0,
@@ -122,10 +122,10 @@ export const Upload: React.FC<UploadProps> = (props) => {
         type: 'SET',
         params: {
           uploadEdits:
-            crop || pointPosition
+            crop || focalPosition
               ? {
                   crop: crop || null,
-                  focalPoint: pointPosition ? pointPosition : null,
+                  focalPoint: focalPosition ? focalPosition : null,
                 }
               : null,
         },
@@ -164,10 +164,12 @@ export const Upload: React.FC<UploadProps> = (props) => {
 
   const hasImageSizes = uploadConfig?.imageSizes?.length > 0
   const hasResizeOptions = Boolean(uploadConfig?.resizeOptions)
+  // Explicity check if set to true, default is undefined
+  const focalPointEnabled = uploadConfig?.focalPoint === true
 
   const { crop: showCrop = true, focalPoint = true } = uploadConfig
 
-  const showFocalPoint = focalPoint && (hasImageSizes || hasResizeOptions)
+  const showFocalPoint = focalPoint && (hasImageSizes || hasResizeOptions || focalPointEnabled)
 
   const lastSubmittedTime = submitted ? new Date().toISOString() : null
 
@@ -234,14 +236,13 @@ export const Upload: React.FC<UploadProps> = (props) => {
       {(value || doc.filename) && (
         <Drawer Header={null} slug={editDrawerSlug}>
           <EditUpload
-            doc={doc || undefined}
             fileName={value?.name || doc?.filename}
             fileSrc={fileSrc || doc?.url}
             imageCacheTag={lastSubmittedTime}
             initialCrop={formQueryParams?.uploadEdits?.crop ?? {}}
             initialFocalPoint={{
-              x: formQueryParams?.uploadEdits?.focalPoint.x || 0,
-              y: formQueryParams?.uploadEdits?.focalPoint.y || 0,
+              x: formQueryParams?.uploadEdits?.focalPoint.x || doc.focalX || 50,
+              y: formQueryParams?.uploadEdits?.focalPoint.y || doc.focalY || 50,
             }}
             onSave={onEditsSave}
             showCrop={showCrop}

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -12,6 +12,7 @@ import { Uploads2 } from './collections/Upload2/index.js'
 import {
   audioSlug,
   enlargeSlug,
+  focalNoSizesSlug,
   mediaSlug,
   reduceSlug,
   relationSlug,
@@ -181,6 +182,16 @@ export default buildConfigWithDefaults({
             width: 900,
           },
         ],
+      },
+    },
+    {
+      slug: focalNoSizesSlug,
+      fields: [],
+      upload: {
+        crop: false,
+        focalPoint: true,
+        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
+        staticDir: './focal-no-sizes',
       },
     },
     {

--- a/test/uploads/payload-types.ts
+++ b/test/uploads/payload-types.ts
@@ -15,6 +15,7 @@ export interface Config {
     'object-fit': ObjectFit;
     'crop-only': CropOnly;
     'focal-only': FocalOnly;
+    'focal-no-sizes': FocalNoSize;
     media: Media;
     enlarge: Enlarge;
     reduce: Reduce;
@@ -64,6 +65,8 @@ export interface Media {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
   sizes?: {
     maintainedAspectRatio?: {
       url?: string | null;
@@ -204,6 +207,8 @@ export interface Version {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -230,6 +235,8 @@ export interface GifResize {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
   sizes?: {
     small?: {
       url?: string | null;
@@ -264,6 +271,8 @@ export interface NoImageSize {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -280,6 +289,8 @@ export interface ObjectFit {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
   sizes?: {
     fitContain?: {
       url?: string | null;
@@ -330,6 +341,8 @@ export interface CropOnly {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
   sizes?: {
     focalTest?: {
       url?: string | null;
@@ -372,6 +385,8 @@ export interface FocalOnly {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
   sizes?: {
     focalTest?: {
       url?: string | null;
@@ -401,6 +416,24 @@ export interface FocalOnly {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "focal-no-sizes".
+ */
+export interface FocalNoSize {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "enlarge".
  */
 export interface Enlarge {
@@ -414,6 +447,8 @@ export interface Enlarge {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
   sizes?: {
     accidentalSameSize?: {
       url?: string | null;
@@ -472,6 +507,8 @@ export interface Reduce {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
   sizes?: {
     accidentalSameSize?: {
       url?: string | null;
@@ -522,6 +559,8 @@ export interface MediaTrim {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
   sizes?: {
     trimNumber?: {
       url?: string | null;
@@ -564,6 +603,8 @@ export interface UnstoredMedia {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -580,6 +621,8 @@ export interface ExternallyServedMedia {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -612,6 +655,8 @@ export interface Uploads1 {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -629,6 +674,8 @@ export interface Uploads2 {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -645,6 +692,8 @@ export interface AdminThumbnailFunction {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -661,6 +710,8 @@ export interface AdminThumbnailSize {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
   sizes?: {
     small?: {
       url?: string | null;
@@ -695,6 +746,8 @@ export interface OptionalFile {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -711,6 +764,8 @@ export interface RequiredFile {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/uploads/shared.ts
+++ b/test/uploads/shared.ts
@@ -1,19 +1,12 @@
 export const usersSlug = 'users'
-
 export const mediaSlug = 'media'
-
 export const relationSlug = 'relation'
-
 export const audioSlug = 'audio'
-
 export const enlargeSlug = 'enlarge'
-
+export const focalNoSizesSlug = 'focal-no-sizes'
+export const focalOnlySlug = 'focal-only'
 export const reduceSlug = 'reduce'
-
 export const adminThumbnailFunctionSlug = 'admin-thumbnail-function'
-
 export const adminThumbnailSizeSlug = 'admin-thumbnail-size'
-
 export const unstoredMediaSlug = 'unstored-media'
-
 export const versionSlug = 'versions'


### PR DESCRIPTION
Store focal point data on uploads as `focalX` and `focalY`

Addresses https://github.com/payloadcms/payload/discussions/4082

Mirrors #6364 for beta branch.