### PR TITLE
fix: check tenant in findOrCreatePage seed script

### DIFF
--- a/examples/multi-tenant-single-domain/scripts/seed.ts
+++ b/examples/multi-tenant-single-domain/scripts/seed.ts
@@ -48,9 +48,17 @@ async function findOrCreatePage({ data, payload }: { data: any; payload: Payload
   const pagesQuery = await payload.find({
     collection: 'pages',
     where: {
-      slug: {
-        equals: data.slug,
-      },
+      and: [
+        {
+          slug: {
+            equals: data.slug
+          },
+        },
+        {
+          tenant: {
+            equals: data.tenant
+          },
+        }]
     },
   })
 


### PR DESCRIPTION
## Description

The FindOrCreatePage seed script did not check the tenant so only the first page is created since all pages have the same "home" slug

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
