### PR TITLE
fix: serialize linebreak in richtext

### DIFF
--- a/templates/website/src/app/_components/RichText/serialize.tsx
+++ b/templates/website/src/app/_components/RichText/serialize.tsx
@@ -1,6 +1,5 @@
 import React, { Fragment } from 'react'
 import escapeHTML from 'escape-html'
-import Link from 'next/link'
 import { Text } from 'slate'
 
 import { Label } from '../Label'
@@ -24,7 +23,8 @@ type Leaf = {
 const serialize = (children?: Children): React.ReactNode[] =>
   children?.map((node, i) => {
     if (Text.isText(node)) {
-      let text = <span dangerouslySetInnerHTML={{ __html: escapeHTML(node.text) }} />
+      const escapedText = escapeHTML(node.text).replaceAll('\n', '<br/>')
+      let text = <span dangerouslySetInnerHTML={{ __html: escapedText }} />
 
       if (node.bold) {
         text = <strong key={i}>{text}</strong>


### PR DESCRIPTION
## Description

When using the `RichText` component, in admin you can enter text with multiple lines and manual do line breaks by entering `Shift+Enter`. Besides normal paragraphs, produced by pressing `Enter`, simple line breaks will be stored as `\n` into the string of the current paragraph. In the `RichText`-component to show the text on a page the line break is not evaluated, so text with line breaks will be shown in a single text line.

Expected output: The text should be formatted as entered in the admin component and preserve the line breaks.

Solution: Replace the `\n` of the string by `br`-tags in the serialize method.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
