### PR TITLE
fix: pin ajv to 8.14.0, as 8.15.0 is broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,6 @@
   },
   "dependencies": {
     "@sentry/react": "^7.77.0",
-    "ajv": "^8.12.0"
+    "ajv": "8.14.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^7.77.0
         version: 7.112.2(react@18.2.0)
       ajv:
-        specifier: ^8.12.0
-        version: 8.12.0
+        specifier: 8.14.0
+        version: 8.14.0
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -437,52 +437,6 @@ importers:
       ts-jest:
         specifier: ^29.1.0
         version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.2.2)
-
-  packages/db-example:
-    dependencies:
-      bson-objectid:
-        specifier: 2.0.4
-        version: 2.0.4
-      deepmerge:
-        specifier: 4.3.1
-        version: 4.3.1
-      get-port:
-        specifier: 5.1.1
-        version: 5.1.1
-      http-status:
-        specifier: 1.6.2
-        version: 1.6.2
-      mongoose:
-        specifier: 6.12.3
-        version: 6.12.3
-      mongoose-aggregate-paginate-v2:
-        specifier: 1.0.6
-        version: 1.0.6
-      mongoose-paginate-v2:
-        specifier: 1.7.22
-        version: 1.7.22
-      prompts:
-        specifier: 2.4.2
-        version: 2.4.2
-      uuid:
-        specifier: 9.0.0
-        version: 9.0.0
-    devDependencies:
-      '@payloadcms/eslint-config':
-        specifier: workspace:*
-        version: link:../eslint-config-payload
-      '@types/mongoose-aggregate-paginate-v2':
-        specifier: 1.0.9
-        version: 1.0.9
-      mongodb:
-        specifier: 4.17.1
-        version: 4.17.1
-      mongodb-memory-server:
-        specifier: ^9
-        version: 9.2.0
-      payload:
-        specifier: workspace:*
-        version: link:../payload
 
   packages/db-mongodb:
     dependencies:
@@ -6836,6 +6790,17 @@ packages:
         optional: true
     dependencies:
       ajv: 8.12.0
+    dev: false
+
+  /ajv-formats@2.1.1(ajv@8.14.0):
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.14.0
 
   /ajv-keywords@3.5.2(ajv@6.12.6):
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -6844,12 +6809,12 @@ packages:
     dependencies:
       ajv: 6.12.6
 
-  /ajv-keywords@5.1.0(ajv@8.12.0):
+  /ajv-keywords@5.1.0(ajv@8.14.0):
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
       ajv: ^8.8.2
     dependencies:
-      ajv: 8.12.0
+      ajv: 8.14.0
       fast-deep-equal: 3.1.3
 
   /ajv@6.12.6:
@@ -6862,6 +6827,15 @@ packages:
 
   /ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+    dev: false
+
+  /ajv@8.14.0:
+    resolution: {integrity: sha512-oYs1UUtO97ZO2lJ4bwnWeQW8/zvOIQLGKcvPTsWmvc2SYgBb+upuNS5NxoLaMU4h8Ju3Nbj6Cq8mD2LQoqVKFA==}
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -16293,9 +16267,9 @@ packages:
     engines: {node: '>= 12.13.0'}
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
-      ajv-keywords: 5.1.0(ajv@8.12.0)
+      ajv: 8.14.0
+      ajv-formats: 2.1.1(ajv@8.14.0)
+      ajv-keywords: 5.1.0(ajv@8.14.0)
 
   /scmp@2.1.0:
     resolution: {integrity: sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==}


### PR DESCRIPTION
See https://discord.com/channels/967097582721572934/1247313351151714389/1247336646878171258

Fixes this:

Module build failed: UnhandledSchemeError: Reading from "node:url" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "node:" URIs.
Import trace for requested module:
node:url
./node_modules/.pnpm/fast-uri@2.3.0/node_modules/fast-uri/index.js
./node_modules/.pnpm/ajv@8.15.0/node_modules/ajv/dist/runtime/uri.js
./node_modules/.pnpm/ajv@8.15.0/node_modules/ajv/dist/core.js
./node_modules/.pnpm/ajv@8.15.0/node_modules/ajv/dist/ajv.js
./node_modules/.pnpm/payload@3.0.0-beta.39_@swc+core@1.5.24_@swc+types@0.1.7_graphql@16.8.1_typescript@5.4.5/node_modules/payload/dist/fields/validations.js
./node_modules/.pnpm/payload@3.0.0-beta.39_@swc+core@1.5.24_@swc+types@0.1.7_graphql@16.8.1_typescript@5.4.5/node_modules/payload/dist/exports/fields/validations.js
./node_modules/.pnpm/@payloadcms+next@3.0.0-beta.39_graphql@16.8.1_monaco-editor@0.49.0_next@15.0.0-rc.0_payload@3_bycrjqlo3lguyhsywwxtlataiy/node_modules/@payloadcms/next/dist/views/ForgotPassword/ForgotPasswordForm/index.js
 GET / 500 in 5561ms
 GET / 500 in 2774ms
^C
