### PR TITLE
feat(richtext-lexical)!: move migration related features to /migrate subpath export in order to decrease module count when those are not used

### DIFF
--- a/docs/lexical/migration.mdx
+++ b/docs/lexical/migration.mdx
@@ -20,7 +20,7 @@ IMPORTANT: This will overwrite all slate data. We recommend doing the following 
 3. Add the SlateToLexicalFeature (as seen below) first, and test it out by loading up the Admin Panel, to see if the migrator works as expected. You might have to build some custom converters for some fields first in order to convert custom Slate nodes. The SlateToLexicalFeature is where the converters are stored. Only fields with this feature added will be migrated.
 
 ```ts
-import { migrateSlateToLexical } from '@payloadcms/richtext-lexical'
+import { migrateSlateToLexical } from '@payloadcms/richtext-lexical/migrate'
 
 await migrateSlateToLexical({ payload })
 ```
@@ -34,7 +34,8 @@ Simply add the `SlateToLexicalFeature` to your editor:
 ```ts
 import type { CollectionConfig } from 'payload'
 
-import { SlateToLexicalFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
+import { SlateToLexicalFeature } from '@payloadcms/richtext-lexical/migrate'
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
 
 const Pages: CollectionConfig = {
   slug: 'pages',
@@ -64,8 +65,8 @@ The easy way to solve this: Edit the richText field and save the document! This 
 If you have custom Slate nodes, create a custom converter for them. Here's the Upload converter as an example:
 
 ```ts
-import type { SerializedUploadNode } from '../uploadNode.'
-import type { SlateNodeConverter } from '@payloadcms/richtext-lexical'
+import type { SerializedUploadNode } from '../uploadNode'
+import type { SlateNodeConverter } from '@payloadcms/richtext-lexical/migrate'
 
 export const SlateUploadConverter: SlateNodeConverter = {
   converter({ slateNode }) {
@@ -95,9 +96,9 @@ When using the `SlateToLexicalFeature`, you can add your custom converters to th
 ```ts
 import type { CollectionConfig } from 'payload'
 
+import {  lexicalEditor } from '@payloadcms/richtext-lexical'
 import {
   SlateToLexicalFeature,
-  lexicalEditor,
   defaultSlateConverters,
 } from '@payloadcms/richtext-lexical'
 

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -23,6 +23,11 @@
       "types": "./src/exports/client/index.ts",
       "default": "./src/exports/client/index.ts"
     },
+    "./migrate": {
+      "import": "./src/exports/server/migrate.ts",
+      "types": "./src/exports/server/migrate.ts",
+      "default": "./src/exports/server/migrate.ts"
+    },
     "./generateComponentMap": "./src/utilities/generateComponentMap.tsx"
   },
   "main": "./src/index.ts",
@@ -108,6 +113,11 @@
         "import": "./dist/exports/client/index.js",
         "types": "./dist/exports/client/index.d.ts",
         "default": "./dist/exports/client/index.js"
+      },
+      "./migrate": {
+        "import": "./dist/exports/server/migrate.js",
+        "types": "./dist/exports/server/migrate.d.ts",
+        "default": "./dist/exports/server/migrate.js"
       },
       "./generateComponentMap": {
         "import": "./dist/utilities/generateComponentMap.js",

--- a/packages/richtext-lexical/src/exports/server/migrate.ts
+++ b/packages/richtext-lexical/src/exports/server/migrate.ts
@@ -1,0 +1,19 @@
+export { LexicalPluginToLexicalFeature } from '../../features/migrations/lexicalPluginToLexical/feature.server.js'
+export { SlateBlockquoteConverter } from '../../features/migrations/slateToLexical/converter/converters/blockquote/converter.js'
+export { SlateHeadingConverter } from '../../features/migrations/slateToLexical/converter/converters/heading/converter.js'
+export { SlateIndentConverter } from '../../features/migrations/slateToLexical/converter/converters/indent/converter.js'
+export { SlateLinkConverter } from '../../features/migrations/slateToLexical/converter/converters/link/converter.js'
+export { SlateListItemConverter } from '../../features/migrations/slateToLexical/converter/converters/listItem/converter.js'
+export { SlateOrderedListConverter } from '../../features/migrations/slateToLexical/converter/converters/orderedList/converter.js'
+export { SlateRelationshipConverter } from '../../features/migrations/slateToLexical/converter/converters/relationship/converter.js'
+export { SlateUnknownConverter } from '../../features/migrations/slateToLexical/converter/converters/unknown/converter.js'
+export { SlateUnorderedListConverter } from '../../features/migrations/slateToLexical/converter/converters/unorderedList/converter.js'
+export { SlateUploadConverter } from '../../features/migrations/slateToLexical/converter/converters/upload/converter.js'
+export { defaultSlateConverters } from '../../features/migrations/slateToLexical/converter/defaultConverters.js'
+export {
+  convertSlateNodesToLexical,
+  convertSlateToLexical,
+} from '../../features/migrations/slateToLexical/converter/index.js'
+
+export { SlateToLexicalFeature } from '../../features/migrations/slateToLexical/feature.server.js'
+export { migrateSlateToLexical } from '../../utilities/migrateSlateToLexical/index.js'

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -879,28 +879,11 @@ export { LinkFeature, type LinkFeatureServerProps } from './features/link/server
 export { ChecklistFeature } from './features/lists/checklist/server/index.js'
 export { OrderedListFeature } from './features/lists/orderedList/server/index.js'
 export { UnorderedListFeature } from './features/lists/unorderedList/server/index.js'
-export { LexicalPluginToLexicalFeature } from './features/migrations/lexicalPluginToLexical/feature.server.js'
-export { SlateBlockquoteConverter } from './features/migrations/slateToLexical/converter/converters/blockquote/converter.js'
-export { SlateHeadingConverter } from './features/migrations/slateToLexical/converter/converters/heading/converter.js'
-export { SlateIndentConverter } from './features/migrations/slateToLexical/converter/converters/indent/converter.js'
-export { SlateLinkConverter } from './features/migrations/slateToLexical/converter/converters/link/converter.js'
-export { SlateListItemConverter } from './features/migrations/slateToLexical/converter/converters/listItem/converter.js'
-export { SlateOrderedListConverter } from './features/migrations/slateToLexical/converter/converters/orderedList/converter.js'
-export { SlateRelationshipConverter } from './features/migrations/slateToLexical/converter/converters/relationship/converter.js'
-export { SlateUnknownConverter } from './features/migrations/slateToLexical/converter/converters/unknown/converter.js'
-export { SlateUnorderedListConverter } from './features/migrations/slateToLexical/converter/converters/unorderedList/converter.js'
-export { SlateUploadConverter } from './features/migrations/slateToLexical/converter/converters/upload/converter.js'
-export { defaultSlateConverters } from './features/migrations/slateToLexical/converter/defaultConverters.js'
 
-export {
-  convertSlateNodesToLexical,
-  convertSlateToLexical,
-} from './features/migrations/slateToLexical/converter/index.js'
 export type {
   SlateNode,
   SlateNodeConverter,
 } from './features/migrations/slateToLexical/converter/types.js'
-export { SlateToLexicalFeature } from './features/migrations/slateToLexical/feature.server.js'
 
 export { ParagraphFeature } from './features/paragraph/server/index.js'
 export {
@@ -1008,7 +991,5 @@ export { defaultRichTextValue } from './populateGraphQL/defaultValue.js'
 export type { LexicalEditorProps, LexicalRichTextAdapter } from './types.js'
 export { createServerFeature } from './utilities/createServerFeature.js'
 export type { FieldsDrawerProps } from './utilities/fieldsDrawer/Drawer.js'
-
-export { migrateSlateToLexical } from './utilities/migrateSlateToLexical/index.js'
 
 export { upgradeLexicalData } from './utilities/upgradeLexicalData/index.js'

--- a/test/fields/collections/LexicalMigrate/index.ts
+++ b/test/fields/collections/LexicalMigrate/index.ts
@@ -2,14 +2,16 @@ import type { CollectionConfig } from 'payload'
 
 import {
   HTMLConverterFeature,
-  LexicalPluginToLexicalFeature,
   LinkFeature,
-  SlateToLexicalFeature,
   TreeViewFeature,
   UploadFeature,
   lexicalEditor,
   lexicalHTML,
 } from '@payloadcms/richtext-lexical'
+import {
+  LexicalPluginToLexicalFeature,
+  SlateToLexicalFeature,
+} from '@payloadcms/richtext-lexical/migrate'
 
 import { lexicalMigrateFieldsSlug } from '../../slugs.js'
 import { getSimpleLexicalData } from './data.js'


### PR DESCRIPTION
This lowers the module count by 31 modules

BREAKING: Migration-related lexical modules are now exported from `@payloadcms/richtext-lexical/migrate` instead of `@payloadcms/richtext-lexical`