### PR TITLE
fix: enable SaveDraft button when creating new documents

### DIFF
--- a/packages/payload/src/admin/components/elements/SaveDraft/index.tsx
+++ b/packages/payload/src/admin/components/elements/SaveDraft/index.tsx
@@ -8,7 +8,6 @@ import { useConfig } from '../../utilities/Config'
 import { useDocumentInfo } from '../../utilities/DocumentInfo'
 import { useEditDepth } from '../../utilities/EditDepth'
 import { useLocale } from '../../utilities/Locale'
-import { useOperation } from '../../utilities/OperationProvider'
 import RenderCustomComponent from '../../utilities/RenderCustomComponent'
 
 const baseClass = 'save-draft'
@@ -70,13 +69,12 @@ export const SaveDraft: React.FC<Props> = ({ CustomComponent }) => {
   } = useConfig()
   const { submit } = useForm()
   const { id, collection, global } = useDocumentInfo()
-  const operation = useOperation()
   const modified = useFormModified()
 
   const { code: locale } = useLocale()
   const { t } = useTranslation('version')
 
-  const canSaveDraft = operation === 'update' && modified
+  const canSaveDraft = modified
 
   const saveDraft = useCallback(async () => {
     const search = `?locale=${locale}&depth=0&fallback-locale=null&draft=true`


### PR DESCRIPTION
## Description

Fixes #6671,  which looks like a regression introduced in v2.19.0 that disables the "save draft" button when creating new documents.

https://github.com/payloadcms/payload/commit/8f03cd7c789eda7613ddced0d45a32afe49b1e01#diff-b7c978f47b1f3beff95c78ad95078e600624cbcd7ac10f9378cc4ad6803db244L75-R79


<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
