### PR TITLE
fix(next): ssr live preview was not dispatching document save events

### DIFF
--- a/test/live-preview/app/live-preview/(pages)/ssr-autosave/[slug]/RefreshRouteOnSave.tsx
+++ b/test/live-preview/app/live-preview/(pages)/ssr-autosave/[slug]/RefreshRouteOnSave.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { RefreshRouteOnSave as PayloadLivePreview } from '@payloadcms/live-preview-react'
+import { useRouter } from 'next/navigation.js'
+import React from 'react'
+
+import { PAYLOAD_SERVER_URL } from '../../../_api/serverURL.js'
+
+export const RefreshRouteOnSave: React.FC = () => {
+  const router = useRouter()
+  return <PayloadLivePreview refresh={() => router.refresh()} serverURL={PAYLOAD_SERVER_URL} />
+}

--- a/test/live-preview/app/live-preview/(pages)/ssr-autosave/[slug]/page.tsx
+++ b/test/live-preview/app/live-preview/(pages)/ssr-autosave/[slug]/page.tsx
@@ -1,0 +1,45 @@
+import { Gutter } from '@payloadcms/ui/elements/Gutter'
+import { notFound } from 'next/navigation.js'
+import React, { Fragment } from 'react'
+
+import type { Page } from '../../../../../payload-types.js'
+
+import { renderedPageTitleID, ssrAutosavePagesSlug } from '../../../../../shared.js'
+import { getDoc } from '../../../_api/getDoc.js'
+import { getDocs } from '../../../_api/getDocs.js'
+import { Blocks } from '../../../_components/Blocks/index.js'
+import { Hero } from '../../../_components/Hero/index.js'
+import { RefreshRouteOnSave } from './RefreshRouteOnSave.js'
+
+export default async function SSRAutosavePage({ params: { slug = '' } }) {
+  const data = await getDoc<Page>({
+    slug,
+    collection: ssrAutosavePagesSlug,
+    draft: true,
+  })
+
+  if (!data) {
+    notFound()
+  }
+
+  return (
+    <Fragment>
+      <RefreshRouteOnSave />
+      <Hero {...data?.hero} />
+      <Blocks blocks={data?.layout} />
+      <Gutter>
+        <div id={renderedPageTitleID}>{`For Testing: ${data.title}`}</div>
+      </Gutter>
+    </Fragment>
+  )
+}
+
+export async function generateStaticParams() {
+  process.env.PAYLOAD_DROP_DATABASE = 'false'
+  try {
+    const ssrPages = await getDocs<Page>(ssrAutosavePagesSlug)
+    return ssrPages?.map(({ slug }) => slug)
+  } catch (error) {
+    return []
+  }
+}

--- a/test/live-preview/collections/SSRAutosave.ts
+++ b/test/live-preview/collections/SSRAutosave.ts
@@ -5,19 +5,26 @@ import { CallToAction } from '../blocks/CallToAction/index.js'
 import { Content } from '../blocks/Content/index.js'
 import { MediaBlock } from '../blocks/MediaBlock/index.js'
 import { hero } from '../fields/hero.js'
-import { ssrPagesSlug, tenantsSlug } from '../shared.js'
+import { ssrAutosavePagesSlug, tenantsSlug } from '../shared.js'
 
-export const SSR: CollectionConfig = {
-  slug: ssrPagesSlug,
+export const SSRAutosave: CollectionConfig = {
+  slug: ssrAutosavePagesSlug,
   labels: {
-    singular: 'SSR Page',
-    plural: 'SSR Pages',
+    singular: 'SSR Autosave Page',
+    plural: 'SSR Autosave Pages',
   },
   access: {
     read: () => true,
     create: () => true,
     update: () => true,
     delete: () => true,
+  },
+  versions: {
+    drafts: {
+      autosave: {
+        interval: 375,
+      },
+    },
   },
   admin: {
     useAsTitle: 'title',

--- a/test/live-preview/config.ts
+++ b/test/live-preview/config.ts
@@ -4,12 +4,19 @@ import { Media } from './collections/Media.js'
 import { Pages } from './collections/Pages.js'
 import { Posts } from './collections/Posts.js'
 import { SSR } from './collections/SSR.js'
+import { SSRAutosave } from './collections/SSRAutosave.js'
 import { Tenants } from './collections/Tenants.js'
 import { Users } from './collections/Users.js'
 import { Footer } from './globals/Footer.js'
 import { Header } from './globals/Header.js'
 import { seed } from './seed/index.js'
-import { mobileBreakpoint, pagesSlug, postsSlug, ssrPagesSlug } from './shared.js'
+import {
+  mobileBreakpoint,
+  pagesSlug,
+  postsSlug,
+  ssrAutosavePagesSlug,
+  ssrPagesSlug,
+} from './shared.js'
 import { formatLivePreviewURL } from './utilities/formatLivePreviewURL.js'
 
 export default buildConfigWithDefaults({
@@ -19,13 +26,13 @@ export default buildConfigWithDefaults({
       // The Live Preview config cascades from the top down, properties are inherited from here
       url: formatLivePreviewURL,
       breakpoints: [mobileBreakpoint],
-      collections: [pagesSlug, postsSlug, ssrPagesSlug],
+      collections: [pagesSlug, postsSlug, ssrPagesSlug, ssrAutosavePagesSlug],
       globals: ['header', 'footer'],
     },
   },
   cors: ['http://localhost:3000', 'http://localhost:3001'],
   csrf: ['http://localhost:3000', 'http://localhost:3001'],
-  collections: [Users, Pages, Posts, SSR, Tenants, Categories, Media],
+  collections: [Users, Pages, Posts, SSR, SSRAutosave, Tenants, Categories, Media],
   globals: [Header, Footer],
   onInit: seed,
 })

--- a/test/live-preview/payload-types.ts
+++ b/test/live-preview/payload-types.ts
@@ -12,6 +12,7 @@ export interface Config {
     pages: Page;
     posts: Post;
     ssr: Ssr;
+    'ssr-autosave': SsrAutosave;
     tenants: Tenant;
     categories: Category;
     media: Media;
@@ -233,7 +234,7 @@ export interface Page {
         id?: string | null;
       }[]
     | null;
-  tab: {
+  tab?: {
     relationshipInTab?: (string | null) | Post;
   };
   meta?: {
@@ -271,6 +272,8 @@ export interface Media {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -419,6 +422,137 @@ export interface Category {
  * via the `definition` "ssr".
  */
 export interface Ssr {
+  id: string;
+  slug: string;
+  tenant?: (string | null) | Tenant;
+  title: string;
+  hero: {
+    type: 'none' | 'highImpact' | 'lowImpact';
+    richText?:
+      | {
+          [k: string]: unknown;
+        }[]
+      | null;
+    media?: string | Media | null;
+  };
+  layout?:
+    | (
+        | {
+            invertBackground?: boolean | null;
+            richText?:
+              | {
+                  [k: string]: unknown;
+                }[]
+              | null;
+            links?:
+              | {
+                  link: {
+                    type?: ('reference' | 'custom') | null;
+                    newTab?: boolean | null;
+                    reference?:
+                      | ({
+                          relationTo: 'posts';
+                          value: string | Post;
+                        } | null)
+                      | ({
+                          relationTo: 'pages';
+                          value: string | Page;
+                        } | null);
+                    url?: string | null;
+                    label: string;
+                    appearance?: ('primary' | 'secondary') | null;
+                  };
+                  id?: string | null;
+                }[]
+              | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'cta';
+          }
+        | {
+            invertBackground?: boolean | null;
+            columns?:
+              | {
+                  size?: ('oneThird' | 'half' | 'twoThirds' | 'full') | null;
+                  richText?:
+                    | {
+                        [k: string]: unknown;
+                      }[]
+                    | null;
+                  enableLink?: boolean | null;
+                  link?: {
+                    type?: ('reference' | 'custom') | null;
+                    newTab?: boolean | null;
+                    reference?:
+                      | ({
+                          relationTo: 'posts';
+                          value: string | Post;
+                        } | null)
+                      | ({
+                          relationTo: 'pages';
+                          value: string | Page;
+                        } | null);
+                    url?: string | null;
+                    label: string;
+                    appearance?: ('default' | 'primary' | 'secondary') | null;
+                  };
+                  id?: string | null;
+                }[]
+              | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'content';
+          }
+        | {
+            invertBackground?: boolean | null;
+            position?: ('default' | 'fullscreen') | null;
+            media: string | Media;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'mediaBlock';
+          }
+        | {
+            introContent?:
+              | {
+                  [k: string]: unknown;
+                }[]
+              | null;
+            populateBy?: ('collection' | 'selection') | null;
+            relationTo?: 'posts' | null;
+            categories?: (string | Category)[] | null;
+            limit?: number | null;
+            selectedDocs?:
+              | {
+                  relationTo: 'posts';
+                  value: string | Post;
+                }[]
+              | null;
+            populatedDocs?:
+              | {
+                  relationTo: 'posts';
+                  value: string | Post;
+                }[]
+              | null;
+            populatedDocsTotal?: number | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'archive';
+          }
+      )[]
+    | null;
+  meta?: {
+    title?: string | null;
+    description?: string | null;
+    image?: string | Media | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ssr-autosave".
+ */
+export interface SsrAutosave {
   id: string;
   slug: string;
   tenant?: (string | null) | Tenant;

--- a/test/live-preview/seed/index.ts
+++ b/test/live-preview/seed/index.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url'
 
 import { devUser } from '../../credentials.js'
 import removeFiles from '../../helpers/removeFiles.js'
-import { pagesSlug, postsSlug, ssrPagesSlug, tenantsSlug } from '../shared.js'
+import { pagesSlug, postsSlug, ssrAutosavePagesSlug, ssrPagesSlug, tenantsSlug } from '../shared.js'
 import { footer } from './footer.js'
 import { header } from './header.js'
 import { home } from './home.js'
@@ -110,6 +110,23 @@ export const seed: Config['onInit'] = async (payload) => {
 
   await payload.create({
     collection: ssrPagesSlug,
+    data: {
+      ...JSON.parse(
+        JSON.stringify(home)
+          .replace(/"\{\{MEDIA_ID\}\}"/g, mediaID)
+          .replace(/"\{\{POSTS_PAGE_ID\}\}"/g, postsPageDocID)
+          .replace(/"\{\{POST_1_ID\}\}"/g, post1DocID)
+          .replace(/"\{\{POST_2_ID\}\}"/g, post2DocID)
+          .replace(/"\{\{POST_3_ID\}\}"/g, post3DocID)
+          .replace(/"\{\{TENANT_1_ID\}\}"/g, tenantID),
+      ),
+      title: 'SSR Home',
+      slug: 'home',
+    },
+  })
+
+  await payload.create({
+    collection: ssrAutosavePagesSlug,
     data: {
       ...JSON.parse(
         JSON.stringify(home)

--- a/test/live-preview/shared.ts
+++ b/test/live-preview/shared.ts
@@ -4,6 +4,8 @@ export const tenantsSlug = 'tenants'
 
 export const ssrPagesSlug = 'ssr'
 
+export const ssrAutosavePagesSlug = 'ssr-autosave'
+
 export const postsSlug = 'posts'
 
 export const mobileBreakpoint = {


### PR DESCRIPTION
## Description

Live Preview was not dispatching document save events, leading to server-side Live Preview _without_ autosave to never trigger a re-render of the previewing app.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes