### PR TITLE
chore(eslint): add missing recommended config for eslint-plugin-react-hooks

### DIFF
--- a/packages/eslint-config/configs/react/index.mjs
+++ b/packages/eslint-config/configs/react/index.mjs
@@ -10,6 +10,9 @@ import { deepMerge } from '../../deepMerge.js'
 export const index = deepMerge(
   react.configs['recommended-type-checked'],
   {
+    rules: reactHooks.configs.recommended.rules,
+  },
+  {
     rules: reactRules,
   },
   {


### PR DESCRIPTION
Adds back eslint warnings if, for example, the dependencies array of a Hook does not include all the required dependencies.