### PR TITLE
fix: adjust version status pill when unpublished

### DIFF
--- a/packages/payload/src/admin/components/views/Version/Version.tsx
+++ b/packages/payload/src/admin/components/views/Version/Version.tsx
@@ -138,7 +138,7 @@ const VersionView: React.FC<Props> = ({ collection, global }) => {
     const publishedNewerThanDraft = formattedPublished?.updatedAt > formattedDraft?.updatedAt
 
     setLatestDraftVersion(publishedNewerThanDraft ? undefined : formattedDraft?.id)
-    setLatestPublishedVersion(publishedNewerThanDraft ? formattedPublished?.id : undefined)
+    setLatestPublishedVersion(formattedPublished.latest ? formattedPublished?.id : undefined)
   }, [draft, published])
 
   useEffect(() => {

--- a/packages/payload/src/admin/components/views/Version/Version.tsx
+++ b/packages/payload/src/admin/components/views/Version/Version.tsx
@@ -138,7 +138,7 @@ const VersionView: React.FC<Props> = ({ collection, global }) => {
     const publishedNewerThanDraft = formattedPublished?.updatedAt > formattedDraft?.updatedAt
 
     setLatestDraftVersion(publishedNewerThanDraft ? undefined : formattedDraft?.id)
-    setLatestPublishedVersion(formattedPublished?.id)
+    setLatestPublishedVersion(publishedNewerThanDraft ? formattedPublished?.id : undefined)
   }, [draft, published])
 
   useEffect(() => {

--- a/packages/payload/src/admin/components/views/Versions/cells/AutosaveCell.tsx
+++ b/packages/payload/src/admin/components/views/Versions/cells/AutosaveCell.tsx
@@ -11,7 +11,6 @@ type AutosaveCellProps = {
 }
 
 export const renderPill = (data, latestVersion, currentLabel, previousLabel, pillStyle) => {
-  console.log(data.id === latestVersion)
   return (
     <React.Fragment>
       {data?.id === latestVersion ? (

--- a/packages/payload/src/admin/components/views/Versions/index.tsx
+++ b/packages/payload/src/admin/components/views/Versions/index.tsx
@@ -123,7 +123,7 @@ const VersionsView: React.FC<IndexProps> = (props) => {
 
     const publishedNewerThanDraft = formattedPublished?.updatedAt > formattedDraft?.updatedAt
     setLatestDraftVersion(publishedNewerThanDraft ? undefined : formattedDraft?.id)
-    setLatestPublishedVersion(formattedPublished?.id)
+    setLatestPublishedVersion(publishedNewerThanDraft ? formattedPublished?.id : undefined)
   }, [draft, published])
 
   useEffect(() => {

--- a/packages/payload/src/admin/components/views/Versions/index.tsx
+++ b/packages/payload/src/admin/components/views/Versions/index.tsx
@@ -123,7 +123,7 @@ const VersionsView: React.FC<IndexProps> = (props) => {
 
     const publishedNewerThanDraft = formattedPublished?.updatedAt > formattedDraft?.updatedAt
     setLatestDraftVersion(publishedNewerThanDraft ? undefined : formattedDraft?.id)
-    setLatestPublishedVersion(publishedNewerThanDraft ? formattedPublished?.id : undefined)
+    setLatestPublishedVersion(formattedPublished.latest ? formattedPublished?.id : undefined)
   }, [draft, published])
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Versions that have been published then unpublished still showed the `current published version` pill - these need to be `previously published`.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes