### PR TITLE
feat(cpa): add support for bun package manager in v3 installer

### DIFF
--- a/packages/create-payload-app/src/lib/create-project.ts
+++ b/packages/create-payload-app/src/lib/create-project.ts
@@ -37,6 +37,8 @@ async function installDeps(args: {
     installCmd = 'yarn'
   } else if (packageManager === 'pnpm') {
     installCmd = 'pnpm install'
+  } else if (packageManager === 'bun') {
+    installCmd = 'bun install'
   }
 
   try {

--- a/packages/create-payload-app/src/lib/get-package-manager.ts
+++ b/packages/create-payload-app/src/lib/get-package-manager.ts
@@ -18,12 +18,16 @@ export async function getPackageManager(args: {
       detected = 'yarn'
     } else if (cliArgs?.['--use-npm'] || fse.existsSync(`${projectDir}/package-lock.json`)) {
       detected = 'npm'
+    } else if (cliArgs?.['--use-bun'] || fse.existsSync(`${projectDir}/bun.lockb`)) {
+      detected = 'bun'
     } else {
       // Otherwise check for existing commands
       if (await commandExists('pnpm')) {
         detected = 'pnpm'
       } else if (await commandExists('yarn')) {
         detected = 'yarn'
+      } else if (await commandExists('bun')) {
+        detected = 'bun'
       } else {
         detected = 'npm'
       }

--- a/packages/create-payload-app/src/lib/get-package-manager.ts
+++ b/packages/create-payload-app/src/lib/get-package-manager.ts
@@ -26,8 +26,6 @@ export async function getPackageManager(args: {
         detected = 'pnpm'
       } else if (await commandExists('yarn')) {
         detected = 'yarn'
-      } else if (await commandExists('bun')) {
-        detected = 'bun'
       } else {
         detected = 'npm'
       }

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -49,6 +49,7 @@ export class Main {
 
         // Package manager
         '--no-deps': Boolean,
+        '--use-bun': Boolean,
         '--use-npm': Boolean,
         '--use-pnpm': Boolean,
         '--use-yarn': Boolean,

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -16,6 +16,7 @@ export interface Args extends arg.Spec {
   '--secret': StringConstructor
   '--template': StringConstructor
   '--template-branch': StringConstructor
+  '--use-bun': BooleanConstructor
   '--use-npm': BooleanConstructor
   '--use-pnpm': BooleanConstructor
   '--use-yarn': BooleanConstructor

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -40,6 +40,7 @@ export function helpMessage(): void {
       --use-npm                     Use npm to install dependencies
       --use-yarn                    Use yarn to install dependencies
       --use-pnpm                    Use pnpm to install dependencies
+      --use-bun                     Use bun to install dependencies (experimental)
       --no-deps                     Do not install any dependencies
       -h                            Show help
 `)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

It adds support for bun package manger in v3, enabled with `--use-bun` flag.
Related: #6932 (for v2)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
