### PR TITLE
chore: add post-merge hook to husky to warn about running pnpm install

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+function changed {
+    git diff --name-only HEAD@{1} HEAD | grep "^$1" >/dev/null 2>&1
+}
+
+if changed 'pnpm-lock.yaml'; then
+    echo "📦 pnpm-lock.yaml changed. Run pnpm install to bring your dependencies up to date."
+fi
+
+exit 0


### PR DESCRIPTION
Adds post-merge hook that checks for lock file diff and warns to run pnpm install