### PR TITLE
fix: render singular label for `ArrayCell` when length is 1

### DIFF
--- a/packages/payload/src/admin/components/views/collections/List/Cell/field-types/Array/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/List/Cell/field-types/Array/index.tsx
@@ -12,7 +12,11 @@ const ArrayCell: React.FC<CellComponentProps<ArrayField, Record<string, unknown>
 }) => {
   const { i18n, t } = useTranslation('general')
   const arrayFields = data ?? []
-  const label = `${arrayFields.length} ${getTranslation(field?.labels?.plural || t('rows'), i18n)}`
+
+  const label =
+    arrayFields.length === 1
+      ? `${arrayFields.length} ${getTranslation(field?.labels?.singular || t('row'), i18n)}`
+      : `${arrayFields.length} ${getTranslation(field?.labels?.plural || t('rows'), i18n)}`
 
   return <span>{label}</span>
 }


### PR DESCRIPTION
## Description

Fixes #6099

![Screenshot 2024-08-08 at 2 40 25 PM](https://github.com/user-attachments/assets/0a7ac732-adfe-456b-80c6-1e4b6ce4c4c8)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
