### PR TITLE
fix(plugin-cloud-storage): missing error handling for invalid plugin config, leading to unexpected webpack errors

### DIFF
--- a/packages/plugin-cloud-storage/src/webpack.ts
+++ b/packages/plugin-cloud-storage/src/webpack.ts
@@ -41,6 +41,16 @@ export const extendWebpackConfig =
           if (adapter.webpack) {
             return adapter.webpack(resultingWebpackConfig)
           }
+        } else {
+          if (!matchedCollection) {
+            throw new Error(
+              `plugin-cloud-storage: The collection "${slug}" which you specified in your plugin options does not exist. You can not run payload with this plugin enabled while there are collections specified that do not exist.`,
+            )
+          } else {
+            throw new Error(
+              `plugin-cloud-storage: The adapter you specified in your plugin options for collection ${slug} is not a valid function. You can not run payload with this plugin enabled while there are collections specified without a valid adapter`,
+            )
+          }
         }
 
         return resultingWebpackConfig


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/4215

If an incorrect collection slug is passed to the plugin, no collection>adapter-specific webpack config will be loaded, however webpack will still try to bundle the adapter. This will not work as the adapter-specific webpack config contains important webpack aliases.

A lot of people do not realize that the collection slug they specify is the issue. Just throwing 15 webpack errors at them would lead them to believe there is a bug in this plugin, even though this plugin is not supposed to work when its config is invalid.