### PR TITLE
feat: add bun support for payload bin scripts

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -145,7 +145,7 @@ Instead, we utilize component paths to reference React Components. This method e
 
 When constructing the `ClientConfig`, Payload uses the component paths as keys to fetch the corresponding React Component imports from the Import Map. It then substitutes the `PayloadComponent` with a `MappedComponent`. A `MappedComponent` includes the React Component and additional metadata, such as whether it's a server or a client component and which props it should receive. These components are then rendered through the `<RenderComponent />` component within the Payload Admin Panel.
 
-Import maps are regenerated whenever you modify any element related to component paths. This regeneration occurs at startup and whenever Hot Module Replacement (HMR) runs. If the import maps fail to regenerate during HMR, you can restart your application and execute the `payload generate:importmap` command to manually create a new import map.
+Import maps are regenerated whenever you modify any element related to component paths. This regeneration occurs at startup and whenever Hot Module Replacement (HMR) runs. If the import maps fail to regenerate during HMR, you can restart your application and execute the `payload generate:importmap` command to manually create a new import map. If you encounter any errors running this command, see the [Troubleshooting](/docs/beta/local-api/outside-nextjs#troubleshooting) section.
 
 ### Component paths in external packages
 

--- a/docs/local-api/outside-nextjs.mdx
+++ b/docs/local-api/outside-nextjs.mdx
@@ -65,10 +65,21 @@ The `payload run` command does two things for you:
 
 ### Troubleshooting
 
-If you encounter import-related errors, try running the script in TSX mode:
+If you encounter import-related errors, you have 2 options:
 
+#### Option 1: enable tsx mode by appending `--use-tsx` to the `payload` command:
+
+Example:
 ```sh
 payload run src/seed.ts --use-tsx
 ```
 
 Note: Install tsx in your project first. Be aware that TSX mode is slower than the default swc mode, so only use it if necessary.
+
+#### Option 2: run the script with bun by replacing `payload` with `payload-bun`:
+
+```sh
+payload-bun run src/seed.ts
+```
+
+You will need to have bun installed on your system for this to work.

--- a/packages/payload/bin-bun.js
+++ b/packages/payload/bin-bun.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env bun
+
+const start = async () => {
+  const { bin } = await import('./dist/bin/index.js')
+  await bin()
+}
+
+void start()

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -64,11 +64,13 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "bin": {
-    "payload": "bin.js"
+    "payload": "bin.js",
+    "payload-bun": "bun-bin.js"
   },
   "files": [
     "dist",
-    "bin.js"
+    "bin.js",
+    "bin-bun.js"
   ],
   "scripts": {
     "build": "rimraf .dist && rimraf tsconfig.tsbuildinfo && pnpm copyfiles && pnpm build:types && pnpm build:swc && pnpm build:esbuild",

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -65,7 +65,7 @@
   "types": "./src/index.ts",
   "bin": {
     "payload": "bin.js",
-    "payload-bun": "bun-bin.js"
+    "payload-bun": "bin-bun.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
While bun does not fully support Next.js, the payload core / config is now fully decoupled from Next.js / React. Bun should be able to run these effortlessly.

This is a great option for people currently encountering issues using swc / tsx (see https://github.com/payloadcms/payload/discussions/7668#discussioncomment-10338844) while we figure this out