### PR TITLE
fix: adjusts json field defaultValue joi validation

### DIFF
--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -196,7 +196,7 @@ export const json = baseField.keys({
     }),
     editorOptions: joi.object().unknown(), // Editor['options'] @monaco-editor/react
   }),
-  defaultValue: joi.alternatives().try(joi.array(), joi.object()),
+  defaultValue: joi.alternatives().try(joi.array(), joi.func(), joi.object()),
   jsonSchema: joi.object().unknown(),
 })
 


### PR DESCRIPTION
## Description

Adjusts JSON field schema validation to allow for functions as default values.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
