### PR TITLE
docs: adds live preview csp troubleshooting tips

### DIFF
--- a/docs/live-preview/frontend.mdx
+++ b/docs/live-preview/frontend.mdx
@@ -274,3 +274,11 @@ const { data } = useLivePreview<PageType>({
   depth: 1, // Ensure this matches the depth of your initial request
 })
 ```
+
+### Iframe refuses to connect
+
+If your front-end application has set a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP) that blocks the Admin Panel from loading your front-end application, the iframe will not be able to load your site. To resolve this, you can whitelist the Admin Panel's domain in your CSP by setting the `frame-ancestors` directive:
+
+```plaintext
+frame-ancestors: "self" localhost:* https://your-site.com;
+```


### PR DESCRIPTION
## Description

Adds troubleshooting tips to Live Preview docs about potentially blocking Content Security Policies.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
