### PR TITLE
fix: webpack error if dbName or enumName is set

### DIFF
--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -5,7 +5,9 @@ import type { Field, FieldBase } from '../../fields/config/types.js'
 export type ClientFieldConfig = Omit<Field, 'access' | 'defaultValue' | 'hooks' | 'validate'>
 
 export type ServerOnlyFieldProperties =
+  | 'dbName' // can be a function
   | 'editor' // This is a `richText` only property
+  | 'enumName' // can be a function
   | 'filterOptions' // This is a `relationship` and `upload` only property
   | 'label'
   | 'typescriptSchema'
@@ -35,6 +37,8 @@ export const createClientFieldConfig = ({
     'editor', // This is a `richText` only property
     'custom',
     'typescriptSchema',
+    'dbName', // can be a function
+    'enumName', // can be a function
     // `fields`
     // `blocks`
     // `tabs`


### PR DESCRIPTION
Something like this:

```ts
  {
    name: 'select',
    type: 'select',
    dbName: ({ tableName }) => `${tableName}_customSelect`,
    enumName: 'selectEnum',
    hasMany: true,
    options: ['a', 'b', 'c'],
},
```
        
caused the "Functions cannot be passed directly to Client Components" error, as the dbName function was sent to the client.

Now, you can run `pnpm dev database` again without it erroring