### PR TITLE
chore: update ReactFc component and types to use function syntax

### DIFF
--- a/examples/auth/next-app/app/_components/Button/index.tsx
+++ b/examples/auth/next-app/app/_components/Button/index.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 
 import classes from './index.module.scss'
 
-export type Props = {
+export type ButtonProps = {
   label?: string
   appearance?: 'default' | 'primary' | 'secondary'
   el?: 'button' | 'link' | 'a'
@@ -18,7 +18,7 @@ export type Props = {
   invert?: boolean
 }
 
-export const Button: React.FC<Props> = ({
+export function Button({
   el: elFromProps = 'link',
   label,
   newTab,
@@ -29,7 +29,7 @@ export const Button: React.FC<Props> = ({
   type = 'button',
   disabled,
   invert,
-}) => {
+}: ButtonProps) {
   let el = elFromProps
   const newTabProps = newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {}
 

--- a/examples/auth/next-app/app/_components/Gutter/index.tsx
+++ b/examples/auth/next-app/app/_components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/auth/next-app/app/_components/Header/Nav/index.tsx
+++ b/examples/auth/next-app/app/_components/Header/Nav/index.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '../../../_providers/Auth'
 
 import classes from './index.module.scss'
 
-export const HeaderNav: React.FC = () => {
+export function HeaderNav() {
   const { user } = useAuth()
 
   return (

--- a/examples/auth/next-app/app/_components/Input/index.tsx
+++ b/examples/auth/next-app/app/_components/Input/index.tsx
@@ -3,7 +3,7 @@ import { FieldValues, UseFormRegister, Validate } from 'react-hook-form'
 
 import classes from './index.module.scss'
 
-type Props = {
+type InputProps = {
   name: string
   label: string
   register: UseFormRegister<FieldValues & any>
@@ -13,7 +13,7 @@ type Props = {
   validate?: (value: string) => boolean | string
 }
 
-export const Input: React.FC<Props> = ({
+export function Input({
   name,
   label,
   required,
@@ -21,7 +21,7 @@ export const Input: React.FC<Props> = ({
   error,
   type = 'text',
   validate,
-}) => {
+}: InputProps) {
   return (
     <div className={classes.inputWrap}>
       <label htmlFor="name" className={classes.label}>

--- a/examples/auth/next-app/app/_components/Message/index.tsx
+++ b/examples/auth/next-app/app/_components/Message/index.tsx
@@ -2,13 +2,15 @@ import React from 'react'
 
 import classes from './index.module.scss'
 
-export const Message: React.FC<{
+type MessageProps = {
   message?: React.ReactNode
   error?: React.ReactNode
   success?: React.ReactNode
   warning?: React.ReactNode
   className?: string
-}> = ({ message, error, success, warning, className }) => {
+}
+
+export function Message({ message, error, success, warning, className }: MessageProps) {
   const messageToRender = message || error || success || warning
 
   if (messageToRender) {

--- a/examples/auth/next-app/app/_components/RenderParams/index.tsx
+++ b/examples/auth/next-app/app/_components/RenderParams/index.tsx
@@ -4,11 +4,17 @@ import { useSearchParams } from 'next/navigation'
 
 import { Message } from '../Message'
 
-export const RenderParams: React.FC<{
+type RenderParamsProps = {
   params?: string[]
   message?: string
   className?: string
-}> = ({ params = ['error', 'message', 'success'], message, className }) => {
+}
+
+export function RenderParams({
+  params = ['error', 'message', 'success'],
+  message,
+  className,
+}: RenderParamsProps) {
   const searchParams = useSearchParams()
   const paramValues = params.map(param => searchParams.get(param)).filter(Boolean)
 

--- a/examples/auth/next-app/app/_components/RichText/index.tsx
+++ b/examples/auth/next-app/app/_components/RichText/index.tsx
@@ -4,7 +4,12 @@ import serialize from './serialize'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{ className?: string; content: any }> = ({ className, content }) => {
+type RichTextProps = {
+  className?: string
+  content: any
+}
+
+function RichText({ className, content }) {
   if (!content) {
     return null
   }

--- a/examples/auth/next-app/app/_components/RichText/serialize.tsx
+++ b/examples/auth/next-app/app/_components/RichText/serialize.tsx
@@ -16,8 +16,8 @@ type Leaf = {
   [key: string]: unknown
 }
 
-const serialize = (children: Children): React.ReactNode[] =>
-  children.map((node, i) => {
+function serialize(children: Children): React.ReactNode[] {
+  return children.map((node, i) => {
     if (Text.isText(node)) {
       let text = <span dangerouslySetInnerHTML={{ __html: escapeHTML(node.text) }} />
 
@@ -88,5 +88,6 @@ const serialize = (children: Children): React.ReactNode[] =>
         return <p key={i}>{serialize(node.children)}</p>
     }
   })
+}
 
 export default serialize

--- a/examples/auth/next-app/app/_providers/Auth/index.tsx
+++ b/examples/auth/next-app/app/_providers/Auth/index.tsx
@@ -9,10 +9,12 @@ import { AuthContext, Create, ForgotPassword, Login, Logout, ResetPassword } fro
 
 const Context = createContext({} as AuthContext)
 
-export const AuthProvider: React.FC<{ children: React.ReactNode; api?: 'rest' | 'gql' }> = ({
-  children,
-  api = 'rest',
-}) => {
+type AuthProviderProps = {
+  children: React.ReactNode
+  api?: 'rest' | 'gql'
+}
+
+export function AuthProvider({ children, api = 'rest' }: AuthProviderProps) {
   const [user, setUser] = useState<User | null>()
 
   const create = useCallback<Create>(

--- a/examples/auth/next-app/app/account/AccountForm/index.tsx
+++ b/examples/auth/next-app/app/account/AccountForm/index.tsx
@@ -18,7 +18,7 @@ type FormData = {
   passwordConfirm: string
 }
 
-export const AccountForm: React.FC = () => {
+export function AccountForm() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
   const { user, setUser } = useAuth()

--- a/examples/auth/next-app/app/create-account/CreateAccountForm/index.tsx
+++ b/examples/auth/next-app/app/create-account/CreateAccountForm/index.tsx
@@ -18,7 +18,7 @@ type FormData = {
   passwordConfirm: string
 }
 
-export const CreateAccountForm: React.FC = () => {
+export function CreateAccountForm() {
   const searchParams = useSearchParams()
   const allParams = searchParams.toString() ? `?${searchParams.toString()}` : ''
   const { login } = useAuth()

--- a/examples/auth/next-app/app/login/LoginForm/index.tsx
+++ b/examples/auth/next-app/app/login/LoginForm/index.tsx
@@ -17,7 +17,7 @@ type FormData = {
   password: string
 }
 
-export const LoginForm: React.FC = () => {
+export function LoginForm() {
   const searchParams = useSearchParams()
   const allParams = searchParams.toString() ? `?${searchParams.toString()}` : ''
   const redirect = useRef(searchParams.get('redirect'))

--- a/examples/auth/next-app/app/logout/LogoutPage/index.tsx
+++ b/examples/auth/next-app/app/logout/LogoutPage/index.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 
 import { useAuth } from '../../_providers/Auth'
 
-export const LogoutPage: React.FC = props => {
+export function LogoutPage(props: any) {
   const { logout } = useAuth()
   const [success, setSuccess] = useState('')
   const [error, setError] = useState('')

--- a/examples/auth/next-app/app/recover-password/RecoverPasswordForm/index.tsx
+++ b/examples/auth/next-app/app/recover-password/RecoverPasswordForm/index.tsx
@@ -14,7 +14,7 @@ type FormData = {
   email: string
 }
 
-export const RecoverPasswordForm: React.FC = () => {
+export function RecoverPasswordForm() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState(false)
 

--- a/examples/auth/next-app/app/reset-password/ResetPasswordForm/index.tsx
+++ b/examples/auth/next-app/app/reset-password/ResetPasswordForm/index.tsx
@@ -16,7 +16,7 @@ type FormData = {
   token: string
 }
 
-export const ResetPasswordForm: React.FC = () => {
+export function ResetPasswordForm() {
   const [error, setError] = useState('')
   const { login } = useAuth()
   const router = useRouter()

--- a/examples/auth/next-pages/src/components/Button/index.tsx
+++ b/examples/auth/next-pages/src/components/Button/index.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 import classes from './index.module.scss'
 
-export type Props = {
+export type ButtonProps = {
   label?: string
   appearance?: 'default' | 'primary' | 'secondary'
   el?: 'button' | 'link' | 'a'
@@ -16,7 +16,7 @@ export type Props = {
   invert?: boolean
 }
 
-export const Button: React.FC<Props> = ({
+export function Button({
   el: elFromProps = 'link',
   label,
   newTab,
@@ -27,7 +27,7 @@ export const Button: React.FC<Props> = ({
   type = 'button',
   disabled,
   invert,
-}) => {
+}: ButtonProps) {
   let el = elFromProps
   const newTabProps = newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {}
 

--- a/examples/auth/next-pages/src/components/Gutter/index.tsx
+++ b/examples/auth/next-pages/src/components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/auth/next-pages/src/components/Header/Nav/index.tsx
+++ b/examples/auth/next-pages/src/components/Header/Nav/index.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '../../../providers/Auth'
 
 import classes from './index.module.scss'
 
-export const HeaderNav: React.FC = () => {
+export function HeaderNav() {
   const { user } = useAuth()
 
   return (

--- a/examples/auth/next-pages/src/components/Header/index.tsx
+++ b/examples/auth/next-pages/src/components/Header/index.tsx
@@ -7,7 +7,7 @@ import { HeaderNav } from './Nav'
 
 import classes from './index.module.scss'
 
-export const Header: React.FC = () => {
+export function Header() {
   return (
     <header className={classes.header}>
       <Gutter className={classes.wrap}>

--- a/examples/auth/next-pages/src/components/Input/index.tsx
+++ b/examples/auth/next-pages/src/components/Input/index.tsx
@@ -3,7 +3,7 @@ import { FieldValues, UseFormRegister, Validate } from 'react-hook-form'
 
 import classes from './index.module.scss'
 
-type Props = {
+type InputProps = {
   name: string
   label: string
   register: UseFormRegister<FieldValues & any>
@@ -13,7 +13,7 @@ type Props = {
   validate?: (value: string) => boolean | string
 }
 
-export const Input: React.FC<Props> = ({
+export function Input({
   name,
   label,
   required,
@@ -21,7 +21,7 @@ export const Input: React.FC<Props> = ({
   error,
   type = 'text',
   validate,
-}) => {
+}: InputProps) {
   return (
     <div className={classes.inputWrap}>
       <label htmlFor="name" className={classes.label}>

--- a/examples/auth/next-pages/src/components/Message/index.tsx
+++ b/examples/auth/next-pages/src/components/Message/index.tsx
@@ -2,13 +2,15 @@ import React from 'react'
 
 import classes from './index.module.scss'
 
-export const Message: React.FC<{
+type MessageProps = {
   message?: React.ReactNode
   error?: React.ReactNode
   success?: React.ReactNode
   warning?: React.ReactNode
   className?: string
-}> = ({ message, error, success, warning, className }) => {
+}
+
+export function Message({ message, error, success, warning, className }: MessageProps) {
   const messageToRender = message || error || success || warning
 
   if (messageToRender) {

--- a/examples/auth/next-pages/src/components/RenderParams/index.tsx
+++ b/examples/auth/next-pages/src/components/RenderParams/index.tsx
@@ -2,11 +2,17 @@ import { useRouter } from 'next/router'
 
 import { Message } from '../Message'
 
-export const RenderParams: React.FC<{
+type RenderParamsProps = {
   params?: string[]
   message?: string
   className?: string
-}> = ({ params = ['error', 'message', 'success'], message, className }) => {
+}
+
+export function RenderParams({
+  params = ['error', 'message', 'success'],
+  message,
+  className,
+}: RenderParamsProps) {
   const router = useRouter()
   const searchParams = new URLSearchParams(router.query as any)
   const paramValues = params.map(param => searchParams.get(param)).filter(Boolean)

--- a/examples/auth/next-pages/src/components/RichText/index.tsx
+++ b/examples/auth/next-pages/src/components/RichText/index.tsx
@@ -4,7 +4,12 @@ import serialize from './serialize'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{ className?: string; content: any }> = ({ className, content }) => {
+type RichTextProps = {
+  className?: string
+  content: any
+}
+
+function RichText({ className, content }: RichTextProps) {
   if (!content) {
     return null
   }

--- a/examples/auth/next-pages/src/pages/account/index.tsx
+++ b/examples/auth/next-pages/src/pages/account/index.tsx
@@ -19,7 +19,7 @@ type FormData = {
   passwordConfirm: string
 }
 
-const Account: React.FC = () => {
+function Account() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
   const { user, setUser } = useAuth()

--- a/examples/auth/next-pages/src/pages/create-account/index.tsx
+++ b/examples/auth/next-pages/src/pages/create-account/index.tsx
@@ -18,7 +18,7 @@ type FormData = {
   passwordConfirm: string
 }
 
-const CreateAccount: React.FC = () => {
+function CreateAccount() {
   const router = useRouter()
   const searchParams = useMemo(() => new URLSearchParams(router.query as any), [router.query])
   const allParams = searchParams.toString() ? `?${searchParams.toString()}` : ''

--- a/examples/auth/next-pages/src/pages/login/index.tsx
+++ b/examples/auth/next-pages/src/pages/login/index.tsx
@@ -17,7 +17,7 @@ type FormData = {
   password: string
 }
 
-const Login: React.FC = () => {
+function Login() {
   const router = useRouter()
   const searchParams = useMemo(() => new URLSearchParams(router.query as any), [router.query])
   const allParams = searchParams.toString() ? `?${searchParams.toString()}` : ''

--- a/examples/auth/next-pages/src/pages/logout/index.tsx
+++ b/examples/auth/next-pages/src/pages/logout/index.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '../../providers/Auth'
 
 import classes from './index.module.scss'
 
-const Logout: React.FC = () => {
+function Logout() {
   const { logout } = useAuth()
   const [success, setSuccess] = useState('')
   const [error, setError] = useState('')

--- a/examples/auth/next-pages/src/pages/recover-password/index.tsx
+++ b/examples/auth/next-pages/src/pages/recover-password/index.tsx
@@ -13,7 +13,7 @@ type FormData = {
   email: string
 }
 
-const RecoverPassword: React.FC = () => {
+function RecoverPassword() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState(false)
 

--- a/examples/auth/next-pages/src/pages/reset-password/index.tsx
+++ b/examples/auth/next-pages/src/pages/reset-password/index.tsx
@@ -15,7 +15,7 @@ type FormData = {
   token: string
 }
 
-const ResetPassword: React.FC = () => {
+function ResetPassword() {
   const [error, setError] = useState('')
   const { login } = useAuth()
   const router = useRouter()

--- a/examples/auth/next-pages/src/providers/Auth/index.tsx
+++ b/examples/auth/next-pages/src/providers/Auth/index.tsx
@@ -7,10 +7,12 @@ import { AuthContext, Create, ForgotPassword, Login, Logout, ResetPassword } fro
 
 const Context = createContext({} as AuthContext)
 
-export const AuthProvider: React.FC<{ children: React.ReactNode; api?: 'rest' | 'gql' }> = ({
-  children,
-  api = 'rest',
-}) => {
+type AuthProviderProps = {
+  children: React.ReactNode
+  api?: 'rest' | 'gql'
+}
+
+export function AuthProvider({ children, api = 'rest' }: AuthProviderProps) {
   const [user, setUser] = useState<User | null>()
 
   const create = useCallback<Create>(

--- a/examples/auth/payload/src/components/BeforeLogin/index.tsx
+++ b/examples/auth/payload/src/components/BeforeLogin/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const BeforeLogin: React.FC = () => {
+function BeforeLogin() {
   if (process.env.PAYLOAD_PUBLIC_SEED === 'true') {
     return (
       <p>

--- a/examples/custom-server/src/app/_components/Gutter/index.tsx
+++ b/examples/custom-server/src/app/_components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/custom-server/src/app/_components/RichText/index.tsx
+++ b/examples/custom-server/src/app/_components/RichText/index.tsx
@@ -6,11 +6,13 @@ import { CustomRenderers, Serialize as SerializeContent } from './Serialize'
 
 import classes from './index.module.scss'
 
-export const RichText: React.FC<{
+type RichTextProps = {
   className?: string
   content: any
   customRenderers?: CustomRenderers
-}> = ({ className, content, customRenderers }) => {
+}
+
+export function RichText({ className, content, customRenderers }: RichTextProps) {
   if (!content) {
     return null
   }

--- a/examples/custom-server/src/components/BeforeLogin/index.tsx
+++ b/examples/custom-server/src/components/BeforeLogin/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const BeforeLogin: React.FC = () => {
+function BeforeLogin() {
   if (process.env.PAYLOAD_PUBLIC_SEED === 'true') {
     return (
       <p>

--- a/examples/draft-preview/next-app/app/[slug]/page.tsx
+++ b/examples/draft-preview/next-app/app/[slug]/page.tsx
@@ -13,7 +13,7 @@ interface PageParams {
   params: { slug: string }
 }
 
-export const PageTemplate: React.FC<{ page: Page | null | undefined }> = ({ page }) => (
+export const PageTemplate = ({ page }: { page: Page | null | undefined }) => (
   <main className={classes.page}>
     <Gutter>
       <h1>{page?.title}</h1>

--- a/examples/draft-preview/next-app/app/_components/AdminBar/index.client.tsx
+++ b/examples/draft-preview/next-app/app/_components/AdminBar/index.client.tsx
@@ -7,9 +7,9 @@ import { Gutter } from '../Gutter'
 
 import classes from './index.module.scss'
 
-const Title: React.FC = () => <span>Dashboard</span>
+const Title = () => <span>Dashboard</span>
 
-export const AdminBarClient: React.FC<PayloadAdminBarProps> = props => {
+export const AdminBarClient = (props: PayloadAdminBarProps) => {
   const [user, setUser] = useState<PayloadMeUser>()
 
   return (

--- a/examples/draft-preview/next-app/app/_components/Button/index.tsx
+++ b/examples/draft-preview/next-app/app/_components/Button/index.tsx
@@ -15,7 +15,7 @@ export type Props = {
   disabled?: boolean
 }
 
-export const Button: React.FC<Props> = ({
+export function Button({
   el: elFromProps = 'link',
   label,
   newTab,
@@ -25,7 +25,7 @@ export const Button: React.FC<Props> = ({
   onClick,
   type = 'button',
   disabled,
-}) => {
+}: Props) {
   let el = elFromProps
   const newTabProps = newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {}
   const className = [

--- a/examples/draft-preview/next-app/app/_components/CMSLink/index.tsx
+++ b/examples/draft-preview/next-app/app/_components/CMSLink/index.tsx
@@ -18,7 +18,7 @@ export type CMSLinkType = {
   className?: string
 }
 
-export const CMSLink: React.FC<CMSLinkType> = ({
+export const CMSLink = ({
   type,
   url,
   newTab,
@@ -27,7 +27,7 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   appearance,
   children,
   className,
-}) => {
+}: CMSLinkType) => {
   const href =
     type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
       ? `/${reference.value.slug === 'home' ? '' : reference.value.slug}`

--- a/examples/draft-preview/next-app/app/_components/Gutter/index.tsx
+++ b/examples/draft-preview/next-app/app/_components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/draft-preview/next-app/app/_components/RichText/index.tsx
+++ b/examples/draft-preview/next-app/app/_components/RichText/index.tsx
@@ -4,7 +4,12 @@ import serialize from './serialize'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{ className?: string; content: any }> = ({ className, content }) => {
+type RichTextProps = {
+  className?: string
+  content: any
+}
+
+function RichText({ className, content }: RichTextProps) {
   if (!content) {
     return null
   }

--- a/examples/draft-preview/next-pages/src/components/AdminBar/index.tsx
+++ b/examples/draft-preview/next-pages/src/components/AdminBar/index.tsx
@@ -5,13 +5,13 @@ import { Gutter } from '../Gutter'
 
 import classes from './index.module.scss'
 
-const Title: React.FC = () => <span>Dashboard</span>
+const Title = () => <span>Dashboard</span>
 
-export const AdminBar: React.FC<{
+export const AdminBar = (props: {
   adminBarProps?: PayloadAdminBarProps
   user?: PayloadMeUser
-  setUser?: (user: PayloadMeUser) => void // eslint-disable-line no-unused-vars
-}> = props => {
+  setUser?: (user: PayloadMeUser) => void // eslint-disable-line no-unused-vars;
+}) => {
   const { adminBarProps, user, setUser } = props
 
   return (

--- a/examples/draft-preview/next-pages/src/components/Button/index.tsx
+++ b/examples/draft-preview/next-pages/src/components/Button/index.tsx
@@ -15,7 +15,7 @@ export type Props = {
   disabled?: boolean
 }
 
-export const Button: React.FC<Props> = ({
+export const Button = ({
   el: elFromProps = 'link',
   label,
   newTab,
@@ -25,7 +25,7 @@ export const Button: React.FC<Props> = ({
   onClick,
   type = 'button',
   disabled,
-}) => {
+}: Props) => {
   let el = elFromProps
   const newTabProps = newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {}
   const className = [

--- a/examples/draft-preview/next-pages/src/components/CMSLink/index.tsx
+++ b/examples/draft-preview/next-pages/src/components/CMSLink/index.tsx
@@ -18,7 +18,7 @@ export type CMSLinkType = {
   className?: string
 }
 
-export const CMSLink: React.FC<CMSLinkType> = ({
+export const CMSLink = ({
   type,
   url,
   newTab,
@@ -27,7 +27,7 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   appearance,
   children,
   className,
-}) => {
+}: CMSLinkType) => {
   const href =
     type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
       ? `/${reference.value.slug === 'home' ? '' : reference.value.slug}`

--- a/examples/draft-preview/next-pages/src/components/Gutter/index.tsx
+++ b/examples/draft-preview/next-pages/src/components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/draft-preview/next-pages/src/components/Header/index.tsx
+++ b/examples/draft-preview/next-pages/src/components/Header/index.tsx
@@ -14,7 +14,7 @@ type HeaderBarProps = {
   children?: React.ReactNode
 }
 
-export const HeaderBar: React.FC<HeaderBarProps> = ({ children }) => {
+export const HeaderBar = ({ children }: HeaderBarProps) => {
   return (
     <header className={classes.header}>
       <Gutter className={classes.wrap}>
@@ -38,12 +38,12 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({ children }) => {
   )
 }
 
-export const Header: React.FC<{
+export const Header = (props: {
   globals: {
     mainMenu: MainMenu
   }
   adminBarProps: PayloadAdminBarProps
-}> = props => {
+}) => {
   const { globals, adminBarProps } = props
 
   const [user, setUser] = useState<PayloadMeUser>()

--- a/examples/draft-preview/next-pages/src/components/RichText/index.tsx
+++ b/examples/draft-preview/next-pages/src/components/RichText/index.tsx
@@ -4,7 +4,7 @@ import serialize from './serialize'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{ className?: string; content: any }> = ({ className, content }) => {
+const RichText = ({ className, content }: { className?: string; content: any }) => {
   if (!content) {
     return null
   }

--- a/examples/draft-preview/next-pages/src/pages/[slug].tsx
+++ b/examples/draft-preview/next-pages/src/pages/[slug].tsx
@@ -9,12 +9,12 @@ import type { MainMenu, Page as PageType } from '../payload-types'
 
 import classes from './[slug].module.scss'
 
-const Page: React.FC<
-  PageType & {
+const Page = (
+  props: PageType & {
     mainMenu: MainMenu
     preview?: boolean
-  }
-> = props => {
+  },
+) => {
   const { title, richText } = props
 
   return (

--- a/examples/draft-preview/payload/src/components/BeforeLogin/index.tsx
+++ b/examples/draft-preview/payload/src/components/BeforeLogin/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const BeforeLogin: React.FC = () => {
+function BeforeLogin() {
   if (process.env.PAYLOAD_PUBLIC_SEED === 'true') {
     return (
       <p>

--- a/examples/form-builder/next-pages/components/Blocks/Form/Checkbox/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/Checkbox/index.tsx
@@ -7,18 +7,7 @@ import { Width } from '../Width'
 
 import classes from './index.module.scss'
 
-export const Checkbox: React.FC<
-  CheckboxField & {
-    register: UseFormRegister<FieldValues & any>
-    setValue: any
-    getValues: any
-    errors: Partial<
-      FieldErrorsImpl<{
-        [x: string]: any
-      }>
-    >
-  }
-> = ({
+export const Checkbox = ({
   name,
   label,
   width,
@@ -27,6 +16,15 @@ export const Checkbox: React.FC<
   getValues,
   required: requiredFromProps,
   errors,
+}: CheckboxField & {
+  register: UseFormRegister<FieldValues & any>
+  setValue: any
+  getValues: any
+  errors: Partial<
+    FieldErrorsImpl<{
+      [x: string]: any
+    }>
+  >
 }) => {
   const [checked, setChecked] = useState(false)
 

--- a/examples/form-builder/next-pages/components/Blocks/Form/Country/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/Country/index.tsx
@@ -8,16 +8,21 @@ import { Width } from '../Width'
 
 import classes from './index.module.scss'
 
-export const Country: React.FC<
-  CountryField & {
-    control: Control<FieldValues, any>
-    errors: Partial<
-      FieldErrorsImpl<{
-        [x: string]: any
-      }>
-    >
-  }
-> = ({ name, label, width, control, required, errors }) => {
+export const Country = ({
+  name,
+  label,
+  width,
+  control,
+  required,
+  errors,
+}: CountryField & {
+  control: Control<FieldValues, any>
+  errors: Partial<
+    FieldErrorsImpl<{
+      [x: string]: any
+    }>
+  >
+}) => {
   return (
     <Width width={width}>
       <div className={classes.select}>

--- a/examples/form-builder/next-pages/components/Blocks/Form/Email/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/Email/index.tsx
@@ -6,16 +6,21 @@ import { Width } from '../Width'
 
 import classes from './index.module.scss'
 
-export const Email: React.FC<
-  EmailField & {
-    register: UseFormRegister<FieldValues & any>
-    errors: Partial<
-      FieldErrorsImpl<{
-        [x: string]: any
-      }>
-    >
-  }
-> = ({ name, width, label, register, required: requiredFromProps, errors }) => {
+export const Email = ({
+  name,
+  width,
+  label,
+  register,
+  required: requiredFromProps,
+  errors,
+}: EmailField & {
+  register: UseFormRegister<FieldValues & any>
+  errors: Partial<
+    FieldErrorsImpl<{
+      [x: string]: any
+    }>
+  >
+}) => {
   return (
     <Width width={width}>
       <div className={classes.wrap}>

--- a/examples/form-builder/next-pages/components/Blocks/Form/Error/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/Error/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import classes from './index.module.scss'
 
-export const Error: React.FC = () => {
+export const Error = () => {
   return <div className={classes.error}>This field is required</div>
 }

--- a/examples/form-builder/next-pages/components/Blocks/Form/Message/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/Message/index.tsx
@@ -5,7 +5,7 @@ import { Width } from '../Width'
 
 import classes from './index.module.scss'
 
-export const Message: React.FC<MessageField> = ({ message }) => {
+export const Message = ({ message }: MessageField) => {
   return (
     <Width width="100">
       <RichText content={message} className={classes.message} />

--- a/examples/form-builder/next-pages/components/Blocks/Form/Number/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/Number/index.tsx
@@ -6,16 +6,21 @@ import { Width } from '../Width'
 
 import classes from './index.module.scss'
 
-export const Number: React.FC<
-  TextField & {
-    register: UseFormRegister<FieldValues & any>
-    errors: Partial<
-      FieldErrorsImpl<{
-        [x: string]: any
-      }>
-    >
-  }
-> = ({ name, label, width, register, required: requiredFromProps, errors }) => {
+export const Number = ({
+  name,
+  label,
+  width,
+  register,
+  required: requiredFromProps,
+  errors,
+}: TextField & {
+  register: UseFormRegister<FieldValues & any>
+  errors: Partial<
+    FieldErrorsImpl<{
+      [x: string]: any
+    }>
+  >
+}) => {
   return (
     <Width width={width}>
       <div className={classes.wrap}>

--- a/examples/form-builder/next-pages/components/Blocks/Form/Select/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/Select/index.tsx
@@ -7,16 +7,22 @@ import { Width } from '../Width'
 
 import classes from './index.module.scss'
 
-export const Select: React.FC<
-  SelectField & {
-    control: Control<FieldValues, any>
-    errors: Partial<
-      FieldErrorsImpl<{
-        [x: string]: any
-      }>
-    >
-  }
-> = ({ name, label, width, options, control, required, errors }) => {
+export const Select = ({
+  name,
+  label,
+  width,
+  options,
+  control,
+  required,
+  errors,
+}: SelectField & {
+  control: Control<FieldValues, any>
+  errors: Partial<
+    FieldErrorsImpl<{
+      [x: string]: any
+    }>
+  >
+}) => {
   return (
     <Width width={width}>
       <div className={classes.select}>

--- a/examples/form-builder/next-pages/components/Blocks/Form/State/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/State/index.tsx
@@ -8,16 +8,21 @@ import { Width } from '../Width'
 
 import classes from './index.module.scss'
 
-export const State: React.FC<
-  StateField & {
-    control: Control<FieldValues, any>
-    errors: Partial<
-      FieldErrorsImpl<{
-        [x: string]: any
-      }>
-    >
-  }
-> = ({ name, label, width, control, required, errors }) => {
+export const State = ({
+  name,
+  label,
+  width,
+  control,
+  required,
+  errors,
+}: StateField & {
+  control: Control<FieldValues, any>
+  errors: Partial<
+    FieldErrorsImpl<{
+      [x: string]: any
+    }>
+  >
+}) => {
   return (
     <Width width={width}>
       <div className={classes.select}>

--- a/examples/form-builder/next-pages/components/Blocks/Form/Text/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/Text/index.tsx
@@ -6,16 +6,21 @@ import { Width } from '../Width'
 
 import classes from './index.module.scss'
 
-export const Text: React.FC<
-  TextField & {
-    register: UseFormRegister<FieldValues & any>
-    errors: Partial<
-      FieldErrorsImpl<{
-        [x: string]: any
-      }>
-    >
-  }
-> = ({ name, label, width, register, required: requiredFromProps, errors }) => {
+export const Text = ({
+  name,
+  label,
+  width,
+  register,
+  required: requiredFromProps,
+  errors,
+}: TextField & {
+  register: UseFormRegister<FieldValues & any>
+  errors: Partial<
+    FieldErrorsImpl<{
+      [x: string]: any
+    }>
+  >
+}) => {
   return (
     <Width width={width}>
       <div className={classes.wrap}>

--- a/examples/form-builder/next-pages/components/Blocks/Form/Textarea/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/Textarea/index.tsx
@@ -6,17 +6,23 @@ import { Width } from '../Width'
 
 import classes from './index.module.scss'
 
-export const Textarea: React.FC<
-  TextField & {
-    register: UseFormRegister<FieldValues & any>
-    rows?: number
-    errors: Partial<
-      FieldErrorsImpl<{
-        [x: string]: any
-      }>
-    >
-  }
-> = ({ name, label, width, rows = 3, register, required: requiredFromProps, errors }) => {
+export const Textarea = ({
+  name,
+  label,
+  width,
+  rows = 3,
+  register,
+  required: requiredFromProps,
+  errors,
+}: TextField & {
+  register: UseFormRegister<FieldValues & any>
+  rows?: number
+  errors: Partial<
+    FieldErrorsImpl<{
+      [x: string]: any
+    }>
+  >
+}) => {
   return (
     <Width width={width}>
       <div className={classes.wrap}>

--- a/examples/form-builder/next-pages/components/Blocks/Form/Width/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/Form/Width/index.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react'
 import classes from './index.module.scss'
 
-export const Width: React.FC<{
-  width?: string
-  children: React.ReactNode
-}> = ({ width, children }) => {
+export const Width = ({ width, children }: { width?: string; children: React.ReactNode }) => {
   return (
     <div className={classes.width} style={{ width: width ? `${width}%` : undefined }}>
       {children}

--- a/examples/form-builder/next-pages/components/Blocks/index.tsx
+++ b/examples/form-builder/next-pages/components/Blocks/index.tsx
@@ -8,9 +8,7 @@ const blockComponents = {
   formBlock: FormBlock,
 }
 
-const Blocks: React.FC<{
-  blocks: Page['layout']
-}> = props => {
+const Blocks = (props: { blocks: Page['layout'] }) => {
   const { blocks } = props
 
   const hasBlocks = blocks && Array.isArray(blocks) && blocks.length > 0

--- a/examples/form-builder/next-pages/components/Button/index.tsx
+++ b/examples/form-builder/next-pages/components/Button/index.tsx
@@ -19,7 +19,7 @@ const elements = {
   button: 'button',
 }
 
-export const Button: React.FC<Props> = ({
+export const Button = ({
   el = 'button',
   label,
   newTab,
@@ -27,7 +27,7 @@ export const Button: React.FC<Props> = ({
   form,
   appearance,
   className: classNameFromProps,
-}) => {
+}: Props) => {
   const newTabProps = newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {}
   const Element = elements[el]
   const className = [classNameFromProps, classes[`appearance--${appearance}`], classes.button]

--- a/examples/form-builder/next-pages/components/CloseModalOnRouteChange/index.tsx
+++ b/examples/form-builder/next-pages/components/CloseModalOnRouteChange/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 import { useModal } from '@faceless-ui/modal'
 import { useRouter } from 'next/router'
 
-export const CloseModalOnRouteChange: React.FC = () => {
+export const CloseModalOnRouteChange = () => {
   const { closeAllModals } = useModal()
   const { asPath } = useRouter()
 

--- a/examples/form-builder/next-pages/components/Gutter/index.tsx
+++ b/examples/form-builder/next-pages/components/Gutter/index.tsx
@@ -9,7 +9,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/form-builder/next-pages/components/Header/MobileMenuModal.tsx
+++ b/examples/form-builder/next-pages/components/Header/MobileMenuModal.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export const slug = 'menu-modal'
 
-export const MobileMenuModal: React.FC<Props> = ({ navItems }) => {
+export const MobileMenuModal = ({ navItems }: Props) => {
   return (
     <Modal slug={slug} className={classes.mobileMenuModal}>
       <HeaderBar />

--- a/examples/form-builder/next-pages/components/Header/index.tsx
+++ b/examples/form-builder/next-pages/components/Header/index.tsx
@@ -14,7 +14,7 @@ type HeaderBarProps = {
   children?: React.ReactNode
 }
 
-export const HeaderBar: React.FC<HeaderBarProps> = ({ children }) => {
+export const HeaderBar = ({ children }: HeaderBarProps) => {
   return (
     <header className={classes.header}>
       <Gutter className={classes.wrap}>
@@ -32,7 +32,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({ children }) => {
   )
 }
 
-export const Header: React.FC = () => {
+export const Header = () => {
   const {
     mainMenu: { navItems },
   } = useGlobals()

--- a/examples/form-builder/next-pages/components/Link/index.tsx
+++ b/examples/form-builder/next-pages/components/Link/index.tsx
@@ -17,7 +17,7 @@ type CMSLinkType = {
   className?: string
 }
 
-export const CMSLink: React.FC<CMSLinkType> = ({
+export const CMSLink = ({
   type,
   url,
   newTab,
@@ -26,7 +26,7 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   appearance,
   children,
   className,
-}) => {
+}: CMSLinkType) => {
   const href =
     type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
       ? `/${reference.value.slug}`

--- a/examples/form-builder/next-pages/components/Logo/index.tsx
+++ b/examples/form-builder/next-pages/components/Logo/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const Logo: React.FC = () => {
+export const Logo = () => {
   return (
     <svg
       width="123"

--- a/examples/form-builder/next-pages/components/RichText/index.tsx
+++ b/examples/form-builder/next-pages/components/RichText/index.tsx
@@ -3,7 +3,7 @@ import serialize from './serialize'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{ className?: string; content: any }> = ({ className, content }) => {
+const RichText = ({ className, content }: { className?: string; content: any }) => {
   if (!content) {
     return null
   }

--- a/examples/form-builder/next-pages/components/VerticalPadding/index.tsx
+++ b/examples/form-builder/next-pages/components/VerticalPadding/index.tsx
@@ -10,12 +10,12 @@ type Props = {
   className?: string
 }
 
-export const VerticalPadding: React.FC<Props> = ({
+export const VerticalPadding = ({
   top = 'medium',
   bottom = 'medium',
   className,
   children,
-}) => {
+}: Props) => {
   return (
     <div
       className={[className, classes[`top-${top}`], classes[`bottom-${bottom}`]]

--- a/examples/form-builder/next-pages/components/icons/Check/index.tsx
+++ b/examples/form-builder/next-pages/components/icons/Check/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classes from './index.module.scss'
 
-export const Check: React.FC = () => {
+export const Check = () => {
   return (
     <svg width="100%" height="100%" viewBox="0 0 25 25" className={classes.checkBox}>
       <path

--- a/examples/form-builder/next-pages/components/icons/Menu/index.tsx
+++ b/examples/form-builder/next-pages/components/icons/Menu/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const MenuIcon: React.FC = () => {
+export const MenuIcon = () => {
   return (
     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
       <rect x="3.5" y="4.5" width="18" height="2" fill="currentColor" />

--- a/examples/form-builder/next-pages/pages/[slug].tsx
+++ b/examples/form-builder/next-pages/pages/[slug].tsx
@@ -3,10 +3,7 @@ import { GetStaticProps, GetStaticPropsContext, GetStaticPaths } from 'next'
 import Blocks from '../components/Blocks'
 import type { Page, MainMenu } from '../payload-types'
 
-const Page: React.FC<{
-  mainMenu: MainMenu
-  page: Page
-}> = props => {
+const Page = (props: { mainMenu: MainMenu; page: Page }) => {
   const {
     page: { layout },
   } = props

--- a/examples/form-builder/next-pages/providers/Globals/index.tsx
+++ b/examples/form-builder/next-pages/providers/Globals/index.tsx
@@ -10,11 +10,11 @@ export interface IGlobals {
 export const GlobalsContext = createContext<IGlobals>({} as IGlobals)
 export const useGlobals = (): IGlobals => useContext(GlobalsContext)
 
-export const GlobalsProvider: React.FC<
-  IGlobals & {
+export const GlobalsProvider = (
+  props: IGlobals & {
     children: React.ReactNode
-  }
-> = props => {
+  },
+) => {
   const { mainMenu, children } = props
 
   return (

--- a/examples/form-builder/payload/src/components/BeforeLogin/index.tsx
+++ b/examples/form-builder/payload/src/components/BeforeLogin/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const BeforeLogin: React.FC = () => {
+function BeforeLogin() {
   if (process.env.PAYLOAD_PUBLIC_SEED === 'true') {
     return (
       <p>

--- a/examples/live-preview/next-app/app/[slug]/page.client.tsx
+++ b/examples/live-preview/next-app/app/[slug]/page.client.tsx
@@ -8,7 +8,7 @@ import RichText from '../_components/RichText'
 
 import classes from './index.module.scss'
 
-export const PageTemplate: React.FC<{ page: Page | null | undefined }> = ({ page }) => {
+export const PageTemplate = ({ page }: { page: Page | null | undefined }) => {
   const { data } = useLivePreview({
     serverURL: process.env.NEXT_PUBLIC_PAYLOAD_URL || '',
     depth: 2,

--- a/examples/live-preview/next-app/app/_components/Button/index.tsx
+++ b/examples/live-preview/next-app/app/_components/Button/index.tsx
@@ -15,7 +15,7 @@ export type Props = {
   disabled?: boolean
 }
 
-export const Button: React.FC<Props> = ({
+export const Button = ({
   el: elFromProps = 'link',
   label,
   newTab,
@@ -25,7 +25,7 @@ export const Button: React.FC<Props> = ({
   onClick,
   type = 'button',
   disabled,
-}) => {
+}: Props) => {
   let el = elFromProps
   const newTabProps = newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {}
   const className = [

--- a/examples/live-preview/next-app/app/_components/CMSLink/index.tsx
+++ b/examples/live-preview/next-app/app/_components/CMSLink/index.tsx
@@ -18,7 +18,7 @@ export type CMSLinkType = {
   className?: string
 }
 
-export const CMSLink: React.FC<CMSLinkType> = ({
+export const CMSLink = ({
   type,
   url,
   newTab,
@@ -27,7 +27,7 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   appearance,
   children,
   className,
-}) => {
+}: CMSLinkType) => {
   const href =
     type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
       ? `/${reference.value.slug === 'home' ? '' : reference.value.slug}`

--- a/examples/live-preview/next-app/app/_components/Gutter/index.tsx
+++ b/examples/live-preview/next-app/app/_components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/live-preview/next-app/app/_components/RichText/index.tsx
+++ b/examples/live-preview/next-app/app/_components/RichText/index.tsx
@@ -4,7 +4,7 @@ import serialize from './serialize'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{ className?: string; content: any }> = ({ className, content }) => {
+const RichText = ({ className, content }: { className?: string; content: any }) => {
   if (!content) {
     return null
   }

--- a/examples/live-preview/next-pages/src/components/Button/index.tsx
+++ b/examples/live-preview/next-pages/src/components/Button/index.tsx
@@ -15,7 +15,7 @@ export type Props = {
   disabled?: boolean
 }
 
-export const Button: React.FC<Props> = ({
+export const Button = ({
   el: elFromProps = 'link',
   label,
   newTab,
@@ -25,7 +25,7 @@ export const Button: React.FC<Props> = ({
   onClick,
   type = 'button',
   disabled,
-}) => {
+}: Props) => {
   let el = elFromProps
   const newTabProps = newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {}
   const className = [

--- a/examples/live-preview/next-pages/src/components/CMSLink/index.tsx
+++ b/examples/live-preview/next-pages/src/components/CMSLink/index.tsx
@@ -18,7 +18,7 @@ export type CMSLinkType = {
   className?: string
 }
 
-export const CMSLink: React.FC<CMSLinkType> = ({
+export const CMSLink = ({
   type,
   url,
   newTab,
@@ -27,7 +27,7 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   appearance,
   children,
   className,
-}) => {
+}: CMSLinkType) => {
   const href =
     type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
       ? `/${reference.value.slug === 'home' ? '' : reference.value.slug}`

--- a/examples/live-preview/next-pages/src/components/Gutter/index.tsx
+++ b/examples/live-preview/next-pages/src/components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/live-preview/next-pages/src/components/Header/index.tsx
+++ b/examples/live-preview/next-pages/src/components/Header/index.tsx
@@ -12,7 +12,7 @@ type HeaderBarProps = {
   children?: React.ReactNode
 }
 
-export const HeaderBar: React.FC<HeaderBarProps> = ({ children }) => {
+export const HeaderBar = ({ children }: HeaderBarProps) => {
   return (
     <header className={classes.header}>
       <Gutter className={classes.wrap}>
@@ -36,11 +36,11 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({ children }) => {
   )
 }
 
-export const Header: React.FC<{
+export const Header = (props: {
   globals: {
     mainMenu: MainMenu
   }
-}> = props => {
+}) => {
   const { globals } = props
 
   const {

--- a/examples/live-preview/next-pages/src/components/RichText/index.tsx
+++ b/examples/live-preview/next-pages/src/components/RichText/index.tsx
@@ -4,7 +4,7 @@ import serialize from './serialize'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{ className?: string; content: any }> = ({ className, content }) => {
+const RichText = ({ className, content }: { className?: string; content: any }) => {
   if (!content) {
     return null
   }

--- a/examples/live-preview/next-pages/src/pages/[slug].tsx
+++ b/examples/live-preview/next-pages/src/pages/[slug].tsx
@@ -10,11 +10,11 @@ import type { MainMenu, Page as PageType } from '../payload-types'
 
 import classes from './[slug].module.scss'
 
-const Page: React.FC<
-  PageType & {
+const Page = (
+  initialPage: PageType & {
     mainMenu: MainMenu
-  }
-> = initialPage => {
+  },
+) => {
   const { data } = useLivePreview({
     serverURL: process.env.NEXT_PUBLIC_PAYLOAD_URL || '',
     depth: 2,

--- a/examples/live-preview/payload/src/components/BeforeLogin/index.tsx
+++ b/examples/live-preview/payload/src/components/BeforeLogin/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const BeforeLogin: React.FC = () => {
+function BeforeLogin() {
   if (process.env.PAYLOAD_PUBLIC_SEED === 'true') {
     return (
       <p>

--- a/examples/nested-docs/next-app/app/[...slug]/page.tsx
+++ b/examples/nested-docs/next-app/app/[...slug]/page.tsx
@@ -11,7 +11,7 @@ interface PageParams {
   params: { slug: string[] }
 }
 
-export const PageTemplate: React.FC<{ page: Page | null | undefined }> = ({ page }) => (
+export const PageTemplate = ({ page }: { page: Page | null | undefined }) => (
   <main className={classes.page}>
     <Gutter>
       <h1>{page?.title}</h1>

--- a/examples/nested-docs/next-app/app/_components/AdminBar/index.client.tsx
+++ b/examples/nested-docs/next-app/app/_components/AdminBar/index.client.tsx
@@ -7,9 +7,9 @@ import { Gutter } from '../Gutter'
 
 import classes from './index.module.scss'
 
-const Title: React.FC = () => <span>Dashboard</span>
+const Title = () => <span>Dashboard</span>
 
-export const AdminBarClient: React.FC<PayloadAdminBarProps> = props => {
+export const AdminBarClient = (props: PayloadAdminBarProps) => {
   const [user, setUser] = useState<PayloadMeUser>()
 
   return (

--- a/examples/nested-docs/next-app/app/_components/Button/index.tsx
+++ b/examples/nested-docs/next-app/app/_components/Button/index.tsx
@@ -15,7 +15,7 @@ export type Props = {
   disabled?: boolean
 }
 
-export const Button: React.FC<Props> = ({
+export const Button = ({
   el: elFromProps = 'link',
   label,
   newTab,
@@ -25,7 +25,7 @@ export const Button: React.FC<Props> = ({
   onClick,
   type = 'button',
   disabled,
-}) => {
+}: Props) => {
   let el = elFromProps
   const newTabProps = newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {}
   const className = [

--- a/examples/nested-docs/next-app/app/_components/CMSLink/index.tsx
+++ b/examples/nested-docs/next-app/app/_components/CMSLink/index.tsx
@@ -18,7 +18,7 @@ export type CMSLinkType = {
   className?: string
 }
 
-export const CMSLink: React.FC<CMSLinkType> = ({
+export const CMSLink = ({
   type,
   url,
   newTab,
@@ -27,7 +27,7 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   appearance,
   children,
   className,
-}) => {
+}: CMSLinkType) => {
   let href = url
 
   if (type === 'reference' && reference && reference.value && typeof reference.value === 'object') {

--- a/examples/nested-docs/next-app/app/_components/Gutter/index.tsx
+++ b/examples/nested-docs/next-app/app/_components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/nested-docs/next-app/app/_components/RichText/index.tsx
+++ b/examples/nested-docs/next-app/app/_components/RichText/index.tsx
@@ -4,7 +4,7 @@ import serialize from './serialize'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{ className?: string; content: any }> = ({ className, content }) => {
+const RichText = ({ className, content }: { className?: string; content: any }) => {
   if (!content) {
     return null
   }

--- a/examples/nested-docs/next-pages/src/components/AdminBar/index.tsx
+++ b/examples/nested-docs/next-pages/src/components/AdminBar/index.tsx
@@ -5,13 +5,13 @@ import { Gutter } from '../Gutter'
 
 import classes from './index.module.scss'
 
-const Title: React.FC = () => <span>Dashboard</span>
+const Title = () => <span>Dashboard</span>
 
-export const AdminBar: React.FC<{
+export const AdminBar = (props: {
   adminBarProps?: PayloadAdminBarProps
   user?: PayloadMeUser
-  setUser?: (user: PayloadMeUser) => void // eslint-disable-line no-unused-vars
-}> = props => {
+  setUser?: (user: PayloadMeUser) => void // eslint-disable-line no-unused-vars;
+}) => {
   const { adminBarProps, user, setUser } = props
 
   return (

--- a/examples/nested-docs/next-pages/src/components/Button/index.tsx
+++ b/examples/nested-docs/next-pages/src/components/Button/index.tsx
@@ -15,7 +15,7 @@ export type Props = {
   disabled?: boolean
 }
 
-export const Button: React.FC<Props> = ({
+export const Button = ({
   el: elFromProps = 'link',
   label,
   newTab,
@@ -25,7 +25,7 @@ export const Button: React.FC<Props> = ({
   onClick,
   type = 'button',
   disabled,
-}) => {
+}: Props) => {
   let el = elFromProps
   const newTabProps = newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {}
   const className = [

--- a/examples/nested-docs/next-pages/src/components/CMSLink/index.tsx
+++ b/examples/nested-docs/next-pages/src/components/CMSLink/index.tsx
@@ -18,7 +18,7 @@ export type CMSLinkType = {
   className?: string
 }
 
-export const CMSLink: React.FC<CMSLinkType> = ({
+export const CMSLink = ({
   type,
   url,
   newTab,
@@ -27,7 +27,7 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   appearance,
   children,
   className,
-}) => {
+}: CMSLinkType) => {
   let href = url
 
   if (type === 'reference' && reference && reference.value && typeof reference.value === 'object') {

--- a/examples/nested-docs/next-pages/src/components/Gutter/index.tsx
+++ b/examples/nested-docs/next-pages/src/components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/nested-docs/next-pages/src/components/Header/index.tsx
+++ b/examples/nested-docs/next-pages/src/components/Header/index.tsx
@@ -14,7 +14,7 @@ type HeaderBarProps = {
   children?: React.ReactNode
 }
 
-export const HeaderBar: React.FC<HeaderBarProps> = ({ children }) => {
+export const HeaderBar = ({ children }: HeaderBarProps) => {
   return (
     <header className={classes.header}>
       <Gutter className={classes.wrap}>
@@ -38,12 +38,12 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({ children }) => {
   )
 }
 
-export const Header: React.FC<{
+export const Header = (props: {
   globals: {
     mainMenu: MainMenu
   }
   adminBarProps: PayloadAdminBarProps
-}> = props => {
+}) => {
   const { globals, adminBarProps } = props
 
   const [user, setUser] = useState<PayloadMeUser>()

--- a/examples/nested-docs/next-pages/src/components/RichText/index.tsx
+++ b/examples/nested-docs/next-pages/src/components/RichText/index.tsx
@@ -4,7 +4,7 @@ import serialize from './serialize'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{ className?: string; content: any }> = ({ className, content }) => {
+const RichText = ({ className, content }: { className?: string; content: any }) => {
   if (!content) {
     return null
   }

--- a/examples/nested-docs/next-pages/src/pages/[...slug].tsx
+++ b/examples/nested-docs/next-pages/src/pages/[...slug].tsx
@@ -8,12 +8,12 @@ import type { MainMenu, Page, Page as PageType } from '../payload-types'
 
 import classes from './[...slug].module.scss'
 
-const Page: React.FC<
-  PageType & {
+const Page = (
+  props: PageType & {
     mainMenu: MainMenu
     preview?: boolean
-  }
-> = props => {
+  },
+) => {
   const { title, richText } = props
 
   return (

--- a/examples/nested-docs/payload/src/BeforeLogin/index.tsx
+++ b/examples/nested-docs/payload/src/BeforeLogin/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const BeforeLogin: React.FC = () => {
+function BeforeLogin() {
   if (process.env.PAYLOAD_PUBLIC_SEED === 'true') {
     return (
       <p>

--- a/examples/redirects/next-pages/components/Button/index.tsx
+++ b/examples/redirects/next-pages/components/Button/index.tsx
@@ -19,14 +19,14 @@ const elements = {
   button: 'button',
 }
 
-export const Button: React.FC<Props> = ({
+export const Button = ({
   el = 'button',
   label,
   newTab,
   href,
   appearance,
   className: classNameFromProps,
-}) => {
+}: Props) => {
   const Element = elements[el]
   const className = [classNameFromProps, classes[`appearance--${appearance}`], classes.button]
     .filter(Boolean)

--- a/examples/redirects/next-pages/components/CMSLink/index.tsx
+++ b/examples/redirects/next-pages/components/CMSLink/index.tsx
@@ -18,7 +18,7 @@ type CMSLinkType = {
   className?: string
 }
 
-export const CMSLink: React.FC<CMSLinkType> = ({
+export const CMSLink = ({
   type,
   url,
   newTab,
@@ -27,7 +27,7 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   appearance,
   children,
   className,
-}) => {
+}: CMSLinkType) => {
   const href =
     type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
       ? `/${reference.value.slug}`

--- a/examples/redirects/next-pages/components/Gutter/index.tsx
+++ b/examples/redirects/next-pages/components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/examples/redirects/next-pages/components/Header/index.tsx
+++ b/examples/redirects/next-pages/components/Header/index.tsx
@@ -12,7 +12,7 @@ type HeaderBarProps = {
   children?: React.ReactNode
 }
 
-export const HeaderBar: React.FC<HeaderBarProps> = ({ children }) => {
+export const HeaderBar = ({ children }: HeaderBarProps) => {
   return (
     <header className={classes.header}>
       <Gutter className={classes.wrap}>
@@ -25,7 +25,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({ children }) => {
   )
 }
 
-export const Header: React.FC = () => {
+export const Header = () => {
   const {
     mainMenu: { navItems },
   } = useGlobals()

--- a/examples/redirects/next-pages/components/Logo/index.tsx
+++ b/examples/redirects/next-pages/components/Logo/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const Logo: React.FC = () => {
+export const Logo = () => {
   return (
     <svg
       width="123"

--- a/examples/redirects/next-pages/components/RichText/index.tsx
+++ b/examples/redirects/next-pages/components/RichText/index.tsx
@@ -4,7 +4,7 @@ import serialize from './serialize'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{ className?: string; content: any }> = ({ className, content }) => {
+const RichText = ({ className, content }: { className?: string; content: any }) => {
   if (!content) {
     return null
   }

--- a/examples/redirects/next-pages/pages/[slug].tsx
+++ b/examples/redirects/next-pages/pages/[slug].tsx
@@ -8,12 +8,12 @@ import type { MainMenu, Page } from '../payload-types'
 
 import classes from './index.module.scss'
 
-const Page: React.FC<
-  Page & {
+const Page = (
+  props: Page & {
     mainMenu: MainMenu
     preview?: boolean
-  }
-> = props => {
+  },
+) => {
   const { title, richText } = props
 
   return (

--- a/examples/redirects/next-pages/providers/Globals/index.tsx
+++ b/examples/redirects/next-pages/providers/Globals/index.tsx
@@ -10,11 +10,11 @@ export interface IGlobals {
 export const GlobalsContext = createContext<IGlobals>({} as IGlobals)
 export const useGlobals = (): IGlobals => useContext(GlobalsContext)
 
-export const GlobalsProvider: React.FC<
-  IGlobals & {
+export const GlobalsProvider = (
+  props: IGlobals & {
     children: React.ReactNode
-  }
-> = props => {
+  },
+) => {
   const { mainMenu, children } = props
 
   return (

--- a/examples/redirects/payload/src/BeforeLogin/index.tsx
+++ b/examples/redirects/payload/src/BeforeLogin/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const BeforeLogin: React.FC = () => {
+function BeforeLogin() {
   if (process.env.PAYLOAD_PUBLIC_SEED === 'true') {
     return (
       <p>

--- a/examples/virtual-fields/src/components/BeforeLogin/index.tsx
+++ b/examples/virtual-fields/src/components/BeforeLogin/index.tsx
@@ -1,24 +1,18 @@
-import React from 'react';
+import React from 'react'
 
-const BeforeLogin: React.FC = () => {
+const BeforeLogin = () => {
   if (process.env.PAYLOAD_PUBLIC_SEED === 'true') {
     return (
       <div>
         <h3>Virtual Fields Demo</h3>
         <p>
-          Log in with the email
-          {' '}
-          <strong>dev@payloadcms.com</strong>
-          {' '}
-          and the password
-          {' '}
-          <strong>test</strong>
-          .
+          Log in with the email <strong>dev@payloadcms.com</strong> and the password{' '}
+          <strong>test</strong>.
         </p>
       </div>
-    );
+    )
   }
-  return null;
-};
+  return null
+}
 
-export default BeforeLogin;
+export default BeforeLogin

--- a/test/admin/components/GlobalAPIButton/index.tsx
+++ b/test/admin/components/GlobalAPIButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'global-api-button'
 
-const GlobalAPIButton: React.FC = () => {
+function GlobalAPIButton() {
   return (
     <div
       className={baseClass}

--- a/test/fields-relationship/PrePopulateFieldUI/index.tsx
+++ b/test/fields-relationship/PrePopulateFieldUI/index.tsx
@@ -3,11 +3,15 @@ import * as React from 'react'
 import useField from '../../../packages/payload/src/admin/components/forms/useField'
 import { collection1Slug } from '../collectionSlugs'
 
-export const PrePopulateFieldUI: React.FC<{
+export const PrePopulateFieldUI = ({
+  hasMany = true,
+  hasMultipleRelations = false,
+  path,
+}: {
   hasMany?: boolean
   hasMultipleRelations?: boolean
   path: string
-}> = ({ hasMany = true, hasMultipleRelations = false, path }) => {
+}) => {
   const { setValue } = useField({ path })
 
   const addDefaults = React.useCallback(() => {

--- a/test/versions/elements/GlobalVersionsButton/index.tsx
+++ b/test/versions/elements/GlobalVersionsButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'global-versions-button'
 
-const GlobalVersionsButton: React.FC = () => {
+function GlobalVersionsButton() {
   return (
     <div
       className={baseClass}


### PR DESCRIPTION
## Description

Motivated by https://github.com/payloadcms/payload/discussions/7513#discussion-7015416, make the implementaion of the discussion.
This PR made transition between React.FC<Props> Like components to function components without breaking the project.

most of changes are like in the print bellow, so nothing should break with them.
![image](https://github.com/user-attachments/assets/7a5d4c65-75e5-43f3-b19b-8688cb41ad9e)


<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] I have made corresponding changes to the documentation
