### PR TITLE
Fix typo in hooks documentation - synchronously should be asynchronously

### DIFF
--- a/docs/hooks/overview.mdx
+++ b/docs/hooks/overview.mdx
@@ -32,7 +32,7 @@ There are many more use cases for Hooks and the sky is the limit.
 
 All hooks can be written as either synchronous or asynchronous functions. If the Hook should modify data before a document is updated or created, and it relies on asynchronous actions such as fetching data from a third party, it might make sense to define your Hook as an asynchronous function, so you can be sure that your Hook completes before the operation's lifecycle continues. Async hooks are run in series - so if you have two async hooks defined, the second hook will wait for the first to complete before it starts.
 
-If your Hook simply performs a side-effect, such as updating a CRM, it might be okay to define it synchronously, so the Payload operation does not have to wait for your hook to complete.
+If your Hook simply performs a side-effect, such as updating a CRM, it might be okay to define it asynchronously, so the Payload operation does not have to wait for your hook to complete.
 
 #### Server-only execution
 


### PR DESCRIPTION
## Description

Fix typo in hooks documentation - synchronously should be asynchronously

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [x] This change requires a documentation update

## Checklist:

- [o] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
