### PR TITLE
feat(ui): expose custom errors in deleteMany

### DIFF
--- a/packages/ui/src/elements/DeleteMany/index.tsx
+++ b/packages/ui/src/elements/DeleteMany/index.tsx
@@ -134,7 +134,7 @@ export const DeleteMany: React.FC<Props> = (props) => {
           >
             {t('general:cancel')}
           </Button>
-          <Button id="confirm-delete" onClick={deleting ? undefined : void handleDelete}>
+          <Button id="confirm-delete" onClick={deleting ? undefined : () => void handleDelete()}>
             {deleting ? t('general:deleting') : t('general:confirm')}
           </Button>
         </div>

--- a/packages/ui/src/elements/DeleteMany/index.tsx
+++ b/packages/ui/src/elements/DeleteMany/index.tsx
@@ -79,7 +79,9 @@ export const DeleteMany: React.FC<Props> = (props) => {
           }
 
           if (json.errors) {
-            toast.error(json.message)
+            toast.error(json.message, {
+              description: json.errors.map((error) => error.message).join('\n'),
+            })
           } else {
             addDefaultError()
           }
@@ -132,7 +134,7 @@ export const DeleteMany: React.FC<Props> = (props) => {
           >
             {t('general:cancel')}
           </Button>
-          <Button id="confirm-delete" onClick={deleting ? undefined : handleDelete}>
+          <Button id="confirm-delete" onClick={deleting ? undefined : void handleDelete}>
             {deleting ? t('general:deleting') : t('general:confirm')}
           </Button>
         </div>


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/7214
Exposes custom errors in the DeleteMany component so they can be more descriptive:

![image](https://github.com/user-attachments/assets/f0c2f2e3-71a9-455f-9137-23eccfd21dbb)
