### PR TITLE
feat(richtext-lexical)!: properly define client-only and server-only exports

### DIFF
--- a/packages/richtext-lexical/src/exports/client/index.ts
+++ b/packages/richtext-lexical/src/exports/client/index.ts
@@ -41,7 +41,6 @@ export { UploadFeatureClientComponent } from '../../features/upload/feature.clie
 
 export { RichTextField } from '../../field/index.js'
 export {
-  type EditorConfigContextType,
   EditorConfigProvider,
   useEditorConfigContext,
 } from '../../lexical/config/client/EditorConfigProvider.js'
@@ -71,3 +70,66 @@ export {
   addSwipeRightListener,
   addSwipeUpListener,
 } from '../../lexical/utils/swipe.js'
+export { createClientFeature } from '../../utilities/createClientFeature.js'
+
+export {
+  DETAIL_TYPE_TO_DETAIL,
+  DOUBLE_LINE_BREAK,
+  ELEMENT_FORMAT_TO_TYPE,
+  ELEMENT_TYPE_TO_FORMAT,
+  IS_ALL_FORMATTING,
+  LTR_REGEX,
+  NON_BREAKING_SPACE,
+  NodeFormat,
+  RTL_REGEX,
+  TEXT_MODE_TO_TYPE,
+  TEXT_TYPE_TO_FORMAT,
+  TEXT_TYPE_TO_MODE,
+} from '../../lexical/utils/nodeFormat.js'
+
+export { ENABLE_SLASH_MENU_COMMAND } from '../../lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/index.js'
+
+export { getEnabledNodes } from '../../lexical/nodes/index.js'
+
+export {
+  $createUploadNode,
+  $isUploadNode,
+  UploadNode,
+} from '../../features/upload/nodes/UploadNode.js'
+
+export {
+  $createRelationshipNode,
+  $isRelationshipNode,
+  RelationshipNode,
+} from '../../features/relationship/nodes/RelationshipNode.js'
+
+export {
+  $createLinkNode,
+  $isLinkNode,
+  LinkNode,
+  TOGGLE_LINK_COMMAND,
+} from '../../features/link/nodes/LinkNode.js'
+
+export {
+  $createAutoLinkNode,
+  $isAutoLinkNode,
+  AutoLinkNode,
+} from '../../features/link/nodes/AutoLinkNode.js'
+
+export { consolidateHTMLConverters } from '../../features/converters/html/field/index.js'
+
+export {
+  convertLexicalNodesToHTML,
+  convertLexicalToHTML,
+} from '../../features/converters/html/converter/index.js'
+
+export { defaultHTMLConverters } from '../../features/converters/html/converter/defaultConverters.js'
+export { LinebreakHTMLConverter } from '../../features/converters/html/converter/converters/linebreak.js'
+export { ParagraphHTMLConverter } from '../../features/converters/html/converter/converters/paragraph.js'
+export { TextHTMLConverter } from '../../features/converters/html/converter/converters/text.js'
+
+export {
+  $createBlockNode,
+  $isBlockNode,
+  BlockNode,
+} from '../../features/blocks/nodes/BlocksNode.js'

--- a/packages/richtext-lexical/src/exports/client/index.ts
+++ b/packages/richtext-lexical/src/exports/client/index.ts
@@ -116,18 +116,6 @@ export {
   AutoLinkNode,
 } from '../../features/link/nodes/AutoLinkNode.js'
 
-export { consolidateHTMLConverters } from '../../features/converters/html/field/index.js'
-
-export {
-  convertLexicalNodesToHTML,
-  convertLexicalToHTML,
-} from '../../features/converters/html/converter/index.js'
-
-export { defaultHTMLConverters } from '../../features/converters/html/converter/defaultConverters.js'
-export { LinebreakHTMLConverter } from '../../features/converters/html/converter/converters/linebreak.js'
-export { ParagraphHTMLConverter } from '../../features/converters/html/converter/converters/paragraph.js'
-export { TextHTMLConverter } from '../../features/converters/html/converter/converters/text.js'
-
 export {
   $createBlockNode,
   $isBlockNode,

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -812,8 +812,6 @@ export { AlignFeature } from './features/align/feature.server.js'
 export { BlockquoteFeature } from './features/blockquote/feature.server.js'
 export { BlocksFeature, type BlocksFeatureProps } from './features/blocks/feature.server.js'
 export {
-  $createBlockNode,
-  $isBlockNode,
   type BlockFields,
   BlockNode,
   type SerializedBlockNode,
@@ -850,17 +848,8 @@ export { HorizontalRuleFeature } from './features/horizontalRule/feature.server.
 export { IndentFeature } from './features/indent/feature.server.js'
 export { LinkFeature, type LinkFeatureServerProps } from './features/link/feature.server.js'
 
-export {
-  $createAutoLinkNode,
-  $isAutoLinkNode,
-  AutoLinkNode,
-} from './features/link/nodes/AutoLinkNode.js'
-export {
-  $createLinkNode,
-  $isLinkNode,
-  LinkNode,
-  TOGGLE_LINK_COMMAND,
-} from './features/link/nodes/LinkNode.js'
+export { AutoLinkNode } from './features/link/nodes/AutoLinkNode.js'
+export { LinkNode } from './features/link/nodes/LinkNode.js'
 export type {
   LinkFields,
   SerializedAutoLinkNode,
@@ -898,8 +887,6 @@ export {
   type RelationshipFeatureProps,
 } from './features/relationship/feature.server.js'
 export {
-  $createRelationshipNode,
-  $isRelationshipNode,
   type RelationshipData,
   RelationshipNode,
   type SerializedRelationshipNode,
@@ -909,7 +896,7 @@ export { FixedToolbarFeature } from './features/toolbars/fixed/feature.server.js
 export { InlineToolbarFeature } from './features/toolbars/inline/feature.server.js'
 
 export type { ToolbarGroup, ToolbarGroupItem } from './features/toolbars/types.js'
-export { createNode } from './features/typeUtilities.js'
+export { createNode } from './features/typeUtilities.js' // Only useful in feature.server.ts
 export type {
   AfterChangeNodeHook,
   AfterChangeNodeHookArgs,
@@ -947,33 +934,31 @@ export { UploadFeature } from './features/upload/feature.server.js'
 
 export type { UploadFeatureProps } from './features/upload/feature.server.js'
 export {
-  $createUploadNode,
-  $isUploadNode,
   type SerializedUploadNode,
   type UploadData,
   UploadNode,
 } from './features/upload/nodes/UploadNode.js'
 
+export type { EditorConfigContextType } from './lexical/config/client/EditorConfigProvider.js'
 export {
   defaultEditorConfig,
   defaultEditorFeatures,
   defaultEditorLexicalConfig,
 } from './lexical/config/server/default.js'
-export { loadFeatures, sortFeaturesForOptimalLoading } from './lexical/config/server/loader.js'
 
+export { loadFeatures, sortFeaturesForOptimalLoading } from './lexical/config/server/loader.js'
 export {
   sanitizeServerEditorConfig,
   sanitizeServerFeatures,
 } from './lexical/config/server/sanitize.js'
+
 export type {
   ClientEditorConfig,
   SanitizedClientEditorConfig,
   SanitizedServerEditorConfig,
   ServerEditorConfig,
 } from './lexical/config/types.js'
-
 export { getEnabledNodes } from './lexical/nodes/index.js'
-export { ENABLE_SLASH_MENU_COMMAND } from './lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/index.js'
 export type { AdapterProps }
 
 export type {
@@ -995,11 +980,10 @@ export {
   TEXT_TYPE_TO_FORMAT,
   TEXT_TYPE_TO_MODE,
 } from './lexical/utils/nodeFormat.js'
-
 export { sanitizeUrl, validateUrl } from './lexical/utils/url.js'
+
 export { defaultRichTextValue } from './populateGraphQL/defaultValue.js'
 
 export type { LexicalEditorProps, LexicalRichTextAdapter } from './types.js'
 
-export { createClientFeature } from './utilities/createClientFeature.js'
 export { createServerFeature } from './utilities/createServerFeature.js'


### PR DESCRIPTION
server-only stuff is exported from /, client-only stuff from /client, and shared stuff from both. This was the best way to avoid duplication within the same environment (server/client).

**BREAKING:** a bunch of exports have been moved around. There are now two of them: `@payloadcms/richtext-lexical` and `@payloadcms/richtext-lexical/client`. The root export is server-only. If any imports don't resolve anymore after this version, simply change the import to one of those, depending on if you are on the server or the client