### PR TITLE
fix!: properly cases custom collection components

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -52,12 +52,12 @@ The following options are available:
 | Path                  | Description                                                                                                                                                                                                         |
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`Nav`**             | Contains the sidebar / mobile menu in its entirety.                                                                                                                                                                 |
-| **`BeforeNavLinks`**  | An array of Custom Components to inject into the built-in Nav, _before_ the links themselves.                                                                                                                       |
-| **`AfterNavLinks`**   | An array of Custom Components to inject into the built-in Nav, _after_ the links.                                                                                                                                   |
-| **`BeforeDashboard`** | An array of Custom Components to inject into the built-in Dashboard, _before_ the default dashboard contents.                                                                                                       |
-| **`AfterDashboard`**  | An array of Custom Components to inject into the built-in Dashboard, _after_ the default dashboard contents.                                                                                                        |
-| **`BeforeLogin`**     | An array of Custom Components to inject into the built-in Login, _before_ the default login form.                                                                                                                   |
-| **`AfterLogin`**      | An array of Custom Components to inject into the built-in Login, _after_ the default login form.                                                                                                                    |
+| **`beforeNavLinks`**  | An array of Custom Components to inject into the built-in Nav, _before_ the links themselves.                                                                                                                       |
+| **`afterNavLinks`**   | An array of Custom Components to inject into the built-in Nav, _after_ the links.                                                                                                                                   |
+| **`beforeDashboard`** | An array of Custom Components to inject into the built-in Dashboard, _before_ the default dashboard contents.                                                                                                       |
+| **`afterDashboard`**  | An array of Custom Components to inject into the built-in Dashboard, _after_ the default dashboard contents.                                                                                                        |
+| **`beforeLogin`**     | An array of Custom Components to inject into the built-in Login, _before_ the default login form.                                                                                                                   |
+| **`afterLogin`**      | An array of Custom Components to inject into the built-in Login, _after_ the default login form.                                                                                                                    |
 | **`logout.Button`**   | The button displayed in the sidebar that logs the user out.                                                                                                                                                         |
 | **`graphics.Icon`**   | The simplified logo used in contexts like the the `Nav` component.                                                                                                                                                  |
 | **`graphics.Logo`**   | The full logo used in contexts like the `Login` view.                                                                                                                                                               |
@@ -140,10 +140,10 @@ The following options are available:
 
 | Path                       | Description                                                                                                            |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **`BeforeList`**           | Array of components to inject _before_ the built-in List view                                                          |
-| **`BeforeListTable`**      | Array of components to inject _before_ the built-in List view's table                                                  |
-| **`AfterList`**            | Array of components to inject _after_ the built-in List view                                                           |
-| **`AfterListTable`**       | Array of components to inject _after_ the built-in List view's table                                                   |
+| **`beforeList`**           | An array of components to inject _before_ the built-in List View                                                          |
+| **`beforeListTable`**      | An array of components to inject _before_ the built-in List View's table                                                  |
+| **`afterList`**            | An array of components to inject _after_ the built-in List View                                                           |
+| **`afterListTable`**       | An array of components to inject _after_ the built-in List View's table                                                   |
 | **`edit.SaveButton`**      | Replace the default `Save` button with a Custom Component. Drafts must be disabled                                     |
 | **`edit.SaveDraftButton`** | Replace the default `Save Draft` button with a Custom Component. Drafts must be enabled and autosave must be disabled. |
 | **`edit.PublishButton`**   | Replace the default `Publish` button with a Custom Component. Drafts must be enabled.                                  |

--- a/packages/payload/src/collections/config/schema.ts
+++ b/packages/payload/src/collections/config/schema.ts
@@ -21,10 +21,10 @@ const collectionSchema = joi.object().keys({
   }),
   admin: joi.object({
     components: joi.object({
-      AfterList: joi.array().items(componentSchema),
-      AfterListTable: joi.array().items(componentSchema),
-      BeforeList: joi.array().items(componentSchema),
-      BeforeListTable: joi.array().items(componentSchema),
+      afterList: joi.array().items(componentSchema),
+      afterListTable: joi.array().items(componentSchema),
+      beforeList: joi.array().items(componentSchema),
+      beforeListTable: joi.array().items(componentSchema),
       edit: joi.object({
         Description: componentSchema,
         PreviewButton: componentSchema,

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -225,10 +225,10 @@ export type CollectionAdminOptions = {
    * Custom admin components
    */
   components?: {
-    AfterList?: CustomComponent[]
-    AfterListTable?: CustomComponent[]
-    BeforeList?: CustomComponent[]
-    BeforeListTable?: CustomComponent[]
+    afterList?: CustomComponent[]
+    afterListTable?: CustomComponent[]
+    beforeList?: CustomComponent[]
+    beforeListTable?: CustomComponent[]
     /**
      * Components within the edit view
      */

--- a/packages/ui/src/providers/ComponentMap/buildComponentMap/collections.tsx
+++ b/packages/ui/src/providers/ComponentMap/buildComponentMap/collections.tsx
@@ -106,7 +106,7 @@ export const mapCollections = (args: {
 
     const Upload = UploadComponent ? <WithServerSideProps Component={UploadComponent} /> : undefined
 
-    const beforeList = collectionConfig?.admin?.components?.BeforeList
+    const beforeList = collectionConfig?.admin?.components?.beforeList
 
     const BeforeList =
       (beforeList &&
@@ -114,7 +114,7 @@ export const mapCollections = (args: {
         beforeList?.map((Component) => <WithServerSideProps Component={Component} />)) ||
       null
 
-    const beforeListTable = collectionConfig?.admin?.components?.BeforeListTable
+    const beforeListTable = collectionConfig?.admin?.components?.beforeListTable
 
     const BeforeListTable =
       (beforeListTable &&
@@ -122,7 +122,7 @@ export const mapCollections = (args: {
         beforeListTable?.map((Component) => <WithServerSideProps Component={Component} />)) ||
       null
 
-    const afterList = collectionConfig?.admin?.components?.AfterList
+    const afterList = collectionConfig?.admin?.components?.afterList
 
     const AfterList =
       (afterList &&
@@ -130,7 +130,7 @@ export const mapCollections = (args: {
         afterList?.map((Component) => <WithServerSideProps Component={Component} />)) ||
       null
 
-    const afterListTable = collectionConfig?.admin?.components?.AfterListTable
+    const afterListTable = collectionConfig?.admin?.components?.afterListTable
 
     const AfterListTable =
       (afterListTable &&


### PR DESCRIPTION
## Description

Properties within the Custom Collection Components config were not properly cased. In the Payload Config, there are places where we expose _an array_ of Custom Components to render. These properties should be cased in `camelCase` to indicate that its type is _**not**_ a component, but rather, it's an _**array**_ of components. This is how all other arrays are already cased throughout the config, therefore these components break exiting convention. The `CapitalCase` convention is reserved for _components themselves_, however, fixing this introduces a breaking change. Here's how to migrate:

Old:

```ts
{
 // ...
 admin: {
   components: {
     AfterList: [],
     AfterListTable: [],
     BeforeList: [],
     BeforeListTable: [],
   }
  }
}
```

New:

```ts
{
 // ...
 admin: {
   components: {
     afterList: [],
     afterListTable: [],
     beforeList: [],
     beforeListTable: [],
   }
 }
}
```

The docs were also out of date for the Root-level Custom Components. These components are documented in CaptalCase but are in fact cased correctly in Payload. This PR fixes that.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
