### PR TITLE
chore: threads customActions through to FileDetails component

### DIFF
--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -197,6 +197,7 @@ export const Upload: React.FC<UploadProps> = (props) => {
       {doc.filename && !replacingFile && (
         <FileDetails
           collectionSlug={collectionSlug}
+          customUploadActions={customActions}
           doc={doc}
           enableAdjustments={showCrop || showFocalPoint}
           handleRemove={canRemoveUpload ? handleFileRemoval : undefined}


### PR DESCRIPTION
## Description

Threads missing customUploadActions through to FileDetails component.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
