### PR TITLE
fix: type error due to invalid relative path

### DIFF
--- a/packages/bundler-webpack/src/index.ts
+++ b/packages/bundler-webpack/src/index.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-import type { PayloadBundler } from '../../payload/dist/bundlers/types'
+import type { PayloadBundler } from 'payload/dist/bundlers/types'
 
 import { buildAdmin } from './scripts/build'
 import { devAdmin } from './scripts/dev'


### PR DESCRIPTION
## Description

Fix the following typescript error that shows up when building when `skipLibCheck: true` is NOT present in `tsconfig.json`:

```
node_modules/@payloadcms/bundler-webpack/dist/index.d.ts:1:37 - error TS2307: Cannot find module '../../payload/dist/bundlers/types' or its corresponding type declarations.

1 import type { PayloadBundler } from '../../payload/dist/bundlers/types';
```
The path is clearly incorrect since going two directories up from `@payloadcms/bundler-webpack/dist/` resolves to `@payloadcms/` which is not where `payload` package is located.

Fix by referring to the package name instead of using relative path.

Also I didn't see the point of the eslint-ignore comment. I think it might have been a remnant of the past where there existed a code that needed it.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
