### PR TITLE
fix(cpa): check cmd exists after first checking flag and lock file

### DIFF
--- a/packages/create-payload-app/src/lib/get-package-manager.ts
+++ b/packages/create-payload-app/src/lib/get-package-manager.ts
@@ -10,22 +10,23 @@ export async function getPackageManager(args: {
   const { cliArgs, projectDir } = args
 
   try {
-    // Check for yarn.lock, package-lock.json, or pnpm-lock.yaml
+    // Check for flag or lockfile
     let detected: PackageManager = 'npm'
-    if (
-      cliArgs?.['--use-pnpm'] ||
-      fse.existsSync(`${projectDir}/pnpm-lock.yaml`) ||
-      (await commandExists('pnpm'))
-    ) {
+    if (cliArgs?.['--use-pnpm'] || fse.existsSync(`${projectDir}/pnpm-lock.yaml`)) {
       detected = 'pnpm'
-    } else if (
-      cliArgs?.['--use-yarn'] ||
-      fse.existsSync(`${projectDir}/yarn.lock`) ||
-      (await commandExists('yarn'))
-    ) {
+    } else if (cliArgs?.['--use-yarn'] || fse.existsSync(`${projectDir}/yarn.lock`)) {
       detected = 'yarn'
     } else if (cliArgs?.['--use-npm'] || fse.existsSync(`${projectDir}/package-lock.json`)) {
       detected = 'npm'
+    } else {
+      // Otherwise check for existing commands
+      if (await commandExists('pnpm')) {
+        detected = 'pnpm'
+      } else if (await commandExists('yarn')) {
+        detected = 'yarn'
+      } else {
+        detected = 'npm'
+      }
     }
 
     return detected


### PR DESCRIPTION
Adjust logic for determining package manager. Needed to move command exists logic to be evaluated only after other possibilities were exhausted.

Closes #7290 