### PR TITLE
chore(eslint): update relative import regex to handle more scenarios

### DIFF
--- a/packages/eslint-plugin/customRules/no-relative-monorepo-imports.js
+++ b/packages/eslint-plugin/customRules/no-relative-monorepo-imports.js
@@ -21,7 +21,7 @@ export const rule = {
         const importPath = node.source.value
 
         // Match imports starting with any number of "../" followed by "packages/"
-        const regex = /^(\.\.\/)*packages\/[^/]+\/src/
+        const regex = /^(\.\.\/)*((?!src\b)\w+\/)+src\//
 
         if (regex.test(importPath)) {
           context.report({


### PR DESCRIPTION
Updates no-relative-monorepo-import regex to handle more scenarios:

❌ Scenarios that will violate the rule:
```ts
import { something } from '../../payload/src/utilities/some-util.js'
import { something } from '../../../packages/payload/src/utilities/some-util.js'
import { something } from 'packages/payload/src/utilities/some-util.js'
```
