### PR TITLE
fix: user verification email broken

### DIFF
--- a/packages/payload/src/auth/sendVerificationEmail.ts
+++ b/packages/payload/src/auth/sendVerificationEmail.ts
@@ -66,7 +66,7 @@ export async function sendVerificationEmail(args: Args): Promise<void> {
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     email.sendEmail({
-      from: `"${email.defaultFromName}" <${email.defaultFromName}>`,
+      from: `"${email.defaultFromName}" <${email.defaultFromAddress}>`,
       html,
       subject,
       to: user.email,


### PR DESCRIPTION
## Description

Closes [#225](https://github.com/payloadcms/payload-3.0-demo/issues/225).

The user verification emails are not being sent and this error is shown:
```ts
APIError: Error sending email: 422 validation_error - Invalid `from` field. The email address needs to follow the `email@example.com` or `Name <email@example.com>` format.
```

The issue is resolved by updating the `from` property on the outgoing verification email:
```ts
from: `"${email.defaultFromName}" <${email.defaultFromName}>`,
// to
from: `"${email.defaultFromName}" <${email. defaultFromAddress}>`,
```

**NOTE:** This was not broken in 2.0, see correct outgoing email [here](https://github.com/payloadcms/payload/blob/main/packages/payload/src/auth/sendVerificationEmail.ts#L69).

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
