### PR TITLE
fix: resolve config without @payload-config in tsconfig

### DIFF
--- a/packages/payload/src/config/find.ts
+++ b/packages/payload/src/config/find.ts
@@ -24,7 +24,7 @@ const getTSConfigPaths = (): {
     const outPath = tsConfig.compilerOptions?.outDir || path.resolve(process.cwd(), 'dist')
     let configPath = path.resolve(
       rootConfigDir,
-      tsConfig.compilerOptions?.paths?.['@payload-config']?.[0],
+      tsConfig.compilerOptions?.paths?.['@payload-config']?.[0] ?? '',
     )
 
     if (configPath) {


### PR DESCRIPTION
## Description

Prior to this change the `payload generate:types` command crashes if `@payload-config` isn't set as `paths` in tsconfig.json.

```
Error parsing tsconfig.json: TypeError [ERR_INVALID_ARG_TYPE]: The "paths[1]" argument must be of type string. Received undefined
node:path:841
    validateString(path, 'path');
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at Object.extname (node:path:841:5)
    at findConfig (file:///D:/Development/gwtools/node_modules/payload/dist/config/find.js:50:14)
    at bin (file:///D:/Development/gwtools/node_modules/payload/dist/bin/index.js:8:24)
    at start (file:///D:/Development/gwtools/node_modules/payload/bin.js:18:3) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```
According to code and comments the function catches errors and tries resolving the config by other means. Since it doesn't return the `configPath` on error the fallback method instantly crashes though.
This change prevents throwing the error in the first place so the fallback method gets enough data to find the config.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
