### PR TITLE
Correct stripe plugin documentation local use webhook url

### DIFF
--- a/docs/plugins/stripe.mdx
+++ b/docs/plugins/stripe.mdx
@@ -114,7 +114,7 @@ const res = await fetch(`/api/stripe/rest`, {
 Development:
 
 1. Login using Stripe cli `stripe login`
-1. Forward events to localhost `stripe listen --forward-to localhost:3000/stripe/webhooks`
+1. Forward events to localhost `stripe listen --forward-to localhost:3000/api/stripe/webhooks`
 1. Paste the given secret into your `.env` file as `STRIPE_WEBHOOKS_ENDPOINT_SECRET`
 
 Production:


### PR DESCRIPTION
## Description
The stripe plugin documentation has an error in the forwarding URL for local development (`/stripe/webhooks` instead of `/api/stripe/webhooks`) 

Spent a day debugging my application because the URL in the docs is wrong. Hoping to save others some time with this correction.

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation correction
