### PR TITLE
fix: passes toast success and error handlers to form handleResponse fn

### DIFF
--- a/packages/next/src/views/ForgotPassword/ForgotPasswordForm/index.tsx
+++ b/packages/next/src/views/ForgotPassword/ForgotPasswordForm/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { FormProps } from '@payloadcms/ui/forms/Form'
 import type { FormState, PayloadRequestWithData } from 'payload/types'
 
 import { Email } from '@payloadcms/ui/fields/Email'
@@ -9,7 +10,6 @@ import { useConfig } from '@payloadcms/ui/providers/Config'
 import { useTranslation } from '@payloadcms/ui/providers/Translation'
 import { email } from 'payload/fields/validations'
 import React, { Fragment, useState } from 'react'
-import { toast } from 'sonner'
 
 export const ForgotPasswordForm: React.FC = () => {
   const config = useConfig()
@@ -22,15 +22,16 @@ export const ForgotPasswordForm: React.FC = () => {
   const { t } = useTranslation()
   const [hasSubmitted, setHasSubmitted] = useState(false)
 
-  const handleResponse = (res) => {
-    res.json().then(
-      () => {
+  const handleResponse: FormProps['handleResponse'] = (res, successToast, errorToast) => {
+    res
+      .json()
+      .then(() => {
         setHasSubmitted(true)
-      },
-      () => {
-        toast.error(t('authentication:emailNotValid'))
-      },
-    )
+        successToast(t('general:submissionSuccessful'))
+      })
+      .catch(() => {
+        errorToast(t('authentication:emailNotValid'))
+      })
   }
 
   const initialState: FormState = {

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -297,7 +297,7 @@ export const Form: React.FC<FormProps> = (props) => {
         setDisabled(false)
 
         if (typeof handleResponse === 'function') {
-          handleResponse(res)
+          handleResponse(res, successToast, errorToast)
           return
         }
 

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -1,5 +1,5 @@
 import type { User } from 'payload/auth'
-import type { Data, Field, FormField , FormState } from 'payload/types'
+import type { Data, Field, FormField, FormState } from 'payload/types'
 import type React from 'react'
 import type { Dispatch } from 'react'
 
@@ -32,7 +32,11 @@ export type FormProps = (
    * feature of the Lexical Rich Text field)
    */
   fields?: Field[]
-  handleResponse?: (res: Response) => void
+  handleResponse?: (
+    res: Response,
+    successToast: (value: string) => void,
+    errorToast: (value: string) => void,
+  ) => void
   initialState?: FormState
   isInitializing?: boolean
   log?: boolean


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/6747

Passes successToast and errorToast through to the Form handleResponse method.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
