### PR TITLE
fix(richtext-lexical)!: html converters not respecting overrideAccess property when populating values, in local API

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -7,7 +7,6 @@ import type { CSSProperties } from 'react'
 import monacoeditor from 'monaco-editor' // IMPORTANT - DO NOT REMOVE: This is required for pnpm's default isolated mode to work - even though the import is not used. This is due to a typescript bug: https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189. (tsbugisolatedmode)
 import type { JSONSchema4 } from 'json-schema'
 import type React from 'react'
-import type { DeepPartial } from 'ts-essentials'
 
 import type { RichTextAdapter, RichTextAdapterProvider } from '../../admin/RichText.js'
 import type { ErrorComponent } from '../../admin/forms/Error.js'
@@ -33,6 +32,10 @@ export type FieldHookArgs<TData extends TypeWithID = any, TValue = any, TSibling
   context: RequestContext
   /** The data passed to update the document within create and update operations, and the full document itself in the afterRead hook. */
   data?: Partial<TData>
+  /**
+   * Only available in the `afterRead` hook.
+   */
+  draft?: boolean
   /** The field which the hook is running against. */
   field: FieldAffectingData
   /** Boolean to denote if this hook is running against finding one, or finding many within the afterRead hook. */
@@ -60,6 +63,10 @@ export type FieldHookArgs<TData extends TypeWithID = any, TValue = any, TSibling
    * The schemaPath of the field, e.g. ["group", "myArray", "textField"]. The schemaPath is the path but without indexes and would be used in the context of field schemas, not field data.
    */
   schemaPath: string[]
+  /**
+   * Only available in the `afterRead` hook.
+   */
+  showHiddenFields?: boolean
   /** The sibling data passed to a field that the hook is running against. */
   siblingData: Partial<TSiblingData>
   /**

--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -205,6 +205,7 @@ export const promise = async ({
                 collection,
                 context,
                 data: doc,
+                draft,
                 field,
                 findMany,
                 global,
@@ -214,6 +215,7 @@ export const promise = async ({
                 path: fieldPath,
                 req,
                 schemaPath: fieldSchemaPath,
+                showHiddenFields,
                 siblingData: siblingDoc,
                 value,
               })
@@ -230,6 +232,7 @@ export const promise = async ({
             collection,
             context,
             data: doc,
+            draft,
             field,
             findMany,
             global,
@@ -239,6 +242,7 @@ export const promise = async ({
             path: fieldPath,
             req,
             schemaPath: fieldSchemaPath,
+            showHiddenFields,
             siblingData: siblingDoc,
             value: siblingDoc[field.name],
           })

--- a/packages/richtext-lexical/src/features/blockquote/feature.server.ts
+++ b/packages/richtext-lexical/src/features/blockquote/feature.server.ts
@@ -28,15 +28,26 @@ export const BlockquoteFeature = createServerFeature({
       createNode({
         converters: {
           html: {
-            converter: async ({ converters, node, parent, req }) => {
+            converter: async ({
+              converters,
+              draft,
+              node,
+              overrideAccess,
+              parent,
+              req,
+              showHiddenFields,
+            }) => {
               const childrenText = await convertLexicalNodesToHTML({
                 converters,
+                draft,
                 lexicalNodes: node.children,
+                overrideAccess,
                 parent: {
                   ...node,
                   parent,
                 },
                 req,
+                showHiddenFields,
               })
 
               return `<blockquote>${childrenText}</blockquote>`

--- a/packages/richtext-lexical/src/features/converters/html/converter/converters/paragraph.ts
+++ b/packages/richtext-lexical/src/features/converters/html/converter/converters/paragraph.ts
@@ -5,15 +5,18 @@ import type { HTMLConverter } from '../types.js'
 import { convertLexicalNodesToHTML } from '../index.js'
 
 export const ParagraphHTMLConverter: HTMLConverter<SerializedParagraphNode> = {
-  async converter({ converters, node, parent, req }) {
+  async converter({ converters, draft, node, overrideAccess, parent, req, showHiddenFields }) {
     const childrenText = await convertLexicalNodesToHTML({
       converters,
+      draft,
       lexicalNodes: node.children,
+      overrideAccess,
       parent: {
         ...node,
         parent,
       },
       req,
+      showHiddenFields,
     })
     return `<p>${childrenText}</p>`
   },

--- a/packages/richtext-lexical/src/features/converters/html/converter/types.ts
+++ b/packages/richtext-lexical/src/features/converters/html/converter/types.ts
@@ -1,22 +1,19 @@
 import type { SerializedLexicalNode } from 'lexical'
-import type { Payload, PayloadRequest } from 'payload'
+import type { PayloadRequest } from 'payload'
 
 export type HTMLConverter<T extends SerializedLexicalNode = SerializedLexicalNode> = {
-  converter: ({
-    childIndex,
-    converters,
-    node,
-    parent,
-    req,
-  }: {
+  converter: (args: {
     childIndex: number
-    converters: HTMLConverter[]
+    converters: HTMLConverter<any>[]
+    draft: boolean
     node: T
+    overrideAccess: boolean
     parent: SerializedLexicalNodeWithParent
     /**
      * When the converter is called, req CAN be passed in depending on where it's run.
      */
     req: PayloadRequest | null
+    showHiddenFields: boolean
   }) => Promise<string> | string
   nodeTypes: string[]
 }

--- a/packages/richtext-lexical/src/features/converters/html/feature.server.ts
+++ b/packages/richtext-lexical/src/features/converters/html/feature.server.ts
@@ -4,8 +4,8 @@ import { createServerFeature } from '../../../utilities/createServerFeature.js'
 
 export type HTMLConverterFeatureProps = {
   converters?:
-    | (({ defaultConverters }: { defaultConverters: HTMLConverter[] }) => HTMLConverter[])
-    | HTMLConverter[]
+    | (({ defaultConverters }: { defaultConverters: HTMLConverter<any>[] }) => HTMLConverter<any>[])
+    | HTMLConverter<any>[]
 }
 
 // This is just used to save the props on the richText field

--- a/packages/richtext-lexical/src/features/converters/html/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/html/field/index.ts
@@ -160,7 +160,16 @@ export const lexicalHTML: (
     },
     hooks: {
       afterRead: [
-        async ({ collection, field, global, req, siblingData }) => {
+        async ({
+          collection,
+          draft,
+          field,
+          global,
+          overrideAccess,
+          req,
+          showHiddenFields,
+          siblingData,
+        }) => {
           const fields = collection ? collection.fields : global.fields
 
           const foundSiblingFields = findFieldPathAndSiblingFields(fields, [], field)
@@ -209,7 +218,10 @@ export const lexicalHTML: (
           return await convertLexicalToHTML({
             converters: finalConverters,
             data: lexicalFieldData,
+            draft,
+            overrideAccess,
             req,
+            showHiddenFields,
           })
         },
       ],

--- a/packages/richtext-lexical/src/features/experimental_table/feature.server.ts
+++ b/packages/richtext-lexical/src/features/experimental_table/feature.server.ts
@@ -46,15 +46,26 @@ export const EXPERIMENTAL_TableFeature = createServerFeature({
         createNode({
           converters: {
             html: {
-              converter: async ({ converters, node, parent, req }) => {
+              converter: async ({
+                converters,
+                draft,
+                node,
+                overrideAccess,
+                parent,
+                req,
+                showHiddenFields,
+              }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  draft,
                   lexicalNodes: node.children,
+                  overrideAccess,
                   parent: {
                     ...node,
                     parent,
                   },
                   req,
+                  showHiddenFields,
                 })
                 return `<table class="lexical-table" style="border-collapse: collapse;">${childrenText}</table>`
               },
@@ -66,15 +77,26 @@ export const EXPERIMENTAL_TableFeature = createServerFeature({
         createNode({
           converters: {
             html: {
-              converter: async ({ converters, node, parent, req }) => {
+              converter: async ({
+                converters,
+                draft,
+                node,
+                overrideAccess,
+                parent,
+                req,
+                showHiddenFields,
+              }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  draft,
                   lexicalNodes: node.children,
+                  overrideAccess,
                   parent: {
                     ...node,
                     parent,
                   },
                   req,
+                  showHiddenFields,
                 })
 
                 const tagName = node.headerState > 0 ? 'th' : 'td'
@@ -95,15 +117,26 @@ export const EXPERIMENTAL_TableFeature = createServerFeature({
         createNode({
           converters: {
             html: {
-              converter: async ({ converters, node, parent, req }) => {
+              converter: async ({
+                converters,
+                draft,
+                node,
+                overrideAccess,
+                parent,
+                req,
+                showHiddenFields,
+              }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  draft,
                   lexicalNodes: node.children,
+                  overrideAccess,
                   parent: {
                     ...node,
                     parent,
                   },
                   req,
+                  showHiddenFields,
                 })
                 return `<tr class="lexical-table-row">${childrenText}</tr>`
               },

--- a/packages/richtext-lexical/src/features/experimental_table/feature.server.ts
+++ b/packages/richtext-lexical/src/features/experimental_table/feature.server.ts
@@ -1,3 +1,9 @@
+import type {
+  SerializedTableCellNode as _SerializedTableCellNode,
+  SerializedTableNode as _SerializedTableNode,
+  SerializedTableRowNode as _SerializedTableRowNode,
+} from '@lexical/table'
+import type { Spread } from 'lexical'
 import type { Config, Field } from 'payload'
 
 import { TableCellNode, TableNode, TableRowNode } from '@lexical/table'
@@ -23,6 +29,27 @@ const fields: Field[] = [
     required: true,
   },
 ]
+
+export type SerializedTableCellNode = Spread<
+  {
+    type: 'tablecell'
+  },
+  _SerializedTableCellNode
+>
+
+export type SerializedTableNode = Spread<
+  {
+    type: 'table'
+  },
+  _SerializedTableNode
+>
+
+export type SerializedTableRowNode = Spread<
+  {
+    type: 'tablerow'
+  },
+  _SerializedTableRowNode
+>
 export const EXPERIMENTAL_TableFeature = createServerFeature({
   feature: async ({ config, isRoot }) => {
     const validRelationships = config.collections.map((c) => c.slug) || []

--- a/packages/richtext-lexical/src/features/heading/feature.server.ts
+++ b/packages/richtext-lexical/src/features/heading/feature.server.ts
@@ -46,15 +46,26 @@ export const HeadingFeature = createServerFeature<
         createNode({
           converters: {
             html: {
-              converter: async ({ converters, node, parent, req }) => {
+              converter: async ({
+                converters,
+                draft,
+                node,
+                overrideAccess,
+                parent,
+                req,
+                showHiddenFields,
+              }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  draft,
                   lexicalNodes: node.children,
+                  overrideAccess,
                   parent: {
                     ...node,
                     parent,
                   },
                   req,
+                  showHiddenFields,
                 })
 
                 return '<' + node?.tag + '>' + childrenText + '</' + node?.tag + '>'

--- a/packages/richtext-lexical/src/features/link/feature.server.ts
+++ b/packages/richtext-lexical/src/features/link/feature.server.ts
@@ -116,15 +116,26 @@ export const LinkFeature = createServerFeature<
         createNode({
           converters: {
             html: {
-              converter: async ({ converters, node, parent, req }) => {
+              converter: async ({
+                converters,
+                draft,
+                node,
+                overrideAccess,
+                parent,
+                req,
+                showHiddenFields,
+              }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  draft,
                   lexicalNodes: node.children,
+                  overrideAccess,
                   parent: {
                     ...node,
                     parent,
                   },
                   req,
+                  showHiddenFields,
                 })
 
                 const rel: string = node.fields.newTab ? ' rel="noopener noreferrer"' : ''
@@ -150,15 +161,26 @@ export const LinkFeature = createServerFeature<
         createNode({
           converters: {
             html: {
-              converter: async ({ converters, node, parent, req }) => {
+              converter: async ({
+                converters,
+                draft,
+                node,
+                overrideAccess,
+                parent,
+                req,
+                showHiddenFields,
+              }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  draft,
                   lexicalNodes: node.children,
+                  overrideAccess,
                   parent: {
                     ...node,
                     parent,
                   },
                   req,
+                  showHiddenFields,
                 })
 
                 const rel: string = node.fields.newTab ? ' rel="noopener noreferrer"' : ''

--- a/packages/richtext-lexical/src/features/lists/htmlConverter.ts
+++ b/packages/richtext-lexical/src/features/lists/htmlConverter.ts
@@ -7,15 +7,18 @@ import type { SerializedListItemNode, SerializedListNode } from './plugin/index.
 import { convertLexicalNodesToHTML } from '../converters/html/converter/index.js'
 
 export const ListHTMLConverter: HTMLConverter<SerializedListNode> = {
-  converter: async ({ converters, node, parent, req }) => {
+  converter: async ({ converters, draft, node, overrideAccess, parent, req, showHiddenFields }) => {
     const childrenText = await convertLexicalNodesToHTML({
       converters,
+      draft,
       lexicalNodes: node.children,
+      overrideAccess,
       parent: {
         ...node,
         parent,
       },
       req,
+      showHiddenFields,
     })
 
     return `<${node?.tag} class="list-${node?.listType}">${childrenText}</${node?.tag}>`
@@ -24,17 +27,20 @@ export const ListHTMLConverter: HTMLConverter<SerializedListNode> = {
 }
 
 export const ListItemHTMLConverter: HTMLConverter<SerializedListItemNode> = {
-  converter: async ({ converters, node, parent, req }) => {
+  converter: async ({ converters, draft, node, overrideAccess, parent, req, showHiddenFields }) => {
     const hasSubLists = node.children.some((child) => child.type === 'list')
 
     const childrenText = await convertLexicalNodesToHTML({
       converters,
+      draft,
       lexicalNodes: node.children,
+      overrideAccess,
       parent: {
         ...node,
         parent,
       },
       req,
+      showHiddenFields,
     })
 
     if ('listType' in parent && parent?.listType === 'check') {

--- a/packages/richtext-lexical/src/features/upload/feature.server.ts
+++ b/packages/richtext-lexical/src/features/upload/feature.server.ts
@@ -99,7 +99,7 @@ export const UploadFeature = createServerFeature<
         createNode({
           converters: {
             html: {
-              converter: async ({ node, req }) => {
+              converter: async ({ draft, node, overrideAccess, req, showHiddenFields }) => {
                 // @ts-expect-error
                 const id = node?.value?.id || node?.value // for backwards-compatibility
 
@@ -115,11 +115,11 @@ export const UploadFeature = createServerFeature<
                       currentDepth: 0,
                       data: uploadDocument,
                       depth: 1,
-                      draft: false,
+                      draft,
                       key: 'value',
-                      overrideAccess: false,
+                      overrideAccess,
                       req,
-                      showHiddenFields: false,
+                      showHiddenFields,
                     })
                   } catch (ignored) {
                     // eslint-disable-next-line no-console

--- a/packages/richtext-lexical/src/nodeTypes.ts
+++ b/packages/richtext-lexical/src/nodeTypes.ts
@@ -9,6 +9,12 @@ import type {
 
 import type { SerializedQuoteNode } from './features/blockquote/feature.server.js'
 import type { SerializedBlockNode } from './features/blocks/nodes/BlocksNode.js'
+import type { SerializedInlineBlockNode } from './features/blocks/nodes/InlineBlocksNode.js'
+import type {
+  SerializedTableCellNode,
+  SerializedTableNode,
+  SerializedTableRowNode,
+} from './features/experimental_table/feature.server.js'
 import type { SerializedHeadingNode } from './features/heading/feature.server.js'
 import type { SerializedHorizontalRuleNode } from './features/horizontalRule/nodes/HorizontalRuleNode.js'
 import type { SerializedAutoLinkNode, SerializedLinkNode } from './features/link/nodes/types.js'
@@ -21,11 +27,15 @@ export type {
   SerializedBlockNode,
   SerializedHeadingNode,
   SerializedHorizontalRuleNode,
+  SerializedInlineBlockNode,
   SerializedLinkNode,
   SerializedListItemNode,
   SerializedListNode,
   SerializedQuoteNode,
   SerializedRelationshipNode,
+  SerializedTableCellNode,
+  SerializedTableNode,
+  SerializedTableRowNode,
   SerializedUploadNode,
 }
 

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -74,6 +74,7 @@ export interface Config {
 export interface UserAuthOperations {
   forgotPassword: {
     email: string;
+    password: string;
   };
   login: {
     email: string;
@@ -85,6 +86,7 @@ export interface UserAuthOperations {
   };
   unlock: {
     email: string;
+    password: string;
   };
 }
 /**


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/7495

When the Upload HTML Converter was called from the local API, the upload document did not populate properly due to overrideAccess not being passed through to the dataloader. This PR also adds new properties to the afterRead field hook, so that these can be used in the lexical html field.

Reproduction here: https://github.com/payloadcms/payload/tree/chore/reproduce-html-converter-issue

**BREAKING:** If you define your own, custom lexical HTML Converters that have sub-nodes, or if you directly call the `convertLexicalNodesToHTML` function anywhere, you now need to pass through the `showHiddenFields`, draft and `overrideAccess` props to the `convertLexicalNodesToHTML` function. These are available in the arguments of your HTML Converter function