### PR TITLE
feat(richtext-lexical): various gutter, error states & add/drag handle improvements

### DIFF
--- a/packages/richtext-lexical/src/cell/index.tsx
+++ b/packages/richtext-lexical/src/cell/index.tsx
@@ -10,7 +10,7 @@ import React, { useEffect, useState } from 'react'
 
 import type { FeatureProviderClient } from '../field/features/types.js'
 import type { SanitizedClientEditorConfig } from '../field/lexical/config/types.js'
-import type { GeneratedFeatureProviderComponent } from '../types.js'
+import type { GeneratedFeatureProviderComponent, LexicalFieldAdminProps } from '../types.js'
 
 import { defaultEditorLexicalConfig } from '../field/lexical/config/client/default.js'
 import { loadClientFeatures } from '../field/lexical/config/client/loader.js'
@@ -18,9 +18,10 @@ import { sanitizeClientEditorConfig } from '../field/lexical/config/client/sanit
 import { getEnabledNodes } from '../field/lexical/nodes/index.js'
 
 export const RichTextCell: React.FC<{
+  admin?: LexicalFieldAdminProps
   lexicalEditorConfig: LexicalEditorConfig
 }> = (props) => {
-  const { lexicalEditorConfig } = props
+  const { admin, lexicalEditorConfig } = props
 
   const [preview, setPreview] = React.useState('Loading...')
   const { schemaPath } = useFieldProps()
@@ -81,11 +82,13 @@ export const RichTextCell: React.FC<{
           sanitizeClientEditorConfig(
             lexicalEditorConfig ? lexicalEditorConfig : defaultEditorLexicalConfig,
             resolvedClientFeatures,
+            admin,
           ),
         )
       }
     }
   }, [
+    admin,
     hasLoadedFeatures,
     clientFunctions,
     schemaPath,

--- a/packages/richtext-lexical/src/field/Field.tsx
+++ b/packages/richtext-lexical/src/field/Field.tsx
@@ -71,6 +71,7 @@ const _RichText: React.FC<
     className,
     showError && 'error',
     readOnly && `${baseClass}--read-only`,
+    editorConfig?.admin?.hideGutter !== true ? `${baseClass}--show-gutter` : null,
   ]
     .filter(Boolean)
     .join(' ')

--- a/packages/richtext-lexical/src/field/features/toolbars/fixed/Toolbar/index.scss
+++ b/packages/richtext-lexical/src/field/features/toolbars/fixed/Toolbar/index.scss
@@ -85,14 +85,28 @@ html[data-theme='dark'] {
   }
 
   + .editor-container {
-    > .editor-scroller > .editor > .ContentEditable__root {
-      padding-top: calc(var(--base) * 1.25);
+    > .editor-scroller > .editor {
+      > .ContentEditable__root {
+        padding-top: calc(var(--base) * 1.25);
+      }
     }
 
     > .editor-placeholder {
       top: calc(var(--base) * 1.25);
     }
   }
+}
 
 
+.rich-text-lexical--show-gutter {
+  .fixed-toolbar {
+    + .editor-container {
+      > .editor-scroller > .editor {
+        > .ContentEditable__root::before {
+          top: calc(var(--base) * 1.25)!important;
+          height: calc(100% - calc(var(--base) * 1.25) - 8px)!important;
+        }
+      }
+    }
+  }
 }

--- a/packages/richtext-lexical/src/field/index.scss
+++ b/packages/richtext-lexical/src/field/index.scss
@@ -23,22 +23,3 @@
   }
 }
 
-html[data-theme='light'] {
-  .rich-text-lexical {
-    &.error {
-      .editor-container {
-        @include lightInputError;
-      }
-    }
-  }
-}
-
-html[data-theme='dark'] {
-  .rich-text-lexical {
-    &.error {
-      .editor-container {
-        @include darkInputError;
-      }
-    }
-  }
-}

--- a/packages/richtext-lexical/src/field/index.tsx
+++ b/packages/richtext-lexical/src/field/index.tsx
@@ -7,7 +7,7 @@ import { useFieldProps } from '@payloadcms/ui/forms/FieldPropsProvider'
 import { useClientFunctions } from '@payloadcms/ui/providers/ClientFunction'
 import React, { Suspense, lazy, useEffect, useState } from 'react'
 
-import type { GeneratedFeatureProviderComponent } from '../types.js'
+import type { GeneratedFeatureProviderComponent, LexicalFieldAdminProps } from '../types.js'
 import type { FeatureProviderClient } from './features/types.js'
 import type { SanitizedClientEditorConfig } from './lexical/config/types.js'
 
@@ -21,12 +21,13 @@ const RichTextEditor = lazy(() =>
 
 export const RichTextField: React.FC<
   FormFieldBase & {
+    admin?: LexicalFieldAdminProps
     lexicalEditorConfig: LexicalEditorConfig
     name: string
     richTextComponentMap: Map<string, React.ReactNode>
   }
 > = (props) => {
-  const { lexicalEditorConfig, richTextComponentMap } = props
+  const { admin, lexicalEditorConfig, richTextComponentMap } = props
   const { schemaPath } = useFieldProps()
   const clientFunctions = useClientFunctions()
   const [hasLoadedFeatures, setHasLoadedFeatures] = useState(false)
@@ -82,11 +83,13 @@ export const RichTextField: React.FC<
           sanitizeClientEditorConfig(
             lexicalEditorConfig ? lexicalEditorConfig : defaultEditorLexicalConfig,
             resolvedClientFeatures,
+            admin,
           ),
         )
       }
     }
   }, [
+    admin,
     hasLoadedFeatures,
     clientFunctions,
     schemaPath,

--- a/packages/richtext-lexical/src/field/lexical/LexicalEditor.scss
+++ b/packages/richtext-lexical/src/field/lexical/LexicalEditor.scss
@@ -22,10 +22,20 @@
     }
   }
 
+  &--show-gutter  {
+    > .rich-text-lexical__wrap > .editor-container > .editor-placeholder {
+      left: 3rem;
+    }
+  }
+
+  // Now rule if it does not have the gutter
+  &:not(&--show-gutter) > .rich-text-lexical__wrap > .editor-container > .editor-placeholder {
+    left: 0;
+  }
+
   .editor-placeholder {
     position: absolute;
     top: 8px;
-    left: 0;
     font-size: 15px;
     color: var(--theme-elevation-500);
     /* Prevent text selection */

--- a/packages/richtext-lexical/src/field/lexical/LexicalEditor.scss
+++ b/packages/richtext-lexical/src/field/lexical/LexicalEditor.scss
@@ -28,7 +28,6 @@
     }
   }
 
-  // Now rule if it does not have the gutter
   &:not(&--show-gutter) > .rich-text-lexical__wrap > .editor-container > .editor-placeholder {
     left: 0;
   }

--- a/packages/richtext-lexical/src/field/lexical/config/client/sanitize.ts
+++ b/packages/richtext-lexical/src/field/lexical/config/client/sanitize.ts
@@ -2,6 +2,7 @@
 
 import type { EditorConfig as LexicalEditorConfig } from 'lexical'
 
+import type { LexicalFieldAdminProps } from '../../../../types.js'
 import type { ResolvedClientFeatureMap, SanitizedClientFeatures } from '../../../features/types.js'
 import type { SanitizedClientEditorConfig } from '../types.js'
 
@@ -205,8 +206,10 @@ export const sanitizeClientFeatures = (
 export function sanitizeClientEditorConfig(
   lexical: LexicalEditorConfig,
   resolvedClientFeatureMap: ResolvedClientFeatureMap,
+  admin?: LexicalFieldAdminProps,
 ): SanitizedClientEditorConfig {
   return {
+    admin,
     features: sanitizeClientFeatures(resolvedClientFeatureMap),
     lexical,
     resolvedFeatureMap: resolvedClientFeatureMap,

--- a/packages/richtext-lexical/src/field/lexical/config/types.ts
+++ b/packages/richtext-lexical/src/field/lexical/config/types.ts
@@ -1,5 +1,6 @@
 import type { EditorConfig as LexicalEditorConfig } from 'lexical'
 
+import type { LexicalFieldAdminProps } from '../../../types.js'
 import type {
   FeatureProviderClient,
   FeatureProviderServer,
@@ -26,6 +27,7 @@ export type ClientEditorConfig = {
 }
 
 export type SanitizedClientEditorConfig = {
+  admin?: LexicalFieldAdminProps
   features: SanitizedClientFeatures
   lexical: LexicalEditorConfig
   resolvedFeatureMap: ResolvedClientFeatureMap

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/AddBlockHandlePlugin/index.scss
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/AddBlockHandlePlugin/index.scss
@@ -10,7 +10,7 @@
   will-change: transform;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background-color: var(--theme-elevation-100);
     .icon {
       opacity: 1;
     }
@@ -25,7 +25,7 @@
 
   html[data-theme='dark'] & {
     .icon {
-      filter: invert(1);
+      background-image: url(../../../ui/icons/Add/light.svg);
     }
   }
 }

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/AddBlockHandlePlugin/index.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/AddBlockHandlePlugin/index.tsx
@@ -2,7 +2,7 @@
 import type { LexicalEditor, LexicalNode, ParagraphNode } from 'lexical'
 
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext.js'
-import { $createParagraphNode, $getNodeByKey } from 'lexical'
+import { $createParagraphNode } from 'lexical'
 import * as React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -10,19 +10,15 @@ import { createPortal } from 'react-dom'
 import { useEditorConfigContext } from '../../../config/client/EditorConfigProvider.js'
 import { isHTMLElement } from '../../../utils/guard.js'
 import { Point } from '../../../utils/point.js'
-import { Rect } from '../../../utils/rect.js'
 import { ENABLE_SLASH_MENU_COMMAND } from '../../SlashMenu/LexicalTypeaheadMenuPlugin/index.js'
-import { getCollapsedMargins } from '../utils/getCollapsedMargins.js'
+import { calculateDistanceFromScrollerElem } from '../utils/calculateDistanceFromScrollerElem.js'
+import { getNodeCloseToPoint } from '../utils/getNodeCloseToPoint.js'
 import { getTopLevelNodeKeys } from '../utils/getTopLevelNodeKeys.js'
 import { isOnHandleElement } from '../utils/isOnHandleElement.js'
 import { setHandlePosition } from '../utils/setHandlePosition.js'
 import './index.scss'
 
 const ADD_BLOCK_MENU_CLASSNAME = 'add-block-menu'
-
-const Downward = 1
-const Upward = -1
-const Indeterminate = 0
 
 let prevIndex = Infinity
 
@@ -37,109 +33,11 @@ function getCurrentIndex(keysLength: number): number {
   return Math.floor(keysLength / 2)
 }
 
-function getBlockElement(
-  anchorElem: HTMLElement,
-  editor: LexicalEditor,
-  event: MouseEvent,
-  useEdgeAsDefault = false,
-  horizontalOffset = 0,
-): {
-  blockElem: HTMLElement | null
-  blockNode: LexicalNode | null
-} {
-  const anchorElementRect = anchorElem.getBoundingClientRect()
-  const topLevelNodeKeys = getTopLevelNodeKeys(editor)
-
-  let blockElem: HTMLElement | null = null
-  let blockNode: LexicalNode | null = null
-
-  // Return null if matching block element is the first or last node
-  editor.getEditorState().read(() => {
-    if (useEdgeAsDefault) {
-      const [firstNode, lastNode] = [
-        editor.getElementByKey(topLevelNodeKeys[0]),
-        editor.getElementByKey(topLevelNodeKeys[topLevelNodeKeys.length - 1]),
-      ]
-
-      const [firstNodeRect, lastNodeRect] = [
-        firstNode?.getBoundingClientRect(),
-        lastNode?.getBoundingClientRect(),
-      ]
-
-      if (firstNodeRect && lastNodeRect) {
-        if (event.y < firstNodeRect.top) {
-          blockElem = firstNode
-        } else if (event.y > lastNodeRect.bottom) {
-          blockElem = lastNode
-        }
-
-        if (blockElem) {
-          return {
-            blockElem: null,
-          }
-        }
-      }
-    }
-
-    // Find matching block element
-    let index = getCurrentIndex(topLevelNodeKeys.length)
-    let direction = Indeterminate
-
-    while (index >= 0 && index < topLevelNodeKeys.length) {
-      const key = topLevelNodeKeys[index]
-      const elem = editor.getElementByKey(key)
-      if (elem === null) {
-        break
-      }
-      const point = new Point(event.x + horizontalOffset, event.y)
-      const domRect = Rect.fromDOM(elem)
-      const { marginBottom, marginTop } = getCollapsedMargins(elem)
-
-      const rect = domRect.generateNewRect({
-        bottom: domRect.bottom + marginBottom,
-        left: anchorElementRect.left,
-        right: anchorElementRect.right,
-        top: domRect.top - marginTop,
-      })
-
-      const {
-        reason: { isOnBottomSide, isOnTopSide },
-        result,
-      } = rect.contains(point)
-
-      if (result) {
-        blockElem = elem
-        blockNode = $getNodeByKey(key)
-        prevIndex = index
-        break
-      }
-
-      if (direction === Indeterminate) {
-        if (isOnTopSide) {
-          direction = Upward
-        } else if (isOnBottomSide) {
-          direction = Downward
-        } else {
-          // stop search block element
-          direction = Infinity
-        }
-      }
-
-      index += direction
-    }
-  })
-
-  return {
-    blockElem,
-    blockNode,
-  }
-}
-
 function useAddBlockHandle(
   editor: LexicalEditor,
   anchorElem: HTMLElement,
   isEditable: boolean,
-): JSX.Element {
+): React.ReactElement {
   const scrollerElem = anchorElem.parentElement
 
   const { editorConfig } = useEditorConfigContext()
@@ -158,45 +56,40 @@ function useAddBlockHandle(
         return
       }
 
-      let distanceFromScrollerElem = 0
-      // Calculate distance between scrollerElem and target if target is not in scrollerElem
-      if (scrollerElem && !scrollerElem.contains(target)) {
-        const { bottom, left, right, top } = scrollerElem.getBoundingClientRect()
-        const { pageX, pageY } = event
-        const horizontalBuffer = 50
-        const verticalBuffer = 25
-        const adjustedTop = top + window.scrollY
-        const adjustedBottom = bottom + window.scrollY
+      const distanceFromScrollerElem = calculateDistanceFromScrollerElem(
+        scrollerElem,
+        event.pageX,
+        event.pageY,
+        target,
+      )
 
-        if (
-          pageY < adjustedTop - verticalBuffer ||
-          pageY > adjustedBottom + verticalBuffer ||
-          pageX < left - horizontalBuffer ||
-          pageX > right + horizontalBuffer
-        ) {
-          if (hoveredElement !== null) {
-            setHoveredElement(null)
-          }
-          return
-        }
-
-        // This is used to allow the _emptyBlockElem to be found when the mouse is in the
-        // buffer zone around the scrollerElem.
-        if (pageX < left || pageX > right) {
-          distanceFromScrollerElem = pageX < left ? pageX - left : pageX - right
-        }
+      if (distanceFromScrollerElem === -1) {
+        setHoveredElement(null)
+        return
       }
 
       if (isOnHandleElement(target, ADD_BLOCK_MENU_CLASSNAME)) {
         return
       }
-      const { blockElem: _emptyBlockElem, blockNode } = getBlockElement(
+      const topLevelNodeKeys = getTopLevelNodeKeys(editor)
+
+      const {
+        blockElem: _emptyBlockElem,
+        blockNode,
+        foundAtIndex,
+      } = getNodeCloseToPoint({
         anchorElem,
+        cache_threshold: 0,
         editor,
-        event,
-        false,
-        -distanceFromScrollerElem,
-      )
+        horizontalOffset: -distanceFromScrollerElem,
+        point: new Point(event.x, event.y),
+        returnEmptyParagraphs: true,
+        startIndex: getCurrentIndex(topLevelNodeKeys.length),
+        useEdgeAsDefault: false,
+      })
+
+      prevIndex = foundAtIndex
+
       if (!_emptyBlockElem) {
         return
       }
@@ -330,7 +223,7 @@ export function AddBlockHandlePlugin({
   anchorElem = document.body,
 }: {
   anchorElem?: HTMLElement
-}): JSX.Element {
+}): React.ReactElement {
   const [editor] = useLexicalComposerContext()
   return useAddBlockHandle(editor, anchorElem, editor._editable)
 }

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/AddBlockHandlePlugin/index.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/AddBlockHandlePlugin/index.tsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
+import { useEditorConfigContext } from '../../../config/client/EditorConfigProvider.js'
 import { isHTMLElement } from '../../../utils/guard.js'
 import { Point } from '../../../utils/point.js'
 import { Rect } from '../../../utils/rect.js'
@@ -17,7 +18,6 @@ import { isOnHandleElement } from '../utils/isOnHandleElement.js'
 import { setHandlePosition } from '../utils/setHandlePosition.js'
 import './index.scss'
 
-const SPACE = -24
 const ADD_BLOCK_MENU_CLASSNAME = 'add-block-menu'
 
 const Downward = 1
@@ -142,6 +142,9 @@ function useAddBlockHandle(
 ): JSX.Element {
   const scrollerElem = anchorElem.parentElement
 
+  const { editorConfig } = useEditorConfigContext()
+  const blockHandleHorizontalOffset = editorConfig?.admin?.hideGutter ? -24 : 12
+
   const menuRef = useRef<HTMLButtonElement>(null)
   const [hoveredElement, setHoveredElement] = useState<{
     elem: HTMLElement
@@ -231,11 +234,19 @@ function useAddBlockHandle(
           hoveredElement?.elem,
           menuRef.current,
           anchorElem,
-          isEmptyParagraph ? SPACE : SPACE - 20,
+          isEmptyParagraph
+            ? blockHandleHorizontalOffset
+            : blockHandleHorizontalOffset - (editorConfig?.admin?.hideGutter ? 20 : 0),
         )
       })
     }
-  }, [anchorElem, hoveredElement, editor])
+  }, [
+    anchorElem,
+    hoveredElement,
+    editor,
+    blockHandleHorizontalOffset,
+    editorConfig?.admin?.hideGutter,
+  ])
 
   const handleAddClick = useCallback(
     (event) => {

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.scss
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.scss
@@ -1,3 +1,5 @@
+@import '../../../../../scss/styles.scss';
+
 .draggable-block-menu {
   border-radius: 4px;
   padding: 0;
@@ -7,13 +9,14 @@
   left: 0;
   top: 0;
   will-change: transform;
+  background-color: var(--theme-bg);
 
   &:active {
     cursor: grabbing;
   }
 
   &:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background-color: var(--theme-elevation-100);
     .icon {
       opacity: 1;
     }
@@ -28,8 +31,14 @@
 
   html[data-theme='dark'] & {
     .icon {
-      filter: invert(1);
+      background-image: url(../../../ui/icons/DraggableBlock/light.svg);
     }
+  }
+}
+
+.rich-text-lexical--show-gutter > .rich-text-lexical__wrap > .editor-container > .editor-scroller > .editor {
+  > .draggable-block-target-line {
+    left: 3rem;
   }
 }
 

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.tsx
@@ -124,13 +124,12 @@ function useDraggableBlockMenu(
         verbose: false,
       })
 
+      prevIndex = foundAtIndex
+
       //if (DEBUG && _draggableBlockElem) {
       //targetBlockElem.style.border = '3px solid red'
       // highlightElemOriginalPosition(debugHighlightRef, _draggableBlockElem, anchorElem)
       //}
-      if (_draggableBlockElem) {
-        prevIndex = foundAtIndex
-      }
 
       if (!_draggableBlockElem && !isFoundNodeEmptyParagraph) {
         return

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.tsx
@@ -6,17 +6,18 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import { eventFiles } from '@lexical/rich-text'
 import { $getNearestNodeFromDOMNode, $getNodeByKey } from 'lexical'
 import * as React from 'react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { useEditorConfigContext } from '../../../config/client/EditorConfigProvider.js'
 import { isHTMLElement } from '../../../utils/guard.js'
 import { Point } from '../../../utils/point.js'
+import { calculateDistanceFromScrollerElem } from '../utils/calculateDistanceFromScrollerElem.js'
+import { getNodeCloseToPoint } from '../utils/getNodeCloseToPoint.js'
 import { getTopLevelNodeKeys } from '../utils/getTopLevelNodeKeys.js'
 import { isOnHandleElement } from '../utils/isOnHandleElement.js'
 import { setHandlePosition } from '../utils/setHandlePosition.js'
 import { getBoundingClientRectWithoutTransform } from './getBoundingRectWithoutTransform.js'
-import { getNodeCloseToPoint } from './getNodeCloseToPoint.js'
 import './index.scss'
 import { setTargetLine } from './setTargetLine.js'
 
@@ -68,7 +69,7 @@ function useDraggableBlockMenu(
   editor: LexicalEditor,
   anchorElem: HTMLElement,
   isEditable: boolean,
-): JSX.Element {
+): React.ReactElement {
   const scrollerElem = anchorElem.parentElement
 
   const menuRef = useRef<HTMLDivElement>(null)
@@ -81,43 +82,6 @@ function useDraggableBlockMenu(
 
   const blockHandleHorizontalOffset = editorConfig?.admin?.hideGutter ? -24 : -8
 
-  const calculateDistanceFromScrollerElem = useCallback(
-    (
-      pageX: number,
-      pageY: number,
-      target: HTMLElement,
-      horizontalBuffer: number = 50,
-      verticalBuffer: number = 25,
-    ): number => {
-      let distanceFromScrollerElem = 0
-      // Calculate distance between scrollerElem and target if target is not in scrollerElem
-      if (scrollerElem && !scrollerElem.contains(target)) {
-        const { bottom, left, right, top } = scrollerElem.getBoundingClientRect()
-
-        const adjustedTop = top + window.scrollY
-        const adjustedBottom = bottom + window.scrollY
-
-        if (
-          pageY < adjustedTop - verticalBuffer ||
-          pageY > adjustedBottom + verticalBuffer ||
-          pageX < left - horizontalBuffer ||
-          pageX > right + horizontalBuffer
-        ) {
-          setDraggableBlockElem(null)
-          return distanceFromScrollerElem
-        }
-
-        // This is used to allow the _draggableBlockElem to be found when the mouse is in the
-        // buffer zone around the scrollerElem.
-        if (pageX < left || pageX > right) {
-          distanceFromScrollerElem = pageX < left ? pageX - left : pageX - right
-        }
-      }
-      return distanceFromScrollerElem
-    },
-    [scrollerElem],
-  )
-
   useEffect(() => {
     /**
      * Handles positioning of the drag handle
@@ -129,16 +93,22 @@ function useDraggableBlockMenu(
       }
 
       const distanceFromScrollerElem = calculateDistanceFromScrollerElem(
+        scrollerElem,
         event.pageX,
         event.pageY,
         target,
       )
+      if (distanceFromScrollerElem === -1) {
+        setDraggableBlockElem(null)
+        return
+      }
 
       if (isOnHandleElement(target, DRAGGABLE_BLOCK_MENU_CLASSNAME)) {
         return
       }
 
       const topLevelNodeKeys = getTopLevelNodeKeys(editor)
+
       const {
         blockElem: _draggableBlockElem,
         foundAtIndex,
@@ -151,12 +121,16 @@ function useDraggableBlockMenu(
         point: new Point(event.x, event.y),
         startIndex: getCurrentIndex(topLevelNodeKeys.length),
         useEdgeAsDefault: false,
+        verbose: false,
       })
+
       //if (DEBUG && _draggableBlockElem) {
       //targetBlockElem.style.border = '3px solid red'
       // highlightElemOriginalPosition(debugHighlightRef, _draggableBlockElem, anchorElem)
       //}
-      prevIndex = foundAtIndex
+      if (_draggableBlockElem) {
+        prevIndex = foundAtIndex
+      }
 
       if (!_draggableBlockElem && !isFoundNodeEmptyParagraph) {
         return
@@ -168,14 +142,14 @@ function useDraggableBlockMenu(
     }
 
     // Since the draggableBlockElem is outside the actual editor, we need to listen to the document
-    // to be able to detect when the mouse is outside the editor and respect a buffer around the
+    // to be able to detect when the mouse is outside the editor and respect a buffer around
     // the scrollerElem to avoid the draggableBlockElem disappearing too early.
     document?.addEventListener('mousemove', onDocumentMouseMove)
 
     return () => {
       document?.removeEventListener('mousemove', onDocumentMouseMove)
     }
-  }, [scrollerElem, anchorElem, editor, calculateDistanceFromScrollerElem, draggableBlockElem])
+  }, [scrollerElem, anchorElem, editor, draggableBlockElem])
 
   useEffect(() => {
     if (menuRef.current) {
@@ -204,6 +178,7 @@ function useDraggableBlockMenu(
       }
 
       const distanceFromScrollerElem = calculateDistanceFromScrollerElem(
+        scrollerElem,
         event.pageX,
         event.pageY,
         target,
@@ -227,6 +202,7 @@ function useDraggableBlockMenu(
         useEdgeAsDefault: true,
         verbose: true,
       })
+
       prevIndex = foundAtIndex
 
       const targetLineElem = targetLineRef.current
@@ -281,6 +257,7 @@ function useDraggableBlockMenu(
           return false
         }
         const distanceFromScrollerElem = calculateDistanceFromScrollerElem(
+          scrollerElem,
           event.pageX,
           event.pageY,
           target,
@@ -352,11 +329,11 @@ function useDraggableBlockMenu(
       document.removeEventListener('drop', onDrop)
     }
   }, [
+    scrollerElem,
     blockHandleHorizontalOffset,
     anchorElem,
     editor,
     lastTargetBlockElem,
-    calculateDistanceFromScrollerElem,
     draggableBlockElem,
   ])
 
@@ -404,7 +381,7 @@ export function DraggableBlockPlugin({
   anchorElem = document.body,
 }: {
   anchorElem?: HTMLElement
-}): JSX.Element {
+}): React.ReactElement {
   const [editor] = useLexicalComposerContext()
   return useDraggableBlockMenu(editor, anchorElem, editor._editable)
 }

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.tsx
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/DraggableBlockPlugin/index.tsx
@@ -9,6 +9,7 @@ import * as React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
+import { useEditorConfigContext } from '../../../config/client/EditorConfigProvider.js'
 import { isHTMLElement } from '../../../utils/guard.js'
 import { Point } from '../../../utils/point.js'
 import { getTopLevelNodeKeys } from '../utils/getTopLevelNodeKeys.js'
@@ -19,7 +20,6 @@ import { getNodeCloseToPoint } from './getNodeCloseToPoint.js'
 import './index.scss'
 import { setTargetLine } from './setTargetLine.js'
 
-const SPACE = -24
 const DRAGGABLE_BLOCK_MENU_CLASSNAME = 'draggable-block-menu'
 const DRAG_DATA_FORMAT = 'application/x-lexical-drag-block'
 
@@ -77,6 +77,9 @@ function useDraggableBlockMenu(
   const isDraggingBlockRef = useRef<boolean>(false)
   const [draggableBlockElem, setDraggableBlockElem] = useState<HTMLElement | null>(null)
   const [lastTargetBlockElem, setLastTargetBlockElem] = useState<HTMLElement | null>(null)
+  const { editorConfig } = useEditorConfigContext()
+
+  const blockHandleHorizontalOffset = editorConfig?.admin?.hideGutter ? -24 : -8
 
   const calculateDistanceFromScrollerElem = useCallback(
     (
@@ -176,9 +179,14 @@ function useDraggableBlockMenu(
 
   useEffect(() => {
     if (menuRef.current) {
-      setHandlePosition(draggableBlockElem, menuRef.current, anchorElem, SPACE)
+      setHandlePosition(
+        draggableBlockElem,
+        menuRef.current,
+        anchorElem,
+        blockHandleHorizontalOffset,
+      )
     }
-  }, [anchorElem, draggableBlockElem])
+  }, [anchorElem, draggableBlockElem, blockHandleHorizontalOffset])
 
   useEffect(() => {
     function onDragover(event: DragEvent): boolean {
@@ -229,7 +237,7 @@ function useDraggableBlockMenu(
 
       if (draggableBlockElem !== targetBlockElem) {
         setTargetLine(
-          SPACE,
+          blockHandleHorizontalOffset,
           targetLineElem,
           targetBlockElem,
           lastTargetBlockElem,
@@ -344,6 +352,7 @@ function useDraggableBlockMenu(
       document.removeEventListener('drop', onDrop)
     }
   }, [
+    blockHandleHorizontalOffset,
     anchorElem,
     editor,
     lastTargetBlockElem,

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/utils/calculateDistanceFromScrollerElem.ts
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/utils/calculateDistanceFromScrollerElem.ts
@@ -1,0 +1,35 @@
+/**
+ * Calculate distance between scrollerElem and target if target is not in scrollerElem
+ */
+export const calculateDistanceFromScrollerElem = (
+  scrollerElem: HTMLElement | null,
+  pageX: number,
+  pageY: number,
+  target: HTMLElement,
+  horizontalBuffer: number = 50,
+  verticalBuffer: number = 25,
+): number => {
+  let distanceFromScrollerElem = 0
+  if (scrollerElem && !scrollerElem.contains(target)) {
+    const { bottom, left, right, top } = scrollerElem.getBoundingClientRect()
+
+    const adjustedTop = top + window.scrollY
+    const adjustedBottom = bottom + window.scrollY
+
+    if (
+      pageY < adjustedTop - verticalBuffer ||
+      pageY > adjustedBottom + verticalBuffer ||
+      pageX < left - horizontalBuffer ||
+      pageX > right + horizontalBuffer
+    ) {
+      return -1
+    }
+
+    // This is used to allow the _draggableBlockElem to be found when the mouse is in the
+    // buffer zone around the scrollerElem.
+    if (pageX < left || pageX > right) {
+      distanceFromScrollerElem = pageX < left ? pageX - left : pageX - right
+    }
+  }
+  return distanceFromScrollerElem
+}

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/utils/getNodeCloseToPoint.ts
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/utils/getNodeCloseToPoint.ts
@@ -4,9 +4,9 @@ import { $getNodeByKey } from 'lexical'
 
 import { Point } from '../../../utils/point.js'
 import { Rect } from '../../../utils/rect.js'
+import { getBoundingClientRectWithoutTransform } from '../DraggableBlockPlugin/getBoundingRectWithoutTransform.js'
 import { getCollapsedMargins } from '../utils/getCollapsedMargins.js'
 import { getTopLevelNodeKeys } from '../utils/getTopLevelNodeKeys.js'
-import { getBoundingClientRectWithoutTransform } from './getBoundingRectWithoutTransform.js'
 
 // Directions
 const Downward = 1
@@ -21,6 +21,10 @@ type Props = {
   fuzzy?: boolean
   horizontalOffset?: number
   point: Point
+  /**
+   * By default, empty paragraphs are not returned. Set this to true to return empty paragraphs. @default false
+   */
+  returnEmptyParagraphs?: boolean
   /**
    * The index to start searching from. It can be a considerable performance optimization to start searching from the index of the
    * previously found node, as the node is likely to be close to the next node.
@@ -72,7 +76,7 @@ export function getNodeCloseToPoint(props: Props): Output {
     isPointClose(cache.props.point, props.point, cache_threshold)
   ) {
     if (verbose) {
-      //console.log('Returning cached result')
+      console.log('Returning cached result')
     }
     return cache.result
   }
@@ -122,7 +126,7 @@ export function getNodeCloseToPoint(props: Props): Output {
 
         if (closestBlockElem?.blockElem) {
           if (verbose) {
-            //console.log('useEdgeAsDefault', useEdgeAsDefault)
+            console.log('useEdgeAsDefault', useEdgeAsDefault)
           }
 
           return {
@@ -142,6 +146,9 @@ export function getNodeCloseToPoint(props: Props): Output {
     }
 
     while (index >= 0 && index < topLevelNodeKeys.length) {
+      if (verbose) {
+        console.log('AAA', index, topLevelNodeKeys)
+      }
       const key = topLevelNodeKeys[index]
       const elem = editor.getElementByKey(key)
       if (elem === null) {
@@ -164,7 +171,7 @@ export function getNodeCloseToPoint(props: Props): Output {
       const { distance, isOnBottomSide, isOnTopSide } = rect.distanceFromPoint(point)
 
       if (verbose) {
-        //console.log('distance', distance)
+        console.log('distance', distance)
       }
 
       if (distance === 0) {
@@ -179,11 +186,14 @@ export function getNodeCloseToPoint(props: Props): Output {
           closestBlockElem.blockNode.getType() === 'paragraph' &&
           closestBlockElem.blockNode.getTextContent() === ''
         ) {
-          if (!fuzzy) {
+          if (!fuzzy && !props.returnEmptyParagraphs) {
             closestBlockElem.blockElem = null
             closestBlockElem.blockNode = null
           }
 
+          if (verbose) {
+            console.log('Empty paragraph found')
+          }
           closestBlockElem.isFoundNodeEmptyParagraph = true
         }
         break
@@ -219,7 +229,9 @@ export function getNodeCloseToPoint(props: Props): Output {
     foundAtIndex: closestBlockElem.foundAtIndex,
     isFoundNodeEmptyParagraph: closestBlockElem.isFoundNodeEmptyParagraph,
   }
-
+  if (verbose) {
+    console.log('returning', closestBlockElem)
+  }
   return {
     blockElem: closestBlockElem.blockElem,
     blockNode: closestBlockElem.blockNode,

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/utils/getNodeCloseToPoint.ts
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/utils/getNodeCloseToPoint.ts
@@ -75,9 +75,6 @@ export function getNodeCloseToPoint(props: Props): Output {
     cache.props.useEdgeAsDefault === props.useEdgeAsDefault &&
     isPointClose(cache.props.point, props.point, cache_threshold)
   ) {
-    if (verbose) {
-      console.log('Returning cached result')
-    }
     return cache.result
   }
 
@@ -125,10 +122,6 @@ export function getNodeCloseToPoint(props: Props): Output {
         }
 
         if (closestBlockElem?.blockElem) {
-          if (verbose) {
-            console.log('useEdgeAsDefault', useEdgeAsDefault)
-          }
-
           return {
             blockElem: null,
             isFoundNodeEmptyParagraph: false,
@@ -141,14 +134,7 @@ export function getNodeCloseToPoint(props: Props): Output {
     let index = startIndex
     let direction = Indeterminate
 
-    if (verbose) {
-      //console.log('start index', startIndex)
-    }
-
     while (index >= 0 && index < topLevelNodeKeys.length) {
-      if (verbose) {
-        console.log('AAA', index, topLevelNodeKeys)
-      }
       const key = topLevelNodeKeys[index]
       const elem = editor.getElementByKey(key)
       if (elem === null) {
@@ -170,10 +156,6 @@ export function getNodeCloseToPoint(props: Props): Output {
 
       const { distance, isOnBottomSide, isOnTopSide } = rect.distanceFromPoint(point)
 
-      if (verbose) {
-        console.log('distance', distance)
-      }
-
       if (distance === 0) {
         closestBlockElem.blockElem = elem
         closestBlockElem.blockNode = $getNodeByKey(key)
@@ -191,9 +173,6 @@ export function getNodeCloseToPoint(props: Props): Output {
             closestBlockElem.blockNode = null
           }
 
-          if (verbose) {
-            console.log('Empty paragraph found')
-          }
           closestBlockElem.isFoundNodeEmptyParagraph = true
         }
         break
@@ -229,9 +208,7 @@ export function getNodeCloseToPoint(props: Props): Output {
     foundAtIndex: closestBlockElem.foundAtIndex,
     isFoundNodeEmptyParagraph: closestBlockElem.isFoundNodeEmptyParagraph,
   }
-  if (verbose) {
-    console.log('returning', closestBlockElem)
-  }
+
   return {
     blockElem: closestBlockElem.blockElem,
     blockNode: closestBlockElem.blockNode,

--- a/packages/richtext-lexical/src/field/lexical/plugins/handles/utils/setHandlePosition.ts
+++ b/packages/richtext-lexical/src/field/lexical/plugins/handles/utils/setHandlePosition.ts
@@ -28,10 +28,15 @@ export function setHandlePosition(
       ? parseInt(targetStyle.lineHeight, 10)
       : 0
 
-    top = targetRect.top + (actualLineHeight - floatingElemRect.height) / 2 - anchorElementRect.top
+    top =
+      targetRect.top + (actualLineHeight - floatingElemRect.height) / 2 - anchorElementRect.top - 1 // 1px inaccuracy
   } else {
     top =
-      targetRect.top - floatingElemRect.height / 2 - anchorElementRect.top + targetRect.height / 2
+      targetRect.top -
+      floatingElemRect.height / 2 -
+      anchorElementRect.top +
+      targetRect.height / 2 -
+      1 // 1px inaccuracy
   }
 
   const left = leftOffset

--- a/packages/richtext-lexical/src/field/lexical/theme/EditorTheme.scss
+++ b/packages/richtext-lexical/src/field/lexical/theme/EditorTheme.scss
@@ -15,6 +15,11 @@
     position: relative;
   }
 
+  // No bottom margin for last paragraph in editor. This also created nice animations when adding a new line at the end
+  .ContentEditable__root > &__paragraph:last-child {
+    margin-bottom: 0;
+  }
+
   &__quote {
     margin: 0 0 10px 20px;
     font-size: 15px;

--- a/packages/richtext-lexical/src/field/lexical/ui/ContentEditable.scss
+++ b/packages/richtext-lexical/src/field/lexical/ui/ContentEditable.scss
@@ -48,3 +48,45 @@ $lexical-contenteditable-bottom-padding: 8px;
     }
   }
 }
+
+html[data-theme='light'] {
+  .rich-text-lexical:not(.rich-text-lexical--show-gutter) {
+    &.error {
+      > .rich-text-lexical__wrap > .editor-container {
+        @include lightInputError;
+      }
+    }
+  }
+
+  .rich-text-lexical.rich-text-lexical--show-gutter {
+    &.error:not(:hover) {
+      > .rich-text-lexical__wrap > .editor-container > .editor-scroller > .editor > .ContentEditable__root::before {
+        border-left: 2px solid var(--theme-error-400);
+      }
+    }
+
+    &.error:hover {
+      > .rich-text-lexical__wrap > .editor-container > .editor-scroller > .editor > .ContentEditable__root::before {
+        border-left: 2px solid var(--theme-error-500);
+      }
+    }
+  }
+}
+
+html[data-theme='dark'] {
+  .rich-text-lexical:not(.rich-text-lexical--show-gutter) {
+    &.error {
+      > .rich-text-lexical__wrap > .editor-container {
+        @include darkInputError;
+      }
+    }
+  }
+
+  .rich-text-lexical.rich-text-lexical--show-gutter {
+    &.error {
+      > .rich-text-lexical__wrap > .editor-container > .editor-scroller > .editor > .ContentEditable__root::before {
+        border-left: 2px solid var(--theme-error-500);
+      }
+    }
+  }
+}

--- a/packages/richtext-lexical/src/field/lexical/ui/ContentEditable.scss
+++ b/packages/richtext-lexical/src/field/lexical/ui/ContentEditable.scss
@@ -1,5 +1,9 @@
 @import '../../../scss/styles.scss';
 
+$lexical-contenteditable-top-padding: 8px;
+$lexical-contenteditable-bottom-padding: 8px;
+
+
 .ContentEditable__root {
   border: 0;
   font-size: 15px;
@@ -7,8 +11,9 @@
   position: relative;
   tab-size: 1;
   outline: 0;
-  padding-top: 8px;
-  min-height: base(10);
+  padding-top: $lexical-contenteditable-top-padding;
+  padding-bottom: $lexical-contenteditable-bottom-padding;
+  //min-height: base(10);
 
   &:focus-visible {
     outline: none !important;
@@ -20,9 +25,26 @@
   }
 }
 
+
 @media (max-width: 1025px) {
   .ContentEditable__root {
     padding-left: 0;
     padding-right: 0;
+  }
+}
+
+@media (min-width: 1026px) {
+  .rich-text-lexical--show-gutter > .rich-text-lexical__wrap > .editor-container > .editor-scroller > .editor {
+    > .ContentEditable__root {
+      padding-left: 3rem;
+    }
+    > .ContentEditable__root::before {
+      content: ' ';
+      position: absolute;
+      top: $lexical-contenteditable-top-padding;
+      left: 0;
+      height: calc(100% - #{$lexical-contenteditable-top-padding} - #{$lexical-contenteditable-bottom-padding});
+      border-left: 1px solid var(--theme-elevation-100);
+    }
   }
 }

--- a/packages/richtext-lexical/src/field/lexical/ui/icons/Add/light.svg
+++ b/packages/richtext-lexical/src/field/lexical/ui/icons/Add/light.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="24" viewBox="0 0 18 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M5,12h8" stroke="#ffffff" />
+    <path d="M9,16V8" stroke="#ffffff" />
+</svg>

--- a/packages/richtext-lexical/src/field/lexical/ui/icons/DraggableBlock/light.svg
+++ b/packages/richtext-lexical/src/field/lexical/ui/icons/DraggableBlock/light.svg
@@ -1,0 +1,9 @@
+<svg width="18" height="24" viewBox="0 0 18 24" fill="#ffffff"
+     xmlns="http://www.w3.org/2000/svg">
+    <circle cx="7" cy="8" r="1"/>
+    <circle cx="11" cy="8" r="1"/>
+    <circle cx="7" cy="12" r="1"/>
+    <circle cx="11" cy="12" r="1"/>
+    <circle cx="7" cy="16" r="1"/>
+    <circle cx="11" cy="16" r="1"/>
+</svg>

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -89,11 +89,17 @@ export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapte
     return {
       CellComponent: withMergedProps({
         Component: RichTextCell,
-        toMergeIntoProps: { lexicalEditorConfig: finalSanitizedEditorConfig.lexical },
+        toMergeIntoProps: {
+          admin: props?.admin,
+          lexicalEditorConfig: finalSanitizedEditorConfig.lexical,
+        },
       }),
       FieldComponent: withMergedProps({
         Component: RichTextField,
-        toMergeIntoProps: { lexicalEditorConfig: finalSanitizedEditorConfig.lexical },
+        toMergeIntoProps: {
+          admin: props?.admin,
+          lexicalEditorConfig: finalSanitizedEditorConfig.lexical,
+        },
       }),
       editorConfig: finalSanitizedEditorConfig,
       features,

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -7,7 +7,15 @@ import type React from 'react'
 import type { FeatureProviderServer } from './field/features/types.js'
 import type { SanitizedServerEditorConfig } from './field/lexical/config/types.js'
 
+export type LexicalFieldAdminProps = {
+  /**
+   * Controls if the gutter (padding to the left & gray vertical line) should be hidden. @default false
+   */
+  hideGutter?: boolean
+}
+
 export type LexicalEditorProps = {
+  admin?: LexicalFieldAdminProps
   features?:
     | (({
         defaultFeatures,

--- a/test/fields/collections/Lexical/index.ts
+++ b/test/fields/collections/Lexical/index.ts
@@ -67,6 +67,9 @@ export const LexicalFields: CollectionConfig = {
       type: 'richText',
       required: true,
       editor: lexicalEditor({
+        admin: {
+          hideGutter: true,
+        },
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,
           //TestRecorderFeature(),

--- a/test/fields/collections/Lexical/index.ts
+++ b/test/fields/collections/Lexical/index.ts
@@ -68,7 +68,7 @@ export const LexicalFields: CollectionConfig = {
       required: true,
       editor: lexicalEditor({
         admin: {
-          hideGutter: true,
+          hideGutter: false,
         },
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,


### PR DESCRIPTION
## Gutter

Adds gutter by default:

![CleanShot 2024-05-21 at 16 24 13](https://github.com/payloadcms/payload/assets/70709113/09c59b6f-bd4a-4e81-bfdd-731d1cbbe075)


![CleanShot 2024-05-21 at 16 20 23](https://github.com/payloadcms/payload/assets/70709113/94df3e8c-663e-4b08-90cb-a24b2a788ff6)

can be disabled with admin.hideGutter

## Error states
![CleanShot 2024-05-21 at 16 21 18](https://github.com/payloadcms/payload/assets/70709113/06754d8f-c674-4aaa-a4e5-47e284970776)

Finally, proper error states display. Cleaner, and previously fields were shown as erroring even though they weren't. No more!

## Drag & Block handles
Improved performance, and cleaned up code. Drag handle positions are now only calculated for one editor rather than all editors on the page. Add block handle calculation now uses a better algorithm to minimize the amount of nodes which are iterated.

Additionally, have you noticed how sometimes the add button jumps to the next node while the drag button is still at the previous node? 

https://github.com/payloadcms/payload/assets/70709113/8dff3081-1de0-4902-8229-62f178f23549

No more! Now they behave the same. Feels a lot cleaner now.
