### PR TITLE
fix(db-postgres): add `ON DELETE CASCADE` to foreign key constraint of select hasMany relationship

### DIFF
--- a/packages/db-postgres/src/schema/traverseFields.ts
+++ b/packages/db-postgres/src/schema/traverseFields.ts
@@ -264,7 +264,7 @@ export const traverseFields = ({
                 name: `${selectTableName}_parent_fk`,
                 columns: [cols.parent],
                 foreignColumns: [adapter.tables[parentTableName].id],
-              }),
+              }).onDelete('cascade'),
             parentIdx: (cols) => index(`${selectTableName}_parent_idx`).on(cols.parent),
           }
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -37,6 +37,7 @@ import {
   tabsFieldsSlug,
   textFieldsSlug,
 } from './slugs'
+import { NotFound } from '../../packages/payload/src/errors'
 
 let client: RESTClient
 let graphQLClient: GraphQLClient
@@ -344,6 +345,26 @@ describe('Fields', () => {
 
       expect(Array.isArray(updatedDoc.selectHasMany)).toBe(true)
       expect(updatedDoc.selectHasMany).toEqual(['one', 'two'])
+    })
+
+    // https://github.com/payloadcms/payload/issues/6485
+    it('delete with selectHasMany relationship', async () => {
+      const { id } = await payload.create({
+        collection: 'select-fields',
+        data: {
+          selectHasMany: ['one', 'two'],
+        },
+      })
+      await payload.delete({
+        collection: 'select-fields',
+        id,
+      })
+      await expect(
+        payload.findByID({
+          collection: 'select-fields',
+          id,
+        }),
+      ).rejects.toThrow(NotFound)
     })
 
     it('should query hasMany in', async () => {


### PR DESCRIPTION
## Description

This PR fixes https://github.com/payloadcms/payload/issues/6485.

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
