### PR TITLE
Fix typo in concepts

### DIFF
--- a/docs/getting-started/concepts.mdx
+++ b/docs/getting-started/concepts.mdx
@@ -135,9 +135,9 @@ If you were to query the Posts endpoint at, say, `http://localhost:3000/api/post
 }
 ```
 
-Notice how the `user.author` is fully populated, but `user.author.department` is left as a document ID? That's because the User collection counted as the first level of `depth` and got populated—but then prevented any further populations from taking place.
+Notice how the `post.author` is fully populated, but `post.author.department` is left as a document ID? That's because the User collection counted as the first level of `depth` and got populated—but then prevented any further populations from taking place.
 
-To populate `user.author.department` in it's entirety you could specify `?depth=2` or _higher_.
+To populate `post.author.department` in it's entirety you could specify `?depth=2` or _higher_.
 
 ```
 // ?depth=2


### PR DESCRIPTION
## Description

In example demonstrating depth, it's for posts, but it mentions "user" as an example

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] This change requires a documentation update

