### PR TITLE
fix: attempts to use query.locale when present in createLocalReq

### DIFF
--- a/packages/next/src/utilities/initPage/index.ts
+++ b/packages/next/src/utilities/initPage/index.ts
@@ -1,4 +1,4 @@
-import type { I18nClient } from '@payloadcms/translations'
+import type { I18n } from '@payloadcms/translations'
 import type { InitPageResult, Locale, PayloadRequest, VisibleEntities } from 'payload'
 
 import { initI18n } from '@payloadcms/translations'
@@ -35,7 +35,7 @@ export const initPage = async ({
   const cookies = parseCookies(headers)
   const language = getRequestLanguage({ config: payload.config, cookies, headers })
 
-  const i18n: I18nClient = await initI18n({
+  const i18n: I18n = await initI18n({
     config: i18nConfig,
     context: 'client',
     language,

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -71,7 +71,9 @@ export const createLocalReq: CreateLocalReq = async (
   if (payload.config?.localization) {
     const locale = localeArg === '*' ? 'all' : localeArg
     const defaultLocale = payload.config.localization.defaultLocale
-    req.locale = locale || req?.locale || defaultLocale
+    const localeCandidate = locale || req?.locale || req?.query?.locale
+    req.locale =
+      localeCandidate && typeof localeCandidate === 'string' ? localeCandidate : defaultLocale
     const fallbackLocaleFromConfig = payload.config.localization.locales.find(
       ({ code }) => req.locale === code,
     )?.fallbackLocale


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/7341

req.locale was incorrectly set, stemming from initPage, where req.query.locale was not being used if present inside the `createLocaleReq` function.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
