### PR TITLE
fix(ui): date field background color specificity

### DIFF
--- a/packages/ui/src/elements/DatePicker/index.scss
+++ b/packages/ui/src/elements/DatePicker/index.scss
@@ -189,7 +189,9 @@ $cal-icon-width: 18px;
       border-right: 1px solid var(--theme-elevation-150);
     }
 
-    &__time {
+    &__time,
+    &__time-container,
+    .react-datepicker__time-container .react-datepicker__time {
       background: none;
     }
 


### PR DESCRIPTION
## Description

Fixes `date` field background in dark mode.

Before:
<img width="464" alt="Screenshot 2024-07-16 at 5 22 42 PM" src="https://github.com/user-attachments/assets/90235512-bd97-4b0a-b7b8-3e4ce49a8ba2">

After:
<img width="502" alt="Screenshot 2024-07-16 at 5 22 53 PM" src="https://github.com/user-attachments/assets/ce3f5bc9-8693-4fc8-a0e3-d0042a92756f">

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Chore (non-breaking change which does not add functionality)
