### PR TITLE
chore: do not throw error if no dependencies are found

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -401,7 +401,7 @@ export class BasePayload<TGeneratedTypes extends GeneratedTypes> {
           foundVersions[version] = _pkg
         }
       }
-      if (Object.keys(foundVersions).length !== 1) {
+      if (Object.keys(foundVersions).length > 1) {
         const formattedVersionsWithPackageNameString = Object.entries(foundVersions)
           .map(([version, pkg]) => `${pkg}@${version}`)
           .join(', ')

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -72,7 +72,7 @@ export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapte
           foundVersions[version] = _pkg
         }
       }
-      if (Object.keys(foundVersions).length !== 1) {
+      if (Object.keys(foundVersions).length > 1) {
         const formattedVersionsWithPackageNameString = Object.entries(foundVersions)
           .map(([version, pkg]) => `${pkg}@${version}`)
           .join(', ')


### PR DESCRIPTION
This fixes support for monorepos where in some conditions no dependencies are found, triggering the runtime dependency check.

While this effectively disables the dependency check in some monorepo setups, most people running monorepos likely know how to properly install dependencies, thus not needing this check as much