### PR TITLE
fix: allow autosave relationship drawers to function properly

### DIFF
--- a/packages/payload/src/admin/components/elements/Autosave/types.ts
+++ b/packages/payload/src/admin/components/elements/Autosave/types.ts
@@ -1,9 +1,11 @@
 import type { SanitizedCollectionConfig } from '../../../../collections/config/types'
 import type { SanitizedGlobalConfig } from '../../../../globals/config/types'
+import type { CollectionEditViewProps } from '../../views/types'
 
 export type Props = {
   collection?: SanitizedCollectionConfig
   global?: SanitizedGlobalConfig
   id?: number | string
+  onSave?: CollectionEditViewProps['onSave']
   publishedDocUpdatedAt: string
 }

--- a/packages/payload/src/admin/components/elements/DocumentControls/index.tsx
+++ b/packages/payload/src/admin/components/elements/DocumentControls/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import type { CollectionPermission, GlobalPermission } from '../../../../auth'
 import type { SanitizedCollectionConfig } from '../../../../collections/config/types'
 import type { SanitizedGlobalConfig } from '../../../../globals/config/types'
+import type { CollectionEditViewProps } from '../../views/types'
 
 import { getTranslation } from '../../../../utilities/getTranslation'
 import { formatDate } from '../../../utilities/formatDate'
@@ -34,6 +35,7 @@ export const DocumentControls: React.FC<{
   id?: string
   isAccountView?: boolean
   isEditing?: boolean
+  onSave?: CollectionEditViewProps['onSave']
   permissions?: CollectionPermission | GlobalPermission
 }> = (props) => {
   const {
@@ -45,6 +47,7 @@ export const DocumentControls: React.FC<{
     hasSavePermission,
     isAccountView,
     isEditing,
+    onSave,
     permissions,
   } = props
 
@@ -111,6 +114,7 @@ export const DocumentControls: React.FC<{
                         collection={collection}
                         global={global}
                         id={id}
+                        onSave={onSave}
                         publishedDocUpdatedAt={publishedDoc?.updatedAt || data?.createdAt}
                       />
                     </li>

--- a/packages/payload/src/admin/components/views/collections/Edit/Default/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/Edit/Default/index.tsx
@@ -35,6 +35,7 @@ export const DefaultCollectionEdit: React.FC<
     hasSavePermission,
     internalState,
     isEditing,
+    onSave,
     permissions,
   } = props
 
@@ -68,6 +69,7 @@ export const DefaultCollectionEdit: React.FC<
         hasSavePermission={hasSavePermission}
         id={id}
         isEditing={isEditing}
+        onSave={onSave}
         permissions={permissions}
       />
       <DocumentFields


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/6887

Collections with autosave enabled would open and immediately close when they were edited inside a relationship field. This PR threads onSave through to autosave and checks the current drawer depth to determine if it should call the onSave function or if it should redirect the user to the doc page when autosave is triggered.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
