### PR TITLE
feat(payload): allow access to express request in beginTransaction

### DIFF
--- a/examples/db-example/src/transactions/beginTransaction.ts
+++ b/examples/db-example/src/transactions/beginTransaction.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { TransactionOptions } from 'mongodb'
 import type { BeginTransaction } from 'payload/database'
+import type { PayloadRequest } from 'payload/types'
 
 import type { ExampleAdapter } from '../index'
 
@@ -12,6 +13,7 @@ import type { ExampleAdapter } from '../index'
  *
  * @param {ExampleAdapter} this - The ExampleAdapter instance.
  * @param {TransactionOptions} options - The options for the transaction.
+ * @param {PayloadRequest} req - The Express request object containing the currently authenticated user.
  * @returns {Promise<null>} A promise resolving to null.
  *
  * This function is optional and can be implemented as needed for database adapters that support transactions.
@@ -19,6 +21,7 @@ import type { ExampleAdapter } from '../index'
 export const beginTransaction: BeginTransaction = async function beginTransaction(
   this: ExampleAdapter,
   options: TransactionOptions,
+  req: PayloadRequest,
 ) {
   return null
 }

--- a/packages/db-mongodb/src/transactions/beginTransaction.ts
+++ b/packages/db-mongodb/src/transactions/beginTransaction.ts
@@ -1,6 +1,5 @@
 import type { TransactionOptions } from 'mongodb'
 import type { BeginTransaction } from 'payload/database'
-import type { PayloadRequest } from 'payload/types'
 
 import { APIError } from 'payload/errors'
 import { v4 as uuid } from 'uuid'
@@ -9,7 +8,7 @@ import type { MongooseAdapter } from '../index'
 
 export const beginTransaction: BeginTransaction = async function beginTransaction(
   this: MongooseAdapter,
-  options?: TransactionOptions,
+  options: TransactionOptions,
 ) {
   if (!this.connection) {
     throw new APIError('beginTransaction called while no connection to the database exists')

--- a/packages/db-mongodb/src/transactions/beginTransaction.ts
+++ b/packages/db-mongodb/src/transactions/beginTransaction.ts
@@ -1,5 +1,6 @@
 import type { TransactionOptions } from 'mongodb'
 import type { BeginTransaction } from 'payload/database'
+import type { PayloadRequest } from 'payload/types'
 
 import { APIError } from 'payload/errors'
 import { v4 as uuid } from 'uuid'
@@ -8,7 +9,7 @@ import type { MongooseAdapter } from '../index'
 
 export const beginTransaction: BeginTransaction = async function beginTransaction(
   this: MongooseAdapter,
-  options: TransactionOptions,
+  options?: TransactionOptions,
 ) {
   if (!this.connection) {
     throw new APIError('beginTransaction called while no connection to the database exists')

--- a/packages/payload/src/auth/strategies/local/register.ts
+++ b/packages/payload/src/auth/strategies/local/register.ts
@@ -23,6 +23,7 @@ export const registerLocalStrategy = async ({
   const existingUser = await payload.find({
     collection: collection.slug,
     depth: 0,
+    req,
     where: {
       email: {
         equals: doc.email,

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -75,9 +75,7 @@ async function findByID<T extends TypeWithID>(incomingArgs: Arguments): Promise<
     const findOneArgs: FindOneArgs = {
       collection: collectionConfig.slug,
       locale,
-      req: {
-        transactionID: req.transactionID,
-      } as PayloadRequest,
+      req,
       where: combineQueries({ id: { equals: id } }, accessResult),
     }
 

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -155,11 +155,12 @@ export type Transaction = (
 
 export type BeginTransaction = (
   options?: Record<string, unknown>,
+  req?: PayloadRequest,
 ) => Promise<null | number | string>
 
-export type RollbackTransaction = (id: number | string | Promise<number | string>) => Promise<void>
+export type RollbackTransaction = (id: Promise<number | string> | number | string) => Promise<void>
 
-export type CommitTransaction = (id: number | string | Promise<number | string>) => Promise<void>
+export type CommitTransaction = (id: Promise<number | string> | number | string) => Promise<void>
 
 export type QueryDraftsArgs = {
   collection: string

--- a/packages/payload/src/preferences/operations/delete.ts
+++ b/packages/payload/src/preferences/operations/delete.ts
@@ -34,6 +34,7 @@ async function deleteOperation(args: PreferenceRequest): Promise<Document> {
   const result = await payload.delete({
     collection: 'payload-preferences',
     depth: 0,
+    req,
     user,
     where,
   })

--- a/packages/payload/src/preferences/operations/findOne.ts
+++ b/packages/payload/src/preferences/operations/findOne.ts
@@ -8,6 +8,7 @@ async function findOne(
   const {
     key,
     req: { payload },
+    req,
     user,
   } = args
 
@@ -25,6 +26,7 @@ async function findOne(
     collection: 'payload-preferences',
     depth: 0,
     pagination: false,
+    req,
     user,
     where,
   })

--- a/packages/payload/src/utilities/initTransaction.ts
+++ b/packages/payload/src/utilities/initTransaction.ts
@@ -18,7 +18,7 @@ export async function initTransaction(req: PayloadRequest): Promise<boolean> {
   }
   if (typeof payload.db.beginTransaction === 'function') {
     // create a new transaction
-    req.transactionID = payload.db.beginTransaction().then((transactionID) => {
+    req.transactionID = payload.db.beginTransaction(undefined, req).then((transactionID) => {
       if (transactionID) {
         req.transactionID = transactionID
       }


### PR DESCRIPTION
## Allow access to the Express Request in beginTransaction

Access to PayloadRequest from `beginTransaction` of the DatabaseAdapter interface could be really useful. I was building one Database Adapter that requires access to the Req object in the BeginTransaction, similar to what we've in db methods like `find` or `create`.

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
