### PR TITLE
fix: #7580 config deepmerge

### DIFF
--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -62,7 +62,7 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
         ...incomingConfig?.admin?.routes,
       },
     },
-    graphql: {
+    graphQL: {
       ...defaults.graphQL,
       ...incomingConfig?.graphQL,
     },

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -47,7 +47,39 @@ const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig>
 }
 
 export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedConfig> => {
-  const configWithDefaults: Config = deepMergeWithReactComponents(defaults, incomingConfig)
+  const configWithDefaults = {
+    ...defaults,
+    ...incomingConfig,
+    admin: {
+      ...defaults.admin,
+      ...incomingConfig?.admin,
+      meta: {
+        ...defaults.admin.meta,
+        ...incomingConfig?.admin?.meta,
+      },
+      routes: {
+        ...defaults.admin.routes,
+        ...incomingConfig?.admin?.routes,
+      },
+    },
+    graphql: {
+      ...defaults.graphQL,
+      ...incomingConfig?.graphQL,
+    },
+    routes: {
+      ...defaults.routes,
+      ...incomingConfig?.routes,
+    },
+    typescript: {
+      ...defaults.typescript,
+      ...incomingConfig?.typescript,
+    },
+  }
+
+  incomingConfig = {
+    ...defaults,
+    ...incomingConfig,
+  }
 
   if (!configWithDefaults?.serverURL) {
     configWithDefaults.serverURL = ''

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -76,11 +76,6 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
     },
   }
 
-  incomingConfig = {
-    ...defaults,
-    ...incomingConfig,
-  }
-
   if (!configWithDefaults?.serverURL) {
     configWithDefaults.serverURL = ''
   }


### PR DESCRIPTION
## Description

https://github.com/payloadcms/payload/issues/7580 - Fixes an infinite loop caused by a faulty deepMerge in config sanitization.