### PR TITLE
feat: add db defaultIDType to generated payload types

### DIFF
--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -118,7 +118,7 @@ function generateAuthEntitySchemas(entities: SanitizedCollectionConfig[]): JSONS
  */
 function generateDbEntitySchema(config: SanitizedConfig): JSONSchema4 {
   const idType: JSONSchema4 =
-    config.db.defaultIDType === 'text' ? { type: 'string' } : { type: 'number' }
+    config.db?.defaultIDType === 'number' ? { type: 'number' } : { type: 'string' }
 
   return {
     type: 'object',

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -117,16 +117,16 @@ function generateAuthEntitySchemas(entities: SanitizedCollectionConfig[]): JSONS
  * @example { db: idType: string }
  */
 function generateDbEntitySchema(config: SanitizedConfig): JSONSchema4 {
-  const idType: JSONSchema4 =
+  const defaultIDType: JSONSchema4 =
     config.db?.defaultIDType === 'number' ? { type: 'number' } : { type: 'string' }
 
   return {
     type: 'object',
     additionalProperties: false,
     properties: {
-      idType,
+      defaultIDType,
     },
-    required: ['idType'],
+    required: ['defaultIDType'],
   }
 }
 

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -112,6 +112,25 @@ function generateAuthEntitySchemas(entities: SanitizedCollectionConfig[]): JSONS
 }
 
 /**
+ * Generates the JSON Schema for database configuration
+ *
+ * @example { db: idType: string }
+ */
+function generateDbEntitySchema(config: SanitizedConfig): JSONSchema4 {
+  const idType: JSONSchema4 =
+    config.db.defaultIDType === 'text' ? { type: 'string' } : { type: 'number' }
+
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      idType,
+    },
+    required: ['idType'],
+  }
+}
+
+/**
  * Returns a JSON Schema Type with 'null' added if the field is not required.
  */
 export function withNullableJSONSchemaType(
@@ -713,11 +732,12 @@ export function configToJSONSchema(
     properties: {
       auth: generateAuthOperationSchemas(config.collections),
       collections: generateEntitySchemas(config.collections || []),
+      db: generateDbEntitySchema(config),
       globals: generateEntitySchemas(config.globals || []),
       locale: generateLocaleEntitySchemas(config.localization),
       user: generateAuthEntitySchemas(config.collections),
     },
-    required: ['user', 'locale', 'collections', 'globals', 'auth'],
+    required: ['user', 'locale', 'collections', 'globals', 'auth', 'db'],
     title: 'Config',
   }
 


### PR DESCRIPTION
Makes it so generated types now includes a `db` object with `idType` set to `string` or `number` depending on the database

```ts
db: {
  defaultIDType: number;
};
```