### PR TITLE
fix: scopes preferences queries and mutations by user

### DIFF
--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -57,9 +57,23 @@ export const ListView: React.FC<AdminViewProps> = async ({
         req,
         user,
         where: {
-          key: {
-            equals: preferenceKey,
-          },
+          and: [
+            {
+              key: {
+                equals: preferenceKey,
+              },
+            },
+            {
+              'user.relationTo': {
+                equals: user.collection,
+              },
+            },
+            {
+              'user.value': {
+                equals: user?.id,
+              },
+            },
+          ],
         },
       })
       ?.then((res) => res?.docs?.[0]?.value)) as ListPreferences

--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -115,9 +115,23 @@ export const buildFormState = async ({ req }: { req: PayloadRequest }): Promise<
           depth: 0,
           limit: 1,
           where: {
-            key: {
-              equals: preferencesKey,
-            },
+            and: [
+              {
+                key: {
+                  equals: preferencesKey,
+                },
+              },
+              {
+                'user.relationTo': {
+                  equals: req.user.collection,
+                },
+              },
+              {
+                'user.value': {
+                  equals: req.user.id,
+                },
+              },
+            ],
           },
         })) as unknown as { docs: { value: DocumentPreferences }[] }
 

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -367,7 +367,21 @@ describe('Auth', () => {
             collection: 'payload-preferences',
             depth: 0,
             where: {
-              key: { equals: key },
+              and: [
+                {
+                  key: { equals: key },
+                },
+                {
+                  'user.relationTo': {
+                    equals: loggedInUser.collection,
+                  },
+                },
+                {
+                  'user.value': {
+                    equals: loggedInUser.id,
+                  },
+                },
+              ],
             },
           })
 
@@ -390,7 +404,21 @@ describe('Auth', () => {
             collection: 'payload-preferences',
             depth: 0,
             where: {
-              key: { equals: key },
+              and: [
+                {
+                  key: { equals: key },
+                },
+                {
+                  'user.relationTo': {
+                    equals: loggedInUser.collection,
+                  },
+                },
+                {
+                  'user.value': {
+                    equals: loggedInUser.id,
+                  },
+                },
+              ],
             },
           })
 

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -373,7 +373,7 @@ describe('Auth', () => {
                 },
                 {
                   'user.relationTo': {
-                    equals: loggedInUser.collection,
+                    equals: 'users',
                   },
                 },
                 {
@@ -410,7 +410,7 @@ describe('Auth', () => {
                 },
                 {
                   'user.relationTo': {
-                    equals: loggedInUser.collection,
+                    equals: 'users',
                   },
                 },
                 {


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/7530

Properly scopes preferences queries/mutations by user.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
