### PR TITLE
fix: only use `metadata.pages` for height if animated

### DIFF
--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -219,7 +219,7 @@ export const generateFileData = async <T>({
       fileData.height = info.height
       if (fileIsAnimated) {
         const metadata = await sharpFile.metadata()
-        fileData.height = info.height / metadata.pages
+        fileData.height = metadata.pages ? info.height / metadata.pages : info.height
       }
       fileData.filesize = info.size
 

--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -364,7 +364,7 @@ export async function resizeAndTransformImageSizes({
         name: imageResizeConfig.name,
         filename: imageNameWithDimensions,
         filesize: size,
-        height: fileIsAnimated ? height / metadata.pages : height,
+        height: fileIsAnimated && metadata.pages ? height / metadata.pages : height,
         mimeType: mimeInfo?.mime || mimeType,
         sizesToSave: [{ buffer: bufferData, path: imagePath }],
         width,


### PR DESCRIPTION
## Description

### Issue: 

Non-animated webp / gif files were using `metadata.pages` to calculate it's resized heights for `imageSizes` or `cropping`.

### Fix: 

It should only use this to calculate it's height if the file's `metadata` contains `metadata.pages`. Non-animated webps and gifs would not have this.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
