### PR TITLE
fix (uploads): correctly prescale image before extracting focal area

### DIFF
--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -291,11 +291,26 @@ export default async function resizeAndTransformImageSizes({
           resizeHeight = Math.round(resizeWidth / originalAspectRatio)
         }
 
+        const resizeAspectRatio = resizeWidth / resizeHeight
+        let scaleDownWidth, scaleDownHeight
+
+        if(resizeAspectRatio > originalAspectRatio) {
+          // target has a wider ratio than orig
+          // -> use resizeWidth and scale height using orig aspect ratio
+          scaleDownHeight = Math.round(resizeWidth / originalAspectRatio);
+          scaleDownWidth = resizeWidth
+        }else{
+          // target has a taller ratio than orig
+          // -> use resizeHeight and scale width using orig aspect ratio
+          scaleDownHeight = resizeHeight
+          scaleDownWidth = Math.round(resizeHeight * originalAspectRatio);
+        }
+
         // Scale the image up or down to fit the resize dimensions
         const scaledImage = imageToResize.resize({
-          height: resizeHeight,
-          width: resizeWidth,
-        })
+          height: scaleDownHeight,
+          width: scaleDownWidth
+        });
 
         const { info: scaledImageInfo } = await scaledImage.toBuffer({ resolveWithObject: true })
 


### PR DESCRIPTION
Related: #6733

## Description

It seems that the latest changes in #6733 to the [`imageResizer.ts`](https://github.com/payloadcms/payload/commit/e40570bd0d64660bb2ae5b5785b4c85c684ca9ab#diff-594a17f5c5ab1ba4ba4a8e705ee2976011cb9fd064f03c3f01ed8420ac49a090) broke the focal-point calculations, meaning they are not taken in consideration anymore when images are resized (all images are resized centered).

### The bug

E.g. image 16x9px should be resized to 5x5px with the focal-point in the bottom-right corner
 - to create a fixed aspect ratio image size both height and width are set in the resize config, here `{width: 5, height: 5}`
 - line [296](https://github.com/payloadcms/payload/commit/e40570bd0d64660bb2ae5b5785b4c85c684ca9ab#diff-594a17f5c5ab1ba4ba4a8e705ee2976011cb9fd064f03c3f01ed8420ac49a090R296): this causes that the scaled-down image is already 1:1 and 5x5px
 - line [304](https://github.com/payloadcms/payload/commit/e40570bd0d64660bb2ae5b5785b4c85c684ca9ab#diff-594a17f5c5ab1ba4ba4a8e705ee2976011cb9fd064f03c3f01ed8420ac49a090R304): afterwards the focal-point is calculated but on the scaled-down image
 - line [327](https://github.com/payloadcms/payload/commit/e40570bd0d64660bb2ae5b5785b4c85c684ca9ab#diff-594a17f5c5ab1ba4ba4a8e705ee2976011cb9fd064f03c3f01ed8420ac49a090R327): causing the focal-area to be extracted to always fit 1:1 the already scaled-down image 
 which results in an image with a full-center-positioned-focal-point

### The fix

My fix adds an inbetween step and creates a scaled down image based on the OG aspect ratio and the new aspect ratio and from that the focal area can correctly be extracted.
 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes