### PR TITLE
fix(ui): reincorporate `basePath` into logout component link

### DIFF
--- a/packages/ui/src/elements/Logout/index.tsx
+++ b/packages/ui/src/elements/Logout/index.tsx
@@ -23,6 +23,7 @@ const DefaultLogout: React.FC<{
     routes: { admin: adminRoute },
   } = config
 
+  const basePath = process.env.NEXT_BASE_PATH ?? ''
   const LinkElement = Link || 'a'
 
   return (
@@ -31,6 +32,7 @@ const DefaultLogout: React.FC<{
       className={`${baseClass}__log-out`}
       href={formatAdminURL({
         adminRoute,
+        basePath,
         path: logoutRoute,
       })}
       tabIndex={tabIndex}

--- a/packages/ui/src/utilities/formatAdminURL.ts
+++ b/packages/ui/src/utilities/formatAdminURL.ts
@@ -3,20 +3,21 @@ import type { Config } from 'payload'
 /** Will read the `routes.admin` config and appropriately handle `"/"` admin paths */
 export const formatAdminURL = (args: {
   adminRoute: Config['routes']['admin']
+  basePath?: string
   path: string
   serverURL?: Config['serverURL']
 }): string => {
-  const { adminRoute, path, serverURL } = args
+  const { adminRoute, basePath = '', path, serverURL } = args
 
   if (adminRoute) {
     if (adminRoute === '/') {
       if (!path) {
-        return `${serverURL || ''}${adminRoute}`
+        return `${serverURL || ''}${basePath}${adminRoute}`
       }
     } else {
-      return `${serverURL || ''}${adminRoute}${path}`
+      return `${serverURL || ''}${basePath}${adminRoute}${path}`
     }
   }
 
-  return `${serverURL || ''}${path}`
+  return `${serverURL || ''}${basePath}${path}`
 }


### PR DESCRIPTION
## Description

Fixes issue where the `basePath` from the `next-config` was not respected for the `logout` button link

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
