### PR TITLE
fix(deps): proper location for scheduler peer dep

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -108,7 +108,6 @@
     "pino-pretty": "10.2.0",
     "pluralize": "8.0.0",
     "sanitize-filename": "1.6.3",
-    "scheduler": "0.23.0",
     "scmp": "2.1.0",
     "ts-essentials": "7.0.3",
     "uuid": "^9.0.1"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -114,6 +114,7 @@
     "react-image-crop": "10.1.8",
     "react-select": "5.8.0",
     "react-toastify": "10.0.5",
+    "scheduler": "0.23.0",
     "use-context-selector": "1.4.1",
     "uuid": "9.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -808,9 +808,6 @@ importers:
       sanitize-filename:
         specifier: 1.6.3
         version: 1.6.3
-      scheduler:
-        specifier: 0.23.0
-        version: 0.23.0
       scmp:
         specifier: 2.1.0
         version: 2.1.0
@@ -1589,6 +1586,9 @@ importers:
       react-toastify:
         specifier: 10.0.5
         version: 10.0.5(react-dom@19.0.0-rc-f994737d14-20240522)(react@19.0.0-rc-f994737d14-20240522)
+      scheduler:
+        specifier: 0.23.0
+        version: 0.23.0
       use-context-selector:
         specifier: 1.4.1
         version: 1.4.1(react-dom@19.0.0-rc-f994737d14-20240522)(react@19.0.0-rc-f994737d14-20240522)(scheduler@0.23.0)


### PR DESCRIPTION
Properly put `scheduler` dep under `ui` instead of `payload`.