### PR TITLE
chore: revert changed localization test suite

### DIFF
--- a/packages/payload/src/admin/components/utilities/Locale/index.tsx
+++ b/packages/payload/src/admin/components/utilities/Locale/index.tsx
@@ -66,7 +66,7 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode }> = ({ child
 
     void initializeLocale()
   }, [defaultLocale, getPreference, handleLocaleChange, localeFromParams, localization, user])
-  console.log({ locale })
+
   return <LocaleContext.Provider value={locale}>{children}</LocaleContext.Provider>
 }
 

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -300,7 +300,28 @@ export default buildConfigWithDefaults({
   localization: {
     defaultLocale,
     fallback: true,
-    locales: [defaultLocale, spanishLocale, portugueseLocale, 'ar'],
+    locales: [
+      {
+        code: defaultLocale,
+        label: 'English',
+        rtl: false,
+      },
+      {
+        code: spanishLocale,
+        label: 'Spanish',
+        rtl: false,
+      },
+      {
+        code: portugueseLocale,
+        fallbackLocale: spanishLocale,
+        label: 'Portuguese',
+      },
+      {
+        code: 'ar',
+        label: 'Arabic',
+        rtl: true,
+      },
+    ],
   },
   onInit: async (payload) => {
     const collection = localizedPostsSlug


### PR DESCRIPTION
## Description

Reverts localization test suite config changes made in https://github.com/payloadcms/payload/pull/6981

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
