### PR TITLE
fix(plugin-cloud-storage): encode filename to remove unsupported chars

### DIFF
--- a/packages/plugin-cloud-storage/src/adapters/azure/generateURL.ts
+++ b/packages/plugin-cloud-storage/src/adapters/azure/generateURL.ts
@@ -10,5 +10,5 @@ interface Args {
 export const getGenerateURL =
   ({ baseURL, containerName }: Args): GenerateURL =>
   ({ filename, prefix = '' }) => {
-    return `${baseURL}/${containerName}/${path.posix.join(prefix, filename)}`
+    return `${baseURL}/${containerName}/${path.posix.join(prefix, encodeURIComponent(filename))}`
   }

--- a/packages/plugin-cloud-storage/src/adapters/gcs/generateURL.ts
+++ b/packages/plugin-cloud-storage/src/adapters/gcs/generateURL.ts
@@ -13,6 +13,6 @@ export const getGenerateURL =
   ({ bucket, getStorageClient }: Args): GenerateURL =>
   ({ filename, prefix = '' }) => {
     return decodeURIComponent(
-      getStorageClient().bucket(bucket).file(path.posix.join(prefix, filename)).publicUrl(),
+      getStorageClient().bucket(bucket).file(path.posix.join(prefix, encodeURIComponent(filename))).publicUrl(),
     )
   }

--- a/packages/plugin-cloud-storage/src/adapters/s3/generateURL.ts
+++ b/packages/plugin-cloud-storage/src/adapters/s3/generateURL.ts
@@ -12,5 +12,5 @@ interface Args {
 export const getGenerateURL =
   ({ bucket, config: { endpoint } }: Args): GenerateURL =>
   ({ filename, prefix = '' }) => {
-    return `${endpoint}/${bucket}/${path.posix.join(prefix, filename)}`
+    return `${endpoint}/${bucket}/${path.posix.join(prefix, encodeURIComponent(filename))}`
   }


### PR DESCRIPTION
## Description

I've used an `encodeURIComponent` to encode incoming filename from DB that is broken when unsupported characters are included in string. 

This fixes #6985 

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
