### PR TITLE
fix(payload): #6800, #5108 - graphql query concurrency issues

### DIFF
--- a/packages/db-mongodb/src/count.ts
+++ b/packages/db-mongodb/src/count.ts
@@ -13,7 +13,7 @@ export const count: Count = async function count(
   { collection, locale, req = {} as PayloadRequest, where },
 ) {
   const Model = this.collections[collection]
-  const options: QueryOptions = withSession(this, req.transactionID)
+  const options: QueryOptions = await withSession(this, req)
 
   let hasNearConstraint = false
 

--- a/packages/db-mongodb/src/create.ts
+++ b/packages/db-mongodb/src/create.ts
@@ -11,7 +11,7 @@ export const create: Create = async function create(
   { collection, data, req = {} as PayloadRequest },
 ) {
   const Model = this.collections[collection]
-  const options = withSession(this, req.transactionID)
+  const options = await withSession(this, req)
   let doc
   try {
     ;[doc] = await Model.create([data], options)

--- a/packages/db-mongodb/src/createGlobal.ts
+++ b/packages/db-mongodb/src/createGlobal.ts
@@ -15,7 +15,7 @@ export const createGlobal: CreateGlobal = async function createGlobal(
     globalType: slug,
     ...data,
   }
-  const options = withSession(this, req.transactionID)
+  const options = await withSession(this, req)
 
   let [result] = (await Model.create([global], options)) as any
 

--- a/packages/db-mongodb/src/createGlobalVersion.ts
+++ b/packages/db-mongodb/src/createGlobalVersion.ts
@@ -11,7 +11,7 @@ export const createGlobalVersion: CreateGlobalVersion = async function createGlo
   { autosave, createdAt, globalSlug, parent, req = {} as PayloadRequest, updatedAt, versionData },
 ) {
   const VersionModel = this.versions[globalSlug]
-  const options = withSession(this, req.transactionID)
+  const options = await withSession(this, req)
 
   const [doc] = await VersionModel.create(
     [

--- a/packages/db-mongodb/src/createVersion.ts
+++ b/packages/db-mongodb/src/createVersion.ts
@@ -19,7 +19,7 @@ export const createVersion: CreateVersion = async function createVersion(
   },
 ) {
   const VersionModel = this.versions[collectionSlug]
-  const options = withSession(this, req.transactionID)
+  const options = await withSession(this, req)
 
   const [doc] = await VersionModel.create(
     [

--- a/packages/db-mongodb/src/deleteMany.ts
+++ b/packages/db-mongodb/src/deleteMany.ts
@@ -11,7 +11,7 @@ export const deleteMany: DeleteMany = async function deleteMany(
 ) {
   const Model = this.collections[collection]
   const options = {
-    ...withSession(this, req.transactionID),
+    ...(await withSession(this, req)),
     lean: true,
   }
 

--- a/packages/db-mongodb/src/deleteOne.ts
+++ b/packages/db-mongodb/src/deleteOne.ts
@@ -12,7 +12,7 @@ export const deleteOne: DeleteOne = async function deleteOne(
   { collection, req = {} as PayloadRequest, where },
 ) {
   const Model = this.collections[collection]
-  const options = withSession(this, req.transactionID)
+  const options = await withSession(this, req)
 
   const query = await Model.buildQuery({
     payload: this.payload,

--- a/packages/db-mongodb/src/deleteVersions.ts
+++ b/packages/db-mongodb/src/deleteVersions.ts
@@ -11,7 +11,7 @@ export const deleteVersions: DeleteVersions = async function deleteVersions(
 ) {
   const VersionsModel = this.versions[collection]
   const options = {
-    ...withSession(this, req.transactionID),
+    ...(await withSession(this, req)),
     lean: true,
   }
 

--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -16,7 +16,7 @@ export const find: Find = async function find(
 ) {
   const Model = this.collections[collection]
   const collectionConfig = this.payload.collections[collection].config
-  const options = withSession(this, req.transactionID)
+  const options = await withSession(this, req)
 
   let hasNearConstraint = false
 

--- a/packages/db-mongodb/src/findGlobal.ts
+++ b/packages/db-mongodb/src/findGlobal.ts
@@ -14,7 +14,7 @@ export const findGlobal: FindGlobal = async function findGlobal(
 ) {
   const Model = this.globals
   const options = {
-    ...withSession(this, req.transactionID),
+    ...(await withSession(this, req)),
     lean: true,
   }
 

--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -30,7 +30,7 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     this.payload.globals.config.find(({ slug }) => slug === global),
   )
   const options = {
-    ...withSession(this, req.transactionID),
+    ...(await withSession(this, req)),
     limit,
     skip,
   }

--- a/packages/db-mongodb/src/findOne.ts
+++ b/packages/db-mongodb/src/findOne.ts
@@ -14,7 +14,7 @@ export const findOne: FindOne = async function findOne(
 ) {
   const Model = this.collections[collection]
   const options: MongooseQueryOptions = {
-    ...withSession(this, req.transactionID),
+    ...(await withSession(this, req)),
     lean: true,
   }
 

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -27,7 +27,7 @@ export const findVersions: FindVersions = async function findVersions(
   const Model = this.versions[collection]
   const collectionConfig = this.payload.collections[collection].config
   const options = {
-    ...withSession(this, req.transactionID),
+    ...(await withSession(this, req)),
     limit,
     skip,
   }

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -16,7 +16,7 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
 ) {
   const VersionModel = this.versions[collection]
   const collectionConfig = this.payload.collections[collection].config
-  const options = withSession(this, req.transactionID)
+  const options = await withSession(this, req)
 
   let hasNearConstraint
   let sort

--- a/packages/db-mongodb/src/transactions/commitTransaction.ts
+++ b/packages/db-mongodb/src/transactions/commitTransaction.ts
@@ -1,6 +1,8 @@
 import type { CommitTransaction } from 'payload/database'
 
 export const commitTransaction: CommitTransaction = async function commitTransaction(id) {
+  if (id instanceof Promise) return
+
   if (!this.sessions[id]?.inTransaction()) {
     return
   }

--- a/packages/db-mongodb/src/transactions/rollbackTransaction.ts
+++ b/packages/db-mongodb/src/transactions/rollbackTransaction.ts
@@ -1,27 +1,35 @@
 import type { RollbackTransaction } from 'payload/database'
 
 export const rollbackTransaction: RollbackTransaction = async function rollbackTransaction(
-  id = '',
+  incomingID = '',
 ) {
+  let transactionID: number | string
+
+  if (incomingID instanceof Promise) {
+    transactionID = await incomingID
+  } else {
+    transactionID = incomingID
+  }
+
   // if multiple operations are using the same transaction, the first will flow through and delete the session.
   // subsequent calls should be ignored.
-  if (!this.sessions[id]) {
+  if (!this.sessions[transactionID]) {
     return
   }
 
   // when session exists but is not inTransaction something unexpected is happening to the session
-  if (!this.sessions[id].inTransaction()) {
+  if (!this.sessions[transactionID].inTransaction()) {
     this.payload.logger.warn('rollbackTransaction called when no transaction exists')
-    delete this.sessions[id]
+    delete this.sessions[transactionID]
     return
   }
 
   // the first call for rollback should be aborted and deleted causing any other operations with the same transaction to fail
   try {
-    await this.sessions[id].abortTransaction()
-    await this.sessions[id].endSession()
+    await this.sessions[transactionID].abortTransaction()
+    await this.sessions[transactionID].endSession()
   } catch (error) {
     // ignore the error as it is likely a race condition from multiple errors
   }
-  delete this.sessions[id]
+  delete this.sessions[transactionID]
 }

--- a/packages/db-mongodb/src/updateGlobal.ts
+++ b/packages/db-mongodb/src/updateGlobal.ts
@@ -12,7 +12,7 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
 ) {
   const Model = this.globals
   const options = {
-    ...withSession(this, req.transactionID),
+    ...(await withSession(this, req)),
     lean: true,
     new: true,
   }

--- a/packages/db-mongodb/src/updateGlobalVersion.ts
+++ b/packages/db-mongodb/src/updateGlobalVersion.ts
@@ -19,7 +19,7 @@ export async function updateGlobalVersion<T extends TypeWithID>(
   const VersionModel = this.versions[global]
   const whereToUse = where || { id: { equals: id } }
   const options = {
-    ...withSession(this, req.transactionID),
+    ...(await withSession(this, req)),
     lean: true,
     new: true,
   }

--- a/packages/db-mongodb/src/updateOne.ts
+++ b/packages/db-mongodb/src/updateOne.ts
@@ -14,7 +14,7 @@ export const updateOne: UpdateOne = async function updateOne(
   const where = id ? { id: { equals: id } } : whereArg
   const Model = this.collections[collection]
   const options = {
-    ...withSession(this, req.transactionID),
+    ...(await withSession(this, req)),
     lean: true,
     new: true,
   }

--- a/packages/db-mongodb/src/updateVersion.ts
+++ b/packages/db-mongodb/src/updateVersion.ts
@@ -12,7 +12,7 @@ export const updateVersion: UpdateVersion = async function updateVersion(
   const VersionModel = this.versions[collection]
   const whereToUse = where || { id: { equals: id } }
   const options = {
-    ...withSession(this, req.transactionID),
+    ...(await withSession(this, req)),
     lean: true,
     new: true,
   }

--- a/packages/db-mongodb/src/withSession.ts
+++ b/packages/db-mongodb/src/withSession.ts
@@ -1,4 +1,5 @@
 import type { ClientSession } from 'mongoose'
+import type { PayloadRequest } from 'payload/types'
 
 import type { MongooseAdapter } from './index'
 
@@ -6,9 +7,15 @@ import type { MongooseAdapter } from './index'
  * returns the session belonging to the transaction of the req.session if exists
  * @returns ClientSession
  */
-export function withSession(
+export async function withSession(
   db: MongooseAdapter,
-  transactionID?: number | string,
-): { session: ClientSession } | object {
-  return db.sessions[transactionID] ? { session: db.sessions[transactionID] } : {}
+  req: PayloadRequest,
+): Promise<{ session: ClientSession } | object> {
+  let transactionID = req.transactionID
+
+  if (transactionID instanceof Promise) {
+    transactionID = await req.transactionID
+  }
+
+  if (req) return db.sessions[transactionID] ? { session: db.sessions[transactionID] } : {}
 }

--- a/packages/db-postgres/src/count.ts
+++ b/packages/db-postgres/src/count.ts
@@ -18,7 +18,7 @@ export const count: Count = async function count(
 
   const tableName = this.tableNameMap.get(toSnakeCase(collectionConfig.slug))
 
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const table = this.tables[tableName]
 
   const { joinAliases, joins, where } = await buildQuery({

--- a/packages/db-postgres/src/create.ts
+++ b/packages/db-postgres/src/create.ts
@@ -9,7 +9,7 @@ export const create: Create = async function create(
   this: PostgresAdapter,
   { collection: collectionSlug, data, req },
 ) {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const collection = this.payload.collections[collectionSlug].config
 
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))

--- a/packages/db-postgres/src/createGlobal.ts
+++ b/packages/db-postgres/src/createGlobal.ts
@@ -11,7 +11,7 @@ export async function createGlobal<T extends TypeWithID>(
   this: PostgresAdapter,
   { slug, data, req = {} as PayloadRequest }: CreateGlobalArgs,
 ): Promise<T> {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const globalConfig = this.payload.globals.config.find((config) => config.slug === slug)
 
   const tableName = this.tableNameMap.get(toSnakeCase(globalConfig.slug))

--- a/packages/db-postgres/src/createGlobalVersion.ts
+++ b/packages/db-postgres/src/createGlobalVersion.ts
@@ -14,7 +14,7 @@ export async function createGlobalVersion<T extends TypeWithID>(
   this: PostgresAdapter,
   { autosave, globalSlug, req = {} as PayloadRequest, versionData }: CreateGlobalVersionArgs,
 ) {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const global = this.payload.globals.config.find(({ slug }) => slug === globalSlug)
 
   const tableName = this.tableNameMap.get(`_${toSnakeCase(global.slug)}${this.versionsSuffix}`)

--- a/packages/db-postgres/src/createVersion.ts
+++ b/packages/db-postgres/src/createVersion.ts
@@ -19,7 +19,7 @@ export async function createVersion<T extends TypeWithID>(
     versionData,
   }: CreateVersionArgs<T>,
 ) {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const collection = this.payload.collections[collectionSlug].config
   const defaultTableName = toSnakeCase(collection.slug)
 

--- a/packages/db-postgres/src/deleteMany.ts
+++ b/packages/db-postgres/src/deleteMany.ts
@@ -12,7 +12,7 @@ export const deleteMany: DeleteMany = async function deleteMany(
   this: PostgresAdapter,
   { collection, req = {} as PayloadRequest, where },
 ) {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const collectionConfig = this.payload.collections[collection].config
 
   const tableName = this.tableNameMap.get(toSnakeCase(collectionConfig.slug))

--- a/packages/db-postgres/src/deleteOne.ts
+++ b/packages/db-postgres/src/deleteOne.ts
@@ -15,7 +15,7 @@ export const deleteOne: DeleteOne = async function deleteOne(
   this: PostgresAdapter,
   { collection: collectionSlug, req = {} as PayloadRequest, where: whereArg },
 ) {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const collection = this.payload.collections[collectionSlug].config
 
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))

--- a/packages/db-postgres/src/deleteVersions.ts
+++ b/packages/db-postgres/src/deleteVersions.ts
@@ -13,7 +13,7 @@ export const deleteVersions: DeleteVersions = async function deleteVersion(
   this: PostgresAdapter,
   { collection, locale, req = {} as PayloadRequest, where: where },
 ) {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
 
   const tableName = this.tableNameMap.get(

--- a/packages/db-postgres/src/find/findMany.ts
+++ b/packages/db-postgres/src/find/findMany.ts
@@ -31,7 +31,7 @@ export const findMany = async function find({
   tableName,
   where: whereArg,
 }: Args) {
-  const db = adapter.sessions[req.transactionID]?.db || adapter.drizzle
+  const db = adapter.sessions[await req.transactionID]?.db || adapter.drizzle
   const table = adapter.tables[tableName]
 
   const limit = limitArg ?? 10

--- a/packages/db-postgres/src/transactions/commitTransaction.ts
+++ b/packages/db-postgres/src/transactions/commitTransaction.ts
@@ -1,6 +1,8 @@
 import type { CommitTransaction } from 'payload/database'
 
 export const commitTransaction: CommitTransaction = async function commitTransaction(id) {
+  if (id instanceof Promise) return
+
   // if the session was deleted it has already been aborted
   if (!this.sessions[id]) {
     return

--- a/packages/db-postgres/src/transactions/rollbackTransaction.ts
+++ b/packages/db-postgres/src/transactions/rollbackTransaction.ts
@@ -1,17 +1,19 @@
 import type { RollbackTransaction } from 'payload/database'
 
 export const rollbackTransaction: RollbackTransaction = async function rollbackTransaction(
-  id = '',
+  incomingID = '',
 ) {
+  const transactionID = incomingID instanceof Promise ? await incomingID : incomingID
+
   // if multiple operations are using the same transaction, the first will flow through and delete the session.
   // subsequent calls should be ignored.
-  if (!this.sessions[id]) {
+  if (!this.sessions[transactionID]) {
     return
   }
 
   // end the session promise in failure by calling reject
-  await this.sessions[id].reject()
+  await this.sessions[transactionID].reject()
 
   // delete the session causing any other operations with the same transaction to fail
-  delete this.sessions[id]
+  delete this.sessions[transactionID]
 }

--- a/packages/db-postgres/src/update.ts
+++ b/packages/db-postgres/src/update.ts
@@ -12,7 +12,7 @@ export const updateOne: UpdateOne = async function updateOne(
   this: PostgresAdapter,
   { id, collection: collectionSlug, data, draft, locale, req, where: whereArg },
 ) {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const collection = this.payload.collections[collectionSlug].config
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))
   const whereToUse = whereArg || { id: { equals: id } }

--- a/packages/db-postgres/src/updateGlobal.ts
+++ b/packages/db-postgres/src/updateGlobal.ts
@@ -11,7 +11,7 @@ export async function updateGlobal<T extends TypeWithID>(
   this: PostgresAdapter,
   { slug, data, req = {} as PayloadRequest }: UpdateGlobalArgs,
 ): Promise<T> {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const globalConfig = this.payload.globals.config.find((config) => config.slug === slug)
   const tableName = this.tableNameMap.get(toSnakeCase(globalConfig.slug))
 

--- a/packages/db-postgres/src/updateGlobalVersion.ts
+++ b/packages/db-postgres/src/updateGlobalVersion.ts
@@ -20,7 +20,7 @@ export async function updateGlobalVersion<T extends TypeWithID>(
     where: whereArg,
   }: UpdateGlobalVersionArgs<T>,
 ) {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const globalConfig: SanitizedGlobalConfig = this.payload.globals.config.find(
     ({ slug }) => slug === global,
   )

--- a/packages/db-postgres/src/updateVersion.ts
+++ b/packages/db-postgres/src/updateVersion.ts
@@ -20,7 +20,7 @@ export async function updateVersion<T extends TypeWithID>(
     where: whereArg,
   }: UpdateVersionArgs<T>,
 ) {
-  const db = this.sessions[req.transactionID]?.db || this.drizzle
+  const db = this.sessions[await req.transactionID]?.db || this.drizzle
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
   const whereToUse = whereArg || { id: { equals: id } }
   const tableName = this.tableNameMap.get(

--- a/packages/payload/src/collections/graphql/resolvers/find.ts
+++ b/packages/payload/src/collections/graphql/resolvers/find.ts
@@ -31,8 +31,8 @@ export default function findResolver(collection: Collection): Resolver {
     let { req } = context
     const locale = req.locale
     const fallbackLocale = req.fallbackLocale
-    req = isolateObjectProperty(req, 'locale')
-    req = isolateObjectProperty(req, 'fallbackLocale')
+
+    req = isolateObjectProperty(req, ['locale', 'fallbackLocale', 'transactionID'])
     req.locale = args.locale || locale
     req.fallbackLocale = args.fallbackLocale || fallbackLocale
     if (!req.query) req.query = {}
@@ -41,8 +41,8 @@ export default function findResolver(collection: Collection): Resolver {
       args.draft ?? req.query?.draft === 'false'
         ? false
         : req.query?.draft === 'true'
-        ? true
-        : undefined
+          ? true
+          : undefined
     if (typeof draft === 'boolean') req.query.draft = String(draft)
 
     context.req = req
@@ -53,7 +53,7 @@ export default function findResolver(collection: Collection): Resolver {
       draft: args.draft,
       limit: args.limit,
       page: args.page,
-      req: isolateObjectProperty<PayloadRequest>(req, 'transactionID'),
+      req,
       sort: args.sort,
       where: args.where,
     }

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -157,9 +157,9 @@ export type BeginTransaction = (
   options?: Record<string, unknown>,
 ) => Promise<null | number | string>
 
-export type RollbackTransaction = (id: number | string) => Promise<void>
+export type RollbackTransaction = (id: number | string | Promise<void>) => Promise<void>
 
-export type CommitTransaction = (id: number | string) => Promise<void>
+export type CommitTransaction = (id: number | string | Promise<void>) => Promise<void>
 
 export type QueryDraftsArgs = {
   collection: string

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -157,9 +157,9 @@ export type BeginTransaction = (
   options?: Record<string, unknown>,
 ) => Promise<null | number | string>
 
-export type RollbackTransaction = (id: number | string | Promise<void>) => Promise<void>
+export type RollbackTransaction = (id: number | string | Promise<number | string>) => Promise<void>
 
-export type CommitTransaction = (id: number | string | Promise<void>) => Promise<void>
+export type CommitTransaction = (id: number | string | Promise<number | string>) => Promise<void>
 
 export type QueryDraftsArgs = {
   collection: string

--- a/packages/payload/src/express/types.ts
+++ b/packages/payload/src/express/types.ts
@@ -59,7 +59,7 @@ export declare type PayloadRequest<U = any> = Request & {
    * Identifier for the database transaction for interactions in a single, all-or-nothing operation.
    * Can also be used to ensure consistency when multiple operations try to create a transaction concurrently on the same request.
    */
-  transactionID?: number | string | Promise<void>
+  transactionID?: number | string | Promise<number | string>
   /** The signed in user */
   user: (U & User) | null
 }

--- a/packages/payload/src/express/types.ts
+++ b/packages/payload/src/express/types.ts
@@ -57,12 +57,9 @@ export declare type PayloadRequest<U = any> = Request & {
   t: TFunction
   /**
    * Identifier for the database transaction for interactions in a single, all-or-nothing operation.
+   * Can also be used to ensure consistency when multiple operations try to create a transaction concurrently on the same request.
    */
-  transactionID?: number | string
-  /**
-   * Used to ensure consistency when multiple operations try to create a transaction concurrently on the same request
-   */
-  transactionIDPromise?: Promise<void>
+  transactionID?: number | string | Promise<void>
   /** The signed in user */
   user: (U & User) | null
 }

--- a/packages/payload/src/utilities/initTransaction.ts
+++ b/packages/payload/src/utilities/initTransaction.ts
@@ -5,25 +5,25 @@ import type { PayloadRequest } from '../express/types'
  * @returns true if beginning a transaction and false when req already has a transaction to use
  */
 export async function initTransaction(req: PayloadRequest): Promise<boolean> {
-  const { payload, transactionID, transactionIDPromise } = req
+  const { payload, transactionID } = req
+  if (transactionID instanceof Promise) {
+    // wait for whoever else is already creating the transaction
+    await transactionID
+    return false
+  }
+
   if (transactionID) {
     // we already have a transaction, we're not in charge of committing it
     return false
   }
-  if (transactionIDPromise) {
-    // wait for whoever else is already creating the transaction
-    await transactionIDPromise
-    return false
-  }
   if (typeof payload.db.beginTransaction === 'function') {
     // create a new transaction
-    req.transactionIDPromise = payload.db.beginTransaction().then((transactionID) => {
+    req.transactionID = payload.db.beginTransaction().then((transactionID) => {
       if (transactionID) {
         req.transactionID = transactionID
       }
-      delete req.transactionIDPromise
     })
-    await req.transactionIDPromise
+    await req.transactionID
     return !!req.transactionID
   }
   return false

--- a/packages/payload/src/utilities/initTransaction.ts
+++ b/packages/payload/src/utilities/initTransaction.ts
@@ -22,6 +22,8 @@ export async function initTransaction(req: PayloadRequest): Promise<boolean> {
       if (transactionID) {
         req.transactionID = transactionID
       }
+
+      return transactionID
     })
     await req.transactionID
     return !!req.transactionID

--- a/packages/payload/src/utilities/isolateObjectProperty.ts
+++ b/packages/payload/src/utilities/isolateObjectProperty.ts
@@ -1,20 +1,32 @@
 /**
  * Creates a proxy for the given object that has its own property
  */
-export default function isolateObjectProperty<T>(object: T, key: keyof T): T {
-  const delegate = {}
-  const handler = {
+export default function isolateObjectProperty<T extends object>(
+  object: T,
+  key: (keyof T)[] | keyof T,
+): T {
+  const keys = Array.isArray(key) ? key : [key]
+  const delegate = {} as T
+
+  // Initialize delegate with the keys, if they exist in the original object
+  for (const k of keys) {
+    if (k in object) {
+      delegate[k] = object[k]
+    }
+  }
+
+  const handler: ProxyHandler<T> = {
     deleteProperty(target, p): boolean {
-      return Reflect.deleteProperty(p === key ? delegate : target, p)
+      return Reflect.deleteProperty(keys.includes(p as keyof T) ? delegate : target, p)
     },
     get(target, p, receiver) {
-      return Reflect.get(p === key ? delegate : target, p, receiver)
+      return Reflect.get(keys.includes(p as keyof T) ? delegate : target, p, receiver)
     },
     has(target, p) {
-      return Reflect.has(p === key ? delegate : target, p)
+      return Reflect.has(keys.includes(p as keyof T) ? delegate : target, p)
     },
     set(target, p, newValue, receiver) {
-      if (p === key) {
+      if (keys.includes(p as keyof T)) {
         // in case of transactionID we must ignore any receiver, because
         // "If provided and target does not have a setter for propertyKey, the property will be set on receiver instead."
         return Reflect.set(delegate, p, newValue)

--- a/packages/payload/src/utilities/killTransaction.ts
+++ b/packages/payload/src/utilities/killTransaction.ts
@@ -5,7 +5,7 @@ import type { PayloadRequest } from '../express/types'
  */
 export async function killTransaction(req: PayloadRequest): Promise<void> {
   const { payload, transactionID } = req
-  if (transactionID) {
+  if (transactionID && !(transactionID instanceof Promise)) {
     await payload.db.rollbackTransaction(req.transactionID)
     delete req.transactionID
   }

--- a/test/dataloader/config.ts
+++ b/test/dataloader/config.ts
@@ -57,6 +57,48 @@ export default buildConfigWithDefaults({
         },
       ],
     },
+    {
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+        },
+        {
+          name: 'items',
+          type: 'relationship',
+          relationTo: 'items',
+          hasMany: true,
+        },
+      ],
+      slug: 'shops',
+      access: { read: () => true },
+    },
+    {
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+        },
+        {
+          name: 'itemTags',
+          type: 'relationship',
+          relationTo: 'itemTags',
+          hasMany: true,
+        },
+      ],
+      slug: 'items',
+      access: { read: () => true },
+    },
+    {
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+        },
+      ],
+      slug: 'itemTags',
+      access: { read: () => true },
+    },
   ],
   onInit: async (payload) => {
     const user = await payload.create({
@@ -71,6 +113,19 @@ export default buildConfigWithDefaults({
       user,
       collection: 'posts',
       data: postDoc,
+    })
+
+    const tag = await payload.create({
+      collection: 'itemTags',
+      data: { name: 'tag1' },
+    })
+    const item = await payload.create({
+      collection: 'items',
+      data: { name: 'item1', itemTags: [tag.id] },
+    })
+    const shop = await payload.create({
+      collection: 'shops',
+      data: { name: 'shop1', items: [item.id] },
     })
   },
 })

--- a/test/dataloader/int.spec.ts
+++ b/test/dataloader/int.spec.ts
@@ -31,6 +31,35 @@ describe('dataloader', () => {
       if (loginResult.token) token = loginResult.token
     })
 
+    it('should allow multiple parallel queries', async () => {
+      for (let i = 0; i < 20; i++) {
+        const query = `
+          query {
+            Shops {
+              docs {
+                name
+                items {
+                  name
+                }
+              }
+            }
+            Items {
+              docs {
+                name
+                itemTags {
+                  name
+                }
+              }
+            }
+          }`
+        const response = await client.request(query)
+        expect(response).toStrictEqual({
+          Shops: { docs: [{ name: 'shop1', items: [{ name: 'item1' }] }] },
+          Items: { docs: [{ name: 'item1', itemTags: [{ name: 'tag1' }] }] },
+        })
+      }
+    })
+
     it('should allow querying via graphql', async () => {
       const query = `query {
         Posts {

--- a/test/dataloader/int.spec.ts
+++ b/test/dataloader/int.spec.ts
@@ -32,7 +32,7 @@ describe('dataloader', () => {
     })
 
     it('should allow multiple parallel queries', async () => {
-      for (let i = 0; i < 20; i++) {
+      for (let i = 0; i < 100; i++) {
         const query = `
           query {
             Shops {


### PR DESCRIPTION
## Description

Fixes #6800 and #5108 by improving the `isolateObjectProperty` utility function and flattening `req.transactionID` and `req.transactionIDPromise` to a single `req.transactionID` property.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
