### PR TITLE
feat: adds the ability to disable caching of the payload instance in getPayload

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -194,6 +194,13 @@ export type InitOptions = {
    * and the backend functionality
    */
   config: Promise<SanitizedConfig> | SanitizedConfig
+
+  /**
+   * Disable caching the payload instance.
+   * This is useful for environments where Payload is initialised in isolation from other instances.
+   */
+  disableCache?: boolean
+
   /**
    * Disable connect to the database on init
    */

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -196,6 +196,7 @@ export type InitOptions = {
   config: Promise<SanitizedConfig> | SanitizedConfig
 
   /**
+   * DANGEROUS.
    * Disable caching the payload instance.
    * This is useful for environments where Payload is initialised in isolation from other instances.
    */

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -641,6 +641,11 @@ export const getPayload = async (options: InitOptions): Promise<BasePayload> => 
     throw new Error('Error: the payload config is required for getPayload to work.')
   }
 
+  // If the cache is disabled, return a new instance immediately
+  if (options?.disableCache) {
+    return new BasePayload().init(options)
+  }
+
   if (cached.payload) {
     return cached.payload
   }


### PR DESCRIPTION
You can now disabling caching the Payload instance entirely. NOTE THAT THIS INITIALISES PAYLOAD AGAIN

```ts
const payload = await getPayload({ config: awaitedConfig, disableCache: true })
```