### PR TITLE
fix!: meta.icons type and schema validation

### DIFF
--- a/packages/payload/src/config/schema.ts
+++ b/packages/payload/src/config/schema.ts
@@ -69,15 +69,17 @@ export default joi.object({
     meta: joi.object().keys({
       defaultOGImageType: joi.string().valid('off', 'dynamic', 'static'),
       description: joi.string(),
-      icons: joi.object().keys({
-        type: joi.string(),
-        color: joi.string(),
-        fetchPriority: joi.string().valid('auto', 'high', 'low'),
-        media: joi.string(),
-        rel: joi.string(),
-        sizes: joi.string(),
-        url: joi.string(),
-      }),
+      icons: joi.array.items(
+        joi.object().keys({
+          type: joi.string(),
+          color: joi.string(),
+          fetchPriority: joi.string().valid('auto', 'high', 'low'),
+          media: joi.string(),
+          rel: joi.string(),
+          sizes: joi.string(),
+          url: joi.string(),
+        }),
+      ),
       openGraph: openGraphSchema,
       titleSuffix: joi.string(),
     }),

--- a/packages/payload/src/config/schema.ts
+++ b/packages/payload/src/config/schema.ts
@@ -69,7 +69,7 @@ export default joi.object({
     meta: joi.object().keys({
       defaultOGImageType: joi.string().valid('off', 'dynamic', 'static'),
       description: joi.string(),
-      icons: joi.array.items(
+      icons: joi.array().items(
         joi.object().keys({
           type: joi.string(),
           color: joi.string(),

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -120,7 +120,7 @@ export type MetaConfig = {
    *
    * For example browser tabs, phone home screens, and search engine results.
    */
-  icons?: IconConfig
+  icons?: IconConfig[]
   /**
    * Overrides the auto-generated <meta name="keywords"> of admin pages
    * @example `"CMS, Payload, Custom"`


### PR DESCRIPTION
## Description

Addresses #6425. Continuation of #6754. The joi schema validation for `meta.images` was incorrectly set to an object, but should remain an array as the name suggests. This is so that projects are able to set multiple icons, i.e. light / dark mode (see admin test suite). This was instead a type error. The reason why tests passed with this change is because CI does not appear to fail on type errors. Labeling this a breaking change since it was previously released in `beta.34`.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Existing test suite passes locally with my changes
