### PR TITLE
fix: incorrect resized animated image filenames

### DIFF
--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -72,7 +72,12 @@ const createImageName = (
   outputImageName: string,
   { height, width }: OutputInfo,
   extension: string,
-) => `${outputImageName}-${width}x${height}.${extension}`
+  metadata: sharp.Metadata,
+) => {
+  // Adjust height if the file is animated
+  const adjustedHeight = metadata.pages ? height / metadata.pages : height
+  return `${outputImageName}-${width}x${adjustedHeight}.${extension}`
+}
 
 type CreateResultArgs = {
   filename?: FileSize['filename']
@@ -361,6 +366,7 @@ export default async function resizeAndTransformImageSizes({
         sanitizedImage.name,
         bufferInfo,
         mimeInfo?.ext || sanitizedImage.ext,
+        metadata,
       )
 
       const imagePath = `${staticPath}/${imageNameWithDimensions}`

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -125,6 +125,25 @@ describe('uploads', () => {
     await saveDocAndAssert(page)
   })
 
+  test('should show proper file names for resized animated file', async () => {
+    await page.goto(animatedTypeMediaURL.create)
+
+    await page.setInputFiles('input[type="file"]', path.resolve(__dirname, './animated.webp'))
+    const animatedFilename = page.locator('.file-field__filename')
+
+    await expect(animatedFilename).toHaveValue('animated.webp')
+
+    await saveDocAndAssert(page)
+
+    await page.locator('.file-field__previewSizes').click()
+
+    const smallSquareFilename = page
+      .locator('.preview-sizes__list .preview-sizes__sizeOption')
+      .nth(1)
+      .locator('.file-meta__url a')
+    await expect(smallSquareFilename).toContainText('animated-1-480x480.webp')
+  })
+
   test('should show resized images', async () => {
     await page.goto(mediaURL.edit(pngDoc.id))
 

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -141,7 +141,7 @@ describe('uploads', () => {
       .locator('.preview-sizes__list .preview-sizes__sizeOption')
       .nth(1)
       .locator('.file-meta__url a')
-    await expect(smallSquareFilename).toContainText('animated-1-480x480.webp')
+    await expect(smallSquareFilename).toContainText(/480x480\.webp$/)
   })
 
   test('should show resized images', async () => {


### PR DESCRIPTION
## Description

Fixes an issue where resized animated files were outputting incorrect resized filenames.

When imageSizes are defined in an upload config - the generated filenames for animated images were using the incorrect height value.

`Before`:
![Screenshot 2024-07-15 at 1 05 41 PM](https://github.com/user-attachments/assets/b98e7cf3-f77e-4821-9f65-4dacfff22c98)

`After`:
![Screenshot 2024-07-15 at 1 06 11 PM](https://github.com/user-attachments/assets/8dc9551b-43a5-4293-97be-5822c54698d4)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
