### PR TITLE
feat(plugin-stripe): add full req object to stripe webhook handlers

### DIFF
--- a/packages/plugin-stripe/src/routes/rest.ts
+++ b/packages/plugin-stripe/src/routes/rest.ts
@@ -1,5 +1,6 @@
-import type { PayloadRequestWithData } from 'payload/types'
+import type { PayloadRequest, PayloadRequestWithData } from 'payload/types'
 
+import { addDataAndFileToRequest } from '@payloadcms/next/utilities'
 import { Forbidden } from 'payload/errors'
 
 import type { StripePluginConfig } from '../types.js'
@@ -8,12 +9,16 @@ import { stripeProxy } from '../utilities/stripeProxy.js'
 
 export const stripeREST = async (args: {
   pluginConfig: StripePluginConfig
-  req: PayloadRequestWithData
+  req: PayloadRequest
 }): Promise<any> => {
   let responseStatus = 200
   let responseJSON
 
   const { pluginConfig, req } = args
+
+  await addDataAndFileToRequest({ request: req })
+
+  const requestWithData = req as PayloadRequestWithData
 
   const {
     data: {
@@ -22,7 +27,7 @@ export const stripeREST = async (args: {
     },
     payload,
     user,
-  } = req
+  } = requestWithData
 
   const { stripeSecretKey } = pluginConfig
 

--- a/packages/plugin-stripe/src/routes/webhooks.ts
+++ b/packages/plugin-stripe/src/routes/webhooks.ts
@@ -1,5 +1,5 @@
 import type { Config as PayloadConfig } from 'payload/config'
-import type { PayloadRequestWithData } from 'payload/types'
+import type { PayloadRequest } from 'payload/types'
 
 import Stripe from 'stripe'
 
@@ -10,7 +10,7 @@ import { handleWebhooks } from '../webhooks/index.js'
 export const stripeWebhooks = async (args: {
   config: PayloadConfig
   pluginConfig: StripePluginConfig
-  req: PayloadRequestWithData
+  req: PayloadRequest
 }): Promise<any> => {
   const { config, pluginConfig, req } = args
   let returnStatus = 200
@@ -47,6 +47,7 @@ export const stripeWebhooks = async (args: {
           event,
           payload: req.payload,
           pluginConfig,
+          req,
           stripe,
         })
 
@@ -57,6 +58,7 @@ export const stripeWebhooks = async (args: {
             event,
             payload: req.payload,
             pluginConfig,
+            req,
             stripe,
           })
         }
@@ -69,6 +71,7 @@ export const stripeWebhooks = async (args: {
               event,
               payload: req.payload,
               pluginConfig,
+              req,
               stripe,
             })
           }

--- a/packages/plugin-stripe/src/types.ts
+++ b/packages/plugin-stripe/src/types.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
 import type { Config as PayloadConfig } from 'payload/config'
+import type { PayloadRequest } from 'payload/types'
 import type Stripe from 'stripe'
 
 export type StripeWebhookHandler<T = any> = (args: {
@@ -7,6 +8,7 @@ export type StripeWebhookHandler<T = any> = (args: {
   event: T
   payload: Payload
   pluginConfig?: StripePluginConfig
+  req: PayloadRequest
   stripe: Stripe
 }) => void
 

--- a/packages/plugin-stripe/src/ui/LinkToDoc.tsx
+++ b/packages/plugin-stripe/src/ui/LinkToDoc.tsx
@@ -2,8 +2,8 @@
 import type { CustomComponent } from 'payload/config'
 import type { UIField } from 'payload/types'
 
+import { CopyToClipboard } from '@payloadcms/ui/elements/CopyToClipboard'
 import { useFieldProps } from '@payloadcms/ui/forms/FieldPropsProvider'
-// import CopyToClipboard from 'payload/dist/admin/components/elements/CopyToClipboard'
 import { useFormFields } from '@payloadcms/ui/forms/Form'
 import React from 'react'
 
@@ -29,7 +29,7 @@ export const LinkToDoc: CustomComponent<UIField> = () => {
           >
             View in Stripe
           </span>
-          {/* <CopyToClipboard value={href} /> */}
+          <CopyToClipboard value={href} />
         </div>
         <div
           style={{

--- a/packages/plugin-stripe/tsconfig.json
+++ b/packages/plugin-stripe/tsconfig.json
@@ -20,5 +20,5 @@
     "src/**/*.spec.tsx"
   ],
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "src/**/*.json"],
-  "references": [{ "path": "../payload" }, { "path": "../ui" }]
+  "references": [{ "path": "../payload" }, { "path": "../ui" }, { "path": "../next" }]
 }


### PR DESCRIPTION
Provides `req` to the webhook handlers in Stripe plugin and fixes type to `PayloadRequest` for req by default.