### PR TITLE
fix: importMap windows paths

### DIFF
--- a/packages/payload/src/bin/generateImportMap/index.ts
+++ b/packages/payload/src/bin/generateImportMap/index.ts
@@ -67,7 +67,7 @@ export function addPayloadComponentToImportMap({
   imports[importIdentifier] = {
     path:
       componentPath.startsWith('.') || componentPath.startsWith('/')
-        ? path.join(baseDir, componentPath.slice(1))
+        ? path.posix.join(baseDir.replace(/\\/g, '/'), componentPath.slice(1))
         : componentPath,
     specifier: exportName,
   }


### PR DESCRIPTION
## Description

Fix windows compatibility for importMap generation

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
