### PR TITLE
fix(ui): withinCollapsible always false from useCollapsible provider

### DIFF
--- a/packages/payload/src/admin/components/elements/Collapsible/provider.tsx
+++ b/packages/payload/src/admin/components/elements/Collapsible/provider.tsx
@@ -18,7 +18,7 @@ export const CollapsibleProvider: React.FC<{
   collapsed?: boolean
   toggle: () => void
   withinCollapsible?: boolean
-}> = ({ children, collapsed, toggle, withinCollapsible }) => {
+}> = ({ children, collapsed, toggle, withinCollapsible = true }) => {
   const { collapsed: parentIsCollapsed, isVisible } = useCollapsible()
 
   const contextValue = React.useMemo((): ContextType => {


### PR DESCRIPTION
## Description

Closes #6760 

The `withinCollapsible` prop from the `useCollapsible()` provider is always returning false.

This bug originated from [this change](https://github.com/payloadcms/payload/pull/6666) from me - in a previous issue, the provider was always returning `withinCollapsible: true`. 

Previous fix was not correct, the `withinCollapsible` should be `false` when creating the initial context, and then be `true`  when it is de-structured in the provider. Tested with tabs, arrays, and groups. All working as expected now.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
