### PR TITLE
feat(db-postgres): fields enhancements

### DIFF
--- a/packages/db-postgres/src/find/traverseFields.ts
+++ b/packages/db-postgres/src/find/traverseFields.ts
@@ -31,6 +31,8 @@ export const traverseFields = ({
   topLevelTableName,
 }: TraverseFieldArgs) => {
   fields.forEach((field) => {
+    if ('dbStore' in field && !field.dbStore) return
+
     // handle simple relationship
     if (
       depth > 0 &&
@@ -83,6 +85,7 @@ export const traverseFields = ({
     if (fieldAffectsData(field)) {
       switch (field.type) {
         case 'array': {
+          if (field.dbJsonColumn) break
           const withArray: Result = {
             columns: {
               _parentID: false,
@@ -124,6 +127,7 @@ export const traverseFields = ({
         }
 
         case 'select': {
+          if (field.dbJsonColumn) break
           if (field.hasMany) {
             const withSelect: Result = {
               columns: {
@@ -141,6 +145,7 @@ export const traverseFields = ({
         }
 
         case 'blocks':
+          if (field.dbJsonColumn) break
           field.blocks.forEach((block) => {
             const blockKey = `_blocks_${block.slug}`
 
@@ -181,6 +186,7 @@ export const traverseFields = ({
           break
 
         case 'group':
+          if (field.dbJsonColumn) break
           traverseFields({
             _locales,
             adapter,

--- a/packages/db-postgres/src/schema/numberColumnMap.ts
+++ b/packages/db-postgres/src/schema/numberColumnMap.ts
@@ -1,0 +1,15 @@
+import type { PgColumnBuilder } from 'drizzle-orm/pg-core'
+import type { NumberField } from 'payload'
+
+import { bigint, integer, numeric, real } from 'drizzle-orm/pg-core'
+
+type NumberFieldDbType = NonNullable<NumberField['dbType']>
+
+export const numberColumnMap: Record<NumberFieldDbType, (name: string) => PgColumnBuilder> = {
+  bigint: (name: string) => {
+    return bigint(name, { mode: 'number' })
+  },
+  integer,
+  numeric,
+  real,
+}

--- a/packages/db-postgres/src/schema/traverseFields.ts
+++ b/packages/db-postgres/src/schema/traverseFields.ts
@@ -8,6 +8,7 @@ import {
   PgNumericBuilder,
   PgUUIDBuilder,
   PgVarcharBuilder,
+  bigint,
   boolean,
   foreignKey,
   index,
@@ -214,7 +215,11 @@ export const traverseFields = ({
           }
         } else {
           targetTable[fieldName] = withDefault(
-            field.dbInteger ? integer(columnName) : numeric(columnName),
+            field.dbType
+              ? field.dbType === 'integer'
+                ? integer(columnName)
+                : bigint(columnName, { mode: 'number' })
+              : numeric(columnName),
             field,
           )
         }

--- a/packages/db-postgres/src/schema/traverseFields.ts
+++ b/packages/db-postgres/src/schema/traverseFields.ts
@@ -245,7 +245,7 @@ export const traverseFields = ({
 
       case 'radio':
       case 'select': {
-        if ('hasMany' in field && field.hasMany) {
+        if ('hasMany' in field && field.hasMany && field.dbJsonColumn) {
           targetTable[fieldName] = withDefault(jsonb(fieldName), field)
           break
         }

--- a/packages/db-postgres/src/schema/traverseFields.ts
+++ b/packages/db-postgres/src/schema/traverseFields.ts
@@ -32,6 +32,7 @@ import { buildTable } from './build.js'
 import { createIndex } from './createIndex.js'
 import { createTableName } from './createTableName.js'
 import { idToUUID } from './idToUUID.js'
+import { numberColumnMap } from './numberColumnMap.js'
 import { parentIDColumnMap } from './parentIDColumnMap.js'
 import { validateExistingBlockIsIdentical } from './validateExistingBlockIsIdentical.js'
 import { withDefault } from './withDefault.js'
@@ -215,11 +216,7 @@ export const traverseFields = ({
           }
         } else {
           targetTable[fieldName] = withDefault(
-            field.dbType
-              ? field.dbType === 'integer'
-                ? integer(columnName)
-                : bigint(columnName, { mode: 'number' })
-              : numeric(columnName),
+            numberColumnMap[field.dbType ?? 'numeric'](fieldName),
             field,
           )
         }

--- a/packages/db-postgres/src/schema/withDefault.ts
+++ b/packages/db-postgres/src/schema/withDefault.ts
@@ -1,6 +1,10 @@
 import type { PgColumnBuilder } from 'drizzle-orm/pg-core'
 import type { FieldAffectingData } from 'payload'
 
+const escapeSQLString = (input: string) => {
+  return input.replace(`'`, `''`)
+}
+
 export const withDefault = (
   column: PgColumnBuilder,
   field: FieldAffectingData,
@@ -8,5 +12,9 @@ export const withDefault = (
   if (typeof field.defaultValue === 'function' || typeof field.defaultValue === 'undefined')
     return column
 
-  return column.default(field.defaultValue)
+  return column.default(
+    typeof field.defaultValue === 'string'
+      ? escapeSQLString(field.defaultValue)
+      : field.defaultValue,
+  )
 }

--- a/packages/db-postgres/src/schema/withDefault.ts
+++ b/packages/db-postgres/src/schema/withDefault.ts
@@ -1,0 +1,11 @@
+import type { PgColumnBuilder } from 'drizzle-orm/pg-core'
+import type { FieldAffectingData } from 'payload'
+
+export const withDefault = (
+  column: PgColumnBuilder,
+  field: FieldAffectingData,
+): PgColumnBuilder => {
+  if (typeof field.defaultValue === 'function') return column
+
+  return column.default(field.defaultValue)
+}

--- a/packages/db-postgres/src/schema/withDefault.ts
+++ b/packages/db-postgres/src/schema/withDefault.ts
@@ -5,7 +5,8 @@ export const withDefault = (
   column: PgColumnBuilder,
   field: FieldAffectingData,
 ): PgColumnBuilder => {
-  if (typeof field.defaultValue === 'function') return column
+  if (typeof field.defaultValue === 'function' || typeof field.defaultValue === 'undefined')
+    return column
 
   return column.default(field.defaultValue)
 }

--- a/packages/db-postgres/src/transform/read/traverseFields.ts
+++ b/packages/db-postgres/src/transform/read/traverseFields.ts
@@ -120,6 +120,8 @@ export const traverseFields = <T extends Record<string, unknown>>({
     }
 
     if (fieldAffectsData(field)) {
+      if ('dbStore' in field && !field.dbStore) return result
+
       const fieldName = `${fieldPrefix || ''}${field.name}`
       const fieldData = table[fieldName]
       const localizedFieldData = {}
@@ -130,6 +132,11 @@ export const traverseFields = <T extends Record<string, unknown>>({
 
       if (fieldPrefix) {
         deletions.push(() => delete table[fieldName])
+      }
+
+      if ('dbJsonColumn' in field && field.dbJsonColumn) {
+        result[field.name] = table[`${fieldPrefix || ''}${field.name}`]
+        return result
       }
 
       if (field.type === 'array') {

--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -123,7 +123,7 @@ export const number = baseField.keys({
     placeholder: joi.string(),
     step: joi.number(),
   }),
-  dbType: joi.string().valid('integer', 'bigint'),
+  dbType: joi.string().valid('integer', 'bigint', 'real', 'numeric'),
   defaultValue: joi
     .alternatives()
     .try(

--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -42,6 +42,8 @@ export const baseField = joi
     }),
     admin: baseAdminFields.default(),
     custom: joi.object().pattern(joi.string(), joi.any()),
+    dbJsonColumn: joi.boolean(),
+    dbStore: joi.boolean(),
     hidden: joi.boolean().default(false),
     hooks: joi
       .object()
@@ -121,6 +123,7 @@ export const number = baseField.keys({
     placeholder: joi.string(),
     step: joi.number(),
   }),
+  dbInteger: joi.boolean(),
   defaultValue: joi
     .alternatives()
     .try(

--- a/packages/payload/src/fields/config/schema.ts
+++ b/packages/payload/src/fields/config/schema.ts
@@ -123,7 +123,7 @@ export const number = baseField.keys({
     placeholder: joi.string(),
     step: joi.number(),
   }),
-  dbInteger: joi.boolean(),
+  dbType: joi.string().valid('integer', 'bigint'),
   defaultValue: joi
     .alternatives()
     .try(

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -251,15 +251,14 @@ export type NumberField = FieldBase & {
     step?: number
   }
   /**
-   * Use `integer` column type in the SQL.
-   * You must be sure that floating values won't be passed.
-   */
-  dbInteger?: boolean
-  /**
    * Disables creation of the field schema in the SQL
    * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
    */
   dbStore?: boolean
+  /**
+   * Only numbers without decimals are accepted, changes SQL type. Used in the default `validation` function.
+   */
+  dbType?: 'bigint' | 'integer'
   /** Maximum value accepted. Used in the default `validation` function. */
   max?: number
   /** Minimum value accepted. Used in the default `validation` function. */

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -256,9 +256,9 @@ export type NumberField = FieldBase & {
    */
   dbStore?: boolean
   /**
-   * Only numbers without decimals are accepted, changes SQL type. Used in the default `validation` function.
+   * Changes SQL column type. With `bigint` and `integer` used in the default `validation` function to accept only integers.
    */
-  dbType?: 'bigint' | 'integer'
+  dbType?: 'bigint' | 'integer' | 'numeric' | 'real'
   /** Maximum value accepted. Used in the default `validation` function. */
   max?: number
   /** Minimum value accepted. Used in the default `validation` function. */

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -250,6 +250,16 @@ export type NumberField = FieldBase & {
     /** Set a value for the number field to increment / decrement using browser controls. */
     step?: number
   }
+  /**
+   * Use `integer` column type in the SQL.
+   * You must be sure that floating values won't be passed.
+   */
+  dbInteger?: boolean
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   /** Maximum value accepted. Used in the default `validation` function. */
   max?: number
   /** Minimum value accepted. Used in the default `validation` function. */
@@ -258,19 +268,21 @@ export type NumberField = FieldBase & {
 } & (
     | {
         /** Makes this field an ordered array of numbers instead of just a single number. */
-        hasMany: true
-        /** Maximum number of numbers in the numbers array, if `hasMany` is set to true. */
-        maxRows?: number
-        /** Minimum number of numbers in the numbers array, if `hasMany` is set to true. */
-        minRows?: number
-      }
-    | {
-        /** Makes this field an ordered array of numbers instead of just a single number. */
         hasMany?: false | undefined
         /** Maximum number of numbers in the numbers array, if `hasMany` is set to true. */
         maxRows?: undefined
         /** Minimum number of numbers in the numbers array, if `hasMany` is set to true. */
         minRows?: undefined
+      }
+    | {
+        /** Store the field in a single JSON column in the SQL */
+        dbJsonColumn?: boolean
+        /** Makes this field an ordered array of numbers instead of just a single number. */
+        hasMany: true
+        /** Maximum number of numbers in the numbers array, if `hasMany` is set to true. */
+        maxRows?: number
+        /** Minimum number of numbers in the numbers array, if `hasMany` is set to true. */
+        minRows?: number
       }
   )
 
@@ -286,18 +298,15 @@ export type TextField = FieldBase & {
     placeholder?: Record<string, string> | string
     rtl?: boolean
   }
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   maxLength?: number
   minLength?: number
   type: 'text'
 } & (
-    | {
-        /** Makes this field an ordered array of strings instead of just a single string. */
-        hasMany: true
-        /** Maximum number of strings in the strings array, if `hasMany` is set to true. */
-        maxRows?: number
-        /** Minimum number of strings in the strings array, if `hasMany` is set to true. */
-        minRows?: number
-      }
     | {
         /** Makes this field an ordered array of strings instead of just a single string. */
         hasMany?: false | undefined
@@ -305,6 +314,16 @@ export type TextField = FieldBase & {
         maxRows?: undefined
         /** Minimum number of strings in the strings array, if `hasMany` is set to true. */
         minRows?: undefined
+      }
+    | {
+        /** Store the field in a single JSON column in the SQL */
+        dbJsonColumn?: boolean
+        /** Makes this field an ordered array of strings instead of just a single string. */
+        hasMany: true
+        /** Maximum number of strings in the strings array, if `hasMany` is set to true. */
+        maxRows?: number
+        /** Minimum number of strings in the strings array, if `hasMany` is set to true. */
+        minRows?: number
       }
   )
 
@@ -319,6 +338,11 @@ export type EmailField = FieldBase & {
     }
     placeholder?: Record<string, string> | string
   }
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   type: 'email'
 }
 
@@ -334,6 +358,11 @@ export type TextareaField = FieldBase & {
     rows?: number
     rtl?: boolean
   }
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   maxLength?: number
   minLength?: number
   type: 'textarea'
@@ -348,6 +377,11 @@ export type CheckboxField = FieldBase & {
       beforeInput?: CustomComponent[]
     }
   }
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   type: 'checkbox'
 }
 
@@ -362,6 +396,12 @@ export type DateField = FieldBase & {
     date?: ConditionalDateProps
     placeholder?: Record<string, string> | string
   }
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
+
   type: 'date'
 }
 
@@ -369,6 +409,13 @@ export type GroupField = Omit<FieldBase, 'required' | 'validation'> & {
   admin?: Admin & {
     hideGutter?: boolean
   }
+  /** Store the field in a single JSON column in the SQL */
+  dbJsonColumn?: boolean
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   fields: Field[]
   /** Customize generated GraphQL and Typescript schema names.
    * By default, it is bound to the collection.
@@ -453,6 +500,13 @@ export type TabsField = Omit<FieldBase, 'admin' | 'localized' | 'name' | 'saveTo
 }
 
 export type TabAsField = Tab & {
+  /** Store the field in a single JSON column in the SQL */
+  dbJsonColumn?: boolean
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   name?: string
   type: 'tab'
 }
@@ -493,6 +547,13 @@ export type UploadField = FieldBase & {
       Label?: CustomComponent<LabelProps>
     }
   }
+  /** Store the field in a single JSON column in the SQL */
+  dbJsonColumn?: boolean
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   filterOptions?: FilterOptions
   /**
    * Sets a maximum population depth for this field, regardless of the remaining depth when this field is reached.
@@ -543,12 +604,19 @@ export type SelectField = FieldBase & {
     isClearable?: boolean
     isSortable?: boolean
   }
+  /** Store the field in a single JSON column in the SQL */
+  dbJsonColumn?: boolean
   /**
    * Customize the SQL table name
    */
   dbName?: DBIdentifierName
   /**
-   * Customize the DB enum name
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
+  /**
+   * Customize the DB enum naFme
    */
   enumName?: DBIdentifierName
   hasMany?: boolean
@@ -557,6 +625,11 @@ export type SelectField = FieldBase & {
 }
 
 type SharedRelationshipProperties = FieldBase & {
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   filterOptions?: FilterOptions
   hasMany?: boolean
   /**
@@ -568,6 +641,8 @@ type SharedRelationshipProperties = FieldBase & {
   type: 'relationship'
 } & (
     | {
+        /** Store the field in a single JSON column in the SQL */
+        dbJsonColumn?: boolean
         hasMany: true
         /**
          * @deprecated Use 'maxRows' instead
@@ -607,6 +682,8 @@ export type PolymorphicRelationshipField = SharedRelationshipProperties & {
   admin?: RelationshipAdmin & {
     sortOptions?: { [collectionSlug: CollectionSlug]: string }
   }
+  /** Store the field in a single JSON column in the SQL */
+  dbJsonColumn?: boolean
   relationTo: CollectionSlug[]
 }
 export type SingleRelationshipField = SharedRelationshipProperties & {
@@ -666,10 +743,17 @@ export type ArrayField = FieldBase & {
      */
     isSortable?: boolean
   }
+  /** Store the field in a single JSON column in the SQL */
+  dbJsonColumn?: boolean
   /**
    * Customize the SQL table name
    */
   dbName?: DBIdentifierName
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   fields: Field[]
   /** Customize generated GraphQL and Typescript schema names.
    * By default, it is bound to the collection.
@@ -696,6 +780,11 @@ export type RadioField = FieldBase & {
    * Customize the SQL table name
    */
   dbName?: DBIdentifierName
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   /**
    * Customize the DB enum name
    */
@@ -742,10 +831,18 @@ export type BlockField = FieldBase & {
     isSortable?: boolean
   }
   blocks: Block[]
+  /** Store the field in a single JSON column in the SQL */
+  dbJsonColumn?: boolean
+  /**
+   * Disables creation of the field schema in the SQL
+   * for [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges)
+   */
+  dbStore?: boolean
   defaultValue?: unknown
   labels?: Labels
   maxRows?: number
   minRows?: number
+
   type: 'blocks'
 }
 

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -341,7 +341,12 @@ export const number: Validate<number | number[], unknown, unknown, NumberField> 
       return t('validation:lessThanMin', { label: t('general:value'), min, value })
     }
 
-    if (dbType && !Number.isInteger(numberValue)) return t('validation:integerOnly')
+    if (
+      typeof dbType === 'string' &&
+      ['bigint', 'integer'].includes(dbType) &&
+      !Number.isInteger(numberValue)
+    )
+      return t('validation:integerOnly')
   }
 
   return true

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -313,7 +313,7 @@ const validateArrayLength = (
 
 export const number: Validate<number | number[], unknown, unknown, NumberField> = (
   value,
-  { hasMany, max, maxRows, min, minRows, req: { t }, required },
+  { dbType, hasMany, max, maxRows, min, minRows, req: { t }, required },
 ) => {
   if (hasMany === true) {
     const lengthValidationResult = validateArrayLength(value, { maxRows, minRows, required, t })
@@ -340,6 +340,8 @@ export const number: Validate<number | number[], unknown, unknown, NumberField> 
     if (typeof min === 'number' && numberValue < min) {
       return t('validation:lessThanMin', { label: t('general:value'), min, value })
     }
+
+    if (dbType && !Number.isInteger(numberValue)) return t('validation:integerOnly')
   }
 
   return true

--- a/packages/translations/scripts/translateNewKeys/translateText.ts
+++ b/packages/translations/scripts/translateNewKeys/translateText.ts
@@ -20,7 +20,7 @@ export async function translateText(text: string, targetLang: string) {
           role: 'user',
         },
       ],
-      model: 'gpt-4',
+      model: 'gpt-3.5-turbo',
     }),
     headers: {
       Authorization: `Bearer ${process.env.OPENAI_KEY}`,

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -332,6 +332,7 @@ export const arTranslations: DefaultTranslationsObject = {
     enterNumber: 'يرجى إدخال رقم صحيح.',
     fieldHasNo: 'هذا الحقل ليس لديه {{label}}',
     greaterThanMax: '{{value}} أكبر من الحد الأقصى المسموح به {{label}} الذي يبلغ {{max}}.',
+    integerOnly: '[SKIPPED]',
     invalidInput: 'هذا الحقل لديه إدخال غير صالح.',
     invalidSelection: 'هذا الحقل لديه اختيار غير صالح.',
     invalidSelections: 'هذا الحقل لديه الاختيارات الغير صالحة التالية:',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -337,6 +337,7 @@ export const azTranslations: DefaultTranslationsObject = {
     enterNumber: 'Xahiş edirik doğru nömrəni daxil edin.',
     fieldHasNo: 'Bu sahədə heç bir {{label}} yoxdur',
     greaterThanMax: '{{value}} icazə verilən maksimal {{label}} olan {{max}}-dən böyükdür.',
+    integerOnly: 'Zəhmət olmasa, ondalıqlar olmadan etibarlı bir nömrə daxil edin.',
     invalidInput: 'Bu sahə yanlış daxil edilmişdir.',
     invalidSelection: 'Bu sahədə yanlış seçim edilmişdir.',
     invalidSelections: 'Bu sahədə aşağıdakı yanlış seçimlər edilmişdir:',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -335,6 +335,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     enterNumber: 'Моля, въведи валиден номер.',
     fieldHasNo: 'Това поле няма {{label}}',
     greaterThanMax: '{{value}} е по-голямо от максимално допустимото {{label}} от {{max}}.',
+    integerOnly: 'Моля, въведете валиден номер без десетични числа.',
     invalidInput: 'Това поле има невалиден вход.',
     invalidSelection: 'Това поле има невалидна селекция.',
     invalidSelections: 'Това поле има следните невалидни селекции:',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -335,6 +335,7 @@ export const csTranslations: DefaultTranslationsObject = {
     enterNumber: 'Zadejte prosím platné číslo.',
     fieldHasNo: 'Toto pole nemá {{label}}',
     greaterThanMax: '{{value}} je vyšší než maximálně povolená {{label}} {{max}}.',
+    integerOnly: 'Zadejte platné číslo bez desetinných míst.',
     invalidInput: 'Toto pole má neplatný vstup.',
     invalidSelection: 'Toto pole má neplatný výběr.',
     invalidSelections: 'Toto pole má následující neplatné výběry:',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -340,6 +340,7 @@ export const deTranslations: DefaultTranslationsObject = {
     enterNumber: 'Bitte gib eine gültige Nummer an,',
     fieldHasNo: 'Dieses Feld hat kein {{label}}',
     greaterThanMax: '{{value}} ist größer als der maximal erlaubte {{label}} von {{max}}.',
+    integerOnly: 'Bitte geben Sie eine gültige Zahl ohne Dezimalstellen ein.',
     invalidInput: 'Dieses Feld hat einen inkorrekten Wert.',
     invalidSelection: 'Dieses Feld hat eine inkorrekte Auswahl.',
     invalidSelections: "'Dieses Feld enthält die folgenden inkorrekten Auswahlen:'",

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -336,6 +336,7 @@ export const enTranslations = {
     enterNumber: 'Please enter a valid number.',
     fieldHasNo: 'This field has no {{label}}',
     greaterThanMax: '{{value}} is greater than the max allowed {{label}} of {{max}}.',
+    integerOnly: 'Please enter a valid number without decimals.',
     invalidInput: 'This field has an invalid input.',
     invalidSelection: 'This field has an invalid selection.',
     invalidSelections: 'This field has the following invalid selections:',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -338,6 +338,7 @@ export const esTranslations: DefaultTranslationsObject = {
     enterNumber: 'Por favor introduce un número válido.',
     fieldHasNo: 'Este campo no tiene {{label}}',
     greaterThanMax: '{{value}} es mayor que el {{label}} máximo permitido de {{max}}.',
+    integerOnly: 'Por favor, ingrese un número válido sin decimales.',
     invalidInput: 'La información en este campo es inválida.',
     invalidSelection: 'La selección en este campo es inválida.',
     invalidSelections: 'Este campo tiene las siguientes selecciones inválidas:',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -335,6 +335,7 @@ export const faTranslations: DefaultTranslationsObject = {
     enterNumber: 'لطفاً یک شماره درست وارد کنید.',
     fieldHasNo: 'این کادر شامل هیچ {{label}} نمی‌شود',
     greaterThanMax: '{{value}} بیشتر از حداکثر مجاز برای {{label}} است که {{max}} است.',
+    integerOnly: 'لطفاً یک عدد صحیح و بدون اعشار وارد کنید.',
     invalidInput: 'این کادر دارای ورودی نامعتبر است.',
     invalidSelection: 'این کادر دارای یک انتخاب نامعتبر است.',
     invalidSelections: 'این کادر دارای انتخاب‌های نامعتبر زیر است:',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -343,6 +343,7 @@ export const frTranslations: DefaultTranslationsObject = {
     enterNumber: 'S’il vous plait, veuillez entrer un nombre valide.',
     fieldHasNo: 'Ce champ n’a pas de {{label}}',
     greaterThanMax: '{{value}} est supérieur au max autorisé {{label}} de {{max}}.',
+    integerOnly: 'Veuillez entrer un numéro valide sans décimales.',
     invalidInput: 'Ce champ a une entrée invalide.',
     invalidSelection: 'Ce champ a une sélection invalide.',
     invalidSelections: 'Ce champ contient les sélections invalides suivantes :',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -328,6 +328,7 @@ export const heTranslations: DefaultTranslationsObject = {
     enterNumber: 'נא להזין מספר תקני.',
     fieldHasNo: 'שדה זה אינו מכיל {{label}}',
     greaterThanMax: '{{value}} גדול מהערך המרבי המותר של {{label}} שהוא {{max}}.',
+    integerOnly: 'בבקשה הכנס מספר תקין ללא ספרות עשרוניות',
     invalidInput: 'שדה זה מכיל קלט לא תקני.',
     invalidSelection: 'שדה זה מכיל בחירה לא תקנית.',
     invalidSelections: 'שדה זה מכיל את הבחירות הבאות שאינן תקניות:',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -336,6 +336,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     enterNumber: 'Molim unesite valjani broj.',
     fieldHasNo: 'Ovo polje nema {{label}}',
     greaterThanMax: '{{value}} exceeds the maximum allowable {{label}} limit of {{max}}.',
+    integerOnly: 'Molimo unesite valjani broj bez decimala.',
     invalidInput: 'Ovo polje ima nevaljan unos.',
     invalidSelection: 'Ovo polje ima nevaljan odabir.',
     invalidSelections: 'Ovo polje ima sljedeće nevaljane odabire:',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -338,6 +338,7 @@ export const huTranslations: DefaultTranslationsObject = {
     enterNumber: 'Kérjük, adjon meg egy érvényes számot.',
     fieldHasNo: 'Ennek a mezőnek nincs {{label}}',
     greaterThanMax: '{{value}} nagyobb, mint a megengedett maximum {{label}} érték, ami {{max}}.',
+    integerOnly: 'Kérjük, adjon meg egy érvényes egész számot.',
     invalidInput: 'Ez a mező érvénytelen értéket tartalmaz.',
     invalidSelection: 'Ez a mező érvénytelen kijelöléssel rendelkezik.',
     invalidSelections: 'Ez a mező a következő érvénytelen kijelöléseket tartalmazza:',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -338,6 +338,7 @@ export const itTranslations: DefaultTranslationsObject = {
     enterNumber: 'Si prega di inserire un numero valido.',
     fieldHasNo: 'Questo campo non ha {{label}}',
     greaterThanMax: '{{value}} è superiore al massimo consentito {{label}} di {{max}}.',
+    integerOnly: 'Per favore inserire un numero valido senza decimali.',
     invalidInput: 'Questo campo ha un input non valido.',
     invalidSelection: 'Questo campo ha una selezione non valida.',
     invalidSelections: "'In questo campo sono presenti le seguenti selezioni non valide:'",

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -335,6 +335,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     enterNumber: '有効な数値を入力してください。',
     fieldHasNo: '{{label}} が必要です。',
     greaterThanMax: '{{value}}は許容最大{{label}}の{{max}}を超えています。',
+    integerOnly: '有効な小数点以下のない数値を入力してください。',
     invalidInput: '無効な入力値です。',
     invalidSelection: '無効な選択です。',
     invalidSelections: '次の無効な選択があります: ',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -334,6 +334,7 @@ export const koTranslations: DefaultTranslationsObject = {
     enterNumber: '유효한 숫자를 입력하세요.',
     fieldHasNo: '이 입력란에는 {{label}}이(가) 없습니다.',
     greaterThanMax: '{{value}}은(는) 최대 허용된 {{label}}인 {{max}}개보다 큽니다.',
+    integerOnly: '소수점이 없는 유효한 숫자를 입력해주세요.',
     invalidInput: '이 입력란에는 유효하지 않은 입력이 있습니다.',
     invalidSelection: '이 입력란에는 유효하지 않은 선택이 있습니다.',
     invalidSelections: '이 입력란에는 다음과 같은 유효하지 않은 선택 사항이 있습니다:',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -340,6 +340,7 @@ export const myTranslations: DefaultTranslationsObject = {
     fieldHasNo: 'ဤအကွက်တွင် {{label}} မရှိပါ။',
     greaterThanMax:
       '{{value}} သည် {{max}} ထက် ပိုမိုကြီးသည်။ ဤသည်ဖြင့် {{label}} အများဆုံးခွင့်ပြုထားသော တန်ဖိုးထက် ကြီးသည်။',
+    integerOnly: 'Veuillez entrer un nombre valide sans décimales.',
     invalidInput: 'ဤအကွက်တွင် မမှန်ကန်သော ထည့်သွင်းမှုတစ်ခုရှိသည်။',
     invalidSelection: 'ဤအကွက်တွင် မမှန်ကန်သော ရွေးချယ်မှုတစ်ခုရှိသည်။',
     invalidSelections: 'ဤအကွက်တွင် အောက်ပါ မမှန်ကန်သော ရွေးချယ်မှုများ ရှိသည်',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -336,6 +336,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     enterNumber: 'Vennligst skriv inn et gyldig tall.',
     fieldHasNo: 'Dette feltet har ingen {{label}}',
     greaterThanMax: '{{value}} er større enn den tillatte maksimale {{label}} på {{max}}.',
+    integerOnly: 'Vennligst skriv inn et gyldig tall uten desimaler.',
     invalidInput: 'Dette feltet har en ugyldig inndata.',
     invalidSelection: 'Dette feltet har en ugyldig utvalg.',
     invalidSelections: 'Dette feltet har følgende ugyldige utvalg:',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -338,6 +338,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     enterNumber: 'Voer een geldig nummer in.',
     fieldHasNo: 'Dit veld heeft geen {{label}}',
     greaterThanMax: '{{value}} is groter dan de maximaal toegestane {{label}} van {{max}}.',
+    integerOnly: 'Voer alstublieft een geldig nummer in zonder decimalen.',
     invalidInput: 'Dit veld heeft een ongeldige invoer.',
     invalidSelection: 'Dit veld heeft een ongeldige selectie.',
     invalidSelections: 'Dit veld heeft de volgende ongeldige selecties:',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -336,6 +336,7 @@ export const plTranslations: DefaultTranslationsObject = {
     enterNumber: 'Wprowadź poprawny numer telefonu.',
     fieldHasNo: 'To pole nie posiada {{label}}',
     greaterThanMax: '{{value}} jest większe niż maksymalnie dozwolony {{label}} wynoszący {{max}}.',
+    integerOnly: 'Proszę wprowadzić poprawną liczbę bez części dziesiętnych.',
     invalidInput: 'To pole zawiera nieprawidłowe dane.',
     invalidSelection: 'To pole ma nieprawidłowy wybór.',
     invalidSelections: 'To pole zawiera następujące, nieprawidłowe wybory:',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -337,6 +337,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     enterNumber: 'Por favor, insira um número válido.',
     fieldHasNo: 'Esse campo não contém {{label}}',
     greaterThanMax: '{{value}} é maior que o máximo permitido de {{label}} que é {{max}}.',
+    integerOnly: 'Por favor, insira um número válido sem decimais.',
     invalidInput: 'Esse campo tem um conteúdo inválido.',
     invalidSelection: 'Esse campo tem uma seleção inválida.',
     invalidSelections: "'Esse campo tem as seguintes seleções inválidas:'",

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -340,6 +340,7 @@ export const roTranslations: DefaultTranslationsObject = {
     fieldHasNo: 'Acest câmp nu are un {{label}}',
     greaterThanMax:
       '{{value}} este mai mare decât valoarea maximă permisă pentru {{label}} de {{max}}.',
+    integerOnly: 'Vă rugăm să introduceți un număr valid fără zecimale.',
     invalidInput: 'Acest câmp are o intrare invalidă.',
     invalidSelection: 'Acest câmp are o selecție invalidă.',
     invalidSelections: 'Acest câmp are următoarele selecții invalide:',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -335,6 +335,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     enterNumber: 'Молимо Вас унесите валидан број.',
     fieldHasNo: 'Ово поље нема {{label}}',
     greaterThanMax: '{{value}} прекорачује максималан дозвољени {{label}} лимит од {{max}}.',
+    integerOnly: 'Molimo unesite ispravan broj bez decimala.',
     invalidInput: 'Ово поље садржи невалидан унос.',
     invalidSelection: 'Ово поље садржи невалидан одабир.',
     invalidSelections: 'Ово поље има следеће невалидне одабире:',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -335,6 +335,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     enterNumber: 'Molimo Vas unesite validan broj.',
     fieldHasNo: 'Ovo polje nema {{label}}',
     greaterThanMax: '{{value}} prekoračuje maksimalan dozvoljeni {{label}} limit od {{max}}.',
+    integerOnly: 'Molim unesite ispravan broj bez decimala.',
     invalidInput: 'Ovo polje sadrži nevalidan unos.',
     invalidSelection: 'Ovo polje sadrži nevalidan odabir.',
     invalidSelections: 'Ovo polje ima sledeće nevalidne odabire:',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -339,6 +339,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     enterNumber: 'Пожалуйста, введите корректный номер.',
     fieldHasNo: 'У этого поля нет {{label}}',
     greaterThanMax: '{{value}} больше максимально допустимого значения {{label}} {{max}}.',
+    integerOnly: 'Пожалуйста, введите целое число без десятичных знаков.',
     invalidInput: 'Это поле имеет недопустимое значение.',
     invalidSelection: 'В этом поле выбран недопустимый вариант.',
     invalidSelections: "'Это поле содержит следующие неправильные варианты:'",

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -337,6 +337,7 @@ export const skTranslations: DefaultTranslationsObject = {
     enterNumber: 'Zadajte prosím platné číslo.',
     fieldHasNo: 'Toto pole nemá {{label}}',
     greaterThanMax: '{{value}} je vyššie ako maximálne povolené {{label}} {{max}}.',
+    integerOnly: 'Prosím, zadajte platné číslo bez desatinných miest.',
     invalidInput: 'Toto pole má neplatný vstup.',
     invalidSelection: 'Toto pole má neplatný výber.',
     invalidSelections: 'Toto pole má nasledujúce neplatné výbery:',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -336,6 +336,7 @@ export const svTranslations: DefaultTranslationsObject = {
     enterNumber: 'Vänligen skriv in ett giltigt nummer.',
     fieldHasNo: 'Detta fält har ingen {{label}}',
     greaterThanMax: '{{value}} är större än den maximalt tillåtna {{label}} av {{max}}.',
+    integerOnly: '[SKIPPED]',
     invalidInput: 'Det här fältet har en ogiltig inmatning.',
     invalidSelection: 'Det här fältet har ett ogiltigt urval.',
     invalidSelections: 'Det här fältet har följande ogiltiga val:',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -330,6 +330,7 @@ export const thTranslations: DefaultTranslationsObject = {
     enterNumber: 'กรุณาระบุตัวเลขที่ถูกต้อง',
     fieldHasNo: 'ช่องนี้ไม่มี {{label}}',
     greaterThanMax: '{{value}} มากกว่าค่าสูงสุดที่อนุญาตของ {{label}} ซึ่งคือ {{max}}.',
+    integerOnly: 'โปรดป้อนตัวเลขที่ถูกต้องโดยไม่มีทศนิยม',
     invalidInput: 'ข้อมูลไม่ถูกต้อง',
     invalidSelection: 'ค่าที่เลือกไม่ถูกต้อง',
     invalidSelections: 'ค่าที่เลือกไม่ถูกต้องดังนี้:',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -340,6 +340,7 @@ export const trTranslations: DefaultTranslationsObject = {
     enterNumber: 'Lütfen geçerli bir sayı girin.',
     fieldHasNo: 'Bu alanda {{label}} girili değil.',
     greaterThanMax: '{{value}} izin verilen maksimum {{label}} değerinden daha büyük.',
+    integerOnly: 'Lütfen ondalık olmayan geçerli bir sayı girin.',
     invalidInput: 'Bu alanda geçersiz bir giriş mevcut.',
     invalidSelection: 'Bu alanda geçersiz bir seçim mevcut.',
     invalidSelections: "'Bu alan şu geçersiz seçimlere sahip:'",

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -336,6 +336,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     enterNumber: 'Будь ласка, введіть валідне число.',
     fieldHasNo: 'В цього полі немає {{label}}',
     greaterThanMax: '{{value}} більше, ніж припустиме максимальне значення {{label}} в {{max}}.',
+    integerOnly: 'Будь ласка, введіть дійсне число без десяткових дробів.',
     invalidInput: 'У цьому полі введено некоректне значення.',
     invalidSelection: 'Це поле має некоректний вибір.',
     invalidSelections: 'Це поле має наступні невірні варіанти вибору:',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -334,6 +334,7 @@ export const viTranslations: DefaultTranslationsObject = {
     enterNumber: 'Vui lòng nhập số.',
     fieldHasNo: 'Field này không có: {{label}}',
     greaterThanMax: '{{value}} lớn hơn giá trị tối đa cho phép của {{label}} là {{max}}.',
+    integerOnly: 'Vui lòng nhập một số hợp lệ mà không có số thập phân.',
     invalidInput: 'Dữ liệu nhập vào không hợp lệ.',
     invalidSelection: 'Lựa chọn ở field này không hợp lệ.',
     invalidSelections: "'Field này có những lựa chọn không hợp lệ sau:'",

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -326,6 +326,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     enterNumber: '请输入一个有效的号码。',
     fieldHasNo: '这个字段没有{{label}}',
     greaterThanMax: '{{value}}超过了允许的最大{{label}}，该最大值为{{max}}。',
+    integerOnly: '请提供一个无小数点的有效数字。',
     invalidInput: '这个字段有一个无效的输入。',
     invalidSelection: '这个字段有一个无效的选择。',
     invalidSelections: '这个字段有以下无效的选择：',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -326,6 +326,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     enterNumber: '請輸入一個有效的數字。',
     fieldHasNo: '這個字串沒有{{label}}',
     greaterThanMax: '{{value}}超過了允許的最大{{label}}，該最大值為{{max}}。',
+    integerOnly: '請輸入一個沒有小數的有效數字。',
     invalidInput: '這個字串有一個無效的輸入。',
     invalidSelection: '這個字串有一個無效的選擇。',
     invalidSelections: '這個字串有以下無效的選擇：',

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -22,9 +22,9 @@ export default buildConfigWithDefaults({
           defaultValue: 'some default',
         },
         {
-          name: 'int',
+          name: 'real',
           type: 'number',
-          dbType: 'bigint',
+          dbType: 'real',
         },
         {
           name: 'select',

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -27,6 +27,19 @@ export default buildConfigWithDefaults({
           dbType: 'real',
         },
         {
+          name: 'virtualField',
+          type: 'text',
+          dbStore: false,
+          hooks: {
+            afterRead: [() => 'Virtual'],
+            beforeChange: [
+              (args) => {
+                delete args.siblingData['virtualField']
+              },
+            ],
+          },
+        },
+        {
           name: 'select',
           type: 'select',
           options: ['some', 'asd'],

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -13,6 +13,33 @@ export default buildConfigWithDefaults({
   // ...extend config here
   collections: [
     PostsCollection,
+    {
+      slug: 'tests',
+      fields: [
+        {
+          name: 'default',
+          type: 'text',
+          defaultValue: 'some default',
+        },
+        {
+          name: 'blocks',
+          type: 'blocks',
+          dbJsonColumn: true,
+          blocks: [{ slug: 'some', fields: [{ type: 'text', name: 'text' }] }],
+        },
+        {
+          name: 'arr',
+          type: 'array',
+          dbJsonColumn: true,
+          fields: [
+            {
+              name: 'text',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+    },
     // MediaCollection
   ],
   cors: ['http://localhost:3000', 'http://localhost:3001'],

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -22,6 +22,11 @@ export default buildConfigWithDefaults({
           defaultValue: 'some default',
         },
         {
+          name: 'int',
+          type: 'number',
+          dbType: 'bigint',
+        },
+        {
           name: 'select',
           type: 'select',
           options: ['some', 'asd'],

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -22,6 +22,12 @@ export default buildConfigWithDefaults({
           defaultValue: 'some default',
         },
         {
+          name: 'select',
+          type: 'select',
+          options: ['some', 'asd'],
+          defaultValue: 'some',
+        },
+        {
           name: 'blocks',
           type: 'blocks',
           dbJsonColumn: true,

--- a/test/live-preview/fields/link.ts
+++ b/test/live-preview/fields/link.ts
@@ -134,14 +134,18 @@ const link: LinkType = ({ appearances, disableLabel = false, overrides = {} } = 
       appearanceOptionsToUse = appearances.map((appearance) => appearanceOptions[appearance])
     }
 
+    const hasDefault = appearanceOptionsToUse.some((option) => option.value === 'default')
+
     linkResult.fields.push({
       name: 'appearance',
       type: 'select',
-      defaultValue: 'default',
       options: appearanceOptionsToUse,
       admin: {
         description: 'Choose how the link should be rendered.',
       },
+      ...(hasDefault && {
+        defaultValue: 'default',
+      }),
     })
   }
 


### PR DESCRIPTION
## Description

The PR adds:

### Field config - `dbStore`
 `dbStore` field property - removes schema creation for a field. Currently using [Virtual Fields](https://payloadcms.com/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges) with Postgres bloats the db with unused columns / tables, as well may join empty arrays / blocks that are meant to be "Virtual". Realted discussion - https://github.com/payloadcms/payload/discussions/6270

### Field config - `dbJsonColumn`
 `dbJsonColumn` field property - stores a field, that should create additional tables (`hasMany` Text / Number / Select, Array / Blocks, Polymorphic / `hasMany` relationships) as a simple `jsonb` column.

Advantages
- Doesn't bloat a DB with too much tables for blocks (you can have them a lot).
- Migrations are  simpler. therefore, chances to screw up them are less.
- 0 Joins and so the performance should be better. While originally you can have them a _lot
- Easier to work with the Payload nested data from DB driver, just `SELECT blocks from table` 

Considerations:
- Querying on a field with `dbJsonColumn`. A solution would be is to implement a universal JSON querying that will work on any field type, that stored as a json column. Still you can use `payload.db.drizzle.query` to query on JSON with SQL.
- Foreign keys aren't created and so when relationship is deleted, setting to `NULL` isn't performed automatically. The same as with MongoDB.

My thoughts:
I haven't ever query on a blocks field, so i don't see a point of adding so much complexity just because of this.
 
### Passing `defaultValue` into a DB schema
Non undefined and non function `defaultValue` is passed into a column builder. This 100% syncs `defaultValue` with a database and resolves a problem when adding a **required** field into a collection with existing docs, currently you can't do that unless you: lose data / modify migration manually.
Discussions: https://github.com/payloadcms/payload/discussions/6691  https://github.com/payloadcms/payload/discussions/6048

### `dbType` for Number field
Accepts: `'integer' | 'bigint' | 'real' | 'numeric'` 
Simply stores number field in a specified column, by default `numeric`.

According to [Postgres documentation](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL)  calculations on numeric values are very slow compared to the integer types, or to the floating-point types.

Adds default validation with `Number.isInteger`.


- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
