### PR TITLE
feat(richtext-lexical): remove unused json-schema dependency

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -119,7 +119,7 @@
     "@payloadcms/eslint-config": "workspace:*",
     "@types/express-fileupload": "1.4.1",
     "@types/joi": "14.3.4",
-    "@types/json-schema": "7.0.12",
+    "@types/json-schema": "7.0.15",
     "@types/jsonwebtoken": "8.5.9",
     "@types/minimist": "1.2.2",
     "@types/nodemailer": "6.4.14",

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -53,7 +53,6 @@
     "@types/uuid": "10.0.0",
     "bson-objectid": "2.0.4",
     "dequal": "2.0.3",
-    "json-schema": "^0.4.0",
     "lexical": "0.16.1",
     "react-error-boundary": "4.0.13",
     "uuid": "10.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,8 +765,8 @@ importers:
         specifier: 14.3.4
         version: 14.3.4
       '@types/json-schema':
-        specifier: 7.0.12
-        version: 7.0.12
+        specifier: 7.0.15
+        version: 7.0.15
       '@types/jsonwebtoken':
         specifier: 8.5.9
         version: 8.5.9
@@ -1177,9 +1177,6 @@ importers:
       dequal:
         specifier: 2.0.3
         version: 2.0.3
-      json-schema:
-        specifier: ^0.4.0
-        version: 0.4.0
       lexical:
         specifier: 0.16.1
         version: 0.16.1
@@ -7150,10 +7147,6 @@ packages:
       parse5: 7.1.2
     dev: true
 
-  /@types/json-schema@7.0.12:
-    resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
-    dev: true
-
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -12810,10 +12803,6 @@ packages:
 
   /json-schema-typed@8.0.1:
     resolution: {integrity: sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==}
-    dev: false
-
-  /json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
     dev: false
 
   /json-stable-stringify-without-jsonify@1.0.1:


### PR DESCRIPTION
Makes @payloadcms/richtext-lexical a bit smaller. Only @types/json-schema is required as a devDependency.