### PR TITLE
fix: first version doc throws error

### DIFF
--- a/packages/next/src/views/Version/index.tsx
+++ b/packages/next/src/views/Version/index.tsx
@@ -119,8 +119,8 @@ export const VersionView: EditViewComponent = async (props) => {
       doc={doc}
       docPermissions={docPermissions}
       initialComparisonDoc={latestVersion}
-      latestDraftVersion={latestDraftVersion.id}
-      latestPublishedVersion={latestPublishedVersion.id}
+      latestDraftVersion={latestDraftVersion?.id}
+      latestPublishedVersion={latestPublishedVersion?.id}
       localeOptions={localeOptions}
       versionID={versionID}
     />


### PR DESCRIPTION
## Description

The first version document throws an error because `latestPublished` and `latestDraft` are undefined.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Existing test suite passes locally with my changes