### PR TITLE
feat(plugin-form-builder): pass beforeChange params into beforeEmail hook and add types to it

### DIFF
--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -109,7 +109,7 @@ The `beforeEmail` property is a [beforeChange](<[beforeChange](https://payloadcm
 // payload.config.ts
 formBuilder({
   // ...
-  beforeEmail: (emailsToSend) => {
+  beforeEmail: (emailsToSend, beforeChangeParams) => {
     // modify the emails in any way before they are sent
     return emails.map((email) => ({
       ...email,
@@ -117,6 +117,23 @@ formBuilder({
     }))
   },
 })
+```
+
+For full types with `beforeChangeParams`, you can import the types from the plugin:
+
+```ts
+import type { BeforeEmail } from '@payloadcms/plugin-form-builder'
+// Your generated FormSubmission type
+import type {FormSubmission} from '@payload-types'
+
+// Pass it through and 'data' or 'originalDoc' will now be typed
+const beforeEmail: BeforeEmail<FormSubmission> = (emailsToSend, beforeChangeParams) => {
+  // modify the emails in any way before they are sent
+  return emails.map((email) => ({
+    ...email,
+    html: email.html, // transform the html in any way you'd like (maybe wrap it in an html template?)
+  }))
+}
 ```
 
 ### `formOverrides`

--- a/packages/plugin-form-builder/src/types.ts
+++ b/packages/plugin-form-builder/src/types.ts
@@ -1,4 +1,10 @@
-import type { Block, CollectionConfig, Field } from 'payload'
+import type {
+  Block,
+  CollectionBeforeChangeHook,
+  CollectionConfig,
+  Field,
+  TypeWithID,
+} from 'payload'
 
 export interface BlockConfig {
   block: Block
@@ -37,7 +43,11 @@ export interface FieldsConfig {
   textarea?: FieldConfig | boolean
 }
 
-export type BeforeEmail = (emails: FormattedEmail[]) => FormattedEmail[] | Promise<FormattedEmail[]>
+type BeforeChangeParams<T extends TypeWithID = any> = Parameters<CollectionBeforeChangeHook<T>>[0]
+export type BeforeEmail<T extends TypeWithID = any> = (
+  emails: FormattedEmail[],
+  beforeChangeParams: BeforeChangeParams<T>,
+) => FormattedEmail[] | Promise<FormattedEmail[]>
 export type HandlePayment = (data: any) => void
 export type FieldsOverride = (args: { defaultFields: Field[] }) => Field[]
 

--- a/test/plugin-form-builder/config.ts
+++ b/test/plugin-form-builder/config.ts
@@ -2,10 +2,13 @@ import { fileURLToPath } from 'node:url'
 import path from 'path'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
+import type { BeforeEmail } from '@payloadcms/plugin-form-builder/types'
 import type { Block } from 'payload'
 
 import { formBuilderPlugin, fields as formFields } from '@payloadcms/plugin-form-builder'
 import { slateEditor } from '@payloadcms/richtext-slate'
+
+import type { FormSubmission } from './payload-types.js'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
@@ -25,6 +28,10 @@ const colorField: Block = {
     plural: 'Colors',
     singular: 'Color',
   },
+}
+
+const beforeEmail: BeforeEmail<FormSubmission> = (emails, { req: { payload }, originalDoc }) => {
+  return emails
 }
 
 export default buildConfigWithDefaults({
@@ -49,7 +56,6 @@ export default buildConfigWithDefaults({
   plugins: [
     formBuilderPlugin({
       // handlePayment: handleFormPayments,
-      // beforeEmail: prepareFormEmails,
       fields: {
         colorField,
         payment: true,
@@ -72,6 +78,7 @@ export default buildConfigWithDefaults({
         //     },
         // },
       },
+      beforeEmail,
       formOverrides: {
         // labels: {
         //   singular: 'Contact Form',


### PR DESCRIPTION
Form Builder Plugin BeforeEmail hook now takes a generic for your generated types and it has the full hook params available to it.

```ts
import type { BeforeEmail } from '@payloadcms/plugin-form-builder'
// Your generated FormSubmission type
import type {FormSubmission} from '@payload-types'

// Pass it through and 'data' or 'originalDoc' will now be typed
const beforeEmail: BeforeEmail<FormSubmission> = (emailsToSend, beforeChangeParams) => {
  // modify the emails in any way before they are sent
  return emails.map((email) => ({
    ...email,
    html: email.html, // transform the html in any way you'd like (maybe wrap it in an html template?)
  }))
}
```