### PR TITLE
fix: set active nav item

### DIFF
--- a/packages/next/src/elements/Nav/index.client.tsx
+++ b/packages/next/src/elements/Nav/index.client.tsx
@@ -85,9 +85,18 @@ export const DefaultNavClient: React.FC = () => {
 
               const LinkElement = Link || 'a'
 
+              const activeCollection = window?.location?.pathname
+                ?.split('/')
+                .find(
+                  (_, index, arr) =>
+                    arr[index - 1] === 'collections' || arr[index - 1] === 'globals',
+                )
+
               return (
                 <LinkElement
-                  className={`${baseClass}__link`}
+                  className={[`${baseClass}__link`, activeCollection === entity?.slug && `active`]
+                    .filter(Boolean)
+                    .join(' ')}
                   href={href}
                   id={id}
                   key={i}


### PR DESCRIPTION
## Description

Closes #7446

Nav items not displaying different style when active.

We were previously using `NavLink` which determines if the item is active and applies the classname. Now we are using the standard `Link` and need to add the `active` classname manually.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
