### PR TITLE
fix(db-postgres): migration template type error

### DIFF
--- a/packages/db-postgres/src/createMigration.ts
+++ b/packages/db-postgres/src/createMigration.ts
@@ -65,7 +65,7 @@ export const createMigration: CreateMigration = async function createMigration(
 
     const sqlStatementsUp = await generateMigration(drizzleJsonBefore, drizzleJsonAfter)
     const sqlStatementsDown = await generateMigration(drizzleJsonAfter, drizzleJsonBefore)
-    const sqlExecute = 'await db.execute(sql`'
+    const sqlExecute = 'await payload.db.drizzle.execute(sql`'
 
     if (sqlStatementsUp?.length) {
       upSQL = `${sqlExecute}\n ${sqlStatementsUp?.join('\n')}\`)`

--- a/packages/db-postgres/src/getMigrationTemplate.ts
+++ b/packages/db-postgres/src/getMigrationTemplate.ts
@@ -6,7 +6,7 @@ export const getMigrationTemplate = ({
   upSQL,
 }: MigrationTemplateArgs): string => `import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
 ${imports ? `${imports}\n` : ''}
-export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+export async function up({ payload, req }: MigrateUpArgs): Promise<void> {
 ${upSQL}
 }
 

--- a/packages/db-postgres/src/getMigrationTemplate.ts
+++ b/packages/db-postgres/src/getMigrationTemplate.ts
@@ -10,7 +10,7 @@ export async function up({ payload, req }: MigrateUpArgs): Promise<void> {
 ${upSQL}
 }
 
-export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+export async function down({ payload, req }: MigrateDownArgs): Promise<void> {
 ${downSQL}
 }
 `

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -156,6 +156,7 @@ declare module 'payload' {
   export interface DatabaseAdapter
     extends Omit<Args, 'idType' | 'logger' | 'migrationDir' | 'pool'>,
       DrizzleAdapter {
+    drizzle: PostgresDB
     enums: Record<string, GenericEnum>
     /**
      * An object keyed on each table, with a key value pair where the constraint name is the key, followed by the dot-notation field name


### PR DESCRIPTION
## Description

Fixes #7402

This fixes a regression from changes to the postgres migration template that were incorrect. It also fixes other type errors for `payload.db.drizzle` which needed to be declared for postgres to avoid confusing it with Libsql for SQLite.


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
