### PR TITLE
feat(templates): add import alias to `tsconfig.json`

### DIFF
--- a/templates/blank/tsconfig.json
+++ b/templates/blank/tsconfig.json
@@ -10,7 +10,8 @@
     "rootDir": "./src",
     "jsx": "react",
     "paths": {
-      "payload/generated-types": ["./src/payload-types.ts"]
+      "payload/generated-types": ["./src/payload-types.ts"],
+       "@/*": ["./src/*"]
     }
   },
   "include": ["src"],

--- a/templates/ecommerce/tsconfig.json
+++ b/templates/ecommerce/tsconfig.json
@@ -25,6 +25,7 @@
     ],
     "paths": {
       "react": ["./node_modules/@types/react"],
+      "@/*": ["./src/*"]
     }
   },
   "include": [

--- a/templates/website/tsconfig.json
+++ b/templates/website/tsconfig.json
@@ -26,6 +26,7 @@
     ],
     "paths": {
       "react": ["./node_modules/@types/react"],
+       "@/*": ["./src/*"]
     }
   },
   "include": [


### PR DESCRIPTION


## Description

Allows imports via the `@/...` instead of going back in directories like `../../../...`

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
