### PR TITLE
feat: add admin.placeholder option to Relationship field 

### DIFF
--- a/docs/fields/relationship.mdx
+++ b/docs/fields/relationship.mdx
@@ -73,6 +73,10 @@ is set to `true`).
 Set to `false` if you'd like to disable the ability to create new documents from within the relationship field (hides
 the "Add new" button in the admin UI).
 
+**`placeholder`**
+
+Set this property to override the default "Select a value..." placeholder string in the input.
+
 **`sortOptions`**
 
 The `sortOptions` property allows you to define a default sorting order for the options within a Relationship field's

--- a/packages/payload/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -8,6 +8,7 @@ import type { DocumentDrawerProps } from '../../../elements/DocumentDrawer/types
 import type { FilterOptionsResult, GetResults, Option, Props, Value } from './types'
 
 import { relationship } from '../../../../../fields/validations'
+import { getTranslation } from '../../../../../utilities/getTranslation'
 import wordBoundariesRegex from '../../../../../utilities/wordBoundariesRegex'
 import { useDebouncedCallback } from '../../../../hooks/useDebouncedCallback'
 import ReactSelect from '../../../elements/ReactSelect'
@@ -535,7 +536,7 @@ const Relationship: React.FC<Props> = (props) => {
               })
             }}
             options={options}
-            placeholder={placeholder}
+            placeholder={getTranslation(placeholder, i18n)}
             showError={showError}
             value={valueToRender ?? null}
           />

--- a/packages/payload/src/admin/components/forms/field-types/Relationship/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Relationship/index.tsx
@@ -44,6 +44,7 @@ const Relationship: React.FC<Props> = (props) => {
       condition,
       description,
       isSortable = true,
+      placeholder,
       readOnly,
       sortOptions,
       style,
@@ -534,6 +535,7 @@ const Relationship: React.FC<Props> = (props) => {
               })
             }}
             options={options}
+            placeholder={placeholder}
             showError={showError}
             value={valueToRender ?? null}
           />

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -508,7 +508,7 @@ type RelationshipAdmin = Admin & {
     Label?: React.ComponentType<LabelProps>
   }
   isSortable?: boolean
-  placeholder?: string
+  placeholder?: Record<string, string> | string
 }
 export type PolymorphicRelationshipField = SharedRelationshipProperties & {
   admin?: RelationshipAdmin & {

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -508,6 +508,7 @@ type RelationshipAdmin = Admin & {
     Label?: React.ComponentType<LabelProps>
   }
   isSortable?: boolean
+  placeholder?: string
 }
 export type PolymorphicRelationshipField = SharedRelationshipProperties & {
   admin?: RelationshipAdmin & {


### PR DESCRIPTION
## Description

Adds the ability to define a custom placeholder for Relationship fields, in line with other fields.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
