### PR TITLE
fix(translations): explicitly declare date-fns v3 as a dependency

### DIFF
--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -34,12 +34,14 @@
     "prepublishOnly": "pnpm clean && pnpm turbo build",
     "translateNewKeys": "tsx scripts/translateNewKeys/run.ts"
   },
+  "dependencies": {
+    "date-fns": "3.3.1"
+  },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",
     "@swc/core": "^1.4.13",
     "@types/react": "npm:types-react@19.0.0-beta.2",
     "@types/react-dom": "npm:types-react-dom@19.0.0-beta.2",
-    "date-fns": "3.3.1",
     "dotenv": "16.4.5",
     "prettier": "^3.0.3",
     "typescript": "5.4.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1363,6 +1363,10 @@ importers:
         version: link:../payload
 
   packages/translations:
+    dependencies:
+      date-fns:
+        specifier: 3.3.1
+        version: 3.3.1
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*
@@ -1376,9 +1380,6 @@ importers:
       '@types/react-dom':
         specifier: npm:types-react-dom@19.0.0-beta.2
         version: /types-react-dom@19.0.0-beta.2
-      date-fns:
-        specifier: 3.3.1
-        version: 3.3.1
       dotenv:
         specifier: 16.4.5
         version: 16.4.5


### PR DESCRIPTION
Fixes an issue where other packages installing date-fns v2 as peer dep break @payloadcms/translations. See https://discord.com/channels/967097582721572934/1247629970281332787/1247633073609248768