### PR TITLE
fix(richtext-lexical): properly set heading level translation for nb and pl

### DIFF
--- a/packages/richtext-lexical/src/features/heading/i18n.ts
+++ b/packages/richtext-lexical/src/features/heading/i18n.ts
@@ -50,13 +50,13 @@ export const i18n: Partial<GenericLanguages> = {
     label: '[SURAT]\n\nKepala {{headingLevel}}',
   },
   nb: {
-    label: 'Overskrift {{overskriftsnivå}}',
+    label: 'Overskrift {{headingLevel}}',
   },
   nl: {
     label: 'Kop {{headingLevel}}',
   },
   pl: {
-    label: 'Nagłówek {{poziom nagłówka}}',
+    label: 'Nagłówek {{headingLevel}}',
   },
   pt: {
     label: 'Cabeçalho {{headingLevel}}',


### PR DESCRIPTION
## Description

Heading level replacer has been translated for nb and pl. This makes the heading level not shown properly in frontend.

![Skjermbilde 2024-06-24 kl  09 54 51](https://github.com/payloadcms/payload/assets/2082176/0c95bb60-0a26-4027-b1f0-a2504c8ed7a4)

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
