### PR TITLE
Fix docker compose command in documentation and examples

### DIFF
--- a/examples/form-builder/payload/README.md
+++ b/examples/form-builder/payload/README.md
@@ -10,7 +10,7 @@ To spin up the project locally, follow these steps:
 
 1. First clone the repo
 1. Then `cd YOUR_PROJECT_REPO && cp .env.example .env`
-1. Next `yarn && yarn dev` (or `docker-compose up`, see [Docker](#docker))
+1. Next `yarn && yarn dev` (or `docker compose up`, see [Docker](#docker))
 1. Now `open http://localhost:3000/admin` to access the admin panel
 1. Create your first admin user using the form on the page
 
@@ -20,8 +20,8 @@ That's it! Changes made in `./src` will be reflected in your app.
 
 Alternatively, you can use [Docker](https://www.docker.com) to spin up this project locally. To do so, follow these steps:
 
-1. Follow [steps 1 and 2 from above](#development), the docker-compose file will automatically use the `.env` file in your project root
-1. Next run `docker-compose up`
+1. Follow [steps 1 and 2 from above](#development), the docker-compose.yml file will automatically use the `.env` file in your project root
+1. Next run `docker compose up`
 1. Follow [steps 4 and 5 from above](#development) to login and create your first admin user
 
 That's it! The Docker instance will help you get up and running quickly while also standardizing the development environment across your teams.

--- a/examples/hierarchy/README.md
+++ b/examples/hierarchy/README.md
@@ -10,7 +10,7 @@ To spin up the project locally, follow these steps:
 
 1. First clone the repo
 1. Then `cd YOUR_PROJECT_REPO && cp .env.example .env`
-1. Next `yarn && yarn dev` (or `docker-compose up`, see [Docker](#docker))
+1. Next `yarn && yarn dev` (or `docker compose up`, see [Docker](#docker))
 1. Now `open http://localhost:3000/admin` to access the admin panel
 1. Create your first admin user using the form on the page
 
@@ -20,8 +20,8 @@ That's it! Changes made in `./src` will be reflected in your app.
 
 Alternatively, you can use [Docker](https://www.docker.com) to spin up this project locally. To do so, follow these steps:
 
-1. Follow [steps 1 and 2 from above](#development), the docker-compose file will automatically use the `.env` file in your project root
-1. Next run `docker-compose up`
+1. Follow [steps 1 and 2 from above](#development), the docker-compose.yml file will automatically use the `.env` file in your project root
+1. Next run `docker compose up`
 1. Follow [steps 4 and 5 from above](#development) to login and create your first admin user
 
 That's it! The Docker instance will help you get up and running quickly while also standardizing the development environment across your teams.

--- a/packages/plugin-cloud-storage/docs/local-dev.md
+++ b/packages/plugin-cloud-storage/docs/local-dev.md
@@ -12,7 +12,7 @@ This repository includes a local development environment for local testing and d
 
 This repository comes with a Docker emulator for Azure Blob Storage.
 
-If you would like to test locally with an emulated blob storage container, you can `cd` into `./src/adapters/azure/emulator` and then run `docker-compose up -d`.
+If you would like to test locally with an emulated blob storage container, you can `cd` into `./src/adapters/azure/emulator` and then run `docker compose up --detach`.
 
 The default `./dev/.env.example` file comes pre-loaded with correct `env` variables that correspond to the Azure Docker emulator.
 
@@ -28,7 +28,7 @@ To use the S3 emulator, use the following steps:
 
 1. Make sure you have `awscli` installed. On Mac, run `brew install awscli` to get started.
 1. Make sure you have an AWS profile created. LocalStack does not verify credentials, so you can create a profile with dummy credentials. However, your `region` will need to match. To create a dummy profile for LocalStack, type `aws configure --profile localstack`. Use the access key and secret from the `./dev/.env.example` and use region `us-east-1`.
-1. Now you can start the Docker container via moving to the `./src/adapters/s3/emulator` folder and running `docker-compose up -d`.
+1. Now you can start the Docker container via moving to the `./src/adapters/s3/emulator` folder and running `docker compose up --detach`.
 1. Once the Docker container is running, you can create a new bucket with the following command: `aws --endpoint-url=http://localhost:4566 s3 mb s3://payload-bucket`. Note that our bucket is called `payload-bucket`.
 1. Finally, attach an ACL to the bucket so it is readable: `aws --endpoint-url=http://localhost:4566 s3api put-bucket-acl --bucket payload-bucket --acl public-read`
 
@@ -38,7 +38,7 @@ Finally, you can run `yarn dev:s3` and then open `http://localhost:3000/admin` i
 
 This repository comes with a Docker emulator for Google Cloud Storage.
 
-If you would like to test locally with an emulated GCS container, you can `cd` into `./src/adapters/gcs/emulator` and then run `docker-compose up -d`.
+If you would like to test locally with an emulated GCS container, you can `cd` into `./src/adapters/gcs/emulator` and then run `docker compose up --detach`.
 
 The default `./dev/.env.example` file comes pre-loaded with correct `env` variables that correspond to the GCS Docker emulator.
 

--- a/templates/_template/README.md
+++ b/templates/_template/README.md
@@ -10,7 +10,7 @@ To spin up the project locally, follow these steps:
 
 1. First clone the repo
 1. Then `cd YOUR_PROJECT_REPO && cp .env.example .env`
-1. Next `yarn && yarn dev` (or `docker-compose up`, see [Docker](#docker))
+1. Next `yarn && yarn dev` (or `docker compose up`, see [Docker](#docker))
 1. Now `open http://localhost:3000/admin` to access the admin panel
 1. Create your first admin user using the form on the page
 
@@ -20,8 +20,8 @@ That's it! Changes made in `./src` will be reflected in your app.
 
 Alternatively, you can use [Docker](https://www.docker.com) to spin up this project locally. To do so, follow these steps:
 
-1. Follow [steps 1 and 2 from above](#development), the docker-compose file will automatically use the `.env` file in your project root
-1. Next run `docker-compose up`
+1. Follow [steps 1 and 2 from above](#development), the docker-compose.yml file will automatically use the `.env` file in your project root
+1. Next run `docker compose up`
 1. Follow [steps 4 and 5 from above](#development) to login and create your first admin user
 
 That's it! The Docker instance will help you get up and running quickly while also standardizing the development environment across your teams.

--- a/templates/blank-3.0/README.md
+++ b/templates/blank-3.0/README.md
@@ -10,7 +10,7 @@ To spin up the project locally, follow these steps:
 
 1. First clone the repo
 1. Then `cd YOUR_PROJECT_REPO && cp .env.example .env`
-1. Next `yarn && yarn dev` (or `docker-compose up`, see [Docker](#docker))
+1. Next `yarn && yarn dev` (or `docker compose up`, see [Docker](#docker))
 1. Now `open http://localhost:3000/admin` to access the admin panel
 1. Create your first admin user using the form on the page
 
@@ -20,8 +20,8 @@ That's it! Changes made in `./src` will be reflected in your app.
 
 Alternatively, you can use [Docker](https://www.docker.com) to spin up this project locally. To do so, follow these steps:
 
-1. Follow [steps 1 and 2 from above](#development), the docker-compose file will automatically use the `.env` file in your project root
-1. Next run `docker-compose up`
+1. Follow [steps 1 and 2 from above](#development), the docker-compose.yml file will automatically use the `.env` file in your project root
+1. Next run `docker compose up`
 1. Follow [steps 4 and 5 from above](#development) to login and create your first admin user
 
 That's it! The Docker instance will help you get up and running quickly while also standardizing the development environment across your teams.

--- a/templates/ecommerce/README.md
+++ b/templates/ecommerce/README.md
@@ -288,8 +288,8 @@ To spin up this example locally, follow the [Quick Start](#quick-start). Then [C
 
 Alternatively, you can use [Docker](https://www.docker.com) to spin up this template locally. To do so, follow these steps:
 
-1. Follow [steps 1 and 2 from above](#development), the docker-compose file will automatically use the `.env` file in your project root
-1. Next run `docker-compose up`
+1. Follow [steps 1 and 2 from above](#development), the docker-compose.yml file will automatically use the `.env` file in your project root
+1. Next run `docker compose up`
 1. Follow [steps 4 and 5 from above](#development) to login and create your first admin user
 
 That's it! The Docker instance will help you get up and running quickly while also standardizing the development environment across your teams.
@@ -304,7 +304,7 @@ To seed the database with a few products and pages you can run `yarn seed`. This
 
 > In a monorepo when routes are bootstrapped to the same host, they can conflict with Payload's own routes if they have the same name. In our template we've named the Nextjs API routes to `next` to avoid this conflict.
 >
-> This can happen with any other routes conflicting with Payload such as `admin` and we recommend using different names for custom routes.  
+> This can happen with any other routes conflicting with Payload such as `admin` and we recommend using different names for custom routes.
 > Alternatively you can also rename Payload's own routes via the [configuration](https://payloadcms.com/docs/configuration/overview).
 
 ## Production

--- a/templates/website/README.md
+++ b/templates/website/README.md
@@ -175,8 +175,8 @@ To spin up this example locally, follow the [Quick Start](#quick-start). Then [S
 
 Alternatively, you can use [Docker](https://www.docker.com) to spin up this template locally. To do so, follow these steps:
 
-1. Follow [steps 1 and 2 from above](#development), the docker-compose file will automatically use the `.env` file in your project root
-1. Next run `docker-compose up`
+1. Follow [steps 1 and 2 from above](#development), the docker-compose.yml file will automatically use the `.env` file in your project root
+1. Next run `docker compose up`
 1. Follow [steps 4 and 5 from above](#development) to login and create your first admin user
 
 That's it! The Docker instance will help you get up and running quickly while also standardizing the development environment across your teams.

--- a/test/plugin-cloud-storage/.env.emulated
+++ b/test/plugin-cloud-storage/.env.emulated
@@ -1,4 +1,4 @@
-# Sample creds for working locally with docker-compose
+# Sample creds for working locally with Docker Compose
 
 MONGODB_URI=mongodb://localhost/payload-plugin-cloud-storage
 PAYLOAD_PUBLIC_SERVER_URL=http://localhost:3000

--- a/test/storage-s3/.env.emulated
+++ b/test/storage-s3/.env.emulated
@@ -1,4 +1,4 @@
-# Sample creds for working locally with docker-compose
+# Sample creds for working locally with Docker Compose
 
 MONGODB_URI=mongodb://localhost/payload-plugin-cloud-storage
 PAYLOAD_PUBLIC_SERVER_URL=http://localhost:3000


### PR DESCRIPTION
## Description

`docker-compose` command is obsolete, it should be `docker compose` instead cf https://docs.docker.com/compose/reference/

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [X] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
