### PR TITLE
fix(templates/ecommerce): theme selector in windows

### DIFF
--- a/templates/ecommerce/src/app/_providers/Theme/ThemeSelector/index.module.scss
+++ b/templates/ecommerce/src/app/_providers/Theme/ThemeSelector/index.module.scss
@@ -13,6 +13,10 @@
 .select {
   all: unset;
   padding-right: 14px;
+  option {
+    background-color: var(--theme-bg);
+    color: var(--theme-text);
+  }
 }
 
 .selectIcon {


### PR DESCRIPTION
## Description

Fix theme selector text not visible in the ecommerce template 

Style change doesn't effect mac, from my testing

![image](https://github.com/user-attachments/assets/8064245a-8ea2-4b4f-a66e-6331855dfe21)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
