### PR TITLE
feat(richtext-lexical): upgradeLexicalData function

### DIFF
--- a/docs/lexical/migration.mdx
+++ b/docs/lexical/migration.mdx
@@ -59,74 +59,6 @@ This is by far the easiest way to migrate from Slate to Lexical, although it doe
 
 The easy way to solve this: Edit the richText field and save the document! This overrides the slate data with the lexical data, and the next time the document is loaded, the lexical data will be used. This solves both the performance and the output issue for that specific document. This, however, is a slow and gradual migration process, thus you will have to support both API formats. Especially for a large number of documents, we recommend running the migration script, as explained above.
 
-### Migration via migration script
-
-The method described above does not solve the issue for all documents, though. If you want to convert all your documents to lexical, you can use a migration script. Here's a simple example:
-
-```ts
-import type { Payload, YourDocumentType } from 'payload'
-import type { YourDocumentType } from 'payload/generated-types'
-
-import {
-  cloneDeep,
-  convertSlateToLexical,
-  defaultSlateConverters,
-} from '@payloadcms/richtext-lexical'
-
-import { AnotherCustomConverter } from './lexicalFeatures/converters/AnotherCustomConverter'
-
-export async function convertAll(payload: Payload, collectionName: string, fieldName: string) {
-  const docs: YourDocumentType[] = await payload.db.collections[collectionName].find({}).exec() // Use MongoDB models directly to query all documents at once
-  console.log(`Found ${docs.length} ${collectionName} docs`)
-
-  const converters = cloneDeep([...defaultSlateConverters, AnotherCustomConverter])
-
-  // Split docs into batches of 20.
-  const batchSize = 20
-  const batches = []
-  for (let i = 0; i < docs.length; i += batchSize) {
-    batches.push(docs.slice(i, i + batchSize))
-  }
-
-  let processed = 0 // Number of processed docs
-
-  for (const batch of batches) {
-    // Process each batch asynchronously
-    const promises = batch.map(async (doc: YourDocumentType) => {
-      const richText = doc[fieldName]
-
-      if (richText && Array.isArray(richText) && !('root' in richText)) {
-        // It's Slate data - skip already-converted data
-        const converted = convertSlateToLexical({
-          converters: converters,
-          slateData: richText,
-        })
-
-        await payload.update({
-          id: doc.id,
-          collection: collectionName as any,
-          depth: 0, // performance optimization. No need to run population.
-          data: {
-            [fieldName]: converted,
-          },
-        })
-      }
-    })
-
-    // Wait for all promises in the batch to complete. Resolving batches of 20 asynchronously is faster than waiting for each doc to update individually
-    await Promise.all(promises)
-
-    // Update the count of processed docs
-    processed += batch.length
-    console.log(`Converted ${processed} of ${docs.length}`)
-  }
-}
-```
-
-The `convertSlateToLexical` is the same method used in the `SlateToLexicalFeature` - it handles traversing the Slate JSON for you.
-
-Do note that this script might require adjustment depending on your document structure, especially if you have nested richText fields or localization enabled.
-
 ### Converting custom Slate nodes
 
 If you have custom Slate nodes, create a custom converter for them. Here's the Upload converter as an example:
@@ -195,3 +127,19 @@ const Pages: CollectionConfig = {
 Migrating from [payload-plugin-lexical](https://github.com/AlessioGr/payload-plugin-lexical) works similar to migrating from Slate.
 
 Instead of a `SlateToLexicalFeature` there is a `LexicalPluginToLexicalFeature` you can use. And instead of `convertSlateToLexical` you can use `convertLexicalPluginToLexical`.
+
+## Migrating lexical data from old version to new version
+
+Each lexical node has a `version` property which is saved in the database. Every time we make a breaking change to the node's data, we increment the version. This way, we can detect an old version and automatically convert old data to the new format once you open up the editor.
+
+The problem is, this migration only happens when you open the editor, modify the richText field (so that the field's `setValue` function is called) and save the document. Until you do that for all documents, some documents will still have the old data.
+
+To solve this, we export an `upgradeLexicalData` function which goes through every single document in your payload app and re-saves it, if it has a lexical editor. This way, the data is automatically converted to the new format, and that automatic conversion gets applied to every single document in your app.
+
+IMPORTANT: Take a backup of your entire database. If anything goes wrong and you do not have a backup, you are on your own and will not receive any support.
+
+```ts
+import { upgradeLexicalData } from '@payloadcms/richtext-lexical'
+
+await upgradeLexicalData({ payload })
+```

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -978,5 +978,6 @@ export type { LexicalEditorProps, LexicalRichTextAdapter } from './types.js'
 
 export { createServerFeature } from './utilities/createServerFeature.js'
 export { migrateSlateToLexical } from './utilities/migrateSlateToLexical/index.js'
+export { upgradeLexicalData } from './utilities/upgradeLexicalData/index.js'
 
 export * from './nodeTypes.js'

--- a/packages/richtext-lexical/src/utilities/migrateSlateToLexical/migrateDocumentFieldsRecursively.ts
+++ b/packages/richtext-lexical/src/utilities/migrateSlateToLexical/migrateDocumentFieldsRecursively.ts
@@ -17,7 +17,7 @@ type NestedRichTextFieldsArgs = {
   found: number
 }
 
-export const migrateDocumentFields = ({
+export const migrateDocumentFieldsRecursively = ({
   data,
   fields,
   found,
@@ -25,13 +25,13 @@ export const migrateDocumentFields = ({
   for (const field of fields) {
     if (fieldHasSubFields(field) && !fieldIsArrayType(field)) {
       if (fieldAffectsData(field) && typeof data[field.name] === 'object') {
-        migrateDocumentFields({
+        migrateDocumentFieldsRecursively({
           data: data[field.name],
           fields: field.fields,
           found,
         })
       } else {
-        migrateDocumentFields({
+        migrateDocumentFieldsRecursively({
           data,
           found,
 
@@ -40,7 +40,7 @@ export const migrateDocumentFields = ({
       }
     } else if (field.type === 'tabs') {
       field.tabs.forEach((tab) => {
-        migrateDocumentFields({
+        migrateDocumentFieldsRecursively({
           data,
           found,
 
@@ -52,7 +52,7 @@ export const migrateDocumentFields = ({
         data[field.name].forEach((row, i) => {
           const block = field.blocks.find(({ slug }) => slug === row?.blockType)
           if (block) {
-            migrateDocumentFields({
+            migrateDocumentFieldsRecursively({
               data: data[field.name][i],
               found,
 
@@ -64,7 +64,7 @@ export const migrateDocumentFields = ({
 
       if (field.type === 'array') {
         data[field.name].forEach((_, i) => {
-          migrateDocumentFields({
+          migrateDocumentFieldsRecursively({
             data: data[field.name][i],
             found,
 

--- a/packages/richtext-lexical/src/utilities/upgradeLexicalData/upgradeDocumentFieldsRecursively.ts
+++ b/packages/richtext-lexical/src/utilities/upgradeLexicalData/upgradeDocumentFieldsRecursively.ts
@@ -1,0 +1,105 @@
+import type { SerializedEditorState } from 'lexical'
+import type { Field } from 'payload'
+
+import { createHeadlessEditor } from '@lexical/headless'
+import { fieldAffectsData, fieldHasSubFields, fieldIsArrayType } from 'payload/shared'
+
+import type { LexicalRichTextAdapter } from '../../types.js'
+
+import { getEnabledNodes } from '../../lexical/nodes/index.js'
+
+type NestedRichTextFieldsArgs = {
+  data: unknown
+
+  fields: Field[]
+  found: number
+}
+
+export const upgradeDocumentFieldsRecursively = ({
+  data,
+  fields,
+  found,
+}: NestedRichTextFieldsArgs): number => {
+  for (const field of fields) {
+    if (fieldHasSubFields(field) && !fieldIsArrayType(field)) {
+      if (fieldAffectsData(field) && typeof data[field.name] === 'object') {
+        upgradeDocumentFieldsRecursively({
+          data: data[field.name],
+          fields: field.fields,
+          found,
+        })
+      } else {
+        upgradeDocumentFieldsRecursively({
+          data,
+          found,
+
+          fields: field.fields,
+        })
+      }
+    } else if (field.type === 'tabs') {
+      field.tabs.forEach((tab) => {
+        upgradeDocumentFieldsRecursively({
+          data,
+          found,
+
+          fields: tab.fields,
+        })
+      })
+    } else if (Array.isArray(data[field.name])) {
+      if (field.type === 'blocks') {
+        data[field.name].forEach((row, i) => {
+          const block = field.blocks.find(({ slug }) => slug === row?.blockType)
+          if (block) {
+            upgradeDocumentFieldsRecursively({
+              data: data[field.name][i],
+              found,
+
+              fields: block.fields,
+            })
+          }
+        })
+      }
+
+      if (field.type === 'array') {
+        data[field.name].forEach((_, i) => {
+          upgradeDocumentFieldsRecursively({
+            data: data[field.name][i],
+            found,
+
+            fields: field.fields,
+          })
+        })
+      }
+    }
+
+    if (
+      field.type === 'richText' &&
+      data[field.name] &&
+      !Array.isArray(data[field.name]) &&
+      'root' in data[field.name]
+    ) {
+      // Lexical richText
+      const editor: LexicalRichTextAdapter = field.editor as LexicalRichTextAdapter
+      if (editor && typeof editor === 'object') {
+        if ('features' in editor && editor.features?.length) {
+          // Load lexical editor into lexical, then save it immediately
+          const editorState: SerializedEditorState = data[field.name]
+
+          const headlessEditor = createHeadlessEditor({
+            nodes: getEnabledNodes({
+              editorConfig: editor.editorConfig,
+            }),
+          })
+          headlessEditor.setEditorState(headlessEditor.parseEditorState(editorState))
+
+          // get editor state
+          data[field.name] = headlessEditor.getEditorState().toJSON()
+
+          found++
+        }
+      }
+    }
+  }
+
+  return found
+}


### PR DESCRIPTION
In case of breaking lexical data changes, you can simply call `upgradeLexicalData({ payload })` to upgrade every lexical field in your payload app to the new data format.