### PR TITLE
fix: missing export for useLeaf hook

### DIFF
--- a/packages/richtext-slate/src/index.tsx
+++ b/packages/richtext-slate/src/index.tsx
@@ -107,6 +107,8 @@ export { ElementButton } from './field/elements/Button.js'
 
 export { toggleElement } from './field/elements/toggle.js'
 export { LeafButton } from './field/leaves/Button.js'
+export { useLeaf } from './field/providers/LeafProvider.js'
+
 export type {
   AdapterArguments,
   ElementNode,


### PR DESCRIPTION
## Description

Hey,
In my project I have custom leaf component for slate editor. Previously `attributes` and `children` were passed via props so I could easily access them. Right now they come from `useLeaf` hook which is missing in the package export.

Previously:
```tsx
const Bold = ({ attributes, children }) => <strong {...attributes}>{children}</strong>

const bold = {
  Button: () => (
    <LeafButton format="bold">
      <BoldIcon />
    </LeafButton>
  ),
  Leaf: Bold,
}
```

Currently:
```tsx
export const Bold = () => {
  const { attributes, children } = useLeaf()
  return <strong {...attributes}>{children}</strong>
}

export const bold: RichTextCustomLeaf = {
  name: 'bold',
  Button: () => (
    <LeafButton format="bold">
      <BoldIcon />
    </LeafButton>
  ),
  Leaf: Bold,
}
```

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
