### PR TITLE
fix: adds translation for authentication:apiKey

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -9,6 +9,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'authentication:accountOfCurrentUser',
   'authentication:alreadyActivated',
   'authentication:alreadyLoggedIn',
+  'authentication:apiKey',
   'authentication:authenticated',
   'authentication:backToLogin',
   'authentication:beginCreateFirstUser',


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/6697

Adds `authentication:apiKey` to client translations.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
