### PR TITLE
fix(payload): retained date milliseconds

### DIFF
--- a/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
+++ b/packages/payload/src/admin/components/elements/DatePicker/DatePicker.tsx
@@ -54,9 +54,12 @@ const DateTime: React.FC<Props> = (props) => {
 
   const onChange = (incomingDate: Date) => {
     const newDate = incomingDate
-    if (newDate instanceof Date && ['dayOnly', 'default', 'monthOnly'].includes(pickerAppearance)) {
-      const tzOffset = incomingDate.getTimezoneOffset() / 60
-      newDate.setHours(12 - tzOffset, 0)
+    if (newDate instanceof Date) {
+      newDate.setMilliseconds(0)
+      if (['dayOnly', 'default', 'monthOnly'].includes(pickerAppearance)) {
+        const tzOffset = incomingDate.getTimezoneOffset() / 60
+        newDate.setHours(12 - tzOffset, 0)
+      }
     }
     if (typeof onChangeFromProps === 'function') onChangeFromProps(newDate)
   }


### PR DESCRIPTION
## Description

Fixes #6108 

Defaults `milliseconds` to `0` for date field picker.

`Before`:
![Screenshot 2024-07-26 at 3 56 45 PM](https://github.com/user-attachments/assets/1806801a-b457-476e-ad84-bcfe3248b61e)


`After`:
![Screenshot 2024-07-26 at 3 54 14 PM](https://github.com/user-attachments/assets/ad92a106-df95-4184-9de2-666d08b636ab)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
