### PR TITLE
fix: withinCollapsible should be undefined by default

### DIFF
--- a/packages/payload/src/admin/components/elements/Collapsible/provider.tsx
+++ b/packages/payload/src/admin/components/elements/Collapsible/provider.tsx
@@ -10,7 +10,7 @@ const Context = createContext({
   collapsed: false,
   isVisible: true,
   toggle: () => {},
-  withinCollapsible: true,
+  withinCollapsible: undefined,
 })
 
 export const CollapsibleProvider: React.FC<{
@@ -18,7 +18,7 @@ export const CollapsibleProvider: React.FC<{
   collapsed?: boolean
   toggle: () => void
   withinCollapsible?: boolean
-}> = ({ children, collapsed, toggle, withinCollapsible = true }) => {
+}> = ({ children, collapsed, toggle, withinCollapsible }) => {
   const { collapsed: parentIsCollapsed, isVisible } = useCollapsible()
 
   const contextValue = React.useMemo((): ContextType => {

--- a/packages/payload/src/admin/components/elements/Collapsible/provider.tsx
+++ b/packages/payload/src/admin/components/elements/Collapsible/provider.tsx
@@ -10,7 +10,7 @@ const Context = createContext({
   collapsed: false,
   isVisible: true,
   toggle: () => {},
-  withinCollapsible: undefined,
+  withinCollapsible: false,
 })
 
 export const CollapsibleProvider: React.FC<{


### PR DESCRIPTION
## Description

Closes #6658

`withinCollapsible` from the collapsible provider is `true` by default, should be undefined. 

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue
