### PR TITLE
fix: ensure if condition is triggered even if valueWithDefault is an …

### DIFF
--- a/packages/payload/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
+++ b/packages/payload/src/admin/components/forms/Form/buildStateFromSchema/addFieldStatePromise.ts
@@ -196,10 +196,10 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
         await Promise.all(promises)
 
         // Add values to field state
-        if (valueWithDefault === null) {
-          fieldState.value = null
+        if (Array.isArray(valueWithDefault) && valueWithDefault.length === 0) {
+          fieldState.value = undefined
           fieldState.previousValue = fieldState.value
-          fieldState.initialValue = null
+          fieldState.initialValue = undefined
         } else {
           fieldState.value = forceFullValue ? arrayValue : arrayValue.length
           fieldState.previousValue = fieldState.value
@@ -315,10 +315,10 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
         await Promise.all(promises)
 
         // Add values to field state
-        if (valueWithDefault === null) {
-          fieldState.value = null
+        if (Array.isArray(valueWithDefault) && valueWithDefault.length === 0) {
+          fieldState.value = undefined
           fieldState.previousValue = fieldState.value
-          fieldState.initialValue = null
+          fieldState.initialValue = undefined
         } else {
           fieldState.value = forceFullValue ? blocksValue : blocksValue.length
           fieldState.previousValue = fieldState.value


### PR DESCRIPTION
## Description
Fixes: #6670


When `hidden:true` is set in CollectionsConfig, `valueWithDefault` is an empty array for array fields, causing the `fieldState.initialValue` and `fieldState.value` to be set to `0`. This behavior overwrites the array fields as empty arrays, similarly affecting block fields.

This commit addresses the issue by ensuring that the `if` condition is correctly triggered, even when `valueWithDefault` is empty for array and block fields.


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] Existing test suite passes locally with my changes
