### PR TITLE
feat: adds @payloadcms/live-preview-vue to release pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:graphql": "turbo build --filter graphql",
     "build:live-preview": "turbo build --filter live-preview",
     "build:live-preview-react": "turbo build --filter live-preview-react",
+    "build:live-preview-vue": "turbo build --filter live-preview-vue",
     "build:next": "turbo build --filter next",
     "build:payload": "turbo build --filter payload",
     "build:plugin-cloud": "turbo build --filter plugin-cloud",

--- a/packages/live-preview-react/package.json
+++ b/packages/live-preview-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@payloadcms/live-preview-react",
   "version": "3.0.0-beta.68",
-  "description": "The official live preview React SDK for Payload",
+  "description": "The official React SDK for Payload Live Preview",
   "homepage": "https://payloadcms.com",
   "repository": {
     "type": "git",

--- a/packages/live-preview-vue/package.json
+++ b/packages/live-preview-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@payloadcms/live-preview-vue",
-  "version": "0.1.0",
-  "description": "The official live preview Vue SDK for Payload",
+  "version": "3.0.0-beta.68",
+  "description": "The official Vue SDK for Payload Live Preview",
   "homepage": "https://payloadcms.com",
   "repository": {
     "type": "git",

--- a/scripts/lib/publishList.ts
+++ b/scripts/lib/publishList.ts
@@ -13,6 +13,7 @@ export const packagePublishList = [
   'db-postgres',
   'live-preview',
   'live-preview-react',
+  'live-preview-vue',
   'richtext-slate',
   'richtext-lexical',
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,9 @@
       "@payloadcms/live-preview-react": [
         "./packages/live-preview-react/src/index.ts"
       ],
+      "@payloadcms/live-preview-vue": [
+        "./packages/live-preview-vue/src/index.ts"
+      ],
       "@payloadcms/ui": [
         "./packages/ui/src/exports/client/index.ts"
       ],
@@ -90,6 +93,9 @@
     },
     {
       "path": "./packages/live-preview-react"
+    },
+    {
+      "path": "./packages/live-preview-vue"
     },
     {
       "path": "./packages/next"


### PR DESCRIPTION
## Description

Closes #7303. Preps `@payloadcms/live-preview-vue` for release. Includes this package in the publish list and adds a tsconfig path alias.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
