### PR TITLE
chore: call refresh after the subscription is ready, fixes CI

### DIFF
--- a/packages/live-preview-react/src/RefreshRouteOnSave.tsx
+++ b/packages/live-preview-react/src/RefreshRouteOnSave.tsx
@@ -39,6 +39,9 @@ export const RefreshRouteOnSave: React.FC<{
       ready({
         serverURL,
       })
+
+      // refresh after the ready message is sent to get the latest data
+      refresh()
     }
 
     return () => {
@@ -46,7 +49,7 @@ export const RefreshRouteOnSave: React.FC<{
         window.removeEventListener('message', onMessage)
       }
     }
-  }, [serverURL, onMessage, depth, apiRoute])
+  }, [serverURL, onMessage, depth, apiRoute, refresh])
 
   return null
 }

--- a/test/live-preview/app/live-preview/_api/getDoc.ts
+++ b/test/live-preview/app/live-preview/_api/getDoc.ts
@@ -1,10 +1,10 @@
-import type { Where } from 'payload'
+import type { CollectionSlug, Where } from 'payload'
 
 import config from '@payload-config'
 import { getPayloadHMR } from '@payloadcms/next/utilities/getPayloadHMR.js'
 
 export const getDoc = async <T>(args: {
-  collection: string
+  collection: CollectionSlug
   depth?: number
   draft?: boolean
   slug?: string


### PR DESCRIPTION
## Description

LivePreview data was stale if the user entered data while the socket connection was being established. This change ensures fresh data is fetched after the connection is established. 

This is easy to see when turning on 4G connection and in CI, where it is especially slow.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
