### PR TITLE
feat: support Next.js basePath config property

### DIFF
--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -136,11 +136,11 @@ const handleCustomEndpoints = ({
     const { pathname } = payloadRequest
 
     /*
-     * This makes sure the next.js basePath property is supported. If basePath is used, payload config.routes.api should be set to it. This makes all outgoing frontend request
-     * target the correct API endpoint starting with basePath.
+     * This makes sure the next.js basePath property is supported. If basePath is used, payload config.routes.api should include it. This makes all outgoing frontend request
+     * target the correct API endpoint starting with basePath, which is good!
      *
-     * The incoming request (here) will not include the basePath though, it's as if it's not there. Since we are adding the basePath to the pathPrefix below though (payloadRequest.payload.config.routes.api) we need the
-     * pathname to be adjusted to include the basePath which next.js strips from the request.
+     * The incoming request (here) will not include the basePath though, as it's automatically stripped by Next.js. Since we are adding the basePath to the pathPrefix below though
+     * (from payloadRequest.payload.config.routes.api) we need to add it to pathname, which does not contain the basePath. Otherwise, no endpoint will be matched if basePath is set.
      */
     let adjustedPathname = pathname
 

--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -144,8 +144,8 @@ const handleCustomEndpoints = ({
      */
     let adjustedPathname = pathname
 
-    if (process.env.NEXT_PUBLIC_BASE_PATH) {
-      adjustedPathname = process.env.NEXT_PUBLIC_BASE_PATH + pathname
+    if (process.env.NEXT_BASE_PATH) {
+      adjustedPathname = process.env.NEXT_BASE_PATH + pathname
     }
 
     const pathPrefix =

--- a/packages/next/src/utilities/getPayloadHMR.ts
+++ b/packages/next/src/utilities/getPayloadHMR.ts
@@ -81,7 +81,9 @@ export const getPayloadHMR = async (options: InitOptions): Promise<Payload> => {
     ) {
       try {
         const port = process.env.PORT || '3000'
-        const ws = new WebSocket(`ws://localhost:${port}/_next/webpack-hmr`)
+        const ws = new WebSocket(
+          `ws://localhost:${port}${process.env.NEXT_BASE_PATH ?? ''}/_next/webpack-hmr`,
+        )
 
         ws.onmessage = (event) => {
           if (typeof event.data === 'string') {

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -103,7 +103,7 @@ export const withPayload = (nextConfig = {}) => {
   }
 
   if (nextConfig.basePath) {
-    toReturn.env.NEXT_PUBLIC_BASE_PATH = nextConfig.basePath
+    toReturn.env.NEXT_BASE_PATH = nextConfig.basePath
   }
 
   return toReturn

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -10,8 +10,11 @@ export const withPayload = (nextConfig = {}) => {
     )
   }
 
-  return {
+  const toReturn = {
     ...nextConfig,
+    env: {
+      ...(nextConfig?.env || {}),
+    },
     experimental: {
       ...(nextConfig?.experimental || {}),
       outputFileTracingExcludes: {
@@ -98,6 +101,12 @@ export const withPayload = (nextConfig = {}) => {
       }
     },
   }
+
+  if (nextConfig.basePath) {
+    toReturn.env.NEXT_PUBLIC_BASE_PATH = nextConfig.basePath
+  }
+
+  return toReturn
 }
 
 export default withPayload

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -10,6 +10,9 @@ export const withPayload = (nextConfig = {}) => {
     )
   }
 
+  /**
+   * @type {import('next').NextConfig}
+   */
   const toReturn = {
     ...nextConfig,
     env: {

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -56,6 +56,13 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
     configWithDefaults.serverURL = ''
   }
 
+  if (process.env.NEXT_BASE_PATH) {
+    if (!incomingConfig?.routes?.api) {
+      // check for incomingConfig, as configWithDefaults will always have a default value for routes.api
+      configWithDefaults.routes.api = process.env.NEXT_BASE_PATH + '/api'
+    }
+  }
+
   const config: Partial<SanitizedConfig> = sanitizeAdminConfig(configWithDefaults)
 
   if (config.localization && config.localization.locales?.length > 0) {


### PR DESCRIPTION
Fixes the following issues if `basePath` is set within your Next.js config:
- webpack HMR will not work, as the websocket URL will be different if `basePath` is set
- custom endpoints will not work, as the matching between request `pathname` and endpoint path will not work. This is because the request `pathname` did not contain the `basePath`, but the endpoint path did. In a blank default payload app, this will cause console errors when requests to `/payload-preferences/` are sent
- nothing will work if `routes.api` (in the payload config) has not been manually set to `{basePath}/api`. This is now automatically done for you, unless you already have a custom api route path set in your payload config. In this case, you will have to adjust it.
`routes.admin` will not need to be adjusted, as next.js automatically handles that. `routes.api` will need to be adjusted, as that is used within fetch requests, and next.js does not automatically rewrite fetch requests. It only automatically rewrites `Link` component href's to account for `basePath`, not outgoing fetch requests.