### PR TITLE
fix(cpa): adjust template file location detection

### DIFF
--- a/packages/create-payload-app/src/lib/update-payload-in-project.ts
+++ b/packages/create-payload-app/src/lib/update-payload-in-project.ts
@@ -74,9 +74,11 @@ export async function updatePayloadInProject(
   info('Payload packages updated successfully.')
 
   info(`Updating Payload Next.js files...`)
-  const templateFilesPath = dirname.endsWith('dist')
-    ? path.resolve(dirname, '../..', 'dist/template')
-    : path.resolve(dirname, '../../../../templates/blank-3.0')
+
+  const templateFilesPath =
+    process.env.JEST_WORKER_ID !== undefined
+      ? path.resolve(dirname, '../../../../templates/blank-3.0')
+      : path.resolve(dirname, '../..', 'dist/template')
 
   const templateSrcDir = path.resolve(templateFilesPath, 'src/app/(payload)')
 


### PR DESCRIPTION
Adjust template file location detection. This was causing issues when run with `pnpm create` because it is not run from a `dist` directory.

```
┌   create-payload-app
│
◇   ────────────────────────────────────────────╮
│                                               │
│  Welcome to Payload. Let's create a project!  │
│                                               │
├───────────────────────────────────────────────╯
│
▲  Payload installation detected in current project.
│
◇  Upgrade Payload in this project?
│  Yes
│
◇  Using pnpm.
│
│
◇  Updating 7 Payload packages to v3.0.0-beta.73...
│
│    - payload
│    - @payloadcms/db-mongodb
│    - @payloadcms/db-postgres
│    - @payloadcms/next
│    - @payloadcms/richtext-lexical
│    - @payloadcms/richtext-slate
│    - @payloadcms/ui
│
◇  Payload packages updated successfully.
│
◇  Updating Payload Next.js files...
│
■  ENOENT: no such file or directory, copyfile '/Users/elliot/Library/pnpm/store/v3/tmp/dlx-99797/node_modules/.pnpm/create-payload-app@3.0.0-beta.73/templates/blank-3.0/src/app/(payload)' -> '/Users/elliot/dev/payload-3.0-demo/src/app/(payload)'
```