### PR TITLE
feat(richtext-lexical): i18n support

### DIFF
--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -40,7 +40,7 @@ export const Account: React.FC<AdminViewProps> = async ({
 
   const collectionConfig = config.collections.find((collection) => collection.slug === userSlug)
 
-  if (collectionConfig) {
+  if (collectionConfig && user?.id) {
     const { docPermissions, hasPublishPermission, hasSavePermission } =
       await getDocumentPermissions({
         id: user.id,

--- a/packages/payload/src/admin/RichText.ts
+++ b/packages/payload/src/admin/RichText.ts
@@ -1,4 +1,4 @@
-import type { I18nClient } from '@payloadcms/translations'
+import type { AcceptedLanguages, GenericLanguages, I18nClient } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
 import type React from 'react'
 
@@ -33,6 +33,7 @@ type RichTextAdapterBase<
     schemaPath: string
   }) => Map<string, Field[]>
   hooks?: FieldBase['hooks']
+  i18n?: Partial<GenericLanguages>
   outputSchema?: ({
     collectionIDFieldTypes,
     config,

--- a/packages/payload/src/admin/RichText.ts
+++ b/packages/payload/src/admin/RichText.ts
@@ -1,4 +1,4 @@
-import type { AcceptedLanguages, GenericLanguages, I18nClient } from '@payloadcms/translations'
+import type { GenericLanguages, I18n, I18nClient } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
 import type React from 'react'
 
@@ -28,7 +28,7 @@ type RichTextAdapterBase<
   }) => Map<string, React.ReactNode>
   generateSchemaMap?: (args: {
     config: SanitizedConfig
-    i18n: I18nClient
+    i18n: I18n<any, any>
     schemaMap: Map<string, Field[]>
     schemaPath: string
   }) => Map<string, Field[]>

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -17,6 +17,7 @@ import { InvalidConfiguration } from '../errors/index.js'
 import { sanitizeGlobals } from '../globals/config/sanitize.js'
 import getPreferencesCollection from '../preferences/preferencesCollection.js'
 import checkDuplicateCollections from '../utilities/checkDuplicateCollections.js'
+import { deepMerge } from '../utilities/deepMerge.js'
 import { isPlainObject } from '../utilities/isPlainObject.js'
 import { defaults } from './defaults.js'
 
@@ -154,6 +155,9 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
       config: config as SanitizedConfig,
       isRoot: true,
     })
+    if (config.editor.i18n && Object.keys(config.editor.i18n).length >= 0) {
+      config.i18n.translations = deepMerge(config.i18n.translations, config.editor.i18n)
+    }
   }
 
   const promises: Promise<void>[] = []

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -8,6 +8,7 @@ import {
   InvalidFieldRelationship,
   MissingFieldType,
 } from '../../errors/index.js'
+import { deepMerge } from '../../utilities/deepMerge.js'
 import { formatLabels, toWords } from '../../utilities/formatLabels.js'
 import { baseBlockFields } from '../baseFields/baseBlockFields.js'
 import { baseIDField } from '../baseFields/baseIDField.js'
@@ -166,6 +167,10 @@ export const sanitizeFields = async ({
             config: _config,
             isRoot: requireFieldLevelRichTextEditor,
           })
+        }
+
+        if (field.editor.i18n && Object.keys(field.editor.i18n).length >= 0) {
+          config.i18n.translations = deepMerge(config.i18n.translations, field.editor.i18n)
         }
 
         // Add editor adapter hooks to field hooks

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -37,7 +37,8 @@
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "clean": "rimraf {dist,*.tsbuildinfo}",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
-    "prepublishOnly": "pnpm clean && pnpm turbo build"
+    "prepublishOnly": "pnpm clean && pnpm turbo build",
+    "translateNewKeys": "tsx scripts/translateNewKeys.ts"
   },
   "dependencies": {
     "@faceless-ui/modal": "2.0.2",

--- a/packages/richtext-lexical/scripts/translateNewKeys.ts
+++ b/packages/richtext-lexical/scripts/translateNewKeys.ts
@@ -1,0 +1,68 @@
+import type {
+  AcceptedLanguages,
+  GenericLanguages,
+  GenericTranslationsObject,
+} from '@payloadcms/translations'
+
+import * as fs from 'node:fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { translateObject } from '../../translations/scripts/translateNewKeys/index.js'
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+// Function to get all files with a specific name recursively in all subdirectories
+function findFilesRecursively(startPath, filter) {
+  let results = []
+
+  const entries = fs.readdirSync(startPath, { withFileTypes: true })
+
+  entries.forEach((dirent) => {
+    const fullPath = path.join(startPath, dirent.name)
+
+    if (dirent.isDirectory()) {
+      results = results.concat(findFilesRecursively(fullPath, filter))
+    } else {
+      if (dirent.name === filter) {
+        results.push(fullPath)
+      }
+    }
+  })
+
+  return results
+}
+
+const i18nFilePaths = findFilesRecursively(path.resolve(dirname, '../src'), 'i18n.ts')
+
+async function translate() {
+  for (const i18nFilePath of i18nFilePaths) {
+    const imported = await import(i18nFilePath)
+    const translationsObject = imported.i18n as Partial<GenericLanguages>
+    const allTranslations: {
+      [key in AcceptedLanguages]?: {
+        dateFNSKey: string
+        translations: GenericTranslationsObject
+      }
+    } = {}
+    for (const lang in translationsObject) {
+      allTranslations[lang] = {
+        dateFNSKey: 'en',
+        translations: translationsObject[lang],
+      }
+    }
+
+    console.log('Translating', i18nFilePath)
+    await translateObject({
+      allTranslationsObject: allTranslations,
+      fromTranslationsObject: translationsObject.en,
+      inlineFile: i18nFilePath,
+      tsFilePrefix: `import { GenericLanguages } from '@payloadcms/translations'
+
+export const i18n: Partial<GenericLanguages> = `,
+      tsFileSuffix: ``,
+    })
+  }
+}
+
+void translate()

--- a/packages/richtext-lexical/src/field/features/horizontalRule/feature.client.tsx
+++ b/packages/richtext-lexical/src/field/features/horizontalRule/feature.client.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import type { ClientTranslationKeys } from '@payloadcms/translations'
+
 import { $isNodeSelection } from 'lexical'
 
 import type { FeatureProviderProviderClient } from '../types.js'
@@ -36,17 +38,23 @@ const HorizontalRuleFeatureClient: FeatureProviderProviderClient<undefined> = (p
                 Icon: HorizontalRuleIcon,
                 key: 'horizontalRule',
                 keywords: ['hr', 'horizontal rule', 'line', 'separator'],
-                label: `Horizontal Rule`,
+                label: ({ i18n }) => {
+                  return i18n.t('lexical:horizontalRule:label')
+                },
+
                 onSelect: ({ editor }) => {
                   editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined)
                 },
               },
             ],
             key: 'basic',
-            label: 'Basic',
+            label: ({ i18n }) => {
+              return i18n.t('validation:limitReached' as ClientTranslationKeys)
+            },
           },
         ],
       },
+
       toolbarFixed: {
         groups: [
           toolbarAddDropdownGroupWithItems([
@@ -61,7 +69,9 @@ const HorizontalRuleFeatureClient: FeatureProviderProviderClient<undefined> = (p
                 return $isHorizontalRuleNode(firstNode)
               },
               key: 'horizontalRule',
-              label: `Horizontal Rule`,
+              label: ({ i18n }) => {
+                return i18n.t('lexical:horizontalRule:label')
+              },
               onSelect: ({ editor }) => {
                 editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined)
               },

--- a/packages/richtext-lexical/src/field/features/horizontalRule/feature.client.tsx
+++ b/packages/richtext-lexical/src/field/features/horizontalRule/feature.client.tsx
@@ -48,9 +48,7 @@ const HorizontalRuleFeatureClient: FeatureProviderProviderClient<undefined> = (p
               },
             ],
             key: 'basic',
-            label: ({ i18n }) => {
-              return i18n.t('validation:limitReached' as ClientTranslationKeys)
-            },
+            label: 'Basic',
           },
         ],
       },

--- a/packages/richtext-lexical/src/field/features/horizontalRule/feature.server.ts
+++ b/packages/richtext-lexical/src/field/features/horizontalRule/feature.server.ts
@@ -2,6 +2,7 @@ import type { FeatureProviderProviderServer } from '../types.js'
 
 import { createNode } from '../typeUtilities.js'
 import { HorizontalRuleFeatureClientComponent } from './feature.client.js'
+import { i18n } from './i18n.js'
 import { MarkdownTransformer } from './markdownTransformer.js'
 import { HorizontalRuleNode } from './nodes/HorizontalRuleNode.js'
 
@@ -12,6 +13,7 @@ export const HorizontalRuleFeature: FeatureProviderProviderServer<undefined, und
     feature: () => {
       return {
         ClientComponent: HorizontalRuleFeatureClientComponent,
+        i18n,
         markdownTransformers: [MarkdownTransformer],
         nodes: [
           createNode({

--- a/packages/richtext-lexical/src/field/features/horizontalRule/i18n.ts
+++ b/packages/richtext-lexical/src/field/features/horizontalRule/i18n.ts
@@ -1,0 +1,100 @@
+import type { GenericLanguages } from '@payloadcms/translations'
+
+export const i18n: Partial<GenericLanguages> = {
+  ar: {
+    label: 'القاعدة الأفقية',
+  },
+  az: {
+    label: 'Üfüqi Xətt',
+  },
+  bg: {
+    label: 'Хоризонтална линия',
+  },
+  cs: {
+    label: 'Vodorovný pravítko',
+  },
+  de: {
+    label: 'Trennlinie',
+  },
+  en: {
+    label: 'Horizontal Rule',
+  },
+  es: {
+    label: 'Regla Horizontal',
+  },
+  fa: {
+    label: 'قاعده افقی',
+  },
+  fr: {
+    label: 'Règle horizontale',
+  },
+  he: {
+    label: 'קו אופקי',
+  },
+  hr: {
+    label: 'Vodoravna linija',
+  },
+  hu: {
+    label: 'Vízszintes vonal',
+  },
+  it: {
+    label: 'Regola Orizzontale',
+  },
+  ja: {
+    label: '水平線',
+  },
+  ko: {
+    label: '수평 규칙',
+  },
+  my: {
+    label: 'Peraturan Mendatar',
+  },
+  nb: {
+    label: 'Horisontal Regel',
+  },
+  nl: {
+    label: 'Horizontale Regel',
+  },
+  pl: {
+    label: 'Pozioma Linia',
+  },
+  pt: {
+    label: 'Regra Horizontal',
+  },
+  ro: {
+    label: 'Linie orizontală',
+  },
+  rs: {
+    label: 'Horizontalna linija',
+  },
+  'rs-latin': {
+    label: 'Horizontalna linija',
+  },
+  ru: {
+    label: 'Горизонтальная линия',
+  },
+  sk: {
+    label: 'Vodorovná čiara',
+  },
+  sv: {
+    label: 'Horisontell linje',
+  },
+  th: {
+    label: 'กฎขีดตรง',
+  },
+  tr: {
+    label: 'Yatay Çizgi',
+  },
+  uk: {
+    label: 'Горизонтальна лінія',
+  },
+  vi: {
+    label: 'Quy tắc ngang',
+  },
+  zh: {
+    label: '水平线',
+  },
+  'zh-TW': {
+    label: '水平線',
+  },
+}

--- a/packages/richtext-lexical/src/field/features/toolbars/types.ts
+++ b/packages/richtext-lexical/src/field/features/toolbars/types.ts
@@ -49,7 +49,7 @@ export type ToolbarGroupItem = {
   }) => boolean
   key: string
   /** The label is displayed as text if the item is part of a dropdown group */
-  label?: (({ i18n }: { i18n: I18nClient }) => string) | string
+  label?: (({ i18n }: { i18n: I18nClient<{}, string> }) => string) | string
   onSelect?: ({ editor, isActive }: { editor: LexicalEditor; isActive: boolean }) => void
   order?: number
 }

--- a/packages/richtext-lexical/src/field/features/types.ts
+++ b/packages/richtext-lexical/src/field/features/types.ts
@@ -1,5 +1,5 @@
 import type { Transformer } from '@lexical/markdown'
-import type { GenericLanguages, I18n } from '@payloadcms/translations'
+import type { GenericLanguages, I18n, I18nClient } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
 import type { Klass, LexicalEditor, LexicalNode, SerializedEditorState } from 'lexical'
 import type { SerializedLexicalNode } from 'lexical'
@@ -283,7 +283,7 @@ export type ServerFeature<ServerProps, ClientFeatureProps> = {
   clientFeatureProps?: ClientFeatureProps
   generateComponentMap?: (args: {
     config: SanitizedConfig
-    i18n: I18n
+    i18n: I18nClient
     props: ServerProps
     schemaPath: string
   }) => {
@@ -291,7 +291,7 @@ export type ServerFeature<ServerProps, ClientFeatureProps> = {
   }
   generateSchemaMap?: (args: {
     config: SanitizedConfig
-    i18n: I18n
+    i18n: I18nClient
     props: ServerProps
     schemaMap: Map<string, Field[]>
     schemaPath: string

--- a/packages/richtext-lexical/src/field/features/types.ts
+++ b/packages/richtext-lexical/src/field/features/types.ts
@@ -320,7 +320,7 @@ export type ServerFeature<ServerProps, ClientFeatureProps> = {
     }) => JSONSchema4
   }
   /**
-   * Here you can provide i18n translations for your feature. These will only be available on the server.
+   * Here you can provide i18n translations for your feature. These will only be available on the server and client.
    *
    * Translations here are automatically scoped to `lexical.featureKey.yourKey`
    *
@@ -335,8 +335,7 @@ export type ServerFeature<ServerProps, ClientFeatureProps> = {
    *   },
    * }
    * ```
-   * In order to access these translations on the server, you would use `i18n.t('lexical:horizontalRule:label')`.
-   * If you want to access them on both the server and the client, you will have to add them to your ClientFeature as well.
+   * In order to access these translations, you would use `i18n.t('lexical:horizontalRule:label')`.
    */
   i18n?: Partial<GenericLanguages>
   markdownTransformers?: Transformer[]

--- a/packages/richtext-lexical/src/field/features/types.ts
+++ b/packages/richtext-lexical/src/field/features/types.ts
@@ -1,5 +1,5 @@
 import type { Transformer } from '@lexical/markdown'
-import type { I18n, I18nClient } from '@payloadcms/translations'
+import type { GenericLanguages, I18n } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
 import type { Klass, LexicalEditor, LexicalNode, SerializedEditorState } from 'lexical'
 import type { SerializedLexicalNode } from 'lexical'
@@ -283,7 +283,7 @@ export type ServerFeature<ServerProps, ClientFeatureProps> = {
   clientFeatureProps?: ClientFeatureProps
   generateComponentMap?: (args: {
     config: SanitizedConfig
-    i18n: I18nClient
+    i18n: I18n
     props: ServerProps
     schemaPath: string
   }) => {
@@ -291,7 +291,7 @@ export type ServerFeature<ServerProps, ClientFeatureProps> = {
   }
   generateSchemaMap?: (args: {
     config: SanitizedConfig
-    i18n: I18nClient
+    i18n: I18n
     props: ServerProps
     schemaMap: Map<string, Field[]>
     schemaPath: string
@@ -319,6 +319,26 @@ export type ServerFeature<ServerProps, ClientFeatureProps> = {
       isRequired: boolean
     }) => JSONSchema4
   }
+  /**
+   * Here you can provide i18n translations for your feature. These will only be available on the server.
+   *
+   * Translations here are automatically scoped to `lexical.featureKey.yourKey`
+   *
+   * @Example
+   * ```ts
+   * i18n: {
+   *   en: {
+   *     label: 'Horizontal Rule',
+   *   },
+   *   de: {
+   *     label: 'Trennlinie',
+   *   },
+   * }
+   * ```
+   * In order to access these translations on the server, you would use `i18n.t('lexical:horizontalRule:label')`.
+   * If you want to access them on both the server and the client, you will have to add them to your ClientFeature as well.
+   */
+  i18n?: Partial<GenericLanguages>
   markdownTransformers?: Transformer[]
   nodes?: Array<NodeWithHooks>
 
@@ -395,8 +415,9 @@ export type SanitizedPlugin =
       key: string
       position: 'belowContainer'
     }
+
 export type SanitizedServerFeatures = Required<
-  Pick<ResolvedServerFeature<unknown, unknown>, 'markdownTransformers' | 'nodes'>
+  Pick<ResolvedServerFeature<unknown, unknown>, 'i18n' | 'markdownTransformers' | 'nodes'>
 > & {
   /**  The node types mapped to their converters */
   converters: {

--- a/packages/richtext-lexical/src/field/lexical/config/server/sanitize.ts
+++ b/packages/richtext-lexical/src/field/lexical/config/server/sanitize.ts
@@ -13,10 +13,10 @@ export const sanitizeServerFeatures = (
       html: [],
     },
     enabledFeatures: [],
-
     generatedTypes: {
       modifyOutputSchemas: [],
     },
+
     hooks: {
       afterChange: new Map(),
       afterRead: new Map(),
@@ -24,6 +24,7 @@ export const sanitizeServerFeatures = (
       beforeDuplicate: new Map(),
       beforeValidate: new Map(),
     },
+    i18n: {},
     markdownTransformers: [],
     nodes: [],
     populationPromises: new Map(),
@@ -38,6 +39,17 @@ export const sanitizeServerFeatures = (
   features.forEach((feature) => {
     if (feature?.generatedTypes?.modifyOutputSchema) {
       sanitized.generatedTypes.modifyOutputSchemas.push(feature.generatedTypes.modifyOutputSchema)
+    }
+
+    if (feature?.i18n) {
+      for (const lang in feature.i18n) {
+        if (!sanitized.i18n[lang]) {
+          sanitized.i18n[lang] = {
+            lexical: {},
+          }
+        }
+        sanitized.i18n[lang].lexical[feature.key] = feature.i18n[lang]
+      }
     }
 
     if (feature.nodes?.length) {

--- a/packages/richtext-lexical/src/field/lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/types.ts
+++ b/packages/richtext-lexical/src/field/lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/types.ts
@@ -13,7 +13,7 @@ export type SlashMenuItem = {
   keyboardShortcut?: string
   // For extra searching.
   keywords?: Array<string>
-  label?: (({ i18n }: { i18n: I18nClient }) => string) | string
+  label?: (({ i18n }: { i18n: I18nClient<{}, string> }) => string) | string
   // What happens when you select this item?
   onSelect: ({ editor, queryString }: { editor: LexicalEditor; queryString: string }) => void
 }
@@ -22,7 +22,7 @@ export type SlashMenuGroup = {
   items: Array<SlashMenuItem>
   key: string
   // Used for class names and, if label is not provided, for display.
-  label?: (({ i18n }: { i18n: I18nClient }) => string) | string
+  label?: (({ i18n }: { i18n: I18nClient<{}, string> }) => string) | string
 }
 
 export type SlashMenuItemInternal = SlashMenuItem & {

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -109,6 +109,7 @@ export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapte
       generateSchemaMap: getGenerateSchemaMap({
         resolvedFeatureMap,
       }),
+      i18n: finalSanitizedEditorConfig.features.i18n,
       /* hooks: {
         afterChange: finalSanitizedEditorConfig.features.hooks.afterChange,
         afterRead: finalSanitizedEditorConfig.features.hooks.afterRead,

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -32,7 +32,7 @@
     "build:types": "tsc --outDir dist",
     "clean": "rimraf {dist,*.tsbuildinfo}",
     "prepublishOnly": "pnpm clean && pnpm turbo build",
-    "translateNewKeys": "tsx scripts/translateNewKeys/index.ts"
+    "translateNewKeys": "tsx scripts/translateNewKeys/run.ts"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",

--- a/packages/translations/scripts/translateNewKeys/index.ts
+++ b/packages/translations/scripts/translateNewKeys/index.ts
@@ -3,7 +3,6 @@
 import fs from 'fs'
 import path from 'path'
 import { format } from 'prettier'
-import { fileURLToPath } from 'url'
 
 import type {
   AcceptedLanguages,
@@ -11,8 +10,6 @@ import type {
   GenericTranslationsObject,
 } from '../../src/types.js'
 
-import { translations } from '../../src/exports/all.js'
-import { enTranslations } from '../../src/languages/en.js'
 import { cloneDeep } from '../../src/utilities/cloneDeep.js'
 import { deepMerge } from '../../src/utilities/deepMerge.js'
 import { acceptedLanguages } from '../../src/utilities/languages.js'
@@ -21,9 +18,6 @@ import { findMissingKeys } from './findMissingKeys.js'
 import { generateTsObjectLiteral } from './generateTsObjectLiteral.js'
 import { sortKeys } from './sortKeys.js'
 import { translateText } from './translateText.js'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 /**
  *
@@ -59,6 +53,13 @@ export async function translateObject(props: {
     }
   }
   fromTranslationsObject: GenericTranslationsObject
+  /**
+   *
+   * If set, will output the entire translations object (incl. all locales) to this file.
+   *
+   * @default false
+   */
+  inlineFile?: string
   languages?: AcceptedLanguages[]
   targetFolder?: string
   tsFilePrefix?: string
@@ -67,6 +68,7 @@ export async function translateObject(props: {
   const {
     allTranslationsObject,
     fromTranslationsObject,
+    inlineFile,
     languages = acceptedLanguages.filter((lang) => lang !== 'en'),
     targetFolder = '',
     tsFilePrefix = `import type { DefaultTranslationsObject, Language } from '../types.js'\n\nexport const {{locale}}Translations: DefaultTranslationsObject = `,
@@ -87,6 +89,12 @@ export async function translateObject(props: {
   const translationPromises: Promise<void>[] = []
 
   for (const targetLang of languages) {
+    if (!allTranslatedTranslationsObject?.[targetLang]) {
+      allTranslatedTranslationsObject[targetLang] = {
+        dateFNSKey: targetLang,
+        translations: {},
+      }
+    }
     const keysWhichDoNotExistInFromlang = findMissingKeys(
       allTranslatedTranslationsObject?.[targetLang].translations,
       fromTranslationsObject,
@@ -168,26 +176,25 @@ export async function translateObject(props: {
   }
 
   // merge with existing translations
-  console.log('Merged object:', allTranslatedTranslationsObject)
+  console.log('Merged object1:', allTranslatedTranslationsObject)
 
-  console.log('New translations:', allOnlyNewTranslatedTranslationsObject)
+  console.log('New translations1:', allOnlyNewTranslatedTranslationsObject)
 
-  // save
+  if (inlineFile?.length) {
+    console.log('Simple')
+    const simpleTranslationsObject = {}
+    for (const lang in allTranslatedTranslationsObject) {
+      simpleTranslationsObject[lang] = allTranslatedTranslationsObject[lang].translations
+    }
 
-  for (const key of languages) {
-    // e.g. sanitize rs-latin to rsLatin
-    const sanitizedKey = key.replace(
-      /-(\w)(\w*)/g,
-      (_, firstLetter, remainingLetters) =>
-        firstLetter.toUpperCase() + remainingLetters.toLowerCase(),
-    )
-    const filePath = path.resolve(dirname, targetFolder, `${sanitizedKey}.ts`)
+    console.log('Writing1', simpleTranslationsObject)
 
-    // prefix & translations
-    let fileContent: string = `${tsFilePrefix.replace('{{locale}}', sanitizedKey)}${generateTsObjectLiteral(allTranslatedTranslationsObject[key].translations)}\n`
+    // write allTranslatedTranslationsObject
+    const filePath = path.resolve(inlineFile)
+    let fileContent: string = `${tsFilePrefix}${generateTsObjectLiteral(simpleTranslationsObject)}\n`
 
     // suffix
-    fileContent += `${tsFileSuffix.replaceAll('{{locale}}', sanitizedKey).replaceAll('{{dateFNSKey}}', `'${allTranslatedTranslationsObject[key].dateFNSKey}'`)}\n`
+    fileContent += `${tsFileSuffix}\n`
 
     // eslint
     fileContent = await applyEslintFixes(fileContent, filePath)
@@ -202,28 +209,40 @@ export async function translateObject(props: {
     })
 
     fs.writeFileSync(filePath, fileContent, 'utf8')
+  } else {
+    // save
+    console.log('Not Simple')
+
+    for (const key of languages) {
+      // e.g. sanitize rs-latin to rsLatin
+      const sanitizedKey = key.replace(
+        /-(\w)(\w*)/g,
+        (_, firstLetter, remainingLetters) =>
+          firstLetter.toUpperCase() + remainingLetters.toLowerCase(),
+      )
+      const filePath = path.resolve(targetFolder, `${sanitizedKey}.ts`)
+
+      // prefix & translations
+      let fileContent: string = `${tsFilePrefix.replace('{{locale}}', sanitizedKey)}${generateTsObjectLiteral(allTranslatedTranslationsObject[key].translations)}\n`
+
+      // suffix
+      fileContent += `${tsFileSuffix.replaceAll('{{locale}}', sanitizedKey).replaceAll('{{dateFNSKey}}', `'${allTranslatedTranslationsObject[key].dateFNSKey}'`)}\n`
+
+      // eslint
+      fileContent = await applyEslintFixes(fileContent, filePath)
+
+      // prettier
+      fileContent = await format(fileContent, {
+        parser: 'typescript',
+        printWidth: 100,
+        semi: false,
+        singleQuote: true,
+        trailingComma: 'all',
+      })
+
+      fs.writeFileSync(filePath, fileContent, 'utf8')
+    }
   }
 
   return allTranslatedTranslationsObject
 }
-
-const allTranslations: {
-  [key in AcceptedLanguages]?: {
-    dateFNSKey: string
-    translations: GenericTranslationsObject
-  }
-} = {}
-
-for (const key of Object.keys(translations)) {
-  allTranslations[key] = {
-    dateFNSKey: translations[key].dateFNSKey,
-    translations: translations[key].translations,
-  }
-}
-
-void translateObject({
-  allTranslationsObject: allTranslations,
-  fromTranslationsObject: enTranslations,
-  //languages: ['de'],
-  targetFolder: '../../src/languages',
-})

--- a/packages/translations/scripts/translateNewKeys/index.ts
+++ b/packages/translations/scripts/translateNewKeys/index.ts
@@ -176,18 +176,15 @@ export async function translateObject(props: {
   }
 
   // merge with existing translations
-  console.log('Merged object1:', allTranslatedTranslationsObject)
+  console.log('Merged object:', allTranslatedTranslationsObject)
 
-  console.log('New translations1:', allOnlyNewTranslatedTranslationsObject)
+  console.log('New translations:', allOnlyNewTranslatedTranslationsObject)
 
   if (inlineFile?.length) {
-    console.log('Simple')
     const simpleTranslationsObject = {}
     for (const lang in allTranslatedTranslationsObject) {
       simpleTranslationsObject[lang] = allTranslatedTranslationsObject[lang].translations
     }
-
-    console.log('Writing1', simpleTranslationsObject)
 
     // write allTranslatedTranslationsObject
     const filePath = path.resolve(inlineFile)
@@ -211,7 +208,6 @@ export async function translateObject(props: {
     fs.writeFileSync(filePath, fileContent, 'utf8')
   } else {
     // save
-    console.log('Not Simple')
 
     for (const key of languages) {
       // e.g. sanitize rs-latin to rsLatin

--- a/packages/translations/scripts/translateNewKeys/run.ts
+++ b/packages/translations/scripts/translateNewKeys/run.ts
@@ -1,0 +1,32 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import type { AcceptedLanguages, GenericTranslationsObject } from '../../src/types.js'
+
+import { translations } from '../../src/exports/all.js'
+import { enTranslations } from '../../src/languages/en.js'
+import { translateObject } from './index.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+const allTranslations: {
+  [key in AcceptedLanguages]?: {
+    dateFNSKey: string
+    translations: GenericTranslationsObject
+  }
+} = {}
+
+for (const key of Object.keys(translations)) {
+  allTranslations[key] = {
+    dateFNSKey: translations[key].dateFNSKey,
+    translations: translations[key].translations,
+  }
+}
+
+void translateObject({
+  allTranslationsObject: allTranslations,
+  fromTranslationsObject: enTranslations,
+  //languages: ['de'],
+  targetFolder: path.resolve(dirname, '../../src/languages'),
+})


### PR DESCRIPTION
## Description

Adds new i18n object to ServerFeature interface. Those will be made available to server & client. For the sake of making it easier to review, this PR only includes i18n for HorizontalRule. Translations for all features will follow in a separate PR

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
