### PR TITLE
chore: turn off autocomplete for create first user form

### DIFF
--- a/packages/next/src/elements/EmailAndUsername/index.tsx
+++ b/packages/next/src/elements/EmailAndUsername/index.tsx
@@ -76,7 +76,7 @@ export function RenderEmailAndUsernameFields(props: RenderEmailAndUsernameFields
           type: 'text',
           CustomField: <EmailFieldComponent loginWithUsername={loginWithUsername} />,
           cellComponentProps: null,
-          fieldComponentProps: { type: 'email', readOnly },
+          fieldComponentProps: { type: 'email', autoComplete: 'off', readOnly },
           fieldIsPresentational: false,
           isFieldAffectingData: true,
           localized: false,

--- a/packages/next/src/views/CreateFirstUser/index.client.tsx
+++ b/packages/next/src/views/CreateFirstUser/index.client.tsx
@@ -64,6 +64,7 @@ export const CreateFirstUserClient: React.FC<{
         readOnly={false}
       />
       <PasswordField
+        autoComplete="off"
         label={t('authentication:newPassword')}
         name="password"
         path="password"


### PR DESCRIPTION
Turns off autocomplete on the first user form so it doesn't conflict with wrong credentials being autofilled