### PR TITLE
feat(richtext-lexical): improve lexical types, improve docs

### DIFF
--- a/docs/lexical/converters.mdx
+++ b/docs/lexical/converters.mdx
@@ -46,34 +46,54 @@ const Pages: CollectionConfig = {
 
 The `lexicalHTML()` function creates a new field that automatically converts the referenced lexical richText field into HTML through an afterRead hook.
 
-### Generating HTML anywhere on the server:
+### Generating HTML anywhere on the server
 
-If you wish to convert JSON to HTML ad-hoc, use this code snippet:
+If you wish to convert JSON to HTML ad-hoc, use the `convertLexicalToHTML` function:
 
 ```ts
-import type { SerializedEditorState } from 'lexical'
-import {
-  type SanitizedEditorConfig,
-  convertLexicalToHTML,
-  consolidateHTMLConverters,
-} from '@payloadcms/richtext-lexical'
+import { consolidateHTMLConverters, convertLexicalToHTML } from '@payloadcms/richtext-lexical'
 
-async function lexicalToHTML(
-  editorData: SerializedEditorState,
-  editorConfig: SanitizedEditorConfig,
-) {
-  return await convertLexicalToHTML({
-    converters: consolidateHTMLConverters({ editorConfig }),
-    data: editorData,
-    payload, // if you have payload but no req available, pass it in here to enable server-only functionality (e.g. proper conversion of upload nodes)
-    req, // if you have req available, pass it in here to enable server-only functionality (e.g. proper conversion of upload nodes). No need to pass in payload if req is passed in.
-  })
-}
+
+await convertLexicalToHTML({
+  converters: consolidateHTMLConverters({ editorConfig }),
+  data: editorData,
+  payload, // if you have payload but no req available, pass it in here to enable server-only functionality (e.g. proper conversion of upload nodes)
+  req, // if you have req available, pass it in here to enable server-only functionality (e.g. proper conversion of upload nodes). No need to pass in payload if req is passed in.
+})
 ```
-
 This method employs `convertLexicalToHTML` from `@payloadcms/richtext-lexical`, which converts the serialized editor state into HTML.
 
 Because every `Feature` is able to provide html converters, and because the `htmlFeature` can modify those or provide their own, we need to consolidate them with the default html Converters using the `consolidateHTMLConverters` function.
+
+#### Example: Generating HTML within an afterRead hook
+
+```ts
+import type { FieldHook } from 'payload'
+
+import {
+  HTMLConverterFeature,
+  consolidateHTMLConverters,
+  convertLexicalToHTML,
+  defaultEditorConfig,
+  defaultEditorFeatures,
+  sanitizeServerEditorConfig,
+} from '@payloadcms/richtext-lexical'
+
+const hook: FieldHook = async ({ req, siblingData }) => {
+  const editorConfig = defaultEditorConfig
+
+  editorConfig.features = [...defaultEditorFeatures, HTMLConverterFeature({})]
+
+  const sanitizedEditorConfig = await sanitizeServerEditorConfig(editorConfig, req.payload.config)
+
+  const html = await convertLexicalToHTML({
+    converters: consolidateHTMLConverters({ editorConfig: sanitizedEditorConfig }),
+    data: siblingData.lexicalSimple,
+    req,
+  })
+  return html
+}
+```
 
 ### CSS
 
@@ -184,10 +204,11 @@ import { createHeadlessEditor } from '@lexical/headless' // <= make sure this pa
 import { getEnabledNodes, sanitizeServerEditorConfig } from '@payloadcms/richtext-lexical'
 
 const yourEditorConfig // <= your editor config here
+const payloadConfig // <= your payload config here
 
 const headlessEditor = createHeadlessEditor({
   nodes: getEnabledNodes({
-    editorConfig: sanitizeServerEditorConfig(yourEditorConfig),
+    editorConfig: sanitizeServerEditorConfig(yourEditorConfig, payloadConfig),
   }),
 })
 ```
@@ -316,7 +337,7 @@ Convert markdown content to the Lexical editor format with the following:
 import { $convertFromMarkdownString } from '@lexical/markdown'
 import { sanitizeServerEditorConfig } from '@payloadcms/richtext-lexical'
 
-const yourSanitizedEditorConfig = sanitizeServerEditorConfig(yourEditorConfig) // <= your editor config here
+const yourSanitizedEditorConfig = sanitizeServerEditorConfig(yourEditorConfig, payloadConfig) // <= your editor config & payload config here
 const markdown = `# Hello World`
 
 headlessEditor.update(
@@ -344,7 +365,7 @@ import { $convertToMarkdownString } from '@lexical/markdown'
 import { sanitizeServerEditorConfig } from '@payloadcms/richtext-lexical'
 import type { SerializedEditorState } from 'lexical'
 
-const yourSanitizedEditorConfig = sanitizeServerEditorConfig(yourEditorConfig) // <= your editor config here
+const yourSanitizedEditorConfig = sanitizeServerEditorConfig(yourEditorConfig, payloadConfig) // <= your editor config & payload config here
 const yourEditorState: SerializedEditorState // <= your current editor state here
 
 // Import editor state into your headless editor

--- a/docs/lexical/overview.mdx
+++ b/docs/lexical/overview.mdx
@@ -89,7 +89,7 @@ import { CallToAction } from '../blocks/CallToAction'
 
 {
   editor: lexicalEditor({
-    features: ({ defaultFeatures }) => [
+    features: ({ defaultFeatures, rootFeatures }) => [
       ...defaultFeatures,
       LinkFeature({
         // Example showing how to customize the built-in fields
@@ -133,6 +133,15 @@ import { CallToAction } from '../blocks/CallToAction'
   })
 }
 ```
+
+`features` can be both an array of features, or a function returning an array of features. The function provides the following props:
+
+
+| Prop                  | Description                                                                                                                                                                                                                                           |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **`defaultFeatures`** | This opinionated array contains all "recommended" default features. You can see which features are included in the default features in the table below.                                                                                               |
+| **`rootFeatures`**    | This array contains all features that are enabled in the root richText editor (the one defined in the payload.config.ts). If this field is the root richText editor, or if the root richText editor is not a lexical editor, this array will be empty. |
+
 
 ## Features overview
 

--- a/docs/lexical/overview.mdx
+++ b/docs/lexical/overview.mdx
@@ -169,3 +169,77 @@ Notice how even the toolbars are features? That's how extensible our lexical edi
 ## Creating your own, custom Feature
 
 You can find more information about creating your own feature in our [building custom feature docs](lexical/building-custom-features).
+
+## TypeScript
+
+Every single piece of saved data is 100% fully-typed within lexical. It provides a type for every single node, which can be imported from `@payloadcms/richtext-lexical` - each type is prefixed with `Serialized`, e.g. `SerializedUploadNode`.
+
+In order to fully type the entire editor JSON, you can use our `TypedEditorState` helper type, which accepts a union of all possible node types as a generic. The reason we do not provide a type which already contains all possible node types is because the possible node types depend on which features you have enabled in your editor. Here is an example:
+
+```ts
+import type {
+  SerializedAutoLinkNode,
+  SerializedBlockNode,
+  SerializedHorizontalRuleNode,
+  SerializedLinkNode,
+  SerializedListItemNode,
+  SerializedListNode,
+  SerializedParagraphNode,
+  SerializedQuoteNode,
+  SerializedRelationshipNode,
+  SerializedTextNode,
+  SerializedUploadNode,
+  TypedEditorState,
+} from '@payloadcms/richtext-lexical'
+
+const editorState: TypedEditorState<
+  | SerializedAutoLinkNode
+  | SerializedBlockNode
+  | SerializedHorizontalRuleNode
+  | SerializedLinkNode
+  | SerializedListItemNode
+  | SerializedListNode
+  | SerializedParagraphNode
+  | SerializedQuoteNode
+  | SerializedRelationshipNode
+  | SerializedTextNode
+  | SerializedUploadNode
+> = {
+  root: {
+    type: 'root',
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    version: 1,
+    children: [
+      {
+        children: [
+          {
+            detail: 0,
+            format: 0,
+            mode: 'normal',
+            style: '',
+            text: 'Some text. Every property here is fully-typed',
+            type: 'text',
+            version: 1,
+          },
+        ],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        type: 'paragraph',
+        textFormat: 0,
+        version: 1,
+      },
+    ],
+  },
+}
+```
+
+This is a type-safe representation of the editor state. Looking at the auto-suggestions of `type` it will show you all the possible node types you can use.
+
+Make sure to only use types exported from `@payloadcms/richtext-lexical`, not from the lexical core packages. We only have control over types we export and can guarantee that those are correct, even though lexical core may export types with identical names.
+
+### Automatic type generation
+
+Lexical does not generate the accurate type definitions for your richText fields for you yet - this will be improved in the future. Currently, it only outputs the rough shape of the editor JSON which you can enhance using type assertions.

--- a/packages/richtext-lexical/src/features/blockquote/feature.server.ts
+++ b/packages/richtext-lexical/src/features/blockquote/feature.server.ts
@@ -1,3 +1,6 @@
+import type { SerializedQuoteNode as _SerializedQuoteNode } from '@lexical/rich-text'
+import type { Spread } from 'lexical'
+
 import { QuoteNode } from '@lexical/rich-text'
 
 // eslint-disable-next-line payload/no-imports-from-exports-dir
@@ -7,6 +10,13 @@ import { convertLexicalNodesToHTML } from '../converters/html/converter/index.js
 import { createNode } from '../typeUtilities.js'
 import { i18n } from './i18n.js'
 import { MarkdownTransformer } from './markdownTransformer.js'
+
+export type SerializedQuoteNode = Spread<
+  {
+    type: 'quote'
+  },
+  _SerializedQuoteNode
+>
 
 export const BlockquoteFeature = createServerFeature({
   feature: {

--- a/packages/richtext-lexical/src/features/blocks/nodes/BlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/nodes/BlocksNode.tsx
@@ -30,7 +30,9 @@ const BlockComponent = React.lazy(() =>
 
 export type SerializedBlockNode = Spread<
   {
+    children?: never // required so that our typed editor state doesn't automatically add children
     fields: BlockFields
+    type: 'block'
   },
   SerializedDecoratorBlockNode
 >
@@ -102,7 +104,7 @@ export class BlockNode extends DecoratorBlockNode {
   exportJSON(): SerializedBlockNode {
     return {
       ...super.exportJSON(),
-      type: this.getType(),
+      type: 'block',
       fields: this.getFields(),
       version: 2,
     }

--- a/packages/richtext-lexical/src/features/converters/html/feature.server.ts
+++ b/packages/richtext-lexical/src/features/converters/html/feature.server.ts
@@ -9,7 +9,7 @@ export type HTMLConverterFeatureProps = {
 }
 
 // This is just used to save the props on the richText field
-export const HTMLConverterFeature = createServerFeature({
+export const HTMLConverterFeature = createServerFeature<HTMLConverterFeatureProps>({
   feature: {},
   key: 'htmlConverter',
 })

--- a/packages/richtext-lexical/src/features/horizontalRule/nodes/HorizontalRuleNode.tsx
+++ b/packages/richtext-lexical/src/features/horizontalRule/nodes/HorizontalRuleNode.tsx
@@ -6,6 +6,7 @@ import type {
   LexicalCommand,
   LexicalNode,
   SerializedLexicalNode,
+  Spread,
 } from 'lexical'
 
 import { addClassNamesToElement } from '@lexical/utils'
@@ -21,7 +22,13 @@ const HorizontalRuleComponent = React.lazy(() =>
 /**
  * Serialized representation of a horizontal rule node. Serialized = converted to JSON. This is what is stored in the database / in the lexical editor state.
  */
-export type SerializedHorizontalRuleNode = SerializedLexicalNode
+export type SerializedHorizontalRuleNode = Spread<
+  {
+    children?: never // required so that our typed editor state doesn't automatically add children
+    type: 'horizontalrule'
+  },
+  SerializedLexicalNode
+>
 
 export const INSERT_HORIZONTAL_RULE_COMMAND: LexicalCommand<void> = createCommand(
   'INSERT_HORIZONTAL_RULE_COMMAND',

--- a/packages/richtext-lexical/src/features/link/nodes/AutoLinkNode.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/AutoLinkNode.ts
@@ -41,10 +41,16 @@ export class AutoLinkNode extends LinkNode {
     return node
   }
 
+  // @ts-expect-error
   exportJSON(): SerializedAutoLinkNode {
+    const serialized = super.exportJSON()
     return {
-      ...super.exportJSON(),
       type: 'autolink',
+      children: serialized.children,
+      direction: serialized.direction,
+      fields: serialized.fields,
+      format: serialized.format,
+      indent: serialized.indent,
       version: 2,
     }
   }

--- a/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
@@ -129,7 +129,7 @@ export class LinkNode extends ElementNode {
   exportJSON(): SerializedLinkNode {
     const returnObject: SerializedLinkNode = {
       ...super.exportJSON(),
-      type: this.getType(),
+      type: 'link',
       fields: this.getFields(),
       version: 3,
     }

--- a/packages/richtext-lexical/src/features/link/nodes/types.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/types.ts
@@ -1,4 +1,4 @@
-import type { SerializedElementNode, Spread } from 'lexical'
+import type { SerializedElementNode, SerializedLexicalNode, Spread } from 'lexical'
 
 export type LinkFields = {
   // unknown, custom fields:
@@ -18,11 +18,14 @@ export type LinkFields = {
   url: string
 }
 
-export type SerializedLinkNode = Spread<
+export type SerializedLinkNode<T extends SerializedLexicalNode = SerializedLexicalNode> = Spread<
   {
     fields: LinkFields
     id?: string // optional if AutoLinkNode
+    type: 'link'
   },
-  SerializedElementNode
+  SerializedElementNode<T>
 >
-export type SerializedAutoLinkNode = Omit<SerializedLinkNode, 'id'>
+export type SerializedAutoLinkNode<T extends SerializedLexicalNode = SerializedLexicalNode> = {
+  type: 'autolink'
+} & Omit<SerializedLinkNode<T>, 'id' | 'type'>

--- a/packages/richtext-lexical/src/features/lists/checklist/feature.server.ts
+++ b/packages/richtext-lexical/src/features/lists/checklist/feature.server.ts
@@ -26,7 +26,7 @@ export const ChecklistFeature = createServerFeature({
               }),
               createNode({
                 converters: {
-                  html: ListItemHTMLConverter,
+                  html: ListItemHTMLConverter as any,
                 },
                 node: ListItemNode,
               }),

--- a/packages/richtext-lexical/src/features/lists/htmlConverter.ts
+++ b/packages/richtext-lexical/src/features/lists/htmlConverter.ts
@@ -1,9 +1,8 @@
-import type { SerializedListItemNode, SerializedListNode } from '@lexical/list'
-
 import { ListItemNode, ListNode } from '@lexical/list'
 import { v4 as uuidv4 } from 'uuid'
 
 import type { HTMLConverter } from '../converters/html/converter/types.js'
+import type { SerializedListItemNode, SerializedListNode } from './plugin/index.js'
 
 import { convertLexicalNodesToHTML } from '../converters/html/converter/index.js'
 

--- a/packages/richtext-lexical/src/features/lists/orderedList/feature.server.ts
+++ b/packages/richtext-lexical/src/features/lists/orderedList/feature.server.ts
@@ -25,7 +25,7 @@ export const OrderedListFeature = createServerFeature({
             }),
             createNode({
               converters: {
-                html: ListItemHTMLConverter,
+                html: ListItemHTMLConverter as any,
               },
               node: ListItemNode,
             }),

--- a/packages/richtext-lexical/src/features/lists/plugin/index.tsx
+++ b/packages/richtext-lexical/src/features/lists/plugin/index.tsx
@@ -1,8 +1,30 @@
 'use client'
+import type {
+  SerializedListItemNode as _SerializedListItemNode,
+  SerializedListNode as _SerializedListNode,
+} from '@lexical/list'
+import type { Spread } from 'lexical'
+
 import { ListPlugin } from '@lexical/react/LexicalListPlugin.js'
 import React from 'react'
 
 import type { PluginComponent } from '../../typesClient.js'
+
+export type SerializedListItemNode = Spread<
+  {
+    checked?: boolean
+    type: 'listitem'
+  },
+  _SerializedListItemNode
+>
+
+export type SerializedListNode = Spread<
+  {
+    checked?: boolean
+    type: 'list'
+  },
+  _SerializedListNode
+>
 
 export const LexicalListPlugin: PluginComponent<undefined> = () => {
   return <ListPlugin />

--- a/packages/richtext-lexical/src/features/lists/unorderedList/feature.server.ts
+++ b/packages/richtext-lexical/src/features/lists/unorderedList/feature.server.ts
@@ -22,7 +22,7 @@ export const UnorderedListFeature = createServerFeature({
       }),
       createNode({
         converters: {
-          html: ListItemHTMLConverter,
+          html: ListItemHTMLConverter as any,
         },
         node: ListItemNode,
       }),

--- a/packages/richtext-lexical/src/features/migrations/lexicalPluginToLexical/converter/converters/list/converter.ts
+++ b/packages/richtext-lexical/src/features/migrations/lexicalPluginToLexical/converter/converters/list/converter.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { SerializedListNode } from '@lexical/list'
-
+import type { SerializedListNode } from '../../../../../lists/plugin/index.js'
 import type { LexicalPluginNodeConverter } from '../../types.js'
 
 import { convertLexicalPluginNodesToLexical } from '../../index.js'

--- a/packages/richtext-lexical/src/features/migrations/lexicalPluginToLexical/converter/converters/listItem/converter.ts
+++ b/packages/richtext-lexical/src/features/migrations/lexicalPluginToLexical/converter/converters/listItem/converter.ts
@@ -1,5 +1,4 @@
-import type { SerializedListItemNode } from '@lexical/list'
-
+import type { SerializedListItemNode } from '../../../../../lists/plugin/index.js'
 import type { LexicalPluginNodeConverter } from '../../types.js'
 
 import { convertLexicalPluginNodesToLexical } from '../../index.js'

--- a/packages/richtext-lexical/src/features/migrations/lexicalPluginToLexical/converter/converters/quote/converter.ts
+++ b/packages/richtext-lexical/src/features/migrations/lexicalPluginToLexical/converter/converters/quote/converter.ts
@@ -1,5 +1,4 @@
-import type { SerializedQuoteNode } from '@lexical/rich-text'
-
+import type { SerializedQuoteNode } from '../../../../../blockquote/feature.server.js'
 import type { LexicalPluginNodeConverter } from '../../types.js'
 
 import { convertLexicalPluginNodesToLexical } from '../../index.js'

--- a/packages/richtext-lexical/src/features/migrations/slateToLexical/converter/converters/blockquote/converter.ts
+++ b/packages/richtext-lexical/src/features/migrations/slateToLexical/converter/converters/blockquote/converter.ts
@@ -1,5 +1,4 @@
-import type { SerializedQuoteNode } from '@lexical/rich-text'
-
+import type { SerializedQuoteNode } from '../../../../../blockquote/feature.server.js'
 import type { SlateNodeConverter } from '../../types.js'
 
 import { convertSlateNodesToLexical } from '../../index.js'

--- a/packages/richtext-lexical/src/features/migrations/slateToLexical/converter/converters/listItem/converter.ts
+++ b/packages/richtext-lexical/src/features/migrations/slateToLexical/converter/converters/listItem/converter.ts
@@ -1,5 +1,4 @@
-import type { SerializedListItemNode } from '@lexical/list'
-
+import type { SerializedListItemNode } from '../../../../../lists/plugin/index.js'
 import type { SlateNodeConverter } from '../../types.js'
 
 import { convertSlateNodesToLexical } from '../../index.js'

--- a/packages/richtext-lexical/src/features/migrations/slateToLexical/converter/converters/orderedList/converter.ts
+++ b/packages/richtext-lexical/src/features/migrations/slateToLexical/converter/converters/orderedList/converter.ts
@@ -1,5 +1,4 @@
-import type { SerializedListNode } from '@lexical/list'
-
+import type { SerializedListNode } from '../../../../../lists/plugin/index.js'
 import type { SlateNodeConverter } from '../../types.js'
 
 import { convertSlateNodesToLexical } from '../../index.js'

--- a/packages/richtext-lexical/src/features/migrations/slateToLexical/converter/converters/unorderedList/converter.ts
+++ b/packages/richtext-lexical/src/features/migrations/slateToLexical/converter/converters/unorderedList/converter.ts
@@ -1,5 +1,4 @@
-import type { SerializedListNode } from '@lexical/list'
-
+import type { SerializedListNode } from '../../../../../lists/plugin/index.js'
 import type { SlateNodeConverter } from '../../types.js'
 
 import { convertSlateNodesToLexical } from '../../index.js'

--- a/packages/richtext-lexical/src/features/relationship/nodes/RelationshipNode.tsx
+++ b/packages/richtext-lexical/src/features/relationship/nodes/RelationshipNode.tsx
@@ -10,6 +10,7 @@ import type {
   NodeKey,
   Spread,
 } from 'lexical'
+import type { CollectionSlug } from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
@@ -22,11 +23,14 @@ const RelationshipComponent = React.lazy(() =>
 )
 
 export type RelationshipData = {
-  relationTo: string
+  relationTo: CollectionSlug
   value: number | string
 }
 
-export type SerializedRelationshipNode = Spread<RelationshipData, SerializedDecoratorBlockNode>
+export type SerializedRelationshipNode = Spread<RelationshipData, SerializedDecoratorBlockNode> & {
+  children?: never // required so that our typed editor state doesn't automatically add children
+  type: 'relationship'
+}
 
 function $relationshipElementToNode(domNode: HTMLDivElement): DOMConversionOutput | null {
   const id = domNode.getAttribute('data-lexical-relationship-id')
@@ -129,7 +133,7 @@ export class RelationshipNode extends DecoratorBlockNode {
     return {
       ...super.exportJSON(),
       ...this.getData(),
-      type: this.getType(),
+      type: 'relationship',
       version: 2,
     }
   }

--- a/packages/richtext-lexical/src/features/upload/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/nodes/UploadNode.tsx
@@ -8,6 +8,7 @@ import type {
   NodeKey,
   Spread,
 } from 'lexical'
+import type { CollectionSlug } from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
@@ -25,7 +26,7 @@ export type UploadData = {
     [key: string]: unknown
   }
   id: string
-  relationTo: string
+  relationTo: CollectionSlug
   value: number | string
 }
 
@@ -66,7 +67,10 @@ function $convertUploadElement(domNode: HTMLImageElement): DOMConversionOutput |
   return null
 }
 
-export type SerializedUploadNode = Spread<UploadData, SerializedDecoratorBlockNode>
+export type SerializedUploadNode = Spread<UploadData, SerializedDecoratorBlockNode> & {
+  children?: never // required so that our typed editor state doesn't automatically add children
+  type: 'upload'
+}
 
 export class UploadNode extends DecoratorBlockNode {
   __data: UploadData
@@ -148,7 +152,7 @@ export class UploadNode extends DecoratorBlockNode {
     return {
       ...super.exportJSON(),
       ...this.getData(),
-      type: this.getType(),
+      type: 'upload',
       version: 3,
     }
   }

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -811,11 +811,7 @@ export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapte
 export { AlignFeature } from './features/align/feature.server.js'
 export { BlockquoteFeature } from './features/blockquote/feature.server.js'
 export { BlocksFeature, type BlocksFeatureProps } from './features/blocks/feature.server.js'
-export {
-  type BlockFields,
-  BlockNode,
-  type SerializedBlockNode,
-} from './features/blocks/nodes/BlocksNode.js'
+export { type BlockFields, BlockNode } from './features/blocks/nodes/BlocksNode.js'
 
 export { LinebreakHTMLConverter } from './features/converters/html/converter/converters/linebreak.js'
 export { ParagraphHTMLConverter } from './features/converters/html/converter/converters/paragraph.js'
@@ -850,11 +846,7 @@ export { LinkFeature, type LinkFeatureServerProps } from './features/link/featur
 
 export { AutoLinkNode } from './features/link/nodes/AutoLinkNode.js'
 export { LinkNode } from './features/link/nodes/LinkNode.js'
-export type {
-  LinkFields,
-  SerializedAutoLinkNode,
-  SerializedLinkNode,
-} from './features/link/nodes/types.js'
+export type { LinkFields } from './features/link/nodes/types.js'
 export { ChecklistFeature } from './features/lists/checklist/feature.server.js'
 export { OrderedListFeature } from './features/lists/orderedList/feature.server.js'
 export { UnorderedListFeature } from './features/lists/unorderedList/feature.server.js'
@@ -889,7 +881,6 @@ export {
 export {
   type RelationshipData,
   RelationshipNode,
-  type SerializedRelationshipNode,
 } from './features/relationship/nodes/RelationshipNode.js'
 
 export { FixedToolbarFeature } from './features/toolbars/fixed/feature.server.js'
@@ -936,11 +927,7 @@ export type {
 export { UploadFeature } from './features/upload/feature.server.js'
 
 export type { UploadFeatureProps } from './features/upload/feature.server.js'
-export {
-  type SerializedUploadNode,
-  type UploadData,
-  UploadNode,
-} from './features/upload/nodes/UploadNode.js'
+export { type UploadData, UploadNode } from './features/upload/nodes/UploadNode.js'
 
 export type { EditorConfigContextType } from './lexical/config/client/EditorConfigProvider.js'
 export {
@@ -990,3 +977,5 @@ export { defaultRichTextValue } from './populateGraphQL/defaultValue.js'
 export type { LexicalEditorProps, LexicalRichTextAdapter } from './types.js'
 
 export { createServerFeature } from './utilities/createServerFeature.js'
+
+export * from './nodeTypes.js'

--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -1,0 +1,48 @@
+import type {
+  SerializedEditorState,
+  SerializedElementNode,
+  SerializedLexicalNode,
+  Spread,
+  TextModeType,
+} from 'lexical'
+export type { SerializedQuoteNode } from './features/blockquote/feature.server.js'
+export type { SerializedBlockNode } from './features/blocks/nodes/BlocksNode.js'
+export type { SerializedHorizontalRuleNode } from './features/horizontalRule/nodes/HorizontalRuleNode.js'
+
+export type { SerializedAutoLinkNode, SerializedLinkNode } from './features/link/nodes/types.js'
+
+export type { SerializedListItemNode, SerializedListNode } from './features/lists/plugin/index.js'
+
+export type { SerializedRelationshipNode } from './features/relationship/nodes/RelationshipNode.js'
+
+export type { SerializedUploadNode } from './features/upload/nodes/UploadNode.js'
+
+export type SerializedParagraphNode<T extends SerializedLexicalNode = SerializedLexicalNode> =
+  Spread<
+    {
+      textFormat: number
+      type: 'paragraph'
+    },
+    SerializedElementNode<T>
+  >
+export type SerializedTextNode = Spread<
+  {
+    children?: never // required so that our typed editor state doesn't automatically add children
+    detail: number
+    format: number
+    mode: TextModeType
+    style: string
+    text: string
+    type: 'text'
+  },
+  SerializedLexicalNode
+>
+
+type RecursiveNodes<T extends SerializedLexicalNode, Depth extends number = 4> = Depth extends 0
+  ? T
+  : { children?: RecursiveNodes<T, DecrementDepth<Depth>>[] } & T
+
+type DecrementDepth<N extends number> = [0, 0, 1, 2, 3, 4][N]
+
+export type TypedEditorState<T extends SerializedLexicalNode = SerializedLexicalNode> =
+  SerializedEditorState<RecursiveNodes<T>>

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -39,7 +39,7 @@ export type LexicalEditorProps = {
         defaultFeatures: FeatureProviderServer<any, any, any>[]
         /**
          * This array contains all features that are enabled in the root richText editor (the one defined in the payload.config.ts).
-         * If this field is the root richText editor, or if the root richText editor is not a lexical editor, this array will be empty
+         * If this field is the root richText editor, or if the root richText editor is not a lexical editor, this array will be empty.
          *
          * @Example
          *

--- a/test/fields/collections/Lexical/generateLexicalRichText.ts
+++ b/test/fields/collections/Lexical/generateLexicalRichText.ts
@@ -1,4 +1,14 @@
-export function generateLexicalRichText() {
+import type {
+  SerializedBlockNode,
+  SerializedParagraphNode,
+  SerializedTextNode,
+  SerializedUploadNode,
+  TypedEditorState,
+} from '@payloadcms/richtext-lexical'
+
+export function generateLexicalRichText(): TypedEditorState<
+  SerializedBlockNode | SerializedParagraphNode | SerializedTextNode | SerializedUploadNode
+> {
   return {
     root: {
       type: 'root',
@@ -22,6 +32,7 @@ export function generateLexicalRichText() {
           format: '',
           indent: 0,
           type: 'paragraph',
+          textFormat: 0,
           version: 1,
         },
         {
@@ -217,6 +228,7 @@ export function generateLexicalRichText() {
           indent: 0,
           type: 'paragraph',
           version: 1,
+          textFormat: 0,
         },
         {
           format: '',
@@ -247,6 +259,7 @@ export function generateLexicalRichText() {
           indent: 0,
           type: 'paragraph',
           version: 1,
+          textFormat: 0,
         },
         {
           format: '',
@@ -272,6 +285,7 @@ export function generateLexicalRichText() {
           indent: 0,
           type: 'paragraph',
           version: 1,
+          textFormat: 0,
         },
         {
           format: '',

--- a/test/fields/collections/Lexical/index.ts
+++ b/test/fields/collections/Lexical/index.ts
@@ -1,13 +1,4 @@
-import type {
-  SerializedBlockNode,
-  SerializedLinkNode,
-  SerializedParagraphNode,
-  SerializedRelationshipNode,
-  SerializedTextNode,
-  SerializedUploadNode,
-  ServerEditorConfig,
-  TypedEditorState,
-} from '@payloadcms/richtext-lexical'
+import type { ServerEditorConfig } from '@payloadcms/richtext-lexical'
 import type { SerializedEditorState } from 'lexical'
 import type { CollectionConfig } from 'payload'
 
@@ -39,44 +30,6 @@ import {
   TextBlock,
   UploadAndRichTextBlock,
 } from './blocks.js'
-
-const a: TypedEditorState<
-  | SerializedBlockNode
-  | SerializedLinkNode
-  | SerializedParagraphNode
-  | SerializedRelationshipNode
-  | SerializedTextNode
-  | SerializedUploadNode
-> = {
-  root: {
-    type: 'root',
-    format: '',
-    indent: 0,
-    version: 1,
-    children: [
-      {
-        children: [
-          {
-            detail: 0,
-            format: 0,
-            mode: 'normal',
-            style: '',
-            text: 'Upload Node:',
-            type: 'text',
-            version: 1,
-          },
-        ],
-        direction: 'ltr',
-        format: '',
-        indent: 0,
-        textFormat: 5,
-        type: 'paragraph',
-        version: 1,
-      },
-    ],
-    direction: 'ltr',
-  },
-}
 
 const editorConfig: ServerEditorConfig = {
   features: [

--- a/test/fields/collections/Lexical/index.ts
+++ b/test/fields/collections/Lexical/index.ts
@@ -1,4 +1,13 @@
-import type { ServerEditorConfig } from '@payloadcms/richtext-lexical'
+import type {
+  SerializedBlockNode,
+  SerializedLinkNode,
+  SerializedParagraphNode,
+  SerializedRelationshipNode,
+  SerializedTextNode,
+  SerializedUploadNode,
+  ServerEditorConfig,
+  TypedEditorState,
+} from '@payloadcms/richtext-lexical'
 import type { SerializedEditorState } from 'lexical'
 import type { CollectionConfig } from 'payload'
 
@@ -30,6 +39,44 @@ import {
   TextBlock,
   UploadAndRichTextBlock,
 } from './blocks.js'
+
+const a: TypedEditorState<
+  | SerializedBlockNode
+  | SerializedLinkNode
+  | SerializedParagraphNode
+  | SerializedRelationshipNode
+  | SerializedTextNode
+  | SerializedUploadNode
+> = {
+  root: {
+    type: 'root',
+    format: '',
+    indent: 0,
+    version: 1,
+    children: [
+      {
+        children: [
+          {
+            detail: 0,
+            format: 0,
+            mode: 'normal',
+            style: '',
+            text: 'Upload Node:',
+            type: 'text',
+            version: 1,
+          },
+        ],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        textFormat: 5,
+        type: 'paragraph',
+        version: 1,
+      },
+    ],
+    direction: 'ltr',
+  },
+}
 
 const editorConfig: ServerEditorConfig = {
   features: [

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1441,46 +1441,5 @@ export interface LexicalBlocksRadioButtonsBlock {
 
 declare module 'payload' {
   // @ts-ignore 
-  export interface GeneratedTypes {
-  
-    collections: {
-      'lexical-fields': LexicalField;
-      'lexical-migrate-fields': LexicalMigrateField;
-      'lexical-localized-fields': LexicalLocalizedField;
-      users: User;
-      'array-fields': ArrayField;
-      'block-fields': BlockField;
-      'checkbox-fields': CheckboxField;
-      'code-fields': CodeField;
-      'collapsible-fields': CollapsibleField;
-      'conditional-logic': ConditionalLogic;
-      'date-fields': DateField;
-      'radio-fields': RadioField;
-      'group-fields': GroupField;
-      'row-fields': RowField;
-      'indexed-fields': IndexedField;
-      'json-fields': JsonField;
-      'number-fields': NumberField;
-      'point-fields': PointField;
-      'relationship-fields': RelationshipField;
-      'rich-text-fields': RichTextField;
-      'select-fields': SelectField;
-      'tabs-fields-2': TabsFields2;
-      'tabs-fields': TabsField;
-      'text-fields': TextField;
-      uploads: Upload;
-      uploads2: Uploads2;
-      uploads3: Uploads3;
-      'ui-fields': UiField;
-      'payload-preferences': PayloadPreference;
-      'payload-migrations': PayloadMigration;
-    };
-    globals: {
-      tabsWithRichText: TabsWithRichText;
-    };
-    locale: 'en' | 'es';
-    user: User & {
-      collection: 'users';
-    };
-    }
+  export interface GeneratedTypes extends Config {}
 }


### PR DESCRIPTION
This exports every single node type from @payloadcms/richtext-lexical. Additionally, we now export `TypedEditorState` which provides truly strong types for the editor state.

It works just like `SerializedEditorState` exported from lexical core, with the difference that our `TypedEditorState` type also provides correct, nested types for children up to 4 levels deep.