### PR TITLE
fix: relaxes equality check for relationship options in filter

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -152,7 +152,7 @@ export const RelationshipField: React.FC<Props> = (props) => {
               options.forEach((opt) => {
                 if (opt.options) {
                   opt.options.some((subOpt) => {
-                    if (subOpt?.value === val.value) {
+                    if (subOpt?.value == val.value) {
                       matchedOption = subOpt
                       return true
                     }
@@ -165,7 +165,7 @@ export const RelationshipField: React.FC<Props> = (props) => {
               return matchedOption
             }
 
-            return options.find((opt) => opt.value === val)
+            return options.find((opt) => opt.value == val)
           })
         }
 
@@ -180,7 +180,7 @@ export const RelationshipField: React.FC<Props> = (props) => {
         options.forEach((opt) => {
           if (opt?.options) {
             opt.options.some((subOpt) => {
-              if (subOpt?.value === valueWithRelation.value) {
+              if (subOpt?.value == valueWithRelation.value) {
                 matchedOption = subOpt
                 return true
               }
@@ -192,7 +192,7 @@ export const RelationshipField: React.FC<Props> = (props) => {
         return matchedOption
       }
 
-      return options.find((opt) => opt.value === value)
+      return options.find((opt) => opt.value == value)
     }
 
     return undefined


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/7271

When extracting the value from the querystring, it is _always_ a string. We were using a strict equality check which would cause the filter options to never find the correct option. This caused an infinite loop when using PG as ID's are numbers by default.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
