### PR TITLE
fix(richtext-lexical): localized sub-fields were omitted from the API output

### DIFF
--- a/packages/richtext-lexical/src/field/features/blocks/populationPromise.ts
+++ b/packages/richtext-lexical/src/field/features/blocks/populationPromise.ts
@@ -40,7 +40,7 @@ export const blockPopulationPromiseHOC = (
       fieldPromises,
       fields: block.fields,
       findMany,
-      flattenLocales,
+      flattenLocales: false, // Disable localization handling which does not work properly yet. Once we fully support hooks, this can be enabled (pass through flattenLocales again)
       overrideAccess,
       populationPromises,
       req,

--- a/packages/richtext-lexical/src/field/features/link/populationPromise.ts
+++ b/packages/richtext-lexical/src/field/features/link/populationPromise.ts
@@ -40,7 +40,7 @@ export const linkPopulationPromiseHOC = (
         fieldPromises,
         fields: props.fields,
         findMany,
-        flattenLocales,
+        flattenLocales: false, // Disable localization handling which does not work properly yet. Once we fully support hooks, this can be enabled (pass through flattenLocales again)
         overrideAccess,
         populationPromises,
         req,

--- a/packages/richtext-lexical/src/field/features/upload/populationPromise.ts
+++ b/packages/richtext-lexical/src/field/features/upload/populationPromise.ts
@@ -64,7 +64,7 @@ export const uploadPopulationPromiseHOC = (
           fieldPromises,
           fields: props?.collections?.[node?.relationTo]?.fields,
           findMany,
-          flattenLocales,
+          flattenLocales: false, // Disable localization handling which does not work properly yet. Once we fully support hooks, this can be enabled (pass through flattenLocales again)
           overrideAccess,
           populationPromises,
           req,


### PR DESCRIPTION
## Description

Closes #6455. Proper localization support will be worked on later, this just resolves the issue where having it enabled not only doesn't localize those fields, it also omits them from the API response. Now, they are not omitted, and localization is simply skipped.

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
