### PR TITLE
fix(ui): properly handles ID field component type based on `payload.db.defaultIDType`

### DIFF
--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -146,6 +146,7 @@ export const ListView: React.FC<AdminViewProps> = async ({
             DefaultListView,
             collection: collectionConfig,
             createMappedComponent,
+            payload,
             t: i18n.t,
           })}
           collectionSlug={collectionSlug}

--- a/packages/ui/src/providers/Config/createClientConfig/collections.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/collections.tsx
@@ -6,6 +6,7 @@ import type {
   EditViewComponent,
   EditViewProps,
   Field,
+  Payload,
   SanitizedCollectionConfig,
   ServerOnlyCollectionAdminProperties,
   ServerOnlyCollectionProperties,
@@ -18,12 +19,14 @@ export const createClientCollectionConfig = ({
   DefaultListView,
   collection,
   createMappedComponent,
+  payload,
   t,
 }: {
   DefaultEditView: React.FC<EditViewProps>
   DefaultListView: React.FC<AdminViewProps>
   collection: SanitizedCollectionConfig
   createMappedComponent: CreateMappedComponent
+  payload: Payload
   t: TFunction
 }): ClientCollectionConfig => {
   const sanitized: ClientCollectionConfig = { ...(collection as any as ClientCollectionConfig) } // invert the type
@@ -31,6 +34,7 @@ export const createClientCollectionConfig = ({
   sanitized.fields = createClientFieldConfigs({
     createMappedComponent,
     fields: sanitized.fields as any as Field[], // invert the type
+    payload,
     t,
   })
 
@@ -197,12 +201,14 @@ export const createClientCollectionConfigs = ({
   DefaultListView,
   collections,
   createMappedComponent,
+  payload,
   t,
 }: {
   DefaultEditView: React.FC<EditViewProps>
   DefaultListView: React.FC<AdminViewProps>
   collections: SanitizedCollectionConfig[]
   createMappedComponent: CreateMappedComponent
+  payload: Payload
   t: TFunction
 }): ClientCollectionConfig[] =>
   collections.map((collection) =>
@@ -211,6 +217,7 @@ export const createClientCollectionConfigs = ({
       DefaultListView,
       collection,
       createMappedComponent,
+      payload,
       t,
     }),
   )

--- a/packages/ui/src/providers/Config/createClientConfig/fields.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/fields.tsx
@@ -5,6 +5,7 @@ import type {
   Field,
   FieldTypes,
   LabelComponent,
+  Payload,
   RowLabelComponent,
   ServerOnlyFieldAdminProperties,
   ServerOnlyFieldProperties,
@@ -104,11 +105,13 @@ export const createClientFieldConfig = ({
   createMappedComponent,
   field: incomingField,
   parentPath,
+  payload,
   t,
 }: {
   createMappedComponent: CreateMappedComponent
   field: Field
   parentPath?: string
+  payload: Payload
   t: TFunction
 }): ClientFieldConfig => {
   const field: ClientFieldConfig = { ...(incomingField as any as ClientFieldConfig) } // invert the type
@@ -180,6 +183,7 @@ export const createClientFieldConfig = ({
         // @ts-expect-error // TODO: see note in `ClientFieldConfig` about <Omit> breaking the inference here
         fields: field.fields,
         parentPath: field._path,
+        payload,
         t,
       })
 
@@ -208,6 +212,7 @@ export const createClientFieldConfig = ({
           createMappedComponent,
           fields: sanitized.fields,
           parentPath: field._path,
+          payload,
           t,
         })
 
@@ -227,6 +232,7 @@ export const createClientFieldConfig = ({
           disableAddingID: true,
           fields: sanitized.fields,
           parentPath: field._path,
+          payload,
           t,
         })
 
@@ -342,16 +348,20 @@ export const createClientFieldConfigs = ({
   disableAddingID,
   fields,
   parentPath,
+  payload,
   t,
 }: {
   createMappedComponent: CreateMappedComponent
   disableAddingID?: boolean
   fields: Field[]
   parentPath?: string
+  payload: Payload
   t: TFunction
 }): ClientFieldConfig[] => {
   const result = [...fields]
-    .map((field) => createClientFieldConfig({ createMappedComponent, field, parentPath, t }))
+    .map((field) =>
+      createClientFieldConfig({ createMappedComponent, field, parentPath, payload, t }),
+    )
     .filter(Boolean)
 
   const hasID =
@@ -360,7 +370,7 @@ export const createClientFieldConfigs = ({
   if (!disableAddingID && !hasID) {
     result.push({
       name: 'id',
-      type: 'text',
+      type: payload.db.defaultIDType === 'number' ? 'number' : 'text',
       _fieldIsPresentational: false,
       _isFieldAffectingData: true,
       admin: {

--- a/packages/ui/src/providers/Config/createClientConfig/globals.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/globals.tsx
@@ -5,6 +5,7 @@ import type {
   EditViewComponent,
   EditViewProps,
   Field,
+  Payload,
   SanitizedConfig,
   ServerOnlyGlobalAdminProperties,
   ServerOnlyGlobalProperties,
@@ -16,11 +17,13 @@ export const createClientGlobalConfig = ({
   DefaultEditView,
   createMappedComponent,
   global,
+  payload,
   t,
 }: {
   DefaultEditView: React.FC<EditViewProps>
   createMappedComponent: CreateMappedComponent
   global: SanitizedConfig['globals'][0]
+  payload: Payload
   t: TFunction
 }): ClientGlobalConfig => {
   const sanitized: ClientGlobalConfig = { ...(global as any as ClientGlobalConfig) } // invert the type
@@ -28,6 +31,7 @@ export const createClientGlobalConfig = ({
   sanitized.fields = createClientFieldConfigs({
     createMappedComponent,
     fields: sanitized.fields as any as Field[], // invert the type
+    payload,
     t,
   })
 
@@ -124,13 +128,15 @@ export const createClientGlobalConfigs = ({
   DefaultEditView,
   createMappedComponent,
   globals,
+  payload,
   t,
 }: {
   DefaultEditView: React.FC<EditViewProps>
   createMappedComponent: CreateMappedComponent
   globals: SanitizedConfig['globals']
+  payload: Payload
   t: TFunction
 }): ClientGlobalConfig[] =>
   globals.map((global) =>
-    createClientGlobalConfig({ DefaultEditView, createMappedComponent, global, t }),
+    createClientGlobalConfig({ DefaultEditView, createMappedComponent, global, payload, t }),
   )

--- a/packages/ui/src/providers/Config/createClientConfig/index.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/index.tsx
@@ -118,6 +118,7 @@ export const createClientConfig = async ({
     DefaultListView,
     collections: [...(clientConfig.collections as any as SanitizedCollectionConfig[])], // invert the type
     createMappedComponent,
+    payload,
     t: i18n.t,
   })
 
@@ -125,6 +126,7 @@ export const createClientConfig = async ({
     DefaultEditView,
     createMappedComponent,
     globals: [...(clientConfig.globals as any as SanitizedGlobalConfig[])], // invert the type
+    payload,
     t: i18n.t,
   })
 


### PR DESCRIPTION
## Description

Duplicate of https://github.com/payloadcms/payload/pull/7416 but onto the `beta-next` branch (moves logic from the component map into the client config).

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
