### PR TITLE
fix: export default was not found in graphql

### DIFF
--- a/packages/graphql/src/exports/types.ts
+++ b/packages/graphql/src/exports/types.ts
@@ -1,3 +1,3 @@
 export { GraphQLJSON, GraphQLJSONObject } from '../packages/graphql-type-json/index.js'
 export { buildPaginatedListType } from '../schema/buildPaginatedListType.js'
-export { default as GraphQL } from 'graphql'
+export * as GraphQL from 'graphql'


### PR DESCRIPTION
## Description

This PR addresses an issue during build caused by a faulty re-export of the `graphql` package from `@payloadcms/graphql/types` trying to re-export the default export which graphql does not have:

![grafik](https://github.com/payloadcms/payload/assets/80046268/bbc4b4fc-bcb2-401f-a9d7-51ea225353fa)

I wasn't sure how to write a test for this but I am more than willing to if needed with some guidance.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
