### PR TITLE
feat: warn if image resizing enabled but sharp is not passed to config

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -429,6 +429,16 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
       this.email = consoleEmailAdapter({ payload: this })
     }
 
+    // Warn if image resizing is enabled but sharp is not installed
+    if (
+      !this.config.sharp &&
+      this.config.collections.some((c) => c.upload.imageSizes || c.upload.formatOptions)
+    ) {
+      this.logger.warn(
+        `Image resizing is enabled for one or more collections, but sharp not installed. Please install 'sharp' and pass into the config.`,
+      )
+    }
+
     this.sendEmail = this.email['sendEmail']
 
     serverInitTelemetry(this)


### PR DESCRIPTION
Warning will now show if image resizing enabled, but sharp is not passed to config.

Fixes #6755