### PR TITLE
fix: safely evaluates `field.admin` in WhereBuilder

### DIFF
--- a/packages/payload/src/admin/components/elements/WhereBuilder/index.tsx
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/index.tsx
@@ -58,7 +58,8 @@ const reduceFields = (fields, i18n) =>
         },
       }
 
-      if ('disableListFilter' in field.admin && field.admin?.disableListFilter) return reduced
+      if (field.admin && 'disableListFilter' in field.admin && field.admin?.disableListFilter)
+        return reduced
 
       return [...reduced, formattedField]
     }


### PR DESCRIPTION
## Description

Safely evaluates `field.admin` in WhereBuilder

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
