### PR TITLE
fix: prevent clearing of language selection on account view

### DIFF
--- a/packages/next/src/views/Account/Settings/LanguageSelector.tsx
+++ b/packages/next/src/views/Account/Settings/LanguageSelector.tsx
@@ -17,6 +17,7 @@ export const LanguageSelector: React.FC<{
   return (
     <ReactSelect
       inputId="language-select"
+      isClearable={false}
       onChange={async (option: Option<AcceptedLanguages>) => {
         await switchLanguage(option.value)
       }}


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/6794

Users should not be able to clear their language selection on the account view.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
