### PR TITLE
fix(ui): hideGutter was ignored in group field

### DIFF
--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/fields.tsx
@@ -458,6 +458,7 @@ export const mapFields = (args: {
                 parentPath: path,
                 readOnly: readOnlyOverride,
               }),
+              hideGutter: field.admin?.hideGutter,
               readOnly: field.admin?.readOnly,
               style: field.admin?.style,
               width: field.admin?.width,


### PR DESCRIPTION
## Description

hidegutter admin parameter in group field was not loaded correctly in v3 beta, causing the functionality in group field not to work.

Before fix:
![before change](https://github.com/payloadcms/payload/assets/2082176/dc1e10e9-14a5-4e62-ac46-acba785cbc0d)

After fix:
![after change](https://github.com/payloadcms/payload/assets/2082176/9ece2ddf-5fbd-4863-97ca-67df8372e81a)

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
