### PR TITLE
fix: version comparison view showing empty localized fields

### DIFF
--- a/packages/next/src/views/Version/Default/index.tsx
+++ b/packages/next/src/views/Version/Default/index.tsx
@@ -74,7 +74,7 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
 
   const [{ data: currentComparisonDoc }] = usePayloadAPI(compareFetchURL, {
     initialData: initialComparisonDoc,
-    initialParams: { depth: 1, draft: 'true', locale: '*' },
+    initialParams: { depth: 1, draft: 'true', locale: 'all' },
   })
 
   const comparison = compareValue?.value && currentComparisonDoc?.version // the `version` key is only present on `versions` documents


### PR DESCRIPTION
## Description

Localized fields show no data for the base comparison data in the version comparison view.

Before:
<img width="1419" alt="Screenshot 2024-07-16 at 4 48 45 PM" src="https://github.com/user-attachments/assets/c4c063a6-41c1-41a5-92b3-ff7d1febe9f1">

After:
<img width="1382" alt="Screenshot 2024-07-16 at 4 46 31 PM" src="https://github.com/user-attachments/assets/bbfa9faf-2753-450d-a911-fbbca27ab051">

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes