### PR TITLE
fix: preserves objectids in deepCopyObject

### DIFF
--- a/packages/payload/src/utilities/deepCopyObject.ts
+++ b/packages/payload/src/utilities/deepCopyObject.ts
@@ -1,4 +1,8 @@
+import ObjectID from 'bson-objectid'
+
 export const deepCopyObject = (inObject) => {
+  if (ObjectID.isValid(inObject)) return inObject
+
   if (inObject instanceof Date) return inObject
 
   if (inObject instanceof Set) return new Set(inObject)


### PR DESCRIPTION
## Description

The `deepCopyObject` function was cannibalizing ObjectIDs, which conflicted with the ability to surface them from the MongoDB adapter. Now, the `deepCopyObject` function will simply pass through ObjectIDs rather than break them. 
