### PR TITLE
fix: pin ajv to 8.14.0, as 8.15.0 is broken

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -82,7 +82,7 @@
     "@payloadcms/translations": "workspace:*",
     "@swc-node/core": "^1.13.0",
     "@swc-node/sourcemap-support": "^0.5.0",
-    "ajv": "^8.12.0",
+    "ajv": "8.14.0",
     "bson-objectid": "2.0.4",
     "ci-info": "^4.0.0",
     "conf": "10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,8 +680,8 @@ importers:
         specifier: ^1.4.13
         version: 1.4.13
       ajv:
-        specifier: ^8.12.0
-        version: 8.12.0
+        specifier: 8.14.0
+        version: 8.14.0
       bson-objectid:
         specifier: 2.0.4
         version: 2.0.4
@@ -7816,7 +7816,7 @@ packages:
       indent-string: 4.0.0
     dev: true
 
-  /ajv-formats@2.1.1(ajv@8.12.0):
+  /ajv-formats@2.1.1(ajv@8.14.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
       ajv: ^8.0.0
@@ -7824,7 +7824,7 @@ packages:
       ajv:
         optional: true
     dependencies:
-      ajv: 8.12.0
+      ajv: 8.14.0
 
   /ajv-keywords@3.5.2(ajv@6.12.6):
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -7834,12 +7834,12 @@ packages:
       ajv: 6.12.6
     dev: true
 
-  /ajv-keywords@5.1.0(ajv@8.12.0):
+  /ajv-keywords@5.1.0(ajv@8.14.0):
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
       ajv: ^8.8.2
     dependencies:
-      ajv: 8.12.0
+      ajv: 8.14.0
       fast-deep-equal: 3.1.3
     dev: true
 
@@ -7851,8 +7851,8 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  /ajv@8.12.0:
-    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+  /ajv@8.14.0:
+    resolution: {integrity: sha512-oYs1UUtO97ZO2lJ4bwnWeQW8/zvOIQLGKcvPTsWmvc2SYgBb+upuNS5NxoLaMU4h8Ju3Nbj6Cq8mD2LQoqVKFA==}
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -8884,8 +8884,8 @@ packages:
     resolution: {integrity: sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==}
     engines: {node: '>=12'}
     dependencies:
-      ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv: 8.14.0
+      ajv-formats: 2.1.1(ajv@8.14.0)
       atomically: 1.7.0
       debounce-fn: 4.0.0
       dot-prop: 6.0.1
@@ -15758,9 +15758,9 @@ packages:
     engines: {node: '>= 12.13.0'}
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
-      ajv-keywords: 5.1.0(ajv@8.12.0)
+      ajv: 8.14.0
+      ajv-formats: 2.1.1(ajv@8.14.0)
+      ajv-keywords: 5.1.0(ajv@8.14.0)
     dev: true
 
   /scmp@2.1.0:


### PR DESCRIPTION
See https://discord.com/channels/967097582721572934/1247313351151714389/1247336646878171258

Fixes this:

Module build failed: UnhandledSchemeError: Reading from "node:url" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "node:" URIs.
Import trace for requested module:
node:url
./node_modules/.pnpm/fast-uri@2.3.0/node_modules/fast-uri/index.js
./node_modules/.pnpm/ajv@8.15.0/node_modules/ajv/dist/runtime/uri.js
./node_modules/.pnpm/ajv@8.15.0/node_modules/ajv/dist/core.js
./node_modules/.pnpm/ajv@8.15.0/node_modules/ajv/dist/ajv.js
./node_modules/.pnpm/payload@3.0.0-beta.39_@swc+core@1.5.24_@swc+types@0.1.7_graphql@16.8.1_typescript@5.4.5/node_modules/payload/dist/fields/validations.js
./node_modules/.pnpm/payload@3.0.0-beta.39_@swc+core@1.5.24_@swc+types@0.1.7_graphql@16.8.1_typescript@5.4.5/node_modules/payload/dist/exports/fields/validations.js
./node_modules/.pnpm/@payloadcms+next@3.0.0-beta.39_graphql@16.8.1_monaco-editor@0.49.0_next@15.0.0-rc.0_payload@3_bycrjqlo3lguyhsywwxtlataiy/node_modules/@payloadcms/next/dist/views/ForgotPassword/ForgotPasswordForm/index.js
 GET / 500 in 5561ms
 GET / 500 in 2774ms
^C
