### PR TITLE
fix: filtered out `disableListColumn` fields reappeared after toggling other fields

### DIFF
--- a/packages/payload/src/admin/components/elements/ColumnSelector/index.tsx
+++ b/packages/payload/src/admin/components/elements/ColumnSelector/index.tsx
@@ -1,6 +1,7 @@
 import React, { useId } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import type { Column } from '../Table/types'
 import type { Props } from './types'
 
 import { getTranslation } from '../../../../utilities/getTranslation'
@@ -13,6 +14,12 @@ import { useTableColumns } from '../TableColumns'
 import './index.scss'
 
 const baseClass = 'column-selector'
+
+const filterColumnFields = (fields: Column[]): Column[] => {
+  return fields.filter((field) => {
+    return !field.admin?.disableListColumn
+  })
+}
 
 const ColumnSelector: React.FC<Props> = (props) => {
   const { slug } = props
@@ -27,10 +34,12 @@ const ColumnSelector: React.FC<Props> = (props) => {
     return null
   }
 
+  const filteredColumns = filterColumnFields(columns)
+
   return (
     <DraggableSortable
       className={baseClass}
-      ids={columns.map((col) => col.accessor)}
+      ids={filteredColumns.map((col) => col.accessor)}
       onDragEnd={({ moveFromIndex, moveToIndex }) => {
         moveColumn({
           fromIndex: moveFromIndex,
@@ -38,7 +47,7 @@ const ColumnSelector: React.FC<Props> = (props) => {
         })
       }}
     >
-      {columns.map((col, i) => {
+      {filteredColumns.map((col, i) => {
         const { name, accessor, active, label } = col
 
         if (col.accessor === '_select') return null

--- a/packages/payload/src/admin/components/elements/Table/types.ts
+++ b/packages/payload/src/admin/components/elements/Table/types.ts
@@ -5,6 +5,7 @@ import type { FieldBase } from '../../../../fields/config/types'
 export type Column = {
   accessor: string
   active: boolean
+  admin?: FieldBase['admin']
   components: {
     Heading: React.ReactNode
     renderCell: (row: any, data: any) => React.ReactNode

--- a/packages/payload/src/admin/components/elements/TableColumns/buildColumns.tsx
+++ b/packages/payload/src/admin/components/elements/TableColumns/buildColumns.tsx
@@ -46,6 +46,10 @@ const buildColumns = ({
       name: field.name,
       accessor: field.name,
       active: isActive,
+      admin: {
+        disableListColumn: field.admin?.disableListColumn,
+        disableListFilter: 'disableListFilter' in field.admin && field.admin?.disableListFilter,
+      },
       components: {
         Heading: (
           <SortColumn

--- a/packages/payload/src/admin/components/elements/TableColumns/buildColumns.tsx
+++ b/packages/payload/src/admin/components/elements/TableColumns/buildColumns.tsx
@@ -42,13 +42,17 @@ const buildColumns = ({
       colIndex += 1
     }
     const props = cellProps?.[colIndex] || {}
+
+    const disableListFilter =
+      field.admin && 'disableListFilter' in field.admin ? field.admin.disableListFilter : false
+
     return {
       name: field.name,
       accessor: field.name,
       active: isActive,
       admin: {
         disableListColumn: field.admin?.disableListColumn,
-        disableListFilter: 'disableListFilter' in field.admin && field.admin?.disableListFilter,
+        disableListFilter,
       },
       components: {
         Heading: (

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -78,6 +78,26 @@ describe('fields', () => {
       ).toBeHidden()
     })
 
+    test('should not display admin.disableListColumn true field in list view column selector if toggling other fields', async () => {
+      await page.goto(url.list)
+      await page.locator('.list-controls__toggle-columns').click()
+
+      await expect(page.locator('.column-selector')).toBeVisible()
+
+      // Click another field in column selector
+      const updatedAtButton = page.locator(`.column-selector .column-selector__column`, {
+        hasText: exactText('Updated At'),
+      })
+      await updatedAtButton.click()
+
+      // Check if "Disable List Column Text" is not present in the column options
+      await expect(
+        page.locator(`.column-selector .column-selector__column`, {
+          hasText: exactText('Disable List Column Text'),
+        }),
+      ).toBeHidden()
+    })
+
     test('should display field in list view filter selector if admin.disableListColumn is true and admin.disableListFilter is false', async () => {
       await page.goto(url.list)
       await page.locator('.list-controls__toggle-where').click()


### PR DESCRIPTION
## Description

There was an issue with fields w/ the `admin.disableListColumn` prop reappearing in the column selector after toggling other fields in the column selector.

This PR makes sure fields with `admin.disableListColumn` set to `true` do not reappear under any circumstance.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
