### PR TITLE
fix: adjusts sizing of remove/add buttons to be same size

### DIFF
--- a/packages/payload/src/admin/components/icons/Plus/index.scss
+++ b/packages/payload/src/admin/components/icons/Plus/index.scss
@@ -1,9 +1,6 @@
 @import '../../../scss/styles';
 
 .icon--plus {
-  width: $baseline;
-  height: $baseline;
-
   .stroke {
     stroke: var(--theme-elevation-800);
     stroke-width: $style-stroke-width;

--- a/packages/payload/src/admin/components/icons/Plus/index.tsx
+++ b/packages/payload/src/admin/components/icons/Plus/index.tsx
@@ -3,7 +3,12 @@ import React from 'react'
 import './index.scss'
 
 const Plus: React.FC = () => (
-  <svg className="icon icon--plus" viewBox="0 0 25 25" xmlns="http://www.w3.org/2000/svg">
+  <svg
+    className="icon icon--plus"
+    viewBox="0 0 25 25"
+    width="25"
+    xmlns="http://www.w3.org/2000/svg"
+  >
     <line className="stroke" x1="12.4589" x2="12.4589" y1="16.9175" y2="8.50115" />
     <line className="stroke" x1="8.05164" x2="16.468" y1="12.594" y2="12.594" />
   </svg>


### PR DESCRIPTION
## Description

Fixes #6098 

`Remove` / `Add` buttons are a bit different in size and different viewpoints.

Before:
![Screenshot 2024-05-28 at 9 06 44 AM](https://github.com/payloadcms/payload/assets/35232443/483b6773-5877-4da2-96d7-43ba701cc138)

![Screenshot 2024-05-28 at 9 06 33 AM](https://github.com/payloadcms/payload/assets/35232443/3a0f55ed-dd83-4ba9-8dc3-58d7378eb7f5)


After:
![Screenshot 2024-05-28 at 9 07 20 AM](https://github.com/payloadcms/payload/assets/35232443/3986544d-ab4c-405c-871a-1fa94b5a49ae)



- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
