### PR TITLE
fix: set correct step nav path to Account on account page

### DIFF
--- a/packages/next/src/views/Account/index.client.tsx
+++ b/packages/next/src/views/Account/index.client.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { type StepNavItem, useStepNav, useTranslation } from '@payloadcms/ui'
+import React from 'react'
+
+export const AccountClient: React.FC = () => {
+  const { setStepNav } = useStepNav()
+  const { t } = useTranslation()
+
+  React.useEffect(() => {
+    const nav: StepNavItem[] = []
+
+    nav.push({
+      label: t('authentication:account'),
+      url: '/account',
+    })
+
+    setStepNav(nav)
+  }, [setStepNav, t])
+
+  return null
+}

--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -10,6 +10,7 @@ import { getDocumentData } from '../Document/getDocumentData.js'
 import { getDocumentPermissions } from '../Document/getDocumentPermissions.js'
 import { EditView } from '../Edit/index.js'
 import { Settings } from './Settings/index.js'
+import { AccountClient } from './index.client.js'
 
 export { generateAccountMetadata } from './meta.js'
 
@@ -99,6 +100,7 @@ export const Account: React.FC<AdminViewProps> = async ({
             user,
           }}
         />
+        <AccountClient />
       </DocumentInfoProvider>
     )
   }


### PR DESCRIPTION
Previously this was set to / {collection} / {collection.id}

![image](https://github.com/user-attachments/assets/5bf52f9b-475b-4f8d-b875-ffab8b4bb676)
