### PR TITLE
chore(translations, ui): updates `addImage` translation to `addFile` translation

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -259,7 +259,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'upload:crop',
   'upload:cropToolDescription',
   'upload:dragAndDrop',
-  'upload:addImage',
+  'upload:addFile',
   'upload:editImage',
   'upload:focalPoint',
   'upload:focalPointDescription',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -317,7 +317,7 @@ export const arTranslations: DefaultTranslationsObject = {
     within: 'في غضون',
   },
   upload: {
-    addImage: 'إضافة صورة',
+    addFile: 'إضافة ملف',
     crop: 'محصول',
     cropToolDescription: 'اسحب الزوايا المحددة للمنطقة، رسم منطقة جديدة أو قم بضبط القيم أدناه.',
     dragAndDrop: 'قم بسحب وإسقاط ملفّ',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -320,7 +320,7 @@ export const azTranslations: DefaultTranslationsObject = {
     within: 'daxilinde',
   },
   upload: {
-    addImage: 'Şəkil əlavə et',
+    addFile: 'Fayl əlavə et',
     crop: 'Məhsul',
     cropToolDescription:
       'Seçilmiş sahənin köşələrini sürükləyin, yeni bir sahə çəkin və ya aşağıdakı dəyərləri düzəltin.',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -318,7 +318,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     within: 'в рамките на',
   },
   upload: {
-    addImage: 'Добавяне на изображение',
+    addFile: 'Добавяне на файл',
     crop: 'Изрязване',
     cropToolDescription:
       'Плъзни ъглите на избраната област, избери нова област или коригирай стойностите по-долу.',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -318,7 +318,7 @@ export const csTranslations: DefaultTranslationsObject = {
     within: 'uvnitř',
   },
   upload: {
-    addImage: 'Přidat obrázek',
+    addFile: 'Přidat soubor',
     crop: 'Ořez',
     cropToolDescription:
       'Přetáhněte rohy vybrané oblasti, nakreslete novou oblast nebo upravte níže uvedené hodnoty.',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -324,7 +324,7 @@ export const deTranslations: DefaultTranslationsObject = {
     within: 'innerhalb',
   },
   upload: {
-    addImage: 'Bild hinzufügen',
+    addFile: 'Datei hinzufügen',
     crop: 'Zuschneiden',
     cropToolDescription:
       'Ziehen Sie die Ecken des ausgewählten Bereichs, zeichnen Sie einen neuen Bereich oder passen Sie die Werte unten an.',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -321,7 +321,7 @@ export const enTranslations = {
     within: 'within',
   },
   upload: {
-    addImage: 'Add Image',
+    addFile: 'Add File',
     crop: 'Crop',
     cropToolDescription:
       'Drag the corners of the selected area, draw a new area or adjust the values below.',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -323,7 +323,7 @@ export const esTranslations: DefaultTranslationsObject = {
     within: 'dentro de',
   },
   upload: {
-    addImage: 'Añadir imagen',
+    addFile: 'Añadir archivo',
     crop: 'Cultivo',
     cropToolDescription:
       'Arrastra las esquinas del área seleccionada, dibuja un nuevo área o ajusta los valores a continuación.',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -318,7 +318,7 @@ export const faTranslations: DefaultTranslationsObject = {
     within: 'در داخل',
   },
   upload: {
-    addImage: 'اضافه کردن تصویر',
+    addFile: 'اضافه کردن فایل',
     crop: 'محصول',
     cropToolDescription:
       'گوشه‌های منطقه انتخاب شده را بکشید، یک منطقه جدید رسم کنید یا مقادیر زیر را تنظیم کنید.',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -327,7 +327,7 @@ export const frTranslations: DefaultTranslationsObject = {
     within: 'dans',
   },
   upload: {
-    addImage: 'Ajouter une image',
+    addFile: 'Ajouter un fichier',
     crop: 'Recadrer',
     cropToolDescription:
       'Faites glisser les coins de la zone sélectionnée, dessinez une nouvelle zone ou ajustez les valeurs ci-dessous.',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -313,7 +313,7 @@ export const heTranslations: DefaultTranslationsObject = {
     within: 'בתוך',
   },
   upload: {
-    addImage: 'הוסף תמונה',
+    addFile: 'הוסף קובץ',
     crop: 'חתוך',
     cropToolDescription: 'גרור את הפינות של האזור שנבחר, צייר אזור חדש או התאם את הערכים למטה.',
     dragAndDrop: 'גרור ושחרר קובץ',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -319,7 +319,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     within: 'unutar',
   },
   upload: {
-    addImage: 'Dodaj sliku',
+    addFile: 'Dodaj datoteku',
     crop: 'Usjev',
     cropToolDescription:
       'Povucite kutove odabranog područja, nacrtajte novo područje ili prilagodite vrijednosti ispod.',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -321,7 +321,7 @@ export const huTranslations: DefaultTranslationsObject = {
     within: 'belül',
   },
   upload: {
-    addImage: 'Kép hozzáadása',
+    addFile: 'Fájl hozzáadása',
     crop: 'Termés',
     cropToolDescription:
       'Húzza a kijelölt terület sarkait, rajzoljon új területet, vagy igazítsa a lentebb található értékeket.',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -321,7 +321,7 @@ export const itTranslations: DefaultTranslationsObject = {
     within: "all'interno",
   },
   upload: {
-    addImage: 'Aggiungi immagine',
+    addFile: 'Aggiungi file',
     crop: 'Raccolto',
     cropToolDescription:
       "Trascina gli angoli dell'area selezionata, disegna una nuova area o regola i valori qui sotto.",

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -319,7 +319,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     within: '内で',
   },
   upload: {
-    addImage: '画像を追加',
+    addFile: 'ファイルを追加',
     crop: 'クロップ',
     cropToolDescription:
       '選択したエリアのコーナーをドラッグしたり、新たなエリアを描画したり、下記の値を調整してください。',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -318,7 +318,7 @@ export const koTranslations: DefaultTranslationsObject = {
     within: '내에서',
   },
   upload: {
-    addImage: '이미지 추가',
+    addFile: '파일 추가',
     crop: '자르기',
     cropToolDescription:
       '선택한 영역의 모퉁이를 드래그하거나 새로운 영역을 그리거나 아래의 값을 조정하세요.',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -322,7 +322,7 @@ export const myTranslations: DefaultTranslationsObject = {
     within: 'အတွင်း',
   },
   upload: {
-    addImage: 'ပုံ ထည့်ပါ',
+    addFile: 'ဖိုင်ထည့်ပါ',
     crop: 'သုန်း',
     cropToolDescription:
       'ရွေးထားသည့်ဧရိယာတွင်မွေးလျှက်မှုများကိုဆွဲပြီး, အသစ်တည်ပြီးသို့မဟုတ်အောက်ပါတ',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -319,7 +319,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     within: 'innen',
   },
   upload: {
-    addImage: 'Legg til bilde',
+    addFile: 'Legg til fil',
     crop: 'Beskjær',
     cropToolDescription:
       'Dra hjørnene av det valgte området, tegn et nytt område eller juster verdiene nedenfor.',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -321,7 +321,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     within: 'binnen',
   },
   upload: {
-    addImage: 'Afbeelding toevoegen',
+    addFile: 'Bestand toevoegen',
     crop: 'Bijsnijden',
     cropToolDescription:
       'Sleep de hoeken van het geselecteerde gebied, teken een nieuw gebied of pas de waarden hieronder aan.',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -319,7 +319,7 @@ export const plTranslations: DefaultTranslationsObject = {
     within: 'w ciągu',
   },
   upload: {
-    addImage: 'Dodaj obraz',
+    addFile: 'Dodaj plik',
     crop: 'Przytnij',
     cropToolDescription:
       'Przeciągnij narożniki wybranego obszaru, narysuj nowy obszar lub dostosuj poniższe wartości.',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -320,7 +320,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     within: 'dentro',
   },
   upload: {
-    addImage: 'Adicionar imagem',
+    addFile: 'Adicionar arquivo',
     crop: 'Cultura',
     cropToolDescription:
       'Arraste as bordas da área selecionada, desenhe uma nova área ou ajuste os valores abaixo.',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -323,7 +323,7 @@ export const roTranslations: DefaultTranslationsObject = {
     within: 'înăuntru',
   },
   upload: {
-    addImage: 'Adaugă imagine',
+    addFile: 'Adaugă fișier',
     crop: 'Cultură',
     cropToolDescription:
       'Trageți colțurile zonei selectate, desenați o nouă zonă sau ajustați valorile de mai jos.',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -318,7 +318,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     within: 'unutar',
   },
   upload: {
-    addImage: 'Додај слику',
+    addFile: 'Додај датотеку',
     crop: 'Исеците слику',
     cropToolDescription:
       'Превуците углове изабраног подручја, нацртајте ново подручје или прилагодите вредности испод.',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -318,7 +318,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     within: 'unutar',
   },
   upload: {
-    addImage: 'Dodaj sliku',
+    addFile: 'Dodaj datoteku',
     crop: 'Isecite sliku',
     cropToolDescription:
       'Prevucite uglove izabranog područja, nacrtajte novo područje ili prilagodite vrednosti ispod.',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -322,7 +322,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     within: 'в пределах',
   },
   upload: {
-    addImage: 'Добавить изображение',
+    addFile: 'Добавить файл',
     crop: 'Обрезать',
     cropToolDescription:
       'Перетащите углы выбранной области, нарисуйте новую область или отрегулируйте значения ниже.',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -320,7 +320,7 @@ export const skTranslations: DefaultTranslationsObject = {
     within: 'vnútri',
   },
   upload: {
-    addImage: 'Pridať obrázok',
+    addFile: 'Pridať súbor',
     crop: 'Orezať',
     cropToolDescription:
       'Potiahnite rohy vybranej oblasti, nakreslite novú oblasť alebo upravte hodnoty nižšie.',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -319,7 +319,7 @@ export const svTranslations: DefaultTranslationsObject = {
     within: 'inom',
   },
   upload: {
-    addImage: 'Lägg till bild',
+    addFile: 'Lägg till fil',
     crop: 'Skörd',
     cropToolDescription:
       'Dra i hörnen på det valda området, rita ett nytt område eller justera värdena nedan.',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -315,7 +315,7 @@ export const thTranslations: DefaultTranslationsObject = {
     within: 'ภายใน',
   },
   upload: {
-    addImage: 'เพิ่มรูปภาพ',
+    addFile: 'เพิ่มไฟล์',
     crop: 'พืชผล',
     cropToolDescription: 'ลากมุมของพื้นที่ที่เลือก, วาดพื้นที่ใหม่หรือปรับค่าด้านล่าง',
     dragAndDrop: 'ลากและวางไฟล์',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -323,7 +323,7 @@ export const trTranslations: DefaultTranslationsObject = {
     within: 'içinde',
   },
   upload: {
-    addImage: 'Resim ekle',
+    addFile: 'Dosya ekle',
     crop: 'Mahsulat',
     cropToolDescription:
       'Seçilen alanın köşelerini sürükleyin, yeni bir alan çizin ya da aşağıdaki değerleri ayarlayın.',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -319,7 +319,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     within: 'в межах',
   },
   upload: {
-    addImage: 'Додати зображення',
+    addFile: 'Додати файл',
     crop: 'Обрізати',
     cropToolDescription:
       'Перетягніть кути обраної області, намалюйте нову область або скоригуйте значення нижче.',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -317,7 +317,7 @@ export const viTranslations: DefaultTranslationsObject = {
     within: 'trong',
   },
   upload: {
-    addImage: 'Thêm hình ảnh',
+    addFile: 'Thêm tập tin',
     crop: 'Mùa vụ',
     cropToolDescription:
       'Kéo các góc của khu vực đã chọn, vẽ một khu vực mới hoặc điều chỉnh các giá trị dưới đây.',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -311,7 +311,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     within: '在...之内',
   },
   upload: {
-    addImage: '添加图片',
+    addFile: '添加文件',
     crop: '作物',
     cropToolDescription: '拖动所选区域的角落，绘制一个新区域或调整以下的值。',
     dragAndDrop: '拖放一个文件',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -311,7 +311,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     within: '在...之內',
   },
   upload: {
-    addImage: '添加圖片',
+    addFile: '添加文件',
     crop: '裁剪',
     cropToolDescription: '拖動所選區域的角落，繪製一個新區域或調整以下的值。',
     dragAndDrop: '拖放一個檔案',

--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { FormState, SanitizedCollectionConfig , UploadEdits } from 'payload'
+import type { FormState, SanitizedCollectionConfig, UploadEdits } from 'payload'
 
 import { useForm, useUploadEdits } from '@payloadcms/ui'
 import { isImage, reduceFieldsToValues } from 'payload/shared'
@@ -268,7 +268,7 @@ export const Upload: React.FC<UploadProps> = (props) => {
                     onClick={handleUrlSubmit}
                     type="button"
                   >
-                    {t('upload:addImage')}
+                    {t('upload:addFile')}
                   </button>
                 </div>
               </div>

--- a/test/fields/collections/Upload/e2e.spec.ts
+++ b/test/fields/collections/Upload/e2e.spec.ts
@@ -100,8 +100,8 @@ describe('Upload', () => {
     const inputField = page.locator('.file-field__upload .file-field__remote-file')
     await inputField.fill(remoteImage)
 
-    const addImageButton = page.locator('.file-field__add-file')
-    await addImageButton.click()
+    const addFileButton = page.locator('.file-field__add-file')
+    await addFileButton.click()
 
     await expect(page.locator('.file-field .file-field__filename')).toHaveValue('og-image.jpg')
 


### PR DESCRIPTION
## Description

For remote url uploads, changes `Add Image` button text to `Add File`.

![Screenshot 2024-07-19 at 9 29 35 AM](https://github.com/user-attachments/assets/c7ecd17b-a18f-4dd4-a90e-bb669689c624)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
