### PR TITLE
fix: handles localized nested relationship fields in versions

### DIFF
--- a/packages/payload/src/admin/components/views/Version/RenderFieldsToDiff/fields/Relationship/index.tsx
+++ b/packages/payload/src/admin/components/views/Version/RenderFieldsToDiff/fields/Relationship/index.tsx
@@ -3,14 +3,12 @@ import ReactDiffViewer from 'react-diff-viewer-continued'
 import { useTranslation } from 'react-i18next'
 
 import type { SanitizedCollectionConfig } from '../../../../../../../collections/config/types'
-import type { Field, RelationshipField } from '../../../../../../../fields/config/types'
+import type { RelationshipField } from '../../../../../../../fields/config/types'
 import type { Props } from '../types'
 
-import {
-  fieldAffectsData,
-  fieldIsPresentationalOnly,
-} from '../../../../../../../fields/config/types'
+import { fieldAffectsData } from '../../../../../../../fields/config/types'
 import { getTranslation } from '../../../../../../../utilities/getTranslation'
+import { useUseTitleField } from '../../../../../../hooks/useUseAsTitle'
 import { useConfig } from '../../../../../utilities/Config'
 import { useLocale } from '../../../../../utilities/Locale'
 import Label from '../../Label'
@@ -50,34 +48,8 @@ const generateLabelFromValue = (
   if (relatedCollection) {
     const useAsTitle = relatedCollection?.admin?.useAsTitle
 
-    const findFieldRecursively = (fields: Field[], fieldName: string): Field | undefined => {
-      for (const field of fields) {
-        if (
-          'name' in field &&
-          field.name === fieldName &&
-          fieldAffectsData(field) &&
-          !fieldIsPresentationalOnly(field)
-        ) {
-          return field
-        }
-        if ('fields' in field && Array.isArray(field.fields)) {
-          const foundField = findFieldRecursively(field.fields, fieldName)
-          if (foundField) {
-            return foundField
-          }
-        } else if ('tabs' in field && Array.isArray(field.tabs)) {
-          for (const tab of field.tabs) {
-            const foundField = findFieldRecursively(tab.fields, fieldName)
-            if (foundField) {
-              return foundField
-            }
-          }
-        }
-      }
-      return undefined
-    }
-
-    const useAsTitleField = findFieldRecursively(relatedCollection.fields, useAsTitle)
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const useAsTitleField = useUseTitleField(relatedCollection)
 
     let titleFieldIsLocalized = false
 


### PR DESCRIPTION
## Description

### Issue: 

When `localization` is `true` and a `relationship` field is nested, in versions the title of the relationship field was returning as `[Object object]` instead of the correct locale version.

Before:
![Screenshot 2024-06-07 at 3 45 32 PM](https://github.com/payloadcms/payload/assets/35232443/fe5df9fd-f16b-4231-8ad4-b76eb795f6bf)

### Fix:

Recursively loop through fields and find the desired field regardless of its nesting level.

After:
![Screenshot 2024-06-07 at 3 45 48 PM](https://github.com/payloadcms/payload/assets/35232443/d5fc942f-b26f-4bd9-a679-6b77b3e7ec75)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
