### PR TITLE
fix: passes onSave to DocumentDrawer in multi-value label for relationship field

### DIFF
--- a/packages/payload/src/admin/components/forms/field-types/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Relationship/select-components/MultiValueLabel/index.tsx
@@ -24,7 +24,8 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
         draggableProps,
         // @ts-expect-error // TODO Fix this - moduleResolution 16 breaks our declare module
         setDrawerIsOpen,
-        // onSave,
+        // @ts-expect-error // TODO Fix this - moduleResolution 16 breaks our declare module
+        onSave,
       } = {},
     } = {},
   } = props
@@ -70,7 +71,7 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
             </Tooltip>
             <Edit />
           </DocumentDrawerToggler>
-          <DocumentDrawer onSave={/* onSave */ null} />
+          <DocumentDrawer onSave={onSave} />
         </Fragment>
       )}
     </div>


### PR DESCRIPTION
## Description

`Issue`: editing a selected document's `title` within a drawer in a `hasMany: true` relationship field would not trigger a refresh after saving the selected document from within the drawer. 

`Fix`: Pass the `onSave` function to the `DocumentDrawer` in the `MultiValueLabel` component for the relationship field.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
