### PR TITLE
fix: critical getPredefinedMigration dependency error

### DIFF
--- a/packages/payload/src/database/migrations/getPredefinedMigration.ts
+++ b/packages/payload/src/database/migrations/getPredefinedMigration.ts
@@ -31,7 +31,7 @@ export const getPredefinedMigration = async ({
       cleanPath = cleanPath.replaceAll('\\', '/')
       const moduleURL = pathToFileURL(cleanPath)
       try {
-        const { downSQL, imports, upSQL } = await import(moduleURL.href)
+        const { downSQL, imports, upSQL } = await eval(`import'${moduleURL.href}')`)
         return { downSQL, imports, upSQL }
       } catch (error) {
         payload.logger.error({

--- a/packages/payload/src/exports/database.ts
+++ b/packages/payload/src/exports/database.ts
@@ -53,7 +53,7 @@ export type {
   UpdateVersionArgs,
 } from '../database/types.js'
 
-export * from '../database/queryValidation/types.js'
+export type * from '../database/queryValidation/types.js'
 
 export { combineQueries } from '../database/combineQueries.js'
 


### PR DESCRIPTION
## Description

![CleanShot 2024-05-30 at 16 33 55](https://github.com/payloadcms/payload/assets/70709113/02fe9d0b-6a5b-4f70-a50f-76a03643a298)

![CleanShot 2024-05-30 at 16 34 10](https://github.com/payloadcms/payload/assets/70709113/30273883-d87c-4d2d-9b27-b77d6afeb690)

webpack tries to bundle all imports. If an import is a variable, webpack cant determine what to bundle and will throw that err

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
