### PR TITLE
feat(cpa): add bun to create-payload-app

### DIFF
--- a/packages/create-payload-app/src/lib/create-project.ts
+++ b/packages/create-payload-app/src/lib/create-project.ts
@@ -32,6 +32,8 @@ async function installDeps(args: {
     installCmd = 'yarn'
   } else if (packageManager === 'pnpm') {
     installCmd = 'pnpm install'
+  } else if (packageManager === 'bun') {
+    installCmd = 'bun install'
   }
 
   try {

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -29,6 +29,7 @@ export class Main {
 
         // Package manager
         '--no-deps': Boolean,
+        '--use-bun': Boolean,
         '--use-npm': Boolean,
         '--use-pnpm': Boolean,
         '--use-yarn': Boolean,
@@ -118,12 +119,16 @@ async function getPackageManager(args: CliArgs): Promise<PackageManager> {
     packageManager = 'yarn'
   } else if (args['--use-pnpm']) {
     packageManager = 'pnpm'
+  } else if (args['--use-bun']) {
+    packageManager = 'bun'
   } else {
     try {
       if (await commandExists('yarn')) {
         packageManager = 'yarn'
       } else if (await commandExists('pnpm')) {
         packageManager = 'pnpm'
+      } else if (await commandExists('bun')) {
+        packageManager = 'bun'
       }
     } catch (error: unknown) {
       packageManager = 'npm'

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -9,6 +9,7 @@ export interface Args extends arg.Spec {
   '--no-deps': BooleanConstructor
   '--secret': StringConstructor
   '--template': StringConstructor
+  '--use-bun': BooleanConstructor
   '--use-npm': BooleanConstructor
   '--use-pnpm': BooleanConstructor
   '--use-yarn': BooleanConstructor
@@ -45,7 +46,7 @@ interface Template {
   type: ProjectTemplate['type']
 }
 
-export type PackageManager = 'npm' | 'pnpm' | 'yarn'
+export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn'
 
 export type DbType = 'mongodb' | 'postgres'
 

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -34,6 +34,7 @@ export function helpMessage(): string {
       --use-npm                     Use npm to install dependencies
       --use-yarn                    Use yarn to install dependencies
       --use-pnpm                    Use pnpm to install dependencies
+      --use-bun                     Use bun to install dependencies
       --no-deps                     Do not install any dependencies
       -h                            Show help
 `


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

This adds support for bun package manager.
Previously forcing bun by `bunx --bun create-payload-app` somehow corrupted project.
Now it should use proper command when given flag `--use-bun`.

My changes only use existing flow. But there is still room for additional detection methods for all package managers like checking user agent.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation

I didnt run tests. And didnt test manually. If you suggest how I can do it, I will run manual test.
Although it should not break anything existing, it might not work for new changes.