### PR TITLE
fix: cannot use empty strings as defaultValue in text-like fields

### DIFF
--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -93,7 +93,7 @@ export const text = baseField.keys({
       .try(joi.object().pattern(joi.string(), [joi.string()]), joi.string()),
     rtl: joi.boolean(),
   }),
-  defaultValue: joi.alternatives().try(joi.string(), joi.func()),
+  defaultValue: joi.alternatives().try(joi.string().allow(''), joi.func()),
   hasMany: joi.boolean().default(false),
   maxLength: joi.number(),
   maxRows: joi.number().when('hasMany', { is: joi.not(true), then: joi.forbidden() }),
@@ -149,7 +149,7 @@ export const textarea = baseField.keys({
     rows: joi.number(),
     rtl: joi.boolean(),
   }),
-  defaultValue: joi.alternatives().try(joi.string(), joi.func()),
+  defaultValue: joi.alternatives().try(joi.string().allow(''), joi.func()),
   maxLength: joi.number(),
   minLength: joi.number(),
 })
@@ -167,7 +167,7 @@ export const email = baseField.keys({
     }),
     placeholder: joi.string(),
   }),
-  defaultValue: joi.alternatives().try(joi.string(), joi.func()),
+  defaultValue: joi.alternatives().try(joi.string().allow(''), joi.func()),
   maxLength: joi.number(),
   minLength: joi.number(),
 })
@@ -183,7 +183,7 @@ export const code = baseField.keys({
     editorOptions: joi.object().unknown(), // Editor['options'] @monaco-editor/react
     language: joi.string(),
   }),
-  defaultValue: joi.alternatives().try(joi.string(), joi.func()),
+  defaultValue: joi.alternatives().try(joi.string().allow(''), joi.func()),
 })
 
 export const json = baseField.keys({

--- a/test/fields/collections/Text/index.ts
+++ b/test/fields/collections/Text/index.ts
@@ -42,12 +42,23 @@ const TextFields: CollectionConfig = {
       },
     },
     {
+      name: 'defaultString',
+      type: 'text',
+      defaultValue: defaultText,
+    },
+    {
+      name: 'defaultEmptyString',
+      type: 'text',
+      defaultValue: '',
+    },
+    {
       name: 'defaultFunction',
       type: 'text',
       defaultValue: () => defaultText,
     },
     {
       name: 'defaultAsync',
+      type: 'text',
       defaultValue: async (): Promise<string> => {
         return new Promise((resolve) =>
           setTimeout(() => {
@@ -55,7 +66,6 @@ const TextFields: CollectionConfig = {
           }, 1),
         )
       },
-      type: 'text',
     },
     {
       name: 'overrideLength',

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -79,9 +79,11 @@ describe('Fields', () => {
     })
 
     it('creates with default values', () => {
-      expect(doc.text).toEqual(text)
-      expect(doc.defaultFunction).toEqual(defaultText)
-      expect(doc.defaultAsync).toEqual(defaultText)
+      expect(doc.text).toStrictEqual(text)
+      expect(doc.defaultString).toStrictEqual(defaultText)
+      expect(doc.defaultEmptyString).toStrictEqual('')
+      expect(doc.defaultFunction).toStrictEqual(defaultText)
+      expect(doc.defaultAsync).toStrictEqual(defaultText)
     })
 
     it('should populate default values in beforeValidate hook', async () => {
@@ -118,16 +120,16 @@ describe('Fields', () => {
       const hit = await payload.create({
         collection: 'text-fields',
         data: {
-          text: 'required',
           hasMany: ['one', 'five'],
+          text: 'required',
         },
       })
 
       const miss = await payload.create({
         collection: 'text-fields',
         data: {
-          text: 'required',
           hasMany: ['two'],
+          text: 'required',
         },
       })
 
@@ -950,15 +952,15 @@ describe('Fields', () => {
 
     it('should hot module reload and still be able to create', async () => {
       const testDoc1 = await payload.findByID({
-        collection: tabsFieldsSlug,
         id: document.id,
+        collection: tabsFieldsSlug,
       })
 
       await reload(payload.config, payload)
 
       const testDoc2 = await payload.findByID({
-        collection: tabsFieldsSlug,
         id: document.id,
+        collection: tabsFieldsSlug,
       })
 
       expect(testDoc1.id).toStrictEqual(testDoc2.id)


### PR DESCRIPTION
## Description

Copy of https://github.com/payloadcms/payload/pull/6842 for beta
