### PR TITLE
chore: getPayloadHMR conditionally call db.connect

### DIFF
--- a/packages/next/src/utilities/getPayloadHMR.ts
+++ b/packages/next/src/utilities/getPayloadHMR.ts
@@ -37,7 +37,9 @@ export const reload = async (config: SanitizedConfig, payload: Payload): Promise
   // TODO: support HMR for other props in the future (see payload/src/index init()) hat may change on Payload singleton
 
   await payload.db.init()
-  await payload.db.connect({ hotReload: true })
+  if (payload.db.connect) {
+    await payload.db.connect({ hotReload: true })
+  }
 }
 
 export const getPayloadHMR = async (options: InitOptions): Promise<Payload> => {


### PR DESCRIPTION
Adds a condition to check if `payload.db.connect` is defined before calling it since it is an optional property of the database adapter interface.