### PR TITLE
fix(db-postgres): incorrect schema type on adapter

### DIFF
--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -141,7 +141,6 @@ export type PostgresAdapter = {
   relations: Record<string, GenericRelation>
   relationshipsSuffix?: string
   resolveInitializing: () => void
-  schema: DrizzleConfig
   schemaName?: Args['schemaName']
   sessions: {
     [id: string]: {
@@ -183,7 +182,7 @@ declare module 'payload' {
     rejectInitializing: () => void
     relationshipsSuffix?: string
     resolveInitializing: () => void
-    schema: Record<string, GenericEnum | GenericRelation | GenericTable>
+    schema: Record<string, unknown>
     schemaName?: Args['schemaName']
     tableNameMap: Map<string, string>
     versionsSuffix?: string


### PR DESCRIPTION
fixes a db-postgres type issue that was introduced in https://github.com/payloadcms/payload/pull/7453