### PR TITLE
fix(email-nodemailer): skipVerify behavior being reversed

### DIFF
--- a/packages/email-nodemailer/src/index.ts
+++ b/packages/email-nodemailer/src/index.ts
@@ -66,7 +66,7 @@ async function buildEmail(emailConfig?: NodemailerAdapterArgs): Promise<{
     transport = await createMockAccount(emailConfig)
   }
 
-  if (emailConfig.skipVerify === false) {
+  if (!emailConfig.skipVerify) {
     await verifyTransport(transport)
   }
 

--- a/packages/email-nodemailer/src/index.ts
+++ b/packages/email-nodemailer/src/index.ts
@@ -66,7 +66,7 @@ async function buildEmail(emailConfig?: NodemailerAdapterArgs): Promise<{
     transport = await createMockAccount(emailConfig)
   }
 
-  if (emailConfig.skipVerify !== false) {
+  if (emailConfig.skipVerify === false) {
     await verifyTransport(transport)
   }
 

--- a/packages/email-nodemailer/src/plugin.spec.ts
+++ b/packages/email-nodemailer/src/plugin.spec.ts
@@ -1,0 +1,60 @@
+import { jest } from '@jest/globals'
+
+import nodemailer, { Transporter } from 'nodemailer'
+import { nodemailerAdapter, NodemailerAdapterArgs } from './index.js'
+
+const defaultArgs: NodemailerAdapterArgs = {
+  defaultFromAddress: 'test@test.com',
+  defaultFromName: 'Test',
+}
+
+describe('email-nodemailer', () => {
+
+  describe('transport verification', () => {
+    let mockedVerify: jest.Mock<Transporter['verify']>
+    let mockTransport: Transporter
+
+    beforeEach(() => {
+      mockedVerify = jest.fn<Transporter['verify']>()
+      mockTransport = nodemailer.createTransport({
+        name: 'existing-transport',
+        // eslint-disable-next-line @typescript-eslint/require-await
+        send: async (mail) => {
+          console.log('mock send', mail)
+        },
+        version: '0.0.1',
+        verify: mockedVerify,
+      })
+    })
+
+    it('should be invoked when skipVerify = false', async () => {
+      await nodemailerAdapter({
+        ...defaultArgs,
+        transport: mockTransport,
+        skipVerify: false,
+      })
+
+      expect(mockedVerify.mock.calls).toHaveLength(1)
+    })
+
+    it('should be invoked when skipVerify is undefined', async () => {
+      await nodemailerAdapter({
+        ...defaultArgs,
+        transport: mockTransport,
+        skipVerify: false,
+      })
+
+      expect(mockedVerify.mock.calls).toHaveLength(1)
+    })
+
+    it('should not be invoked when skipVerify = true', async () => {
+      await nodemailerAdapter({
+        ...defaultArgs,
+        transport: mockTransport,
+        skipVerify: true,
+      })
+
+      expect(mockedVerify.mock.calls).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
## Description
Fixes #6789

The skipVerify field in NodemailerAdapterArgs worked in reverse of what it was supposed to do:
- With skipVerify = true -> Verified transport
- With skipVerify = false -> Did not verify transport

This PR makes the property work in the intended way:
- With skipVerify = true -> DO NOT verify transport
- With skipVerify = false -> DO verify transport



- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
