### PR TITLE
fix(db-postgres): #7492 migrate snapshots

### DIFF
--- a/packages/db-postgres/package.json
+++ b/packages/db-postgres/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@payloadcms/drizzle": "workspace:*",
     "console-table-printer": "2.11.2",
-    "drizzle-kit": "0.23.2",
+    "drizzle-kit": "0.23.2-df9e596",
     "drizzle-orm": "0.32.1",
     "pg": "8.11.3",
     "prompts": "2.4.2",

--- a/packages/db-postgres/src/createMigration.ts
+++ b/packages/db-postgres/src/createMigration.ts
@@ -64,14 +64,10 @@ export const createMigration: CreateMigration = async function createMigration(
       .reverse()?.[0]
 
     if (latestSnapshot) {
-      const latestSnapshotJSON: DrizzleSnapshotJSON = JSON.parse(
-        fs.readFileSync(`${dir}/${latestSnapshot}`, 'utf8'),
-      ) as DrizzleSnapshotJSON
+      drizzleJsonBefore = JSON.parse(fs.readFileSync(`${dir}/${latestSnapshot}`, 'utf8'))
 
-      if (latestSnapshotJSON.version < drizzleJsonBefore.version) {
-        drizzleJsonBefore = upPgSnapshot(latestSnapshotJSON)
-      } else {
-        drizzleJsonBefore = latestSnapshotJSON
+      if (drizzleJsonBefore.version < drizzleJsonAfter.version) {
+        drizzleJsonBefore = upPgSnapshot(drizzleJsonBefore)
       }
     }
 

--- a/packages/db-postgres/src/createMigration.ts
+++ b/packages/db-postgres/src/createMigration.ts
@@ -25,7 +25,7 @@ export const createMigration: CreateMigration = async function createMigration(
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)
   }
-  const { generateDrizzleJson, generateMigration } = require('drizzle-kit/api')
+  const { generateDrizzleJson, generateMigration, upPgSnapshot } = require('drizzle-kit/api')
   const drizzleJsonAfter = generateDrizzleJson(this.schema)
   const [yyymmdd, hhmmss] = new Date().toISOString().split('T')
   const formattedDate = yyymmdd.replace(/\D/g, '')
@@ -64,9 +64,15 @@ export const createMigration: CreateMigration = async function createMigration(
       .reverse()?.[0]
 
     if (latestSnapshot) {
-      drizzleJsonBefore = JSON.parse(
+      const latestSnapshotJSON: DrizzleSnapshotJSON = JSON.parse(
         fs.readFileSync(`${dir}/${latestSnapshot}`, 'utf8'),
       ) as DrizzleSnapshotJSON
+
+      if (latestSnapshotJSON.version < drizzleJsonBefore.version) {
+        drizzleJsonBefore = upPgSnapshot(latestSnapshotJSON)
+      } else {
+        drizzleJsonBefore = latestSnapshotJSON
+      }
     }
 
     const sqlStatementsUp = await generateMigration(drizzleJsonBefore, drizzleJsonAfter)

--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -46,7 +46,7 @@
     "@libsql/client": "^0.6.2",
     "@payloadcms/drizzle": "workspace:*",
     "console-table-printer": "2.11.2",
-    "drizzle-kit": "0.23.2",
+    "drizzle-kit": "0.23.2-df9e596",
     "drizzle-orm": "0.32.1",
     "prompts": "2.4.2",
     "to-snake-case": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,8 +302,8 @@ importers:
         specifier: 2.11.2
         version: 2.11.2
       drizzle-kit:
-        specifier: 0.23.2
-        version: 0.23.2
+        specifier: 0.23.2-df9e596
+        version: 0.23.2-df9e596
       drizzle-orm:
         specifier: 0.32.1
         version: 0.32.1(@libsql/client@0.6.2)(@types/pg@8.10.2)(pg@8.11.3)(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.0)
@@ -351,8 +351,8 @@ importers:
         specifier: 2.11.2
         version: 2.11.2
       drizzle-kit:
-        specifier: 0.23.2
-        version: 0.23.2
+        specifier: 0.23.2-df9e596
+        version: 0.23.2-df9e596
       drizzle-orm:
         specifier: 0.32.1
         version: 0.32.1(@libsql/client@0.6.2)(@types/pg@8.10.2)(pg@8.11.3)(react@19.0.0-rc-fb9a90fa48-20240614)(types-react@19.0.0-rc.0)
@@ -9063,8 +9063,8 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /drizzle-kit@0.23.2:
-    resolution: {integrity: sha512-NWkQ7GD2OTbQ7HzcjsaCOf3n0tlFPSEAF38fvDpwDj8jRbGWGFtN2cD8I8wp4lU+5Os/oyP2xycTKGLHdPipUw==}
+  /drizzle-kit@0.23.2-df9e596:
+    resolution: {integrity: sha512-MOvoeDE1c05XGevXLqhRVu/TNHwueibPZqMUH/kG1v6DOHD5pB2poRpjphr4sjae2QDS6h+PU5pCfzqEa6le6Q==}
     hasBin: true
     dependencies:
       '@drizzle-team/brocli': 0.8.2


### PR DESCRIPTION
## Description

fixes #7492 

In order to run createMigration, we need to read in the previous snapshot file if one exists. When that snapshot was generated from an older version of drizzle-kit, we have to first migrate it up match the latest version for drizzle to generate the new migration. This change adds in the call to check the version and migrate the snapshot if needed.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
