### PR TITLE
fix(db-postgres): proper migrations table detection query for earlier versions of PG

### DIFF
--- a/packages/drizzle/src/utilities/migrationTableExists.ts
+++ b/packages/drizzle/src/utilities/migrationTableExists.ts
@@ -5,7 +5,7 @@ export const migrationTableExists = async (adapter: DrizzleAdapter): Promise<boo
 
   if (adapter.name === 'postgres') {
     const prependSchema = adapter.schemaName ? `"${adapter.schemaName}".` : ''
-    statement = `SELECT to_regclass('${prependSchema}"payload_migrations"') exists;`
+    statement = `SELECT to_regclass('${prependSchema}"payload_migrations"') AS exists;`
   }
 
   if (adapter.name === 'sqlite') {


### PR DESCRIPTION
Fixes postgres sql query to detect migrations table.

`error: syntax error at or near "exists"`

This was causing issues in PG 13 for me locally.