### PR TITLE
feat(db-*, payload): better transactions

### DIFF
--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -156,6 +156,7 @@ declare module 'payload' {
   export interface DatabaseAdapter
     extends Omit<Args, 'idType' | 'logger' | 'migrationDir' | 'pool'>,
       DrizzleAdapter {
+    beginTransaction: (options?: PgTransactionConfig) => Promise<null | number | string>
     drizzle: PostgresDB
     enums: Record<string, GenericEnum>
     /**

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -144,6 +144,7 @@ declare module 'payload' {
   export interface DatabaseAdapter
     extends Omit<Args, 'idType' | 'logger' | 'migrationDir' | 'pool'>,
       DrizzleAdapter {
+    beginTransaction: (options?: SQLiteTransactionConfig) => Promise<null | number | string>
     drizzle: LibSQLDatabase
     /**
      * An object keyed on each table, with a key value pair where the constraint name is the key, followed by the dot-notation field name

--- a/packages/drizzle/src/transactions/beginTransaction.ts
+++ b/packages/drizzle/src/transactions/beginTransaction.ts
@@ -6,6 +6,7 @@ import type { DrizzleAdapter, DrizzleTransaction } from '../types.js'
 
 export const beginTransaction: BeginTransaction = async function beginTransaction(
   this: DrizzleAdapter,
+  options: DrizzleAdapter['transactionOptions'],
 ) {
   let id
   try {
@@ -41,7 +42,7 @@ export const beginTransaction: BeginTransaction = async function beginTransactio
           }
           transactionReady()
         })
-      }, this.transactionOptions)
+      }, options || this.transactionOptions)
       .catch(() => {
         // swallow
       })

--- a/packages/payload/src/auth/getAccessResults.ts
+++ b/packages/payload/src/auth/getAccessResults.ts
@@ -2,7 +2,6 @@ import type { AllOperations, PayloadRequest } from '../types/index.js'
 import type { Permissions } from './types.js'
 
 import { getEntityPolicies } from '../utilities/getEntityPolicies.js'
-import isolateObjectProperty from '../utilities/isolateObjectProperty.js'
 
 type GetAccessResultsArgs = {
   req: PayloadRequest
@@ -45,9 +44,7 @@ export async function getAccessResults({ req }: GetAccessResultsArgs): Promise<P
         type: 'collection',
         entity: collection,
         operations: collectionOperations,
-        // Do not re-use our existing req object, as we need a new req.transactionID. Cannot re-use our existing one, as this is run in parallel (Promise.all above) which is
-        // not supported on the same transaction ID. Not passing a transaction ID here creates a new transaction ID.
-        req: isolateObjectProperty(req, 'transactionID'),
+        req,
       })
       results.collections = {
         ...results.collections,
@@ -68,9 +65,7 @@ export async function getAccessResults({ req }: GetAccessResultsArgs): Promise<P
         type: 'global',
         entity: global,
         operations: globalOperations,
-        // Do not re-use our existing req object, as we need a new req.transactionID. Cannot re-use our existing one, as this is run in parallel (Promise.all above) which is
-        // not supported on the same transaction ID. Not passing a transaction ID here creates a new transaction ID.
-        req: isolateObjectProperty(req, 'transactionID'),
+        req,
       })
       results.globals = {
         ...results.globals,

--- a/packages/payload/src/auth/operations/access.ts
+++ b/packages/payload/src/auth/operations/access.ts
@@ -1,8 +1,6 @@
 import type { PayloadRequest } from '../../types/index.js'
 import type { Permissions } from '../types.js'
 
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { adminInit as adminInitTelemetry } from '../../utilities/telemetry/events/adminInit.js'
 import { getAccessResults } from '../getAccessResults.js'
@@ -17,10 +15,7 @@ export const accessOperation = async (args: Arguments): Promise<Permissions> => 
   adminInitTelemetry(req)
 
   try {
-    const shouldCommit = await initTransaction(req)
-    const results = getAccessResults({ req })
-    if (shouldCommit) await commitTransaction(req)
-    return results
+    return getAccessResults({ req })
   } catch (e: unknown) {
     await killTransaction(req)
     throw e

--- a/packages/payload/src/collections/operations/count.ts
+++ b/packages/payload/src/collections/operations/count.ts
@@ -6,8 +6,6 @@ import type { Collection } from '../config/types.js'
 import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { buildAfterOperation } from './utils.js'
 
@@ -25,8 +23,6 @@ export const countOperation = async <TSlug extends CollectionSlug>(
   let args = incomingArgs
 
   try {
-    const shouldCommit = await initTransaction(args.req)
-
     // /////////////////////////////////////
     // beforeOperation - Collection
     // /////////////////////////////////////
@@ -101,8 +97,6 @@ export const countOperation = async <TSlug extends CollectionSlug>(
     // /////////////////////////////////////
     // Return results
     // /////////////////////////////////////
-
-    if (shouldCommit) await commitTransaction(req)
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -1,7 +1,7 @@
 import httpStatus from 'http-status'
 
 import type { AccessResult } from '../../config/types.js'
-import type { CollectionSlug, GeneratedTypes } from '../../index.js'
+import type { CollectionSlug } from '../../index.js'
 import type { PayloadRequest, Where } from '../../types/index.js'
 import type { BeforeOperationHook, Collection, DataFromCollectionSlug } from '../config/types.js'
 

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug, JsonObject, TypeWithID } from '../../index.js'
+import type { CollectionSlug } from '../../index.js'
 import type { PayloadRequest } from '../../types/index.js'
 import type { BeforeOperationHook, Collection, DataFromCollectionSlug } from '../config/types.js'
 

--- a/packages/payload/src/collections/operations/docAccess.ts
+++ b/packages/payload/src/collections/operations/docAccess.ts
@@ -2,9 +2,7 @@ import type { CollectionPermission } from '../../auth/index.js'
 import type { AllOperations, PayloadRequest } from '../../types/index.js'
 import type { Collection } from '../config/types.js'
 
-import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { getEntityPolicies } from '../../utilities/getEntityPolicies.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 
 const allOperations: AllOperations[] = ['create', 'read', 'update', 'delete']
@@ -37,8 +35,6 @@ export async function docAccessOperation(args: Arguments): Promise<CollectionPer
   }
 
   try {
-    const shouldCommit = await initTransaction(req)
-
     const result = await getEntityPolicies({
       id,
       type: 'collection',
@@ -46,8 +42,6 @@ export async function docAccessOperation(args: Arguments): Promise<CollectionPer
       operations: collectionOperations,
       req,
     })
-
-    if (shouldCommit) await commitTransaction(req)
 
     return result
   } catch (e: unknown) {

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -8,8 +8,6 @@ import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
 import { appendVersionToQueryKey } from '../../versions/drafts/appendVersionToQueryKey.js'
@@ -38,8 +36,6 @@ export const findOperation = async <TSlug extends CollectionSlug>(
   let args = incomingArgs
 
   try {
-    const shouldCommit = await initTransaction(args.req)
-
     // /////////////////////////////////////
     // beforeOperation - Collection
     // /////////////////////////////////////
@@ -252,8 +248,6 @@ export const findOperation = async <TSlug extends CollectionSlug>(
     // /////////////////////////////////////
     // Return results
     // /////////////////////////////////////
-
-    if (shouldCommit) await commitTransaction(req)
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -7,8 +7,6 @@ import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import replaceWithDraftIfAvailable from '../../versions/drafts/replaceWithDraftIfAvailable.js'
 import { buildAfterOperation } from './utils.js'
@@ -31,8 +29,6 @@ export const findByIDOperation = async <TSlug extends CollectionSlug>(
   let args = incomingArgs
 
   try {
-    const shouldCommit = await initTransaction(args.req)
-
     // /////////////////////////////////////
     // beforeOperation - Collection
     // /////////////////////////////////////
@@ -181,8 +177,6 @@ export const findByIDOperation = async <TSlug extends CollectionSlug>(
     // /////////////////////////////////////
     // Return results
     // /////////////////////////////////////
-
-    if (shouldCommit) await commitTransaction(req)
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/findVersionByID.ts
@@ -8,8 +8,6 @@ import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { APIError, Forbidden, NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 
 export type Arguments = {
@@ -43,8 +41,6 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
   }
 
   try {
-    const shouldCommit = await initTransaction(req)
-
     // /////////////////////////////////////
     // Access
     // /////////////////////////////////////
@@ -140,8 +136,6 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
     // /////////////////////////////////////
     // Return results
     // /////////////////////////////////////
-
-    if (shouldCommit) await commitTransaction(req)
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -7,8 +7,6 @@ import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields.js'
 import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
@@ -44,8 +42,6 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
   } = args
 
   try {
-    const shouldCommit = await initTransaction(req)
-
     // /////////////////////////////////////
     // Access
     // /////////////////////////////////////
@@ -174,8 +170,6 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
       ...result,
       docs: result.docs.map((doc) => sanitizeInternalFields<TData>(doc)),
     }
-
-    if (shouldCommit) await commitTransaction(req)
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -10,8 +10,6 @@ import { combineQueries } from '../../database/combineQueries.js'
 import { APIError, Forbidden, NotFound } from '../../errors/index.js'
 import { afterChange } from '../../fields/hooks/afterChange/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { getLatestCollectionVersion } from '../../versions/getLatestCollectionVersion.js'
 
@@ -40,8 +38,6 @@ export const restoreVersionOperation = async <TData extends TypeWithID = any>(
   } = args
 
   try {
-    const shouldCommit = await initTransaction(req)
-
     if (!id) {
       throw new APIError('Missing ID of version to restore.', httpStatus.BAD_REQUEST)
     }
@@ -199,8 +195,6 @@ export const restoreVersionOperation = async <TData extends TypeWithID = any>(
           req,
         })) || result
     }, Promise.resolve())
-
-    if (shouldCommit) await commitTransaction(req)
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -3,7 +3,7 @@ import type { DeepPartial } from 'ts-essentials'
 import httpStatus from 'http-status'
 
 import type { FindOneArgs } from '../../database/types.js'
-import type { CollectionSlug, GeneratedTypes } from '../../index.js'
+import type { CollectionSlug } from '../../index.js'
 import type { PayloadRequest } from '../../types/index.js'
 import type {
   Collection,

--- a/packages/payload/src/globals/operations/findOne.ts
+++ b/packages/payload/src/globals/operations/findOne.ts
@@ -4,8 +4,6 @@ import type { SanitizedGlobalConfig } from '../config/types.js'
 
 import executeAccess from '../../auth/executeAccess.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import replaceWithDraftIfAvailable from '../../versions/drafts/replaceWithDraftIfAvailable.js'
 
@@ -34,8 +32,6 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
   } = args
 
   try {
-    const shouldCommit = await initTransaction(req)
-
     // /////////////////////////////////////
     // Retrieve and execute access
     // /////////////////////////////////////
@@ -124,12 +120,6 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
           req,
         })) || doc
     }, Promise.resolve())
-
-    // /////////////////////////////////////
-    // Return results
-    // /////////////////////////////////////
-
-    if (shouldCommit) await commitTransaction(req)
 
     // /////////////////////////////////////
     // Return results

--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -7,9 +7,7 @@ import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { Forbidden, NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
-import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { deepCopyObjectSimple } from '../../utilities/deepCopyObject.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 
 export type Arguments = {
@@ -39,8 +37,6 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
   } = args
 
   try {
-    const shouldCommit = await initTransaction(req)
-
     // /////////////////////////////////////
     // Access
     // /////////////////////////////////////
@@ -135,12 +131,6 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
           req,
         })) || result.version
     }, Promise.resolve())
-
-    // /////////////////////////////////////
-    // Return results
-    // /////////////////////////////////////
-
-    if (shouldCommit) await commitTransaction(req)
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -7,8 +7,6 @@ import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields.js'
 import { buildVersionGlobalFields } from '../../versions/buildGlobalFields.js'
@@ -44,8 +42,6 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
   const versionFields = buildVersionGlobalFields(globalConfig)
 
   try {
-    const shouldCommit = await initTransaction(req)
-
     // /////////////////////////////////////
     // Access
     // /////////////////////////////////////
@@ -146,8 +142,6 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
       ...result,
       docs: result.docs.map((doc) => sanitizeInternalFields<T>(doc)),
     }
-
-    if (shouldCommit) await commitTransaction(req)
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/utilities/killTransaction.ts
+++ b/packages/payload/src/utilities/killTransaction.ts
@@ -6,7 +6,11 @@ import type { PayloadRequest } from '../types/index.js'
 export async function killTransaction(req: PayloadRequest): Promise<void> {
   const { payload, transactionID } = req
   if (transactionID && !(transactionID instanceof Promise)) {
-    await payload.db.rollbackTransaction(req.transactionID)
+    try {
+      await payload.db.rollbackTransaction(req.transactionID)
+    } catch (error) {
+      // swallow any errors while attempting to rollback
+    }
     delete req.transactionID
   }
 }

--- a/test/hooks/collections/Hook/index.ts
+++ b/test/hooks/collections/Hook/index.ts
@@ -11,8 +11,8 @@ const Hooks: CollectionConfig = {
   },
   hooks: {
     beforeOperation: [
-      ({ req }) => {
-        if (!req.transactionID) {
+      ({ req, operation }) => {
+        if (!req.transactionID && ['create', 'delete', 'update'].includes(operation)) {
           throw new Error('transactionID is missing in beforeOperation hook')
         }
       },


### PR DESCRIPTION
## Description

### payload
- Removes calls to beginTransaction and commitTransaction from read operations

### db-sqlite, db-postgres
- beginTransaction() options are passed through and used to create a transaction
- declare module type adds beginTransaction with proper transaction config args for postgres and sqlite

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
