### PR TITLE
chore(live-preview): ensures dev points to src

### DIFF
--- a/packages/live-preview-react/package.json
+++ b/packages/live-preview-react/package.json
@@ -10,8 +10,7 @@
   "license": "MIT",
   "homepage": "https://payloadcms.com",
   "author": "Payload CMS, Inc.",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc",

--- a/packages/live-preview-react/package.json
+++ b/packages/live-preview-react/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://payloadcms.com",
   "author": "Payload CMS, Inc.",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc",

--- a/packages/live-preview-vue/package.json
+++ b/packages/live-preview-vue/package.json
@@ -10,8 +10,8 @@
   "license": "MIT",
   "homepage": "https://payloadcms.com",
   "author": "Payload CMS, Inc.",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc",

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -10,8 +10,7 @@
   "license": "MIT",
   "homepage": "https://payloadcms.com",
   "author": "Payload CMS, Inc.",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc",

--- a/packages/live-preview/package.json
+++ b/packages/live-preview/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://payloadcms.com",
   "author": "Payload CMS, Inc.",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:swc && pnpm build:types",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc",

--- a/test/live-preview/next-app/tsconfig.json
+++ b/test/live-preview/next-app/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./*"],
-      "@payloadcms/live-preview": ["../../../packages/live-preview"]
+      "@payloadcms/live-preview": ["../../../packages/live-preview"],
+      "@payloadcms/live-preview-react": ["../../../packages/live-preview-react"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
@@ -28,6 +29,9 @@
   "references": [
     {
       "path": "../../../packages/live-preview"
+    },
+    {
+      "path": "../../../packages/live-preview-react"
     }
   ]
 }


### PR DESCRIPTION
## Description

When running the `live-preview` test suite, it currently requires you to build the `@payloadcms/live-preview-react` and `@payloadcms/live-preview-react` modules locally. This was because their respective `main` properties were pointing to `dist` instead of `src`. This has been a point of confusion for many attempting to demo live preview through the test suite, because the rendered app would not simply respond to updates unless the modules were built. Now it works as expected.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
