### PR TITLE
chore(templates): pin TS 5.4.5

### DIFF
--- a/templates/_template/package.json
+++ b/templates/_template/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.4.5",
     "eslint": "^8",
     "eslint-config-next": "15.0.0-rc.0",
-    "typescript": "^5.4.5"
+    "typescript": "5.4.5"
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0"

--- a/templates/blank-3.0/package.json
+++ b/templates/blank-3.0/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.4.5",
     "eslint": "^8",
     "eslint-config-next": "15.0.0-rc.0",
-    "typescript": "^5.4.5"
+    "typescript": "5.4.5"
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0"

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.4.5",
     "eslint": "^8",
     "eslint-config-next": "15.0.0-rc.0",
-    "typescript": "^5.4.5"
+    "typescript": "5.4.5"
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0"

--- a/templates/with-payload-cloud/package.json
+++ b/templates/with-payload-cloud/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.4.5",
     "eslint": "^8",
     "eslint-config-next": "15.0.0-rc.0",
-    "typescript": "^5.4.5"
+    "typescript": "5.4.5"
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0"

--- a/templates/with-vercel-mongodb/package.json
+++ b/templates/with-vercel-mongodb/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.4.5",
     "eslint": "^8",
     "eslint-config-next": "15.0.0-rc.0",
-    "typescript": "^5.4.5"
+    "typescript": "5.4.5"
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0"

--- a/templates/with-vercel-postgres/package.json
+++ b/templates/with-vercel-postgres/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.4.5",
     "eslint": "^8",
     "eslint-config-next": "15.0.0-rc.0",
-    "typescript": "^5.4.5"
+    "typescript": "5.4.5"
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0"


### PR DESCRIPTION
Pinning `typescript` for all templates to `5.4.5` until https://github.com/payloadcms/payload/pull/6893 is released.