### PR TITLE
docs: improves plugins overview

### DIFF
--- a/docs/plugins/build-your-own.mdx
+++ b/docs/plugins/build-your-own.mdx
@@ -6,7 +6,7 @@ desc: Starting to build your own plugin? Find everything you need and learn best
 keywords: plugins, template, config, configuration, extensions, custom, documentation, Content Management System, cms, headless, javascript, node, react, nextjs
 ---
 
-Building your own plugin is easy, and if you&apos;re already familiar with Payload then you&apos;ll have everything you need to get started. You can either start from scratch or use the Payload plugin template to get up and running quickly.
+Building your own [Payload Plugin](./overview) is easy, and if you&apos;re already familiar with Payload then you&apos;ll have everything you need to get started. You can either start from scratch or use the [Plugin Template](#plugin-template) to get up and running quickly.
 
 <Banner type="success">
   To use the template, run `npx create-payload-app@latest -t plugin -n my-new-plugin` directly in
@@ -57,11 +57,11 @@ The initialization process goes in the following order:
 
 ## Plugin Template
 
-In the [Payload plugin template](https://github.com/payloadcms/payload-plugin-template), you will see a common file structure that is used across plugins:
+In the [Payload Plugin Template](https://github.com/payloadcms/payload-plugin-template), you will see a common file structure that is used across plugins:
 
-1. root folder - general configuration
-2. /src folder - everything related to the plugin
-3. /dev folder - sanitized test project for development
+1. `/` root folder - general configuration
+2. `/src` folder - everything related to the plugin
+3. `/dev` folder - sanitized test project for development
 
 ### The root folder
 
@@ -169,7 +169,7 @@ First up, the `src/index.ts` file - this is where the plugin should be imported 
 
 **Plugin.ts**
 
-To reiterate, the essence of a payload plugin is simply to extend the Payload config - and that is exactly what we are doing in this file.
+To reiterate, the essence of a [Payload Plugin](./overview) is simply to extend the [Payload Config](../configuration/overview) - and that is exactly what we are doing in this file.
 
 ```
 export const samplePlugin =

--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -61,7 +61,7 @@ Some plugins have become so widely used that they are adopted as an [Official Pl
 
 ## Installing Plugins
 
-The base [Payload Config](../configuration/overview) allows for a `plugins` property which takes an `array` of Plugin Configs.
+The base [Payload Config](../configuration/overview) allows for a `plugins` property which takes an `array` of [Plugin Configs](./build-your-own).
 
 ```ts
 import { buildConfig } from 'payload/config'
@@ -91,10 +91,10 @@ const config = buildConfig({
 ```
 
 <Banner type="warning">
-  Payload Plugins are executed _after_ the incoming config is validated, but before it is sanitized and had default options merged in. After all plugins are executed, the full config with all plugins will be sanitized.
+  Payload Plugins are executed _after_ the incoming config is validated, but before it is sanitized and has had default options merged in. After all plugins are executed, the full config with all plugins will be sanitized.
 </Banner>
 
-Here is an example what the `addLastModified` plugin from above might look like. It adds a `lastModifiedBy` field to all Payload collections. For full details, [how to build your own plugin](./build-your-own).
+Here is an example what the `addLastModified` plugin from above might look like. It adds a `lastModifiedBy` field to all Payload collections. For full details, see [how to build your own plugin](./build-your-own).
 
 ```ts
 import { Config, Plugin } from 'payload/config'

--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -6,15 +6,17 @@ desc: Plugins provide a great way to modularize Payload functionalities into eas
 keywords: plugins, config, configuration, extensions, custom, documentation, Content Management System, cms, headless, javascript, node, react, nextjs
 ---
 
-Payload comes with a built-in Plugins infrastructure that allows developers to build their own modular and easily reusable sets of functionality.
+Payload Plugins take full advantage of the modularity of the [Payload Config](../configuration/overview), allowing developers to easily extend Payload's core functionality in a precise and granular way. This pattern allows developers to easily inject custom—sometimes complex—functionality into Payload apps from a very small touch-point.
+
+There are many [Official Plugins](#official-plugins) available that solve for some of the most common uses cases, such as the [Form Builder Plugin](./seo) or [SEO Plugin](./seo). There are also [Community Plugins](#community-plugins) available, maintained entirely by contributing members. To extend Payload's functionality in some other way, you can easily [build your own plugin](./build-your-own).
+
+Writing plugins is no more complex than writing regular JavaScript. If you know the basic concept of [callback functions](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function) or how [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) works, and are up to speed with Payload concepts, then writing a plugin will be a breeze.
 
 <Banner type="success">
-  Because we rely on a simple config-based structure, Payload plugins simply take in a user's
-  existing config and return a modified config with new fields, hooks, collections, admin views, or
+  Because we rely on a simple config-based structure, Payload Plugins simply take in an
+  existing config and returns a _modified_ config with new fields, hooks, collections, admin views, or
   anything else you can think of.
 </Banner>
-
-Writing plugins is no more complex than writing regular JavaScript. If you know how [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) works and are up to speed with Payload concepts, writing a plugin will be a breeze.
 
 **Example use cases:**
 
@@ -27,37 +29,49 @@ Writing plugins is no more complex than writing regular JavaScript. If you know 
 - Integrate all `upload`-enabled collections with a third-party file host like S3 or Cloudinary
 - Add custom endpoints or GraphQL queries / mutations with any type of custom functionality that you can think of
 
-## How to install plugins
+## Official Plugins
 
-The base Payload config allows for a `plugins` property which takes an `array` of [`Plugins`](https://github.com/payloadcms/payload/blob/main/packages/payload/src/config/types.ts).
+Payload maintains a set of Official Plugins that solve for some of the common use cases. These plugins are maintained by the Payload team and its contributors and are guaranteed to be stable and up-to-date.
 
-```js
+- [Form Builder](./form-builder)
+- [Nested Docs](./nested-docs)
+- [Redirects](./redirects)
+- [Search](./search)
+- [Sentry](./sentry)
+- [SEO](./seo)
+- [Stripe](./stripe)
+
+You can also [build your own plugin](./build-your-own) to easily extend Payload's functionality in some other way. Once your plugin is ready, consider [sharing it with the community](#community-plugins).
+
+Plugins are changing every day, so be sure to check back often to see what new plugins may have been added. If you have a specific plugin you would like to see, please feel free to start a new [Discussion](https://github.com/payloadcms/payload/discussions).
+
+<Banner type="warning">
+  For a complete list of Official Plugins, visit the [Packages Directory](https://github.com/payloadcms/payload/tree/main/packages) of the [Payload Monorepo](https://github.com/payloadcms/payload).
+</Banner>
+
+## Community Plugins
+
+Community Plugins are those that are maintained entirely by outside contributors. They are a great way to share your work across the ecosystem for others to use. You can discover Community Plugins by browsing the `payload-plugin` topic on [GitHub](https://github.com/topics/payload-plugin).
+
+Some plugins have become so widely used that they are adopted as an [Official Plugin](#official-plugin), such as the [Lexical Plugin](https://github.com/AlessioGr/payload-plugin-lexical). If you have a plugin that you think should be an Official Plugin, please feel free to start a new [Discussion](https://github.com/payloadcms/payload/discussions).
+
+<Banner type="warning">
+  For maintainers building plugins for others to use, please add the `payload-plugin` topic on [GitHub](https://github.com/topics/payload-plugin) to help others find it.
+</Banner>
+
+## Installing Plugins
+
+The base [Payload Config](../configuration/overview) allows for a `plugins` property which takes an `array` of Plugin Configs.
+
+```ts
 import { buildConfig } from 'payload/config'
 // note: these plugins are not real (yet?)
 import addLastModified from 'payload-add-last-modified'
 import passwordProtect from 'payload-password-protect'
-import { mongooseAdapter } from '@payloadcms/db-mongodb'
-import { postgresAdapter } from '@payloadcms/db-postgres'
 
 const config = buildConfig({
-  collections: [
-    {
-      slug: 'pages',
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          required: true,
-        },
-        {
-          name: 'content',
-          type: 'richText',
-          required: true,
-        },
-      ],
-    },
-  ],
-  db: mongooseAdapter({}) // or postgresAdapter({})
+  // ...
+  // highlight-start
   plugins: [
     // Many plugins require options to be passed.
     // In the following example, we call the function
@@ -72,20 +86,15 @@ const config = buildConfig({
     // To understand how to use the plugins you're interested in,
     // consult their corresponding documentation
   ],
+  // highlight-end
 })
-
-export default config
 ```
 
-### When Plugins are initialized
+<Banner type="warning">
+  Payload Plugins are executed _after_ the incoming config is validated, but before it is sanitized and had default options merged in. After all plugins are executed, the full config with all plugins will be sanitized.
+</Banner>
 
-Payload Plugins are executed _after_ the incoming config is validated, but before it is sanitized and had default options merged in.
-
-After all plugins are executed, the full config with all plugins will be sanitized.
-
-## Simple example
-
-Here is an example for how to automatically add a `lastModifiedBy` field to all Payload collections using a Plugin written in TypeScript.
+Here is an example what the `addLastModified` plugin from above might look like. It adds a `lastModifiedBy` field to all Payload collections. For full details, [how to build your own plugin](./build-your-own).
 
 ```ts
 import { Config, Plugin } from 'payload/config'
@@ -136,9 +145,3 @@ const addLastModified: Plugin = (incomingConfig: Config): Config => {
 
 export default addLastModified
 ```
-
-## Available Plugins
-
-You can discover existing plugins by browsing the `payload-plugin` topic on [GitHub](https://github.com/topics/payload-plugin).
-
-For maintainers building plugins for others to use, please add the topic to help others find it. If you would like one to be built by the core Payload team, [open a Feature Request](https://github.com/payloadcms/payload/discussions) in our GitHub Discussions board. We would be happy to review your code and maybe feature you and your plugin where appropriate.


### PR DESCRIPTION
## Description

Improves the plugins overview docs:
 - More compelling introduction
 - Explicitly lists official plugins
 - Reorganizes content
 - Describes Official Plugins vs Community Plugins
 - Misc cleanup

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
