### PR TITLE
fix: filtering by non-poly `relationships` with `not_equals` operator

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -136,14 +136,6 @@ export const sanitizeQueryValue = ({
       }
     }
 
-    if (operator === 'not_equals' && formattedValue && typeof formattedValue === 'string') {
-      return {
-        rawQuery: {
-          [`${path}`]: { $ne: formattedValue },
-        },
-      }
-    }
-
     if (['in', 'not_in'].includes(operator) && Array.isArray(formattedValue)) {
       if ('hasMany' in field && field.hasMany) {
         formattedValue = handleHasManyValues(formattedValue)

--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -136,6 +136,14 @@ export const sanitizeQueryValue = ({
       }
     }
 
+    if (operator === 'not_equals' && formattedValue && typeof formattedValue === 'string') {
+      return {
+        rawQuery: {
+          [`${path}`]: { $ne: formattedValue },
+        },
+      }
+    }
+
     if (['in', 'not_in'].includes(operator) && Array.isArray(formattedValue)) {
       if ('hasMany' in field && field.hasMany) {
         formattedValue = handleHasManyValues(formattedValue)

--- a/test/fields/collections/Relationship/index.ts
+++ b/test/fields/collections/Relationship/index.ts
@@ -32,6 +32,18 @@ const RelationshipFields: CollectionConfig = {
       },
     },
     {
+      name: 'relationNoHasManyNonPolymorphic',
+      relationTo: 'text-fields',
+      type: 'relationship',
+      hasMany: false,
+    },
+    {
+      name: 'relationHasManyNonPolymorphic',
+      relationTo: 'text-fields',
+      type: 'relationship',
+      hasMany: true,
+    },
+    {
       name: 'relationToSelf',
       relationTo: relationshipFieldsSlug,
       type: 'relationship',

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -955,6 +955,8 @@ export interface RelationshipField {
           }
       )[]
     | null
+  relationNoHasManyNonPolymorphic?: (string | null) | TextField
+  relationHasManyNonPolymorphic?: (string | TextField)[] | null
   relationToSelf?: (string | null) | RelationshipField
   relationToSelfSelectOnly?: (string | null) | RelationshipField
   relationWithDynamicDefault?: (string | null) | User


### PR DESCRIPTION
## Description

Fixes #5212

Fixes #6278 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
