### PR TITLE
docs: root-level routes require directory rename

### DIFF
--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -170,12 +170,12 @@ The following options are available:
 | `graphQLPlayground`| `/graphql-playground`   | The GraphQL Playground.               |
 
 <Banner type="warning">
-  <strong>Reminder:</strong>
-  The `routes` key is defined in the _top-level_ of your [Payload Config](../configuration/overview), _outside_ the `admin` key. To customize routes in the _Admin Panel_, use [admin-level routes](#admin-level-routes) instead.
+  <strong>Warning:</strong>
+  Changing Root-level Routes _after_ your project was generated will also require you to manually update the corresponding directories in your project. For example, changing `routes.admin` will require you to rename the `(payload)/admin` directory in your project to match the new route. [More details](#project-structure).
 </Banner>
 
 <Banner type="success">
-  <strong>Note:</strong>
+  <strong>Tip:</strong>
    You can easily add _new_ routes to the Admin Panel through the `endpoints` property of the Payload Config. See [Custom Endpoints](../rest-api/overview#custom-endpoints) for more information.
 </Banner>
 

--- a/docs/fields/text.mdx
+++ b/docs/fields/text.mdx
@@ -11,14 +11,12 @@ keywords: text, fields, config, configuration, documentation, Content Management
   provides the Admin panel with a simple text input.
 </Banner>
 
-<TextField label="This is a Payload UI text field rendered in MDX!" />
-
-{/* <LightDarkImage
+<LightDarkImage
   srcLight="https://payloadcms.com/images/docs/fields/text.png"
   srcDark="https://payloadcms.com/images/docs/fields/text-dark.png"
   alt="Shows a text field and read-only text field in the Payload admin panel"
   caption="Admin panel screenshot of a Text field and read-only Text field"
-/> */}
+/>
 
 ## Config
 


### PR DESCRIPTION
## Description

Adds a warning banner describing how changing root-level routes _after_ the project was generated requires a manual rename of the directory corresponding to that route. Also removes the invalid MDX component that was preventing build.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
