### PR TITLE
fix: corrects block duplicate action and add tests

### DIFF
--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -247,7 +247,7 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
     case 'DUPLICATE_ROW': {
       const { path, rowIndex } = action
       const { remainingFields, rows } = separateRows(path, state)
-      const rowsMetadata = state[path]?.rows || []
+      const rowsMetadata = [...(state[path].rows || [])]
 
       const duplicateRowMetadata = deepCopyObject(rowsMetadata[rowIndex])
       if (duplicateRowMetadata.id) duplicateRowMetadata.id = new ObjectId().toHexString()
@@ -264,13 +264,13 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
 
       const newState = {
         ...remainingFields,
+        ...flattenRows(path, rows),
         [path]: {
           ...state[path],
           disableFormData: true,
           rows: rowsMetadata,
           value: rows.length,
         },
-        ...flattenRows(path, rows),
       }
 
       return newState

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -115,6 +115,21 @@ describe('Block fields', () => {
     await expect(addedRow.locator('.blocks-field__block-pill-content')).toContainText('Content') // went from `Number` to `Content`
   })
 
+  test('should duplicate block', async () => {
+    await page.goto(url.create)
+    const firstRow = page.locator('#field-blocks #blocks-row-0')
+    const rowActions = firstRow.locator('.collapsible__actions')
+    await expect(rowActions).toBeVisible()
+
+    await rowActions.locator('.array-actions__button').click()
+    const duplicateButton = rowActions.locator('.array-actions__action.array-actions__duplicate')
+    await expect(duplicateButton).toBeVisible()
+    await duplicateButton.click()
+
+    const blocks = page.locator('#field-blocks > .blocks-field__rows > div')
+    expect(await blocks.count()).toEqual(4)
+  })
+
   test('should use i18n block labels', async () => {
     await page.goto(url.create)
     await expect(page.locator('#field-i18nBlocks .blocks-field__header')).toContainText('Block en')


### PR DESCRIPTION
## Description

Closes #6401 

Duplicating a block creates 2 new block copies (should be 1) and duplicating the last block crashes the admin panel.

This change fixes the duplicate action in `Form > fieldReducer.ts` and adds e2e test for block duplicating.

**NOTE:** Need to enable `reactStrictMode: true` in the next.config to replicate this issue.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works