### PR TITLE
chore: add user type argument to generate email html and subject types

### DIFF
--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -74,26 +74,28 @@ export type User = {
  */
 export type ClientUser = Omit<User, 'collection'>
 
-type GenerateVerifyEmailHTML = (args: {
+type GenerateVerifyEmailHTML<TUser = any> = (args: {
   req: PayloadRequestWithData
   token: string
-  user: any
-}) => Promise<string> | string
-type GenerateVerifyEmailSubject = (args: {
-  req: PayloadRequestWithData
-  token: string
-  user: any
+  user: TUser
 }) => Promise<string> | string
 
-type GenerateForgotPasswordEmailHTML = (args?: {
-  req?: PayloadRequestWithData
-  token?: string
-  user?: unknown
+type GenerateVerifyEmailSubject<TUser = any> = (args: {
+  req: PayloadRequestWithData
+  token: string
+  user: TUser
 }) => Promise<string> | string
-type GenerateForgotPasswordEmailSubject = (args?: {
+
+type GenerateForgotPasswordEmailHTML<TUser = any> = (args?: {
   req?: PayloadRequestWithData
   token?: string
-  user?: any
+  user?: TUser
+}) => Promise<string> | string
+
+type GenerateForgotPasswordEmailSubject<TUser = any> = (args?: {
+  req?: PayloadRequestWithData
+  token?: string
+  user?: TUser
 }) => Promise<string> | string
 
 export type AuthStrategyFunctionArgs = {


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/6953

```ts
// the following types can now take in arguments for User type
GenerateVerifyEmailHTML<User>
GenerateVerifyEmailSubject<User>
GenerateForgotPasswordEmailHTML<User>
GenerateForgotPasswordEmailSubject<User>
```