### PR TITLE
chore: extends buildConfigWithDefaults to accept options arg 

### DIFF
--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -37,12 +37,16 @@ import { reInitEndpoint } from './helpers/reInit.js'
 import { localAPIEndpoint } from './helpers/sdk/endpoint.js'
 import { testEmailAdapter } from './testEmailAdapter.js'
 
-// process.env.POSTGRES_URL = 'postgres://postgres:postgres@127.0.0.1:5432/payload'
+// process.env.POSTGRES_URL = 'postgres://postgres:postgres@127.0.0.1:5432/payloadtests'
 // process.env.PAYLOAD_DATABASE = 'postgres'
 // process.env.PAYLOAD_DATABASE = 'sqlite'
 
 export async function buildConfigWithDefaults(
   testConfig?: Partial<Config>,
+  options?: {
+    dbType?: 'mongodb' | 'postgres' | 'sqlite'
+    disableAutoLogin?: boolean
+  },
 ): Promise<SanitizedConfig> {
   const databaseAdapters = {
     mongodb: mongooseAdapter({
@@ -85,7 +89,7 @@ export async function buildConfigWithDefaults(
   }
 
   const config: Config = {
-    db: databaseAdapters[process.env.PAYLOAD_DATABASE || 'mongodb'],
+    db: databaseAdapters[process.env.PAYLOAD_DATABASE || options?.dbType || 'mongodb'],
     editor: lexicalEditor({
       features: [
         ParagraphFeature(),
@@ -195,7 +199,7 @@ export async function buildConfigWithDefaults(
 
   if (config.admin.autoLogin === undefined) {
     config.admin.autoLogin =
-      process.env.PAYLOAD_PUBLIC_DISABLE_AUTO_LOGIN === 'true'
+      process.env.PAYLOAD_PUBLIC_DISABLE_AUTO_LOGIN === 'true' || options?.disableAutoLogin
         ? false
         : {
             email: 'dev@payloadcms.com',


### PR DESCRIPTION
## Description

Adds options object to be extended as other see fit. Currently adds the ability to disableAutoLogin and set db type without needed to add ENV variables.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
