### PR TITLE
fix: error 431 when having a lot of relationship items

### DIFF
--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -618,3 +618,41 @@ export const Orders: CollectionConfig = {
   **req** will have the **payload** object and can be used inside your endpoint handlers for making
   calls like req.payload.find() that will make use of access control and hooks.
 </Banner>
+
+## Method Override for GET Requests
+
+Payload supports a method override feature that allows you to send GET requests using the HTTP POST method. This can be particularly useful in scenarios when the query string in a regular GET request is too long.
+
+### How to Use
+
+To use this feature, include the `X-HTTP-Method-Override` header set to `GET` in your POST request. The parameters should be sent in the body of the request with the `Content-Type` set to `application/x-www-form-urlencoded`.
+
+### Example
+
+Here is an example of how to use the method override to perform a GET request:
+
+#### Using Method Override (POST)
+
+```http
+POST /api/{collection-slug} HTTP/1.1
+Host: your-payload-instance.com
+Content-Type: application/x-www-form-urlencoded
+X-HTTP-Method-Override: GET
+
+depth=1&locale=en
+```
+
+##### Explanation
+
+- **URL**: The endpoint you want to send the GET request to.
+- **Headers**:
+  - `Content-Type`: Should be set to `application/x-www-form-urlencoded`.
+  - `X-HTTP-Method-Override`: Should be set to `GET` to override the POST method.
+- **Body**: Parameters normally included in the query string of a GET request should be included in the body of the POST request, encoded as `application/x-www-form-urlencoded`.
+
+#### Equivalent Regular GET Request
+
+```http
+GET /api/{collection-slug}?depth=1&locale=en HTTP/1.1
+Host: your-payload-instance.com
+```

--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -633,26 +633,30 @@ Here is an example of how to use the method override to perform a GET request:
 
 #### Using Method Override (POST)
 
-```http
-POST /api/{collection-slug} HTTP/1.1
-Host: your-payload-instance.com
-Content-Type: application/x-www-form-urlencoded
-X-HTTP-Method-Override: GET
-
-depth=1&locale=en
+```ts
+const res = await fetch(`${api}/${collectionSlug}`, {
+  method: 'POST',
+  credentials: 'include',
+  headers: {
+    'Accept-Language': i18n.language,
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'X-HTTP-Method-Override': 'GET',
+  },
+  body: qs.stringify({
+    depth: 1,
+    locale: 'en',
+  }),
+})
 ```
-
-##### Explanation
-
-- **URL**: The endpoint you want to send the GET request to.
-- **Headers**:
-  - `Content-Type`: Should be set to `application/x-www-form-urlencoded`.
-  - `X-HTTP-Method-Override`: Should be set to `GET` to override the POST method.
-- **Body**: Parameters normally included in the query string of a GET request should be included in the body of the POST request, encoded as `application/x-www-form-urlencoded`.
 
 #### Equivalent Regular GET Request
 
-```http
-GET /api/{collection-slug}?depth=1&locale=en HTTP/1.1
-Host: your-payload-instance.com
+```ts
+const res = await fetch(`${api}/${collectionSlug}?depth=1&locale=en`, {
+  method: 'GET',
+  credentials: 'include',
+  headers: {
+    'Accept-Language': i18n.language,
+  },
+})
 ```

--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -407,6 +407,11 @@ export const POST =
     let res: Response
     let collection: Collection
 
+    const overrideHttpMethod = request.headers.get('X-HTTP-Method-Override')
+    if (overrideHttpMethod === 'GET') {
+      return await GET(config)(request, { params: { slug } })
+    }
+
     try {
       req = await createPayloadRequest({
         config,

--- a/packages/next/src/utilities/createPayloadRequest.ts
+++ b/packages/next/src/utilities/createPayloadRequest.ts
@@ -59,6 +59,17 @@ export const createPayloadRequest = async ({
     fallbackLocale = locales.fallbackLocale
   }
 
+  const overrideHttpMethod = request.headers.get('X-HTTP-Method-Override')
+  const queryToParse = overrideHttpMethod === 'GET' ? await request.text() : urlProperties.search
+
+  const query = queryToParse
+    ? qs.parse(queryToParse, {
+        arrayLimit: 1000,
+        depth: 10,
+        ignoreQueryPrefix: true,
+      })
+    : {}
+
   const customRequest: CustomPayloadRequestProperties = {
     context: {},
     fallbackLocale,
@@ -75,13 +86,7 @@ export const createPayloadRequest = async ({
     payloadUploadSizes: {},
     port: urlProperties.port,
     protocol: urlProperties.protocol,
-    query: urlProperties.search
-      ? qs.parse(urlProperties.search, {
-          arrayLimit: 1000,
-          depth: 10,
-          ignoreQueryPrefix: true,
-        })
-      : {},
+    query,
     routeParams: params || {},
     search: urlProperties.search,
     searchParams: urlProperties.searchParams,

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -201,11 +201,15 @@ const RelationshipField: React.FC<RelationshipFieldProps> = (props) => {
               query.where.and.push(relationFilterOption)
             }
 
-            const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(query)}`, {
+            const response = await fetch(`${serverURL}${api}/${relation}`, {
+              body: qs.stringify(query),
               credentials: 'include',
               headers: {
                 'Accept-Language': i18n.language,
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-HTTP-Method-Override': 'GET',
               },
+              method: 'POST',
             })
 
             if (response.ok) {
@@ -326,11 +330,15 @@ const RelationshipField: React.FC<RelationshipFieldProps> = (props) => {
         }
 
         if (!errorLoading) {
-          const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(query)}`, {
+          const response = await fetch(`${serverURL}${api}/${relation}`, {
+            body: qs.stringify(query),
             credentials: 'include',
             headers: {
               'Accept-Language': i18n.language,
+              'Content-Type': 'application/x-www-form-urlencoded',
+              'X-HTTP-Method-Override': 'GET',
             },
+            method: 'POST',
           })
 
           const collection = collections.find((coll) => coll.slug === relation)


### PR DESCRIPTION
## Description

To fix the issue of GET request getting a too long query variable as described in #6486, I have implemented X-HTTP-Method-Override header to allow this query to be sent as a POST request and giving the information that is it actually a GET request.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [X] I have made corresponding changes to the documentation
