### PR TITLE
chore(eslint): consolidates and prevents duplicate imports 

### DIFF
--- a/packages/create-payload-app/src/lib/configure-payload-config.ts
+++ b/packages/create-payload-app/src/lib/configure-payload-config.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import type { DbType, StorageAdapterType } from '../types.js'
 
 import { warning } from '../utils/log.js'
-import { configReplacements, dbReplacements, storageReplacements } from './replacements.js'
+import { dbReplacements, storageReplacements } from './replacements.js'
 
 /** Update payload config with necessary imports and adapters */
 export async function configurePayloadConfig(args: {
@@ -15,8 +15,8 @@ export async function configurePayloadConfig(args: {
   }
   packageJsonName?: string
   projectDirOrConfigPath: { payloadConfigPath: string } | { projectDir: string }
-  storageAdapter?: StorageAdapterType
   sharp?: boolean
+  storageAdapter?: StorageAdapterType
 }): Promise<void> {
   if (!args.dbType) {
     return
@@ -93,32 +93,32 @@ export async function configurePayloadConfig(args: {
     const dbReplacement = dbReplacements[args.dbType]
 
     configLines = replaceInConfigLines({
-      replacement: dbReplacement.configReplacement(args.envNames?.dbUri),
-      startMatch: `// database-adapter-config-start`,
       endMatch: `// database-adapter-config-end`,
       lines: configLines,
+      replacement: dbReplacement.configReplacement(args.envNames?.dbUri),
+      startMatch: `// database-adapter-config-start`,
     })
 
     configLines = replaceInConfigLines({
+      lines: configLines,
       replacement: [dbReplacement.importReplacement],
       startMatch: '// database-adapter-import',
-      lines: configLines,
     })
 
     // Storage Adapter Replacement
     if (args.storageAdapter) {
       const replacement = storageReplacements[args.storageAdapter]
       configLines = replaceInConfigLines({
+        lines: configLines,
         replacement: replacement.configReplacement,
         startMatch: '// storage-adapter-placeholder',
-        lines: configLines,
       })
 
       if (replacement?.importReplacement) {
         configLines = replaceInConfigLines({
+          lines: configLines,
           replacement: [replacement.importReplacement],
           startMatch: '// storage-adapter-import-placeholder',
-          lines: configLines,
         })
       }
     }
@@ -126,14 +126,14 @@ export async function configurePayloadConfig(args: {
     // Sharp Replacement (provided by default, only remove if explicitly set to false)
     if (args.sharp === false) {
       configLines = replaceInConfigLines({
+        lines: configLines,
         replacement: [],
         startMatch: 'sharp,',
-        lines: configLines,
       })
       configLines = replaceInConfigLines({
+        lines: configLines,
         replacement: [],
         startMatch: "import sharp from 'sharp'",
-        lines: configLines,
       })
     }
 
@@ -146,16 +146,16 @@ export async function configurePayloadConfig(args: {
 }
 
 function replaceInConfigLines({
-  replacement,
-  startMatch,
   endMatch,
   lines,
+  replacement,
+  startMatch,
 }: {
-  replacement: string[]
-  startMatch: string
   /** Optional endMatch to replace multiple lines */
   endMatch?: string
   lines: string[]
+  replacement: string[]
+  startMatch: string
 }) {
   if (!replacement) {
     return lines

--- a/packages/create-payload-app/src/lib/replacements.ts
+++ b/packages/create-payload-app/src/lib/replacements.ts
@@ -66,9 +66,9 @@ const diskReplacement: StorageAdapterReplacement = {
 }
 
 export const storageReplacements: Record<StorageAdapterType, StorageAdapterReplacement> = {
+  localDisk: diskReplacement,
   payloadCloud: payloadCloudReplacement,
   vercelBlobStorage: vercelBlobStorageReplacement,
-  localDisk: diskReplacement,
 }
 
 /**

--- a/packages/create-payload-app/src/lib/wrap-next-config.ts
+++ b/packages/create-payload-app/src/lib/wrap-next-config.ts
@@ -4,8 +4,7 @@ import chalk from 'chalk'
 import { Syntax, parseModule } from 'esprima-next'
 import fs from 'fs'
 
-import { warning } from '../utils/log.js'
-import { log } from '../utils/log.js'
+import { log , warning } from '../utils/log.js'
 
 export const withPayloadStatement = {
   cjs: `const { withPayload } = require('@payloadcms/next/withPayload')\n`,

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -77,4 +77,4 @@ export type NextAppDetails = {
 
 export type NextConfigType = 'cjs' | 'esm'
 
-export type StorageAdapterType = 'payloadCloud' | 'vercelBlobStorage' | 'localDisk'
+export type StorageAdapterType = 'localDisk' | 'payloadCloud' | 'vercelBlobStorage'

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -3,8 +3,7 @@ import chalk from 'chalk'
 import path from 'path'
 import terminalLink from 'terminal-link'
 
-import type { ProjectTemplate } from '../types.js'
-import type { PackageManager } from '../types.js'
+import type { PackageManager , ProjectTemplate } from '../types.js'
 
 import { getValidTemplates } from '../lib/templates.js'
 

--- a/packages/db-mongodb/src/createGlobalVersion.ts
+++ b/packages/db-mongodb/src/createGlobalVersion.ts
@@ -1,6 +1,5 @@
 import type { CreateGlobalVersion } from 'payload/database'
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Document } from 'payload/types'
+import type { Document , PayloadRequestWithData } from 'payload/types'
 
 import type { MongooseAdapter } from './index.js'
 

--- a/packages/db-mongodb/src/createVersion.ts
+++ b/packages/db-mongodb/src/createVersion.ts
@@ -1,6 +1,5 @@
 import type { CreateVersion } from 'payload/database'
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Document } from 'payload/types'
+import type { Document , PayloadRequestWithData } from 'payload/types'
 
 import type { MongooseAdapter } from './index.js'
 

--- a/packages/db-mongodb/src/deleteOne.ts
+++ b/packages/db-mongodb/src/deleteOne.ts
@@ -1,6 +1,5 @@
 import type { DeleteOne } from 'payload/database'
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Document } from 'payload/types'
+import type { Document , PayloadRequestWithData } from 'payload/types'
 
 import type { MongooseAdapter } from './index.js'
 

--- a/packages/db-mongodb/src/findOne.ts
+++ b/packages/db-mongodb/src/findOne.ts
@@ -1,7 +1,6 @@
 import type { MongooseQueryOptions } from 'mongoose'
 import type { FindOne } from 'payload/database'
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Document } from 'payload/types'
+import type { Document , PayloadRequestWithData } from 'payload/types'
 
 import type { MongooseAdapter } from './index.js'
 

--- a/packages/db-mongodb/src/queries/buildSearchParams.ts
+++ b/packages/db-mongodb/src/queries/buildSearchParams.ts
@@ -1,13 +1,11 @@
 import type { Payload } from 'payload'
 import type { PathToQuery } from 'payload/database'
-import type { Field } from 'payload/types'
-import type { Operator } from 'payload/types'
+import type { Field , Operator } from 'payload/types'
 
 import ObjectIdImport from 'bson-objectid'
 import mongoose from 'mongoose'
 import { getLocalizedPaths } from 'payload/database'
-import { fieldAffectsData } from 'payload/types'
-import { validOperators } from 'payload/types'
+import { fieldAffectsData , validOperators } from 'payload/types'
 
 import type { MongooseAdapter } from '../index.js'
 

--- a/packages/db-mongodb/src/queries/parseParams.ts
+++ b/packages/db-mongodb/src/queries/parseParams.ts
@@ -2,8 +2,7 @@
 /* eslint-disable no-await-in-loop */
 import type { FilterQuery } from 'mongoose'
 import type { Payload } from 'payload'
-import type { Operator, Where } from 'payload/types'
-import type { Field } from 'payload/types'
+import type { Field, Operator , Where } from 'payload/types'
 
 import deepmerge from 'deepmerge'
 import { validOperators } from 'payload/types'

--- a/packages/eslint-config-payload/eslint-config/index.js
+++ b/packages/eslint-config-payload/eslint-config/index.js
@@ -10,7 +10,7 @@ const baseRules = {
   'no-use-before-define': 'off',
   'object-shorthand': 'warn',
   'no-useless-escape': 'warn',
-  'import/no-duplicates': 'error',
+  'import/no-duplicates': 'warn',
   'perfectionist/sort-objects': [
     'error',
     {

--- a/packages/eslint-config-payload/eslint-config/index.js
+++ b/packages/eslint-config-payload/eslint-config/index.js
@@ -10,6 +10,7 @@ const baseRules = {
   'no-use-before-define': 'off',
   'object-shorthand': 'warn',
   'no-useless-escape': 'warn',
+  'import/no-duplicates': 'error',
   'perfectionist/sort-objects': [
     'error',
     {
@@ -123,7 +124,7 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
-  plugins: [], // Plugins are defined in the overrides to be more specific and only target the files they are meant for.
+  plugins: ['import'], // Plugins are defined in the overrides to be more specific and only target the files they are meant for.
   overrides: [
     {
       files: ['**/*.ts'],

--- a/packages/eslint-config-payload/package.json
+++ b/packages/eslint-config-payload/package.json
@@ -21,6 +21,7 @@
     "@typescript-eslint/parser": "7.3.1",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
+    "eslint-plugin-import": "2.25.2",
     "eslint-plugin-jest": "27.9.0",
     "eslint-plugin-jest-dom": "5.1.0",
     "eslint-plugin-jsx-a11y": "6.8.0",

--- a/packages/graphql/src/resolvers/collections/count.ts
+++ b/packages/graphql/src/resolvers/collections/count.ts
@@ -1,5 +1,4 @@
-import type { PayloadRequestWithData, Where } from 'payload/types'
-import type { Collection } from 'payload/types'
+import type { Collection, PayloadRequestWithData , Where } from 'payload/types'
 
 import { countOperation } from 'payload/operations'
 import { isolateObjectProperty } from 'payload/utilities'

--- a/packages/graphql/src/resolvers/collections/create.ts
+++ b/packages/graphql/src/resolvers/collections/create.ts
@@ -1,6 +1,5 @@
 import type { GeneratedTypes } from 'payload'
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Collection } from 'payload/types'
+import type { Collection , PayloadRequestWithData } from 'payload/types'
 import type { MarkOptional } from 'ts-essentials'
 
 import { createOperation } from 'payload/operations'

--- a/packages/graphql/src/resolvers/collections/delete.ts
+++ b/packages/graphql/src/resolvers/collections/delete.ts
@@ -1,6 +1,5 @@
 import type { GeneratedTypes } from 'payload'
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Collection } from 'payload/types'
+import type { Collection , PayloadRequestWithData } from 'payload/types'
 
 import { deleteByIDOperation } from 'payload/operations'
 import { isolateObjectProperty } from 'payload/utilities'

--- a/packages/graphql/src/resolvers/collections/duplicate.ts
+++ b/packages/graphql/src/resolvers/collections/duplicate.ts
@@ -1,6 +1,5 @@
 import type { GeneratedTypes } from 'payload'
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Collection } from 'payload/types'
+import type { Collection , PayloadRequestWithData } from 'payload/types'
 
 import { duplicateOperation } from 'payload/operations'
 import { isolateObjectProperty } from 'payload/utilities'

--- a/packages/graphql/src/resolvers/collections/find.ts
+++ b/packages/graphql/src/resolvers/collections/find.ts
@@ -1,6 +1,5 @@
 import type { PaginatedDocs } from 'payload/database'
-import type { PayloadRequestWithData, Where } from 'payload/types'
-import type { Collection } from 'payload/types'
+import type { Collection, PayloadRequestWithData , Where } from 'payload/types'
 
 import { findOperation } from 'payload/operations'
 import { isolateObjectProperty } from 'payload/utilities'

--- a/packages/graphql/src/resolvers/collections/findByID.ts
+++ b/packages/graphql/src/resolvers/collections/findByID.ts
@@ -1,6 +1,5 @@
 import type { GeneratedTypes } from 'payload'
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Collection } from 'payload/types'
+import type { Collection , PayloadRequestWithData } from 'payload/types'
 
 import { findByIDOperation } from 'payload/operations'
 import { isolateObjectProperty } from 'payload/utilities'

--- a/packages/graphql/src/resolvers/collections/findVersionByID.ts
+++ b/packages/graphql/src/resolvers/collections/findVersionByID.ts
@@ -1,5 +1,4 @@
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Collection, TypeWithID } from 'payload/types'
+import type { Collection , PayloadRequestWithData, TypeWithID } from 'payload/types'
 import type { TypeWithVersion } from 'payload/versions'
 
 import { findVersionByIDOperation } from 'payload/operations'

--- a/packages/graphql/src/resolvers/collections/findVersions.ts
+++ b/packages/graphql/src/resolvers/collections/findVersions.ts
@@ -1,6 +1,5 @@
 import type { PaginatedDocs } from 'payload/database'
-import type { PayloadRequestWithData, Where } from 'payload/types'
-import type { Collection } from 'payload/types'
+import type { Collection, PayloadRequestWithData , Where } from 'payload/types'
 
 import { findVersionsOperation } from 'payload/operations'
 import { isolateObjectProperty } from 'payload/utilities'

--- a/packages/graphql/src/resolvers/collections/restoreVersion.ts
+++ b/packages/graphql/src/resolvers/collections/restoreVersion.ts
@@ -1,5 +1,4 @@
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Collection } from 'payload/types'
+import type { Collection , PayloadRequestWithData } from 'payload/types'
 
 import { restoreVersionOperation } from 'payload/operations'
 import { isolateObjectProperty } from 'payload/utilities'

--- a/packages/graphql/src/resolvers/collections/update.ts
+++ b/packages/graphql/src/resolvers/collections/update.ts
@@ -1,6 +1,5 @@
 import type { GeneratedTypes } from 'payload'
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Collection } from 'payload/types'
+import type { Collection , PayloadRequestWithData } from 'payload/types'
 
 import { updateByIDOperation } from 'payload/operations'
 import { isolateObjectProperty } from 'payload/utilities'

--- a/packages/graphql/src/schema/buildMutationInputType.ts
+++ b/packages/graphql/src/schema/buildMutationInputType.ts
@@ -37,8 +37,7 @@ import {
   GraphQLString,
 } from 'graphql'
 import { fieldAffectsData, optionIsObject, tabHasName } from 'payload/types'
-import { toWords } from 'payload/utilities'
-import { flattenTopLevelFields } from 'payload/utilities'
+import { flattenTopLevelFields , toWords } from 'payload/utilities'
 
 import { GraphQLJSON } from '../packages/graphql-type-json/index.js'
 import combineParentName from '../utilities/combineParentName.js'

--- a/packages/next/src/routes/rest/auth/refresh.ts
+++ b/packages/next/src/routes/rest/auth/refresh.ts
@@ -1,6 +1,5 @@
 import httpStatus from 'http-status'
-import { extractJWT } from 'payload/auth'
-import { generatePayloadCookie } from 'payload/auth'
+import { extractJWT , generatePayloadCookie } from 'payload/auth'
 import { refreshOperation } from 'payload/operations'
 
 import type { CollectionRouteHandler } from '../types.js'

--- a/packages/next/src/utilities/createPayloadRequest.ts
+++ b/packages/next/src/utilities/createPayloadRequest.ts
@@ -1,8 +1,7 @@
 import type { CustomPayloadRequestProperties, PayloadRequest, SanitizedConfig } from 'payload/types'
 
 import { initI18n } from '@payloadcms/translations'
-import { executeAuthStrategies } from 'payload/auth'
-import { parseCookies } from 'payload/auth'
+import { executeAuthStrategies , parseCookies } from 'payload/auth'
 import { getDataLoader } from 'payload/utilities'
 import qs from 'qs'
 import { URL } from 'url'

--- a/packages/next/src/utilities/meta.ts
+++ b/packages/next/src/utilities/meta.ts
@@ -2,8 +2,7 @@ import type { Metadata } from 'next'
 import type { Icon } from 'next/dist/lib/metadata/types/metadata-types.js'
 import type { MetaConfig } from 'payload/config'
 
-import { staticOGImage } from '@payloadcms/ui/assets'
-import { payloadFaviconDark, payloadFaviconLight } from '@payloadcms/ui/assets'
+import { payloadFaviconDark , payloadFaviconLight, staticOGImage } from '@payloadcms/ui/assets'
 import QueryString from 'qs'
 
 const defaultOpenGraph = {

--- a/packages/next/src/views/Version/Default/types.ts
+++ b/packages/next/src/views/Version/Default/types.ts
@@ -1,6 +1,5 @@
 import type { CollectionPermission, GlobalPermission } from 'payload/auth'
-import type { OptionObject } from 'payload/types'
-import type { Document } from 'payload/types'
+import type { Document , OptionObject } from 'payload/types'
 
 export type CompareOption = {
   label: string

--- a/packages/payload/src/auth/operations/local/login.ts
+++ b/packages/payload/src/auth/operations/local/login.ts
@@ -1,5 +1,4 @@
-import type { Payload, RequestContext } from '../../../index.js'
-import type { GeneratedTypes } from '../../../index.js'
+import type { GeneratedTypes, Payload , RequestContext } from '../../../index.js'
 import type { PayloadRequestWithData } from '../../../types/index.js'
 import type { Result } from '../login.js'
 

--- a/packages/payload/src/auth/operations/local/resetPassword.ts
+++ b/packages/payload/src/auth/operations/local/resetPassword.ts
@@ -1,5 +1,4 @@
-import type { Payload, RequestContext } from '../../../index.js'
-import type { GeneratedTypes } from '../../../index.js'
+import type { GeneratedTypes, Payload , RequestContext } from '../../../index.js'
 import type { PayloadRequestWithData } from '../../../types/index.js'
 import type { Result } from '../resetPassword.js'
 

--- a/packages/payload/src/auth/operations/local/unlock.ts
+++ b/packages/payload/src/auth/operations/local/unlock.ts
@@ -1,5 +1,4 @@
-import type { Payload, RequestContext } from '../../../index.js'
-import type { GeneratedTypes } from '../../../index.js'
+import type { GeneratedTypes, Payload , RequestContext } from '../../../index.js'
 import type { PayloadRequestWithData } from '../../../types/index.js'
 
 import { APIError } from '../../../errors/index.js'

--- a/packages/payload/src/auth/operations/local/verifyEmail.ts
+++ b/packages/payload/src/auth/operations/local/verifyEmail.ts
@@ -1,5 +1,4 @@
-import type { Payload, RequestContext } from '../../../index.js'
-import type { GeneratedTypes } from '../../../index.js'
+import type { GeneratedTypes, Payload , RequestContext } from '../../../index.js'
 import type { PayloadRequestWithData } from '../../../types/index.js'
 
 import { APIError } from '../../../errors/index.js'

--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -2,8 +2,7 @@ import jwt from 'jsonwebtoken'
 import url from 'url'
 
 import type { BeforeOperationHook, Collection } from '../../collections/config/types.js'
-import type { PayloadRequestWithData } from '../../types/index.js'
-import type { Document } from '../../types/index.js'
+import type { Document , PayloadRequestWithData } from '../../types/index.js'
 
 import { buildAfterOperation } from '../../collections/operations/utils.js'
 import { Forbidden } from '../../errors/index.js'

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -1,7 +1,6 @@
 import type { MarkOptional } from 'ts-essentials'
 
-import type { GeneratedTypes } from '../../../index.js'
-import type { Payload } from '../../../index.js'
+import type { GeneratedTypes , Payload } from '../../../index.js'
 import type { Document, PayloadRequestWithData, RequestContext } from '../../../types/index.js'
 import type { File } from '../../../uploads/types.js'
 

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -1,7 +1,5 @@
-import type { Payload } from '../../../index.js'
-import type { GeneratedTypes } from '../../../index.js'
-import type { PayloadRequestWithData, RequestContext } from '../../../types/index.js'
-import type { Document, Where } from '../../../types/index.js'
+import type { GeneratedTypes , Payload } from '../../../index.js'
+import type { Document, PayloadRequestWithData , RequestContext, Where } from '../../../types/index.js'
 import type { BulkOperationResult } from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -19,8 +19,7 @@ import type {
 } from '../../config/types.js'
 import type { DBIdentifierName } from '../../database/types.js'
 import type { Field } from '../../fields/config/types.js'
-import type { PayloadRequestWithData, RequestContext } from '../../types/index.js'
-import type { Where } from '../../types/index.js'
+import type { PayloadRequestWithData, RequestContext , Where } from '../../types/index.js'
 import type { IncomingGlobalVersions, SanitizedGlobalVersions } from '../../versions/types.js'
 
 export type TypeWithID = {

--- a/packages/plugin-cloud-storage/src/adapters/vercelBlob/staticHandler.ts
+++ b/packages/plugin-cloud-storage/src/adapters/vercelBlob/staticHandler.ts
@@ -1,5 +1,5 @@
 import type { StaticHandler } from '@payloadcms/plugin-cloud-storage/types'
-import type { CollectionConfig, PayloadRequestWithData, UploadConfig } from 'payload/types'
+import type { CollectionConfig } from 'payload/types'
 
 import { head } from '@vercel/blob'
 import path from 'path'
@@ -17,7 +17,7 @@ export const getStaticHandler = (
 ): StaticHandler => {
   return async (req, { params: { filename } }) => {
     try {
-      const prefix = await getFilePrefix({ collection, req, filename })
+      const prefix = await getFilePrefix({ collection, filename, req })
 
       const fileUrl = `${baseUrl}/${path.posix.join(prefix, filename)}`
 

--- a/packages/plugin-cloud-storage/src/admin/fields/getFields.ts
+++ b/packages/plugin-cloud-storage/src/admin/fields/getFields.ts
@@ -1,5 +1,4 @@
-import type { GroupField, TextField } from 'payload/types'
-import type { CollectionConfig, Field } from 'payload/types'
+import type { CollectionConfig, Field , GroupField, TextField } from 'payload/types'
 
 import path from 'path'
 

--- a/packages/plugin-cloud-storage/src/fields/getFields.ts
+++ b/packages/plugin-cloud-storage/src/fields/getFields.ts
@@ -1,5 +1,4 @@
-import type { GroupField, TextField } from 'payload/types'
-import type { CollectionConfig, Field } from 'payload/types'
+import type { CollectionConfig, Field , GroupField, TextField } from 'payload/types'
 
 import path from 'path'
 

--- a/packages/plugin-cloud-storage/src/hooks/afterDelete.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterDelete.ts
@@ -1,5 +1,4 @@
-import type { FileData, TypeWithID } from 'payload/types'
-import type { CollectionAfterDeleteHook, CollectionConfig } from 'payload/types'
+import type { CollectionAfterDeleteHook, CollectionConfig , FileData, TypeWithID } from 'payload/types'
 
 import type { GeneratedAdapter, TypeWithPrefix } from '../types.js'
 

--- a/packages/plugin-cloud-storage/src/hooks/beforeChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/beforeChange.ts
@@ -1,5 +1,4 @@
-import type { FileData, TypeWithID } from 'payload/types'
-import type { CollectionBeforeChangeHook, CollectionConfig } from 'payload/types'
+import type { CollectionBeforeChangeHook, CollectionConfig , FileData, TypeWithID } from 'payload/types'
 
 import type { GeneratedAdapter } from '../types.js'
 

--- a/packages/plugin-cloud-storage/src/types.ts
+++ b/packages/plugin-cloud-storage/src/types.ts
@@ -1,6 +1,4 @@
-import type { Field, FileData, ImageSize } from 'payload/types'
-import type { TypeWithID } from 'payload/types'
-import type { CollectionConfig, PayloadRequestWithData } from 'payload/types'
+import type { CollectionConfig, Field, FileData , ImageSize , PayloadRequestWithData, TypeWithID } from 'payload/types'
 
 export interface File {
   buffer: Buffer

--- a/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
@@ -2,12 +2,12 @@ import type { CollectionConfig, PayloadRequestWithData, UploadConfig } from 'pay
 
 export async function getFilePrefix({
   collection,
-  req,
   filename,
+  req,
 }: {
   collection: CollectionConfig
-  req: PayloadRequestWithData
   filename: string
+  req: PayloadRequestWithData
 }): Promise<string> {
   const imageSizes = (collection?.upload as UploadConfig)?.imageSizes || []
 

--- a/packages/richtext-lexical/src/field/features/link/nodes/LinkNode.ts
+++ b/packages/richtext-lexical/src/field/features/link/nodes/LinkNode.ts
@@ -1,5 +1,4 @@
-import type { BaseSelection } from 'lexical'
-import type {
+import type { BaseSelection ,
   DOMConversionMap,
   DOMConversionOutput,
   EditorConfig,

--- a/packages/richtext-lexical/src/field/features/types.ts
+++ b/packages/richtext-lexical/src/field/features/types.ts
@@ -1,9 +1,7 @@
 import type { Transformer } from '@lexical/markdown'
 import type { GenericLanguages, I18nClient } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
-import type { Klass, LexicalEditor, LexicalNode, SerializedEditorState } from 'lexical'
-import type { SerializedLexicalNode } from 'lexical'
-import type { LexicalNodeReplacement } from 'lexical'
+import type { Klass, LexicalEditor, LexicalNode, LexicalNodeReplacement , SerializedEditorState , SerializedLexicalNode } from 'lexical'
 import type { RequestContext } from 'payload'
 import type { SanitizedConfig } from 'payload/config'
 import type {

--- a/packages/richtext-lexical/src/field/lexical/nodes/index.ts
+++ b/packages/richtext-lexical/src/field/lexical/nodes/index.ts
@@ -1,5 +1,4 @@
-import type { Klass, LexicalNode } from 'lexical'
-import type { LexicalNodeReplacement } from 'lexical'
+import type { Klass, LexicalNode , LexicalNodeReplacement } from 'lexical'
 
 import type { SanitizedClientEditorConfig, SanitizedServerEditorConfig } from '../config/types.js'
 

--- a/packages/richtext-lexical/src/field/lexical/utils/nodeFormat.ts
+++ b/packages/richtext-lexical/src/field/lexical/utils/nodeFormat.ts
@@ -3,9 +3,8 @@
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
 //This copy-and-pasted from lexical here: https://github.com/facebook/lexical/blob/c2ceee223f46543d12c574e62155e619f9a18a5d/packages/lexical/src/LexicalConstants.ts
 
-import type { ElementFormatType, TextFormatType } from 'lexical'
+import type { ElementFormatType, TextFormatType , TextModeType } from 'lexical'
 export type TextDetailType = 'directionless' | 'unmergable'
-import type { TextModeType } from 'lexical'
 
 // DOM
 export const NodeFormat = {

--- a/packages/richtext-lexical/src/field/lexical/utils/nodeFormat.ts
+++ b/packages/richtext-lexical/src/field/lexical/utils/nodeFormat.ts
@@ -1,9 +1,10 @@
 /* eslint-disable perfectionist/sort-objects */
 /* eslint-disable regexp/no-obscure-range */
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
+/* eslint-disable regexp/no-misleading-unicode-character */
 //This copy-and-pasted from lexical here: https://github.com/facebook/lexical/blob/c2ceee223f46543d12c574e62155e619f9a18a5d/packages/lexical/src/LexicalConstants.ts
 
-import type { ElementFormatType, TextFormatType , TextModeType } from 'lexical'
+import type { ElementFormatType, TextFormatType, TextModeType } from 'lexical'
 export type TextDetailType = 'directionless' | 'unmergable'
 
 // DOM

--- a/packages/richtext-lexical/src/populateGraphQL/populate.ts
+++ b/packages/richtext-lexical/src/populateGraphQL/populate.ts
@@ -1,5 +1,4 @@
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Collection } from 'payload/types'
+import type { Collection , PayloadRequestWithData } from 'payload/types'
 
 import { createDataloaderCacheKey } from 'payload/utilities'
 

--- a/packages/richtext-slate/src/data/populate.ts
+++ b/packages/richtext-slate/src/data/populate.ts
@@ -1,5 +1,4 @@
-import type { PayloadRequestWithData } from 'payload/types'
-import type { Collection, Field, RichTextField } from 'payload/types'
+import type { Collection, Field, PayloadRequestWithData, RichTextField } from 'payload/types'
 
 import { createDataloaderCacheKey } from 'payload/utilities'
 

--- a/packages/storage-vercel-blob/src/index.ts
+++ b/packages/storage-vercel-blob/src/index.ts
@@ -1,8 +1,7 @@
 import type {
+  Adapter,
   PluginOptions as CloudStoragePluginOptions,
-  CollectionOptions,
-} from '@payloadcms/plugin-cloud-storage/types'
-import type { Adapter, GeneratedAdapter } from '@payloadcms/plugin-cloud-storage/types'
+ CollectionOptions, GeneratedAdapter } from '@payloadcms/plugin-cloud-storage/types'
 import type { Config, Plugin } from 'payload/config'
 
 import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'

--- a/packages/translations/src/utilities/init.ts
+++ b/packages/translations/src/utilities/init.ts
@@ -1,11 +1,10 @@
 import type {
+  DefaultTranslationKeys,
   DefaultTranslationsObject,
   I18n,
   InitI18n,
   InitTFunction,
-  Language,
-} from '../types.js'
-import type { DefaultTranslationKeys } from '../types.js'
+ Language } from '../types.js'
 
 import { importDateFNSLocale } from '../importDateFNSLocale.js'
 import { deepMerge } from './deepMerge.js'

--- a/packages/ui/src/fields/Relationship/types.ts
+++ b/packages/ui/src/fields/Relationship/types.ts
@@ -1,6 +1,5 @@
 import type { I18nClient } from '@payloadcms/translations'
-import type { ClientCollectionConfig, FieldBase, RelationshipField } from 'payload/types'
-import type { SanitizedConfig } from 'payload/types'
+import type { ClientCollectionConfig, FieldBase, RelationshipField , SanitizedConfig } from 'payload/types'
 
 import type { FormFieldBase } from '../shared/index.js'
 

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -1,6 +1,5 @@
 import type { User } from 'payload/auth'
-import type { Field, FormField, FormState } from 'payload/types'
-import type { Data } from 'payload/types'
+import type { Data, Field, FormField , FormState } from 'payload/types'
 import type React from 'react'
 import type { Dispatch } from 'react'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,6 +411,9 @@ importers:
       eslint-config-prettier:
         specifier: 9.1.0
         version: 9.1.0(eslint@8.57.0)
+      eslint-plugin-import:
+        specifier: 2.25.2
+        version: 2.25.2(@typescript-eslint/parser@7.3.1)(eslint@8.57.0)
       eslint-plugin-jest:
         specifier: 27.9.0
         version: 27.9.0(@typescript-eslint/eslint-plugin@7.3.1)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5)
@@ -7015,6 +7018,10 @@ packages:
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  /@types/json5@0.0.29:
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: false
+
   /@types/jsonfile@6.1.4:
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
     dependencies:
@@ -9376,6 +9383,17 @@ packages:
       ms: 2.0.0
     dev: false
 
+  /debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: false
+
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -10175,6 +10193,45 @@ packages:
       eslint: 8.57.0
     dev: false
 
+  /eslint-import-resolver-node@0.3.9:
+    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.13.1
+      resolve: 1.22.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /eslint-module-utils@2.8.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+    resolution: {integrity: sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 7.3.1(eslint@8.57.0)(typescript@5.4.5)
+      debug: 3.2.7
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /eslint-plugin-es@3.0.1(eslint@8.57.0):
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
@@ -10184,6 +10241,37 @@ packages:
       eslint: 8.57.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
+    dev: false
+
+  /eslint-plugin-import@2.25.2(@typescript-eslint/parser@7.3.1)(eslint@8.57.0):
+    resolution: {integrity: sha512-qCwQr9TYfoBHOFcVGKY9C9unq05uOxxdklmBXLVvcwo68y5Hta6/GzCZEMx2zQiu0woKNEER0LE7ZgaOfBU14g==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 7.3.1(eslint@8.57.0)(typescript@5.4.5)
+      array-includes: 3.1.8
+      array.prototype.flat: 1.3.2
+      debug: 2.6.9
+      doctrine: 2.1.0
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      has: 1.0.4
+      is-core-module: 2.13.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.2.0
+      resolve: 1.22.8
+      tsconfig-paths: 3.15.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: false
 
   /eslint-plugin-jest-dom@5.1.0(eslint@8.57.0):
@@ -11403,6 +11491,11 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+
+  /has@1.0.4:
+    resolution: {integrity: sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==}
+    engines: {node: '>= 0.4.0'}
+    dev: false
 
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -12656,6 +12749,13 @@ packages:
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  /json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
+    dev: false
 
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -16327,6 +16427,11 @@ packages:
     dependencies:
       ansi-regex: 6.0.1
 
+  /strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+    dev: false
+
   /strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
     engines: {node: '>=8'}
@@ -16854,6 +16959,15 @@ packages:
       typescript: 5.4.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  /tsconfig-paths@3.15.0:
+    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+    dev: false
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}


### PR DESCRIPTION
## Description

Adds ESLint rule to consolidate duplicate imports using the `import/no-duplicates` rule of the `eslint-plugin-import` plugin. More here: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md. This was needed as opposed to `no-duplicate-imports` because of the auto-fix feature.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works