### PR TITLE
fix(ui): tooltips for fields rendered outside RenderFields not positioned correctly

### DIFF
--- a/packages/ui/src/forms/RenderFields/index.scss
+++ b/packages/ui/src/forms/RenderFields/index.scss
@@ -1,5 +1,12 @@
 @import '../../scss/styles.scss';
 
+// Positioned field-type__wrap is needed for correct positioning of field tooltips.
+// This is set outside of .render-fields, so that manually rendered fields (e.g. in Auth/index.tsx)
+// outside RenderFields also receive this styling.
+.field-type__wrap {
+  position: relative;
+}
+
 .render-fields {
   --spacing-field: var(--base);
 
@@ -9,10 +16,6 @@
 
   &--margins-none {
     --spacing-field: 0;
-  }
-
-  .field-type__wrap {
-    position: relative;
   }
 
   & > .field-type {


### PR DESCRIPTION
![image](https://github.com/payloadcms/payload/assets/70709113/af937d66-37f5-4061-8d28-978a301f03c7)

Fixes this tooltip above an erroring Auth E-Mail field.