### PR TITLE
chore(refactoring): remove React.FC test components

### DIFF
--- a/test/admin/components/AdminButton/index.tsx
+++ b/test/admin/components/AdminButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'admin-button'
 
-const AdminButton: React.FC = () => {
+const AdminButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/admin/components/AfterDashboard/index.tsx
+++ b/test/admin/components/AfterDashboard/index.tsx
@@ -4,7 +4,7 @@ import './index.scss'
 
 const baseClass = 'after-dashboard'
 
-const AfterDashboard: React.FC = () => {
+const AfterDashboard = () => {
   return (
     <div className={baseClass}>
       <h4>Test Config</h4>

--- a/test/admin/components/AfterNavLinks/index.tsx
+++ b/test/admin/components/AfterNavLinks/index.tsx
@@ -9,7 +9,7 @@ import { useConfig } from '../../../../packages/payload/src/admin/components/uti
 
 const baseClass = 'after-nav-links'
 
-const AfterNavLinks: React.FC = () => {
+const AfterNavLinks = () => {
   const {
     routes: { admin: adminRoute },
   } = useConfig()

--- a/test/admin/components/BeforeLogin/index.tsx
+++ b/test/admin/components/BeforeLogin/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-const BeforeLogin: React.FC<{ i18n }> = () => {
+const BeforeLogin = () => {
   const { t } = useTranslation()
   return (
     <div>

--- a/test/admin/components/CollectionAPIButton/index.tsx
+++ b/test/admin/components/CollectionAPIButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'collection-api-button'
 
-const CollectionAPIButton: React.FC = () => {
+const CollectionAPIButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/admin/components/CollectionEditButton/index.tsx
+++ b/test/admin/components/CollectionEditButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'collection-edit-button'
 
-const CollectionEditButton: React.FC = () => {
+const CollectionEditButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/admin/components/CollectionListButton/index.tsx
+++ b/test/admin/components/CollectionListButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'collection-list-button'
 
-const CollectionListButton: React.FC = () => {
+const CollectionListButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/admin/components/CustomProvider/index.tsx
+++ b/test/admin/components/CustomProvider/index.tsx
@@ -7,7 +7,7 @@ type CustomContext = {
 
 const Context = createContext({} as CustomContext)
 
-const CustomProvider: React.FC = ({ children }) => {
+const CustomProvider = ({ children }) => {
   const [getCustom, setCustom] = useState({})
 
   const value = {

--- a/test/admin/components/DemoUIField/Cell.tsx
+++ b/test/admin/components/DemoUIField/Cell.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
 
-const DemoUIFieldCell: React.FC = () => <p>Demo UI Field Cell</p>
+const DemoUIFieldCell = () => <p>Demo UI Field Cell</p>
 
 export default DemoUIFieldCell

--- a/test/admin/components/DemoUIField/Field.tsx
+++ b/test/admin/components/DemoUIField/Field.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
 
-const DemoUIField: React.FC = () => <p className="field-type">Demo UI Field</p>
+const DemoUIField = () => <p className="field-type">Demo UI Field</p>
 
 export default DemoUIField

--- a/test/admin/components/GlobalAPIButton/index.tsx
+++ b/test/admin/components/GlobalAPIButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'global-api-button'
 
-const GlobalAPIButton: React.FC = () => {
+const GlobalAPIButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/admin/components/GlobalEditButton/index.tsx
+++ b/test/admin/components/GlobalEditButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'global-edit-button'
 
-const GlobalEditButton: React.FC = () => {
+const GlobalEditButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/admin/components/Logout/index.tsx
+++ b/test/admin/components/Logout/index.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import LogOut from '../../../../packages/payload/src/admin/components/icons/LogOut'
 import { useConfig } from '../../../../packages/payload/src/admin/components/utilities/Config'
 
-const Logout: React.FC = () => {
+const Logout = () => {
   const config = useConfig()
   const {
     admin: { logoutRoute },

--- a/test/admin/components/richText/elements/Button/Button/index.tsx
+++ b/test/admin/components/richText/elements/Button/Button/index.tsx
@@ -50,7 +50,7 @@ const insertButton = (editor, { href, label, newTab = false, style }: any) => {
   ReactEditor.focus(editor)
 }
 
-const ToolbarButton: React.FC<{ path: string }> = ({ path }) => {
+const ToolbarButton = ({ path }: { path: string }) => {
   const { closeAll, open } = useModal()
   const editor = useSlate()
 

--- a/test/admin/components/richText/elements/Button/Element/index.tsx
+++ b/test/admin/components/richText/elements/Button/Element/index.tsx
@@ -4,7 +4,7 @@ import './index.scss'
 
 const baseClass = 'rich-text-button'
 
-const ButtonElement: React.FC = ({ attributes, children, element }) => {
+const ButtonElement = ({ attributes, children, element }) => {
   const { label, style = 'primary' } = element
 
   return (

--- a/test/admin/components/richText/leaves/PurpleBackground/Leaf/index.tsx
+++ b/test/admin/components/richText/leaves/PurpleBackground/Leaf/index.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 
-const PurpleBackground: React.FC<any> = ({ attributes, children }) => (
+export type PurpleBackgroundProps = {
+  attributes: any
+  children: React.ReactNode
+}
+const PurpleBackground = ({ attributes, children }: PurpleBackgroundProps) => (
   <span {...attributes} style={{ backgroundColor: 'purple' }}>
     {children}
   </span>

--- a/test/admin/components/views/CustomMinimal/index.tsx
+++ b/test/admin/components/views/CustomMinimal/index.tsx
@@ -14,7 +14,7 @@ import './index.scss'
 
 const baseClass = 'custom-minimal-view'
 
-const CustomMinimalView: React.FC = () => {
+const CustomMinimalView = () => {
   const {
     routes: { admin: adminRoute },
   } = useConfig()

--- a/test/auth/AuthDebug.tsx
+++ b/test/auth/AuthDebug.tsx
@@ -5,7 +5,7 @@ import type { UIField } from '../../packages/payload/src/fields/config/types'
 
 import { useAuth } from '../../packages/payload/src/admin/components/utilities/Auth'
 
-export const AuthDebug: React.FC<UIField> = () => {
+export const AuthDebug = () => {
   const [state, setState] = useState<User | null | undefined>()
   const { user } = useAuth()
 

--- a/test/auth/ui/AuthDebug.tsx
+++ b/test/auth/ui/AuthDebug.tsx
@@ -5,7 +5,7 @@ import type { UIField } from '../../../packages/payload/src/fields/config/types'
 
 import { useAuth } from '../../../packages/payload/src/admin/components/utilities/Auth'
 
-export const AuthDebug: React.FC<UIField> = () => {
+export const AuthDebug = () => {
   const [state, setState] = useState<User | null | undefined>()
   const { user } = useAuth()
 

--- a/test/fields-relationship/PrePopulateFieldUI/index.tsx
+++ b/test/fields-relationship/PrePopulateFieldUI/index.tsx
@@ -3,11 +3,17 @@ import * as React from 'react'
 import useField from '../../../packages/payload/src/admin/components/forms/useField'
 import { collection1Slug } from '../collectionSlugs'
 
-export const PrePopulateFieldUI: React.FC<{
+export type PrePopulateFieldUIProps = {
   hasMany?: boolean
   hasMultipleRelations?: boolean
   path: string
-}> = ({ hasMany = true, hasMultipleRelations = false, path }) => {
+}
+
+export const PrePopulateFieldUI = ({
+  hasMany = true,
+  hasMultipleRelations = false,
+  path,
+}: PrePopulateFieldUIProps) => {
   const { setValue } = useField({ path })
 
   const addDefaults = React.useCallback(() => {

--- a/test/fields/collections/Blocks/components/AddCustomBlocks/index.tsx
+++ b/test/fields/collections/Blocks/components/AddCustomBlocks/index.tsx
@@ -6,7 +6,7 @@ import './index.scss'
 
 const baseClass = 'custom-blocks-field-management'
 
-export const AddCustomBlocks: React.FC = () => {
+export const AddCustomBlocks = () => {
   const { addFieldRow, replaceFieldRow } = useForm()
   const { value } = useField<number>({ path: 'customBlocks' })
 

--- a/test/fields/collections/Tabs/UIField.tsx
+++ b/test/fields/collections/Tabs/UIField.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
 
-export const UIField: React.FC = () => {
+export const UIField = () => {
   return <p>This is a UI field within a tab component.</p>
 }

--- a/test/fields/collections/Text/AfterInput.tsx
+++ b/test/fields/collections/Text/AfterInput.tsx
@@ -2,6 +2,6 @@
 
 import React from 'react'
 
-export const AfterInput: React.FC = () => {
+export const AfterInput = () => {
   return <label className="after-input">#after-input</label>
 }

--- a/test/fields/collections/Text/BeforeInput.tsx
+++ b/test/fields/collections/Text/BeforeInput.tsx
@@ -2,6 +2,6 @@
 
 import React from 'react'
 
-export const BeforeInput: React.FC = () => {
+export const BeforeInput = () => {
   return <label className="before-input">#before-input</label>
 }

--- a/test/fields/collections/Text/CustomError.tsx
+++ b/test/fields/collections/Text/CustomError.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import type { Props } from '../../../../packages/payload/src/admin/components/forms/Error/types'
 
-const CustomError: React.FC<Props> = (props) => {
+const CustomError = (props: Props) => {
   const { showError = false } = props
 
   if (showError) {

--- a/test/fields/collections/Text/CustomLabel.tsx
+++ b/test/fields/collections/Text/CustomLabel.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 
-const CustomLabel: React.FC<{ htmlFor: string }> = ({ htmlFor }) => {
+const CustomLabel = ({ htmlFor }: { htmlFor: string }) => {
   return (
     <label htmlFor={htmlFor} className="custom-label">
       #label

--- a/test/live-preview/components/CollectionLivePreviewButton/index.tsx
+++ b/test/live-preview/components/CollectionLivePreviewButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'collection-live-preview-button'
 
-const CollectionLivePreviewButton: React.FC = () => {
+const CollectionLivePreviewButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/live-preview/components/GlobalLivePreviewButton/index.tsx
+++ b/test/live-preview/components/GlobalLivePreviewButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'global-live-preview-button'
 
-const GlobalLivePreviewButton: React.FC = () => {
+const GlobalLivePreviewButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/live-preview/next-app/app/(pages)/[slug]/page.client.tsx
+++ b/test/live-preview/next-app/app/(pages)/[slug]/page.client.tsx
@@ -7,9 +7,11 @@ import { PAYLOAD_SERVER_URL } from '@/app/_api/serverURL'
 import { Hero } from '@/app/_components/Hero'
 import { Blocks } from '@/app/_components/Blocks'
 
-export const PageClient: React.FC<{
+export type PageClientProps = {
   page: PageType
-}> = ({ page: initialPage }) => {
+}
+
+export const PageClient = ({ page: initialPage }: PageClientProps) => {
   const { data } = useLivePreview<PageType>({
     initialData: initialPage,
     serverURL: PAYLOAD_SERVER_URL,

--- a/test/live-preview/next-app/app/(pages)/posts/[slug]/page.client.tsx
+++ b/test/live-preview/next-app/app/(pages)/posts/[slug]/page.client.tsx
@@ -7,9 +7,11 @@ import { PAYLOAD_SERVER_URL } from '@/app/_api/serverURL'
 import { Blocks } from '@/app/_components/Blocks'
 import { PostHero } from '@/app/_heros/PostHero'
 
-export const PostClient: React.FC<{
+export type PostClientProps = {
   post: PostType
-}> = ({ post: initialPost }) => {
+}
+
+export const PostClient = ({ post: initialPost }: PostClientProps) => {
   const { data } = useLivePreview<PostType>({
     initialData: initialPost,
     serverURL: PAYLOAD_SERVER_URL,

--- a/test/live-preview/next-app/app/_blocks/ArchiveBlock/index.tsx
+++ b/test/live-preview/next-app/app/_blocks/ArchiveBlock/index.tsx
@@ -7,11 +7,11 @@ import { ArchiveBlockProps } from './types'
 
 import classes from './index.module.scss'
 
-export const ArchiveBlock: React.FC<
-  ArchiveBlockProps & {
-    id?: string
-  }
-> = (props) => {
+export type ArchiveBlockProps = ArchiveBlockProps & {
+  id?: string
+}
+
+export const ArchiveBlock = ({ props }: ArchiveBlockProps) => {
   const {
     introContent,
     id,

--- a/test/live-preview/next-app/app/_blocks/CallToAction/index.tsx
+++ b/test/live-preview/next-app/app/_blocks/CallToAction/index.tsx
@@ -10,11 +10,15 @@ import classes from './index.module.scss'
 
 type Props = Extract<Exclude<Page['layout'], undefined>[0], { blockType: 'cta' }>
 
-export const CallToActionBlock: React.FC<
-  Props & {
-    id?: string
-  }
-> = ({ links, richText, invertBackground }) => {
+export type CallToActionBlockProps = Props & {
+  id?: string
+}
+
+export const CallToActionBlock = ({
+  links,
+  richText,
+  invertBackground,
+}: CallToActionBlockProps) => {
   return (
     <Gutter>
       <VerticalPadding

--- a/test/live-preview/next-app/app/_blocks/Content/index.tsx
+++ b/test/live-preview/next-app/app/_blocks/Content/index.tsx
@@ -7,13 +7,11 @@ import RichText from '../../_components/RichText'
 
 import classes from './index.module.scss'
 
-type Props = Extract<Exclude<Page['layout'], undefined>[0], { blockType: 'content' }>
-
-export const ContentBlock: React.FC<
-  Props & {
-    id?: string
-  }
-> = (props) => {
+type ContentBlockProps = Extract<
+  Exclude<Page['layout'], undefined>[0],
+  { blockType: 'content'; id?: string }
+>
+export const ContentBlock = (props: ContentBlockProps) => {
   const { columns } = props
 
   return (

--- a/test/live-preview/next-app/app/_blocks/MediaBlock/index.tsx
+++ b/test/live-preview/next-app/app/_blocks/MediaBlock/index.tsx
@@ -8,12 +8,15 @@ import RichText from '../../_components/RichText'
 
 import classes from './index.module.scss'
 
-type Props = Extract<Exclude<Page['layout'], undefined>[0], { blockType: 'mediaBlock' }> & {
+type MediaBlockProps = Extract<
+  Exclude<Page['layout'], undefined>[0],
+  { blockType: 'mediaBlock' }
+> & {
   staticImage?: StaticImageData
   id?: string
 }
 
-export const MediaBlock: React.FC<Props> = (props) => {
+export const MediaBlock = (props: MediaBlockProps) => {
   const { media, position = 'default', staticImage } = props
 
   let caption

--- a/test/live-preview/next-app/app/_blocks/RelatedPosts/index.tsx
+++ b/test/live-preview/next-app/app/_blocks/RelatedPosts/index.tsx
@@ -15,7 +15,7 @@ export type RelatedPostsProps = {
   relationTo: 'posts'
 }
 
-export const RelatedPosts: React.FC<RelatedPostsProps> = (props) => {
+export const RelatedPosts = (props: RelatedPostsProps) => {
   const { introContent, docs, relationTo } = props
 
   return (

--- a/test/live-preview/next-app/app/_blocks/Relationships/index.tsx
+++ b/test/live-preview/next-app/app/_blocks/Relationships/index.tsx
@@ -12,7 +12,7 @@ export type RelationshipsBlockProps = {
   data: Page
 }
 
-export const RelationshipsBlock: React.FC<RelationshipsBlockProps> = (props) => {
+export const RelationshipsBlock = (props: RelationshipsBlockProps) => {
   const { data } = props
 
   return (

--- a/test/live-preview/next-app/app/_components/BackgroundColor/index.tsx
+++ b/test/live-preview/next-app/app/_components/BackgroundColor/index.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 
 import classes from './index.module.scss'
 
-type Props = {
+type BackgroundColorProps = {
   invert?: boolean | null
   className?: string
   children?: React.ReactNode
   id?: string
 }
 
-export const BackgroundColor: React.FC<Props> = (props) => {
+export const BackgroundColor = (props: BackgroundColorProps) => {
   const { id, className, children, invert } = props
 
   return (

--- a/test/live-preview/next-app/app/_components/Blocks/index.tsx
+++ b/test/live-preview/next-app/app/_components/Blocks/index.tsx
@@ -22,10 +22,12 @@ const blockComponents = {
 
 type Block = NonNullable<Page['layout']>[number]
 
-export const Blocks: React.FC<{
+export type BlocksProps = {
   blocks?: (Block | RelatedPostsProps | RelationshipsBlockProps)[] | null
   disableTopPadding?: boolean
-}> = (props) => {
+}
+
+export const Blocks = (props: BlocksProps) => {
   const { disableTopPadding, blocks } = props
 
   const hasBlocks = blocks && Array.isArray(blocks) && blocks.length > 0

--- a/test/live-preview/next-app/app/_components/Button/index.tsx
+++ b/test/live-preview/next-app/app/_components/Button/index.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 
 import classes from './index.module.scss'
 
-export type Props = {
+export type ButtonProps = {
   label?: string
   appearance?: 'default' | 'primary' | 'secondary' | 'none'
   el?: 'button' | 'link' | 'a'
@@ -18,7 +18,7 @@ export type Props = {
   invert?: boolean
 }
 
-export const Button: React.FC<Props> = ({
+export const Button = ({
   el: elFromProps = 'link',
   label,
   newTab,
@@ -29,7 +29,7 @@ export const Button: React.FC<Props> = ({
   type = 'button',
   disabled,
   invert,
-}) => {
+}: ButtonProps) => {
   let el = elFromProps
 
   const newTabProps = newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {}

--- a/test/live-preview/next-app/app/_components/Card/index.tsx
+++ b/test/live-preview/next-app/app/_components/Card/index.tsx
@@ -6,7 +6,7 @@ import { Media } from '../Media'
 
 import classes from './index.module.scss'
 
-export const Card: React.FC<{
+export type CardProps = {
   alignItems?: 'center'
   className?: string
   showCategories?: boolean
@@ -15,7 +15,9 @@ export const Card: React.FC<{
   relationTo?: 'posts'
   doc?: Post
   orientation?: 'horizontal' | 'vertical'
-}> = (props) => {
+}
+
+export const Card = (props: CardProps) => {
   const {
     relationTo,
     showCategories,

--- a/test/live-preview/next-app/app/_components/Chevron/index.tsx
+++ b/test/live-preview/next-app/app/_components/Chevron/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 
-export const Chevron: React.FC<{
+export type ChevronProps = {
   className?: string
   rotate?: number
-}> = ({ className, rotate }) => {
+}
+
+export const Chevron = ({ className, rotate }: ChevronProps) => {
   return (
     <svg
       width="100%"

--- a/test/live-preview/next-app/app/_components/CollectionArchive/PopulateByCollection/index.tsx
+++ b/test/live-preview/next-app/app/_components/CollectionArchive/PopulateByCollection/index.tsx
@@ -31,7 +31,7 @@ export type Props = Omit<ArchiveBlockProps, 'blockType'> & {
   sort?: string
 }
 
-export const CollectionArchiveByCollection: React.FC<Props> = (props) => {
+export const CollectionArchiveByCollection = (props: Props) => {
   const {
     className,
     relationTo,

--- a/test/live-preview/next-app/app/_components/CollectionArchive/PopulateBySelection/index.tsx
+++ b/test/live-preview/next-app/app/_components/CollectionArchive/PopulateBySelection/index.tsx
@@ -13,7 +13,7 @@ export type Props = {
   selectedDocs?: ArchiveBlockProps['selectedDocs']
 }
 
-export const CollectionArchiveBySelection: React.FC<Props> = (props) => {
+export const CollectionArchiveBySelection = (props: Props) => {
   const { className, selectedDocs } = props
 
   const result = selectedDocs?.map((doc) => doc.value)

--- a/test/live-preview/next-app/app/_components/CollectionArchive/index.tsx
+++ b/test/live-preview/next-app/app/_components/CollectionArchive/index.tsx
@@ -4,12 +4,12 @@ import type { ArchiveBlockProps } from '../../_blocks/ArchiveBlock/types'
 import { CollectionArchiveBySelection } from './PopulateBySelection'
 import { CollectionArchiveByCollection } from './PopulateByCollection'
 
-export type Props = Omit<ArchiveBlockProps, 'blockType'> & {
+export type CollectionArchiveProps = Omit<ArchiveBlockProps, 'blockType'> & {
   className?: string
   sort?: string
 }
 
-export const CollectionArchive: React.FC<Props> = (props) => {
+export const CollectionArchive = (props: CollectionArchiveProps) => {
   const { className, populateBy, selectedDocs } = props
 
   if (populateBy === 'selection') {

--- a/test/live-preview/next-app/app/_components/Gutter/index.tsx
+++ b/test/live-preview/next-app/app/_components/Gutter/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   ref?: Ref<HTMLDivElement>
 }
 
-export const Gutter: React.FC<Props> = forwardRef<HTMLDivElement, Props>((props, ref) => {
+export const Gutter = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const { left = true, right = true, className, children } = props
 
   return (

--- a/test/live-preview/next-app/app/_components/Header/Nav/index.tsx
+++ b/test/live-preview/next-app/app/_components/Header/Nav/index.tsx
@@ -7,7 +7,11 @@ import { CMSLink } from '../../Link'
 
 import classes from './index.module.scss'
 
-export const HeaderNav: React.FC<{ header: HeaderType }> = ({ header }) => {
+export type HeaderNavProps = {
+  header: HeaderType
+}
+
+export const HeaderNav = ({ header }: HeaderNavProps) => {
   const navItems = header?.navItems || []
 
   return (

--- a/test/live-preview/next-app/app/_components/Hero/index.tsx
+++ b/test/live-preview/next-app/app/_components/Hero/index.tsx
@@ -9,7 +9,9 @@ const heroes = {
   lowImpact: LowImpactHero,
 }
 
-export const Hero: React.FC<Page['hero']> = (props) => {
+export type HeroProps = Page['hero']
+
+export const Hero = (props: HeroProps) => {
   const { type } = props || {}
 
   if (!type || type === 'none') return null

--- a/test/live-preview/next-app/app/_components/Link/index.tsx
+++ b/test/live-preview/next-app/app/_components/Link/index.tsx
@@ -19,7 +19,7 @@ type CMSLinkType = {
   invert?: ButtonProps['invert']
 }
 
-export const CMSLink: React.FC<CMSLinkType> = ({
+export const CMSLink = ({
   type,
   url,
   newTab,
@@ -29,7 +29,7 @@ export const CMSLink: React.FC<CMSLinkType> = ({
   children,
   className,
   invert,
-}) => {
+}: CMSLinkType) => {
   const href =
     type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
       ? `/${reference.value.slug}`

--- a/test/live-preview/next-app/app/_components/Media/Image/index.tsx
+++ b/test/live-preview/next-app/app/_components/Media/Image/index.tsx
@@ -11,7 +11,7 @@ import { PAYLOAD_SERVER_URL } from '@/app/_api/serverURL'
 
 const { breakpoints } = cssVariables
 
-export const Image: React.FC<MediaProps> = (props) => {
+export const Image = (props: MediaProps) => {
   const {
     imgClassName,
     onClick,

--- a/test/live-preview/next-app/app/_components/Media/Video/index.tsx
+++ b/test/live-preview/next-app/app/_components/Media/Video/index.tsx
@@ -7,7 +7,7 @@ import { Props as MediaProps } from '../types'
 import classes from './index.module.scss'
 import { PAYLOAD_SERVER_URL } from '@/app/_api/serverURL'
 
-export const Video: React.FC<MediaProps> = (props) => {
+export const Video = (props: MediaProps) => {
   const { videoClassName, resource, onClick } = props
 
   const videoRef = useRef<HTMLVideoElement>(null)

--- a/test/live-preview/next-app/app/_components/Media/index.tsx
+++ b/test/live-preview/next-app/app/_components/Media/index.tsx
@@ -4,7 +4,7 @@ import { Image } from './Image'
 import { Props } from './types'
 import { Video } from './Video'
 
-export const Media: React.FC<Props> = (props) => {
+export const Media = (props: Props) => {
   const { className, resource, htmlElement = 'div' } = props
 
   const isVideo = typeof resource !== 'string' && resource?.mimeType?.includes('video')

--- a/test/live-preview/next-app/app/_components/PageRange/index.tsx
+++ b/test/live-preview/next-app/app/_components/PageRange/index.tsx
@@ -14,7 +14,7 @@ const defaultCollectionLabels = {
   },
 }
 
-export const PageRange: React.FC<{
+export type PageRangeProps = {
   className?: string
   totalDocs?: number
   currentPage?: number
@@ -24,7 +24,9 @@ export const PageRange: React.FC<{
     singular?: string
     plural?: string
   }
-}> = (props) => {
+}
+
+export const PageRange = (props: PageRangeProps) => {
   const {
     className,
     totalDocs,

--- a/test/live-preview/next-app/app/_components/Pagination/index.tsx
+++ b/test/live-preview/next-app/app/_components/Pagination/index.tsx
@@ -4,12 +4,14 @@ import { Chevron } from '../Chevron'
 
 import classes from './index.module.scss'
 
-export const Pagination: React.FC<{
+export type PaginationProps = {
   page: number
   totalPages: number
   onClick: (page: number) => void
   className?: string
-}> = (props) => {
+}
+
+export const Pagination = (props: PaginationProps) => {
   const { page, totalPages, onClick, className } = props
   const hasNextPage = page < totalPages
   const hasPrevPage = page > 1

--- a/test/live-preview/next-app/app/_components/RichText/index.tsx
+++ b/test/live-preview/next-app/app/_components/RichText/index.tsx
@@ -5,12 +5,19 @@ import serializeLexical from './serializeLexical'
 
 import classes from './index.module.scss'
 
-const RichText: React.FC<{
+export type RichTextProps = {
   className?: string
   content: any
   renderUploadFilenameOnly?: boolean
   serializer?: 'lexical' | 'slate'
-}> = ({ className, content, renderUploadFilenameOnly, serializer = 'slate' }) => {
+}
+
+const RichText = ({
+  className,
+  content,
+  renderUploadFilenameOnly,
+  serializer = 'slate',
+}: RichTextProps) => {
   if (!content) {
     return null
   }

--- a/test/live-preview/next-app/app/_components/VerticalPadding/index.tsx
+++ b/test/live-preview/next-app/app/_components/VerticalPadding/index.tsx
@@ -11,12 +11,12 @@ type Props = {
   className?: string
 }
 
-export const VerticalPadding: React.FC<Props> = ({
+export const VerticalPadding = ({
   top = 'medium',
   bottom = 'medium',
   className,
   children,
-}) => {
+}: Props) => {
   return (
     <div
       className={[className, classes[`top-${top}`], classes[`bottom-${bottom}`]]

--- a/test/live-preview/next-app/app/_heros/HighImpact/index.tsx
+++ b/test/live-preview/next-app/app/_heros/HighImpact/index.tsx
@@ -7,7 +7,9 @@ import RichText from '../../_components/RichText'
 
 import classes from './index.module.scss'
 
-export const HighImpactHero: React.FC<Page['hero']> = ({ richText, media }) => {
+export type HighImpactHeroProps = Page['hero']
+
+export const HighImpactHero = ({ richText, media }: HighImpactHeroProps) => {
   return (
     <Gutter className={classes.hero}>
       <div className={classes.content}>

--- a/test/live-preview/next-app/app/_heros/LowImpact/index.tsx
+++ b/test/live-preview/next-app/app/_heros/LowImpact/index.tsx
@@ -7,7 +7,9 @@ import { VerticalPadding } from '../../_components/VerticalPadding'
 
 import classes from './index.module.scss'
 
-export const LowImpactHero: React.FC<Page['hero']> = ({ richText }) => {
+export type LowImpactHeroProps = Page['hero']
+
+export const LowImpactHero = ({ richText }: LowImpactHeroProps) => {
   return (
     <Gutter className={classes.lowImpactHero}>
       <div className={classes.content}>

--- a/test/live-preview/next-app/app/_heros/PostHero/index.tsx
+++ b/test/live-preview/next-app/app/_heros/PostHero/index.tsx
@@ -10,9 +10,11 @@ import { formatDateTime } from '../../_utilities/formatDateTime'
 import classes from './index.module.scss'
 import { PAYLOAD_SERVER_URL } from '@/app/_api/serverURL'
 
-export const PostHero: React.FC<{
+export type PostHeroProps = {
   post: Post
-}> = ({ post }) => {
+}
+
+export const PostHero = ({ post }: PostHeroProps) => {
   const { id, meta: { image: metaImage, description } = {}, createdAt } = post
 
   return (

--- a/test/refresh-permissions/GlobalViewWithRefresh.tsx
+++ b/test/refresh-permissions/GlobalViewWithRefresh.tsx
@@ -5,7 +5,7 @@ import type { Props } from '../../packages/payload/src/admin/components/views/Gl
 import { useAuth } from '../../packages/payload/src/admin/components/utilities/Auth'
 import DefaultGlobalView from '../../packages/payload/src/admin/components/views/Global/Default'
 
-const GlobalView: React.FC<Props> = (props) => {
+const GlobalView = (props: Props) => {
   const { onSave } = props
   const { refreshPermissions } = useAuth()
   const modifiedOnSave = useCallback(

--- a/test/versions/elements/CollectionVersionButton/index.tsx
+++ b/test/versions/elements/CollectionVersionButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'collection-version-button'
 
-const CollectionVersionButton: React.FC = () => {
+const CollectionVersionButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/versions/elements/CollectionVersionsButton/index.tsx
+++ b/test/versions/elements/CollectionVersionsButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'collection-versions-button'
 
-const CollectionVersionsButton: React.FC = () => {
+const CollectionVersionsButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/versions/elements/GlobalVersionButton/index.tsx
+++ b/test/versions/elements/GlobalVersionButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'global-version-button'
 
-const GlobalVersionButton: React.FC = () => {
+const GlobalVersionButton = () => {
   return (
     <div
       className={baseClass}

--- a/test/versions/elements/GlobalVersionsButton/index.tsx
+++ b/test/versions/elements/GlobalVersionsButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const baseClass = 'global-versions-button'
 
-const GlobalVersionsButton: React.FC = () => {
+const GlobalVersionsButton = () => {
   return (
     <div
       className={baseClass}


### PR DESCRIPTION
## Description

I have made a change to the test folder to remove React.FC (https://github.com/payloadcms/payload/discussions/7513).

remaining folders to remove React.RC
docs
examples
packages
templates

I used this command to refactor the code.

npx jscodeshift -- -t https://raw.githubusercontent.com/gndelia/codemod-replace-react-fc-typescript/main/dist/index.js --extensions=tsx --verbose=2 test\fields-relationship

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
