### PR TITLE
fix!: changes casing of admin views config to reflect types

### DIFF
--- a/docs/admin/views.mdx
+++ b/docs/admin/views.mdx
@@ -31,7 +31,9 @@ const config = buildConfig({
   admin: {
     components: {
       views: {
-        Dashboard: MyCustomDashboardView, // highlight-line
+        dashboard: {
+          Component: MyCustomDashboardView, // highlight-line
+        }
       },
     },
   },
@@ -44,8 +46,8 @@ The following options are available:
 
 | Property        | Description                                                                   |
 | --------------- | ----------------------------------------------------------------------------- |
-| **`Account`**   | The Account view is used to show the currently logged in user's Account page. |
-| **`Dashboard`** | The main landing page of the [Admin Panel](./overview).                                     |
+| **`account`**   | The Account view is used to show the currently logged in user's Account page. |
+| **`dashboard`** | The main landing page of the [Admin Panel](./overview).                                     |
 
 For more granular control, pass a configuration object instead. Payload exposes the following properties for each view:
 
@@ -72,7 +74,7 @@ const config = buildConfig({
     components: {
       views: {
         // highlight-start
-        MyCustomView: {
+        myCustomView: {
         // highlight-end
           Component: MyCustomView,
           path: '/my-custom-view',
@@ -108,7 +110,9 @@ export const MyCollectionConfig: SanitizedCollectionConfig = {
   admin: {
     components: {
       views: {
-        Edit: MyCustomEditView, // highlight-line
+        edit: {
+          Component: MyCustomEditView, // highlight-line
+        }
       },
     },
   },
@@ -126,8 +130,8 @@ The following options are available:
 
 | Property   | Description                                                                                                       |
 | ---------- | ----------------------------------------------------------------------------------------------------------------- |
-| **`Edit`** | The Edit View is used to edit a single document for any given Collection. [More details](#document-views).     |
-| **`List`** | The List View is used to show a list of documents for any given Collection.                                         |
+| **`edit`** | The Edit View is used to edit a single document for any given Collection. [More details](#document-views).     |
+| **`list`** | The List View is used to show a list of documents for any given Collection.                                         |
 
 <Banner type="success">
   <strong>Note:</strong>
@@ -148,7 +152,7 @@ export const MyGlobalConfig: SanitizedGlobalConfig = {
   admin: {
     components: {
       views: {
-        Edit: MyCustomEditView, // highlight-line
+        edit: MyCustomEditView, // highlight-line
       },
     },
   },
@@ -166,7 +170,7 @@ The following options are available:
 
 | Property   | Description                                                         |
 | ---------- | ------------------------------------------------------------------- |
-| **`Edit`** | The Edit View is used to edit a single document for any given Global. [More details](#document-views). |
+| **`edit`** | The Edit View is used to edit a single document for any given Global. [More details](#document-views). |
 
 <Banner type="success">
   <strong>Note:</strong>
@@ -187,8 +191,8 @@ export const MyCollectionOrGlobalConfig: SanitizedCollectionConfig = {
   admin: {
     components: {
       views: {
-        Edit: {
-          API: {
+        edit: {
+          api: {
             Component: MyCustomAPIView, // highlight-line
           },
         },
@@ -209,15 +213,15 @@ The following options are available:
 
 | Property          | Description                                                                                                                 |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| **`Default`**     | The Default view is the primary view in which your document is edited.                                                      |
-| **`Versions`**    | The Versions view is used to view the version history of a single document. [More details](../versions).                    |
-| **`Version`**     | The Version view is used to view a single version of a single document for a given collection. [More details](../versions). |
-| **`API`**         | The API view is used to display the REST API JSON response for a given document.                                            |
-| **`LivePreview`** | The LivePreview view is used to display the Live Preview interface. [More details](../live-preview).                        |
+| **`default`**     | The Default view is the primary view in which your document is edited.                                                      |
+| **`versions`**    | The Versions view is used to view the version history of a single document. [More details](../versions).                    |
+| **`version`**     | The Version view is used to view a single version of a single document for a given collection. [More details](../versions). |
+| **`api`**         | The API view is used to display the REST API JSON response for a given document.                                            |
+| **`livePreview`** | The LivePreview view is used to display the Live Preview interface. [More details](../live-preview).                        |
 
 ### Document Tabs
 
-Each Document View can be given a new tab in the Edit View, if desired. Tabs are highly configurable, from as simple as changing the label to swapping out the entire component, they can be modified in any way. To add or customize tabs in the Edit View, use the `Component.Tab` key:
+Each Document View can be given a new tab in the Edit View, if desired. Tabs are highly configurable, from as simple as changing the label to swapping out the entire component, they can be modified in any way. To add or customize tabs in the Edit View, use the `tab` key:
 
 ```ts
 import type { SanitizedCollectionConfig } from 'payload'
@@ -227,17 +231,19 @@ export const MyCollection: SanitizedCollectionConfig = {
   admin: {
     components: {
       views: {
-        Edit: {
-          MyCustomTab: {
+        edit: {
+          myCustomTab: {
             Component: MyCustomTab,
             path: '/my-custom-tab',
-            Tab: MyCustomTab // highlight-line
+            tab: {
+              Component: MyCustomTabComponent // highlight-line
+            }
           },
-          AnotherCustomView: {
+          anotherCustomTab: {
             Component: AnotherCustomView,
             path: '/another-custom-view',
             // highlight-start
-            Tab: {
+            tab: {
               label: 'Another Custom View',
               href: '/another-custom-view',
             }
@@ -268,7 +274,9 @@ export const MyCollectionConfig: SanitizedCollectionConfig = {
   admin: {
     components: {
       views: {
-        Edit: MyCustomView, // highlight-line
+        edit: {
+          Component: MyCustomView // highlight-line
+        }
       },
     },
   },

--- a/packages/next/src/elements/DocumentHeader/Tabs/getCustomViews.ts
+++ b/packages/next/src/elements/DocumentHeader/Tabs/getCustomViews.ts
@@ -12,9 +12,9 @@ export const getCustomViews = (args: {
 
   if (collectionConfig) {
     const collectionViewsConfig =
-      typeof collectionConfig?.admin?.components?.views?.Edit === 'object' &&
-      typeof collectionConfig?.admin?.components?.views?.Edit !== 'function'
-        ? collectionConfig?.admin?.components?.views?.Edit
+      typeof collectionConfig?.admin?.components?.views?.edit === 'object' &&
+      typeof collectionConfig?.admin?.components?.views?.edit !== 'function'
+        ? collectionConfig?.admin?.components?.views?.edit
         : undefined
 
     customViews = Object.entries(collectionViewsConfig || {}).reduce((prev, [key, view]) => {
@@ -28,9 +28,9 @@ export const getCustomViews = (args: {
 
   if (globalConfig) {
     const globalViewsConfig =
-      typeof globalConfig?.admin?.components?.views?.Edit === 'object' &&
-      typeof globalConfig?.admin?.components?.views?.Edit !== 'function'
-        ? globalConfig?.admin?.components?.views?.Edit
+      typeof globalConfig?.admin?.components?.views?.edit === 'object' &&
+      typeof globalConfig?.admin?.components?.views?.edit !== 'function'
+        ? globalConfig?.admin?.components?.views?.edit
         : undefined
 
     customViews = Object.entries(globalViewsConfig || {}).reduce((prev, [key, view]) => {

--- a/packages/next/src/elements/DocumentHeader/Tabs/getViewConfig.ts
+++ b/packages/next/src/elements/DocumentHeader/Tabs/getViewConfig.ts
@@ -9,9 +9,9 @@ export const getViewConfig = (args: {
 
   if (collectionConfig) {
     const collectionConfigViewsConfig =
-      typeof collectionConfig?.admin?.components?.views?.Edit === 'object' &&
-      typeof collectionConfig?.admin?.components?.views?.Edit !== 'function'
-        ? collectionConfig?.admin?.components?.views?.Edit
+      typeof collectionConfig?.admin?.components?.views?.edit === 'object' &&
+      typeof collectionConfig?.admin?.components?.views?.edit !== 'function'
+        ? collectionConfig?.admin?.components?.views?.edit
         : undefined
 
     return collectionConfigViewsConfig?.[name]
@@ -19,9 +19,9 @@ export const getViewConfig = (args: {
 
   if (globalConfig) {
     const globalConfigViewsConfig =
-      typeof globalConfig?.admin?.components?.views?.Edit === 'object' &&
-      typeof globalConfig?.admin?.components?.views?.Edit !== 'function'
-        ? globalConfig?.admin?.components?.views?.Edit
+      typeof globalConfig?.admin?.components?.views?.edit === 'object' &&
+      typeof globalConfig?.admin?.components?.views?.edit !== 'function'
+        ? globalConfig?.admin?.components?.views?.edit
         : undefined
 
     return globalConfigViewsConfig?.[name]

--- a/packages/next/src/elements/DocumentHeader/Tabs/tabs/index.tsx
+++ b/packages/next/src/elements/DocumentHeader/Tabs/tabs/index.tsx
@@ -4,13 +4,13 @@ import type React from 'react'
 import { VersionsPill } from './VersionsPill/index.js'
 
 export const documentViewKeys = [
-  'API',
-  'Default',
-  'LivePreview',
-  'References',
-  'Relationships',
-  'Version',
-  'Versions',
+  'api',
+  'default',
+  'livePreview',
+  'references',
+  'relationships',
+  'version',
+  'versions',
 ]
 
 export type DocumentViewKey = (typeof documentViewKeys)[number]
@@ -22,7 +22,7 @@ export const tabs: Record<
     order?: number // TODO: expose this to the globalConfig config
   } & DocumentTabConfig
 > = {
-  API: {
+  api: {
     condition: ({ collectionConfig, globalConfig }) =>
       (collectionConfig && !collectionConfig?.admin?.hideAPIURL) ||
       (globalConfig && !globalConfig?.admin?.hideAPIURL),
@@ -30,14 +30,14 @@ export const tabs: Record<
     label: 'API',
     order: 1000,
   },
-  Default: {
+  default: {
     href: '',
     // isActive: ({ href, location }) =>
     // location.pathname === href || location.pathname === `${href}/create`,
     label: ({ t }) => t('general:edit'),
     order: 0,
   },
-  LivePreview: {
+  livePreview: {
     condition: ({ collectionConfig, config, globalConfig }) => {
       if (collectionConfig) {
         return Boolean(
@@ -59,16 +59,16 @@ export const tabs: Record<
     label: ({ t }) => t('general:livePreview'),
     order: 100,
   },
-  References: {
+  references: {
     condition: () => false,
   },
-  Relationships: {
+  relationships: {
     condition: () => false,
   },
-  Version: {
+  version: {
     condition: () => false,
   },
-  Versions: {
+  versions: {
     Pill_Component: VersionsPill,
     condition: ({ collectionConfig, globalConfig, permissions }) =>
       Boolean(

--- a/packages/next/src/views/API/index.client.tsx
+++ b/packages/next/src/views/API/index.client.tsx
@@ -120,7 +120,7 @@ export const APIViewClient: React.FC = () => {
       />
       <SetViewActions
         actions={
-          (collectionClientConfig || globalClientConfig)?.admin?.components?.views?.Edit?.API
+          (collectionClientConfig || globalClientConfig)?.admin?.components?.views?.edit?.api
             ?.actions
         }
       />

--- a/packages/next/src/views/Document/getCustomViewByKey.tsx
+++ b/packages/next/src/views/Document/getCustomViewByKey.tsx
@@ -6,8 +6,8 @@ export const getCustomViewByKey = (
     | SanitizedGlobalConfig['admin']['components']['views'],
   customViewKey: string,
 ): EditViewComponent => {
-  return typeof views?.Edit?.[customViewKey] === 'object' &&
-    'Component' in views.Edit[customViewKey]
-    ? views?.Edit?.[customViewKey].Component
+  return typeof views?.edit?.[customViewKey] === 'object' &&
+    'Component' in views.edit[customViewKey]
+    ? views?.edit?.[customViewKey].Component
     : null
 }

--- a/packages/next/src/views/Document/getCustomViewByRoute.tsx
+++ b/packages/next/src/views/Document/getCustomViewByRoute.tsx
@@ -13,8 +13,8 @@ export const getCustomViewByRoute = ({
     | SanitizedCollectionConfig['admin']['components']['views']
     | SanitizedGlobalConfig['admin']['components']['views']
 }): EditViewComponent => {
-  if (typeof views?.Edit === 'object' && typeof views?.Edit !== 'function') {
-    const foundViewConfig = Object.entries(views.Edit).find(([, view]) => {
+  if (typeof views?.edit === 'object' && typeof views?.edit !== 'function') {
+    const foundViewConfig = Object.entries(views.edit).find(([, view]) => {
       if (typeof view === 'object' && typeof view !== 'function' && 'path' in view) {
         const viewPath = `${baseRoute}${view.path}`
 

--- a/packages/next/src/views/Document/getViewsFromConfig.tsx
+++ b/packages/next/src/views/Document/getViewsFromConfig.tsx
@@ -35,7 +35,6 @@ export const getViewsFromConfig = ({
 }: {
   collectionConfig?: SanitizedCollectionConfig
   config: SanitizedConfig
-
   docPermissions: CollectionPermission | GlobalPermission
   globalConfig?: SanitizedGlobalConfig
   routeSegments: string[]
@@ -67,7 +66,7 @@ export const getViewsFromConfig = ({
     config?.admin?.livePreview?.globals?.includes(globalConfig?.slug)
 
   if (collectionConfig) {
-    const editConfig = collectionConfig?.admin?.components?.views?.Edit
+    const editConfig = collectionConfig?.admin?.components?.views?.edit
     const EditOverride = typeof editConfig === 'function' ? editConfig : null
 
     if (EditOverride) {
@@ -88,7 +87,7 @@ export const getViewsFromConfig = ({
               case 'create': {
                 if ('create' in docPermissions && docPermissions?.create?.permission) {
                   CustomView = {
-                    payloadComponent: getCustomViewByKey(views, 'Default'),
+                    payloadComponent: getCustomViewByKey(views, 'default'),
                   }
                   DefaultView = {
                     Component: DefaultEditView,
@@ -103,7 +102,7 @@ export const getViewsFromConfig = ({
 
               default: {
                 CustomView = {
-                  payloadComponent: getCustomViewByKey(views, 'Default'),
+                  payloadComponent: getCustomViewByKey(views, 'default'),
                 }
                 DefaultView = {
                   Component: DefaultEditView,
@@ -120,7 +119,7 @@ export const getViewsFromConfig = ({
               case 'api': {
                 if (collectionConfig?.admin?.hideAPIURL !== true) {
                   CustomView = {
-                    payloadComponent: getCustomViewByKey(views, 'API'),
+                    payloadComponent: getCustomViewByKey(views, 'api'),
                   }
                   DefaultView = {
                     Component: DefaultAPIView,
@@ -141,7 +140,7 @@ export const getViewsFromConfig = ({
               case 'versions': {
                 if (docPermissions?.readVersions?.permission) {
                   CustomView = {
-                    payloadComponent: getCustomViewByKey(views, 'Versions'),
+                    payloadComponent: getCustomViewByKey(views, 'versions'),
                   }
                   DefaultView = {
                     Component: DefaultVersionsView,
@@ -186,7 +185,7 @@ export const getViewsFromConfig = ({
             if (segment4 === 'versions') {
               if (docPermissions?.readVersions?.permission) {
                 CustomView = {
-                  payloadComponent: getCustomViewByKey(views, 'Version'),
+                  payloadComponent: getCustomViewByKey(views, 'version'),
                 }
                 DefaultView = {
                   Component: DefaultVersionView,
@@ -226,7 +225,7 @@ export const getViewsFromConfig = ({
   }
 
   if (globalConfig) {
-    const editConfig = globalConfig?.admin?.components?.views?.Edit
+    const editConfig = globalConfig?.admin?.components?.views?.edit
     const EditOverride = typeof editConfig === 'function' ? editConfig : null
 
     if (EditOverride) {
@@ -242,7 +241,7 @@ export const getViewsFromConfig = ({
         switch (routeSegments.length) {
           case 2: {
             CustomView = {
-              payloadComponent: getCustomViewByKey(views, 'Default'),
+              payloadComponent: getCustomViewByKey(views, 'default'),
             }
             DefaultView = {
               Component: DefaultEditView,
@@ -256,7 +255,7 @@ export const getViewsFromConfig = ({
               case 'api': {
                 if (globalConfig?.admin?.hideAPIURL !== true) {
                   CustomView = {
-                    payloadComponent: getCustomViewByKey(views, 'API'),
+                    payloadComponent: getCustomViewByKey(views, 'api'),
                   }
                   DefaultView = {
                     Component: DefaultAPIView,
@@ -277,7 +276,7 @@ export const getViewsFromConfig = ({
               case 'versions': {
                 if (docPermissions?.readVersions?.permission) {
                   CustomView = {
-                    payloadComponent: getCustomViewByKey(views, 'Versions'),
+                    payloadComponent: getCustomViewByKey(views, 'versions'),
                   }
                   DefaultView = {
                     Component: DefaultVersionsView,
@@ -326,7 +325,7 @@ export const getViewsFromConfig = ({
             if (segment3 === 'versions') {
               if (docPermissions?.readVersions?.permission) {
                 CustomView = {
-                  payloadComponent: getCustomViewByKey(views, 'Version'),
+                  payloadComponent: getCustomViewByKey(views, 'version'),
                 }
                 DefaultView = {
                   Component: DefaultVersionView,

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -116,14 +116,14 @@ export const Document: React.FC<AdminViewProps> = async ({
     apiURL = `${serverURL}${apiRoute}/${collectionSlug}/${id}${apiQueryParams}`
 
     ViewOverride =
-      collectionConfig?.admin?.components?.views?.Edit?.Default &&
-      'Component' in collectionConfig.admin.components.views.Edit.Default
+      collectionConfig?.admin?.components?.views?.edit?.default &&
+      'Component' in collectionConfig.admin.components.views.edit.default
         ? createMappedComponent(
-            collectionConfig?.admin?.components?.views?.Edit?.Default
+            collectionConfig?.admin?.components?.views?.edit?.default
               ?.Component as EditViewComponent, // some type info gets lost from Config => SanitizedConfig due to our usage of Deep type operations from ts-essentials. Despite .Component being defined as EditViewComponent, this info is lost and we need cast it here.
             undefined,
             undefined,
-            'collectionConfig?.admin?.components?.views?.Edit?.Default',
+            'collectionConfig?.admin?.components?.views?.edit?.default',
           )
         : null
 
@@ -141,12 +141,14 @@ export const Document: React.FC<AdminViewProps> = async ({
         collectionViews?.CustomView?.Component,
         'collectionViews?.CustomView.payloadComponent',
       )
+
       DefaultView = createMappedComponent(
         collectionViews?.DefaultView?.payloadComponent,
         undefined,
         collectionViews?.DefaultView?.Component,
         'collectionViews?.DefaultView.payloadComponent',
       )
+
       ErrorView = createMappedComponent(
         collectionViews?.ErrorView?.payloadComponent,
         undefined,
@@ -179,7 +181,7 @@ export const Document: React.FC<AdminViewProps> = async ({
 
     apiURL = `${serverURL}${apiRoute}/${globalSlug}${apiQueryParams}`
 
-    const editConfig = globalConfig?.admin?.components?.views?.Edit
+    const editConfig = globalConfig?.admin?.components?.views?.edit
     ViewOverride = typeof editConfig === 'function' ? editConfig : null
 
     if (!ViewOverride) {
@@ -196,12 +198,14 @@ export const Document: React.FC<AdminViewProps> = async ({
         globalViews?.CustomView?.Component,
         'globalViews?.CustomView.payloadComponent',
       )
+
       DefaultView = createMappedComponent(
         globalViews?.DefaultView?.payloadComponent,
         undefined,
         globalViews?.DefaultView?.Component,
         'globalViews?.DefaultView.payloadComponent',
       )
+
       ErrorView = createMappedComponent(
         globalViews?.ErrorView?.payloadComponent,
         undefined,

--- a/packages/next/src/views/Edit/index.client.tsx
+++ b/packages/next/src/views/Edit/index.client.tsx
@@ -13,7 +13,7 @@ export const EditViewClient: React.FC = () => {
   const collectionConfig = getEntityConfig({ collectionSlug }) as ClientCollectionConfig
   const globalConfig = getEntityConfig({ globalSlug }) as ClientGlobalConfig
 
-  const Edit = (collectionConfig || globalConfig)?.admin?.components?.views?.Edit?.Default
+  const Edit = (collectionConfig || globalConfig)?.admin?.components?.views?.edit?.default
     ?.Component
 
   if (!Edit) {
@@ -24,7 +24,7 @@ export const EditViewClient: React.FC = () => {
     <Fragment>
       <SetViewActions
         actions={
-          (collectionConfig || globalConfig)?.admin?.components?.views?.Edit?.Default?.actions
+          (collectionConfig || globalConfig)?.admin?.components?.views?.edit?.default?.actions
         }
       />
       <RenderComponent mappedComponent={Edit} />

--- a/packages/next/src/views/List/Default/index.tsx
+++ b/packages/next/src/views/List/Default/index.tsx
@@ -57,7 +57,7 @@ export const DefaultListView: React.FC = () => {
         beforeList,
         beforeListTable,
         views: {
-          List: { actions },
+          list: { actions },
         },
       },
     },

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -146,10 +146,10 @@ export const ListView: React.FC<AdminViewProps> = async ({
     })
 
     const ListComponent = createMappedComponent(
-      collectionConfig?.admin?.components?.views?.List?.Component,
+      collectionConfig?.admin?.components?.views?.list?.Component,
       undefined,
       DefaultListView,
-      'collectionConfig?.admin?.components?.views?.List?.Component',
+      'collectionConfig?.admin?.components?.views?.list?.Component',
     )
 
     let clientCollectionConfig = deepCopyObjectSimple(

--- a/packages/next/src/views/LivePreview/index.client.tsx
+++ b/packages/next/src/views/LivePreview/index.client.tsx
@@ -239,7 +239,7 @@ export const LivePreviewClient: React.FC<{
     <Fragment>
       <SetViewActions
         actions={
-          (collectionConfig || globalConfig)?.admin?.components?.views?.Edit?.LivePreview?.actions
+          (collectionConfig || globalConfig)?.admin?.components?.views?.edit?.livePreview?.actions
         }
       />
       <LivePreviewProvider

--- a/packages/next/src/views/Version/Default/index.tsx
+++ b/packages/next/src/views/Version/Default/index.tsx
@@ -80,7 +80,7 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
     <main className={baseClass}>
       <SetViewActions
         actions={
-          (collectionConfig || globalConfig)?.admin?.components?.views?.Edit?.Version?.actions
+          (collectionConfig || globalConfig)?.admin?.components?.views?.edit?.version?.actions
         }
       />
       <SetStepNav

--- a/packages/next/src/views/Versions/index.client.tsx
+++ b/packages/next/src/views/Versions/index.client.tsx
@@ -43,7 +43,7 @@ export const VersionsViewClient: React.FC<{
     <React.Fragment>
       <SetViewActions
         actions={
-          (collectionConfig || globalConfig)?.admin?.components?.views?.Edit?.Versions?.actions
+          (collectionConfig || globalConfig)?.admin?.components?.views?.edit?.versions?.actions
         }
       />
       <LoadingOverlayToggle name="versions" show={!data} />

--- a/packages/payload/src/admin/views/types.ts
+++ b/packages/payload/src/admin/views/types.ts
@@ -35,8 +35,8 @@ export type AdminViewProps = {
 export type AdminViewComponent = PayloadComponent<AdminViewProps>
 
 export type EditViewProps = {
-  collectionSlug?: string
-  globalSlug?: string
+  readonly collectionSlug?: string
+  readonly globalSlug?: string
 }
 
 export type VisibleEntities = {

--- a/packages/payload/src/bin/generateImportMap/iterateCollections.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateCollections.ts
@@ -41,8 +41,8 @@ export function iterateCollections({
     addToImportMap(collection.admin?.components?.edit?.SaveDraftButton)
     addToImportMap(collection.admin?.components?.edit?.Upload)
 
-    if (collection.admin?.components?.views?.Edit) {
-      for (const editViewConfig of Object.values(collection.admin?.components?.views?.Edit)) {
+    if (collection.admin?.components?.views?.edit) {
+      for (const editViewConfig of Object.values(collection.admin?.components?.views?.edit)) {
         if ('Component' in editViewConfig) {
           addToImportMap(editViewConfig?.Component)
         }
@@ -58,7 +58,7 @@ export function iterateCollections({
       }
     }
 
-    addToImportMap(collection.admin?.components?.views?.List?.Component)
-    addToImportMap(collection.admin?.components?.views?.List?.actions)
+    addToImportMap(collection.admin?.components?.views?.list?.Component)
+    addToImportMap(collection.admin?.components?.views?.list?.actions)
   }
 }

--- a/packages/payload/src/bin/generateImportMap/iterateGlobals.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateGlobals.ts
@@ -34,8 +34,9 @@ export function iterateGlobals({
     addToImportMap(global.admin?.components?.elements?.PublishButton)
     addToImportMap(global.admin?.components?.elements?.SaveButton)
     addToImportMap(global.admin?.components?.elements?.SaveDraftButton)
-    if (global.admin?.components?.views?.Edit) {
-      for (const editViewConfig of Object.values(global.admin?.components?.views?.Edit)) {
+
+    if (global.admin?.components?.views?.edit) {
+      for (const editViewConfig of Object.values(global.admin?.components?.views?.edit)) {
         if ('Component' in editViewConfig) {
           addToImportMap(editViewConfig?.Component)
         }

--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -30,15 +30,15 @@ export type ClientCollectionConfig = {
         Upload: MappedComponent
       }
       views: {
-        Edit: {
+        edit: {
           [key: string]: MappedView
-          API: MappedView
-          Default: MappedView
-          LivePreview: MappedView
-          Version: MappedView
-          Versions: MappedView
+          api: MappedView
+          default: MappedView
+          livePreview: MappedView
+          version: MappedView
+          versions: MappedView
         }
-        List: {
+        list: {
           Component: MappedComponent
           actions: MappedComponent[]
         }

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -287,11 +287,11 @@ export type CollectionAdminOptions = {
     }
     views?: {
       /**
-       * Set to a React component to replace the entire "Edit" view, including all nested routes.
+       * Set to a React component to replace the entire Edit View, including all nested routes.
        * Set to an object to replace or modify individual nested routes, or to add new ones.
        */
-      Edit?: EditConfig
-      List?: {
+      edit?: EditConfig
+      list?: {
         Component?: PayloadComponent
         actions?: CustomComponent[]
       }
@@ -342,7 +342,7 @@ export type CollectionAdminOptions = {
    */
   preview?: GeneratePreviewURL
   /**
-   * Field to use as title in Edit view and first column in List view
+   * Field to use as title in Edit View and first column in List view
    */
   useAsTitle?: string
 }

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -386,7 +386,7 @@ export type EditViewConfig =
   | {
       path?: string
       /**
-       * Add a new Edit view to the admin panel
+       * Add a new Edit View to the admin panel
        * i.e. you can render a custom view that has no tab, if desired
        * Or override a specific properties of an existing one
        * i.e. you can customize the `Default` view tab label, if desired
@@ -916,23 +916,23 @@ export type EditConfig = {
   [key: string]: Partial<EditViewConfig>
   /**
    * Replace or modify individual nested routes, or add new ones:
-   * + `Default` - `/admin/collections/:collection/:id`
-   * + `API` - `/admin/collections/:collection/:id/api`
-   * + `LivePreview` - `/admin/collections/:collection/:id/preview`
-   * + `References` - `/admin/collections/:collection/:id/references`
-   * + `Relationships` - `/admin/collections/:collection/:id/relationships`
-   * + `Versions` - `/admin/collections/:collection/:id/versions`
-   * + `Version` - `/admin/collections/:collection/:id/versions/:version`
-   * + `CustomView` - `/admin/collections/:collection/:id/:path`
+   * + `default` - `/admin/collections/:collection/:id`
+   * + `api` - `/admin/collections/:collection/:id/api`
+   * + `livePreview` - `/admin/collections/:collection/:id/preview`
+   * + `references` - `/admin/collections/:collection/:id/references`
+   * + `relationships` - `/admin/collections/:collection/:id/relationships`
+   * + `versions` - `/admin/collections/:collection/:id/versions`
+   * + `version` - `/admin/collections/:collection/:id/versions/:version`
+   * + `customView` - `/admin/collections/:collection/:id/:path`
    */
-  API?: Partial<EditViewConfig>
-  Default?: Partial<EditViewConfig>
-  LivePreview?: Partial<EditViewConfig>
-  Version?: Partial<EditViewConfig>
-  Versions?: Partial<EditViewConfig>
+  api?: Partial<EditViewConfig>
+  default?: Partial<EditViewConfig>
+  livePreview?: Partial<EditViewConfig>
+  version?: Partial<EditViewConfig>
+  versions?: Partial<EditViewConfig>
   // TODO: uncomment these as they are built
-  // References?: EditView
-  // Relationships?: EditView
+  // references?: EditView
+  // relationships?: EditView
 }
 
 export type EntityDescriptionComponent = CustomComponent

--- a/packages/payload/src/globals/config/client.ts
+++ b/packages/payload/src/globals/config/client.ts
@@ -23,13 +23,13 @@ export type ClientGlobalConfig = {
         SaveDraftButton: MappedComponent
       }
       views: {
-        Edit: {
+        edit: {
           [key: string]: MappedView
-          API: MappedView
-          Default: MappedView
-          LivePreview: MappedView
-          Version: MappedView
-          Versions: MappedView
+          api: MappedView
+          default: MappedView
+          livePreview: MappedView
+          version: MappedView
+          versions: MappedView
         }
       }
     }

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -100,10 +100,10 @@ export type GlobalAdminOptions = {
     }
     views?: {
       /**
-       * Set to a React component to replace the entire "Edit" view, including all nested routes.
+       * Set to a React component to replace the entire Edit View, including all nested routes.
        * Set to an object to replace or modify individual nested routes, or to add new ones.
        */
-      Edit?: EditConfig
+      edit?: EditConfig
     }
   }
   /** Extension point to add your custom data. Available in server and client. */
@@ -121,7 +121,7 @@ export type GlobalAdminOptions = {
    */
   hidden?: ((args: { user: PayloadRequest['user'] }) => boolean) | boolean
   /**
-   * Hide the API URL within the Edit view
+   * Hide the API URL within the Edit View
    */
   hideAPIURL?: boolean
   /**

--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -39,7 +39,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   const [isOpen, setIsOpen] = useState(false)
   const [collectionConfig] = useRelatedCollections(collectionSlug)
 
-  const Edit = collectionConfig.admin.components.views.Edit.Default.Component
+  const Edit = collectionConfig.admin.components.views.edit.default.Component
 
   const isEditing = Boolean(docID)
   const apiURL = docID

--- a/packages/ui/src/elements/DocumentDrawer/types.ts
+++ b/packages/ui/src/elements/DocumentDrawer/types.ts
@@ -5,19 +5,19 @@ import type { DocumentInfoContext } from '../../providers/DocumentInfo/types.js'
 import type { Props as DrawerProps } from '../Drawer/types.js'
 
 export type DocumentDrawerProps = {
-  collectionSlug: string
-  drawerSlug?: string
-  id?: null | number | string
-  onSave?: DocumentInfoContext['onSave']
+  readonly collectionSlug: string
+  readonly drawerSlug?: string
+  readonly id?: null | number | string
+  readonly onSave?: DocumentInfoContext['onSave']
 } & Pick<DrawerProps, 'Header'>
 
 export type DocumentTogglerProps = {
-  children?: React.ReactNode
-  className?: string
-  collectionSlug: string
-  disabled?: boolean
-  drawerSlug?: string
-  id?: string
+  readonly children?: React.ReactNode
+  readonly className?: string
+  readonly collectionSlug: string
+  readonly disabled?: boolean
+  readonly drawerSlug?: string
+  readonly id?: string
 } & HTMLAttributes<HTMLButtonElement>
 
 export type UseDocumentDrawer = (args: { collectionSlug: string; id?: number | string }) => [

--- a/packages/ui/src/elements/Drawer/types.ts
+++ b/packages/ui/src/elements/Drawer/types.ts
@@ -1,13 +1,13 @@
 import type { HTMLAttributes } from 'react'
 
 export type Props = {
-  Header?: React.ReactNode
-  children: React.ReactNode
-  className?: string
-  gutter?: boolean
-  hoverTitle?: boolean
-  slug: string
-  title?: string
+  readonly Header?: React.ReactNode
+  readonly children: React.ReactNode
+  readonly className?: string
+  readonly gutter?: boolean
+  readonly hoverTitle?: boolean
+  readonly slug: string
+  readonly title?: string
 }
 
 export type TogglerProps = {

--- a/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
@@ -80,7 +80,7 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
     },
   )
 
-  const List = selectedCollectionConfig?.admin?.components.views.List.Component
+  const List = selectedCollectionConfig?.admin?.components.views.list.Component
 
   const [selectedOption, setSelectedOption] = useState<Option | Option[]>(() =>
     selectedCollectionConfig

--- a/packages/ui/src/elements/ListDrawer/types.ts
+++ b/packages/ui/src/elements/ListDrawer/types.ts
@@ -3,12 +3,15 @@ import type React from 'react'
 import type { HTMLAttributes } from 'react'
 
 export type ListDrawerProps = {
-  collectionSlugs: string[]
-  customHeader?: React.ReactNode
-  drawerSlug?: string
-  filterOptions?: FilterOptionsResult
-  onSelect?: (args: { collectionSlug: SanitizedCollectionConfig['slug']; docID: string }) => void
-  selectedCollection?: string
+  readonly collectionSlugs: string[]
+  readonly customHeader?: React.ReactNode
+  readonly drawerSlug?: string
+  readonly filterOptions?: FilterOptionsResult
+  readonly onSelect?: (args: {
+    collectionSlug: SanitizedCollectionConfig['slug']
+    docID: string
+  }) => void
+  readonly selectedCollection?: string
 }
 
 export type ListTogglerProps = {

--- a/packages/ui/src/providers/Config/createClientConfig/collections.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/collections.tsx
@@ -215,46 +215,48 @@ export const createClientCollectionConfig = ({
     'admin' in collection &&
     'components' in collection.admin &&
     'views' in collection.admin.components &&
-    'Edit' in collection.admin.components.views &&
-    'Default' in collection.admin.components.views.Edit
+    'edit' in collection.admin.components.views &&
+    'default' in collection.admin.components.views.edit
 
-  if (!clientCollection.admin.components.views.Edit) {
-    clientCollection.admin.components.views.Edit =
-      {} as ClientCollectionConfig['admin']['components']['views']['Edit']
+  if (!clientCollection.admin.components.views.edit) {
+    clientCollection.admin.components.views.edit =
+      {} as ClientCollectionConfig['admin']['components']['views']['edit']
   }
 
-  clientCollection.admin.components.views.Edit.Default = {
+  clientCollection.admin.components.views.edit.default = {
     Component: createMappedComponent(
       hasEditView &&
-        'Component' in collection.admin.components.views.Edit.Default &&
-        collection.admin.components.views.Edit.Default.Component,
+        'Component' in collection.admin.components.views.edit.default &&
+        collection.admin.components.views.edit.default.Component,
       {
         collectionSlug: collection.slug,
       },
       DefaultEditView,
-      'collection.admin.components.views.Edit.Default',
+      'collection.admin.components.views.edit.default',
     ),
   }
 
-  if (collection?.admin?.components?.views?.Edit) {
-    for (const key in collection.admin.components.views.Edit) {
-      const view: EditViewConfig = collection.admin.components.views.Edit[key]
-      if (!clientCollection.admin.components.views.Edit[key]) {
-        clientCollection.admin.components.views.Edit[key] = {} as MappedView
+  if (collection?.admin?.components?.views?.edit) {
+    for (const key in collection.admin.components.views.edit) {
+      const view: EditViewConfig = collection.admin.components.views.edit[key]
+
+      if (!clientCollection.admin.components.views.edit[key]) {
+        clientCollection.admin.components.views.edit[key] = {} as MappedView
       }
-      if ('Component' in view && key !== 'Default') {
-        clientCollection.admin.components.views.Edit[key].Component = createMappedComponent(
+
+      if ('Component' in view && key !== 'default') {
+        clientCollection.admin.components.views.edit[key].Component = createMappedComponent(
           view.Component,
           {
             collectionSlug: collection.slug,
           },
           undefined,
-          'collection.admin.components.views.Edit.key.Component',
+          'collection.admin.components.views.edit.key.Component',
         )
       }
 
       if ('actions' in view && view.actions?.length) {
-        clientCollection.admin.components.views.Edit[key].actions = view.actions.map((Component) =>
+        clientCollection.admin.components.views.edit[key].actions = view.actions.map((Component) =>
           createMappedComponent(
             Component,
             undefined,
@@ -270,36 +272,36 @@ export const createClientCollectionConfig = ({
     'admin' in collection &&
     'components' in collection.admin &&
     'views' in collection.admin.components &&
-    'List' in collection.admin.components.views
+    'list' in collection.admin.components.views
 
-  if (!clientCollection.admin.components.views.List) {
-    clientCollection.admin.components.views.List =
-      {} as ClientCollectionConfig['admin']['components']['views']['List']
+  if (!clientCollection.admin.components.views.list) {
+    clientCollection.admin.components.views.list =
+      {} as ClientCollectionConfig['admin']['components']['views']['list']
   }
 
-  clientCollection.admin.components.views.List.Component = createMappedComponent(
+  clientCollection.admin.components.views.list.Component = createMappedComponent(
     hasListView &&
-      'Component' in collection.admin.components.views.List &&
-      collection.admin.components.views.List.Component,
+      'Component' in collection.admin.components.views.list &&
+      collection.admin.components.views.list.Component,
     {
       collectionSlug: collection.slug,
     },
     DefaultListView,
-    'collection.admin.components.views.List ',
+    'collection.admin.components.views.list ',
   )
 
   if (
     hasListView &&
-    'actions' in collection.admin.components.views.List &&
-    collection.admin.components.views.List.actions
+    'actions' in collection.admin.components.views.list &&
+    collection.admin.components.views.list.actions
   ) {
-    clientCollection.admin.components.views.List.actions =
-      collection.admin.components.views.List.actions.map((Component) =>
+    clientCollection.admin.components.views.list.actions =
+      collection.admin.components.views.list.actions.map((Component) =>
         createMappedComponent(
           Component,
           undefined,
           undefined,
-          'collection.admin.components.views.List',
+          'collection.admin.components.views.list',
         ),
       )
   }

--- a/packages/ui/src/providers/Config/createClientConfig/globals.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/globals.tsx
@@ -122,47 +122,47 @@ export const createClientGlobalConfig = ({
       'admin' in global &&
       'components' in global.admin &&
       'views' in global.admin.components &&
-      'Edit' in global.admin.components.views &&
-      'Default' in global.admin.components.views.Edit
+      'edit' in global.admin.components.views &&
+      'default' in global.admin.components.views.edit
 
-    if (!clientGlobal.admin.components.views.Edit) {
-      clientGlobal.admin.components.views.Edit =
-        {} as ClientGlobalConfig['admin']['components']['views']['Edit']
+    if (!clientGlobal.admin.components.views.edit) {
+      clientGlobal.admin.components.views.edit =
+        {} as ClientGlobalConfig['admin']['components']['views']['edit']
     }
 
-    clientGlobal.admin.components.views.Edit.Default = {
+    clientGlobal.admin.components.views.edit.default = {
       Component: createMappedComponent(
         hasEditView &&
-          'Component' in global.admin.components.views.Edit.Default &&
-          global.admin.components.views.Edit.Default.Component,
+          'Component' in global.admin.components.views.edit.default &&
+          global.admin.components.views.edit.default.Component,
         {
           globalSlug: global.slug,
         },
         DefaultEditView,
-        'global.admin.components.views.Edit.Default',
+        'global.admin.components.views.edit.default',
       ),
     }
 
-    if (global?.admin?.components?.views?.Edit) {
-      for (const key in global.admin.components.views.Edit) {
-        const view: EditViewConfig = global.admin.components.views.Edit[key]
-        if (!clientGlobal.admin.components.views.Edit[key]) {
-          clientGlobal.admin.components.views.Edit[key] = {} as MappedView
+    if (global?.admin?.components?.views?.edit) {
+      for (const key in global.admin.components.views.edit) {
+        const view: EditViewConfig = global.admin.components.views.edit[key]
+        if (!clientGlobal.admin.components.views.edit[key]) {
+          clientGlobal.admin.components.views.edit[key] = {} as MappedView
         }
 
-        if ('Component' in view && key !== 'Default') {
-          clientGlobal.admin.components.views.Edit[key].Component = createMappedComponent(
+        if ('Component' in view && key !== 'default') {
+          clientGlobal.admin.components.views.edit[key].Component = createMappedComponent(
             view.Component,
             {
               globalSlug: global.slug,
             },
             undefined,
-            'global.admin.components.views.Edit.key.Component',
+            'global.admin.components.views.edit.key.Component',
           )
         }
 
         if ('actions' in view && view.actions?.length) {
-          clientGlobal.admin.components.views.Edit[key].actions = view.actions.map((Component) =>
+          clientGlobal.admin.components.views.edit[key].actions = view.actions.map((Component) =>
             createMappedComponent(
               Component,
               undefined,

--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -94,7 +94,7 @@ export const buildFormState = async ({ req }: { req: PayloadRequest }): Promise<
   // If the request does not include doc preferences,
   // we should fetch them. This is useful for DocumentInfoProvider
   // as it reduces the amount of client-side fetches necessary
-  // when we fetch data for the Edit view
+  // when we fetch data for the Edit View
   if (!docPreferences) {
     let preferencesKey
 

--- a/test/admin/collections/CustomViews1.ts
+++ b/test/admin/collections/CustomViews1.ts
@@ -7,10 +7,10 @@ export const CustomViews1: CollectionConfig = {
   admin: {
     components: {
       views: {
-        // This will override the entire Edit view including all nested views, i.e. `/edit/:id/*`
+        // This will override the entire Edit View including all nested views, i.e. `/edit/:id/*`
         // To override one specific nested view, use the nested view's slug as the key
-        Edit: {
-          Default: {
+        edit: {
+          default: {
             Component: '/components/views/CustomEdit/index.js#CustomEditView',
           },
         },

--- a/test/admin/collections/CustomViews2.ts
+++ b/test/admin/collections/CustomViews2.ts
@@ -15,9 +15,9 @@ export const CustomViews2: CollectionConfig = {
   admin: {
     components: {
       views: {
-        Edit: {
+        edit: {
           // This will override one specific nested view within the `/edit/:id` route, i.e. `/edit/:id/versions`
-          CustomViewWithParam: {
+          customViewWithParam: {
             Component: '/components/views/CustomTabWithParam/index.js#CustomTabWithParamView',
             tab: {
               href: `${customCollectionParamViewPathBase}/123`,
@@ -25,12 +25,12 @@ export const CustomViews2: CollectionConfig = {
             },
             path: customCollectionParamViewPath,
           },
-          Default: {
+          default: {
             tab: {
               label: customEditLabel,
             },
           },
-          MyCustomView: {
+          myCustomView: {
             Component: '/components/views/CustomTabLabel/index.js#CustomTabLabelView',
             tab: {
               href: '/custom-tab-view',
@@ -38,14 +38,14 @@ export const CustomViews2: CollectionConfig = {
             },
             path: '/custom-tab-view',
           },
-          MyCustomViewWithCustomTab: {
+          myCustomViewWithCustomTab: {
             Component: '/components/views/CustomTabComponent/index.js#CustomTabComponentView',
             tab: {
               Component: '/components/CustomTabComponent/index.js#CustomTabComponent',
             },
             path: customTabViewPath,
           },
-          MyCustomViewWithNestedPath: {
+          myCustomViewWithNestedPath: {
             Component: '/components/views/CustomTabNested/index.js#CustomNestedTabView',
             tab: {
               href: customNestedTabViewPath,
@@ -53,7 +53,7 @@ export const CustomViews2: CollectionConfig = {
             },
             path: customNestedTabViewPath,
           },
-          Versions: {
+          versions: {
             Component: '/components/views/CustomVersions/index.js#CustomVersionsView',
           },
         },

--- a/test/admin/collections/Geo.ts
+++ b/test/admin/collections/Geo.ts
@@ -7,15 +7,15 @@ export const Geo: CollectionConfig = {
   admin: {
     components: {
       views: {
-        Edit: {
-          API: {
+        edit: {
+          api: {
             actions: ['/components/CollectionAPIButton/index.js#CollectionAPIButton'],
           },
           Default: {
             actions: ['/components/CollectionEditButton/index.js#CollectionEditButton'],
           },
         },
-        List: {
+        list: {
           actions: ['/components/CollectionListButton/index.js#CollectionListButton'],
         },
       },

--- a/test/admin/components/views/CustomEdit/index.tsx
+++ b/test/admin/components/views/CustomEdit/index.tsx
@@ -47,7 +47,7 @@ export const CustomEditView: PayloadServerReactComponent<EditViewComponent> = ({
       >
         <h1>Custom Edit View</h1>
         <p>This custom edit view was added through the following Payload config:</p>
-        <code>components.views.Edit</code>
+        <code>components.views.edit</code>
         <p>
           {'This takes precedence over the default edit view, '}
           <b>as well as all nested views like versions.</b>

--- a/test/admin/components/views/CustomEditDefault/index.tsx
+++ b/test/admin/components/views/CustomEditDefault/index.tsx
@@ -49,7 +49,7 @@ export const CustomDefaultEditView: PayloadServerReactComponent<EditViewComponen
         <p>This custom Default view was added through one of the following Payload configs:</p>
         <ul>
           <li>
-            <code>components.views.Edit.Default</code>
+            <code>components.views.edit.default</code>
             <p>
               {'This allows you to override only the default edit view specifically, but '}
               <b>
@@ -61,7 +61,7 @@ export const CustomDefaultEditView: PayloadServerReactComponent<EditViewComponen
             </p>
           </li>
           <li>
-            <code>components.views.Edit.Default.Component</code>
+            <code>components.views.edit.default.Component</code>
             <p>
               This is the most granular override, allowing you to override only the Default
               component, or any of its other properties like path and label.

--- a/test/admin/components/views/CustomVersions/index.tsx
+++ b/test/admin/components/views/CustomVersions/index.tsx
@@ -49,7 +49,7 @@ export const CustomVersionsView: PayloadServerReactComponent<EditViewComponent> 
         <p>This custom Versions view was added through one of the following Payload configs:</p>
         <ul>
           <li>
-            <code>components.views.Edit.Versions</code>
+            <code>components.views.edit.Versions</code>
             <p>
               {'This allows you to override only the Versions edit view specifically, but '}
               <b>
@@ -59,7 +59,7 @@ export const CustomVersionsView: PayloadServerReactComponent<EditViewComponent> 
             </p>
           </li>
           <li>
-            <code>components.views.Edit.Versions.Component</code>
+            <code>components.views.edit.versions.Component</code>
           </li>
           <p>
             This is the most granular override, allowing you to override only the Versions

--- a/test/admin/globals/CustomViews1.ts
+++ b/test/admin/globals/CustomViews1.ts
@@ -7,8 +7,8 @@ export const CustomGlobalViews1: GlobalConfig = {
   admin: {
     components: {
       views: {
-        Edit: {
-          Default: {
+        edit: {
+          default: {
             Component: '/components/views/CustomEdit/index.js#CustomEditView',
           },
         },

--- a/test/admin/globals/CustomViews2.ts
+++ b/test/admin/globals/CustomViews2.ts
@@ -7,11 +7,11 @@ export const CustomGlobalViews2: GlobalConfig = {
   admin: {
     components: {
       views: {
-        Edit: {
-          Default: {
+        edit: {
+          default: {
             Component: '/components/views/CustomEditDefault/index.js#CustomDefaultEditView',
           },
-          MyCustomView: {
+          myCustomView: {
             Component: '/components/views/CustomTabLabel/index.js#CustomTabLabelView',
             tab: {
               href: '/custom-tab-view',
@@ -19,14 +19,14 @@ export const CustomGlobalViews2: GlobalConfig = {
             },
             path: '/custom-tab-view',
           },
-          MyCustomViewWithCustomTab: {
+          myCustomViewWithCustomTab: {
             Component: '/components/views/CustomTabComponent/index.js#CustomTabComponentView',
             tab: {
               Component: '/components/CustomTabComponent/index.js#CustomTabComponent',
             },
             path: '/custom-tab-component',
           },
-          Versions: {
+          versions: {
             Component: '/components/views/CustomVersions/index.js#CustomVersionsView',
           },
         },

--- a/test/admin/globals/Global.ts
+++ b/test/admin/globals/Global.ts
@@ -7,11 +7,11 @@ export const Global: GlobalConfig = {
   admin: {
     components: {
       views: {
-        Edit: {
-          API: {
+        edit: {
+          api: {
             actions: ['/components/GlobalAPIButton/index.js#GlobalAPIButton'],
           },
-          Default: {
+          default: {
             actions: ['/components/GlobalEditButton/index.js#GlobalEditButton'],
           },
         },

--- a/test/live-preview/collections/Pages.ts
+++ b/test/live-preview/collections/Pages.ts
@@ -23,8 +23,8 @@ export const Pages: CollectionConfig = {
     defaultColumns: ['id', 'title', 'slug', 'createdAt'],
     components: {
       views: {
-        Edit: {
-          LivePreview: {
+        edit: {
+          livePreview: {
             actions: [
               '/components/CollectionLivePreviewButton/index.js#CollectionLivePreviewButton',
             ],

--- a/test/live-preview/components/CollectionLivePreviewButton/index.tsx
+++ b/test/live-preview/components/CollectionLivePreviewButton/index.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 const baseClass = 'collection-live-preview-button'
 
 export const CollectionLivePreviewButton: PayloadServerReactComponent<
-  SanitizedCollectionConfig['admin']['components']['views']['Edit']['LivePreview']
+  SanitizedCollectionConfig['admin']['components']['views']['edit']['livePreview']
 > = () => {
   return (
     <div

--- a/test/live-preview/components/GlobalLivePreviewButton/index.tsx
+++ b/test/live-preview/components/GlobalLivePreviewButton/index.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 const baseClass = 'global-live-preview-button'
 
 export const GlobalLivePreviewButton: PayloadServerReactComponent<
-  SanitizedGlobalConfig['admin']['components']['views']['Edit']['LivePreview']
+  SanitizedGlobalConfig['admin']['components']['views']['edit']['livePreview']
 > = () => {
   return (
     <div

--- a/test/live-preview/globals/Footer.ts
+++ b/test/live-preview/globals/Footer.ts
@@ -11,8 +11,8 @@ export const Footer: GlobalConfig = {
   admin: {
     components: {
       views: {
-        Edit: {
-          LivePreview: {
+        edit: {
+          livePreview: {
             actions: ['/components/GlobalLivePreviewButton/index.js#GlobalLivePreviewButton'],
           },
         },

--- a/test/versions/collections/Drafts.ts
+++ b/test/versions/collections/Drafts.ts
@@ -33,11 +33,11 @@ const DraftPosts: CollectionConfig = {
         PublishButton: '/elements/CustomSaveButton/index.js#CustomPublishButton',
       },
       views: {
-        Edit: {
-          Version: {
+        edit: {
+          version: {
             actions: ['/elements/CollectionVersionButton/index.js'],
           },
-          Versions: {
+          versions: {
             actions: ['/elements/CollectionVersionsButton/index.js'],
           },
         },

--- a/test/versions/collections/DraftsWithMax.ts
+++ b/test/versions/collections/DraftsWithMax.ts
@@ -33,11 +33,11 @@ const DraftWithMaxPosts: CollectionConfig = {
         PublishButton: '/elements/CustomSaveButton/index.js#CustomPublishButton',
       },
       views: {
-        Edit: {
-          Version: {
+        edit: {
+          version: {
             actions: ['/elements/CollectionVersionButton/index.js'],
           },
-          Versions: {
+          versions: {
             actions: ['/elements/CollectionVersionsButton/index.js'],
           },
         },

--- a/test/versions/globals/Draft.ts
+++ b/test/versions/globals/Draft.ts
@@ -9,11 +9,11 @@ const DraftGlobal: GlobalConfig = {
     preview: () => 'https://payloadcms.com',
     components: {
       views: {
-        Edit: {
-          Version: {
+        edit: {
+          version: {
             actions: ['/elements/GlobalVersionButton/index.js'],
           },
-          Versions: {
+          versions: {
             actions: ['/elements/GlobalVersionsButton/index.js'],
           },
         },

--- a/test/versions/globals/DraftWithMax.ts
+++ b/test/versions/globals/DraftWithMax.ts
@@ -9,11 +9,11 @@ const DraftWithMaxGlobal: GlobalConfig = {
     preview: () => 'https://payloadcms.com',
     components: {
       views: {
-        Edit: {
-          Version: {
+        edit: {
+          version: {
             actions: ['/elements/GlobalVersionButton/index.js'],
           },
-          Versions: {
+          versions: {
             actions: ['/elements/GlobalVersionsButton/index.js'],
           },
         },


### PR DESCRIPTION
## Description

Custom views and tabs are now fully config objects, no longer accepting raw components on their root keys as the capital casing might suggest. To better reflect this change semantically, these keys are now lowercase to indicate they are in fact config objects and never components themselves. Similar to the change made to view tabs here: c4c5cee0b8

Breaking change:

Old: 

```tsx
// collection.ts
{
  // ...
  admin: {
    views: {
      Edit: {
        Default: MyDefaultView,
        CustomView: {
          // ...
          Tab: MyCustomTab
        }
      },
      List: MyListView
    }
  }
}
```

New: 

```tsx
// collection.ts
{
  // ...
  admin: {
    views: {
      edit: {
        default: {
          Component: 'path-to-my-default-view'
        },
        customView: {
          // ...
          tab: {
            Component: 'path-to-my-custom-tab'
          }
        }
      },
      list: {
        Component: 'path-to-my-custom-view'
      }
    }
  }
}
```

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.