### PR TITLE
fix: empty path in error message

### DIFF
--- a/packages/payload/src/database/getLocalizedPaths.ts
+++ b/packages/payload/src/database/getLocalizedPaths.ts
@@ -33,7 +33,7 @@ export async function getLocalizedPaths({
       fields: flattenFields(fields, false),
       globalSlug,
       invalid: false,
-      path: incomingPath,
+      path: '',
     },
   ]
 
@@ -111,9 +111,10 @@ export async function getLocalizedPaths({
                 ['relationTo', 'value'].includes(pathSegments[pathSegments.length - 1]) ||
                 pathSegments.length === 1
 
+              lastIncompletePath.path = pathSegments.join('.')
+
               if (lastSegmentIsValid) {
                 lastIncompletePath.complete = true
-                lastIncompletePath.path = pathSegments.join('.')
               } else {
                 lastIncompletePath.invalid = true
                 return paths

--- a/packages/payload/src/database/getLocalizedPaths.ts
+++ b/packages/payload/src/database/getLocalizedPaths.ts
@@ -33,7 +33,7 @@ export async function getLocalizedPaths({
       fields: flattenFields(fields, false),
       globalSlug,
       invalid: false,
-      path: '',
+      path: incomingPath,
     },
   ]
 


### PR DESCRIPTION
## Description

Closes #7524

The query path is overwritten as an empty string in the `getLocalizedPaths()` function - then when it should throw an invalid path error it no longer has this info. 

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [ ] Chore (non-breaking change which does not add functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
