### PR TITLE
feat(richtext-lexical): make req available to html converters, use req.dataLoader instead of payload.findByID for upload node population

### DIFF
--- a/packages/richtext-lexical/src/features/blockquote/feature.server.ts
+++ b/packages/richtext-lexical/src/features/blockquote/feature.server.ts
@@ -21,7 +21,7 @@ export const BlockquoteFeature: FeatureProviderProviderServer<undefined, undefin
           createNode({
             converters: {
               html: {
-                converter: async ({ converters, node, parent, payload }) => {
+                converter: async ({ converters, node, parent, req }) => {
                   const childrenText = await convertLexicalNodesToHTML({
                     converters,
                     lexicalNodes: node.children,
@@ -29,7 +29,7 @@ export const BlockquoteFeature: FeatureProviderProviderServer<undefined, undefin
                       ...node,
                       parent,
                     },
-                    payload,
+                    req,
                   })
 
                   return `<blockquote>${childrenText}</blockquote>`

--- a/packages/richtext-lexical/src/features/converters/html/converter/converters/paragraph.ts
+++ b/packages/richtext-lexical/src/features/converters/html/converter/converters/paragraph.ts
@@ -5,7 +5,7 @@ import type { HTMLConverter } from '../types.js'
 import { convertLexicalNodesToHTML } from '../index.js'
 
 export const ParagraphHTMLConverter: HTMLConverter<SerializedParagraphNode> = {
-  async converter({ converters, node, parent, payload }) {
+  async converter({ converters, node, parent, req }) {
     const childrenText = await convertLexicalNodesToHTML({
       converters,
       lexicalNodes: node.children,
@@ -13,7 +13,7 @@ export const ParagraphHTMLConverter: HTMLConverter<SerializedParagraphNode> = {
         ...node,
         parent,
       },
-      payload,
+      req,
     })
     return `<p>${childrenText}</p>`
   },

--- a/packages/richtext-lexical/src/features/converters/html/converter/types.ts
+++ b/packages/richtext-lexical/src/features/converters/html/converter/types.ts
@@ -1,5 +1,5 @@
 import type { SerializedLexicalNode } from 'lexical'
-import type { Payload } from 'payload'
+import type { Payload, PayloadRequest } from 'payload'
 
 export type HTMLConverter<T extends SerializedLexicalNode = SerializedLexicalNode> = {
   converter: ({
@@ -7,16 +7,16 @@ export type HTMLConverter<T extends SerializedLexicalNode = SerializedLexicalNod
     converters,
     node,
     parent,
-    payload,
+    req,
   }: {
     childIndex: number
     converters: HTMLConverter[]
     node: T
     parent: SerializedLexicalNodeWithParent
     /**
-     * When the converter is called, payload CAN be passed in depending on where it's run.
+     * When the converter is called, req CAN be passed in depending on where it's run.
      */
-    payload: Payload | null
+    req: PayloadRequest | null
   }) => Promise<string> | string
   nodeTypes: string[]
 }

--- a/packages/richtext-lexical/src/features/converters/html/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/html/field/index.ts
@@ -209,7 +209,7 @@ export const lexicalHTML: (
           return await convertLexicalToHTML({
             converters: finalConverters,
             data: lexicalFieldData,
-            payload: req.payload,
+            req,
           })
         },
       ],

--- a/packages/richtext-lexical/src/features/heading/feature.server.ts
+++ b/packages/richtext-lexical/src/features/heading/feature.server.ts
@@ -36,7 +36,7 @@ export const HeadingFeature: FeatureProviderProviderServer<
           createNode({
             converters: {
               html: {
-                converter: async ({ converters, node, parent, payload }) => {
+                converter: async ({ converters, node, parent, req }) => {
                   const childrenText = await convertLexicalNodesToHTML({
                     converters,
                     lexicalNodes: node.children,
@@ -44,7 +44,7 @@ export const HeadingFeature: FeatureProviderProviderServer<
                       ...node,
                       parent,
                     },
-                    payload,
+                    req,
                   })
 
                   return '<' + node?.tag + '>' + childrenText + '</' + node?.tag + '>'

--- a/packages/richtext-lexical/src/features/link/feature.server.ts
+++ b/packages/richtext-lexical/src/features/link/feature.server.ts
@@ -128,7 +128,7 @@ export const LinkFeature: FeatureProviderProviderServer<LinkFeatureServerProps, 
           createNode({
             converters: {
               html: {
-                converter: async ({ converters, node, parent, payload }) => {
+                converter: async ({ converters, node, parent, req }) => {
                   const childrenText = await convertLexicalNodesToHTML({
                     converters,
                     lexicalNodes: node.children,
@@ -136,7 +136,7 @@ export const LinkFeature: FeatureProviderProviderServer<LinkFeatureServerProps, 
                       ...node,
                       parent,
                     },
-                    payload,
+                    req,
                   })
 
                   const rel: string = node.fields.newTab ? ' rel="noopener noreferrer"' : ''
@@ -162,7 +162,7 @@ export const LinkFeature: FeatureProviderProviderServer<LinkFeatureServerProps, 
           createNode({
             converters: {
               html: {
-                converter: async ({ converters, node, parent, payload }) => {
+                converter: async ({ converters, node, parent, req }) => {
                   const childrenText = await convertLexicalNodesToHTML({
                     converters,
                     lexicalNodes: node.children,
@@ -170,7 +170,7 @@ export const LinkFeature: FeatureProviderProviderServer<LinkFeatureServerProps, 
                       ...node,
                       parent,
                     },
-                    payload,
+                    req,
                   })
 
                   const rel: string = node.fields.newTab ? ' rel="noopener noreferrer"' : ''

--- a/packages/richtext-lexical/src/features/lists/htmlConverter.ts
+++ b/packages/richtext-lexical/src/features/lists/htmlConverter.ts
@@ -8,7 +8,7 @@ import type { HTMLConverter } from '../converters/html/converter/types.js'
 import { convertLexicalNodesToHTML } from '../converters/html/converter/index.js'
 
 export const ListHTMLConverter: HTMLConverter<SerializedListNode> = {
-  converter: async ({ converters, node, parent, payload }) => {
+  converter: async ({ converters, node, parent, req }) => {
     const childrenText = await convertLexicalNodesToHTML({
       converters,
       lexicalNodes: node.children,
@@ -16,7 +16,7 @@ export const ListHTMLConverter: HTMLConverter<SerializedListNode> = {
         ...node,
         parent,
       },
-      payload,
+      req,
     })
 
     return `<${node?.tag} class="list-${node?.listType}">${childrenText}</${node?.tag}>`
@@ -25,7 +25,7 @@ export const ListHTMLConverter: HTMLConverter<SerializedListNode> = {
 }
 
 export const ListItemHTMLConverter: HTMLConverter<SerializedListItemNode> = {
-  converter: async ({ converters, node, parent, payload }) => {
+  converter: async ({ converters, node, parent, req }) => {
     const hasSubLists = node.children.some((child) => child.type === 'list')
 
     const childrenText = await convertLexicalNodesToHTML({
@@ -35,7 +35,7 @@ export const ListItemHTMLConverter: HTMLConverter<SerializedListItemNode> = {
         ...node,
         parent,
       },
-      payload,
+      req,
     })
 
     if ('listType' in parent && parent?.listType === 'check') {

--- a/packages/richtext-lexical/src/features/relationship/feature.server.ts
+++ b/packages/richtext-lexical/src/features/relationship/feature.server.ts
@@ -84,7 +84,7 @@ export const RelationshipFeature: FeatureProviderProviderServer<
                   populationPromises.push(
                     populate({
                       id,
-                      collection,
+                      collectionSlug: collection.config.slug,
                       currentDepth,
                       data: node,
                       depth: populateDepth,

--- a/packages/richtext-lexical/src/features/relationship/graphQLPopulationPromise.ts
+++ b/packages/richtext-lexical/src/features/relationship/graphQLPopulationPromise.ts
@@ -30,7 +30,7 @@ export const relationshipPopulationPromiseHOC = (
         populationPromises.push(
           populate({
             id,
-            collection,
+            collectionSlug: collection.config.slug,
             currentDepth,
             data: node,
             depth: populateDepth,

--- a/packages/richtext-lexical/src/features/upload/graphQLPopulationPromise.ts
+++ b/packages/richtext-lexical/src/features/upload/graphQLPopulationPromise.ts
@@ -36,7 +36,7 @@ export const uploadPopulationPromiseHOC = (
         populationPromises.push(
           populate({
             id,
-            collection,
+            collectionSlug: collection.config.slug,
             currentDepth,
             data: node,
             depth: populateDepth,

--- a/packages/richtext-lexical/src/populateGraphQL/populate.ts
+++ b/packages/richtext-lexical/src/populateGraphQL/populate.ts
@@ -15,7 +15,7 @@ type Arguments = {
 
 export const populate = async ({
   id,
-  collection,
+  collectionSlug,
   currentDepth,
   data,
   depth,
@@ -25,7 +25,7 @@ export const populate = async ({
   req,
   showHiddenFields,
 }: Arguments & {
-  collection: Collection
+  collectionSlug: string
   id: number | string
 }): Promise<void> => {
   const shouldPopulate = depth && currentDepth <= depth
@@ -38,7 +38,7 @@ export const populate = async ({
 
   const doc = await req.payloadDataLoader.load(
     createDataloaderCacheKey({
-      collectionSlug: collection.config.slug,
+      collectionSlug,
       currentDepth: currentDepth + 1,
       depth,
       docID: id as string,

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -672,6 +672,8 @@ export interface TextField {
   text: string;
   localizedText?: string | null;
   i18nText?: string | null;
+  defaultString?: string | null;
+  defaultEmptyString?: string | null;
   defaultFunction?: string | null;
   defaultAsync?: string | null;
   overrideLength?: string | null;
@@ -915,6 +917,17 @@ export interface JsonField {
     | number
     | boolean
     | null;
+  group?: {
+    jsonWithinGroup?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+  };
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
Now, when the lexicalHTML field is used, the upload node population in the HTML converter will be on the same transaction