### PR TITLE
fix: ensure relationship field pills respect isSortable property

### DIFF
--- a/packages/ui/src/elements/ReactSelect/MultiValue/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/MultiValue/index.tsx
@@ -32,7 +32,7 @@ export const MultiValue: React.FC<MultiValueProps<Option>> = (props) => {
   const classes = [
     baseClass,
     className,
-    !isDisabled && 'draggable',
+    !isDisabled && isSortable && 'draggable',
     isDragging && `${baseClass}--is-dragging`,
   ]
     .filter(Boolean)
@@ -45,9 +45,13 @@ export const MultiValue: React.FC<MultiValueProps<Option>> = (props) => {
         {...props}
         className={classes}
         innerProps={{
+          ...(isSortable
+            ? {
+                ...attributes,
+                ...listeners,
+              }
+            : {}),
           ...innerProps,
-          ...attributes,
-          ...listeners,
           onMouseDown: (e) => {
             if (!disableMouseDown) {
               // we need to prevent the dropdown from opening when clicking on the drag handle, but not when a modal is open (i.e. the 'Relationship' field component)
@@ -55,10 +59,12 @@ export const MultiValue: React.FC<MultiValueProps<Option>> = (props) => {
             }
           },
           ref: setNodeRef,
-          style: {
-            transform,
-            ...attributes?.style,
-          },
+          style: isSortable
+            ? {
+                transform,
+                ...attributes?.style,
+              }
+            : {},
         }}
       />
     </React.Fragment>

--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
@@ -524,6 +524,7 @@ export const mapFields = (args: {
               className: field.admin?.className,
               disabled: field.admin?.disabled,
               hasMany: field.hasMany,
+              isSortable: field.admin?.isSortable,
               readOnly: field.admin?.readOnly,
               relationTo: field.relationTo,
               required: field.required,


### PR DESCRIPTION
## Description

Addresses issue brought up [here](https://github.com/payloadcms/payload/issues/6185#issuecomment-2137707886).

`isSortable` on relationship fields was not being respected.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
