### PR TITLE
fix: previousValue missing from ValidateOptions type

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -128,12 +128,13 @@ export type Labels = {
   singular: Record<string, string> | string
 }
 
-export type ValidateOptions<TData, TSiblingData, TFieldConfig> = {
+export type ValidateOptions<TData, TSiblingData, TFieldConfig, TValue> = {
   config: SanitizedConfig
   data: Partial<TData>
   id?: number | string
   operation?: Operation
   payload?: Payload
+  previousValue?: TValue
   req?: PayloadRequest
   siblingData: Partial<TSiblingData>
   t: TFunction
@@ -143,7 +144,7 @@ export type ValidateOptions<TData, TSiblingData, TFieldConfig> = {
 // TODO: Having TFieldConfig as any breaks all type checking / auto-completions for the base ValidateOptions properties.
 export type Validate<TValue = any, TData = any, TSiblingData = any, TFieldConfig = any> = (
   value: TValue,
-  options: ValidateOptions<TData, TSiblingData, TFieldConfig>,
+  options: ValidateOptions<TData, TSiblingData, TFieldConfig, TValue>,
 ) => Promise<string | true> | string | true
 
 export type OptionObject = {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

The `previousValue` property was added to the validationOptions passed into validate functions with https://github.com/payloadcms/payload/pull/6805. This PR updates the `ValidateOptions` type to reflect that.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Existing test suite passes locally with my changes
- [ ] ~I have made corresponding changes to the documentation~
