### PR TITLE
chore(cpa): replaces missing type assertion

### DIFF
--- a/packages/create-payload-app/src/lib/wrap-next-config.ts
+++ b/packages/create-payload-app/src/lib/wrap-next-config.ts
@@ -138,7 +138,7 @@ export async function parseAndModifyConfigContent(
       (m) =>
         m.type === 'ExportDefaultExpression' &&
         (m.expression.type === 'Identifier' || m.expression.type === 'CallExpression'),
-    )
+    ) as ExportDefaultExpression | undefined
 
     if (exportDefaultDeclaration) {
       if (!('span' in exportDefaultDeclaration.expression)) {


### PR DESCRIPTION
## Description

Replaces the type assertion that was removed as a result of a merge commit in this PR: https://github.com/payloadcms/payload/pull/7360 which throws a build error for create-payload-app.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)


## Checklist:

- [x] Existing test suite passes locally with my changes
