### PR TITLE
fix(payload): incorrect resized animated image filenames

### DIFF
--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -1,4 +1,4 @@
-import type { OutputInfo, Sharp, SharpOptions } from 'sharp'
+import type { Metadata, OutputInfo, Sharp, SharpOptions } from 'sharp'
 
 import { fileTypeFromBuffer } from 'file-type'
 import fs from 'fs'
@@ -72,7 +72,12 @@ const createImageName = (
   outputImageName: string,
   { height, width }: OutputInfo,
   extension: string,
-) => `${outputImageName}-${width}x${height}.${extension}`
+  metadata: Metadata,
+) => {
+  // Adjust height if the file is animated
+  const adjustedHeight = metadata.pages ? height / metadata.pages : height
+  return `${outputImageName}-${width}x${adjustedHeight}.${extension}`
+}
 
 type CreateResultArgs = {
   filename?: FileSize['filename']
@@ -363,6 +368,7 @@ export async function resizeAndTransformImageSizes({
         sanitizedImage.name,
         bufferInfo,
         mimeInfo?.ext || sanitizedImage.ext,
+        metadata,
       )
 
       const imagePath = `${staticPath}/${imageNameWithDimensions}`

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -143,6 +143,25 @@ describe('uploads', () => {
     await saveDocAndAssert(page)
   })
 
+  test('should show proper file names for resized animated file', async () => {
+    await page.goto(animatedTypeMediaURL.create)
+
+    await page.setInputFiles('input[type="file"]', path.resolve(dirname, './animated.webp'))
+    const animatedFilename = page.locator('.file-field__filename')
+
+    await expect(animatedFilename).toHaveValue('animated.webp')
+
+    await saveDocAndAssert(page)
+
+    await page.locator('.file-field__previewSizes').click()
+
+    const smallSquareFilename = page
+      .locator('.preview-sizes__list .preview-sizes__sizeOption')
+      .nth(1)
+      .locator('.file-meta__url a')
+    await expect(smallSquareFilename).toContainText(/480x480\.webp$/)
+  })
+
   test('should show resized images', async () => {
     await page.goto(mediaURL.edit(pngDoc.id))
 


### PR DESCRIPTION
## Description

V2 PR [here](https://github.com/payloadcms/payload/pull/7150)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
