### PR TITLE
Updates all of the Readme localhost:3000 Code to Links

### DIFF
--- a/examples/auth/payload/README.md
+++ b/examples/auth/payload/README.md
@@ -15,7 +15,7 @@ To spin up this example locally, follow these steps:
 2. `cd` into this directory and run `yarn` or `npm install`
 3. `cp .env.example .env` to copy the example environment variables
 4. `yarn dev` or `npm run dev` to start the server and seed the database
-5. `open http://localhost:3000/admin` to access the admin panel
+5. Open [http://localhost:3000/admin](http://localhost:3000/admin)  to access the admin panel
 6. Login with email `demo@payloadcms.com` and password `demo`
 
 That's it! Changes made in `./src` will be reflected in your app. See the [Development](#development) section for more details.

--- a/examples/custom-server/README.md
+++ b/examples/custom-server/README.md
@@ -9,7 +9,7 @@ To spin up this example locally, follow these steps:
 1. First clone the repo
 1. Then `cd YOUR_PROJECT_REPO && cp .env.example .env`
 1. Next `yarn && yarn dev`
-1. Now `open http://localhost:3000/admin` to access the admin panel
+1. Now Open [http://localhost:3000/admin](http://localhost:3000/admin)  to access the admin panel
 1. Login with email `demo@payloadcms.com` and password `demo`
 
 That's it! Changes made in `./src` will be reflected in your app. See the [Development](#development) section for more details.

--- a/examples/draft-preview/payload/README.md
+++ b/examples/draft-preview/payload/README.md
@@ -13,7 +13,7 @@ Follow the instructions in each respective README to get started. If you are set
 2. `cd` into this directory and run `yarn` or `npm install`
 3. `cp .env.example .env` to copy the example environment variables
 4. `yarn dev` or `npm run dev` to start the server and seed the database
-5. `open http://localhost:3000/admin` to access the admin panel
+5. Open [http://localhost:3000/admin](http://localhost:3000/admin)  to access the admin panel
 6. Login with email `demo@payloadcms.com` and password `demo`
 
 That's it! Changes made in `./src` will be reflected in your app. See the [Development](#development) section for more details.

--- a/examples/hierarchy/README.md
+++ b/examples/hierarchy/README.md
@@ -9,7 +9,7 @@ To spin up the project locally, follow these steps:
 1. First clone the repo
 1. Then `cd YOUR_PROJECT_REPO && cp .env.example .env`
 1. Next `yarn && yarn dev` (or `docker-compose up`, see [Docker](#docker))
-1. Now `open http://localhost:3000/admin` to access the admin panel
+1. Now Open [http://localhost:3000/admin](http://localhost:3000/admin)  to access the admin panel
 1. Create your first admin user using the form on the page
 
 That's it! Changes made in `./src` will be reflected in your app.

--- a/examples/live-preview/payload/README.md
+++ b/examples/live-preview/payload/README.md
@@ -15,7 +15,7 @@ Follow the instructions in each respective README to get started. If you are set
 2. `cd` into this directory and run `yarn` or `npm install`
 3. `cp .env.example .env` to copy the example environment variables
 4. `yarn dev` or `npm run dev` to start the server and seed the database
-5. `open http://localhost:3000/admin` to access the admin panel
+5. Open [http://localhost:3000/admin](http://localhost:3000/admin)  to access the admin panel
 6. Login with email `demo@payloadcms.com` and password `demo`
 
 That's it! Changes made in `./src` will be reflected in your app. See the [Development](#development) section for more details.

--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -9,7 +9,7 @@ To spin up this example locally, follow these steps:
 1. First clone the repo
 1. Then `cd YOUR_PROJECT_REPO && cp .env.example .env`
 1. Next `yarn && yarn dev`
-1. Now `open http://localhost:3000/admin` to access the admin panel
+1. Now Open [http://localhost:3000/admin](http://localhost:3000/admin)  to access the admin panel
 1. Login with email `demo@payloadcms.com` and password `demo`
 
 That's it! Changes made in `./src` will be reflected in your app. See the [Development](#development) section for more details on how to log in as a tenant.

--- a/examples/nested-docs/payload/README.md
+++ b/examples/nested-docs/payload/README.md
@@ -17,7 +17,7 @@ To spin up this example locally, follow these steps:
 2. `cd` into this directory and run `yarn` or `npm install`
 3. `cp .env.example .env` to copy the example environment variables
 4. `yarn dev` or `npm run dev` to start the server and seed the database
-5. `open http://localhost:3000/admin` to access the admin panel
+5. Open [http://localhost:3000/admin](http://localhost:3000/admin)  to access the admin panel
 6. Login with email `demo@payloadcms.com` and password `demo`
 
 ## How it works

--- a/examples/redirects/payload/README.md
+++ b/examples/redirects/payload/README.md
@@ -16,7 +16,7 @@ To spin up this example locally, follow these steps:
 2. `cd` into this directory and run `yarn` or `npm install`
 3. `cp .env.example .env` to copy the example environment variables
 4. `yarn dev` or `npm run dev` to start the server and seed the database
-5. `open http://localhost:3000/admin` to access the admin panel
+5. Open [http://localhost:3000/admin](http://localhost:3000/admin)  to access the admin panel
 6. Login with email `demo@payloadcms.com` and password `demo`
 
 ## How it works

--- a/templates/blank/README.md
+++ b/templates/blank/README.md
@@ -11,7 +11,7 @@ To spin up the project locally, follow these steps:
 1. First clone the repo
 1. Then `cd YOUR_PROJECT_REPO && cp .env.example .env`
 1. Next `yarn && yarn dev` (or `docker-compose up`, see [Docker](#docker))
-1. Now `open http://localhost:3000/admin` to access the admin panel
+1. Now Open [http://localhost:3000/admin](http://localhost:3000/admin)  to access the admin panel
 1. Create your first admin user using the form on the page
 
 That's it! Changes made in `./src` will be reflected in your app.

--- a/templates/ecommerce/README.md
+++ b/templates/ecommerce/README.md
@@ -49,7 +49,7 @@ If you have not done so already, you need to have standalone copy of this repo o
 1. First [clone the repo](#clone) if you have not done so already
 1. `cd my-project && cp .env.example .env` to copy the example environment variables
 1. `yarn && yarn dev` to install dependencies and start the dev server
-1. `open http://localhost:3000` to open the app in your browser
+1. Open [http://localhost:3000](http://localhost:3000) to open the app in your browser
 
 That's it! Changes made in `./src` will be reflected in your app. Follow the on-screen instructions to login and create your first admin user. To begin accepting payment, follow the [Stripe](#stripe) guide. Then check out [Production](#production) once you're ready to build and serve your app, and [Deployment](#deployment) when you're ready to go live.
 

--- a/templates/website/README.md
+++ b/templates/website/README.md
@@ -50,7 +50,7 @@ If you have not done so already, you need to have standalone copy of this repo o
 1. First [clone the repo](#clone) if you have not done so already
 1. `cd my-project && cp .env.example .env` to copy the example environment variables
 1. `yarn && yarn dev` to install dependencies and start the dev server
-1. `open http://localhost:3000` to open the app in your browser
+1. Open [http://localhost:3000](http://localhost:3000) to open the app in your browser
 
 That's it! Changes made in `./src` will be reflected in your app. Follow the on-screen instructions to login and create your first admin user. Then check out [Production](#production) once you're ready to build and serve your app, and [Deployment](#deployment) when you're ready to go live.
 


### PR DESCRIPTION
## Description

### Issue
In the `README.md` documentation, there was a line of Markdown that followed this structure:

`open http://localhost:3000/admin` to access the admin panel

### Solution
This update changes the lines to include a clickable link, instead of rendering the instruction as code.
Examples:

Open [http://localhost:3000/](http://localhost:3000/) to open the app in your browser
Open [http://localhost:3000/admin](http://localhost:3000/admin) to access the admin panel

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [x] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)

## Checklist:

- [N/A] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
