### PR TITLE
fix: fetches and sets permissions before setting user

### DIFF
--- a/packages/payload/src/admin/components/utilities/Auth/index.tsx
+++ b/packages/payload/src/admin/components/utilities/Auth/index.tsx
@@ -71,10 +71,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   )
 
   const setActiveUser = React.useCallback(
-    (user: User | null) => {
-      setUser(user)
-      userIDRef.current = user?.id || null
-      void refreshPermissions()
+    async (userToSet: User | null) => {
+      userIDRef.current = userToSet?.id || null
+      await refreshPermissions()
+      setUser(userToSet)
     },
     [refreshPermissions],
   )
@@ -208,7 +208,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         const json = await request.json()
 
         if (json?.user) {
-          setActiveUser(json.user)
+          await setActiveUser(json.user)
           if (json?.token) {
             setTokenAndExpiration(json)
           }
@@ -227,16 +227,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           })
           if (autoLoginResult.status === 200) {
             const autoLoginJson = await autoLoginResult.json()
-            setActiveUser(autoLoginJson.user)
+            await setActiveUser(autoLoginJson.user)
             if (autoLoginJson?.token) {
               setTokenAndExpiration(autoLoginJson)
             }
           } else {
-            setActiveUser(null)
+            await setActiveUser(null)
             revokeTokenAndExpire()
           }
         } else {
-          setActiveUser(null)
+          await setActiveUser(null)
           revokeTokenAndExpire()
         }
       }
@@ -298,8 +298,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     if (remainingTime > 0) {
       forceLogOut = setTimeout(
-        () => {
-          setActiveUser(null)
+        async () => {
+          await setActiveUser(null)
           revokeTokenAndExpire()
           redirectToInactivityRoute()
         },

--- a/packages/payload/src/admin/components/utilities/Auth/types.ts
+++ b/packages/payload/src/admin/components/utilities/Auth/types.ts
@@ -2,12 +2,12 @@ import type { Permissions, User } from '../../../../auth/types'
 
 export type AuthContext<T = User> = {
   fetchFullUser: () => Promise<void>
-  logOut: () => void
+  logOut: () => Promise<void>
   permissions?: Permissions
   refreshCookie: (forceRefresh?: boolean) => void
   refreshCookieAsync: () => Promise<User>
   refreshPermissions: ({ locale }?: { locale?: string }) => Promise<void>
-  setUser: (user: T) => void
+  setUser: (user: T) => Promise<void>
   strategy?: string
   token?: string
   tokenExpiration?: number

--- a/packages/payload/src/admin/components/views/Logout/index.tsx
+++ b/packages/payload/src/admin/components/views/Logout/index.tsx
@@ -25,7 +25,7 @@ const Logout: React.FC<{ inactivity?: boolean }> = (props) => {
   const redirect = query.get('redirect')
 
   useEffect(() => {
-    logOut()
+    void logOut()
   }, [logOut])
 
   return (


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/7330

Ensures permissions are always present before setting the user.

Before, permissions were fetched after the user was set. This lead to conditionals checking for `user` from the auth provider, but then subsequent checks relied on permissions to show certain aspects of the admin panel which caused flashes of `Unauthorized` and `Alread Logged In` views.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
