### PR TITLE
fix: cascade draft arg when querying globals with graphql

### DIFF
--- a/packages/payload/src/globals/graphql/resolvers/findVersionByID.ts
+++ b/packages/payload/src/globals/graphql/resolvers/findVersionByID.ts
@@ -24,15 +24,31 @@ export type Resolver = (
 
 export default function findVersionByIDResolver(globalConfig: SanitizedGlobalConfig): Resolver {
   return async function resolver(_, args, context) {
-    if (args.locale) context.req.locale = args.locale
-    if (args.fallbackLocale) context.req.fallbackLocale = args.fallbackLocale
+    let { req } = context
+    const locale = req.locale
+    const fallbackLocale = req.fallbackLocale
+    req = isolateObjectProperty(req, 'locale')
+    req = isolateObjectProperty(req, 'fallbackLocale')
+    req.locale = args.locale || locale
+    req.fallbackLocale = args.fallbackLocale || fallbackLocale
+    if (!req.query) req.query = {}
+
+    const draft: boolean =
+      args.draft ?? req.query?.draft === 'false'
+        ? false
+        : req.query?.draft === 'true'
+          ? true
+          : undefined
+    if (typeof draft === 'boolean') req.query.draft = String(draft)
+
+    context.req = req
 
     const options = {
       id: args.id,
       depth: 0,
       draft: args.draft,
       globalConfig,
-      req: isolateObjectProperty<PayloadRequest>(context.req, 'transactionID'),
+      req: isolateObjectProperty<PayloadRequest>(req, 'transactionID'),
     }
 
     const result = await findVersionByID(options)

--- a/packages/payload/src/globals/graphql/resolvers/findVersionByID.ts
+++ b/packages/payload/src/globals/graphql/resolvers/findVersionByID.ts
@@ -31,22 +31,12 @@ export default function findVersionByIDResolver(globalConfig: SanitizedGlobalCon
     req = isolateObjectProperty(req, 'fallbackLocale')
     req.locale = args.locale || locale
     req.fallbackLocale = args.fallbackLocale || fallbackLocale
-    if (!req.query) req.query = {}
-
-    const draft: boolean =
-      args.draft ?? req.query?.draft === 'false'
-        ? false
-        : req.query?.draft === 'true'
-          ? true
-          : undefined
-    if (typeof draft === 'boolean') req.query.draft = String(draft)
 
     context.req = req
 
     const options = {
       id: args.id,
       depth: 0,
-      draft: args.draft,
       globalConfig,
       req: isolateObjectProperty<PayloadRequest>(req, 'transactionID'),
     }

--- a/packages/payload/src/globals/graphql/resolvers/update.ts
+++ b/packages/payload/src/globals/graphql/resolvers/update.ts
@@ -29,8 +29,8 @@ export default function updateResolver<TSlug extends keyof GeneratedTypes['globa
     let { req } = context
     const locale = req.locale
     const fallbackLocale = req.fallbackLocale
-    req = isolateObjectProperty(req, 'locale')
-    req = isolateObjectProperty(req, 'fallbackLocale')
+    req = isolateObjectProperty<PayloadRequest>(req, 'locale')
+    req = isolateObjectProperty<PayloadRequest>(req, 'fallbackLocale')
     req.locale = args.locale || locale
     req.fallbackLocale = args.fallbackLocale || fallbackLocale
     if (!req.query) req.query = {}

--- a/packages/payload/src/globals/graphql/resolvers/update.ts
+++ b/packages/payload/src/globals/graphql/resolvers/update.ts
@@ -26,18 +26,32 @@ export default function updateResolver<TSlug extends keyof GeneratedTypes['globa
   globalConfig: SanitizedGlobalConfig,
 ): Resolver<TSlug> {
   return async function resolver(_, args, context) {
-    if (args.locale) context.req.locale = args.locale
-    if (args.fallbackLocale) context.req.fallbackLocale = args.fallbackLocale
+    let { req } = context
+    const locale = req.locale
+    const fallbackLocale = req.fallbackLocale
+    req = isolateObjectProperty(req, 'locale')
+    req = isolateObjectProperty(req, 'fallbackLocale')
+    req.locale = args.locale || locale
+    req.fallbackLocale = args.fallbackLocale || fallbackLocale
+    if (!req.query) req.query = {}
 
-    const { slug } = globalConfig
+    const draft: boolean =
+      args.draft ?? req.query?.draft === 'false'
+        ? false
+        : req.query?.draft === 'true'
+          ? true
+          : undefined
+    if (typeof draft === 'boolean') req.query.draft = String(draft)
+
+    context.req = req
 
     const options = {
+      slug: globalConfig.slug,
       data: args.data,
       depth: 0,
       draft: args.draft,
       globalConfig,
-      req: isolateObjectProperty<PayloadRequest>(context.req, 'transactionID'),
-      slug,
+      req: isolateObjectProperty<PayloadRequest>(req, 'transactionID'),
     }
 
     const result = await update<TSlug>(options)

--- a/packages/payload/src/utilities/isolateObjectProperty.ts
+++ b/packages/payload/src/utilities/isolateObjectProperty.ts
@@ -1,7 +1,7 @@
 /**
  * Creates a proxy for the given object that has its own property
  */
-export default function isolateObjectProperty<T>(object: T, key): T {
+export default function isolateObjectProperty<T>(object: T, key: keyof T): T {
   const delegate = {}
   const handler = {
     deleteProperty(target, p): boolean {

--- a/test/collections-graphql/config.ts
+++ b/test/collections-graphql/config.ts
@@ -380,6 +380,29 @@ export default buildConfigWithDefaults({
       ],
     },
   ],
+  globals: [
+    {
+      slug: 'global-1',
+      access: {
+        read: openAccess.read,
+        update: openAccess.update,
+      },
+      fields: [
+        {
+          type: 'text',
+          name: 'title',
+        },
+        {
+          name: 'relationship',
+          type: 'relationship',
+          relationTo: 'cyclical-relationship',
+        },
+      ],
+      versions: {
+        drafts: true,
+      },
+    },
+  ],
   graphQL: {
     queries: (GraphQL) => {
       return {

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -984,6 +984,59 @@ describe('collections-graphql', () => {
         expect(queriedDoc.media.title).toEqual('example')
       })
     })
+
+    it('should cascade draft arg with globals', async () => {
+      // publish relationship doc
+      const newDoc = await payload.create({
+        collection: 'cyclical-relationship',
+        draft: false,
+        data: {
+          title: '1',
+        },
+      })
+
+      // save draft version relationship doc
+      await payload.update({
+        collection: 'cyclical-relationship',
+        id: newDoc.id,
+        draft: true,
+        data: {
+          title: '2',
+        },
+      })
+
+      // update global (published data)
+      await payload.updateGlobal({
+        slug: 'global-1',
+        data: {
+          title: 'published title',
+          relationship: newDoc.id,
+        },
+      })
+
+      // update global (draft data)
+      await payload.updateGlobal({
+        slug: 'global-1',
+        draft: true,
+        data: {
+          title: 'draft title',
+        },
+      })
+
+      const query = `{
+        Global1(draft: true) {
+          title
+          relationship {
+            title
+          }
+        }
+      }`
+      const response = (await client.request(query)) as any
+
+      const queriedGlobal = response.Global1
+      expect(queriedGlobal.title).toEqual('draft title')
+      expect(queriedGlobal.relationship.title).toEqual('2')
+    })
   })
 
   describe('Error Handler', () => {

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -991,7 +991,7 @@ describe('collections-graphql', () => {
         collection: 'cyclical-relationship',
         draft: false,
         data: {
-          title: '1',
+          title: 'published relationship',
         },
       })
 
@@ -1001,7 +1001,7 @@ describe('collections-graphql', () => {
         id: newDoc.id,
         draft: true,
         data: {
-          title: '2',
+          title: 'draft relationship',
         },
       })
 
@@ -1035,7 +1035,7 @@ describe('collections-graphql', () => {
 
       const queriedGlobal = response.Global1
       expect(queriedGlobal.title).toEqual('draft title')
-      expect(queriedGlobal.relationship.title).toEqual('2')
+      expect(queriedGlobal.relationship.title).toEqual('draft relationship')
     })
   })
 


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/6642

Also updates global graphql resolvers to match collection resolvers req formatting.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
