### PR TITLE
fix: search plugin localized fields

### DIFF
--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -32,6 +32,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
           pluginSearchRead: true,
         },
         locale: 'all',
+        overrideAccess: false,
         req,
       })
     }
@@ -72,6 +73,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
             ...dataToSave,
             priority: defaultPriority,
           },
+          overrideAccess: false,
           req,
         })
       }
@@ -83,6 +85,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
         const searchDocQuery = await payload.find({
           collection: 'search',
           depth: 0,
+          overrideAccess: false,
           req,
           where: {
             'doc.value': {
@@ -105,6 +108,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
             const duplicativeDocIDs = duplicativeDocs.map(({ id }) => id)
             await payload.delete({
               collection: 'search',
+              overrideAccess: false,
               req,
               where: { id: { in: duplicativeDocIDs } },
             })
@@ -126,6 +130,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
                   ...dataToSave,
                   priority: foundDoc.priority || defaultPriority,
                 },
+                overrideAccess: false,
                 req,
               })
             } catch (err: unknown) {
@@ -138,6 +143,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
               await payload.delete({
                 id: searchDocID,
                 collection: 'search',
+                overrideAccess: false,
                 req,
               })
             } catch (err: unknown) {
@@ -152,6 +158,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
                 ...dataToSave,
                 priority: defaultPriority,
               },
+              overrideAccess: false,
               req,
             })
           } catch (err: unknown) {

--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -28,9 +28,6 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
       docToSyncWith = await payload.findByID({
         id,
         collection,
-        context: {
-          pluginSearchRead: true,
-        },
         locale: 'all',
         req,
       })

--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -23,8 +23,20 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
   }
 
   if (typeof beforeSync === 'function') {
+    let docToSyncWith = doc
+    if (payload.config?.localization) {
+      docToSyncWith = await payload.findByID({
+        id,
+        collection,
+        context: {
+          pluginSearchRead: true,
+        },
+        locale: 'all',
+        req,
+      })
+    }
     dataToSave = await beforeSync({
-      originalDoc: doc,
+      originalDoc: docToSyncWith,
       payload,
       req,
       searchDoc: dataToSave,

--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -32,7 +32,6 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
           pluginSearchRead: true,
         },
         locale: 'all',
-        overrideAccess: false,
         req,
       })
     }
@@ -73,7 +72,6 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
             ...dataToSave,
             priority: defaultPriority,
           },
-          overrideAccess: false,
           req,
         })
       }
@@ -85,7 +83,6 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
         const searchDocQuery = await payload.find({
           collection: 'search',
           depth: 0,
-          overrideAccess: false,
           req,
           where: {
             'doc.value': {
@@ -108,7 +105,6 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
             const duplicativeDocIDs = duplicativeDocs.map(({ id }) => id)
             await payload.delete({
               collection: 'search',
-              overrideAccess: false,
               req,
               where: { id: { in: duplicativeDocIDs } },
             })
@@ -130,7 +126,6 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
                   ...dataToSave,
                   priority: foundDoc.priority || defaultPriority,
                 },
-                overrideAccess: false,
                 req,
               })
             } catch (err: unknown) {
@@ -143,7 +138,6 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
               await payload.delete({
                 id: searchDocID,
                 collection: 'search',
-                overrideAccess: false,
                 req,
               })
             } catch (err: unknown) {
@@ -158,7 +152,6 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
                 ...dataToSave,
                 priority: defaultPriority,
               },
-              overrideAccess: false,
               req,
             })
           } catch (err: unknown) {

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -13,10 +13,10 @@ export const searchPlugin =
 
     if (collections) {
       const pluginConfig: SearchPluginConfig = {
-        ...incomingPluginConfig,
+        // write any config defaults here
         deleteDrafts: true,
         syncDrafts: false,
-        // write any config defaults here
+        ...incomingPluginConfig,
       }
 
       // add afterChange and afterDelete hooks to every search-enabled collection

--- a/test/plugin-search/collections/Posts.ts
+++ b/test/plugin-search/collections/Posts.ts
@@ -26,5 +26,10 @@ export const Posts: CollectionConfig = {
       label: 'Excerpt',
       type: 'text',
     },
+    {
+      type: 'text',
+      name: 'slug',
+      localized: true,
+    },
   ],
 }

--- a/test/plugin-search/config.ts
+++ b/test/plugin-search/config.ts
@@ -31,10 +31,13 @@ export default buildConfigWithDefaults({
   },
   plugins: [
     searchPlugin({
-      beforeSync: ({ originalDoc, searchDoc }) => ({
-        ...searchDoc,
-        excerpt: originalDoc?.excerpt || 'This is a fallback excerpt',
-      }),
+      beforeSync: ({ originalDoc, searchDoc }) => {
+        return {
+          ...searchDoc,
+          excerpt: originalDoc?.excerpt || 'This is a fallback excerpt',
+          slug: originalDoc.slug,
+        }
+      },
       collections: ['pages', 'posts'],
       defaultPriorities: {
         pages: 10,
@@ -49,6 +52,12 @@ export default buildConfigWithDefaults({
             admin: {
               position: 'sidebar',
             },
+          },
+          {
+            name: 'slug',
+            required: false,
+            type: 'text',
+            localized: true,
           },
         ],
       },

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -184,4 +184,43 @@ describe('@payloadcms/plugin-search', () => {
 
     expect(deletedResults).toHaveLength(0)
   })
+
+  it('should sync localized data', async () => {
+    const createdDoc = await payload.create({
+      collection: 'posts',
+      data: {
+        _status: 'draft',
+        title: 'test title',
+        slug: 'es',
+      },
+      locale: 'es',
+    })
+
+    await payload.update({
+      collection: 'posts',
+      id: createdDoc.id,
+      data: {
+        _status: 'published',
+        title: 'test title',
+        slug: 'en',
+      },
+      locale: 'en',
+    })
+
+    const syncedSearchData = await payload.find({
+      collection: 'search',
+      locale: 'es',
+      where: {
+        and: [
+          {
+            'doc.value': {
+              equals: createdDoc.id,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(syncedSearchData.docs[0].slug).toEqual('es')
+  })
 })

--- a/test/plugin-search/payload-types.ts
+++ b/test/plugin-search/payload-types.ts
@@ -18,6 +18,9 @@ export interface Config {
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
+  db: {
+    defaultIDType: string;
+  };
   globals: {};
   locale: 'en' | 'es' | 'de';
   user: User & {
@@ -29,12 +32,15 @@ export interface UserAuthOperations {
     email: string;
   };
   login: {
-    password: string;
     email: string;
+    password: string;
   };
   registerFirstUser: {
     email: string;
     password: string;
+  };
+  unlock: {
+    email: string;
   };
 }
 /**
@@ -74,6 +80,7 @@ export interface Post {
   id: string;
   title: string;
   excerpt?: string | null;
+  slug?: string | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -96,6 +103,7 @@ export interface Search {
         value: string | Post;
       };
   excerpt?: string | null;
+  slug?: string | null;
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/7203

The search plugin now queries the doc data before sending it through beforeSync, this ensures that the full document data is present.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
