### PR TITLE
chore(test): fix localization fallback config

### DIFF
--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -7,12 +7,15 @@ import { ArrayCollection } from './collections/Array'
 import { NestedToArrayAndBlock } from './collections/NestedToArrayAndBlock'
 import { RestrictedByLocaleCollection } from './collections/RestrictedByLocale'
 import {
+  arabicLocale,
+  arabicTitle,
   blocksWithLocalizedSameName,
   defaultLocale,
   englishTitle,
   localizedPostsSlug,
   localizedSortSlug,
   portugueseLocale,
+  portugueseTitle,
   relationEnglishTitle,
   relationEnglishTitle2,
   relationSpanishTitle,
@@ -300,7 +303,28 @@ export default buildConfigWithDefaults({
   localization: {
     defaultLocale,
     fallback: true,
-    locales: [defaultLocale, spanishLocale, portugueseLocale, 'ar'],
+    locales: [
+      {
+        code: englishLocale,
+        label: englishTitle,
+        rtl: false,
+      },
+      {
+        code: spanishLocale,
+        label: spanishTitle,
+        rtl: false,
+      },
+      {
+        code: portugueseLocale,
+        fallbackLocale: spanishLocale,
+        label: portugueseTitle,
+      },
+      {
+        code: arabicLocale,
+        label: arabicTitle,
+        rtl: true,
+      },
+    ],
   },
   onInit: async (payload) => {
     const collection = localizedPostsSlug

--- a/test/localization/shared.ts
+++ b/test/localization/shared.ts
@@ -1,5 +1,7 @@
 export const englishTitle = 'english'
 export const spanishTitle = 'spanish'
+export const portugueseTitle = 'portuguese'
+export const arabicTitle = 'arabic'
 export const relationEnglishTitle = 'english-relation'
 export const relationSpanishTitle = 'spanish-relation'
 export const relationEnglishTitle2 = `${relationEnglishTitle}2`
@@ -8,6 +10,7 @@ export const relationSpanishTitle2 = `${relationSpanishTitle}2`
 export const defaultLocale = 'en'
 export const spanishLocale = 'es'
 export const portugueseLocale = 'pt'
+export const arabicLocale = 'ar'
 
 // Slugs
 export const localizedPostsSlug = 'localized-posts'


### PR DESCRIPTION
## Description

This PR reverts the localization test configuration changes that broke the fallback locale test - https://github.com/payloadcms/payload/pull/6981/commits/abd9f7a15cf174ff1ddd856e387dce4453380038#diff-52f2ded97e96189e2bcc0c1f69cc1399726fd2d2382c9bbc295166521f783e34L301

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
