### PR TITLE
chore: rename React component props type from Args to Props

### DIFF
--- a/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/app/(payload)/layout.tsx
+++ b/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/examples/auth/payload/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/examples/auth/payload/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/examples/auth/payload/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/examples/auth/payload/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/examples/auth/payload/src/app/(payload)/layout.tsx
+++ b/examples/auth/payload/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/examples/form-builder/payload/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/examples/form-builder/payload/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/examples/form-builder/payload/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/examples/form-builder/payload/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/examples/form-builder/payload/src/app/(payload)/layout.tsx
+++ b/examples/form-builder/payload/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/examples/hierarchy/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/examples/hierarchy/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -3,7 +3,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -12,6 +12,6 @@ type Args = {
   }
 }
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/examples/hierarchy/src/app/(payload)/layout.tsx
+++ b/examples/hierarchy/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/examples/live-preview/payload/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/examples/live-preview/payload/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/examples/live-preview/payload/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/examples/live-preview/payload/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/examples/live-preview/payload/src/app/(payload)/layout.tsx
+++ b/examples/live-preview/payload/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/examples/multi-tenant-single-domain/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/examples/multi-tenant-single-domain/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/examples/multi-tenant-single-domain/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/examples/multi-tenant-single-domain/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/examples/multi-tenant-single-domain/src/app/(payload)/layout.tsx
+++ b/examples/multi-tenant-single-domain/src/app/(payload)/layout.tsx
@@ -1,18 +1,16 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
-import configPromise from "@payload-config";
-import "@payloadcms/next/css";
-import { RootLayout } from "@payloadcms/next/layouts";
+import configPromise from '@payload-config'
+import '@payloadcms/next/css'
+import { RootLayout } from '@payloadcms/next/layouts'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
-import React from "react";
+import React from 'react'
 
-import "./custom.scss";
+import './custom.scss'
 
-type Args = {
-  children: React.ReactNode;
-};
+type Props = {
+  children: React.ReactNode
+}
 
-const Layout = ({ children }: Args) => (
-  <RootLayout config={configPromise}>{children}</RootLayout>
-);
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
-export default Layout;
+export default Layout

--- a/examples/tailwind-shadcn-ui/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/examples/tailwind-shadcn-ui/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -3,7 +3,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -12,6 +12,6 @@ type Args = {
   }
 }
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/examples/tailwind-shadcn-ui/src/app/(payload)/layout.tsx
+++ b/examples/tailwind-shadcn-ui/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/examples/virtual-fields/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/examples/virtual-fields/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -3,7 +3,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -12,6 +12,6 @@ type Args = {
   }
 }
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/examples/virtual-fields/src/app/(payload)/layout.tsx
+++ b/examples/virtual-fields/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/examples/whitelabel/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/examples/whitelabel/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -3,7 +3,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -12,6 +12,6 @@ type Args = {
   }
 }
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/examples/whitelabel/src/app/(payload)/layout.tsx
+++ b/examples/whitelabel/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/packages/next/src/views/API/RenderJSON/index.tsx
+++ b/packages/next/src/views/API/RenderJSON/index.tsx
@@ -34,7 +34,7 @@ const Bracket = ({
   )
 }
 
-type Args = {
+type Props = {
   isEmpty?: boolean
   object: Record<string, any> | any[]
   objectKey?: string
@@ -48,7 +48,7 @@ export const RenderJSON = ({
   objectKey,
   parentType = 'object',
   trailingComma = false,
-}: Args) => {
+}: Props) => {
   const objectKeys = object ? Object.keys(object) : []
   const objectLength = objectKeys.length
   const [isOpen, setIsOpen] = React.useState<boolean>(true)

--- a/packages/next/src/views/ResetPassword/index.client.tsx
+++ b/packages/next/src/views/ResetPassword/index.client.tsx
@@ -16,7 +16,7 @@ import { useRouter } from 'next/navigation.js'
 import React from 'react'
 import { toast } from 'sonner'
 
-type Args = {
+type Props = {
   token: string
 }
 
@@ -33,7 +33,7 @@ const initialState: FormState = {
   },
 }
 
-export const ResetPasswordClient: React.FC<Args> = ({ token }) => {
+export const ResetPasswordClient: React.FC<Props> = ({ token }) => {
   const i18n = useTranslation()
   const {
     admin: {

--- a/packages/ui/src/elements/DocumentFields/index.tsx
+++ b/packages/ui/src/elements/DocumentFields/index.tsx
@@ -9,7 +9,7 @@ import './index.scss'
 
 const baseClass = 'document-fields'
 
-type Args = {
+type Props = {
   AfterFields?: React.ReactNode
   BeforeFields?: React.ReactNode
   description?: Description
@@ -20,7 +20,7 @@ type Args = {
   schemaPath: string
 }
 
-export const DocumentFields: React.FC<Args> = ({
+export const DocumentFields: React.FC<Props> = ({
   AfterFields,
   BeforeFields,
   description,

--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -15,7 +15,7 @@ import { DefaultCell } from '../Table/DefaultCell/index.js'
 
 const fieldIsPresentationalOnly = (field: MappedField): boolean => field.type === 'ui'
 
-type Args = {
+type Props = {
   cellProps: Partial<CellComponentProps>[]
   columnPreferences: ColumnPreferences
   columns?: ColumnPreferences
@@ -23,7 +23,8 @@ type Args = {
   fieldMap: FieldMap
   useAsTitle: SanitizedCollectionConfig['admin']['useAsTitle']
 }
-export const buildColumnState = (args: Args): Column[] => {
+
+export const buildColumnState = (args: Props): Column[] => {
   const { cellProps, columnPreferences, columns, enableRowSelections, fieldMap, useAsTitle } = args
 
   let sortedFieldMap = flattenFieldMap(fieldMap)

--- a/templates/_template/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/templates/_template/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/templates/_template/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/templates/_template/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/templates/_template/src/app/(payload)/layout.tsx
+++ b/templates/_template/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/templates/blank-3.0/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/templates/blank-3.0/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/templates/blank-3.0/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/templates/blank-3.0/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/templates/blank-3.0/src/app/(payload)/layout.tsx
+++ b/templates/blank-3.0/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/templates/blank/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/templates/blank/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/templates/blank/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/templates/blank/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/templates/blank/src/app/(payload)/layout.tsx
+++ b/templates/blank/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/templates/vercel-postgres/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/templates/vercel-postgres/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/templates/vercel-postgres/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/templates/vercel-postgres/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/templates/vercel-postgres/src/app/(payload)/layout.tsx
+++ b/templates/vercel-postgres/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/templates/website/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/templates/website/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/templates/website/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/templates/website/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/templates/website/src/app/(payload)/layout.tsx
+++ b/templates/website/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/templates/with-payload-cloud/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/templates/with-payload-cloud/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/templates/with-payload-cloud/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/templates/with-payload-cloud/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/templates/with-payload-cloud/src/app/(payload)/layout.tsx
+++ b/templates/with-payload-cloud/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/templates/with-vercel-mongodb/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/templates/with-vercel-mongodb/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/templates/with-vercel-mongodb/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/templates/with-vercel-mongodb/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/templates/with-vercel-mongodb/src/app/(payload)/layout.tsx
+++ b/templates/with-vercel-mongodb/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/templates/with-vercel-postgres/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/templates/with-vercel-postgres/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/templates/with-vercel-postgres/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/templates/with-vercel-postgres/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/templates/with-vercel-postgres/src/app/(payload)/layout.tsx
+++ b/templates/with-vercel-postgres/src/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/test/admin-root/app/(payload)/[[...segments]]/not-found.tsx
+++ b/test/admin-root/app/(payload)/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/test/admin-root/app/(payload)/[[...segments]]/page.tsx
+++ b/test/admin-root/app/(payload)/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/test/admin-root/app/(payload)/layout.tsx
+++ b/test/admin-root/app/(payload)/layout.tsx
@@ -7,10 +7,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout

--- a/test/live-preview/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/test/live-preview/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views/NotFound/index.js'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params })
 
-const NotFound = ({ params, searchParams }: Args) => NotFoundPage({ config, params, searchParams })
+const NotFound = ({ params, searchParams }: Props) => NotFoundPage({ config, params, searchParams })
 
 export default NotFound

--- a/test/live-preview/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/test/live-preview/app/(payload)/admin/[[...segments]]/page.tsx
@@ -5,7 +5,7 @@ import config from '@payload-config'
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views/Root/index.js'
 
-type Args = {
+type Props = {
   params: {
     segments: string[]
   }
@@ -14,9 +14,9 @@ type Args = {
   }
 }
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
+export const generateMetadata = ({ params, searchParams }: Props): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 
-const Page = ({ params, searchParams }: Args) => RootPage({ config, params, searchParams })
+const Page = ({ params, searchParams }: Props) => RootPage({ config, params, searchParams })
 
 export default Page

--- a/test/live-preview/app/(payload)/layout.tsx
+++ b/test/live-preview/app/(payload)/layout.tsx
@@ -6,10 +6,10 @@ import React from 'react'
 
 import './custom.scss'
 
-type Args = {
+type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Args) => <RootLayout config={configPromise}>{children}</RootLayout>
+const Layout = ({ children }: Props) => <RootLayout config={configPromise}>{children}</RootLayout>
 
 export default Layout


### PR DESCRIPTION
## Description

So satisfying to name React props type Props like everybody instead of Args.

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.X
## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
