### PR TITLE
fix: separate sort and search fields when looking up relationship.

### DIFF
--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -154,13 +154,12 @@ const RelationshipField: React.FC<RelationshipFieldProps> = (props) => {
 
           if (resultsFetched < 10) {
             const collection = collections.find((coll) => coll.slug === relation)
-            let fieldToSearch = collection?.defaultSort || collection?.admin?.useAsTitle || 'id'
-            if (!searchArg) {
-              if (typeof sortOptions === 'string') {
-                fieldToSearch = sortOptions
-              } else if (sortOptions?.[relation]) {
-                fieldToSearch = sortOptions[relation]
-              }
+            const fieldToSearch = collection?.admin?.useAsTitle || 'id'
+            let fieldToSort = collection?.defaultSort || 'id'
+            if (typeof sortOptions === 'string') {
+              fieldToSort = sortOptions
+            } else if (sortOptions?.[relation]) {
+              fieldToSort = sortOptions[relation]
             }
 
             const query: {
@@ -172,7 +171,7 @@ const RelationshipField: React.FC<RelationshipFieldProps> = (props) => {
               limit: maxResultsPerRequest,
               locale,
               page: lastLoadedPageToUse,
-              sort: fieldToSearch,
+              sort: fieldToSort,
               where: {
                 and: [
                   {


### PR DESCRIPTION
## Description

Default sort is used as searching field which is causing unexpected behaviour described in https://github.com/payloadcms/payload/issues/4815 and https://github.com/payloadcms/payload/issues/5222 This bugfix separates which field is used for sorting and which is used for searching.

Fixes: https://github.com/payloadcms/payload/issues/4815 https://github.com/payloadcms/payload/issues/5222

@denolfe This fix is a port of the fix in [#5964](https://github.com/payloadcms/payload/pull/5964) to beta branch.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
