### PR TITLE
fix(richtext-lexical): newly created upload nodes with extra fields do not display fields when opening extra fields drawer

### DIFF
--- a/packages/richtext-lexical/src/features/experimental_table/plugins/TablePlugin/index.tsx
+++ b/packages/richtext-lexical/src/features/experimental_table/plugins/TablePlugin/index.tsx
@@ -117,7 +117,6 @@ export const TablePlugin: PluginComponent = () => {
   return (
     <React.Fragment>
       <FieldsDrawer
-        data={{}}
         drawerSlug={drawerSlug}
         drawerTitle="Create Table"
         featureKey="experimental_table"

--- a/packages/richtext-lexical/src/features/link/plugins/floatingLinkEditor/LinkEditor/index.tsx
+++ b/packages/richtext-lexical/src/features/link/plugins/floatingLinkEditor/LinkEditor/index.tsx
@@ -42,7 +42,7 @@ export function LinkEditor({ anchorElem }: { anchorElem: HTMLElement }): React.R
 
   const { i18n, t } = useTranslation()
 
-  const [stateData, setStateData] = useState<({ id?: string; text: string } & LinkFields) | {}>({})
+  const [stateData, setStateData] = useState<{ id?: string; text: string } & LinkFields>(null)
 
   const { closeModal, toggleModal } = useModal()
   const editDepth = useEditDepth()
@@ -66,7 +66,7 @@ export function LinkEditor({ anchorElem }: { anchorElem: HTMLElement }): React.R
     setLinkUrl(null)
     setLinkLabel(null)
     setSelectedNodes([])
-    setStateData({})
+    setStateData(null)
   }, [setIsLink, setLinkUrl, setLinkLabel, setSelectedNodes])
 
   const $updateLinkEditor = useCallback(() => {

--- a/packages/richtext-lexical/src/utilities/fieldsDrawer/Drawer.tsx
+++ b/packages/richtext-lexical/src/utilities/fieldsDrawer/Drawer.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { FormState } from 'payload'
+import type { Data, FormState } from 'payload'
 
 import { Drawer } from '@payloadcms/ui'
 import React from 'react'
@@ -8,7 +8,7 @@ import { DrawerContent } from './DrawerContent.js'
 
 export type FieldsDrawerProps = {
   className?: string
-  data: any
+  data?: Data
   drawerSlug: string
   drawerTitle?: string
   featureKey: string

--- a/packages/richtext-lexical/src/utilities/fieldsDrawer/DrawerContent.tsx
+++ b/packages/richtext-lexical/src/utilities/fieldsDrawer/DrawerContent.tsx
@@ -45,7 +45,7 @@ export const DrawerContent: React.FC<Omit<FieldsDrawerProps, 'drawerSlug' | 'dra
         apiRoute: config.routes.api,
         body: {
           id,
-          data,
+          data: data ?? {},
           operation: 'update',
           schemaPath: schemaFieldsPath,
         },
@@ -55,9 +55,7 @@ export const DrawerContent: React.FC<Omit<FieldsDrawerProps, 'drawerSlug' | 'dra
       setInitialState(state)
     }
 
-    if (data) {
-      void awaitInitialState()
-    }
+    void awaitInitialState()
   }, [config.routes.api, config.serverURL, schemaFieldsPath, id, data])
 
   const onChange: FormProps['onChange'][0] = useCallback(


### PR DESCRIPTION
Fixes #7128 

E2E for this is in separate PR: https://github.com/payloadcms/payload/pull/7156