### PR TITLE
chore: swcrc syntax fix

### DIFF
--- a/test/.swcrc
+++ b/test/.swcrc
@@ -7,7 +7,7 @@
       "syntax": "typescript",
       "tsx": true,
       "dts": true
-    },
+    }
   },
   "module": {
     "type": "es6"


### PR DESCRIPTION
## Description

Extra comma is preventing the local test runner with error: 

`Error: Error parsing C:\code\payload-v3\test\.swcrc: [object Object], [object Object]`
