### PR TITLE
fix(translations): adds new `userEmailAlreadyRegistered` translations

### DIFF
--- a/packages/payload/src/auth/strategies/local/register.ts
+++ b/packages/payload/src/auth/strategies/local/register.ts
@@ -35,7 +35,7 @@ export const registerLocalStrategy = async ({
 
   if (existingUser.docs.length > 0) {
     throw new ValidationError([
-      { field: 'email', message: 'A user with the given email is already registered' },
+      { field: 'email', message: req.t('error:userEmailAlreadyRegistered') },
     ])
   }
 

--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -69,6 +69,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'error:unauthorized',
   'error:unknown',
   'error:unspecific',
+  'error:userEmailAlreadyRegistered',
   'error:tokenNotProvided',
   'error:unPublishingDocument',
 

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -110,6 +110,7 @@ export const arTranslations: DefaultTranslationsObject = {
     unauthorized: 'غير مصرّح لك ، عليك أن تقوم بتسجيل الدّخول لتتمكّن من تقديم هذا الطّلب.',
     unknown: 'حدث خطأ غير معروف.',
     unspecific: 'حدث خطأ.',
+    userEmailAlreadyRegistered: 'يوجد مستخدم مسجل بالفعل بهذا البريد الإلكتروني.',
     userLocked: 'تمّ قفل هذا المستخدم نظرًا لوجود عدد كبير من محاولات تسجيل الدّخول الغير ناجحة.',
     valueMustBeUnique: 'على القيمة أن تكون فريدة',
     verificationTokenInvalid: 'رمز التحقّق غير صالح.',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -110,6 +110,7 @@ export const azTranslations: DefaultTranslationsObject = {
     unauthorized: 'İcazəniz yoxdur, bu tələbi yerinə yetirmək üçün daxil olmalısınız.',
     unknown: 'Naməlum bir xəta baş verdi.',
     unspecific: 'Xəta baş verdi.',
+    userEmailAlreadyRegistered: 'Verilən e-poçt ünvanı ilə artıq istifadəçi qeydiyyatdan keçib.',
     userLocked: 'Bu istifadəçi çoxsaylı uğursuz giriş cəhdləri səbəbindən kilidlənib.',
     valueMustBeUnique: 'Dəyər təkrar olmamalıdır',
     verificationTokenInvalid: 'Doğrulama tokenı yanlışdır.',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -110,6 +110,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     unauthorized: 'Неавторизиран, трябва да влезеш, за да извършиш тази заявка.',
     unknown: 'Неизвестна грешка.',
     unspecific: 'Грешка.',
+    userEmailAlreadyRegistered: 'Потребител с дадения имейл вече е регистриран.',
     userLocked: 'Този потребител има прекалено много невалидни опити за влизане и е заключен.',
     valueMustBeUnique: 'Стойността трябва да е уникална',
     verificationTokenInvalid: 'Ключът за верификация е невалиден.',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -110,6 +110,7 @@ export const csTranslations: DefaultTranslationsObject = {
     unauthorized: 'Neautorizováno, pro zadání tohoto požadavku musíte být přihlášeni.',
     unknown: 'Došlo k neznámé chybě.',
     unspecific: 'Došlo k chybě.',
+    userEmailAlreadyRegistered: 'Uživatel s daným e-mailem je již zaregistrován.',
     userLocked: 'Tento uživatel je uzamčen kvůli příliš mnoha neúspěšným pokusům o přihlášení.',
     valueMustBeUnique: 'Hodnota musí být jedinečná',
     verificationTokenInvalid: 'Ověřovací token je neplatný.',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -112,6 +112,7 @@ export const deTranslations: DefaultTranslationsObject = {
     unauthorized: 'Nicht autorisiert - du musst angemeldet sein, um diese Anfrage zu stellen.',
     unknown: 'Ein unbekannter Fehler ist aufgetreten.',
     unspecific: 'Ein Fehler ist aufgetreten.',
+    userEmailAlreadyRegistered: 'Ein Benutzer mit der angegebenen E-Mail ist bereits registriert.',
     userLocked:
       'Dieser Benutzer ist auf Grund zu vieler unerfolgreicher Anmelde-Versuche gesperrt.',
     valueMustBeUnique: 'Wert muss einzigartig sein',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -110,6 +110,7 @@ export const enTranslations = {
     unauthorized: 'Unauthorized, you must be logged in to make this request.',
     unknown: 'An unknown error has occurred.',
     unspecific: 'An error has occurred.',
+    userEmailAlreadyRegistered: 'A user with the given email is already registered.',
     userLocked: 'This user is locked due to having too many failed login attempts.',
     valueMustBeUnique: 'Value must be unique',
     verificationTokenInvalid: 'Verification token is invalid.',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -110,6 +110,8 @@ export const esTranslations: DefaultTranslationsObject = {
     unauthorized: 'No autorizado, debes iniciar sesión para realizar esta solicitud.',
     unknown: 'Ocurrió un error desconocido.',
     unspecific: 'Ocurrió un error.',
+    userEmailAlreadyRegistered:
+      'Ya hay un usuario registrado con el correo electrónico proporcionado.',
     userLocked:
       'Este usuario ha sido bloqueado debido a que tiene muchos intentos fallidos para iniciar sesión.',
     valueMustBeUnique: 'El valor debe ser único',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -109,6 +109,7 @@ export const faTranslations: DefaultTranslationsObject = {
     unauthorized: 'درخواست نامعتبر، جهت فرستادن این درخواست باید وارد شوید.',
     unknown: 'یک خطای ناشناخته رخ داد.',
     unspecific: 'خطایی رخ داد.',
+    userEmailAlreadyRegistered: 'کاربری با ایمیل داده شده قبلاً ثبت نام کرده است.',
     userLocked: 'این کاربر به دلیل تلاش های زیاد برای ورود ناموفق قفل شده است.',
     valueMustBeUnique: 'مقدار باید منحصر به فرد باشد',
     verificationTokenInvalid: 'ژتون تأیید نامعتبر است.',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -114,6 +114,7 @@ export const frTranslations: DefaultTranslationsObject = {
     unauthorized: 'Non autorisé, vous devez être connecté pour effectuer cette demande.',
     unknown: 'Une erreur inconnue s’est produite.',
     unspecific: 'Une erreur est survenue.',
+    userEmailAlreadyRegistered: "Un utilisateur avec l'email donné est déjà enregistré.",
     userLocked:
       'Cet utilisateur est verrouillé en raison d’un trop grand nombre de tentatives de connexion infructueuses.',
     valueMustBeUnique: 'La valeur doit être unique',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -22,16 +22,19 @@ export const heTranslations: DefaultTranslationsObject = {
     failedToUnlock: 'ביטול נעילה נכשל',
     forceUnlock: 'אלץ ביטול נעילה',
     forgotPassword: 'שכחתי סיסמה',
-    forgotPasswordEmailInstructions: 'אנא הזן את כתובת הדוא"ל שלך למטה. תקבל הודעה עם הוראות לאיפוס הסיסמה שלך.',
+    forgotPasswordEmailInstructions:
+      'אנא הזן את כתובת הדוא"ל שלך למטה. תקבל הודעה עם הוראות לאיפוס הסיסמה שלך.',
     forgotPasswordQuestion: 'שכחת סיסמה?',
     generate: 'יצירה',
     generateNewAPIKey: 'יצירת מפתח API חדש',
-    generatingNewAPIKeyWillInvalidate: 'יצירת מפתח API חדש תבטל את המפתח הקודם. האם אתה בטוח שברצונך להמשיך?',
+    generatingNewAPIKeyWillInvalidate:
+      'יצירת מפתח API חדש תבטל את המפתח הקודם. האם אתה בטוח שברצונך להמשיך?',
     lockUntil: 'נעילה עד',
     logBackIn: 'התחברות מחדש',
     logOut: 'התנתקות',
     loggedIn: 'כדי להתחבר עם משתמש אחר, יש להתנתק תחילה.',
-    loggedInChangePassword: 'כדי לשנות את הסיסמה שלך, יש לעבור ל<a href="{{serverURL}}">חשבון</a> שלך ולערוך את הסיסמה שם.',
+    loggedInChangePassword:
+      'כדי לשנות את הסיסמה שלך, יש לעבור ל<a href="{{serverURL}}">חשבון</a> שלך ולערוך את הסיסמה שם.',
     loggedOutInactivity: 'התנתקת בשל חוסר פעילות.',
     loggedOutSuccessfully: 'התנתקת בהצלחה.',
     loggingOut: 'מתנתק...',
@@ -43,7 +46,8 @@ export const heTranslations: DefaultTranslationsObject = {
     logoutSuccessful: 'התנתקות הצליחה.',
     logoutUser: 'התנתקות משתמש',
     newAPIKeyGenerated: 'נוצר מפתח API חדש.',
-    newAccountCreated: 'נוצר חשבון חדש עבורך כדי לגשת אל <a href="{{serverURL}}">{{serverURL}}</a>. אנא לחץ על הקישור הבא או הדבק את ה-URL בדפדפן שלך כדי לאמת את הדוא"ל שלך: <a href="{{verificationURL}}">{{verificationURL}}</a>.<br> לאחר אימות כתובת הדוא"ל, תוכל להתחבר בהצלחה.',
+    newAccountCreated:
+      'נוצר חשבון חדש עבורך כדי לגשת אל <a href="{{serverURL}}">{{serverURL}}</a>. אנא לחץ על הקישור הבא או הדבק את ה-URL בדפדפן שלך כדי לאמת את הדוא"ל שלך: <a href="{{verificationURL}}">{{verificationURL}}</a>.<br> לאחר אימות כתובת הדוא"ל, תוכל להתחבר בהצלחה.',
     newPassword: 'סיסמה חדשה',
     passed: 'אימות הצליח',
     passwordResetSuccessfully: 'איפוס הסיסמה הצליח.',
@@ -61,9 +65,11 @@ export const heTranslations: DefaultTranslationsObject = {
     verify: 'אמת',
     verifyUser: 'אמת משתמש',
     verifyYourEmail: 'אמת את כתובת הדוא"ל שלך',
-    youAreInactive: 'לא היית פעיל לזמן קצר ובקרוב תתנתק אוטומטית כדי לשמור על האבטחה של חשבונך. האם ברצונך להישאר מחובר?',
-    youAreReceivingResetPassword: 'קיבלת הודעה זו מכיוון שאתה (או מישהו אחר) ביקשת לאפס את הסיסמה של החשבון שלך. אנא לחץ על הקישור הבא או הדבק אותו בשורת הכתובת בדפדפן שלך כדי להשלים את התהליך:',
-    youDidNotRequestPassword: 'אם לא ביקשת זאת, אנא התעלם מההודעה והסיסמה שלך תישאר ללא שינוי.'
+    youAreInactive:
+      'לא היית פעיל לזמן קצר ובקרוב תתנתק אוטומטית כדי לשמור על האבטחה של חשבונך. האם ברצונך להישאר מחובר?',
+    youAreReceivingResetPassword:
+      'קיבלת הודעה זו מכיוון שאתה (או מישהו אחר) ביקשת לאפס את הסיסמה של החשבון שלך. אנא לחץ על הקישור הבא או הדבק אותו בשורת הכתובת בדפדפן שלך כדי להשלים את התהליך:',
+    youDidNotRequestPassword: 'אם לא ביקשת זאת, אנא התעלם מההודעה והסיסמה שלך תישאר ללא שינוי.',
   },
   error: {
     accountAlreadyActivated: 'חשבון זה כבר הופעל.',
@@ -101,6 +107,7 @@ export const heTranslations: DefaultTranslationsObject = {
     unauthorized: 'אין הרשאה, עליך להתחבר כדי לבצע בקשה זו.',
     unknown: 'אירעה שגיאה לא ידועה.',
     unspecific: 'אירעה שגיאה.',
+    userEmailAlreadyRegistered: 'משתמש עם האימייל הנתון כבר רשום.',
     userLocked: 'המשתמש נעול עקב מספר נסיונות התחברות כושלים.',
     valueMustBeUnique: 'הערך חייב להיות ייחודי',
     verificationTokenInvalid: 'טוקן אימות אינו תקין.',
@@ -339,7 +346,8 @@ export const heTranslations: DefaultTranslationsObject = {
     type: 'סוג',
     aboutToPublishSelection: 'אתה עומד לפרסם את כל ה{{label}} שנבחרו. האם אתה בטוח?',
     aboutToRestore: 'אתה עומד לשחזר את מסמך {{label}} למצב שהיה בו בתאריך {{versionDate}}.',
-    aboutToRestoreGlobal: 'אתה עומד לשחזר את {{label}} הגלובלי למצב שהיה בו בתאריך {{versionDate}}.',
+    aboutToRestoreGlobal:
+      'אתה עומד לשחזר את {{label}} הגלובלי למצב שהיה בו בתאריך {{versionDate}}.',
     aboutToRevertToPublished: 'אתה עומד להחזיר את השינויים במסמך הזה לגרסה שפורסמה. האם אתה בטוח?',
     aboutToUnpublish: 'אתה עומד לבטל את הפרסום של מסמך זה. האם אתה בטוח?',
     aboutToUnpublishSelection: 'אתה עומד לבטל את הפרסום של כל ה{{label}} שנבחרו. האם אתה בטוח?',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -111,6 +111,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     unauthorized: 'Neovlašten, morate biti prijavljeni da biste uputili ovaj zahtjev.',
     unknown: 'Došlo je do nepoznate pogreške.',
     unspecific: 'Došlo je do pogreške.',
+    userEmailAlreadyRegistered: 'Korisnik s navedenom e-poštom je već registriran.',
     userLocked: 'Ovaj korisnik je zaključan zbog previše neuspješnih pokušaja prijave.',
     valueMustBeUnique: 'Vrijednost mora biti jedinstvena.',
     verificationTokenInvalid: 'Verifikacijski token je nevaljan.',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -112,6 +112,7 @@ export const huTranslations: DefaultTranslationsObject = {
     unauthorized: 'Jogosulatlan, a kéréshez be kell jelentkeznie.',
     unknown: 'Ismeretlen hiba történt.',
     unspecific: 'Hiba történt.',
+    userEmailAlreadyRegistered: 'A megadott email címmel már regisztráltak egy felhasználót.',
     userLocked: 'Ez a felhasználó túl sok sikertelen bejelentkezési kísérlet miatt zárolva van.',
     valueMustBeUnique: 'Az értéknek egyedinek kell lennie',
     verificationTokenInvalid: 'Az ellenőrző token érvénytelen.',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -113,6 +113,7 @@ export const itTranslations: DefaultTranslationsObject = {
     unauthorized: 'Non autorizzato, devi essere loggato per effettuare questa richiesta.',
     unknown: 'Si è verificato un errore sconosciuto.',
     unspecific: 'Si è verificato un errore.',
+    userEmailAlreadyRegistered: "Un utente con l'email fornita è già registrato.",
     userLocked: 'Questo utente è bloccato a causa di troppi tentativi di accesso non riusciti.',
     valueMustBeUnique: 'Il valore deve essere univoco',
     verificationTokenInvalid: 'Il token di verifica non è valido.',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -111,6 +111,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     unauthorized: '認証されていません。このリクエストを行うにはログインが必要です。',
     unknown: '不明なエラーが発生しました。',
     unspecific: 'エラーが発生しました。',
+    userEmailAlreadyRegistered: '指定されたメールのユーザーはすでに登録されています。',
     userLocked: 'このユーザーは、ログイン試行回数が多すぎるため、ロックされています。',
     valueMustBeUnique: 'ユニークな値である必要があります。',
     verificationTokenInvalid: '認証トークンが無効です。',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -110,6 +110,7 @@ export const koTranslations: DefaultTranslationsObject = {
     unauthorized: '권한 없음, 이 요청을 수행하려면 로그인해야 합니다.',
     unknown: '알 수 없는 오류가 발생했습니다.',
     unspecific: '오류가 발생했습니다.',
+    userEmailAlreadyRegistered: '주어진 이메일로 이미 등록된 사용자가 있습니다.',
     userLocked: '이 사용자는 로그인 실패 횟수가 너무 많아 잠겼습니다.',
     valueMustBeUnique: '값은 고유해야 합니다.',
     verificationTokenInvalid: '확인 토큰이 유효하지 않습니다.',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -110,6 +110,7 @@ export const myTranslations: DefaultTranslationsObject = {
     unauthorized: 'အခွင့်မရှိပါ။ ဤတောင်းဆိုချက်ကို လုပ်ဆောင်နိုင်ရန် သင်သည် လော့ဂ်အင်ဝင်ရပါမည်။',
     unknown: 'ဘာမှန်းမသိသော error တက်သွားပါသည်။',
     unspecific: 'Error တက်နေပါသည်။',
+    userEmailAlreadyRegistered: 'ပေးထားသော အီးမေးလ်ဖြင့် အသုံးပြုသူ တစ်ဦး ရှိပြီးဖြစ်သည်။',
     userLocked:
       'အကောင့်ထဲကို ဝင်ရန် အရမ်းအရမ်းကို ကြိုးပမ်းနေသောကြောင့် အကောင့်အား လော့ခ်ချလိုက်ပါသည်။',
     valueMustBeUnique: 'value သည် အဓိပ္ပာယ်ရှိရပါမည်။',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -110,6 +110,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     unauthorized: 'Uautorisert, du må være innlogget for å gjøre denne forespørselen.',
     unknown: 'En ukjent feil har oppstått.',
     unspecific: 'En feil har oppstått.',
+    userEmailAlreadyRegistered: 'En bruker med den oppgitte e-posten er allerede registrert.',
     userLocked: 'Denne brukeren er låst på grunn av for mange mislykkede innloggingsforsøk.',
     valueMustBeUnique: 'Verdien må være unik',
     verificationTokenInvalid: 'Verifiseringskoden er ugyldig.',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -111,6 +111,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     unauthorized: 'Ongeautoriseerd, u moet ingelogd zijn om dit verzoek te doen.',
     unknown: 'Er is een onbekende fout opgetreden.',
     unspecific: 'Er is een fout opgetreden.',
+    userEmailAlreadyRegistered: 'Een gebruiker met het opgegeven e-mailadres is al geregistreerd.',
     userLocked: 'Deze gebruiker is vergrendeld wegens te veel mislukte inlogpogingen.',
     valueMustBeUnique: 'De waarde moet uniek zijn',
     verificationTokenInvalid: 'Verificatietoken is ongeldig.',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -110,6 +110,7 @@ export const plTranslations: DefaultTranslationsObject = {
     unauthorized: 'Brak dostępu, musisz być zalogowany.',
     unknown: 'Wystąpił nieznany błąd.',
     unspecific: 'Wystąpił błąd',
+    userEmailAlreadyRegistered: 'Użytkownik o podanym adresie e-mail jest już zarejestrowany.',
     userLocked: 'Ten użytkownik został zablokowany z powodu zbyt wielu nieudanych prób logowania.',
     valueMustBeUnique: 'Wartość musi być unikalna',
     verificationTokenInvalid: 'Token weryfikacyjny jest nieprawidłowy.',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -111,6 +111,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     unauthorized: 'Não autorizado. Você deve estar logado para fazer essa requisição',
     unknown: 'Ocorreu um erro desconhecido.',
     unspecific: 'Ocorreu um erro.',
+    userEmailAlreadyRegistered: 'Um usuário com o email fornecido já está registrado.',
     userLocked: 'Esse usuário está bloqueado devido a muitas tentativas de login malsucedidas.',
     valueMustBeUnique: 'Valor deve ser único',
     verificationTokenInvalid: 'Token de verificação inválido.',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -112,6 +112,7 @@ export const roTranslations: DefaultTranslationsObject = {
     unauthorized: 'neautorizat, trebuie să vă conectați pentru a face această cerere.',
     unknown: 'S-a produs o eroare necunoscută.',
     unspecific: 'S-a produs o eroare.',
+    userEmailAlreadyRegistered: 'Un utilizator cu emailul dat este deja înregistrat.',
     userLocked:
       'Acest utilizator este blocat din cauza unui număr prea mare de încercări de autentificare eșuate.',
     valueMustBeUnique: 'Valoarea trebuie să fie unică',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -110,6 +110,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     unauthorized: 'Нисте ауторизовани да бисте упутили овај захтев.',
     unknown: 'Дошло је до непознате грешке.',
     unspecific: 'Дошло је до грешке.',
+    userEmailAlreadyRegistered: 'Корисник са датом имејл адресом је већ регистрован.',
     userLocked: 'Овај корисник је закључан због превеликог броја неуспешних покушаја пријаве.',
     valueMustBeUnique: 'Вредност мора бити јединствена.',
     verificationTokenInvalid: 'Верификациони токен је невалидан.',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -110,6 +110,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     unauthorized: 'Niste autorizovani da biste uputili ovaj zahtev.',
     unknown: 'Došlo je do nepoznate greške.',
     unspecific: 'Došlo je do greške.',
+    userEmailAlreadyRegistered: 'Korisnik sa datom imejl adresom je već registrovan.',
     userLocked: 'Ovaj korisnik je zaključan zbog prevelikog broja neuspešnih pokušaja prijave.',
     valueMustBeUnique: 'Vrednost mora biti jedinstvena.',
     verificationTokenInvalid: 'Verifikacioni token je nevalidan.',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -111,6 +111,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     unauthorized: 'Нет доступа, вы должны войти, чтобы сделать этот запрос.',
     unknown: 'Произошла неизвестная ошибка.',
     unspecific: 'Произошла ошибка.',
+    userEmailAlreadyRegistered: 'Пользователь с указанным email уже зарегистрирован.',
     userLocked:
       'Этот пользователь заблокирован из-за слишком большого количества неудачных попыток входа.',
     valueMustBeUnique: 'Значение должно быть уникальным',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -111,6 +111,7 @@ export const skTranslations: DefaultTranslationsObject = {
     unauthorized: 'Neautorizováno, pro zadání tohoto požadavku musíte být přihlášeni.',
     unknown: 'Došlo k neznámej chybe.',
     unspecific: 'Došlo k chybe.',
+    userEmailAlreadyRegistered: 'Používateľ s daným e-mailom je už zaregistrovaný.',
     userLocked:
       'Tento používateľ je uzamknutý kvôli príliš mnohým neúspešným pokusom o prihlásenie.',
     valueMustBeUnique: 'Hodnota musí byť jedinečná',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -110,6 +110,7 @@ export const svTranslations: DefaultTranslationsObject = {
     unauthorized: 'Obehörig, du måste vara inloggad för att göra denna begäran.',
     unknown: 'Ett okänt fel har uppstått.',
     unspecific: 'Ett fel har uppstått.',
+    userEmailAlreadyRegistered: 'En användare med den angivna e-postadressen är redan registrerad.',
     userLocked: 'Den här användaren är låst på grund av för många misslyckade inloggningsförsök.',
     valueMustBeUnique: 'Värdet måste vara unikt',
     verificationTokenInvalid: 'Verifieringstoken är ogiltig.',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -108,6 +108,7 @@ export const thTranslations: DefaultTranslationsObject = {
     unauthorized: 'คุณไม่ได้รับอนุญาต กรุณาเข้าสู่ระบบเพื่อทำคำขอนี้',
     unknown: 'เกิดปัญหาบางอย่างที่ไม่ทราบสาเหตุ',
     unspecific: 'เกิดปัญหาบางอย่าง',
+    userEmailAlreadyRegistered: 'ผู้ใช้ที่มีอีเมลดังกล่าวได้ลงทะเบียนแล้ว',
     userLocked: 'บัญชีนี้ถูกล็อกเนื่องจากมีการพยายามเข้าสู่ระบบมากเกินไป',
     valueMustBeUnique: 'ค่าต้องไม่ซ้ำกับเอกสารอื่น',
     verificationTokenInvalid: 'Token ยืนยันตัวตนไม่ถูกต้อง',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -111,6 +111,7 @@ export const trTranslations: DefaultTranslationsObject = {
     unauthorized: 'Bu işlemi gerçekleştirmek için lütfen giriş yapın.',
     unknown: 'Bilinmeyen bir hata oluştu.',
     unspecific: 'Bir hata oluştu.',
+    userEmailAlreadyRegistered: 'Verilen e-posta ile zaten kayıtlı bir kullanıcı var.',
     userLocked:
       'Hesabınız hatalı giriş denemeleri yüzünden geçici olarak kilitlendi. Lütfen daha sonra tekrar deneyin.',
     valueMustBeUnique: 'Değer benzersiz olmalıdır',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -111,6 +111,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     unauthorized: 'Немає доступу, ви повинні увійти, щоб виконати цей запит.',
     unknown: 'Виникла невідома помилка.',
     unspecific: 'Виникла помилка.',
+    userEmailAlreadyRegistered: 'Користувач із вказаною електронною поштою вже зареєстрований.',
     userLocked: 'Цей користувач заблокований через велику кількість невдалих спроб входу.',
     valueMustBeUnique: 'Значення має бути унікальним.',
     verificationTokenInvalid: 'Токен верифікації недійсний.',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -109,6 +109,7 @@ export const viTranslations: DefaultTranslationsObject = {
     unauthorized: 'Lỗi - Bạn cần phải đăng nhập trước khi gửi request sau.',
     unknown: 'Lỗi - Không xác định (unknown error).',
     unspecific: 'Lỗi - Đã xảy ra (unspecific error).',
+    userEmailAlreadyRegistered: 'Người dùng với email đã cho đã được đăng ký.',
     userLocked: 'Lỗi- Tài khoản đã bị khóa do đăng nhập thất bại nhiều lần.',
     valueMustBeUnique: 'Lỗi - Giá trị không được trùng lặp.',
     verificationTokenInvalid: 'Lỗi - Token dùng để xác thực không hợp lệ.',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -105,6 +105,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     unauthorized: '未经授权，您必须登录才能提出这个请求。',
     unknown: '发生了一个未知的错误。',
     unspecific: '发生了一个错误。',
+    userEmailAlreadyRegistered: '给定电子邮件的用户已经注册。',
     userLocked: '该用户由于有太多次失败的登录尝试而被锁定。',
     valueMustBeUnique: '值必须是唯一的',
     verificationTokenInvalid: '验证令牌无效。',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -105,6 +105,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     unauthorized: '未經授權，您必須登錄才能提出這個請求。',
     unknown: '發生了一個未知的錯誤。',
     unspecific: '發生了一個錯誤。',
+    userEmailAlreadyRegistered: '給定電子郵件的用戶已經註冊。',
     userLocked: '該使用者由於有太多次失敗的登錄嘗試而被鎖定。',
     valueMustBeUnique: '數值必須是唯一的',
     verificationTokenInvalid: '驗證令牌無效。',

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -1190,7 +1190,7 @@ describe('collections-graphql', () => {
       expect(errors[1].path[0]).toEqual('test3')
       expect(errors[1].extensions.name).toEqual('ValidationError')
       expect(errors[1].extensions.data[0].message).toEqual(
-        'A user with the given email is already registered',
+        'A user with the given email is already registered.',
       )
       expect(errors[1].extensions.data[0].field).toEqual('email')
 


### PR DESCRIPTION
## Description

V2 PR [here](https://github.com/payloadcms/payload/pull/6549)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
