### PR TITLE
feat(plugin-redirects): added new option for redirect type in the redirects collection

### DIFF
--- a/packages/plugin-redirects/src/index.ts
+++ b/packages/plugin-redirects/src/index.ts
@@ -1,10 +1,24 @@
-import type { CollectionConfig, Config, Field } from 'payload'
+import type { CollectionConfig, Config, Field, SelectField } from 'payload'
 
 import type { RedirectsPluginConfig } from './types.js'
 
+import { redirectOptions } from './redirectTypes.js'
+
+export { redirectOptions, redirectTypes } from './redirectTypes.js'
 export const redirectsPlugin =
   (pluginConfig: RedirectsPluginConfig) =>
   (incomingConfig: Config): Config => {
+    const redirectSelectField: SelectField = {
+      name: 'type',
+      type: 'select',
+      label: 'Redirect Type',
+      options: redirectOptions.filter((option) =>
+        pluginConfig?.redirectTypes?.includes(option.value),
+      ),
+      required: true,
+      ...(pluginConfig?.redirectTypeFieldOverride || {}),
+    }
+
     const defaultFields: Field[] = [
       {
         name: 'from',
@@ -58,6 +72,7 @@ export const redirectsPlugin =
         ],
         label: false,
       },
+      ...(pluginConfig?.redirectTypes ? [redirectSelectField] : []),
     ]
 
     const redirectsCollection: CollectionConfig = {

--- a/packages/plugin-redirects/src/redirectTypes.ts
+++ b/packages/plugin-redirects/src/redirectTypes.ts
@@ -1,0 +1,24 @@
+export const redirectTypes = ['301', '302', '303', '307', '308'] as const
+
+export const redirectOptions: { label: string; value: (typeof redirectTypes)[number] }[] = [
+  {
+    label: '301 - Permanent',
+    value: '301',
+  },
+  {
+    label: '302 - Temporary',
+    value: '302',
+  },
+  {
+    label: '303 - See Other',
+    value: '303',
+  },
+  {
+    label: '307 - Temporary Redirect',
+    value: '307',
+  },
+  {
+    label: '308 - Permanent Redirect',
+    value: '308',
+  },
+]

--- a/packages/plugin-redirects/src/types.ts
+++ b/packages/plugin-redirects/src/types.ts
@@ -1,8 +1,11 @@
-import type { CollectionConfig, Field } from 'payload'
+import type { CollectionConfig, Field, SelectField } from 'payload'
 
+import type { redirectTypes } from './redirectTypes.js'
 export type FieldsOverride = (args: { defaultFields: Field[] }) => Field[]
 
 export type RedirectsPluginConfig = {
   collections?: string[]
   overrides?: { fields?: FieldsOverride } & Partial<Omit<CollectionConfig, 'fields'>>
+  redirectTypeFieldOverride?: Partial<SelectField>
+  redirectTypes?: (typeof redirectTypes)[number][]
 }

--- a/test/plugin-redirects/config.ts
+++ b/test/plugin-redirects/config.ts
@@ -42,6 +42,10 @@ export default buildConfigWithDefaults({
           ]
         },
       },
+      redirectTypes: ['301', '302'],
+      redirectTypeFieldOverride: {
+        label: 'Redirect Type (Overridden)',
+      },
     }),
   ],
   typescript: {

--- a/test/plugin-redirects/int.spec.ts
+++ b/test/plugin-redirects/int.spec.ts
@@ -49,6 +49,7 @@ describe('@payloadcms/plugin-redirects', () => {
             value: page.id,
           },
         },
+        type: '301',
       },
     })
 
@@ -66,6 +67,7 @@ describe('@payloadcms/plugin-redirects', () => {
           type: 'custom',
           url: '/test',
         },
+        type: '301',
       },
     })
 

--- a/test/plugin-redirects/payload-types.ts
+++ b/test/plugin-redirects/payload-types.ts
@@ -17,6 +17,9 @@ export interface Config {
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
+  db: {
+    defaultIDType: string;
+  };
   globals: {};
   locale: 'en' | 'es' | 'de';
   user: User & {
@@ -26,12 +29,17 @@ export interface Config {
 export interface UserAuthOperations {
   forgotPassword: {
     email: string;
+    password: string;
   };
   login: {
-    password: string;
     email: string;
+    password: string;
   };
   registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
     email: string;
     password: string;
   };
@@ -80,6 +88,7 @@ export interface Redirect {
     } | null;
     url?: string | null;
   };
+  type: '301' | '302';
   customField?: string | null;
   updatedAt: string;
   createdAt: string;


### PR DESCRIPTION
You can now add a redirect type to your redirects if needed:

```ts
// Supported types
redirectTypes: ['301', '302'],

// Override the select field
redirectTypeFieldOverride: {
  label: 'Redirect Type (Overridden)',
},
```