### PR TITLE
fix: ability to query relationships not equal to ID

### DIFF
--- a/packages/db-mongodb/src/queries/buildSearchParams.ts
+++ b/packages/db-mongodb/src/queries/buildSearchParams.ts
@@ -193,17 +193,19 @@ export async function buildSearchParam({
 
       if (field.type === 'relationship' || field.type === 'upload') {
         let hasNumberIDRelation
+        let multiIDCondition = '$or'
+        if (operatorKey === '$ne') multiIDCondition = '$and'
 
         const result = {
           value: {
-            $or: [{ [path]: { [operatorKey]: formattedValue } }],
+            [multiIDCondition]: [{ [path]: { [operatorKey]: formattedValue } }],
           },
         }
 
         if (typeof formattedValue === 'string') {
           if (mongoose.Types.ObjectId.isValid(formattedValue)) {
-            result.value.$or.push({
-              [path]: { [operatorKey]: new ObjectId(formattedValue) },
+            result.value[multiIDCondition].push({
+              [path]: { [operatorKey]: ObjectId(formattedValue) },
             })
           } else {
             ;(Array.isArray(field.relationTo) ? field.relationTo : [field.relationTo]).forEach(
@@ -218,11 +220,13 @@ export async function buildSearchParam({
             )
 
             if (hasNumberIDRelation)
-              result.value.$or.push({ [path]: { [operatorKey]: parseFloat(formattedValue) } })
+              result.value[multiIDCondition].push({
+                [path]: { [operatorKey]: parseFloat(formattedValue) },
+              })
           }
         }
 
-        if (result.value.$or.length > 1) {
+        if (result.value[multiIDCondition].length > 1) {
           return result
         }
       }

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -618,6 +618,30 @@ describe('collections-rest', () => {
         })
       })
 
+      it('should query relationships by not_equals', async () => {
+        const ogPost = await createPost({
+          relationMultiRelationTo: { relationTo: relationSlug, value: relation.id },
+        })
+        await createPost()
+
+        const response = await restClient.GET(`/${slug}`, {
+          query: {
+            where: {
+              and: [
+                {
+                  'relationMultiRelationTo.value': { not_equals: relation.id },
+                },
+              ],
+            },
+          },
+        })
+        const result = await response.json()
+
+        expect(response.status).toEqual(200)
+        const foundExcludedDoc = result.docs.some((doc) => ogPost.id === doc.id)
+        expect(foundExcludedDoc).toBe(false)
+      })
+
       describe('relationTo multi hasMany', () => {
         it('nested by id', async () => {
           const post1 = await createPost({


### PR DESCRIPTION
## Description

Fixes issue where filtering relationship fields using `not_equals` would not properly filter documents out.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
