### PR TITLE
fix: Add missing He lang export in payload/i18n

### DIFF
--- a/packages/payload/src/exports/i18n/he.ts
+++ b/packages/payload/src/exports/i18n/he.ts
@@ -1,0 +1,1 @@
+export { he } from '@payloadcms/translations/languages/he'


### PR DESCRIPTION
## Description
Fixed missing Hebrew language export in payload/i18n module.
The import statement import { he } from 'payload/i18n/he' was not functioning due to he not being exported correctly.


<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
