### PR TITLE
fix: localised relationship fields

### DIFF
--- a/packages/next/src/utilities/createPayloadRequest.ts
+++ b/packages/next/src/utilities/createPayloadRequest.ts
@@ -47,15 +47,6 @@ export const createPayloadRequest = async ({
 
   let locale
   let fallbackLocale
-  if (config.localization) {
-    const locales = sanitizeLocales({
-      fallbackLocale: searchParams.get('fallback-locale'),
-      locale: searchParams.get('locale'),
-      localization: payload.config.localization,
-    })
-    locale = locales.locale
-    fallbackLocale = locales.fallbackLocale
-  }
 
   const overrideHttpMethod = request.headers.get('X-HTTP-Method-Override')
   const queryToParse = overrideHttpMethod === 'GET' ? await request.text() : urlProperties.search
@@ -67,6 +58,20 @@ export const createPayloadRequest = async ({
         ignoreQueryPrefix: true,
       })
     : {}
+
+  if (config.localization) {
+    const locales = sanitizeLocales({
+      fallbackLocale: searchParams.get('fallback-locale'),
+      locale: searchParams.get('locale'),
+      localization: payload.config.localization,
+    })
+    locale = locales.locale
+    fallbackLocale = locales.fallbackLocale
+
+    // Override if query params are present, in order to respect HTTP method override
+    if (query.locale) locale = query.locale
+    if (query?.['fallback-locale']) fallbackLocale = query['fallback-locale']
+  }
 
   const customRequest: CustomPayloadRequestProperties = {
     context: {},

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -234,6 +234,23 @@ describe('Localization', () => {
       await expect(page.locator('.row-1 .cell-title')).toContainText(spanishTitle)
     })
   })
+
+  describe('localized relationships', () => {
+    test('ensure relationship field fetches are localised as well', async () => {
+      await page.goto(url.list)
+      await changeLocale(page, spanishLocale)
+
+      const localisedPost = page.locator('.cell-title a').first()
+      const localisedPostUrl = await localisedPost.getAttribute('href')
+      await page.goto(serverURL + localisedPostUrl)
+      await page.waitForURL(serverURL + localisedPostUrl)
+
+      const selectField = page.locator('#field-children .rs__control')
+      await selectField.click()
+
+      await expect(page.locator('#field-children .rs__menu')).toContainText('spanish-relation2')
+    })
+  })
 })
 
 async function fillValues(data: Partial<LocalizedPost>) {


### PR DESCRIPTION
Fixes the issue where locale is not passed into the relationship field resulting in documents without titles in some situations

![image](https://github.com/user-attachments/assets/67f0a70c-29a0-4f54-a395-f4aa9b132d6f)
