### PR TITLE
fix(plugin-stripe): properly types async webhooks

### DIFF
--- a/packages/plugin-stripe/src/types.ts
+++ b/packages/plugin-stripe/src/types.ts
@@ -8,7 +8,7 @@ export type StripeWebhookHandler<T = any> = (args: {
   payload: Payload
   stripe: Stripe
   stripeConfig?: StripeConfig
-}) => void
+}) => Promise<void> | void
 
 export interface StripeWebhookHandlers {
   [webhookName: string]: StripeWebhookHandler


### PR DESCRIPTION
## Description

Closes #4492. When the `'@typescript-eslint/no-misused-promises': 'on'` ESLint rule is set, the `webhooks` property in the Stripe Plugin config throws an error. This is because its return value was not properly typed as a promise. The ESLint config in the monorepo has this rule turned off, explaining why this was not previously caught.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
