### PR TITLE
fix(db-mongodb): removes precedence of regular chars over international chars in sort

### DIFF
--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -55,7 +55,7 @@ export const find: Find = async function find(
     useEstimatedCount,
   }
 
-  if (locale) {
+  if (locale && locale !== 'all' && locale !== '*') {
     paginationOptions.collation = { locale, strength: 1 }
   }
 

--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -55,6 +55,10 @@ export const find: Find = async function find(
     useEstimatedCount,
   }
 
+  if (locale) {
+    paginationOptions.collation = { locale, strength: 1 }
+  }
+
   if (!useEstimatedCount && Object.keys(query).length === 0 && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding
     // a hint. By default, if no hint is provided, MongoDB does not use an indexed field to count the returned documents,

--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -74,6 +74,10 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     useEstimatedCount,
   }
 
+  if (locale) {
+    paginationOptions.collation = { locale, strength: 1 }
+  }
+
   if (!useEstimatedCount && Object.keys(query).length === 0 && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding
     // a hint. By default, if no hint is provided, MongoDB does not use an indexed field to count the returned documents,

--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -74,7 +74,7 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     useEstimatedCount,
   }
 
-  if (locale) {
+  if (locale && locale !== 'all' && locale !== '*') {
     paginationOptions.collation = { locale, strength: 1 }
   }
 

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -70,7 +70,7 @@ export const findVersions: FindVersions = async function findVersions(
     useEstimatedCount,
   }
 
-  if (locale) {
+  if (locale && locale !== 'all' && locale !== '*') {
     paginationOptions.collation = { locale, strength: 1 }
   }
 

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -70,6 +70,10 @@ export const findVersions: FindVersions = async function findVersions(
     useEstimatedCount,
   }
 
+  if (locale) {
+    paginationOptions.collation = { locale, strength: 1 }
+  }
+
   if (!useEstimatedCount && Object.keys(query).length === 0 && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding
     // a hint. By default, if no hint is provided, MongoDB does not use an indexed field to count the returned documents,

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -58,7 +58,7 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     useEstimatedCount,
   }
 
-  if (locale) {
+  if (locale && locale !== 'all' && locale !== '*') {
     paginationOptions.collation = { locale, strength: 1 }
   }
 

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -58,6 +58,10 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     useEstimatedCount,
   }
 
+  if (locale) {
+    paginationOptions.collation = { locale, strength: 1 }
+  }
+
   if (
     !useEstimatedCount &&
     Object.keys(versionQuery).length === 0 &&

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -65,6 +65,10 @@ export default buildConfigWithDefaults({
         },
         {
           name: 'description',
+          type: 'text',
+        },
+        {
+          name: 'localizedDescription',
           localized: true,
           type: 'text',
         },

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -8,6 +8,7 @@ import {
   blocksWithLocalizedSameName,
   defaultLocale,
   englishTitle,
+  hungarianLocale,
   localizedPostsSlug,
   localizedSortSlug,
   portugueseLocale,
@@ -64,6 +65,7 @@ export default buildConfigWithDefaults({
         },
         {
           name: 'description',
+          localized: true,
           type: 'text',
         },
         {
@@ -306,6 +308,11 @@ export default buildConfigWithDefaults({
         label: 'Arabic',
         rtl: true,
       },
+      {
+        code: hungarianLocale,
+        label: 'Hungarian',
+        rtl: false,
+      },
     ],
   },
   onInit: async (payload) => {
@@ -365,6 +372,7 @@ export default buildConfigWithDefaults({
         title: relationEnglishTitle2,
       },
     })
+
     await payload.update({
       id: localizedPost.id,
       collection,

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -302,7 +302,7 @@ describe('Localization', () => {
           collection,
           data: {
             title: 'non accent post',
-            description: 'something',
+            localizedDescription: 'something',
           },
           locale: englishLocale,
         })
@@ -312,7 +312,7 @@ describe('Localization', () => {
           collection,
           data: {
             title: 'accent post',
-            description: 'veterinarian',
+            localizedDescription: 'veterinarian',
           },
           locale: englishLocale,
         })
@@ -322,7 +322,7 @@ describe('Localization', () => {
           collection,
           data: {
             title: 'non accent post',
-            description: 'valami',
+            localizedDescription: 'valami',
           },
           locale: hungarianLocale,
         })
@@ -332,7 +332,7 @@ describe('Localization', () => {
           collection,
           data: {
             title: 'accent post',
-            description: 'állatorvos',
+            localizedDescription: 'állatorvos',
           },
           locale: hungarianLocale,
         })

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -350,8 +350,6 @@ describe('Localization', () => {
           locale: hungarianLocale,
         })
 
-        console.log(sortByDescriptionQuery.docs)
-
         expect(sortByDescriptionQuery.docs[0].id).toEqual(localizedAccentPostTwo.id)
       })
     })

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -293,66 +293,68 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized sorting', () => {
-      let localizedAccentPostOne: LocalizedPost
-      let localizedAccentPostTwo: LocalizedPost
-      beforeEach(async () => {
-        // @ts-expect-error Force typing
-        localizedAccentPostOne = await payload.create({
-          collection,
-          data: {
-            title: 'non accent post',
-            localizedDescription: 'something',
-          },
-          locale: englishLocale,
-        })
-
-        // @ts-expect-error Force typing
-        localizedAccentPostTwo = await payload.create({
-          collection,
-          data: {
-            title: 'accent post',
-            localizedDescription: 'veterinarian',
-          },
-          locale: englishLocale,
-        })
-
-        await payload.update({
-          id: localizedAccentPostOne.id,
-          collection,
-          data: {
-            title: 'non accent post',
-            localizedDescription: 'valami',
-          },
-          locale: hungarianLocale,
-        })
-
-        await payload.update({
-          id: localizedAccentPostTwo.id,
-          collection,
-          data: {
-            title: 'accent post',
-            localizedDescription: 'állatorvos',
-          },
-          locale: hungarianLocale,
-        })
-      })
-
-      it('should sort alphabetically even with accented letters', async () => {
-        const sortByDescriptionQuery = await payload.find({
-          collection,
-          sort: 'description',
-          where: {
-            title: {
-              like: 'accent',
+    if (['mongoose'].includes(process.env.PAYLOAD_DATABASE)) {
+      describe('Localized sorting', () => {
+        let localizedAccentPostOne: LocalizedPost
+        let localizedAccentPostTwo: LocalizedPost
+        beforeEach(async () => {
+          // @ts-expect-error Force typing
+          localizedAccentPostOne = await payload.create({
+            collection,
+            data: {
+              title: 'non accent post',
+              localizedDescription: 'something',
             },
-          },
-          locale: hungarianLocale,
+            locale: englishLocale,
+          })
+
+          // @ts-expect-error Force typing
+          localizedAccentPostTwo = await payload.create({
+            collection,
+            data: {
+              title: 'accent post',
+              localizedDescription: 'veterinarian',
+            },
+            locale: englishLocale,
+          })
+
+          await payload.update({
+            id: localizedAccentPostOne.id,
+            collection,
+            data: {
+              title: 'non accent post',
+              localizedDescription: 'valami',
+            },
+            locale: hungarianLocale,
+          })
+
+          await payload.update({
+            id: localizedAccentPostTwo.id,
+            collection,
+            data: {
+              title: 'accent post',
+              localizedDescription: 'állatorvos',
+            },
+            locale: hungarianLocale,
+          })
         })
 
-        expect(sortByDescriptionQuery.docs[0].id).toEqual(localizedAccentPostTwo.id)
+        it('should sort alphabetically even with accented letters', async () => {
+          const sortByDescriptionQuery = await payload.find({
+            collection,
+            sort: 'description',
+            where: {
+              title: {
+                like: 'accent',
+              },
+            },
+            locale: hungarianLocale,
+          })
+
+          expect(sortByDescriptionQuery.docs[0].id).toEqual(localizedAccentPostTwo.id)
+        })
       })
-    })
+    }
   })
 
   describe('Localized Sort Count', () => {

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -13,7 +13,7 @@ import { RESTClient } from '../helpers/rest'
 import { arrayCollectionSlug } from './collections/Array'
 import { nestedToArrayAndBlockCollectionSlug } from './collections/NestedToArrayAndBlock'
 import configPromise from './config'
-import { defaultLocale, localizedSortSlug } from './shared'
+import { defaultLocale, hungarianLocale, localizedSortSlug } from './shared'
 import {
   englishTitle,
   localizedPostsSlug,
@@ -290,6 +290,69 @@ describe('Localization', () => {
         })
 
         expect(result.docs.map(({ id }) => id)).toContain(localizedPost.id)
+      })
+    })
+
+    describe('Localized sorting', () => {
+      let localizedAccentPostOne: LocalizedPost
+      let localizedAccentPostTwo: LocalizedPost
+      beforeEach(async () => {
+        // @ts-expect-error Force typing
+        localizedAccentPostOne = await payload.create({
+          collection,
+          data: {
+            title: 'non accent post',
+            description: 'something',
+          },
+          locale: englishLocale,
+        })
+
+        // @ts-expect-error Force typing
+        localizedAccentPostTwo = await payload.create({
+          collection,
+          data: {
+            title: 'accent post',
+            description: 'veterinarian',
+          },
+          locale: englishLocale,
+        })
+
+        await payload.update({
+          id: localizedAccentPostOne.id,
+          collection,
+          data: {
+            title: 'non accent post',
+            description: 'valami',
+          },
+          locale: hungarianLocale,
+        })
+
+        await payload.update({
+          id: localizedAccentPostTwo.id,
+          collection,
+          data: {
+            title: 'accent post',
+            description: 'állatorvos',
+          },
+          locale: hungarianLocale,
+        })
+      })
+
+      it('should sort alphabetically even with accented letters', async () => {
+        const sortByDescriptionQuery = await payload.find({
+          collection,
+          sort: 'description',
+          where: {
+            title: {
+              like: 'accent',
+            },
+          },
+          locale: hungarianLocale,
+        })
+
+        console.log(sortByDescriptionQuery.docs)
+
+        expect(sortByDescriptionQuery.docs[0].id).toEqual(localizedAccentPostTwo.id)
       })
     })
   })

--- a/test/localization/shared.ts
+++ b/test/localization/shared.ts
@@ -8,6 +8,7 @@ export const relationSpanishTitle2 = `${relationSpanishTitle}2`
 export const defaultLocale = 'en'
 export const spanishLocale = 'es'
 export const portugueseLocale = 'pt'
+export const hungarianLocale = 'hu'
 
 // Slugs
 export const localizedPostsSlug = 'localized-posts'


### PR DESCRIPTION
## Description

Fixes #6719 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
