### PR TITLE
fix(ui): passes onSave to DocumentDrawer in multi-value label for relationship field

### DIFF
--- a/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
@@ -24,8 +24,9 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
         // @ts-expect-error-next-line// TODO Fix this - moduleResolution 16 breaks our declare module
         draggableProps,
         // @ts-expect-error-next-line // TODO Fix this - moduleResolution 16 breaks our declare module
+        onSave,
+        // @ts-expect-error-next-line // TODO Fix this - moduleResolution 16 breaks our declare module
         setDrawerIsOpen,
-        // onSave,
       } = {},
     } = {},
   } = props
@@ -77,7 +78,7 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
             </Tooltip>
             <EditIcon className={`${baseClass}__icon`} />
           </DocumentDrawerToggler>
-          <DocumentDrawer onSave={/* onSave */ null} />
+          <DocumentDrawer onSave={onSave} />
         </Fragment>
       )}
     </div>


### PR DESCRIPTION
## Description

V2 PR [here](https://github.com/payloadcms/payload/pull/7205)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
