### PR TITLE
fix(db-mongodb): removes precedence of regular chars over international chars in sort

### DIFF
--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -54,6 +54,10 @@ export const find: Find = async function find(
     useEstimatedCount,
   }
 
+  if (locale && locale !== 'all' && locale !== '*') {
+    paginationOptions.collation = { locale, strength: 1 }
+  }
+
   if (!useEstimatedCount && Object.keys(query).length === 0 && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding
     // a hint. By default, if no hint is provided, MongoDB does not use an indexed field to count the returned documents,

--- a/packages/db-mongodb/src/findGlobalVersions.ts
+++ b/packages/db-mongodb/src/findGlobalVersions.ts
@@ -72,6 +72,10 @@ export const findGlobalVersions: FindGlobalVersions = async function findGlobalV
     useEstimatedCount,
   }
 
+  if (locale && locale !== 'all' && locale !== '*') {
+    paginationOptions.collation = { locale, strength: 1 }
+  }
+
   if (!useEstimatedCount && Object.keys(query).length === 0 && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding
     // a hint. By default, if no hint is provided, MongoDB does not use an indexed field to count the returned documents,

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -69,6 +69,10 @@ export const findVersions: FindVersions = async function findVersions(
     useEstimatedCount,
   }
 
+  if (locale && locale !== 'all' && locale !== '*') {
+    paginationOptions.collation = { locale, strength: 1 }
+  }
+
   if (!useEstimatedCount && Object.keys(query).length === 0 && this.disableIndexHints !== true) {
     // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding
     // a hint. By default, if no hint is provided, MongoDB does not use an indexed field to count the returned documents,

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -57,6 +57,10 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     useEstimatedCount,
   }
 
+  if (locale && locale !== 'all' && locale !== '*') {
+    paginationOptions.collation = { locale, strength: 1 }
+  }
+
   if (
     !useEstimatedCount &&
     Object.keys(versionQuery).length === 0 &&

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -12,6 +12,7 @@ import {
   blocksWithLocalizedSameName,
   defaultLocale,
   englishTitle,
+  hungarianLocale,
   localizedPostsSlug,
   localizedSortSlug,
   portugueseLocale,
@@ -68,6 +69,11 @@ export default buildConfigWithDefaults({
         },
         {
           name: 'description',
+          type: 'text',
+        },
+        {
+          name: 'localizedDescription',
+          localized: true,
           type: 'text',
         },
         {
@@ -309,6 +315,11 @@ export default buildConfigWithDefaults({
         code: 'ar',
         label: 'Arabic',
         rtl: true,
+      },
+      {
+        code: hungarianLocale,
+        label: 'Hungarian',
+        rtl: false,
       },
     ],
   },

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -27,7 +27,7 @@ export interface Config {
   globals: {
     'global-array': GlobalArray;
   };
-  locale: 'en' | 'es' | 'pt' | 'ar';
+  locale: 'en' | 'es' | 'hu' | 'pt' | 'ar';
   user: User & {
     collection: 'users';
   };
@@ -70,6 +70,7 @@ export interface User {
 export interface LocalizedPost {
   id: string;
   title?: string | null;
+  localizedDescription?: string | null;
   description?: string | null;
   localizedCheckbox?: boolean | null;
   children?: (string | LocalizedPost)[] | null;
@@ -316,6 +317,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore 
+  // @ts-ignore
   export interface GeneratedTypes extends Config {}
 }

--- a/test/localization/shared.ts
+++ b/test/localization/shared.ts
@@ -8,6 +8,7 @@ export const relationSpanishTitle2 = `${relationSpanishTitle}2`
 export const defaultLocale = 'en'
 export const spanishLocale = 'es'
 export const portugueseLocale = 'pt'
+export const hungarianLocale = 'hu'
 
 // Slugs
 export const localizedPostsSlug = 'localized-posts'


### PR DESCRIPTION
## Description

V2 PR [here](https://github.com/payloadcms/payload/pull/6923)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
