### PR TITLE
fix: #7488, cant deploy SQLite to Vercel

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -25,6 +25,12 @@ export const withPayload = (nextConfig = {}) => {
           ...(nextConfig.experimental?.outputFileTracingExcludes?.['**/*'] || []),
           'drizzle-kit',
           'drizzle-kit/payload',
+        ],
+      },
+      outputFileTracingIncludes: {
+        '**/*': [
+          ...(nextConfig.experimental?.outputFileTracingIncludes?.['**/*'] || []),
+          '@libsql/client',
           'libsql',
         ],
       },
@@ -64,7 +70,6 @@ export const withPayload = (nextConfig = {}) => {
       ...(nextConfig?.serverExternalPackages || []),
       'drizzle-kit',
       'drizzle-kit/payload',
-      'libsql',
       'pino',
       'pino-pretty',
       'graphql',

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -31,7 +31,6 @@ export const withPayload = (nextConfig = {}) => {
         '**/*': [
           ...(nextConfig.experimental?.outputFileTracingIncludes?.['**/*'] || []),
           '@libsql/client',
-          'libsql',
         ],
       },
       turbo: {
@@ -71,6 +70,7 @@ export const withPayload = (nextConfig = {}) => {
       'drizzle-kit',
       'drizzle-kit/payload',
       'pino',
+      'libsql',
       'pino-pretty',
       'graphql',
     ],


### PR DESCRIPTION
## Description

Closes #7488

Note - you'll also need to manually have `@libsql/client` installed in your Next.js repository. This is not ideal, but it might be outside of the scope of what we can handle internally.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Follow-up

The original runtime issue was real, but the bare `@libsql/client` tracing entry added here is not a valid filesystem glob. With Next 16.3.x/Turbopack and pnpm symlinks, it can cause an `EISDIR` build panic. Follow-up PR [#18238](https://github.com/payloadcms/payload/pull/18238) removes the injected entry while preserving the original standalone deployment fix.
