### PR TITLE
feat(plugin-seo): export fields from plugin seo so that they can be imported freely in a collection fields config

### DIFF
--- a/docs/plugins/seo.mdx
+++ b/docs/plugins/seo.mdx
@@ -68,7 +68,7 @@ const config = buildConfig({
         'pages',
       ],
       uploadsCollection: 'media',
-      generateTitle: ({ doc }) => `Website.com — ${doc.title.value}`,
+      generateTitle: ({ doc }) => `Website.com — ${doc.title}`,
       generateDescription: ({ doc }) => doc.excerpt
     })
   ]

--- a/docs/plugins/seo.mdx
+++ b/docs/plugins/seo.mdx
@@ -210,7 +210,7 @@ There is the option to directly import any of the fields from the plugin so that
 </Banner>
 
 ```ts
-import { MetaDescriptionField, MetaImageField, MetaTitleField, OverviewField, PreviewField } from '@payloadcms/plugin-seo'
+import { MetaDescriptionField, MetaImageField, MetaTitleField, OverviewField, PreviewField } from '@payloadcms/plugin-seo/fields'
 
 // Used as fields
 MetaImageField({

--- a/docs/plugins/seo.mdx
+++ b/docs/plugins/seo.mdx
@@ -119,7 +119,7 @@ A function that allows you to return any meta title, including from document's c
 {
   // ...
   seoPlugin({
-    generateTitle: ({ ...docInfo, doc, locale }) => `Website.com — ${doc?.title?.value}`,
+    generateTitle: ({ ...docInfo, doc, locale }) => `Website.com — ${doc?.title}`,
   })
 }
 ```
@@ -133,7 +133,7 @@ A function that allows you to return any meta description, including from docume
 {
   // ...
   seoPlugin({
-    generateDescription: ({ ...docInfo, doc, locale }) => doc?.excerpt?.value,
+    generateDescription: ({ ...docInfo, doc, locale }) => doc?.excerpt,
   })
 }
 ```
@@ -147,7 +147,7 @@ A function that allows you to return any meta image, including from document's c
 {
   // ...
   seoPlugin({
-    generateImage: ({ ...docInfo, doc, locale }) => doc?.featuredImage?.value,
+    generateImage: ({ ...docInfo, doc, locale }) => doc?.featuredImage,
   })
 }
 ```
@@ -162,7 +162,7 @@ A function called by the search preview component to display the actual URL of y
   // ...
   seoPlugin({
     generateURL: ({ ...docInfo, doc, locale }) =>
-      `https://yoursite.com/${collection?.slug}/${doc?.slug?.value}`,
+      `https://yoursite.com/${collection?.slug}/${doc?.slug}`,
   })
 }
 ```
@@ -200,6 +200,54 @@ seoPlugin({
 })
 ```
 
+## Direct use of fields
+
+There is the option to directly import any of the fields from the plugin so that you can include them anywhere as needed.
+
+<Banner type="info">
+  You will still need to configure the plugin in the Payload config in order to configure the generation functions.
+  Since these fields are imported and used directly, they don't have access to the plugin config so they may need additional arguments to work the same way.
+</Banner>
+
+```ts
+import { MetaDescriptionField, MetaImageField, MetaTitleField, OverviewField, PreviewField } from '@payloadcms/plugin-seo'
+
+// Used as fields
+MetaImageField({
+  // the upload collection slug
+  relationTo: 'media',
+
+  // if the `generateImage` function is configured
+  hasGenerateFn: true,
+})
+
+MetaDescriptionField({
+  // if the `generateDescription` function is configured
+  hasGenerateFn: true,
+})
+
+MetaTitleField({
+  // if the `generateTitle` function is configured
+  hasGenerateFn: true,
+})
+
+PreviewField({
+  // if the `generateUrl` function is configured
+  hasGenerateFn: true,
+
+  // field paths to match the target field for data
+  titlePath: 'meta.title',
+  descriptionPath: 'meta.description',
+})
+
+OverviewField({
+  // field paths to match the target field for data
+  titlePath: 'meta.title',
+  descriptionPath: 'meta.description',
+  imagePath: 'meta.image',
+})
+```
+
 ## TypeScript
 
 All types can be directly imported:
@@ -211,6 +259,18 @@ import {
   GenerateDescription
   GenerateURL
 } from '@payloadcms/plugin-seo/types';
+```
+
+You can then pass the collections from your generated Payload types into the generation types, for example:
+
+```ts
+import { Page } from './payload-types.ts';
+
+import { GenerateTitle } from '@payloadcms/plugin-seo/types';
+
+const generateTitle: GenerateTitle<Page> = async ({ doc, locale }) => {
+  return `Website.com — ${doc?.title}`
+}
 ```
 
 ## Examples

--- a/packages/plugin-seo/package.json
+++ b/packages/plugin-seo/package.json
@@ -29,6 +29,11 @@
       "import": "./src/exports/types.ts",
       "types": "./src/exports/types.ts",
       "default": "./src/exports/types.ts"
+    },
+    "./fields": {
+      "import": "./src/exports/fields.ts",
+      "types": "./src/exports/fields.ts",
+      "default": "./src/exports/fields.ts"
     }
   },
   "main": "./src/index.tsx",
@@ -73,6 +78,11 @@
         "import": "./dist/exports/types.js",
         "types": "./dist/exports/types.d.ts",
         "default": "./dist/exports/types.js"
+      },
+      "./fields": {
+        "import": "./dist/exports/fields.js",
+        "types": "./dist/exports/fields.d.ts",
+        "default": "./dist/exports/fields.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/plugin-seo/src/exports/fields.ts
+++ b/packages/plugin-seo/src/exports/fields.ts
@@ -1,0 +1,5 @@
+export { MetaDescriptionField } from '../fields/MetaDescription/index.js'
+export { MetaImageField } from '../fields/MetaImage/index.js'
+export { MetaTitleField } from '../fields/MetaTitle/index.js'
+export { OverviewField } from '../fields/Overview/index.js'
+export { PreviewField } from '../fields/Preview/index.js'

--- a/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
@@ -29,7 +29,7 @@ type MetaDescriptionProps = FormFieldBase & {
 }
 
 export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) => {
-  const { CustomLabel, hasGenerateDescriptionFn, label, labelProps, path, required } = props
+  const { CustomLabel, hasGenerateDescriptionFn, label, labelProps, required } = props
   const { path: pathFromContext } = useFieldProps()
 
   const { t } = useTranslation<PluginSEOTranslations, PluginSEOTranslationKeys>()
@@ -39,7 +39,7 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
   const docInfo = useDocumentInfo()
 
   const field: FieldType<string> = useField({
-    path,
+    path: pathFromContext,
   } as Options)
 
   const { errorMessage, setValue, showError, value } = field

--- a/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
@@ -4,7 +4,7 @@ import type { FieldType, FormFieldBase, Options } from '@payloadcms/ui'
 
 import {
   FieldLabel,
-  TextInput,
+  TextareaInput,
   useDocumentInfo,
   useField,
   useFieldProps,
@@ -14,45 +14,45 @@ import {
 } from '@payloadcms/ui'
 import React, { useCallback } from 'react'
 
-import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../translations/index.js'
-import type { GenerateTitle } from '../types.js'
+import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../../translations/index.js'
+import type { GenerateDescription } from '../../types.js'
 
-import { defaults } from '../defaults.js'
-import { LengthIndicator } from '../ui/LengthIndicator.js'
-import './index.scss'
+import { defaults } from '../../defaults.js'
+import { LengthIndicator } from '../../ui/LengthIndicator.js'
 
-const { maxLength, minLength } = defaults.title
+const { maxLength, minLength } = defaults.description
 
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-type MetaTitleProps = FormFieldBase & {
-  hasGenerateTitleFn: boolean
+type MetaDescriptionProps = FormFieldBase & {
+  hasGenerateDescriptionFn: boolean
+  path: string
 }
 
-export const MetaTitle: React.FC<MetaTitleProps> = (props) => {
-  const { CustomLabel, hasGenerateTitleFn, label, labelProps, path, required } = props || {}
+export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) => {
+  const { CustomLabel, hasGenerateDescriptionFn, label, labelProps, path, required } = props
   const { path: pathFromContext } = useFieldProps()
 
   const { t } = useTranslation<PluginSEOTranslations, PluginSEOTranslationKeys>()
-
-  const field: FieldType<string> = useField({
-    path,
-  } as Options)
 
   const locale = useLocale()
   const { getData } = useForm()
   const docInfo = useDocumentInfo()
 
+  const field: FieldType<string> = useField({
+    path,
+  } as Options)
+
   const { errorMessage, setValue, showError, value } = field
 
-  const regenerateTitle = useCallback(async () => {
-    if (!hasGenerateTitleFn) return
+  const regenerateDescription = useCallback(async () => {
+    if (!hasGenerateDescriptionFn) return
 
-    const genTitleResponse = await fetch('/api/plugin-seo/generate-title', {
+    const genDescriptionResponse = await fetch('/api/plugin-seo/generate-description', {
       body: JSON.stringify({
         ...docInfo,
         doc: { ...getData() },
         locale: typeof locale === 'object' ? locale?.code : locale,
-      } satisfies Parameters<GenerateTitle>[0]),
+      } satisfies Parameters<GenerateDescription>[0]),
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
@@ -60,10 +60,10 @@ export const MetaTitle: React.FC<MetaTitleProps> = (props) => {
       method: 'POST',
     })
 
-    const { result: generatedTitle } = await genTitleResponse.json()
+    const { result: generatedDescription } = await genDescriptionResponse.json()
 
-    setValue(generatedTitle || '')
-  }, [hasGenerateTitleFn, docInfo, getData, locale, setValue])
+    setValue(generatedDescription || '')
+  }, [hasGenerateDescriptionFn, docInfo, getData, locale, setValue])
 
   return (
     <div
@@ -79,11 +79,11 @@ export const MetaTitle: React.FC<MetaTitleProps> = (props) => {
       >
         <div className="plugin-seo__field">
           <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
-          {hasGenerateTitleFn && (
+          {hasGenerateDescriptionFn && (
             <React.Fragment>
               &nbsp; &mdash; &nbsp;
               <button
-                onClick={regenerateTitle}
+                onClick={regenerateDescription}
                 style={{
                   background: 'none',
                   backgroundColor: 'transparent',
@@ -105,15 +105,14 @@ export const MetaTitle: React.FC<MetaTitleProps> = (props) => {
             color: '#9A9A9A',
           }}
         >
-          {t('plugin-seo:lengthTipTitle', { maxLength, minLength })}
+          {t('plugin-seo:lengthTipDescription', { maxLength, minLength })}
           <a
-            href="https://developers.google.com/search/docs/advanced/appearance/title-link#page-titles"
+            href="https://developers.google.com/search/docs/advanced/appearance/snippet#meta-descriptions"
             rel="noopener noreferrer"
             target="_blank"
           >
             {t('plugin-seo:bestPractices')}
           </a>
-          .
         </div>
       </div>
       <div
@@ -122,7 +121,7 @@ export const MetaTitle: React.FC<MetaTitleProps> = (props) => {
           position: 'relative',
         }}
       >
-        <TextInput
+        <TextareaInput
           CustomError={errorMessage}
           onChange={setValue}
           path={pathFromContext}

--- a/packages/plugin-seo/src/fields/MetaDescription/index.ts
+++ b/packages/plugin-seo/src/fields/MetaDescription/index.ts
@@ -14,7 +14,7 @@ interface FieldFunctionProps {
 
 type FieldFunction = ({ hasGenerateFn, overrides }: FieldFunctionProps) => TextareaField
 
-export const MetaDescription: FieldFunction = ({ hasGenerateFn = false, overrides }) => {
+export const MetaDescriptionField: FieldFunction = ({ hasGenerateFn = false, overrides }) => {
   return {
     name: 'description',
     type: 'textarea',

--- a/packages/plugin-seo/src/fields/MetaDescription/index.ts
+++ b/packages/plugin-seo/src/fields/MetaDescription/index.ts
@@ -5,6 +5,9 @@ import { withMergedProps } from '@payloadcms/ui/shared'
 import { MetaDescriptionComponent } from './MetaDescriptionComponent.js'
 
 interface FieldFunctionProps {
+  /**
+   * Tell the component if the generate function is available as configured in the plugin config
+   */
   hasGenerateFn?: boolean
   overrides?: Partial<TextareaField>
 }

--- a/packages/plugin-seo/src/fields/MetaDescription/index.ts
+++ b/packages/plugin-seo/src/fields/MetaDescription/index.ts
@@ -1,0 +1,32 @@
+import type { TextareaField } from 'payload'
+
+import { withMergedProps } from '@payloadcms/ui/shared'
+
+import { MetaDescriptionComponent } from './MetaDescriptionComponent.js'
+
+interface FieldFunctionProps {
+  hasGenerateFn?: boolean
+  overrides?: Partial<TextareaField>
+}
+
+type FieldFunction = ({ hasGenerateFn, overrides }: FieldFunctionProps) => TextareaField
+
+export const MetaDescription: FieldFunction = ({ hasGenerateFn = false, overrides }) => {
+  return {
+    name: 'description',
+    type: 'textarea',
+    admin: {
+      components: {
+        Field: withMergedProps({
+          Component: MetaDescriptionComponent,
+          sanitizeServerOnlyProps: true,
+          toMergeIntoProps: {
+            hasGenerateDescriptionFn: hasGenerateFn,
+          },
+        }),
+      },
+    },
+    localized: true,
+    ...((overrides as unknown as TextareaField) ?? {}),
+  }
+}

--- a/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
@@ -14,17 +14,17 @@ import {
 } from '@payloadcms/ui'
 import React, { useCallback } from 'react'
 
-import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../translations/index.js'
-import type { GenerateImage } from '../types.js'
+import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../../translations/index.js'
+import type { GenerateImage } from '../../types.js'
 
-import { Pill } from '../ui/Pill.js'
+import { Pill } from '../../ui/Pill.js'
 
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 type MetaImageProps = UploadInputProps & {
   hasGenerateImageFn: boolean
 }
 
-export const MetaImage: React.FC<MetaImageProps> = (props) => {
+export const MetaImageComponent: React.FC<MetaImageProps> = (props) => {
   const { CustomLabel, hasGenerateImageFn, label, labelProps, relationTo, required } = props || {}
 
   const field: FieldType<string> = useField(props as Options)

--- a/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
@@ -8,6 +8,7 @@ import {
   useConfig,
   useDocumentInfo,
   useField,
+  useFieldProps,
   useForm,
   useLocale,
   useTranslation,
@@ -26,8 +27,9 @@ type MetaImageProps = UploadInputProps & {
 
 export const MetaImageComponent: React.FC<MetaImageProps> = (props) => {
   const { CustomLabel, hasGenerateImageFn, label, labelProps, relationTo, required } = props || {}
+  const { path: pathFromContext } = useFieldProps()
 
-  const field: FieldType<string> = useField(props as Options)
+  const field: FieldType<string> = useField({ ...props, path: pathFromContext } as Options)
 
   const { t } = useTranslation<PluginSEOTranslations, PluginSEOTranslationKeys>()
 

--- a/packages/plugin-seo/src/fields/MetaImage/index.ts
+++ b/packages/plugin-seo/src/fields/MetaImage/index.ts
@@ -5,6 +5,9 @@ import { withMergedProps } from '@payloadcms/ui/shared'
 import { MetaImageComponent } from './MetaImageComponent.js'
 
 interface FieldFunctionProps {
+  /**
+   * Tell the component if the generate function is available as configured in the plugin config
+   */
   hasGenerateFn?: boolean
   overrides?: Partial<UploadField>
   relationTo: string

--- a/packages/plugin-seo/src/fields/MetaImage/index.ts
+++ b/packages/plugin-seo/src/fields/MetaImage/index.ts
@@ -1,0 +1,36 @@
+import type { UploadField } from 'payload'
+
+import { withMergedProps } from '@payloadcms/ui/shared'
+
+import { MetaImageComponent } from './MetaImageComponent.js'
+
+interface FieldFunctionProps {
+  hasGenerateFn?: boolean
+  overrides?: Partial<UploadField>
+  relationTo: string
+}
+
+type FieldFunction = ({ hasGenerateFn, overrides }: FieldFunctionProps) => UploadField
+
+export const MetaImage: FieldFunction = ({ hasGenerateFn = false, overrides, relationTo }) => {
+  return {
+    name: 'image',
+    type: 'upload',
+    admin: {
+      components: {
+        Field: withMergedProps({
+          Component: MetaImageComponent,
+          sanitizeServerOnlyProps: true,
+          toMergeIntoProps: {
+            hasGenerateImageFn: hasGenerateFn,
+          },
+        }),
+      },
+      description: 'Maximum upload file size: 12MB. Recommended file size for images is <500KB.',
+    },
+    label: 'Meta Image',
+    localized: true,
+    relationTo,
+    ...((overrides as unknown as UploadField) ?? {}),
+  }
+}

--- a/packages/plugin-seo/src/fields/MetaImage/index.ts
+++ b/packages/plugin-seo/src/fields/MetaImage/index.ts
@@ -15,7 +15,7 @@ interface FieldFunctionProps {
 
 type FieldFunction = ({ hasGenerateFn, overrides }: FieldFunctionProps) => UploadField
 
-export const MetaImage: FieldFunction = ({ hasGenerateFn = false, overrides, relationTo }) => {
+export const MetaImageField: FieldFunction = ({ hasGenerateFn = false, overrides, relationTo }) => {
   return {
     name: 'image',
     type: 'upload',

--- a/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
@@ -4,7 +4,7 @@ import type { FieldType, FormFieldBase, Options } from '@payloadcms/ui'
 
 import {
   FieldLabel,
-  TextareaInput,
+  TextInput,
   useDocumentInfo,
   useField,
   useFieldProps,
@@ -14,45 +14,45 @@ import {
 } from '@payloadcms/ui'
 import React, { useCallback } from 'react'
 
-import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../translations/index.js'
-import type { GenerateDescription } from '../types.js'
+import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../../translations/index.js'
+import type { GenerateTitle } from '../../types.js'
 
-import { defaults } from '../defaults.js'
-import { LengthIndicator } from '../ui/LengthIndicator.js'
+import { defaults } from '../../defaults.js'
+import { LengthIndicator } from '../../ui/LengthIndicator.js'
+import '../index.scss'
 
-const { maxLength, minLength } = defaults.description
+const { maxLength, minLength } = defaults.title
 
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-type MetaDescriptionProps = FormFieldBase & {
-  hasGenerateDescriptionFn: boolean
-  path: string
+type MetaTitleProps = FormFieldBase & {
+  hasGenerateTitleFn: boolean
 }
 
-export const MetaDescription: React.FC<MetaDescriptionProps> = (props) => {
-  const { CustomLabel, hasGenerateDescriptionFn, label, labelProps, path, required } = props
+export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
+  const { CustomLabel, hasGenerateTitleFn, label, labelProps, path, required } = props || {}
   const { path: pathFromContext } = useFieldProps()
 
   const { t } = useTranslation<PluginSEOTranslations, PluginSEOTranslationKeys>()
-
-  const locale = useLocale()
-  const { getData } = useForm()
-  const docInfo = useDocumentInfo()
 
   const field: FieldType<string> = useField({
     path,
   } as Options)
 
+  const locale = useLocale()
+  const { getData } = useForm()
+  const docInfo = useDocumentInfo()
+
   const { errorMessage, setValue, showError, value } = field
 
-  const regenerateDescription = useCallback(async () => {
-    if (!hasGenerateDescriptionFn) return
+  const regenerateTitle = useCallback(async () => {
+    if (!hasGenerateTitleFn) return
 
-    const genDescriptionResponse = await fetch('/api/plugin-seo/generate-description', {
+    const genTitleResponse = await fetch('/api/plugin-seo/generate-title', {
       body: JSON.stringify({
         ...docInfo,
         doc: { ...getData() },
         locale: typeof locale === 'object' ? locale?.code : locale,
-      } satisfies Parameters<GenerateDescription>[0]),
+      } satisfies Parameters<GenerateTitle>[0]),
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
@@ -60,10 +60,10 @@ export const MetaDescription: React.FC<MetaDescriptionProps> = (props) => {
       method: 'POST',
     })
 
-    const { result: generatedDescription } = await genDescriptionResponse.json()
+    const { result: generatedTitle } = await genTitleResponse.json()
 
-    setValue(generatedDescription || '')
-  }, [hasGenerateDescriptionFn, docInfo, getData, locale, setValue])
+    setValue(generatedTitle || '')
+  }, [hasGenerateTitleFn, docInfo, getData, locale, setValue])
 
   return (
     <div
@@ -79,11 +79,11 @@ export const MetaDescription: React.FC<MetaDescriptionProps> = (props) => {
       >
         <div className="plugin-seo__field">
           <FieldLabel CustomLabel={CustomLabel} label={label} {...(labelProps || {})} />
-          {hasGenerateDescriptionFn && (
+          {hasGenerateTitleFn && (
             <React.Fragment>
               &nbsp; &mdash; &nbsp;
               <button
-                onClick={regenerateDescription}
+                onClick={regenerateTitle}
                 style={{
                   background: 'none',
                   backgroundColor: 'transparent',
@@ -105,14 +105,15 @@ export const MetaDescription: React.FC<MetaDescriptionProps> = (props) => {
             color: '#9A9A9A',
           }}
         >
-          {t('plugin-seo:lengthTipDescription', { maxLength, minLength })}
+          {t('plugin-seo:lengthTipTitle', { maxLength, minLength })}
           <a
-            href="https://developers.google.com/search/docs/advanced/appearance/snippet#meta-descriptions"
+            href="https://developers.google.com/search/docs/advanced/appearance/title-link#page-titles"
             rel="noopener noreferrer"
             target="_blank"
           >
             {t('plugin-seo:bestPractices')}
           </a>
+          .
         </div>
       </div>
       <div
@@ -121,7 +122,7 @@ export const MetaDescription: React.FC<MetaDescriptionProps> = (props) => {
           position: 'relative',
         }}
       >
-        <TextareaInput
+        <TextInput
           CustomError={errorMessage}
           onChange={setValue}
           path={pathFromContext}

--- a/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
@@ -29,13 +29,13 @@ type MetaTitleProps = FormFieldBase & {
 }
 
 export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
-  const { CustomLabel, hasGenerateTitleFn, label, labelProps, path, required } = props || {}
+  const { CustomLabel, hasGenerateTitleFn, label, labelProps, required } = props || {}
   const { path: pathFromContext } = useFieldProps()
 
   const { t } = useTranslation<PluginSEOTranslations, PluginSEOTranslationKeys>()
 
   const field: FieldType<string> = useField({
-    path,
+    path: pathFromContext,
   } as Options)
 
   const locale = useLocale()

--- a/packages/plugin-seo/src/fields/MetaTitle/index.ts
+++ b/packages/plugin-seo/src/fields/MetaTitle/index.ts
@@ -5,6 +5,9 @@ import { withMergedProps } from '@payloadcms/ui/shared'
 import { MetaTitleComponent } from './MetaTitleComponent.js'
 
 interface FieldFunctionProps {
+  /**
+   * Tell the component if the generate function is available as configured in the plugin config
+   */
   hasGenerateFn?: boolean
   overrides?: Partial<TextField>
 }

--- a/packages/plugin-seo/src/fields/MetaTitle/index.ts
+++ b/packages/plugin-seo/src/fields/MetaTitle/index.ts
@@ -14,7 +14,7 @@ interface FieldFunctionProps {
 
 type FieldFunction = ({ hasGenerateFn, overrides }: FieldFunctionProps) => TextField
 
-export const MetaTitle: FieldFunction = ({ hasGenerateFn = false, overrides }) => {
+export const MetaTitleField: FieldFunction = ({ hasGenerateFn = false, overrides }) => {
   return {
     name: 'title',
     type: 'text',

--- a/packages/plugin-seo/src/fields/MetaTitle/index.ts
+++ b/packages/plugin-seo/src/fields/MetaTitle/index.ts
@@ -1,0 +1,32 @@
+import type { TextField } from 'payload'
+
+import { withMergedProps } from '@payloadcms/ui/shared'
+
+import { MetaTitleComponent } from './MetaTitleComponent.js'
+
+interface FieldFunctionProps {
+  hasGenerateFn?: boolean
+  overrides?: Partial<TextField>
+}
+
+type FieldFunction = ({ hasGenerateFn, overrides }: FieldFunctionProps) => TextField
+
+export const MetaTitle: FieldFunction = ({ hasGenerateFn = false, overrides }) => {
+  return {
+    name: 'title',
+    type: 'text',
+    admin: {
+      components: {
+        Field: withMergedProps({
+          Component: MetaTitleComponent,
+          sanitizeServerOnlyProps: true,
+          toMergeIntoProps: {
+            hasGenerateTitleFn: hasGenerateFn,
+          },
+        }),
+      },
+    },
+    localized: true,
+    ...((overrides as unknown as TextField) ?? {}),
+  }
+}

--- a/packages/plugin-seo/src/fields/Overview/OverviewComponent.tsx
+++ b/packages/plugin-seo/src/fields/Overview/OverviewComponent.tsx
@@ -1,30 +1,44 @@
 'use client'
 
-import type { FormField } from 'payload'
+import type { FormField, UIField } from 'payload'
 
 import { useAllFormFields, useForm, useTranslation } from '@payloadcms/ui'
 import React, { useCallback, useEffect, useState } from 'react'
 
-import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../translations/index.js'
+import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../../translations/index.js'
 
-import { defaults } from '../defaults.js'
+import { defaults } from '../../defaults.js'
 
 const {
   description: { maxLength: maxDesc, minLength: minDesc },
   title: { maxLength: maxTitle, minLength: minTitle },
 } = defaults
 
-export const Overview: React.FC = () => {
+type OverviewProps = UIField & {
+  descriptionPath?: string
+  imagePath?: string
+  titlePath?: string
+}
+
+export const OverviewComponent: React.FC<OverviewProps> = ({
+  descriptionPath: descriptionPathFromContext,
+  imagePath: imagePathFromContext,
+  titlePath: titlePathFromContext,
+}) => {
   const {
     //  dispatchFields,
     getFields,
   } = useForm()
 
+  const descriptionPath = descriptionPathFromContext || 'meta.description'
+  const titlePath = titlePathFromContext || 'meta.title'
+  const imagePath = imagePathFromContext || 'meta.image'
+
   const [
     {
-      'meta.description': { value: metaDesc } = {} as FormField,
-      'meta.image': { value: metaImage } = {} as FormField,
-      'meta.title': { value: metaTitle } = {} as FormField,
+      [descriptionPath]: { value: metaDesc } = {} as FormField,
+      [imagePath]: { value: metaImage } = {} as FormField,
+      [titlePath]: { value: metaTitle } = {} as FormField,
     },
   ] = useAllFormFields()
   const { t } = useTranslation<PluginSEOTranslations, PluginSEOTranslationKeys>()

--- a/packages/plugin-seo/src/fields/Overview/index.tsx
+++ b/packages/plugin-seo/src/fields/Overview/index.tsx
@@ -28,7 +28,12 @@ interface FieldFunctionProps {
 
 type FieldFunction = ({ overrides }: FieldFunctionProps) => UIField
 
-export const Overview: FieldFunction = ({ descriptionPath, imagePath, overrides, titlePath }) => {
+export const OverviewField: FieldFunction = ({
+  descriptionPath,
+  imagePath,
+  overrides,
+  titlePath,
+}) => {
   return {
     name: 'overview',
     type: 'ui',

--- a/packages/plugin-seo/src/fields/Overview/index.tsx
+++ b/packages/plugin-seo/src/fields/Overview/index.tsx
@@ -1,0 +1,51 @@
+import type { UIField } from 'payload'
+
+import { withMergedProps } from '@payloadcms/ui/shared'
+
+import { OverviewComponent } from './OverviewComponent.js'
+
+interface FieldFunctionProps {
+  /**
+   * Path to the description field to use for the preview
+   *
+   * @default 'meta.description'
+   */
+  descriptionPath?: string
+  /**
+   * Path to the image field to use for the preview
+   *
+   * @default 'meta.image'
+   */
+  imagePath?: string
+  overrides?: Partial<UIField>
+  /**
+   * Path to the title field to use for the preview
+   *
+   * @default 'meta.title'
+   */
+  titlePath?: string
+}
+
+type FieldFunction = ({ overrides }: FieldFunctionProps) => UIField
+
+export const Overview: FieldFunction = ({ descriptionPath, imagePath, overrides, titlePath }) => {
+  return {
+    name: 'overview',
+    type: 'ui',
+    admin: {
+      components: {
+        Field: withMergedProps({
+          Component: OverviewComponent,
+          sanitizeServerOnlyProps: true,
+          toMergeIntoProps: {
+            descriptionPath,
+            imagePath,
+            titlePath,
+          },
+        }),
+      },
+    },
+    label: 'Overview',
+    ...((overrides as unknown as UIField) ?? {}),
+  }
+}

--- a/packages/plugin-seo/src/fields/Preview/PreviewComponent.tsx
+++ b/packages/plugin-seo/src/fields/Preview/PreviewComponent.tsx
@@ -9,16 +9,23 @@ import {
   useLocale,
   useTranslation,
 } from '@payloadcms/ui'
+import { get } from 'http'
 import React, { useEffect, useState } from 'react'
 
-import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../translations/index.js'
-import type { GenerateURL } from '../types.js'
+import type { PluginSEOTranslationKeys, PluginSEOTranslations } from '../../translations/index.js'
+import type { GenerateURL } from '../../types.js'
 
 type PreviewProps = UIField & {
+  descriptionPath?: string
   hasGenerateURLFn: boolean
+  titlePath?: string
 }
 
-export const Preview: React.FC<PreviewProps> = ({ hasGenerateURLFn }) => {
+export const PreviewComponent: React.FC<PreviewProps> = ({
+  descriptionPath: descriptionPathFromContext,
+  hasGenerateURLFn,
+  titlePath: titlePathFromContext,
+}) => {
   const { t } = useTranslation<PluginSEOTranslations, PluginSEOTranslationKeys>()
 
   const locale = useLocale()
@@ -26,9 +33,12 @@ export const Preview: React.FC<PreviewProps> = ({ hasGenerateURLFn }) => {
   const { getData } = useForm()
   const docInfo = useDocumentInfo()
 
+  const descriptionPath = descriptionPathFromContext || 'meta.description'
+  const titlePath = titlePathFromContext || 'meta.title'
+
   const {
-    'meta.description': { value: metaDescription } = {} as FormField,
-    'meta.title': { value: metaTitle } = {} as FormField,
+    [descriptionPath]: { value: metaDescription } = {} as FormField,
+    [titlePath]: { value: metaTitle } = {} as FormField,
   } = fields
 
   const [href, setHref] = useState<string>()

--- a/packages/plugin-seo/src/fields/Preview/index.tsx
+++ b/packages/plugin-seo/src/fields/Preview/index.tsx
@@ -26,7 +26,7 @@ interface FieldFunctionProps {
 
 type FieldFunction = ({ hasGenerateFn, overrides }: FieldFunctionProps) => UIField
 
-export const Preview: FieldFunction = ({
+export const PreviewField: FieldFunction = ({
   descriptionPath,
   hasGenerateFn = false,
   overrides,

--- a/packages/plugin-seo/src/fields/Preview/index.tsx
+++ b/packages/plugin-seo/src/fields/Preview/index.tsx
@@ -1,0 +1,54 @@
+import type { UIField } from 'payload'
+
+import { withMergedProps } from '@payloadcms/ui/shared'
+
+import { PreviewComponent } from './PreviewComponent.js'
+
+interface FieldFunctionProps {
+  /**
+   * Path to the description field to use for the preview
+   *
+   * @default 'meta.description'
+   */
+  descriptionPath?: string
+  /**
+   * Tell the component if the generate function is available as configured in the plugin config
+   */
+  hasGenerateFn?: boolean
+  overrides?: Partial<UIField>
+  /**
+   * Path to the title field to use for the preview
+   *
+   * @default 'meta.title'
+   */
+  titlePath?: string
+}
+
+type FieldFunction = ({ hasGenerateFn, overrides }: FieldFunctionProps) => UIField
+
+export const Preview: FieldFunction = ({
+  descriptionPath,
+  hasGenerateFn = false,
+  overrides,
+  titlePath,
+}) => {
+  return {
+    name: 'preview',
+    type: 'ui',
+    admin: {
+      components: {
+        Field: withMergedProps({
+          Component: PreviewComponent,
+          sanitizeServerOnlyProps: true,
+          toMergeIntoProps: {
+            descriptionPath,
+            hasGenerateURLFn: hasGenerateFn,
+            titlePath,
+          },
+        }),
+      },
+    },
+    label: 'Preview',
+    ...((overrides as unknown as UIField) ?? {}),
+  }
+}

--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -12,12 +12,16 @@ import type {
   SEOPluginConfig,
 } from './types.js'
 
-import { MetaDescription } from './fields/MetaDescription.js'
-import { MetaImage } from './fields/MetaImage.js'
-import { MetaTitle } from './fields/MetaTitle.js'
+import { MetaDescriptionComponent } from './fields/MetaDescription/MetaDescriptionComponent.js'
+import { MetaImageComponent } from './fields/MetaImage/MetaImageComponent.js'
+import { MetaTitleComponent } from './fields/MetaTitle/MetaTitleComponent.js'
 import { translations } from './translations/index.js'
 import { Overview } from './ui/Overview.js'
 import { Preview } from './ui/Preview.js'
+
+export { MetaDescription } from './fields/MetaDescription/index.js'
+export { MetaImage } from './fields/MetaImage/index.js'
+export { MetaTitle } from './fields/MetaTitle/index.js'
 
 export const seoPlugin =
   (pluginConfig: SEOPluginConfig) =>
@@ -43,7 +47,7 @@ export const seoPlugin =
             admin: {
               components: {
                 Field: withMergedProps({
-                  Component: MetaTitle,
+                  Component: MetaTitleComponent,
                   sanitizeServerOnlyProps: true,
                   toMergeIntoProps: {
                     hasGenerateTitleFn: typeof pluginConfig?.generateTitle === 'function',
@@ -60,7 +64,7 @@ export const seoPlugin =
             admin: {
               components: {
                 Field: withMergedProps({
-                  Component: MetaDescription,
+                  Component: MetaDescriptionComponent,
                   sanitizeServerOnlyProps: true,
                   toMergeIntoProps: {
                     hasGenerateDescriptionFn:
@@ -81,7 +85,7 @@ export const seoPlugin =
                   admin: {
                     components: {
                       Field: withMergedProps({
-                        Component: MetaImage,
+                        Component: MetaImageComponent,
                         sanitizeServerOnlyProps: true,
                         toMergeIntoProps: {
                           hasGenerateImageFn: typeof pluginConfig?.generateImage === 'function',

--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -19,12 +19,6 @@ import { OverviewComponent } from './fields/Overview/OverviewComponent.js'
 import { PreviewComponent } from './fields/Preview/PreviewComponent.js'
 import { translations } from './translations/index.js'
 
-export { MetaDescriptionField } from './fields/MetaDescription/index.js'
-export { MetaImageField } from './fields/MetaImage/index.js'
-export { MetaTitleField } from './fields/MetaTitle/index.js'
-export { OverviewField } from './fields/Overview/index.js'
-export { PreviewField } from './fields/Preview/index.js'
-
 export const seoPlugin =
   (pluginConfig: SEOPluginConfig) =>
   (config: Config): Config => {

--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -15,13 +15,15 @@ import type {
 import { MetaDescriptionComponent } from './fields/MetaDescription/MetaDescriptionComponent.js'
 import { MetaImageComponent } from './fields/MetaImage/MetaImageComponent.js'
 import { MetaTitleComponent } from './fields/MetaTitle/MetaTitleComponent.js'
+import { OverviewComponent } from './fields/Overview/OverviewComponent.js'
+import { PreviewComponent } from './fields/Preview/PreviewComponent.js'
 import { translations } from './translations/index.js'
-import { Overview } from './ui/Overview.js'
-import { Preview } from './ui/Preview.js'
 
 export { MetaDescription } from './fields/MetaDescription/index.js'
 export { MetaImage } from './fields/MetaImage/index.js'
 export { MetaTitle } from './fields/MetaTitle/index.js'
+export { Overview } from './fields/Overview/index.js'
+export { Preview } from './fields/Preview/index.js'
 
 export const seoPlugin =
   (pluginConfig: SEOPluginConfig) =>
@@ -36,7 +38,7 @@ export const seoPlugin =
             type: 'ui',
             admin: {
               components: {
-                Field: Overview,
+                Field: OverviewComponent,
               },
             },
             label: 'Overview',
@@ -109,7 +111,7 @@ export const seoPlugin =
             admin: {
               components: {
                 Field: withMergedProps({
-                  Component: Preview,
+                  Component: PreviewComponent,
                   sanitizeServerOnlyProps: true,
                   toMergeIntoProps: {
                     hasGenerateURLFn: typeof pluginConfig?.generateURL === 'function',

--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -19,11 +19,11 @@ import { OverviewComponent } from './fields/Overview/OverviewComponent.js'
 import { PreviewComponent } from './fields/Preview/PreviewComponent.js'
 import { translations } from './translations/index.js'
 
-export { MetaDescription } from './fields/MetaDescription/index.js'
-export { MetaImage } from './fields/MetaImage/index.js'
-export { MetaTitle } from './fields/MetaTitle/index.js'
-export { Overview } from './fields/Overview/index.js'
-export { Preview } from './fields/Preview/index.js'
+export { MetaDescriptionField } from './fields/MetaDescription/index.js'
+export { MetaImageField } from './fields/MetaImage/index.js'
+export { MetaTitleField } from './fields/MetaTitle/index.js'
+export { OverviewField } from './fields/Overview/index.js'
+export { PreviewField } from './fields/Preview/index.js'
 
 export const seoPlugin =
   (pluginConfig: SEOPluginConfig) =>

--- a/test/plugin-seo/collections/PagesWithImportedFields.ts
+++ b/test/plugin-seo/collections/PagesWithImportedFields.ts
@@ -1,0 +1,82 @@
+import type { CollectionConfig } from 'payload'
+
+import { MetaDescription, MetaImage, MetaTitle } from '@payloadcms/plugin-seo'
+
+import { pagesWithImportedFieldsSlug } from '../shared.js'
+
+export const PagesWithImportedFields: CollectionConfig = {
+  slug: pagesWithImportedFieldsSlug,
+  labels: {
+    singular: 'Page with imported fields',
+    plural: 'Pages with imported fields',
+  },
+  admin: {
+    useAsTitle: 'title',
+  },
+  versions: {
+    drafts: true,
+  },
+  fields: [
+    {
+      name: 'title',
+      label: 'Title',
+      type: 'text',
+      required: true,
+    },
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'General',
+          fields: [
+            {
+              name: 'excerpt',
+              label: 'Excerpt',
+              type: 'text',
+            },
+            {
+              name: 'slug',
+              type: 'text',
+              required: true,
+              // NOTE: in order for position: 'sidebar' to work here,
+              // the first field of this config must be of type `tabs`,
+              // and this field must be a sibling of it
+              // See `./Posts` or the `../../README.md` for more info
+              admin: {
+                position: 'sidebar',
+              },
+            },
+          ],
+        },
+        {
+          label: 'Meta',
+          name: 'metaAndSEO',
+          fields: [
+            MetaTitle({
+              hasGenerateFn: true,
+            }),
+            {
+              type: 'group',
+              name: 'innerMeta',
+              fields: [
+                MetaDescription({
+                  hasGenerateFn: true,
+                }),
+              ],
+            },
+            {
+              type: 'group',
+              name: 'innerMedia',
+              fields: [
+                MetaImage({
+                  relationTo: 'media',
+                  hasGenerateFn: true,
+                }),
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/test/plugin-seo/collections/PagesWithImportedFields.ts
+++ b/test/plugin-seo/collections/PagesWithImportedFields.ts
@@ -6,7 +6,7 @@ import {
   MetaTitleField,
   OverviewField,
   PreviewField,
-} from '@payloadcms/plugin-seo'
+} from '@payloadcms/plugin-seo/fields'
 
 import { pagesWithImportedFieldsSlug } from '../shared.js'
 

--- a/test/plugin-seo/collections/PagesWithImportedFields.ts
+++ b/test/plugin-seo/collections/PagesWithImportedFields.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from 'payload'
 
-import { MetaDescription, MetaImage, MetaTitle } from '@payloadcms/plugin-seo'
+import { MetaDescription, MetaImage, MetaTitle, Overview, Preview } from '@payloadcms/plugin-seo'
 
 import { pagesWithImportedFieldsSlug } from '../shared.js'
 
@@ -23,6 +23,11 @@ export const PagesWithImportedFields: CollectionConfig = {
       type: 'text',
       required: true,
     },
+    Overview({
+      titlePath: 'metaAndSEO.title',
+      descriptionPath: 'metaAndSEO.innerMeta.description',
+      imagePath: 'metaAndSEO.innerMedia.image',
+    }),
     {
       type: 'tabs',
       tabs: [
@@ -54,6 +59,11 @@ export const PagesWithImportedFields: CollectionConfig = {
           fields: [
             MetaTitle({
               hasGenerateFn: true,
+            }),
+            Preview({
+              hasGenerateFn: true,
+              titlePath: 'metaAndSEO.title',
+              descriptionPath: 'metaAndSEO.innerMeta.description',
             }),
             {
               type: 'group',

--- a/test/plugin-seo/collections/PagesWithImportedFields.ts
+++ b/test/plugin-seo/collections/PagesWithImportedFields.ts
@@ -1,6 +1,12 @@
 import type { CollectionConfig } from 'payload'
 
-import { MetaDescription, MetaImage, MetaTitle, Overview, Preview } from '@payloadcms/plugin-seo'
+import {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
+} from '@payloadcms/plugin-seo'
 
 import { pagesWithImportedFieldsSlug } from '../shared.js'
 
@@ -23,7 +29,7 @@ export const PagesWithImportedFields: CollectionConfig = {
       type: 'text',
       required: true,
     },
-    Overview({
+    OverviewField({
       titlePath: 'metaAndSEO.title',
       descriptionPath: 'metaAndSEO.innerMeta.description',
       imagePath: 'metaAndSEO.innerMedia.image',
@@ -57,10 +63,10 @@ export const PagesWithImportedFields: CollectionConfig = {
           label: 'Meta',
           name: 'metaAndSEO',
           fields: [
-            MetaTitle({
+            MetaTitleField({
               hasGenerateFn: true,
             }),
-            Preview({
+            PreviewField({
               hasGenerateFn: true,
               titlePath: 'metaAndSEO.title',
               descriptionPath: 'metaAndSEO.innerMeta.description',
@@ -69,7 +75,7 @@ export const PagesWithImportedFields: CollectionConfig = {
               type: 'group',
               name: 'innerMeta',
               fields: [
-                MetaDescription({
+                MetaDescriptionField({
                   hasGenerateFn: true,
                 }),
               ],
@@ -78,7 +84,7 @@ export const PagesWithImportedFields: CollectionConfig = {
               type: 'group',
               name: 'innerMedia',
               fields: [
-                MetaImage({
+                MetaImageField({
                   relationTo: 'media',
                   hasGenerateFn: true,
                 }),

--- a/test/plugin-seo/config.ts
+++ b/test/plugin-seo/config.ts
@@ -13,6 +13,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { Media } from './collections/Media.js'
 import { Pages } from './collections/Pages.js'
+import { PagesWithImportedFields } from './collections/PagesWithImportedFields.js'
 import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
 
@@ -29,7 +30,7 @@ const generateURL: GenerateURL<Page> = ({ doc, locale }) => {
 }
 
 export default buildConfigWithDefaults({
-  collections: [Users, Pages, Media],
+  collections: [Users, Pages, Media, PagesWithImportedFields],
   i18n: {
     supportedLanguages: {
       en,

--- a/test/plugin-seo/payload-types.ts
+++ b/test/plugin-seo/payload-types.ts
@@ -11,6 +11,7 @@ export interface Config {
     users: User;
     pages: Page;
     media: Media;
+    pagesWithImportedFields: PagesWithImportedField;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -89,6 +90,28 @@ export interface Media {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pagesWithImportedFields".
+ */
+export interface PagesWithImportedField {
+  id: string;
+  title: string;
+  excerpt?: string | null;
+  slug: string;
+  metaAndSEO?: {
+    title?: string | null;
+    innerMeta?: {
+      description?: string | null;
+    };
+    innerMedia?: {
+      image?: string | Media | null;
+    };
+  };
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-seo/shared.ts
+++ b/test/plugin-seo/shared.ts
@@ -1,3 +1,5 @@
 export const pagesSlug = 'pages'
 
+export const pagesWithImportedFieldsSlug = 'pagesWithImportedFields'
+
 export const mediaSlug = 'media'


### PR DESCRIPTION
Exports the fields from the SEO plugin so that they can be used anywhere inside a collection, new exports:

```ts
import { MetaDescriptionField, MetaImageField, MetaTitleField, OverviewField, PreviewField } from '@payloadcms/plugin-seo/fields'

// Used as fields
MetaImageField({
  relationTo: 'media',
  hasGenerateFn: true,
})

MetaDescriptionField({
  hasGenerateFn: true,
})

MetaTitleField({
  hasGenerateFn: true,
})

PreviewField({
  hasGenerateFn: true,
  titlePath: 'meta.title',
  descriptionPath: 'meta.description',
})

OverviewField({
  titlePath: 'meta.title',
  descriptionPath: 'meta.description',
  imagePath: 'meta.image',
})

```