### PR TITLE
chore: re-enables onSave for multi-select relationship drawer updates

### DIFF
--- a/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
@@ -25,7 +25,8 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
         draggableProps,
         // @ts-expect-error-next-line // TODO Fix this - moduleResolution 16 breaks our declare module
         setDrawerIsOpen,
-        // onSave,
+        // @ts-expect-error-next-line // TODO Fix this - moduleResolution 16 breaks our declare module
+        onSave,
       } = {},
     } = {},
   } = props
@@ -77,7 +78,7 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
             </Tooltip>
             <EditIcon className={`${baseClass}__icon`} />
           </DocumentDrawerToggler>
-          <DocumentDrawer onSave={/* onSave */ null} />
+          <DocumentDrawer onSave={onSave} />
         </Fragment>
       )}
     </div>


### PR DESCRIPTION
## Description

`onSave` was not being called when a multi-select relationship select document was edited.

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
