### PR TITLE
feat(storage-azure): expose storage client

### DIFF
--- a/packages/storage-azure/src/utils/getStorageClient.ts
+++ b/packages/storage-azure/src/utils/getStorageClient.ts
@@ -1,0 +1,19 @@
+import type { ContainerClient } from '@azure/storage-blob'
+
+import { BlobServiceClient } from '@azure/storage-blob'
+
+import type { AzureStorageOptions } from '../index.js'
+
+let storageClient: ContainerClient | null = null
+
+export function getStorageClient(
+  options: Pick<AzureStorageOptions, 'connectionString' | 'containerName'>,
+): ContainerClient {
+  if (storageClient) return storageClient
+
+  const { connectionString, containerName } = options
+
+  const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString)
+  storageClient = blobServiceClient.getContainerClient(containerName)
+  return storageClient
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1663,6 +1663,9 @@ importers:
       execa:
         specifier: 5.1.1
         version: 5.1.1
+      file-type:
+        specifier: 17.1.6
+        version: 17.1.6
       http-status:
         specifier: 1.6.2
         version: 1.6.2

--- a/test/package.json
+++ b/test/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-payload": "workspace:*",
     "eslint-plugin-playwright": "1.5.3",
     "execa": "5.1.1",
+    "file-type": "17.1.6",
     "http-status": "1.6.2",
     "jwt-decode": "4.0.0",
     "lexical": "0.15.0",


### PR DESCRIPTION
Expose the storage client for re-use.

```ts
import { getStorageClient } from '@payloadcms/storage-azure'
import { getPayload } from 'payload'


const awaitedConfig = await importConfig('./config.ts')
const payload = await getPayload({ config: awaitedConfig })


// Get internal azure blob storage client
const storageClient = getStorageClient({
  connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
  containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
})
```