### PR TITLE
fix(ui): set checkbox htmlFor by default, fixing some checkbox labels not toggling the checkbox

### DIFF
--- a/packages/ui/src/fields/Checkbox/Input.tsx
+++ b/packages/ui/src/fields/Checkbox/Input.tsx
@@ -78,6 +78,7 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = ({
       </div>
       <FieldLabel
         CustomLabel={CustomLabel}
+        htmlFor={id}
         label={label}
         required={required}
         {...(labelProps || {})}


### PR DESCRIPTION
e.g. in API view