### PR TITLE
fix(ui): unflattening json objects containing keys with periods

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -111,7 +111,7 @@
     "bson-objectid": "2.0.4",
     "date-fns": "3.3.1",
     "deep-equal": "2.2.2",
-    "flatley": "5.2.0",
+    "is-buffer": "^2.0.5",
     "md5": "2.3.0",
     "object-to-formdata": "4.5.1",
     "qs": "6.11.2",

--- a/packages/ui/src/forms/Form/getDataByPath.ts
+++ b/packages/ui/src/forms/Form/getDataByPath.ts
@@ -1,7 +1,6 @@
 import type { FormState } from 'payload'
 
-import flatleyImport from 'flatley'
-const { unflatten } = flatleyImport
+import { unflatten } from '../../utilities/unflatten.js'
 
 export const getDataByPath = <T = unknown>(fields: FormState, path: string): T => {
   const pathPrefixToRemove = path.substring(0, path.lastIndexOf('.') + 1)

--- a/packages/ui/src/forms/Form/getSiblingData.ts
+++ b/packages/ui/src/forms/Form/getSiblingData.ts
@@ -1,9 +1,7 @@
 import type { Data, FormState } from 'payload'
 
-import flatleyImport from 'flatley'
-const { unflatten } = flatleyImport
-
 import { reduceFieldsToValues } from '../../utilities/reduceFieldsToValues.js'
+import { unflatten } from '../../utilities/unflatten.js'
 
 export const getSiblingData = (fields: FormState, path: string): Data => {
   if (!fields) return null
@@ -39,5 +37,5 @@ export const getSiblingData = (fields: FormState, path: string): Data => {
     }
   })
 
-  return unflatten(siblingFields, { safe: true })
+  return unflatten(siblingFields)
 }

--- a/packages/ui/src/utilities/reduceFieldsToValues.ts
+++ b/packages/ui/src/utilities/reduceFieldsToValues.ts
@@ -1,7 +1,6 @@
 import type { Data, FormState } from 'payload'
 
-import flatleyImport from 'flatley'
-const { unflatten: flatleyUnflatten } = flatleyImport
+import { unflatten as flatleyUnflatten } from './unflatten.js'
 /**
  * Reduce flattened form fields (Fields) to just map to the respective values instead of the full FormField object
  *
@@ -25,7 +24,7 @@ export const reduceFieldsToValues = (
   })
 
   if (unflatten) {
-    data = flatleyUnflatten(data, { safe: true })
+    data = flatleyUnflatten(data)
   }
 
   return data

--- a/packages/ui/src/utilities/reduceFieldsToValuesWithValidation.ts
+++ b/packages/ui/src/utilities/reduceFieldsToValuesWithValidation.ts
@@ -1,7 +1,6 @@
 import type { Data, FormState } from 'payload'
 
-import flatleyImport from 'flatley'
-const { unflatten: flatleyUnflatten } = flatleyImport
+import { unflatten as flatleyUnflatten } from './unflatten.js'
 
 type ReturnType = {
   data: Data
@@ -35,7 +34,7 @@ export const reduceFieldsToValuesWithValidation = (
   })
 
   if (unflatten) {
-    state.data = flatleyUnflatten(state.data, { safe: true })
+    state.data = flatleyUnflatten(state.data)
   }
 
   return state

--- a/packages/ui/src/utilities/unflatten.ts
+++ b/packages/ui/src/utilities/unflatten.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2014, Hugh Kennedy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import isBuffer from 'is-buffer'
+
+interface Opts {
+  delimiter?: string
+  object?: any
+  overwrite?: boolean
+  recursive?: boolean
+}
+
+export const unflatten = (target, opts?: Opts) => {
+  opts = opts || {}
+
+  const delimiter = opts.delimiter || '.'
+  const overwrite = opts.overwrite || false
+  const recursive = opts.recursive || false
+  const result = {}
+
+  const isbuffer = isBuffer(target)
+
+  if (isbuffer || Object.prototype.toString.call(target) !== '[object Object]') {
+    return target
+  }
+
+  // safely ensure that the key is an integer.
+  const getkey = (key) => {
+    const parsedKey = Number(key)
+    return isNaN(parsedKey) || key.indexOf('.') !== -1 || opts.object ? key : parsedKey
+  }
+
+  const sortedKeys = Object.keys(target).sort((keyA, keyB) => keyA.length - keyB.length)
+
+  sortedKeys.forEach((key) => {
+    const split = key.split(delimiter)
+    let key1 = getkey(split.shift())
+    let key2 = getkey(split[0])
+    let recipient = result
+
+    while (key2 !== undefined) {
+      if (key1 === '__proto__') {
+        return
+      }
+
+      const type = Object.prototype.toString.call(recipient[key1])
+      const isobject = type === '[object Object]' || type === '[object Array]'
+
+      // do not write over falsey, non-undefined values if overwrite is false
+      if (!overwrite && !isobject && typeof recipient[key1] !== 'undefined') {
+        return
+      }
+
+      if ((overwrite && !isobject) || (!overwrite && recipient[key1] == null)) {
+        recipient[key1] = typeof key2 === 'number' && !opts.object ? [] : {}
+      }
+
+      recipient = recipient[key1]
+
+      if (split.length > 0) {
+        key1 = getkey(split.shift())
+        key2 = getkey(split[0])
+      }
+    }
+
+    // unflatten again for 'messy objects'
+    recipient[key1] = recursive ? unflatten(target[key], opts) : target[key]
+  })
+
+  return result
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,7 +154,7 @@ importers:
         version: 9.1.8
       next:
         specifier: 15.0.0-rc.0
-        version: 15.0.0-rc.0(@babel/core@7.24.5)(@playwright/test@1.43.0)(babel-plugin-react-compiler@0.0.0-experimental-592953e-20240517)(react-dom@19.0.0-rc-f994737d14-20240522)(react@19.0.0-rc-f994737d14-20240522)
+        version: 15.0.0-rc.0(@babel/core@7.24.5)(@playwright/test@1.43.0)(react-dom@19.0.0-rc-f994737d14-20240522)(react@19.0.0-rc-f994737d14-20240522)(sass@1.77.4)
       open:
         specifier: ^10.1.0
         version: 10.1.0
@@ -1440,9 +1440,9 @@ importers:
       deep-equal:
         specifier: 2.2.2
         version: 2.2.2
-      flatley:
-        specifier: 5.2.0
-        version: 5.2.0
+      is-buffer:
+        specifier: ^2.0.5
+        version: 2.0.5
       md5:
         specifier: 2.3.0
         version: 2.3.0
@@ -1545,7 +1545,7 @@ importers:
         version: link:../payload
       postcss-loader:
         specifier: ^8.1.1
-        version: 8.1.1(postcss@8.4.38)(typescript@5.4.5)(webpack@5.91.0)
+        version: 8.1.1(postcss@8.4.38)(webpack@5.91.0)
       postcss-preset-env:
         specifier: ^9.5.14
         version: 9.5.14(postcss@8.4.38)
@@ -2570,7 +2570,7 @@ packages:
       '@babel/traverse': 7.24.5
       '@babel/types': 7.24.5
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2666,7 +2666,7 @@ packages:
       '@babel/core': 7.24.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.5
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -3817,7 +3817,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -9227,6 +9227,21 @@ packages:
       yaml: 1.10.2
     dev: false
 
+  /cosmiconfig@9.0.0:
+    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: 5.4.5
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+    dev: true
+
   /cosmiconfig@9.0.0(typescript@5.4.5):
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
@@ -9348,7 +9363,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
       semver: 7.6.0
-      webpack: 5.91.0(@swc/core@1.6.1)(esbuild@0.19.12)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.6.1)(esbuild@0.21.5)
     dev: true
 
   /css-minimizer-webpack-plugin@6.0.0(esbuild@0.19.12)(webpack@5.91.0):
@@ -9621,6 +9636,17 @@ packages:
     dependencies:
       ms: 2.1.3
     dev: false
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -11242,12 +11268,6 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
     dev: true
-
-  /flatley@5.2.0:
-    resolution: {integrity: sha512-vsb0/03uIHu7/3jRqABweblFUJMLokz1uMrcgFlvx6OAr6V3FiSic2iXeiJCj+cciTiQeumSDsIFAAnN1yvu4w==}
-    dependencies:
-      is-buffer: 1.1.6
-    dev: false
 
   /flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
@@ -13503,7 +13523,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.91.0(@swc/core@1.6.1)(esbuild@0.19.12)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.6.1)(esbuild@0.21.5)
       webpack-sources: 1.4.3
     dev: true
 
@@ -13822,6 +13842,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    dev: false
 
   /next@15.0.0-rc.0(@babel/core@7.24.5)(@playwright/test@1.43.0)(react-dom@19.0.0-rc-f994737d14-20240522)(react@19.0.0-rc-f994737d14-20240522)(sass@1.77.4):
     resolution: {integrity: sha512-IWcCvxUSCAuOK5gig4+9yiyt/dLKpIa+WT01Qcx4CBE4TtwJljyTDnCVVn64jDZ4qmSzsaEYXpb4DTI8qbk03A==}
@@ -13869,7 +13890,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    dev: false
 
   /nice-napi@1.0.2:
     resolution: {integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==}
@@ -14840,7 +14860,29 @@ packages:
       jiti: 1.21.0
       postcss: 8.4.38
       semver: 7.6.0
-      webpack: 5.91.0(@swc/core@1.6.1)(esbuild@0.19.12)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.6.1)(esbuild@0.21.5)
+    transitivePeerDependencies:
+      - typescript
+    dev: true
+
+  /postcss-loader@8.1.1(postcss@8.4.38)(webpack@5.91.0):
+    resolution: {integrity: sha512-0IeqyAsG6tYiDRCYKQJLAmgQr47DX6N7sFSWvQxt6AcupX8DIdmykuk/o/tx0Lze3ErGHJEp5OSRxrelC6+NdQ==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || 1.x
+      postcss: ^7.0.0 || ^8.0.1
+      webpack: ^5.0.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      cosmiconfig: 9.0.0
+      jiti: 1.21.0
+      postcss: 8.4.38
+      semver: 7.6.0
+      webpack: 5.91.0(@swc/core@1.6.1)(esbuild@0.21.5)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -17075,7 +17117,7 @@ packages:
     dependencies:
       '@swc/core': 1.6.1
       '@swc/counter': 0.1.3
-      webpack: 5.91.0(@swc/core@1.6.1)(esbuild@0.19.12)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.6.1)(esbuild@0.21.5)
     dev: true
 
   /swc-plugin-transform-remove-imports@1.12.1:
@@ -17811,7 +17853,7 @@ packages:
       consola: 3.2.3
       effect: 3.1.5
       fast-check: 3.18.0
-      next: 15.0.0-rc.0(@babel/core@7.24.5)(@playwright/test@1.43.0)(babel-plugin-react-compiler@0.0.0-experimental-592953e-20240517)(react-dom@19.0.0-rc-f994737d14-20240522)(react@19.0.0-rc-f994737d14-20240522)
+      next: 15.0.0-rc.0(@babel/core@7.24.5)(@playwright/test@1.43.0)(react-dom@19.0.0-rc-f994737d14-20240522)(react@19.0.0-rc-f994737d14-20240522)(sass@1.77.4)
       std-env: 3.7.0
 
   /uri-js@4.4.1:

--- a/test/fields/collections/JSON/index.tsx
+++ b/test/fields/collections/JSON/index.tsx
@@ -2,13 +2,6 @@ import type { CollectionConfig } from 'payload'
 
 import { jsonFieldsSlug } from '../../slugs.js'
 
-type JSONField = {
-  createdAt: string
-  id: string
-  json?: any
-  updatedAt: string
-}
-
 const JSON: CollectionConfig = {
   slug: jsonFieldsSlug,
   access: {
@@ -33,6 +26,16 @@ const JSON: CollectionConfig = {
         },
         uri: 'a://b/foo.json',
       },
+    },
+    {
+      name: 'group',
+      type: 'group',
+      fields: [
+        {
+          name: 'jsonWithinGroup',
+          type: 'json',
+        },
+      ],
     },
   ],
   versions: {

--- a/test/fields/e2e.spec.ts
+++ b/test/fields/e2e.spec.ts
@@ -153,12 +153,34 @@ describe('fields', () => {
       const input = '{"foo": "bar"}'
       await page.goto(url.create)
       await page.waitForURL(url.create)
-      await expect(() => expect(page.locator('.json-field .code-editor')).toBeVisible()).toPass({
+      const jsonCodeEditor = page.locator('.json-field .code-editor').first()
+      await expect(() => expect(jsonCodeEditor).toBeVisible()).toPass({
         timeout: POLL_TOPASS_TIMEOUT,
       })
-      await page.locator('.json-field .inputarea').fill(input)
+      const jsonFieldInputArea = page.locator('.json-field .inputarea').first()
+      await jsonFieldInputArea.fill(input)
+
       await saveDocAndAssert(page)
-      await expect(page.locator('.json-field')).toContainText('"foo": "bar"')
+      const jsonField = page.locator('.json-field').first()
+      await expect(jsonField).toContainText('"foo": "bar"')
+    })
+
+    test('should not unflatten json field containing keys with dots', async () => {
+      const input = '{"foo.with.periods": "bar"}'
+
+      await page.goto(url.create)
+      await page.waitForURL(url.create)
+      const jsonCodeEditor = page.locator('.group-field .json-field .code-editor').first()
+      await expect(() => expect(jsonCodeEditor).toBeVisible()).toPass({
+        timeout: POLL_TOPASS_TIMEOUT,
+      })
+      const json = page.locator('.group-field .json-field .inputarea')
+      await json.fill(input)
+
+      await saveDocAndAssert(page, '.form-submit button')
+      await expect(page.locator('.group-field .json-field')).toContainText(
+        '"foo.with.periods": "bar"',
+      )
     })
   })
 


### PR DESCRIPTION
## Description

Fixes an issue where the `unflatten` function would also unflatten json objects when they contained a `.` in one of their keys

V2 PR [here](https://github.com/payloadcms/payload/pull/6834)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
