### PR TITLE
chore: version field in docker-compose.yml files is obsolete

### DIFF
--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -237,8 +237,6 @@ CMD HOSTNAME="0.0.0.0" node server.js
 Here is an example of a docker-compose.yml file that can be used for development
 
 ```yml
-version: '3'
-
 services:
   payload:
     image: node:18-alpine

--- a/examples/form-builder/payload/docker-compose.yml
+++ b/examples/form-builder/payload/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   payload:
     image: node:18-alpine

--- a/packages/plugin-cloud-storage/docker-compose.yml
+++ b/packages/plugin-cloud-storage/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.2'
 services:
   localstack:
     image: localstack/localstack:latest

--- a/packages/plugin-cloud-storage/src/adapters/azure/emulator/docker-compose.yml
+++ b/packages/plugin-cloud-storage/src/adapters/azure/emulator/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   azure-storage:
     image: mcr.microsoft.com/azure-storage/azurite:3.18.0

--- a/packages/plugin-cloud-storage/src/adapters/gcs/emulator/docker-compose.yml
+++ b/packages/plugin-cloud-storage/src/adapters/gcs/emulator/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   google-cloud-storage:
     image: fsouza/fake-gcs-server

--- a/packages/plugin-cloud-storage/src/adapters/s3/emulator/docker-compose.yml
+++ b/packages/plugin-cloud-storage/src/adapters/s3/emulator/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.2'
 services:
   localstack:
     image: localstack/localstack:latest

--- a/packages/storage-s3/docker-compose.yml
+++ b/packages/storage-s3/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.2'
 services:
   localstack:
     image: localstack/localstack:latest

--- a/templates/_template/docker-compose.yml
+++ b/templates/_template/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   payload:
     image: node:18-alpine

--- a/templates/blank-3.0/docker-compose.yml
+++ b/templates/blank-3.0/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   payload:
     image: node:18-alpine

--- a/templates/blank/docker-compose.yml
+++ b/templates/blank/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   payload:
     image: node:18-alpine

--- a/templates/ecommerce/docker-compose.yml
+++ b/templates/ecommerce/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   payload:
     image: node:18-alpine

--- a/templates/website/docker-compose.yml
+++ b/templates/website/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   payload:
     image: node:18-alpine

--- a/templates/with-payload-cloud/docker-compose.yml
+++ b/templates/with-payload-cloud/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   payload:
     image: node:18-alpine

--- a/templates/with-vercel-mongodb/docker-compose.yml
+++ b/templates/with-vercel-mongodb/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   payload:
     image: node:18-alpine

--- a/templates/with-vercel-postgres/docker-compose.yml
+++ b/templates/with-vercel-postgres/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   payload:
     image: node:18-alpine


### PR DESCRIPTION
## Description

See https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
