### PR TITLE
fix: migrationTableExists utility to work with custom schemas other than public

### DIFF
--- a/packages/db-postgres/src/migrate.ts
+++ b/packages/db-postgres/src/migrate.ts
@@ -32,7 +32,7 @@ export async function migrate(this: PostgresAdapter): Promise<void> {
   let latestBatch = 0
   let migrationsInDB = []
 
-  const hasMigrationTable = await migrationTableExists(this.drizzle)
+  const hasMigrationTable = await migrationTableExists(this)
 
   if (hasMigrationTable) {
     ;({ docs: migrationsInDB } = await payload.find({

--- a/packages/db-postgres/src/migrateDown.ts
+++ b/packages/db-postgres/src/migrateDown.ts
@@ -50,7 +50,7 @@ export async function migrateDown(this: PostgresAdapter): Promise<void> {
         msg: `Migrated down:  ${migrationFile.name} (${Date.now() - start}ms)`,
       })
 
-      const tableExists = await migrationTableExists(this.drizzle)
+      const tableExists = await migrationTableExists(this)
       if (tableExists) {
         await payload.delete({
           id: migration.id,

--- a/packages/db-postgres/src/migrateRefresh.ts
+++ b/packages/db-postgres/src/migrateRefresh.ts
@@ -54,7 +54,7 @@ export async function migrateRefresh(this: PostgresAdapter) {
         msg: `Migrated down:  ${migration.name} (${Date.now() - start}ms)`,
       })
 
-      const tableExists = await migrationTableExists(this.drizzle)
+      const tableExists = await migrationTableExists(this)
       if (tableExists) {
         await payload.delete({
           collection: 'payload-migrations',

--- a/packages/db-postgres/src/migrateReset.ts
+++ b/packages/db-postgres/src/migrateReset.ts
@@ -45,7 +45,7 @@ export async function migrateReset(this: PostgresAdapter): Promise<void> {
         msg: `Migrated down:  ${migrationFile.name} (${Date.now() - start}ms)`,
       })
 
-      const tableExists = await migrationTableExists(this.drizzle)
+      const tableExists = await migrationTableExists(this)
       if (tableExists) {
         await payload.delete({
           id: migration.id,
@@ -71,7 +71,7 @@ export async function migrateReset(this: PostgresAdapter): Promise<void> {
 
   // Delete dev migration
 
-  const tableExists = await migrationTableExists(this.drizzle)
+  const tableExists = await migrationTableExists(this)
   if (tableExists) {
     try {
       await payload.delete({

--- a/packages/db-postgres/src/migrateStatus.ts
+++ b/packages/db-postgres/src/migrateStatus.ts
@@ -14,7 +14,7 @@ export async function migrateStatus(this: PostgresAdapter): Promise<void> {
   })
 
   let existingMigrations = []
-  const hasMigrationTable = await migrationTableExists(this.drizzle)
+  const hasMigrationTable = await migrationTableExists(this)
 
   if (hasMigrationTable) {
     ;({ existingMigrations } = await getMigrations({ payload }))

--- a/packages/db-postgres/src/utilities/migrationTableExists.ts
+++ b/packages/db-postgres/src/utilities/migrationTableExists.ts
@@ -1,9 +1,13 @@
 import { sql } from 'drizzle-orm'
 
-import type { DrizzleDB } from '../types.js'
+import type { PostgresAdapter } from '../types.js'
 
-export const migrationTableExists = async (db: DrizzleDB): Promise<boolean> => {
-  const queryRes = await db.execute(sql`SELECT to_regclass('public.payload_migrations');`)
+export const migrationTableExists = async (adapter: PostgresAdapter): Promise<boolean> => {
+  const prependSchema = adapter.schemaName ? `"${adapter.schemaName}".` : ''
+
+  const queryRes = await adapter.drizzle.execute(
+    sql`SELECT to_regclass('${prependSchema}.payload_migrations');`,
+  )
 
   // Returns table name 'payload_migrations' or null
   const exists = queryRes.rows?.[0]?.to_regclass === 'payload_migrations'


### PR DESCRIPTION
## Description

Migrations are currently broken for anyone who has used a custom schema for Payload, because `migrationTableExists` assumes the migrations table is within the `public` schema.

This change passes the Postgres adapter to the utility function so that the custom schema name config can be used.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
