### PR TITLE
fix(db-postgres)!: create predefined migration missing json schema output

### DIFF
--- a/packages/db-postgres/src/createMigration.ts
+++ b/packages/db-postgres/src/createMigration.ts
@@ -121,10 +121,10 @@ export const createMigration: CreateMigration = async function createMigration(
         process.exit(0)
       }
     }
-
-    // write schema
-    fs.writeFileSync(`${filePath}.json`, JSON.stringify(drizzleJsonAfter, null, 2))
   }
+
+  // write schema
+  fs.writeFileSync(`${filePath}.json`, JSON.stringify(drizzleJsonAfter, null, 2))
 
   // write migration
   fs.writeFileSync(

--- a/packages/db-postgres/src/predefinedMigrations/v2-v3/index.ts
+++ b/packages/db-postgres/src/predefinedMigrations/v2-v3/index.ts
@@ -46,21 +46,21 @@ export const migratePostgresV2toV3 = async ({ debug, payload, req }: Args) => {
   const { generateDrizzleJson, generateMigration } = require('drizzle-kit/payload')
   const drizzleJsonAfter = generateDrizzleJson(adapter.schema)
 
-  // Get latest migration snapshot
-  const latestSnapshot = fs
+  // Get the previous migration snapshot
+  const previousSnapshot = fs
     .readdirSync(dir)
-    .filter((file) => file.endsWith('.json'))
+    .filter((file) => file.endsWith('.json') && !file.endsWith('relationships_v2_v3.json'))
     .sort()
     .reverse()?.[0]
 
-  if (!latestSnapshot) {
+  if (!previousSnapshot) {
     throw new Error(
       `No previous migration schema file found! A prior migration from v2 is required to migrate to v3.`,
     )
   }
 
   const drizzleJsonBefore = JSON.parse(
-    fs.readFileSync(`${dir}/${latestSnapshot}`, 'utf8'),
+    fs.readFileSync(`${dir}/${previousSnapshot}`, 'utf8'),
   ) as DrizzleSnapshotJSON
 
   const generatedSQL = await generateMigration(drizzleJsonBefore, drizzleJsonAfter)

--- a/packages/db-postgres/src/utilities/pushDevSchema.ts
+++ b/packages/db-postgres/src/utilities/pushDevSchema.ts
@@ -17,10 +17,7 @@ export const pushDevSchema = async (db: PostgresAdapter) => {
   const { pushSchema } = require('drizzle-kit/payload')
 
   // This will prompt if clarifications are needed for Drizzle to push new schema
-  const { apply, hasDataLoss, statementsToExecute, warnings } = await pushSchema(
-    db.schema,
-    db.drizzle,
-  )
+  const { apply, hasDataLoss, warnings } = await pushSchema(db.schema, db.drizzle)
 
   if (warnings.length) {
     let message = `Warnings detected during schema push: \n\n${warnings.join('\n')}\n\n`


### PR DESCRIPTION
## Description

fixes #6630

# BREAKING CHANGES
This only applies to you if you using db-postgres and have created the `v2-v3-relationships` migration released in [v3.0.0-beta.39](https://github.com/payloadcms/payload/releases/tag/v3.0.0-beta.39) from @payloadcms/db-postgres <= v3.0.0-beta.40.

### Steps to fix

- Delete the existing v2-v3-relationships migration file. 
- If changes were made to your config since the previous migration was made, you will need to revert those by checking out a previous commit in your version control.
- Recreate the migration using `payload migrate:create --file @payloadcms/db-postgres/relationships-v2-v3` to make the migration with the snapshot .json file. 
