### PR TITLE
docs: fixes syntax error in access control overview

### DIFF
--- a/docs/access-control/overview.mdx
+++ b/docs/access-control/overview.mdx
@@ -37,9 +37,12 @@ const defaultPayloadAccess = ({ req: { user } }) => {
   <strong>Note:</strong>
   <br />
   In the Local API, all Access Control functions are skipped by default, allowing your server to do
-  whatever it needs. But, you can opt back in by setting the option <strong>
+  whatever it needs. But, you can opt back in by setting the option
+  {' '}
+  <strong>
     overrideAccess
-  </strong>{' '}
+  </strong>
+  {' '}
   to <strong>false</strong>.
 </Banner>
 


### PR DESCRIPTION
## Description

There is a syntax error in the Access Control overview doc that is preventing build.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
