### PR TITLE
chore(ui)!: uses consistent button naming conventions

### DIFF
--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -15,9 +15,9 @@ import { DuplicateDocument } from '../DuplicateDocument/index.js'
 import { Gutter } from '../Gutter/index.js'
 import { Popup, PopupList } from '../Popup/index.js'
 import { PreviewButton } from '../PreviewButton/index.js'
-import { Publish } from '../Publish/index.js'
-import { Save } from '../Save/index.js'
-import { SaveDraft } from '../SaveDraft/index.js'
+import { PublishButton } from '../PublishButton/index.js'
+import { SaveButton } from '../SaveButton/index.js'
+import { SaveDraftButton } from '../SaveDraftButton/index.js'
 import { Status } from '../Status/index.js'
 import './index.scss'
 
@@ -169,12 +169,12 @@ export const DocumentControls: React.FC<{
                       !collectionConfig?.versions?.drafts?.autosave) ||
                       (globalConfig?.versions?.drafts &&
                         !globalConfig?.versions?.drafts?.autosave)) && (
-                      <SaveDraft CustomComponent={componentMap.SaveDraftButton} />
+                      <SaveDraftButton CustomComponent={componentMap.SaveDraftButton} />
                     )}
-                    <Publish CustomComponent={componentMap.PublishButton} />
+                    <PublishButton CustomComponent={componentMap.PublishButton} />
                   </React.Fragment>
                 ) : (
-                  <Save CustomComponent={componentMap.SaveButton} />
+                  <SaveButton CustomComponent={componentMap.SaveButton} />
                 )}
               </React.Fragment>
             )}

--- a/packages/ui/src/elements/EditMany/index.tsx
+++ b/packages/ui/src/elements/EditMany/index.tsx
@@ -55,7 +55,8 @@ const Submit: React.FC<{ action: string; disabled: boolean }> = ({ action, disab
     </FormSubmit>
   )
 }
-const Publish: React.FC<{ action: string; disabled: boolean }> = ({ action, disabled }) => {
+
+const PublishButton: React.FC<{ action: string; disabled: boolean }> = ({ action, disabled }) => {
   const { submit } = useForm()
   const { t } = useTranslation()
 
@@ -76,7 +77,8 @@ const Publish: React.FC<{ action: string; disabled: boolean }> = ({ action, disa
     </FormSubmit>
   )
 }
-const SaveDraft: React.FC<{ action: string; disabled: boolean }> = ({ action, disabled }) => {
+
+const SaveDraftButton: React.FC<{ action: string; disabled: boolean }> = ({ action, disabled }) => {
   const { submit } = useForm()
   const { t } = useTranslation()
 
@@ -219,11 +221,11 @@ export const EditMany: React.FC<EditManyProps> = (props) => {
                       <div className={`${baseClass}__document-actions`}>
                         {collection?.versions?.drafts ? (
                           <React.Fragment>
-                            <Publish
+                            <PublishButton
                               action={`${serverURL}${apiRoute}/${slug}${getQueryParams()}&draft=true`}
                               disabled={selected.length === 0}
                             />
-                            <SaveDraft
+                            <SaveDraftButton
                               action={`${serverURL}${apiRoute}/${slug}${getQueryParams()}&draft=true`}
                               disabled={selected.length === 0}
                             />

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -94,7 +94,7 @@ type Props = {
   CustomComponent?: React.ReactNode
 }
 
-export const Publish: React.FC<Props> = ({ CustomComponent }) => {
+export const PublishButton: React.FC<Props> = ({ CustomComponent }) => {
   if (CustomComponent) return CustomComponent
 
   return <DefaultPublishButton />

--- a/packages/ui/src/elements/SaveButton/index.tsx
+++ b/packages/ui/src/elements/SaveButton/index.tsx
@@ -8,6 +8,7 @@ import { useHotkey } from '../../hooks/useHotkey.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { useOperation } from '../../providers/Operation/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+
 export const DefaultSaveButton: React.FC<{ label?: string }> = ({ label: labelProp }) => {
   const { t } = useTranslation()
   const { submit } = useForm()
@@ -49,8 +50,7 @@ type Props = {
   CustomComponent?: React.ReactNode
 }
 
-export const Save: React.FC<Props> = ({ CustomComponent }) => {
+export const SaveButton: React.FC<Props> = ({ CustomComponent }) => {
   if (CustomComponent) return CustomComponent
-
   return <DefaultSaveButton />
 }

--- a/packages/ui/src/elements/SaveDraftButton/index.tsx
+++ b/packages/ui/src/elements/SaveDraftButton/index.tsx
@@ -88,8 +88,7 @@ type Props = {
   CustomComponent?: React.ReactNode
 }
 
-export const SaveDraft: React.FC<Props> = ({ CustomComponent }) => {
+export const SaveDraftButton: React.FC<Props> = ({ CustomComponent }) => {
   if (CustomComponent) return CustomComponent
-
   return <DefaultSaveDraftButton />
 }

--- a/test/versions/elements/CustomSaveButton/index.tsx
+++ b/test/versions/elements/CustomSaveButton/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 import type { CustomPublishButton as CustomPublishButtonType } from 'payload/types'
 
-import { DefaultPublishButton } from '@payloadcms/ui/elements/Publish'
+import { DefaultPublishButton } from '@payloadcms/ui/elements/PublishButton'
 import * as React from 'react'
 
 import classes from './index.module.scss'


### PR DESCRIPTION
## Description

Renames the `Save` to `SaveButton`, etc. to match the already established convention of the `PreviewButton`, etc. This matches the imports with their respective component and type names, and also gives these components more context to the developer whenever they're rendered, i.e. its clearly just a button and not an entire block or complex component.

**BREAKING**:

Import paths for these components have changed, if you were previously importing these components into your own projects to customize, change the import paths accordingly:

Old:
```ts
import { PublishButton } from '@payloadcms/ui/elements/Publish'
import { SaveButton } from '@payloadcms/ui/elements/Save'
import { SaveDraftButton } from '@payloadcms/ui/elements/SaveDraft'
```

New:
```ts
import { PublishButton } from '@payloadcms/ui/elements/PublishButton'
import { SaveButton } from '@payloadcms/ui/elements/SaveButton'
import { SaveDraftButton } from '@payloadcms/ui/elements/SaveDraftButton'
```

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.