### PR TITLE
fix: cannot use empty strings as defaultValue in text-like fields

### DIFF
--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -85,7 +85,7 @@ export const text = baseField.keys({
       .try(joi.object().pattern(joi.string(), [joi.string()]), joi.string()),
     rtl: joi.boolean(),
   }),
-  defaultValue: joi.alternatives().try(joi.string(), joi.func()),
+  defaultValue: joi.alternatives().try(joi.string().allow(''), joi.func()),
   hasMany: joi.boolean().default(false),
   maxLength: joi.number(),
   maxRows: joi.number().when('hasMany', { is: joi.not(true), then: joi.forbidden() }),
@@ -141,7 +141,7 @@ export const textarea = baseField.keys({
     rows: joi.number(),
     rtl: joi.boolean(),
   }),
-  defaultValue: joi.alternatives().try(joi.string(), joi.func()),
+  defaultValue: joi.alternatives().try(joi.string().allow(''), joi.func()),
   maxLength: joi.number(),
   minLength: joi.number(),
 })
@@ -159,7 +159,7 @@ export const email = baseField.keys({
     }),
     placeholder: joi.string(),
   }),
-  defaultValue: joi.alternatives().try(joi.string(), joi.func()),
+  defaultValue: joi.alternatives().try(joi.string().allow(''), joi.func()),
   maxLength: joi.number(),
   minLength: joi.number(),
 })
@@ -175,7 +175,7 @@ export const code = baseField.keys({
     editorOptions: joi.object().unknown(), // Editor['options'] @monaco-editor/react
     language: joi.string(),
   }),
-  defaultValue: joi.alternatives().try(joi.string(), joi.func()),
+  defaultValue: joi.alternatives().try(joi.string().allow(''), joi.func()),
 })
 
 export const json = baseField.keys({

--- a/test/fields/collections/Text/index.ts
+++ b/test/fields/collections/Text/index.ts
@@ -41,6 +41,16 @@ const TextFields: CollectionConfig = {
       type: 'text',
     },
     {
+      name: 'defaultString',
+      defaultValue: defaultText,
+      type: 'text',
+    },
+    {
+      name: 'defaultEmptyString',
+      defaultValue: '',
+      type: 'text',
+    },
+    {
       name: 'defaultFunction',
       defaultValue: () => defaultText,
       type: 'text',

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -82,8 +82,13 @@ describe('Fields', () => {
 
     it('creates with default values', () => {
       expect(doc.text).toEqual(text)
+      expect(doc.defaultString).toEqual(defaultText)
       expect(doc.defaultFunction).toEqual(defaultText)
       expect(doc.defaultAsync).toEqual(defaultText)
+    })
+
+    it('supports empty strings as default value', () => {
+      expect(doc.defaultEmptyString).toEqual('')
     })
 
     it('should populate default values in beforeValidate hook', async () => {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->
Allows empty strings (`''`) as defaultValue for fields of types: `'text'`; `'textarea'`; `'email'`; `'code'`. This can be useful when you want to ensure the value is always a `string` instead of `null`/`undefined`.


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] ~I have made corresponding changes to the documentation~
