### PR TITLE
fix: should not display create/login view with disableLocalStrategy: true

### DIFF
--- a/packages/next/src/views/Root/index.tsx
+++ b/packages/next/src/views/Root/index.tsx
@@ -73,7 +73,14 @@ export const RootPage = async ({
 
     const routeWithAdmin = `${adminRoute}${createFirstUserRoute}`
 
-    if (!dbHasUser && currentRoute !== routeWithAdmin) {
+    const collectionConfig = config.collections.find(({ slug }) => slug === userSlug)
+    const disableLocalStrategy = collectionConfig?.auth?.disableLocalStrategy
+
+    if (disableLocalStrategy && currentRoute === routeWithAdmin) {
+      redirect(adminRoute)
+    }
+
+    if (!dbHasUser && currentRoute !== routeWithAdmin && !disableLocalStrategy) {
       redirect(routeWithAdmin)
     }
 


### PR DESCRIPTION
## Description

The `createFirstUser` view should not be displayed or accessible when `disableLocalStrategy: false`.

Issue reported in Discord [here](https://discord.com/channels/967097582721572934/1215659716538273832/1255510914711687335).

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes
