### PR TITLE
fix(ui): global documents disabled after save

### DIFF
--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -354,12 +354,14 @@ export const DocumentInfoProvider: React.FC<
 
       const docPreferences = await getDocPreferences()
 
+      const newData = collectionSlug ? json.doc : json.result
+
       const newState = await getFormState({
         apiRoute: api,
         body: {
           id,
           collectionSlug,
-          data: json.doc,
+          data: newData,
           docPreferences,
           globalSlug,
           locale,
@@ -368,8 +370,6 @@ export const DocumentInfoProvider: React.FC<
         },
         serverURL,
       })
-
-      const newData = json.doc
 
       setInitialState(newState)
       setData(newData)

--- a/test/admin/e2e/1/e2e.spec.ts
+++ b/test/admin/e2e/1/e2e.spec.ts
@@ -619,14 +619,14 @@ describe('admin1', () => {
   })
 
   describe('form state', () => {
-    test('collection — should re-enable fields after saving as completed', async () => {
+    test('collection — should re-enable fields after save', async () => {
       await page.goto(postsUrl.create)
       await page.locator('#field-title').fill(title)
       await saveDocAndAssert(page)
       await expect(page.locator('#field-title')).toBeEnabled()
     })
 
-    test('global — should re-enable fields after saving as completed', async () => {
+    test('global — should re-enable fields after save', async () => {
       await page.goto(globalURL.global(globalSlug))
       await page.locator('#field-title').fill(title)
       await saveDocAndAssert(page)

--- a/test/admin/e2e/1/e2e.spec.ts
+++ b/test/admin/e2e/1/e2e.spec.ts
@@ -69,6 +69,7 @@ describe('admin1', () => {
   let page: Page
   let geoUrl: AdminUrlUtil
   let postsUrl: AdminUrlUtil
+  let globalURL: AdminUrlUtil
   let customViewsURL: AdminUrlUtil
   let disableDuplicateURL: AdminUrlUtil
   let serverURL: string
@@ -87,6 +88,7 @@ describe('admin1', () => {
     }))
     geoUrl = new AdminUrlUtil(serverURL, geoCollectionSlug)
     postsUrl = new AdminUrlUtil(serverURL, postsCollectionSlug)
+    globalURL = new AdminUrlUtil(serverURL, globalSlug)
     customViewsURL = new AdminUrlUtil(serverURL, customViews2CollectionSlug)
     disableDuplicateURL = new AdminUrlUtil(serverURL, disableDuplicateSlug)
 
@@ -616,6 +618,22 @@ describe('admin1', () => {
     })
   })
 
+  describe('form state', () => {
+    test('collection — should re-enable fields after saving as completed', async () => {
+      await page.goto(postsUrl.create)
+      await page.locator('#field-title').fill(title)
+      await saveDocAndAssert(page)
+      await expect(page.locator('#field-title')).toBeEnabled()
+    })
+
+    test('global — should re-enable fields after saving as completed', async () => {
+      await page.goto(globalURL.global(globalSlug))
+      await page.locator('#field-title').fill(title)
+      await saveDocAndAssert(page)
+      await expect(page.locator('#field-title')).toBeEnabled()
+    })
+  })
+
   describe('document titles', () => {
     test('collection — should render fallback titles when creating new', async () => {
       await page.goto(postsUrl.create)
@@ -647,13 +665,17 @@ describe('admin1', () => {
     })
 
     test('global — should render custom, localized label', async () => {
-      await page.goto(postsUrl.admin)
-      await page.waitForURL(postsUrl.admin)
+      await page.goto(globalURL.global(globalSlug))
+      await page.waitForURL(globalURL.global(globalSlug))
       await openNav(page)
       const label = 'My Global Label'
       const globalLabel = page.locator(`#nav-global-global`)
       await expect(globalLabel).toContainText(label)
       await globalLabel.click()
+      await checkPageTitle(page, label)
+      await checkBreadcrumb(page, label)
+      await page.locator('#field-title').fill(title)
+      await saveDocAndAssert(page)
       await checkPageTitle(page, label)
       await checkBreadcrumb(page, label)
     })


### PR DESCRIPTION
## Description

Global documents were getting stuck in the disabled state after saving. This was because the `onSave` callback in the `DocumentInfoProvider` was not handling the response appropriately for globals vs. collections. Original discussion from Discord here: https://discord.com/channels/967097582721572934/1215659716538273832/1247605835673108563

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes