### PR TITLE
Docs: Change reference to v2 PassportJS docs to utilize new custom strategies docs.

### DIFF
--- a/docs/authentication/config.mdx
+++ b/docs/authentication/config.mdx
@@ -23,7 +23,7 @@ To enable Authentication on a collection, define an `auth` property and set it t
 | **`forgotPassword`**       | Customize the way that the `forgotPassword` operation functions. [More](/docs/authentication/config#forgot-password)                                                                                                                |
 | **`verify`**               | Set to `true` or pass an object with verification options to require users to verify by email before they are allowed to log into your app. [More](/docs/authentication/config#email-verification)                                  |
 | **`disableLocalStrategy`** | Advanced - disable Payload's built-in local auth strategy. Only use this property if you have replaced Payload's auth mechanisms with your own.                                                                                     |
-| **`strategies`**           | Advanced - an array of PassportJS authentication strategies to extend this collection's authentication with. [More](/docs/authentication/config#strategies)                                                                         |
+| **`strategies`**           | Advanced - an array of custom authentification strategies to extend this collection's authentication with. [More](/docs/authentication/custom-strategies)                                                                         |
 
 ### Forgot Password
 

--- a/packages/storage-azure/README.md
+++ b/packages/storage-azure/README.md
@@ -12,7 +12,7 @@ pnpm add @payloadcms/storage-azure
 
 ## Usage
 
-- Configure the `collections` object to specify which collections should use the Vercel Blob adapter. The slug _must_ match one of your existing collection slugs.
+- Configure the `collections` object to specify which collections should use the Azure Blob Storage adapter. The slug _must_ match one of your existing collection slugs.
 - When enabled, this package will automatically set `disableLocalStorage` to `true` for each collection.
 
 ```ts

--- a/packages/storage-gcs/README.md
+++ b/packages/storage-gcs/README.md
@@ -12,7 +12,7 @@ pnpm add @payloadcms/storage-gcs
 
 ## Usage
 
-- Configure the `collections` object to specify which collections should use the Vercel Blob adapter. The slug _must_ match one of your existing collection slugs.
+- Configure the `collections` object to specify which collections should use the Google Cloud Storage adapter. The slug _must_ match one of your existing collection slugs.
 - When enabled, this package will automatically set `disableLocalStorage` to `true` for each collection.
 
 ```ts

--- a/packages/storage-s3/README.md
+++ b/packages/storage-s3/README.md
@@ -12,7 +12,7 @@ pnpm add @payloadcms/storage-s3
 
 ## Usage
 
-- Configure the `collections` object to specify which collections should use the Vercel Blob adapter. The slug _must_ match one of your existing collection slugs.
+- Configure the `collections` object to specify which collections should use the AWS S3 adapter. The slug _must_ match one of your existing collection slugs.
 - The `config` object can be any [`S3ClientConfig`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3) object (from [`@aws-sdk/client-s3`](https://github.com/aws/aws-sdk-js-v3)). _This is highly dependent on your AWS setup_. Check the AWS documentation for more information.
 - When enabled, this package will automatically set `disableLocalStorage` to `true` for each collection.
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

The v3 documentation mislead people by using PassportJS even though it's not in v3 and custom strategies should be used instead with the correct link.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [x] This change requires a documentation update

## Checklist:
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
