### PR TITLE
fix: re-exports graphql json types for external use

### DIFF
--- a/packages/graphql/src/exports/types.ts
+++ b/packages/graphql/src/exports/types.ts
@@ -1,0 +1,1 @@
+export { GraphQLJSON, GraphQLJSONObject } from '../packages/graphql-type-json/index.js'

--- a/test/custom-graphql/config.ts
+++ b/test/custom-graphql/config.ts
@@ -1,3 +1,4 @@
+import { GraphQLJSON } from '@payloadcms/graphql/types'
 import { commitTransaction, initTransaction, killTransaction } from 'payload/database'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
@@ -30,6 +31,11 @@ export default buildConfigWithDefaults({
         TransactionID2: {
           type: GraphQL.GraphQLString,
           resolve: resolveTransactionId,
+        },
+        foo: {
+          type: GraphQLJSON,
+          args: {},
+          resolve: () => 'json test',
         },
       }
     },


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/6683

Exports import `GraphQLJSON` and `GraphQLJSONObject` from `@payloadcms/graphql/types`

```ts
import { GraphQLJSON, GraphQLJSONObject } from '@payloadcms/graphql/types'
```

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
