### PR TITLE
docs: add  warning about forbidden chars in custom ID field

### DIFF
--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -145,6 +145,7 @@ const field: Field = {
 Collections ID fields are generated automatically by default. An explicit `id` field can be declared in the `fields` array to override this behavior.
 Users are then required to provide a custom ID value when creating a record through the Admin UI or API.
 Valid ID types are `number` and `text`.
+When using the text value, remember that it shouldn't contain the / (slash) sign, as the API will read it separately and this can result in unexpected behavior.
 
 Example:
 


### PR DESCRIPTION
## Description

Add a warning text for users in DOCs, that will notify them about forbidden characters while using `text` as a custom ID.
It resolves #7021 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
