### PR TITLE
fix: ensures req has headers, passes it through in view rendering

### DIFF
--- a/packages/next/src/utilities/initPage/index.ts
+++ b/packages/next/src/utilities/initPage/index.ts
@@ -59,6 +59,7 @@ export const initPage = async ({
     {
       fallbackLocale: null,
       req: {
+        headers,
         host: headers.get('host'),
         i18n,
         query: qs.parse(queryString, {

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -27,6 +27,7 @@ export const ListView: React.FC<AdminViewProps> = async ({
     collectionConfig,
     locale: fullLocale,
     permissions,
+    req,
     req: {
       i18n,
       locale,
@@ -53,6 +54,7 @@ export const ListView: React.FC<AdminViewProps> = async ({
         collection: 'payload-preferences',
         depth: 0,
         limit: 1,
+        req,
         user,
         where: {
           key: {
@@ -109,6 +111,7 @@ export const ListView: React.FC<AdminViewProps> = async ({
       locale,
       overrideAccess: false,
       page,
+      req,
       sort,
       user,
       where: whereQuery || {},

--- a/packages/next/src/views/Version/index.tsx
+++ b/packages/next/src/views/Version/index.tsx
@@ -19,6 +19,7 @@ export const VersionView: EditViewComponent = async (props) => {
     docID: id,
     globalConfig,
     permissions,
+    req,
     req: { payload, payload: { config } = {}, user } = {},
   } = initPageResult
 
@@ -48,6 +49,7 @@ export const VersionView: EditViewComponent = async (props) => {
         depth: 1,
         locale: '*',
         overrideAccess: false,
+        req,
         user,
       })
 
@@ -58,6 +60,7 @@ export const VersionView: EditViewComponent = async (props) => {
         draft: false,
         locale: '*',
         overrideAccess: false,
+        req,
         user,
       })
 
@@ -68,6 +71,7 @@ export const VersionView: EditViewComponent = async (props) => {
         draft: true,
         locale: '*',
         overrideAccess: false,
+        req,
         user,
       })
     } catch (error) {
@@ -87,6 +91,7 @@ export const VersionView: EditViewComponent = async (props) => {
         depth: 1,
         locale: '*',
         overrideAccess: false,
+        req,
         user,
       })
 
@@ -96,6 +101,7 @@ export const VersionView: EditViewComponent = async (props) => {
         draft: false,
         locale: '*',
         overrideAccess: false,
+        req,
         user,
       })
 
@@ -105,6 +111,7 @@ export const VersionView: EditViewComponent = async (props) => {
         draft: true,
         locale: '*',
         overrideAccess: false,
+        req,
         user,
       })
     } catch (error) {

--- a/packages/next/src/views/Versions/index.tsx
+++ b/packages/next/src/views/Versions/index.tsx
@@ -19,6 +19,7 @@ export const VersionsView: EditViewComponent = async (props) => {
     collectionConfig,
     docID: id,
     globalConfig,
+    req,
     req: {
       i18n,
       payload,
@@ -48,6 +49,7 @@ export const VersionsView: EditViewComponent = async (props) => {
         limit: limitToUse,
         overrideAccess: false,
         page: page ? parseInt(page.toString(), 10) : undefined,
+        req,
         sort: sort as string,
         user,
         where: {
@@ -70,6 +72,7 @@ export const VersionsView: EditViewComponent = async (props) => {
         limit: limitToUse,
         overrideAccess: false,
         page: page ? parseInt(page as string, 10) : undefined,
+        req,
         sort: sort as string,
         user,
       })


### PR DESCRIPTION
## Description

`req.headers` was missing when admin views fetched data to render. Threads headers through inside of initPage.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
