### PR TITLE
fix: `admin.disableListLolumn` fields after toggling other fields

### DIFF
--- a/packages/payload/src/admin/components/elements/TableColumns/columnReducer.ts
+++ b/packages/payload/src/admin/components/elements/TableColumns/columnReducer.ts
@@ -36,13 +36,6 @@ type MOVE = {
 
 export type Action = MOVE | SET | TOGGLE
 
-const getFieldLabel = (field: Field): string => {
-  if ('label' in field) {
-    return field.label as string
-  }
-  return ''
-}
-
 const filterDisabledColumns = (
   columns: Pick<Column, 'accessor' | 'active'>[],
   collection: SanitizedCollectionConfig,
@@ -58,7 +51,7 @@ const filterDisabledColumns = (
             Heading: null as React.ReactNode,
             renderCell: () => null,
           },
-          label: getFieldLabel(field) || col.accessor,
+          label: 'label' in field ? field.label : col.accessor,
         } as Column
       }
       return null

--- a/packages/payload/src/admin/components/elements/TableColumns/columnReducer.ts
+++ b/packages/payload/src/admin/components/elements/TableColumns/columnReducer.ts
@@ -1,5 +1,4 @@
 import type { SanitizedCollectionConfig } from '../../../../collections/config/types'
-import type { Field } from '../../../../fields/config/types'
 import type { Props as CellProps } from '../../views/collections/List/Cell/types'
 import type { Column } from '../Table/types'
 

--- a/packages/payload/src/admin/components/elements/TableColumns/getInitialColumns.ts
+++ b/packages/payload/src/admin/components/elements/TableColumns/getInitialColumns.ts
@@ -4,6 +4,10 @@ import { fieldAffectsData, fieldHasSubFields, tabHasName } from '../../../../fie
 
 const getRemainingColumns = (fields: Field[], useAsTitle: string): string[] =>
   fields.reduce((remaining, field) => {
+    if (field.admin?.disableListColumn) {
+      return remaining
+    }
+
     if (fieldAffectsData(field) && field.name === useAsTitle) {
       return remaining
     }

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -78,6 +78,26 @@ describe('fields', () => {
       ).toBeHidden()
     })
 
+    test('should not display admin.disableListColumn true field in list view column selector if toggling other fields', async () => {
+      await page.goto(url.list)
+      await page.locator('.list-controls__toggle-columns').click()
+
+      await expect(page.locator('.column-selector')).toBeVisible()
+
+      // Click another field in column selector
+      const updatedAtButton = page.locator(`.column-selector .column-selector__column`, {
+        hasText: exactText('Updated At'),
+      })
+      await updatedAtButton.click()
+
+      // Check if "Disable List Column Text" is not present in the column options
+      await expect(
+        page.locator(`.column-selector .column-selector__column`, {
+          hasText: exactText('Disable List Column Text'),
+        }),
+      ).toBeHidden()
+    })
+
     test('should display field in list view filter selector if admin.disableListColumn is true and admin.disableListFilter is false', async () => {
       await page.goto(url.list)
       await page.locator('.list-controls__toggle-where').click()


### PR DESCRIPTION
## Description

There was an issue with fields w/ the `admin.disableListColumn` prop reappearing in the column selector after toggling other fields in the column selector.

This PR makes sure fields with `admin.disableListColumn` set to `true` do not reappear under any circumstance.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
