### PR TITLE
feat: allow for migrationDir override

### DIFF
--- a/packages/payload/src/database/migrations/migrate.ts
+++ b/packages/payload/src/database/migrations/migrate.ts
@@ -7,9 +7,14 @@ import { killTransaction } from '../../utilities/killTransaction.js'
 import { getMigrations } from './getMigrations.js'
 import { readMigrationFiles } from './readMigrationFiles.js'
 
-export async function migrate(this: BaseDatabaseAdapter): Promise<void> {
+export const migrate: BaseDatabaseAdapter['migrate'] = async function migrate(
+  this: BaseDatabaseAdapter,
+  args,
+): Promise<void> {
+  const migrationDirOverride = args?.migrationDir
+
   const { payload } = this
-  const migrationFiles = await readMigrationFiles({ payload })
+  const migrationFiles = await readMigrationFiles({ migrationDir: migrationDirOverride, payload })
   const { existingMigrations, latestBatch } = await getMigrations({ payload })
 
   const newBatch = latestBatch + 1

--- a/packages/payload/src/database/migrations/readMigrationFiles.ts
+++ b/packages/payload/src/database/migrations/readMigrationFiles.ts
@@ -8,29 +8,33 @@ import type { Migration } from '../types.js'
  * Read the migration files from disk
  */
 export const readMigrationFiles = async ({
+  migrationDir: migrationDirOverride,
   payload,
 }: {
+  migrationDir?: string
   payload: Payload
 }): Promise<Migration[]> => {
-  if (!fs.existsSync(payload.db.migrationDir)) {
+  const migrationDir = migrationDirOverride || payload.db.migrationDir
+
+  if (!fs.existsSync(migrationDir)) {
     payload.logger.error({
-      msg: `No migration directory found at ${payload.db.migrationDir}`,
+      msg: `No migration directory found at ${migrationDir}`,
     })
     return []
   }
 
   payload.logger.info({
-    msg: `Reading migration files from ${payload.db.migrationDir}`,
+    msg: `Reading migration files from ${migrationDir}`,
   })
 
   const files = fs
-    .readdirSync(payload.db.migrationDir)
+    .readdirSync(migrationDir)
     .sort()
     .filter((f) => {
       return f.endsWith('.ts') || f.endsWith('.js')
     })
     .map((file) => {
-      return path.resolve(payload.db.migrationDir, file)
+      return path.resolve(migrationDir, file)
     })
 
   return Promise.all(

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -68,7 +68,7 @@ export interface BaseDatabaseAdapter {
   /**
    * Run any migration up functions that have not yet been performed and update the status
    */
-  migrate: () => Promise<void>
+  migrate: (args?: { migrationDir?: string }) => Promise<void>
 
   /**
    * Run any migration down functions that have been performed


### PR DESCRIPTION
## Description

Allows for the override of migrationDir while using `payload.db.migrate` directly.