### PR TITLE
chore: run esbuild scripts in sync, hopefully fixing publishing issues

### DIFF
--- a/packages/db-postgres/bundle.js
+++ b/packages/db-postgres/bundle.js
@@ -6,8 +6,8 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
 
-const resultServer = await esbuild
-  .build({
+async function build() {
+  const resultServer = await esbuild.build({
     entryPoints: ['src/index.ts'],
     bundle: true,
     platform: 'node',
@@ -30,10 +30,8 @@ const resultServer = await esbuild
     plugins: [commonjs()],
     sourcemap: true,
   })
-  .then((res, err) => {
-    console.log('db-postgres bundled successfully')
-    return res
-  })
-  .catch(() => process.exit(1))
+  console.log('db-postgres bundled successfully')
 
-fs.writeFileSync('meta_server.json', JSON.stringify(resultServer.metafile))
+  fs.writeFileSync('meta_server.json', JSON.stringify(resultServer.metafile))
+}
+await build()

--- a/packages/db-postgres/bundle.js
+++ b/packages/db-postgres/bundle.js
@@ -2,38 +2,34 @@ import * as esbuild from 'esbuild'
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
 
-const resultServer = await esbuild
-  .build({
-    entryPoints: ['src/index.ts'],
-    bundle: true,
-    platform: 'node',
-    format: 'esm',
-    outfile: 'dist/index.js',
-    splitting: false,
-    external: [
-      '*.scss',
-      '*.css',
-      'drizzle-kit',
-      'libsql',
-      'pg',
-      '@payloadcms/translations',
-      'payload',
-      'payload/*',
-    ],
-    minify: true,
-    metafile: true,
-    tsconfig: path.resolve(dirname, './tsconfig.json'),
-    plugins: [commonjs()],
-    sourcemap: true,
-  })
-  .then((res, err) => {
-    console.log('db-postgres bundled successfully')
-    return res
-  })
-  .catch(() => process.exit(1))
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+const resultServer = esbuild.buildSync({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: 'dist/index.js',
+  splitting: false,
+  external: [
+    '*.scss',
+    '*.css',
+    'drizzle-kit',
+    'libsql',
+    'pg',
+    '@payloadcms/translations',
+    'payload',
+    'payload/*',
+  ],
+  minify: true,
+  metafile: true,
+  tsconfig: path.resolve(dirname, './tsconfig.json'),
+  plugins: [commonjs()],
+  sourcemap: true,
+})
+console.log('db-postgres bundled successfully')
 
 fs.writeFileSync('meta_server.json', JSON.stringify(resultServer.metafile))

--- a/packages/db-postgres/bundle.js
+++ b/packages/db-postgres/bundle.js
@@ -2,34 +2,38 @@ import * as esbuild from 'esbuild'
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
-
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
+import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
 
-const resultServer = esbuild.buildSync({
-  entryPoints: ['src/index.ts'],
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  outfile: 'dist/index.js',
-  splitting: false,
-  external: [
-    '*.scss',
-    '*.css',
-    'drizzle-kit',
-    'libsql',
-    'pg',
-    '@payloadcms/translations',
-    'payload',
-    'payload/*',
-  ],
-  minify: true,
-  metafile: true,
-  tsconfig: path.resolve(dirname, './tsconfig.json'),
-  plugins: [commonjs()],
-  sourcemap: true,
-})
-console.log('db-postgres bundled successfully')
+const resultServer = await esbuild
+  .build({
+    entryPoints: ['src/index.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    outfile: 'dist/index.js',
+    splitting: false,
+    external: [
+      '*.scss',
+      '*.css',
+      'drizzle-kit',
+      'libsql',
+      'pg',
+      '@payloadcms/translations',
+      'payload',
+      'payload/*',
+    ],
+    minify: true,
+    metafile: true,
+    tsconfig: path.resolve(dirname, './tsconfig.json'),
+    plugins: [commonjs()],
+    sourcemap: true,
+  })
+  .then((res, err) => {
+    console.log('db-postgres bundled successfully')
+    return res
+  })
+  .catch(() => process.exit(1))
 
 fs.writeFileSync('meta_server.json', JSON.stringify(resultServer.metafile))

--- a/packages/next/bundleScss.js
+++ b/packages/next/bundleScss.js
@@ -21,39 +21,26 @@ async function build() {
     }
   })
 
-  await fs.unlink('dist/esbuildEntry.js', (err) => {
-    if (err) {
-      console.error(`Error while deleting dist/esbuildEntry.js: ${err}`)
-      throw err
-    }
-  })
-
-  await fs.unlink('dist/prod/esbuildEntry.js', (err) => {
-    if (err) {
-      console.error(`Error while deleting dist/prod/esbuildEntry.js: ${err}`)
-      throw err
-    }
-  })
-
-  await fs.unlink('dist/esbuildEntry.d.ts', (err) => {
-    if (err) {
-      console.error(`Error while deleting dist/esbuildEntry.d.ts: ${err}`)
-      throw err
-    }
-  })
-  await fs.unlink('dist/esbuildEntry.d.ts.map', (err) => {
-    if (err) {
-      console.error(`Error while deleting dist/esbuildEntry.d.ts.map: ${err}`)
-      throw err
-    }
-  })
-  await fs.unlink('dist/esbuildEntry.js.map', (err) => {
-    if (err) {
-      console.error(`Error while deleting dist/esbuildEntry.js.map: ${err}`)
-      throw err
-    }
-  })
   console.log('styles.css bundled successfully')
+
+  const filesToDelete = [
+    'dist/esbuildEntry.js',
+    'dist/prod/esbuildEntry.js',
+    'dist/esbuildEntry.d.ts',
+    'dist/esbuildEntry.d.ts.map',
+    'dist/esbuildEntry.js.map',
+  ]
+
+  for (const file of filesToDelete) {
+    await fs.unlink(file, (err) => {
+      if (err) {
+        console.error(`Error while deleting ${file}: ${err}`)
+        throw err
+      }
+    })
+  }
+
+  console.log('Files renamed and deleted successfully')
 }
 
 await build()

--- a/packages/next/bundleScss.js
+++ b/packages/next/bundleScss.js
@@ -1,52 +1,45 @@
 import * as esbuild from 'esbuild'
 import fs from 'fs'
-
+import path from 'path'
+import { fileURLToPath } from 'url'
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 import { sassPlugin } from 'esbuild-sass-plugin'
 
 // Bundle only the .scss files into a single css file
-esbuild.buildSync({
-  entryPoints: ['src/esbuildEntry.ts'],
-  bundle: true,
-  minify: true,
-  outdir: 'dist/prod',
-  packages: 'external',
-  plugins: [sassPlugin({ css: 'external' })],
-})
+await esbuild
+  .build({
+    entryPoints: ['src/esbuildEntry.ts'],
+    bundle: true,
+    minify: true,
+    outdir: 'dist/prod',
+    packages: 'external',
+    plugins: [sassPlugin({ css: 'external' })],
+  })
+  .then(() => {
+    fs.rename('dist/prod/esbuildEntry.css', 'dist/prod/styles.css', (err) => {
+      if (err) console.error(`Error while renaming index.css: ${err}`)
+    })
 
-try {
-  fs.renameSync('dist/prod/esbuildEntry.css', 'dist/prod/styles.css')
-} catch (err) {
-  console.error(`Error while renaming index.css: ${err}`)
-}
+    fs.unlink('dist/esbuildEntry.js', (err) => {
+      if (err) console.error(`Error while deleting dist/esbuildEntry.js: ${err}`)
+    })
 
-try {
-  fs.unlinkSync('dist/esbuildEntry.js')
-} catch (err) {
-  console.error(`Error while deleting dist/esbuildEntry.js: ${err}`)
-}
+    fs.unlink('dist/prod/esbuildEntry.js', (err) => {
+      if (err) console.error(`Error while deleting dist/prod/esbuildEntry.js: ${err}`)
+    })
 
-try {
-  fs.unlinkSync('dist/prod/esbuildEntry.js')
-} catch (err) {
-  console.error(`Error while deleting dist/prod/esbuildEntry.js: ${err}`)
-}
-
-try {
-  fs.unlinkSync('dist/esbuildEntry.d.ts')
-} catch (err) {
-  console.error(`Error while deleting dist/esbuildEntry.d.ts: ${err}`)
-}
-
-try {
-  fs.unlinkSync('dist/esbuildEntry.d.ts.map')
-} catch (err) {
-  console.error(`Error while deleting dist/esbuildEntry.d.ts.map: ${err}`)
-}
-
-try {
-  fs.unlinkSync('dist/esbuildEntry.js.map')
-} catch (err) {
-  console.error(`Error while deleting dist/esbuildEntry.js.map: ${err}`)
-}
-
-console.log('styles.css bundled successfully')
+    fs.unlink('dist/esbuildEntry.d.ts', (err) => {
+      if (err) console.error(`Error while deleting dist/esbuildEntry.d.ts: ${err}`)
+    })
+    fs.unlink('dist/esbuildEntry.d.ts.map', (err) => {
+      if (err) console.error(`Error while deleting dist/esbuildEntry.d.ts.map: ${err}`)
+    })
+    fs.unlink('dist/esbuildEntry.js.map', (err) => {
+      if (err) console.error(`Error while deleting dist/esbuildEntry.js.map: ${err}`)
+    })
+    console.log('styles.css bundled successfully')
+  })
+  .catch((e) => {
+    throw e
+  })

--- a/packages/next/bundleScss.js
+++ b/packages/next/bundleScss.js
@@ -1,14 +1,11 @@
 import * as esbuild from 'esbuild'
 import fs from 'fs'
-import path from 'path'
-import { fileURLToPath } from 'url'
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
+
 import { sassPlugin } from 'esbuild-sass-plugin'
 
-// Bundle only the .scss files into a single css file
-await esbuild
-  .build({
+async function build() {
+  // Bundle only the .scss files into a single css file
+  await esbuild.build({
     entryPoints: ['src/esbuildEntry.ts'],
     bundle: true,
     minify: true,
@@ -16,30 +13,47 @@ await esbuild
     packages: 'external',
     plugins: [sassPlugin({ css: 'external' })],
   })
-  .then(() => {
-    fs.rename('dist/prod/esbuildEntry.css', 'dist/prod/styles.css', (err) => {
-      if (err) console.error(`Error while renaming index.css: ${err}`)
-    })
 
-    fs.unlink('dist/esbuildEntry.js', (err) => {
-      if (err) console.error(`Error while deleting dist/esbuildEntry.js: ${err}`)
-    })
-
-    fs.unlink('dist/prod/esbuildEntry.js', (err) => {
-      if (err) console.error(`Error while deleting dist/prod/esbuildEntry.js: ${err}`)
-    })
-
-    fs.unlink('dist/esbuildEntry.d.ts', (err) => {
-      if (err) console.error(`Error while deleting dist/esbuildEntry.d.ts: ${err}`)
-    })
-    fs.unlink('dist/esbuildEntry.d.ts.map', (err) => {
-      if (err) console.error(`Error while deleting dist/esbuildEntry.d.ts.map: ${err}`)
-    })
-    fs.unlink('dist/esbuildEntry.js.map', (err) => {
-      if (err) console.error(`Error while deleting dist/esbuildEntry.js.map: ${err}`)
-    })
-    console.log('styles.css bundled successfully')
+  await fs.rename('dist/prod/esbuildEntry.css', 'dist/prod/styles.css', (err) => {
+    if (err) {
+      console.error(`Error while renaming index.css: ${err}`)
+      throw err
+    }
   })
-  .catch((e) => {
-    throw e
+
+  await fs.unlink('dist/esbuildEntry.js', (err) => {
+    if (err) {
+      console.error(`Error while deleting dist/esbuildEntry.js: ${err}`)
+      throw err
+    }
   })
+
+  await fs.unlink('dist/prod/esbuildEntry.js', (err) => {
+    if (err) {
+      console.error(`Error while deleting dist/prod/esbuildEntry.js: ${err}`)
+      throw err
+    }
+  })
+
+  await fs.unlink('dist/esbuildEntry.d.ts', (err) => {
+    if (err) {
+      console.error(`Error while deleting dist/esbuildEntry.d.ts: ${err}`)
+      throw err
+    }
+  })
+  await fs.unlink('dist/esbuildEntry.d.ts.map', (err) => {
+    if (err) {
+      console.error(`Error while deleting dist/esbuildEntry.d.ts.map: ${err}`)
+      throw err
+    }
+  })
+  await fs.unlink('dist/esbuildEntry.js.map', (err) => {
+    if (err) {
+      console.error(`Error while deleting dist/esbuildEntry.js.map: ${err}`)
+      throw err
+    }
+  })
+  console.log('styles.css bundled successfully')
+}
+
+await build()

--- a/packages/next/bundleScss.js
+++ b/packages/next/bundleScss.js
@@ -1,45 +1,52 @@
 import * as esbuild from 'esbuild'
 import fs from 'fs'
-import path from 'path'
-import { fileURLToPath } from 'url'
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
+
 import { sassPlugin } from 'esbuild-sass-plugin'
 
 // Bundle only the .scss files into a single css file
-await esbuild
-  .build({
-    entryPoints: ['src/esbuildEntry.ts'],
-    bundle: true,
-    minify: true,
-    outdir: 'dist/prod',
-    packages: 'external',
-    plugins: [sassPlugin({ css: 'external' })],
-  })
-  .then(() => {
-    fs.rename('dist/prod/esbuildEntry.css', 'dist/prod/styles.css', (err) => {
-      if (err) console.error(`Error while renaming index.css: ${err}`)
-    })
+esbuild.buildSync({
+  entryPoints: ['src/esbuildEntry.ts'],
+  bundle: true,
+  minify: true,
+  outdir: 'dist/prod',
+  packages: 'external',
+  plugins: [sassPlugin({ css: 'external' })],
+})
 
-    fs.unlink('dist/esbuildEntry.js', (err) => {
-      if (err) console.error(`Error while deleting dist/esbuildEntry.js: ${err}`)
-    })
+try {
+  fs.renameSync('dist/prod/esbuildEntry.css', 'dist/prod/styles.css')
+} catch (err) {
+  console.error(`Error while renaming index.css: ${err}`)
+}
 
-    fs.unlink('dist/prod/esbuildEntry.js', (err) => {
-      if (err) console.error(`Error while deleting dist/prod/esbuildEntry.js: ${err}`)
-    })
+try {
+  fs.unlinkSync('dist/esbuildEntry.js')
+} catch (err) {
+  console.error(`Error while deleting dist/esbuildEntry.js: ${err}`)
+}
 
-    fs.unlink('dist/esbuildEntry.d.ts', (err) => {
-      if (err) console.error(`Error while deleting dist/esbuildEntry.d.ts: ${err}`)
-    })
-    fs.unlink('dist/esbuildEntry.d.ts.map', (err) => {
-      if (err) console.error(`Error while deleting dist/esbuildEntry.d.ts.map: ${err}`)
-    })
-    fs.unlink('dist/esbuildEntry.js.map', (err) => {
-      if (err) console.error(`Error while deleting dist/esbuildEntry.js.map: ${err}`)
-    })
-    console.log('styles.css bundled successfully')
-  })
-  .catch((e) => {
-    throw e
-  })
+try {
+  fs.unlinkSync('dist/prod/esbuildEntry.js')
+} catch (err) {
+  console.error(`Error while deleting dist/prod/esbuildEntry.js: ${err}`)
+}
+
+try {
+  fs.unlinkSync('dist/esbuildEntry.d.ts')
+} catch (err) {
+  console.error(`Error while deleting dist/esbuildEntry.d.ts: ${err}`)
+}
+
+try {
+  fs.unlinkSync('dist/esbuildEntry.d.ts.map')
+} catch (err) {
+  console.error(`Error while deleting dist/esbuildEntry.d.ts.map: ${err}`)
+}
+
+try {
+  fs.unlinkSync('dist/esbuildEntry.js.map')
+} catch (err) {
+  console.error(`Error while deleting dist/esbuildEntry.js.map: ${err}`)
+}
+
+console.log('styles.css bundled successfully')

--- a/packages/payload/bundle.js
+++ b/packages/payload/bundle.js
@@ -4,10 +4,9 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
 
-const resultIndex = await esbuild
-  .build({
+async function build() {
+  const resultIndex = await esbuild.build({
     entryPoints: ['src/exports/index.ts'],
     bundle: true,
     platform: 'node',
@@ -33,14 +32,9 @@ const resultIndex = await esbuild
     // plugins: [commonjs()],
     sourcemap: true,
   })
-  .then((res, err) => {
-    console.log('payload server bundled successfully')
-    return res
-  })
-  .catch(() => process.exit(1))
+  console.log('payload server bundled successfully')
 
-const resultShared = await esbuild
-  .build({
+  const resultShared = await esbuild.build({
     entryPoints: ['src/exports/shared.ts'],
     bundle: true,
     platform: 'node',
@@ -65,11 +59,10 @@ const resultShared = await esbuild
     // plugins: [commonjs()],
     sourcemap: true,
   })
-  .then((res, err) => {
-    console.log('payload shared bundled successfully')
-    return res
-  })
-  .catch(() => process.exit(1))
+  console.log('payload shared bundled successfully')
 
-fs.writeFileSync('meta_index.json', JSON.stringify(resultIndex.metafile))
-fs.writeFileSync('meta_shared.json', JSON.stringify(resultShared.metafile))
+  fs.writeFileSync('meta_index.json', JSON.stringify(resultIndex.metafile))
+  fs.writeFileSync('meta_shared.json', JSON.stringify(resultShared.metafile))
+}
+
+await build()

--- a/packages/payload/bundle.js
+++ b/packages/payload/bundle.js
@@ -4,61 +4,72 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
+import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
 
-const resultIndex = esbuild.buildSync({
-  entryPoints: ['src/exports/index.ts'],
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  outfile: 'dist/exports/index.js',
-  splitting: false,
-  external: [
-    'lodash',
-    //'joi',
-    '*.scss',
-    '*.css',
-    '@payloadcms/translations',
-    'memoizee',
-    'pino-pretty',
-    'pino',
-    //'ajv',
-    //'conf',
-    //'image-size',
-  ],
-  minify: true,
-  metafile: true,
-  tsconfig: path.resolve(dirname, './tsconfig.json'),
-  // plugins: [commonjs()],
-  sourcemap: true,
-})
-console.log('payload server bundled successfully')
+const resultIndex = await esbuild
+  .build({
+    entryPoints: ['src/exports/index.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    outfile: 'dist/exports/index.js',
+    splitting: false,
+    external: [
+      'lodash',
+      //'joi',
+      '*.scss',
+      '*.css',
+      '@payloadcms/translations',
+      'memoizee',
+      'pino-pretty',
+      'pino',
+      //'ajv',
+      //'conf',
+      //'image-size',
+    ],
+    minify: true,
+    metafile: true,
+    tsconfig: path.resolve(dirname, './tsconfig.json'),
+    // plugins: [commonjs()],
+    sourcemap: true,
+  })
+  .then((res, err) => {
+    console.log('payload server bundled successfully')
+    return res
+  })
+  .catch(() => process.exit(1))
 
-const resultShared = esbuild.buildSync({
-  entryPoints: ['src/exports/shared.ts'],
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  outfile: 'dist/exports/shared.js',
-  splitting: false,
-  external: [
-    'lodash',
-    '*.scss',
-    '*.css',
-    '@payloadcms/translations',
-    'memoizee',
-    'pino-pretty',
-    'pino',
-    //'ajv',
-    //'conf',
-    //'image-size',
-  ],
-  minify: true,
-  metafile: true,
-  tsconfig: path.resolve(dirname, './tsconfig.json'),
-  // plugins: [commonjs()],
-  sourcemap: true,
-})
-console.log('payload shared bundled successfully')
+const resultShared = await esbuild
+  .build({
+    entryPoints: ['src/exports/shared.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    outfile: 'dist/exports/shared.js',
+    splitting: false,
+    external: [
+      'lodash',
+      '*.scss',
+      '*.css',
+      '@payloadcms/translations',
+      'memoizee',
+      'pino-pretty',
+      'pino',
+      //'ajv',
+      //'conf',
+      //'image-size',
+    ],
+    minify: true,
+    metafile: true,
+    tsconfig: path.resolve(dirname, './tsconfig.json'),
+    // plugins: [commonjs()],
+    sourcemap: true,
+  })
+  .then((res, err) => {
+    console.log('payload shared bundled successfully')
+    return res
+  })
+  .catch(() => process.exit(1))
 
 fs.writeFileSync('meta_index.json', JSON.stringify(resultIndex.metafile))
 fs.writeFileSync('meta_shared.json', JSON.stringify(resultShared.metafile))

--- a/packages/payload/bundle.js
+++ b/packages/payload/bundle.js
@@ -4,72 +4,61 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
 
-const resultIndex = await esbuild
-  .build({
-    entryPoints: ['src/exports/index.ts'],
-    bundle: true,
-    platform: 'node',
-    format: 'esm',
-    outfile: 'dist/exports/index.js',
-    splitting: false,
-    external: [
-      'lodash',
-      //'joi',
-      '*.scss',
-      '*.css',
-      '@payloadcms/translations',
-      'memoizee',
-      'pino-pretty',
-      'pino',
-      //'ajv',
-      //'conf',
-      //'image-size',
-    ],
-    minify: true,
-    metafile: true,
-    tsconfig: path.resolve(dirname, './tsconfig.json'),
-    // plugins: [commonjs()],
-    sourcemap: true,
-  })
-  .then((res, err) => {
-    console.log('payload server bundled successfully')
-    return res
-  })
-  .catch(() => process.exit(1))
+const resultIndex = esbuild.buildSync({
+  entryPoints: ['src/exports/index.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: 'dist/exports/index.js',
+  splitting: false,
+  external: [
+    'lodash',
+    //'joi',
+    '*.scss',
+    '*.css',
+    '@payloadcms/translations',
+    'memoizee',
+    'pino-pretty',
+    'pino',
+    //'ajv',
+    //'conf',
+    //'image-size',
+  ],
+  minify: true,
+  metafile: true,
+  tsconfig: path.resolve(dirname, './tsconfig.json'),
+  // plugins: [commonjs()],
+  sourcemap: true,
+})
+console.log('payload server bundled successfully')
 
-const resultShared = await esbuild
-  .build({
-    entryPoints: ['src/exports/shared.ts'],
-    bundle: true,
-    platform: 'node',
-    format: 'esm',
-    outfile: 'dist/exports/shared.js',
-    splitting: false,
-    external: [
-      'lodash',
-      '*.scss',
-      '*.css',
-      '@payloadcms/translations',
-      'memoizee',
-      'pino-pretty',
-      'pino',
-      //'ajv',
-      //'conf',
-      //'image-size',
-    ],
-    minify: true,
-    metafile: true,
-    tsconfig: path.resolve(dirname, './tsconfig.json'),
-    // plugins: [commonjs()],
-    sourcemap: true,
-  })
-  .then((res, err) => {
-    console.log('payload shared bundled successfully')
-    return res
-  })
-  .catch(() => process.exit(1))
+const resultShared = esbuild.buildSync({
+  entryPoints: ['src/exports/shared.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: 'dist/exports/shared.js',
+  splitting: false,
+  external: [
+    'lodash',
+    '*.scss',
+    '*.css',
+    '@payloadcms/translations',
+    'memoizee',
+    'pino-pretty',
+    'pino',
+    //'ajv',
+    //'conf',
+    //'image-size',
+  ],
+  minify: true,
+  metafile: true,
+  tsconfig: path.resolve(dirname, './tsconfig.json'),
+  // plugins: [commonjs()],
+  sourcemap: true,
+})
+console.log('payload shared bundled successfully')
 
 fs.writeFileSync('meta_index.json', JSON.stringify(resultIndex.metafile))
 fs.writeFileSync('meta_shared.json', JSON.stringify(resultShared.metafile))

--- a/packages/richtext-lexical/bundle.js
+++ b/packages/richtext-lexical/bundle.js
@@ -18,9 +18,9 @@ const removeCSSImports = {
   },
 }
 
-// Bundle only the .scss files into a single css file
-await esbuild
-  .build({
+async function build() {
+  // Bundle only the .scss files into a single css file
+  await esbuild.build({
     entryPoints: ['src/exports/client/index.ts'],
     bundle: true,
     minify: true,
@@ -30,18 +30,14 @@ await esbuild
     //external: ['*.svg'],
     plugins: [sassPlugin({ css: 'external' })],
   })
-  .then(() => {
-    fs.rename('dist/field/index.css', 'dist/exports/client/bundled.css', (err) => {
-      if (err) console.error(`Error while renaming index.css: ${err}`)
-    })
-
-    console.log('dist/field/bundled.css bundled successfully')
+  await fs.rename('dist/field/index.css', 'dist/exports/client/bundled.css', (err) => {
+    if (err) console.error(`Error while renaming index.css: ${err}`)
   })
-  .catch(() => process.exit(1))
 
-// Bundle `client.ts`
-const resultClient = await esbuild
-  .build({
+  console.log('dist/field/bundled.css bundled successfully')
+
+  // Bundle `client.ts`
+  const resultClient = await esbuild.build({
     entryPoints: ['src/exports/client/index.ts'],
     bundle: true,
     platform: 'browser',
@@ -90,15 +86,14 @@ const resultClient = await esbuild
     plugins: [
       removeCSSImports,
       /*commonjs({
-        ignore: ['date-fns', '@floating-ui/react'],
-      }),*/
+          ignore: ['date-fns', '@floating-ui/react'],
+        }),*/
     ],
     sourcemap: true,
   })
-  .then((res, err) => {
-    console.log('client/index.ts bundled successfully')
-    return res
-  })
-  .catch(() => process.exit(1))
+  console.log('client/index.ts bundled successfully')
 
-fs.writeFileSync('meta_client.json', JSON.stringify(resultClient.metafile))
+  fs.writeFileSync('meta_client.json', JSON.stringify(resultClient.metafile))
+}
+
+await build()

--- a/packages/richtext-lexical/bundle.js
+++ b/packages/richtext-lexical/bundle.js
@@ -19,86 +19,73 @@ const removeCSSImports = {
 }
 
 // Bundle only the .scss files into a single css file
-await esbuild
-  .build({
-    entryPoints: ['src/exports/client/index.ts'],
-    bundle: true,
-    minify: true,
-    outdir: 'dist/field',
-    loader: { '.svg': 'dataurl' },
-    packages: 'external',
-    //external: ['*.svg'],
-    plugins: [sassPlugin({ css: 'external' })],
-  })
-  .then(() => {
-    fs.rename('dist/field/index.css', 'dist/exports/client/bundled.css', (err) => {
-      if (err) console.error(`Error while renaming index.css: ${err}`)
-    })
-
-    console.log('dist/field/bundled.css bundled successfully')
-  })
-  .catch(() => process.exit(1))
+esbuild.buildSync({
+  entryPoints: ['src/exports/client/index.ts'],
+  bundle: true,
+  minify: true,
+  outdir: 'dist/field',
+  loader: { '.svg': 'dataurl' },
+  packages: 'external',
+  //external: ['*.svg'],
+  plugins: [sassPlugin({ css: 'external' })],
+})
+console.log('dist/field/bundled.css bundled successfully')
 
 // Bundle `client.ts`
-const resultClient = await esbuild
-  .build({
-    entryPoints: ['src/exports/client/index.ts'],
-    bundle: true,
-    platform: 'browser',
-    format: 'esm',
-    outdir: 'dist/exports/client',
-    //outfile: 'index.js',
-    // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
-    splitting: true,
-    external: [
-      '*.scss',
-      '*.css',
-      '*.svg',
-      'qs-esm',
-      '@dnd-kit/core',
-      '@payloadcms/graphql',
-      '@payloadcms/translations',
-      'dequal',
+const resultClient = esbuild.buildSync({
+  entryPoints: ['src/exports/client/index.ts'],
+  bundle: true,
+  platform: 'browser',
+  format: 'esm',
+  outdir: 'dist/exports/client',
+  //outfile: 'index.js',
+  // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
+  splitting: true,
+  external: [
+    '*.scss',
+    '*.css',
+    '*.svg',
+    'qs-esm',
+    '@dnd-kit/core',
+    '@payloadcms/graphql',
+    '@payloadcms/translations',
+    'dequal',
 
-      //'side-channel',
-      '@payloadcms/ui',
-      '@payloadcms/ui/*',
-      '@payloadcms/ui/client',
-      '@payloadcms/ui/shared',
-      'lexical',
-      'lexical/*',
-      '@lexical',
-      '@lexical/*',
-      '@faceless-ui/*',
-      'bson-objectid',
-      'payload',
-      'payload/*',
-      'react',
-      'react-dom',
-      'next',
-      'react-animate-height',
-      'crypto',
-      'lodash',
-      'ui',
-    ],
-    packages: 'external',
-    minify: true,
-    metafile: true,
-    treeShaking: true,
+    //'side-channel',
+    '@payloadcms/ui',
+    '@payloadcms/ui/*',
+    '@payloadcms/ui/client',
+    '@payloadcms/ui/shared',
+    'lexical',
+    'lexical/*',
+    '@lexical',
+    '@lexical/*',
+    '@faceless-ui/*',
+    'bson-objectid',
+    'payload',
+    'payload/*',
+    'react',
+    'react-dom',
+    'next',
+    'react-animate-height',
+    'crypto',
+    'lodash',
+    'ui',
+  ],
+  packages: 'external',
+  minify: true,
+  metafile: true,
+  treeShaking: true,
 
-    tsconfig: path.resolve(dirname, './tsconfig.json'),
-    plugins: [
-      removeCSSImports,
-      /*commonjs({
+  tsconfig: path.resolve(dirname, './tsconfig.json'),
+  plugins: [
+    removeCSSImports,
+    /*commonjs({
         ignore: ['date-fns', '@floating-ui/react'],
       }),*/
-    ],
-    sourcemap: true,
-  })
-  .then((res, err) => {
-    console.log('client/index.ts bundled successfully')
-    return res
-  })
-  .catch(() => process.exit(1))
+  ],
+  sourcemap: true,
+})
+console.log('client/index.ts bundled successfully')
 
 fs.writeFileSync('meta_client.json', JSON.stringify(resultClient.metafile))

--- a/packages/richtext-lexical/bundle.js
+++ b/packages/richtext-lexical/bundle.js
@@ -19,73 +19,86 @@ const removeCSSImports = {
 }
 
 // Bundle only the .scss files into a single css file
-esbuild.buildSync({
-  entryPoints: ['src/exports/client/index.ts'],
-  bundle: true,
-  minify: true,
-  outdir: 'dist/field',
-  loader: { '.svg': 'dataurl' },
-  packages: 'external',
-  //external: ['*.svg'],
-  plugins: [sassPlugin({ css: 'external' })],
-})
-console.log('dist/field/bundled.css bundled successfully')
+await esbuild
+  .build({
+    entryPoints: ['src/exports/client/index.ts'],
+    bundle: true,
+    minify: true,
+    outdir: 'dist/field',
+    loader: { '.svg': 'dataurl' },
+    packages: 'external',
+    //external: ['*.svg'],
+    plugins: [sassPlugin({ css: 'external' })],
+  })
+  .then(() => {
+    fs.rename('dist/field/index.css', 'dist/exports/client/bundled.css', (err) => {
+      if (err) console.error(`Error while renaming index.css: ${err}`)
+    })
+
+    console.log('dist/field/bundled.css bundled successfully')
+  })
+  .catch(() => process.exit(1))
 
 // Bundle `client.ts`
-const resultClient = esbuild.buildSync({
-  entryPoints: ['src/exports/client/index.ts'],
-  bundle: true,
-  platform: 'browser',
-  format: 'esm',
-  outdir: 'dist/exports/client',
-  //outfile: 'index.js',
-  // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
-  splitting: true,
-  external: [
-    '*.scss',
-    '*.css',
-    '*.svg',
-    'qs-esm',
-    '@dnd-kit/core',
-    '@payloadcms/graphql',
-    '@payloadcms/translations',
-    'dequal',
+const resultClient = await esbuild
+  .build({
+    entryPoints: ['src/exports/client/index.ts'],
+    bundle: true,
+    platform: 'browser',
+    format: 'esm',
+    outdir: 'dist/exports/client',
+    //outfile: 'index.js',
+    // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
+    splitting: true,
+    external: [
+      '*.scss',
+      '*.css',
+      '*.svg',
+      'qs-esm',
+      '@dnd-kit/core',
+      '@payloadcms/graphql',
+      '@payloadcms/translations',
+      'dequal',
 
-    //'side-channel',
-    '@payloadcms/ui',
-    '@payloadcms/ui/*',
-    '@payloadcms/ui/client',
-    '@payloadcms/ui/shared',
-    'lexical',
-    'lexical/*',
-    '@lexical',
-    '@lexical/*',
-    '@faceless-ui/*',
-    'bson-objectid',
-    'payload',
-    'payload/*',
-    'react',
-    'react-dom',
-    'next',
-    'react-animate-height',
-    'crypto',
-    'lodash',
-    'ui',
-  ],
-  packages: 'external',
-  minify: true,
-  metafile: true,
-  treeShaking: true,
+      //'side-channel',
+      '@payloadcms/ui',
+      '@payloadcms/ui/*',
+      '@payloadcms/ui/client',
+      '@payloadcms/ui/shared',
+      'lexical',
+      'lexical/*',
+      '@lexical',
+      '@lexical/*',
+      '@faceless-ui/*',
+      'bson-objectid',
+      'payload',
+      'payload/*',
+      'react',
+      'react-dom',
+      'next',
+      'react-animate-height',
+      'crypto',
+      'lodash',
+      'ui',
+    ],
+    packages: 'external',
+    minify: true,
+    metafile: true,
+    treeShaking: true,
 
-  tsconfig: path.resolve(dirname, './tsconfig.json'),
-  plugins: [
-    removeCSSImports,
-    /*commonjs({
+    tsconfig: path.resolve(dirname, './tsconfig.json'),
+    plugins: [
+      removeCSSImports,
+      /*commonjs({
         ignore: ['date-fns', '@floating-ui/react'],
       }),*/
-  ],
-  sourcemap: true,
-})
-console.log('client/index.ts bundled successfully')
+    ],
+    sourcemap: true,
+  })
+  .then((res, err) => {
+    console.log('client/index.ts bundled successfully')
+    return res
+  })
+  .catch(() => process.exit(1))
 
 fs.writeFileSync('meta_client.json', JSON.stringify(resultClient.metafile))

--- a/packages/ui/bundle.js
+++ b/packages/ui/bundle.js
@@ -58,9 +58,9 @@ const useClientPlugin = {
   },
 }
 
-// Bundle only the .scss files into a single css file
-await esbuild
-  .build({
+async function build() {
+  // Bundle only the .scss files into a single css file
+  await esbuild.build({
     entryPoints: ['src/exports/client/index.ts'],
     bundle: true,
     minify: true,
@@ -68,24 +68,23 @@ await esbuild
     packages: 'external',
     plugins: [sassPlugin({ css: 'external' })],
   })
-  .then(() => {
-    fs.rename('dist/index.css', 'dist/styles.css', (err) => {
-      if (err) console.error(`Error while renaming index.css: ${err}`)
-    })
-
-    fs.unlink('dist/index.js', (err) => {
-      if (err) console.error(`Error while deleting index.js: ${err}`)
-    })
-
-    console.log('styles.css bundled successfully')
-  })
-  .catch((e) => {
-    throw e
+  await fs.rename('dist/index.css', 'dist/styles.css', (err) => {
+    if (err) {
+      console.error(`Error while renaming index.css: ${err}`)
+      throw err
+    }
   })
 
-// Bundle `client.ts`
-const resultClient = await esbuild
-  .build({
+  await fs.unlink('dist/index.js', (err) => {
+    if (err) {
+      console.error(`Error while deleting index.js: ${err}`)
+      throw err
+    }
+  })
+
+  console.log('styles.css bundled successfully')
+  // Bundle `client.ts`
+  const resultClient = await esbuild.build({
     entryPoints: ['src/exports/client/index.ts'],
     bundle: true,
     platform: 'browser',
@@ -138,21 +137,14 @@ function require(m) {
       removeCSSImports,
       useClientPlugin, // required for banner to work
       /*commonjs({
-        ignore: ['date-fns', '@floating-ui/react'],
-      }),*/
+          ignore: ['date-fns', '@floating-ui/react'],
+        }),*/
     ],
     sourcemap: true,
   })
-  .then((res, err) => {
-    console.log('client.ts bundled successfully')
-    return res
-  })
-  .catch((e) => {
-    throw e
-  })
+  console.log('client.ts bundled successfully')
 
-const resultShared = await esbuild
-  .build({
+  const resultShared = await esbuild.build({
     entryPoints: ['src/exports/shared/index.ts'],
     bundle: true,
     platform: 'node',
@@ -188,13 +180,10 @@ const resultShared = await esbuild
     plugins: [removeCSSImports, commonjs()],
     sourcemap: true,
   })
-  .then((res, err) => {
-    console.log('shared.ts bundled successfully')
-    return res
-  })
-  .catch((e) => {
-    throw e
-  })
+  console.log('shared.ts bundled successfully')
 
-fs.writeFileSync('meta_client.json', JSON.stringify(resultClient.metafile))
-fs.writeFileSync('meta_shared.json', JSON.stringify(resultShared.metafile))
+  fs.writeFileSync('meta_client.json', JSON.stringify(resultClient.metafile))
+  fs.writeFileSync('meta_shared.json', JSON.stringify(resultShared.metafile))
+}
+
+await build()

--- a/packages/ui/bundle.js
+++ b/packages/ui/bundle.js
@@ -59,8 +59,8 @@ const useClientPlugin = {
 }
 
 // Bundle only the .scss files into a single css file
-await esbuild
-  .build({
+esbuild
+  .buildSync({
     entryPoints: ['src/exports/client/index.ts'],
     bundle: true,
     minify: true,
@@ -84,19 +84,18 @@ await esbuild
   })
 
 // Bundle `client.ts`
-const resultClient = await esbuild
-  .build({
-    entryPoints: ['src/exports/client/index.ts'],
-    bundle: true,
-    platform: 'browser',
-    format: 'esm',
-    outdir: 'dist/exports/client',
-    //outfile: 'index.js',
-    // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
-    splitting: true,
-    write: true, // required for useClientPlugin
-    banner: {
-      js: `// Workaround for react-datepicker and other cjs dependencies potentially inserting require("react") statements
+const resultClient = await esbuild.build({
+  entryPoints: ['src/exports/client/index.ts'],
+  bundle: true,
+  platform: 'browser',
+  format: 'esm',
+  outdir: 'dist/exports/client',
+  //outfile: 'index.js',
+  // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
+  splitting: true,
+  write: true, // required for useClientPlugin
+  banner: {
+    js: `// Workaround for react-datepicker and other cjs dependencies potentially inserting require("react") statements
 import * as requireReact from 'react';
 import * as requireReactDom from 'react-dom';
 
@@ -107,94 +106,81 @@ function require(m) {
 }
 // Workaround end
 `, // react-datepicker fails due to require("react") statements making it to the browser, which is not supported.
-      // This is a workaround to get it to work, without having to mark react-dateopicker as external
-      // See https://stackoverflow.com/questions/68423950/when-using-esbuild-with-external-react-i-get-dynamic-require-of-react-is-not-s
-    },
-    external: [
-      '*.scss',
-      '*.css',
-      'qs-esm',
-      '@dnd-kit/core',
-      '@payloadcms/graphql',
-      '@payloadcms/translations',
-      'dequal',
+    // This is a workaround to get it to work, without having to mark react-dateopicker as external
+    // See https://stackoverflow.com/questions/68423950/when-using-esbuild-with-external-react-i-get-dynamic-require-of-react-is-not-s
+  },
+  external: [
+    '*.scss',
+    '*.css',
+    'qs-esm',
+    '@dnd-kit/core',
+    '@payloadcms/graphql',
+    '@payloadcms/translations',
+    'dequal',
 
-      //'side-channel',
-      'payload',
-      'payload/*',
-      'react',
-      'react-dom',
-      'next',
-      'react-animate-height',
-      'crypto',
-    ],
-    //packages: 'external',
-    minify: true,
-    metafile: true,
-    treeShaking: true,
+    //'side-channel',
+    'payload',
+    'payload/*',
+    'react',
+    'react-dom',
+    'next',
+    'react-animate-height',
+    'crypto',
+  ],
+  //packages: 'external',
+  minify: true,
+  metafile: true,
+  treeShaking: true,
 
-    tsconfig: path.resolve(dirname, './tsconfig.json'),
-    plugins: [
-      removeCSSImports,
-      useClientPlugin, // required for banner to work
-      /*commonjs({
+  tsconfig: path.resolve(dirname, './tsconfig.json'),
+  plugins: [
+    removeCSSImports,
+    useClientPlugin, // required for banner to work
+    /*commonjs({
         ignore: ['date-fns', '@floating-ui/react'],
       }),*/
-    ],
-    sourcemap: true,
-  })
-  .then((res, err) => {
-    console.log('client.ts bundled successfully')
-    return res
-  })
-  .catch((e) => {
-    throw e
-  })
+  ],
+  sourcemap: true,
+})
+console.log('client.ts bundled successfully')
 
-const resultShared = await esbuild
-  .build({
-    entryPoints: ['src/exports/shared/index.ts'],
-    bundle: true,
-    platform: 'node',
-    format: 'esm',
-    outdir: 'dist/exports/shared',
-    //outfile: 'index.js',
-    // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
-    splitting: false,
-    treeShaking: true,
-    external: [
-      '*.scss',
-      '*.css',
-      'qs-esm',
-      '@dnd-kit/core',
-      '@payloadcms/graphql',
-      '@payloadcms/translations',
-      'dequal',
-      'payload',
-      'payload/*',
-      'react',
-      'react-dom',
-      'next',
-      'react-animate-height',
-      'crypto',
-      '@floating-ui/react',
-      'date-fns',
-      'react-datepicker',
-    ],
-    //packages: 'external',
-    minify: true,
-    metafile: true,
-    tsconfig: path.resolve(dirname, './tsconfig.json'),
-    plugins: [removeCSSImports, commonjs()],
-    sourcemap: true,
-  })
-  .then((res, err) => {
-    console.log('shared.ts bundled successfully')
-    return res
-  })
-  .catch((e) => {
-    throw e
-  })
+const resultShared = esbuild.buildSync({
+  entryPoints: ['src/exports/shared/index.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outdir: 'dist/exports/shared',
+  //outfile: 'index.js',
+  // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
+  splitting: false,
+  treeShaking: true,
+  external: [
+    '*.scss',
+    '*.css',
+    'qs-esm',
+    '@dnd-kit/core',
+    '@payloadcms/graphql',
+    '@payloadcms/translations',
+    'dequal',
+    'payload',
+    'payload/*',
+    'react',
+    'react-dom',
+    'next',
+    'react-animate-height',
+    'crypto',
+    '@floating-ui/react',
+    'date-fns',
+    'react-datepicker',
+  ],
+  //packages: 'external',
+  minify: true,
+  metafile: true,
+  tsconfig: path.resolve(dirname, './tsconfig.json'),
+  plugins: [removeCSSImports, commonjs()],
+  sourcemap: true,
+})
+console.log('shared.ts bundled successfully')
 
 fs.writeFileSync('meta_client.json', JSON.stringify(resultClient.metafile))
 fs.writeFileSync('meta_shared.json', JSON.stringify(resultShared.metafile))

--- a/packages/ui/bundle.js
+++ b/packages/ui/bundle.js
@@ -59,8 +59,8 @@ const useClientPlugin = {
 }
 
 // Bundle only the .scss files into a single css file
-esbuild
-  .buildSync({
+await esbuild
+  .build({
     entryPoints: ['src/exports/client/index.ts'],
     bundle: true,
     minify: true,
@@ -84,18 +84,19 @@ esbuild
   })
 
 // Bundle `client.ts`
-const resultClient = await esbuild.build({
-  entryPoints: ['src/exports/client/index.ts'],
-  bundle: true,
-  platform: 'browser',
-  format: 'esm',
-  outdir: 'dist/exports/client',
-  //outfile: 'index.js',
-  // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
-  splitting: true,
-  write: true, // required for useClientPlugin
-  banner: {
-    js: `// Workaround for react-datepicker and other cjs dependencies potentially inserting require("react") statements
+const resultClient = await esbuild
+  .build({
+    entryPoints: ['src/exports/client/index.ts'],
+    bundle: true,
+    platform: 'browser',
+    format: 'esm',
+    outdir: 'dist/exports/client',
+    //outfile: 'index.js',
+    // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
+    splitting: true,
+    write: true, // required for useClientPlugin
+    banner: {
+      js: `// Workaround for react-datepicker and other cjs dependencies potentially inserting require("react") statements
 import * as requireReact from 'react';
 import * as requireReactDom from 'react-dom';
 
@@ -106,81 +107,94 @@ function require(m) {
 }
 // Workaround end
 `, // react-datepicker fails due to require("react") statements making it to the browser, which is not supported.
-    // This is a workaround to get it to work, without having to mark react-dateopicker as external
-    // See https://stackoverflow.com/questions/68423950/when-using-esbuild-with-external-react-i-get-dynamic-require-of-react-is-not-s
-  },
-  external: [
-    '*.scss',
-    '*.css',
-    'qs-esm',
-    '@dnd-kit/core',
-    '@payloadcms/graphql',
-    '@payloadcms/translations',
-    'dequal',
+      // This is a workaround to get it to work, without having to mark react-dateopicker as external
+      // See https://stackoverflow.com/questions/68423950/when-using-esbuild-with-external-react-i-get-dynamic-require-of-react-is-not-s
+    },
+    external: [
+      '*.scss',
+      '*.css',
+      'qs-esm',
+      '@dnd-kit/core',
+      '@payloadcms/graphql',
+      '@payloadcms/translations',
+      'dequal',
 
-    //'side-channel',
-    'payload',
-    'payload/*',
-    'react',
-    'react-dom',
-    'next',
-    'react-animate-height',
-    'crypto',
-  ],
-  //packages: 'external',
-  minify: true,
-  metafile: true,
-  treeShaking: true,
+      //'side-channel',
+      'payload',
+      'payload/*',
+      'react',
+      'react-dom',
+      'next',
+      'react-animate-height',
+      'crypto',
+    ],
+    //packages: 'external',
+    minify: true,
+    metafile: true,
+    treeShaking: true,
 
-  tsconfig: path.resolve(dirname, './tsconfig.json'),
-  plugins: [
-    removeCSSImports,
-    useClientPlugin, // required for banner to work
-    /*commonjs({
+    tsconfig: path.resolve(dirname, './tsconfig.json'),
+    plugins: [
+      removeCSSImports,
+      useClientPlugin, // required for banner to work
+      /*commonjs({
         ignore: ['date-fns', '@floating-ui/react'],
       }),*/
-  ],
-  sourcemap: true,
-})
-console.log('client.ts bundled successfully')
+    ],
+    sourcemap: true,
+  })
+  .then((res, err) => {
+    console.log('client.ts bundled successfully')
+    return res
+  })
+  .catch((e) => {
+    throw e
+  })
 
-const resultShared = esbuild.buildSync({
-  entryPoints: ['src/exports/shared/index.ts'],
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  outdir: 'dist/exports/shared',
-  //outfile: 'index.js',
-  // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
-  splitting: false,
-  treeShaking: true,
-  external: [
-    '*.scss',
-    '*.css',
-    'qs-esm',
-    '@dnd-kit/core',
-    '@payloadcms/graphql',
-    '@payloadcms/translations',
-    'dequal',
-    'payload',
-    'payload/*',
-    'react',
-    'react-dom',
-    'next',
-    'react-animate-height',
-    'crypto',
-    '@floating-ui/react',
-    'date-fns',
-    'react-datepicker',
-  ],
-  //packages: 'external',
-  minify: true,
-  metafile: true,
-  tsconfig: path.resolve(dirname, './tsconfig.json'),
-  plugins: [removeCSSImports, commonjs()],
-  sourcemap: true,
-})
-console.log('shared.ts bundled successfully')
+const resultShared = await esbuild
+  .build({
+    entryPoints: ['src/exports/shared/index.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    outdir: 'dist/exports/shared',
+    //outfile: 'index.js',
+    // IMPORTANT: splitting the client bundle means that the `use client` directive will be lost for every chunk
+    splitting: false,
+    treeShaking: true,
+    external: [
+      '*.scss',
+      '*.css',
+      'qs-esm',
+      '@dnd-kit/core',
+      '@payloadcms/graphql',
+      '@payloadcms/translations',
+      'dequal',
+      'payload',
+      'payload/*',
+      'react',
+      'react-dom',
+      'next',
+      'react-animate-height',
+      'crypto',
+      '@floating-ui/react',
+      'date-fns',
+      'react-datepicker',
+    ],
+    //packages: 'external',
+    minify: true,
+    metafile: true,
+    tsconfig: path.resolve(dirname, './tsconfig.json'),
+    plugins: [removeCSSImports, commonjs()],
+    sourcemap: true,
+  })
+  .then((res, err) => {
+    console.log('shared.ts bundled successfully')
+    return res
+  })
+  .catch((e) => {
+    throw e
+  })
 
 fs.writeFileSync('meta_client.json', JSON.stringify(resultClient.metafile))
 fs.writeFileSync('meta_shared.json', JSON.stringify(resultShared.metafile))


### PR DESCRIPTION
We are suspecting that operations within those esbuild scripts are not awaited properly - potentially causing issues in the publish script, publishing the next package without any built .js files