### PR TITLE
fix: global draft validations

### DIFF
--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -15,6 +15,7 @@ import { getBaseUploadFields } from '../../uploads/getBaseFields.js'
 import { formatLabels } from '../../utilities/formatLabels.js'
 import { isPlainObject } from '../../utilities/isPlainObject.js'
 import baseVersionFields from '../../versions/baseFields.js'
+import { versionDefaults } from '../../versions/defaults.js'
 import { authDefaults, defaults } from './defaults.js'
 
 export const sanitizeCollection = async (
@@ -90,7 +91,7 @@ export const sanitizeCollection = async (
 
       if (sanitized.versions.drafts.autosave === true) {
         sanitized.versions.drafts.autosave = {
-          interval: 2000,
+          interval: versionDefaults.autosaveInterval,
         }
       }
 

--- a/packages/payload/src/exports/versions.ts
+++ b/packages/payload/src/exports/versions.ts
@@ -1,5 +1,6 @@
 export { buildVersionCollectionFields } from '../versions/buildCollectionFields.js'
 export { buildVersionGlobalFields } from '../versions/buildGlobalFields.js'
+export { versionDefaults } from '../versions/defaults.js'
 export { deleteCollectionVersions } from '../versions/deleteCollectionVersions.js'
 export { enforceMaxVersions } from '../versions/enforceMaxVersions.js'
 export { getLatestCollectionVersion } from '../versions/getLatestCollectionVersion.js'

--- a/packages/payload/src/globals/config/sanitize.ts
+++ b/packages/payload/src/globals/config/sanitize.ts
@@ -7,6 +7,7 @@ import { fieldAffectsData } from '../../fields/config/types.js'
 import mergeBaseFields from '../../fields/mergeBaseFields.js'
 import { toWords } from '../../utilities/formatLabels.js'
 import baseVersionFields from '../../versions/baseFields.js'
+import { versionDefaults } from '../../versions/defaults.js'
 
 export const sanitizeGlobals = async (
   config: Config,
@@ -47,13 +48,18 @@ export const sanitizeGlobals = async (
         if (global.versions.drafts === true) {
           global.versions.drafts = {
             autosave: false,
+            validate: false,
           }
         }
 
         if (global.versions.drafts.autosave === true) {
           global.versions.drafts.autosave = {
-            interval: 2000,
+            interval: versionDefaults.autosaveInterval,
           }
+        }
+
+        if (global.versions.drafts.validate === undefined) {
+          global.versions.drafts.validate = false
         }
 
         global.fields = mergeBaseFields(global.fields, baseVersionFields)

--- a/packages/payload/src/globals/config/schema.ts
+++ b/packages/payload/src/globals/config/schema.ts
@@ -90,6 +90,7 @@ const globalSchema = joi
                 interval: joi.number(),
               }),
             ),
+            validate: joi.boolean(),
           }),
           joi.boolean(),
         ),

--- a/packages/payload/src/globals/operations/update.ts
+++ b/packages/payload/src/globals/operations/update.ts
@@ -167,7 +167,8 @@ export const updateOperation = async <TSlug extends keyof GeneratedTypes['global
       global: globalConfig,
       operation: 'update',
       req,
-      skipValidation: shouldSaveDraft,
+      skipValidation:
+        shouldSaveDraft && globalConfig.versions.drafts && !globalConfig.versions.drafts.validate,
     })
 
     // /////////////////////////////////////

--- a/packages/payload/src/versions/defaults.ts
+++ b/packages/payload/src/versions/defaults.ts
@@ -1,0 +1,3 @@
+export const versionDefaults = {
+  autosaveInterval: 2000,
+}

--- a/packages/ui/src/utilities/reduceFieldsToValuesWithValidation.ts
+++ b/packages/ui/src/utilities/reduceFieldsToValuesWithValidation.ts
@@ -1,0 +1,42 @@
+import type { Data, FormState } from 'payload/types'
+
+import flatleyImport from 'flatley'
+const { unflatten: flatleyUnflatten } = flatleyImport
+
+type ReturnType = {
+  data: Data
+  valid: boolean
+}
+
+/**
+ * Reduce flattened form fields (Fields) to just map to the respective values instead of the full FormField object
+ *
+ * @param unflatten This also unflattens the data if `unflatten` is true. The unflattened data should match the original data structure
+ * @param ignoreDisableFormData - if true, will include fields that have `disableFormData` set to true, for example, blocks or arrays fields.
+ *
+ */
+export const reduceFieldsToValuesWithValidation = (
+  fields: FormState,
+  unflatten?: boolean,
+  ignoreDisableFormData?: boolean,
+): ReturnType => {
+  const state: ReturnType = {
+    data: {},
+    valid: true,
+  }
+
+  if (!fields) return state
+
+  Object.keys(fields).forEach((key) => {
+    if (ignoreDisableFormData === true || !fields[key]?.disableFormData) {
+      state.data[key] = fields[key]?.value
+      if (!fields[key].valid) state.valid = false
+    }
+  })
+
+  if (unflatten) {
+    state.data = flatleyUnflatten(state.data, { safe: true })
+  }
+
+  return state
+}

--- a/test/field-error-states/config.ts
+++ b/test/field-error-states/config.ts
@@ -5,6 +5,7 @@ import Uploads from './collections/Upload/index.js'
 import { ValidateDraftsOff } from './collections/ValidateDraftsOff/index.js'
 import { ValidateDraftsOn } from './collections/ValidateDraftsOn/index.js'
 import { ValidateDraftsOnAndAutosave } from './collections/ValidateDraftsOnAutosave/index.js'
+import { GlobalValidateDraftsOn } from './globals/ValidateDraftsOn/index.js'
 
 export default buildConfigWithDefaults({
   collections: [
@@ -14,6 +15,7 @@ export default buildConfigWithDefaults({
     ValidateDraftsOff,
     ValidateDraftsOnAndAutosave,
   ],
+  globals: [GlobalValidateDraftsOn],
   onInit: async (payload) => {
     await payload.create({
       collection: 'users',

--- a/test/field-error-states/globals/ValidateDraftsOn/index.ts
+++ b/test/field-error-states/globals/ValidateDraftsOn/index.ts
@@ -1,0 +1,26 @@
+import type { GlobalConfig } from 'payload/types'
+
+import { slugs } from '../../shared.js'
+
+export const GlobalValidateDraftsOn: GlobalConfig = {
+  slug: slugs.globalValidateDraftsOn,
+  fields: [
+    {
+      name: 'group',
+      type: 'group',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          required: true,
+        },
+      ],
+    },
+  ],
+  versions: {
+    drafts: {
+      validate: true,
+      autosave: true,
+    },
+  },
+}

--- a/test/field-error-states/shared.ts
+++ b/test/field-error-states/shared.ts
@@ -1,4 +1,5 @@
 export const slugs = {
+  globalValidateDraftsOn: 'global-validate-drafts-on',
   validateDraftsOn: 'validate-drafts-on',
   validateDraftsOnAutosave: 'validate-drafts-on-autosave',
   validateDraftsOff: 'validate-drafts-off',


### PR DESCRIPTION
## Description

Extends draft validation from https://github.com/payloadcms/payload/pull/6677 to work with globals as well.

Fixes bug from https://github.com/payloadcms/payload/pull/6677 where autosave was not saving properly after first autosave.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
