### PR TITLE
fix: locale comparison not displaying values correctly

### DIFF
--- a/packages/next/src/views/Version/Default/index.tsx
+++ b/packages/next/src/views/Version/Default/index.tsx
@@ -125,7 +125,7 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
             value={compareValue}
             versionID={versionID}
           />
-          {localization && (
+          {Boolean(localization) && (
             <SelectLocales onChange={setLocales} options={localeOptions} value={locales} />
           )}
         </div>
@@ -138,7 +138,9 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
             i18n={i18n}
             locales={
               locales
-                ? locales.map(({ label }) => (typeof label === 'string' ? label : undefined))
+                ? locales
+                    .map(({ value }) => (typeof value === 'string' ? value : undefined))
+                    .filter((label) => Boolean(label))
                 : []
             }
             version={


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/7381

Locale labels were being passed into the diffViewer, but it expects locale codes.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
