### PR TITLE
fix(plugin-stripe): properly types async webhooks

### DIFF
--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -70,8 +70,6 @@ const typescriptRules = {
   '@typescript-eslint/no-unsafe-argument': 'off',
   '@typescript-eslint/no-unsafe-return': 'off',
   '@typescript-eslint/unbound-method': 'warn',
-  // This rule doesn't work well in .tsx files
-  '@typescript-eslint/no-misused-promises': 'off',
   '@typescript-eslint/consistent-type-imports': 'warn',
   '@typescript-eslint/no-explicit-any': 'warn',
   // Type-aware any rules end

--- a/packages/plugin-stripe/src/types.ts
+++ b/packages/plugin-stripe/src/types.ts
@@ -8,7 +8,7 @@ export type StripeWebhookHandler<T = any> = (args: {
   pluginConfig?: StripePluginConfig
   req: PayloadRequest
   stripe: Stripe
-}) => void
+}) => Promise<void> | void
 
 export type StripeWebhookHandlers = {
   [webhookName: string]: StripeWebhookHandler

--- a/test/plugin-stripe/config.ts
+++ b/test/plugin-stripe/config.ts
@@ -87,7 +87,6 @@ export default buildConfigWithDefaults({
         'customer.subscription.updated': subscriptionCreatedOrUpdated,
         'product.created': syncPriceJSON,
         'product.updated': syncPriceJSON,
-        something: async () => Promise.resolve(),
       },
     }),
   ],

--- a/test/plugin-stripe/config.ts
+++ b/test/plugin-stripe/config.ts
@@ -87,6 +87,7 @@ export default buildConfigWithDefaults({
         'customer.subscription.updated': subscriptionCreatedOrUpdated,
         'product.created': syncPriceJSON,
         'product.updated': syncPriceJSON,
+        something: async () => Promise.resolve(),
       },
     }),
   ],

--- a/test/plugin-stripe/webhooks/syncPriceJSON.ts
+++ b/test/plugin-stripe/webhooks/syncPriceJSON.ts
@@ -9,8 +9,6 @@ export const syncPriceJSON = async (args) => {
 
   const { id: eventID, default_price } = event.data.object
 
-  console.log(event.data.object)
-
   let payloadProductID
 
   // First lookup the product in Payload


### PR DESCRIPTION
## Description

Same as #7316 but for beta. When the `'@typescript-eslint/no-misused-promises': 'on'` ESLint rule is set, the `webhooks` property in the Stripe Plugin config throws an error. This is because its return value was not properly typed as a promise. The ESLint config in the monorepo has this rule turned off, explaining why this was not previously caught.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
