### PR TITLE
feat(richtext-lexical): simplify schemaMap handling

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/feature.server.ts
+++ b/packages/richtext-lexical/src/features/blocks/feature.server.ts
@@ -1,6 +1,5 @@
 import type { Block, BlockField, Config, Field } from 'payload'
 
-import { traverseFields } from '@payloadcms/ui/utilities/buildFieldSchemaMap/traverseFields'
 import { baseBlockFields, fieldsToJSONSchema, formatLabels, sanitizeFields } from 'payload'
 
 import type { BlocksFeatureClientProps } from './feature.client.js'

--- a/packages/richtext-lexical/src/features/blocks/feature.server.ts
+++ b/packages/richtext-lexical/src/features/blocks/feature.server.ts
@@ -57,9 +57,7 @@ export const BlocksFeature = createServerFeature<
     return {
       ClientFeature: BlocksFeatureClient,
       clientFeatureProps: clientProps,
-      generateSchemaMap: ({ config, i18n, props }) => {
-        const validRelationships = config.collections.map((c) => c.slug) || []
-
+      generateSchemaMap: ({ props }) => {
         /**
          * Add sub-fields to the schemaMap. E.g. if you have an array field as part of the block, and it runs addRow, it will request these
          * sub-fields from the component map. Thus, we need to put them in the component map here.
@@ -68,15 +66,6 @@ export const BlocksFeature = createServerFeature<
 
         for (const block of props.blocks) {
           schemaMap.set(block.slug, block.fields || [])
-
-          traverseFields({
-            config,
-            fields: block.fields,
-            i18n,
-            schemaMap,
-            schemaPath: block.slug,
-            validRelationships,
-          })
         }
 
         return schemaMap

--- a/packages/richtext-lexical/src/features/link/feature.server.ts
+++ b/packages/richtext-lexical/src/features/link/feature.server.ts
@@ -101,25 +101,13 @@ export const LinkFeature = createServerFeature<
         disabledCollections: props.disabledCollections,
         enabledCollections: props.enabledCollections,
       } as ExclusiveLinkCollectionsProps,
-      generateSchemaMap: ({ config, i18n }) => {
+      generateSchemaMap: () => {
         if (!sanitizedFields || !Array.isArray(sanitizedFields) || sanitizedFields.length === 0) {
           return null
         }
 
         const schemaMap = new Map<string, Field[]>()
-
-        const validRelationships = config.collections.map((c) => c.slug) || []
-
         schemaMap.set('fields', sanitizedFields)
-
-        traverseFields({
-          config,
-          fields: sanitizedFields,
-          i18n,
-          schemaMap,
-          schemaPath: 'fields',
-          validRelationships,
-        })
 
         return schemaMap
       },

--- a/packages/richtext-lexical/src/features/link/feature.server.ts
+++ b/packages/richtext-lexical/src/features/link/feature.server.ts
@@ -1,6 +1,5 @@
 import type { CollectionSlug, Config, Field, FieldAffectingData, SanitizedConfig } from 'payload'
 
-import { traverseFields } from '@payloadcms/ui/utilities/buildFieldSchemaMap/traverseFields'
 import { sanitizeFields } from 'payload'
 import { deepCopyObject } from 'payload/shared'
 

--- a/packages/richtext-lexical/src/features/upload/feature.server.ts
+++ b/packages/richtext-lexical/src/features/upload/feature.server.ts
@@ -8,7 +8,6 @@ import type {
   TypeWithID,
 } from 'payload'
 
-import { traverseFields } from '@payloadcms/ui/utilities/buildFieldSchemaMap/traverseFields'
 import { sanitizeFields } from 'payload'
 
 import type { UploadFeaturePropsClient } from './feature.client.js'

--- a/packages/richtext-lexical/src/features/upload/feature.server.ts
+++ b/packages/richtext-lexical/src/features/upload/feature.server.ts
@@ -82,23 +82,14 @@ export const UploadFeature = createServerFeature<
     return {
       ClientFeature: UploadFeatureClient,
       clientFeatureProps: clientProps,
-      generateSchemaMap: ({ config, i18n, props }) => {
+      generateSchemaMap: ({ props }) => {
         if (!props?.collections) return null
 
         const schemaMap = new Map<string, Field[]>()
-        const validRelationships = config.collections.map((c) => c.slug) || []
 
         for (const collection in props.collections) {
           if (props.collections[collection].fields?.length) {
             schemaMap.set(collection, props.collections[collection].fields)
-            traverseFields({
-              config,
-              fields: props.collections[collection].fields,
-              i18n,
-              schemaMap,
-              schemaPath: collection,
-              validRelationships,
-            })
           }
         }
 

--- a/packages/richtext-lexical/src/utilities/generateSchemaMap.ts
+++ b/packages/richtext-lexical/src/utilities/generateSchemaMap.ts
@@ -24,6 +24,8 @@ export const getGenerateSchemaMap =
 
       if (schemas) {
         for (const [schemaKey, fields] of schemas.entries()) {
+          schemaMap.set(`${schemaPath}.feature.${featureKey}.${schemaKey}`, fields)
+
           // generate schema map entries for sub-fields using traverseFields
           traverseFields({
             config,
@@ -32,7 +34,6 @@ export const getGenerateSchemaMap =
             schemaMap,
             schemaPath: schemaKey,
           })
-          schemaMap.set(`${schemaPath}.feature.${featureKey}.${schemaKey}`, fields)
         }
       }
     }

--- a/packages/richtext-lexical/src/utilities/generateSchemaMap.ts
+++ b/packages/richtext-lexical/src/utilities/generateSchemaMap.ts
@@ -24,7 +24,7 @@ export const getGenerateSchemaMap =
 
       if (schemas) {
         for (const [schemaKey, fields] of schemas.entries()) {
-          // generate schema map entried for sub-fields using traverseFields
+          // generate schema map entries for sub-fields using traverseFields
           traverseFields({
             config,
             fields,

--- a/packages/richtext-lexical/src/utilities/generateSchemaMap.ts
+++ b/packages/richtext-lexical/src/utilities/generateSchemaMap.ts
@@ -24,16 +24,16 @@ export const getGenerateSchemaMap =
 
       if (schemas) {
         for (const [schemaKey, fields] of schemas.entries()) {
-          schemaMap.set(`${schemaPath}.feature.${featureKey}.${schemaKey}`, fields)
-
           // generate schema map entries for sub-fields using traverseFields
           traverseFields({
             config,
             fields,
             i18n,
-            schemaMap,
+            schemaMap: schemas,
             schemaPath: schemaKey,
           })
+
+          schemaMap.set(`${schemaPath}.feature.${featureKey}.${schemaKey}`, fields)
         }
       }
     }

--- a/packages/richtext-lexical/src/utilities/generateSchemaMap.ts
+++ b/packages/richtext-lexical/src/utilities/generateSchemaMap.ts
@@ -1,5 +1,7 @@
 import type { RichTextAdapter } from 'payload'
 
+import { traverseFields } from '@payloadcms/ui/utilities/buildFieldSchemaMap/traverseFields'
+
 import type { ResolvedServerFeatureMap } from '../features/typesServer.js'
 
 export const getGenerateSchemaMap =
@@ -22,6 +24,14 @@ export const getGenerateSchemaMap =
 
       if (schemas) {
         for (const [schemaKey, fields] of schemas.entries()) {
+          // generate schema map entried for sub-fields using traverseFields
+          traverseFields({
+            config,
+            fields,
+            i18n,
+            schemaMap,
+            schemaPath: schemaKey,
+          })
           schemaMap.set(`${schemaPath}.feature.${featureKey}.${schemaKey}`, fields)
         }
       }

--- a/packages/ui/src/utilities/buildFieldSchemaMap/index.ts
+++ b/packages/ui/src/utilities/buildFieldSchemaMap/index.ts
@@ -13,8 +13,6 @@ export const buildFieldSchemaMap = (args: {
 
   const result: FieldSchemaMap = new Map()
 
-  const validRelationships = config.collections.map((c) => c.slug) || []
-
   config.collections.forEach((collection) => {
     traverseFields({
       config,
@@ -22,7 +20,6 @@ export const buildFieldSchemaMap = (args: {
       i18n,
       schemaMap: result,
       schemaPath: collection.slug,
-      validRelationships,
     })
   })
 
@@ -33,7 +30,6 @@ export const buildFieldSchemaMap = (args: {
       i18n,
       schemaMap: result,
       schemaPath: global.slug,
-      validRelationships,
     })
   })
 

--- a/packages/ui/src/utilities/buildFieldSchemaMap/traverseFields.ts
+++ b/packages/ui/src/utilities/buildFieldSchemaMap/traverseFields.ts
@@ -12,17 +12,9 @@ type Args = {
   i18n: I18n<any, any>
   schemaMap: FieldSchemaMap
   schemaPath: string
-  validRelationships: string[]
 }
 
-export const traverseFields = ({
-  config,
-  fields,
-  i18n,
-  schemaMap,
-  schemaPath,
-  validRelationships,
-}: Args) => {
+export const traverseFields = ({ config, fields, i18n, schemaMap, schemaPath }: Args) => {
   fields.map((field) => {
     switch (field.type) {
       case 'group':
@@ -35,7 +27,6 @@ export const traverseFields = ({
           i18n,
           schemaMap,
           schemaPath: `${schemaPath}.${field.name}`,
-          validRelationships,
         })
         break
 
@@ -47,7 +38,6 @@ export const traverseFields = ({
           i18n,
           schemaMap,
           schemaPath,
-          validRelationships,
         })
         break
 
@@ -63,7 +53,6 @@ export const traverseFields = ({
             i18n,
             schemaMap,
             schemaPath: blockSchemaPath,
-            validRelationships,
           })
         })
         break
@@ -101,7 +90,6 @@ export const traverseFields = ({
             i18n,
             schemaMap,
             schemaPath: tabSchemaPath,
-            validRelationships,
           })
         })
         break

--- a/packages/ui/src/utilities/buildFieldSchemaMap/traverseFields.ts
+++ b/packages/ui/src/utilities/buildFieldSchemaMap/traverseFields.ts
@@ -15,7 +15,7 @@ type Args = {
 }
 
 export const traverseFields = ({ config, fields, i18n, schemaMap, schemaPath }: Args) => {
-  fields.map((field) => {
+  for (const field of fields) {
     switch (field.type) {
       case 'group':
       case 'array':
@@ -94,5 +94,5 @@ export const traverseFields = ({ config, fields, i18n, schemaMap, schemaPath }: 
         })
         break
     }
-  })
+  }
 }


### PR DESCRIPTION
see commits. Now, features do not have to run traverseFields themselves anymore. This should also make it more performant, as we do not have to map over all collections to construct `validRelationships` anymore.