### PR TITLE
Fix: avoid deleting associated files on update for versioned collection docs

### DIFF
--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -187,14 +187,16 @@ async function update<TSlug extends keyof GeneratedTypes['collections']>(
           showHiddenFields: true,
         })
 
-        await deleteAssociatedFiles({
-          collectionConfig,
-          config,
-          doc,
-          files: filesToUpload,
-          overrideDelete: false,
-          t,
-        })
+        if(!collectionConfig.versions){
+          await deleteAssociatedFiles({
+            collectionConfig,
+            config,
+            doc,
+            files: filesToUpload,
+            overrideDelete: false,
+            t,
+          })
+        }
 
         // /////////////////////////////////////
         // beforeValidate - Fields

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -161,14 +161,16 @@ async function updateByID<TSlug extends keyof GeneratedTypes['collections']>(
     // Delete any associated files
     // /////////////////////////////////////
 
-    await deleteAssociatedFiles({
-      collectionConfig,
-      config,
-      doc: docWithLocales,
-      files: filesToUpload,
-      overrideDelete: false,
-      t,
-    })
+    if(!collectionConfig.versions){
+      await deleteAssociatedFiles({
+        collectionConfig,
+        config,
+        doc: docWithLocales,
+        files: filesToUpload,
+        overrideDelete: false,
+        t,
+      })
+    }
 
     // /////////////////////////////////////
     // beforeValidate - Fields

--- a/packages/plugin-cloud-storage/src/hooks/beforeChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/beforeChange.ts
@@ -20,7 +20,8 @@ export const getBeforeChangeHook =
         // If there is an original doc,
         // And we have new files,
         // We need to delete the old files before uploading new
-        if (originalDoc) {
+        // unless the collection is versioned (then only delete on delete)
+        if (originalDoc && !collection.versions) {
           let filesToDelete: string[] = []
 
           if (typeof originalDoc?.filename === 'string') {


### PR DESCRIPTION
## Description

Currently it is not possible to restore any other version of a document with files (`collectionConfig.uploads=true`) as those files get always deleted on update.

For a versioned collection the files should be kept until the related version is deleted  or the entire document is deleted.
Otherwise it is not possible to restore an older file version.

This is includes also the package `plugin-cloud-storage`.

### The fix
I added in the operations for `update` and `updateById` a check if the collection is versioned and avoid running the `deleteAssociatedFiles` method if so.

For the package `plugin-cloud-storage` I added the check in the `beforeChange` handler which will avoid deleting files if the collection is versioned.

The files are still correctly deleted once the whole document is deleted.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
