### PR TITLE
Optimize Dockerfiles in create-payload-app templates

### DIFF
--- a/templates/blank/Dockerfile
+++ b/templates/blank/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.2.0-alpine as base
+FROM node:20.14-alpine as base
 
 FROM base as builder
 

--- a/templates/blank/Dockerfile
+++ b/templates/blank/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.8-alpine as base
+FROM node:22.2.0-alpine as base
 
 FROM base as builder
 
@@ -9,16 +9,21 @@ COPY . .
 RUN yarn install
 RUN yarn build
 
-FROM base as runtime
-
-ENV NODE_ENV=production
-ENV PAYLOAD_CONFIG_PATH=dist/payload.config.js
+FROM base as prod_deps
 
 WORKDIR /home/node/app
 COPY package*.json  ./
 COPY yarn.lock ./
 
 RUN yarn install --production
+
+FROM base as runtime
+
+ENV NODE_ENV=production
+ENV PAYLOAD_CONFIG_PATH=dist/payload.config.js
+
+WORKDIR /home/node/app
+COPY --from=prod_deps /home/node/app/node_modules ./node_modules
 COPY --from=builder /home/node/app/dist ./dist
 COPY --from=builder /home/node/app/build ./build
 

--- a/templates/ecommerce/Dockerfile
+++ b/templates/ecommerce/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.2.0-alpine as base
+FROM node:20.14-alpine as base
 
 FROM base as builder
 

--- a/templates/ecommerce/Dockerfile
+++ b/templates/ecommerce/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.8-alpine as base
+FROM node:22.2.0-alpine as base
 
 FROM base as builder
 
@@ -9,16 +9,21 @@ COPY . .
 RUN yarn install
 RUN yarn build
 
-FROM base as runtime
-
-ENV NODE_ENV=production
-ENV PAYLOAD_CONFIG_PATH=dist/payload.config.js
+FROM base as prod_deps
 
 WORKDIR /home/node/app
 COPY package*.json  ./
 COPY yarn.lock ./
 
 RUN yarn install --production
+
+FROM base as runtime
+
+ENV NODE_ENV=production
+ENV PAYLOAD_CONFIG_PATH=dist/payload.config.js
+
+WORKDIR /home/node/app
+COPY --from=prod_deps /home/node/app/node_modules ./node_modules
 COPY --from=builder /home/node/app/dist ./dist
 COPY --from=builder /home/node/app/build ./build
 

--- a/templates/website/Dockerfile
+++ b/templates/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.2.0-alpine as base
+FROM node:20.14-alpine as base
 
 FROM base as builder
 

--- a/templates/website/Dockerfile
+++ b/templates/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.8-alpine as base
+FROM node:22.2.0-alpine as base
 
 FROM base as builder
 
@@ -9,16 +9,21 @@ COPY . .
 RUN yarn install
 RUN yarn build
 
-FROM base as runtime
-
-ENV NODE_ENV=production
-ENV PAYLOAD_CONFIG_PATH=dist/payload.config.js
+FROM base as prod_deps
 
 WORKDIR /home/node/app
 COPY package*.json  ./
 COPY yarn.lock ./
 
 RUN yarn install --production
+
+FROM base as runtime
+
+ENV NODE_ENV=production
+ENV PAYLOAD_CONFIG_PATH=dist/payload.config.js
+
+WORKDIR /home/node/app
+COPY --from=prod_deps /home/node/app/node_modules ./node_modules
 COPY --from=builder /home/node/app/dist ./dist
 COPY --from=builder /home/node/app/build ./build
 


### PR DESCRIPTION
## Description

The Dockerfiles that ship with the create-payload-app templates produce images that are around 1.5GiB in size, which is quite large.

I tracked this down to the installation of production dependencies in the runtime build step. This keeps all the no-longer-needed build dependencies in the final image.

Moving this to a new build step ensures only the minimum necessary dependencies make it to the final image, reducing the final image to around 500MiB (approximately 1GiB or 67% smaller than before).

- Upgraded base Node image to `22.2.0-alpine` to include the latest security updates
- Moved installation of production dependencies to a separate build step to reduce the final image size

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
