### PR TITLE
fix(ui): handle `abort()` call signal error

### DIFF
--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -220,7 +220,13 @@ export const Autosave: React.FC<Props> = ({
 
     return () => {
       if (autosaveTimeout) clearTimeout(autosaveTimeout)
-      if (abortController.signal) abortController.abort()
+      if (abortController.signal) {
+        try {
+          abortController.abort()
+        } catch (error) {
+          // swallow error
+        }
+      }
       setSaving(false)
     }
   }, [

--- a/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -248,7 +248,13 @@ export const RelationshipField: React.FC<Props> = (props) => {
 
     return () => {
       abortControllers.forEach((controller) => {
-        if (controller.signal) controller.abort()
+        if (controller.signal) {
+          try {
+            controller.abort()
+          } catch (error) {
+            // swallow error
+          }
+        }
       })
     }
   }, [i18n, loadRelationOptions, relationTo])

--- a/packages/ui/src/hooks/usePayloadAPI.ts
+++ b/packages/ui/src/hooks/usePayloadAPI.ts
@@ -89,7 +89,11 @@ export const usePayloadAPI: UsePayloadAPI = (url, options = {}) => {
     }
 
     return () => {
-      abortController.abort()
+      try {
+        abortController.abort()
+      } catch (error) {
+        // swallow error
+      }
     }
   }, [url, locale, search, i18n.language, initialData])
 

--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -455,7 +455,11 @@ const DocumentInfo: React.FC<
     }
 
     return () => {
-      abortController.abort()
+      try {
+        abortController.abort()
+      } catch (error) {
+        // swallow error
+      }
     }
   }, [
     api,


### PR DESCRIPTION
## Description

Swallows `.abort()` call signal errors

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
