### PR TITLE
fix(ui): `disableListColumn` fields not hidden in table columns

### DIFF
--- a/packages/ui/src/elements/TableColumns/filterFields.tsx
+++ b/packages/ui/src/elements/TableColumns/filterFields.tsx
@@ -4,7 +4,7 @@ import type { FieldMap, MappedField } from '../../providers/ComponentMap/buildCo
 // 2. Maps through top-level `tabs` fields and filters out the same
 export const filterFields = (fieldMap: FieldMap): FieldMap => {
   const shouldSkipField = (field: MappedField): boolean =>
-    field.type !== 'ui' && field.disabled === true
+    (field.type !== 'ui' && field.disabled === true) || field?.disableListColumn === true
 
   const fields: FieldMap = fieldMap.reduce((formatted, field) => {
     if (shouldSkipField(field)) {


### PR DESCRIPTION
## Description

Setting `disableListColumn` to `true` on a field would hide the field from the column selector but not from the table columns.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
