### PR TITLE
feat(payload, next): DatabaseCache implementation /w next/cache + in-memory

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -42,6 +42,11 @@
       "import": "./src/exports/views.ts",
       "types": "./src/exports/views.ts",
       "default": "./src/exports/views.ts"
+    },
+    "./cache": {
+      "import": "./src/exports/cache.ts",
+      "types": "./src/exports/cache.ts",
+      "default": "./src/exports/cache.ts"
     }
   },
   "main": "./src/index.js",
@@ -135,6 +140,11 @@
         "import": "./dist/exports/views.js",
         "types": "./dist/exports/views.d.ts",
         "default": "./dist/exports/views.js"
+      },
+      "./cache": {
+        "import": "./dist/exports/cache.js",
+        "types": "./dist/exports/cache.d.ts",
+        "default": "./dist/exports/cache.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/next/src/exports/cache.ts
+++ b/packages/next/src/exports/cache.ts
@@ -1,0 +1,1 @@
+export { nextDatabaseCache } from '../next-cache/index.js'

--- a/packages/next/src/next-cache/NextDatabaseCacheStorage.ts
+++ b/packages/next/src/next-cache/NextDatabaseCacheStorage.ts
@@ -1,0 +1,20 @@
+import type { DatabaseCacheStorage } from 'payload'
+
+import { revalidateTag, unstable_cache } from 'next/cache.js'
+
+export class NextDatabaseCacheStorage implements DatabaseCacheStorage {
+  cacheFn<T extends (...args: unknown[]) => Promise<unknown>>(
+    callback: T,
+    keyParts: string[],
+    tags: string[],
+    revalidate?: number,
+  ): T {
+    const cachedFn = unstable_cache(callback, keyParts, { revalidate, tags })
+
+    return cachedFn
+  }
+
+  invalidateTags(tags: string[]): Promise<void> | void {
+    tags.forEach(revalidateTag)
+  }
+}

--- a/packages/next/src/next-cache/index.ts
+++ b/packages/next/src/next-cache/index.ts
@@ -1,0 +1,9 @@
+import type { DatabaseCacheOptions } from 'payload'
+
+import { createDatabaseCache } from 'payload'
+
+import { NextDatabaseCacheStorage } from './NextDatabaseCacheStorage.js'
+
+export const nextDatabaseCache = (options: DatabaseCacheOptions) => {
+  return createDatabaseCache({ options, storage: new NextDatabaseCacheStorage() })
+}

--- a/packages/next/src/routes/rest/collections/count.ts
+++ b/packages/next/src/routes/rest/collections/count.ts
@@ -6,11 +6,13 @@ import { countOperation } from 'payload'
 import type { CollectionRouteHandler } from '../types.js'
 
 export const count: CollectionRouteHandler = async ({ collection, req }) => {
-  const { where } = req.query as {
+  const { cache, where } = req.query as {
+    cache?: string
     where?: Where
   }
 
   const result = await countOperation({
+    cache: cache === 'true',
     collection,
     req,
     where,

--- a/packages/next/src/routes/rest/collections/find.ts
+++ b/packages/next/src/routes/rest/collections/find.ts
@@ -9,7 +9,8 @@ import type { CollectionRouteHandler } from '../types.js'
 import { headersWithCors } from '../../../utilities/headersWithCors.js'
 
 export const find: CollectionRouteHandler = async ({ collection, req }) => {
-  const { depth, draft, limit, page, sort, where } = req.query as {
+  const { cache, depth, draft, limit, page, sort, where } = req.query as {
+    cache?: string
     depth?: string
     draft?: string
     limit?: string
@@ -19,6 +20,7 @@ export const find: CollectionRouteHandler = async ({ collection, req }) => {
   }
 
   const result = await findOperation({
+    cache: cache === 'true',
     collection,
     depth: isNumber(depth) ? Number(depth) : undefined,
     draft: draft === 'true',

--- a/packages/next/src/routes/rest/collections/findByID.ts
+++ b/packages/next/src/routes/rest/collections/findByID.ts
@@ -14,6 +14,7 @@ export const findByID: CollectionRouteHandlerWithID = async ({
 }) => {
   const { searchParams } = req
   const depth = searchParams.get('depth')
+  const cache = searchParams.get('cache')
 
   const id = sanitizeCollectionID({
     id: incomingID,
@@ -23,6 +24,7 @@ export const findByID: CollectionRouteHandlerWithID = async ({
 
   const result = await findByIDOperation({
     id,
+    cache: cache === 'true',
     collection,
     depth: isNumber(depth) ? Number(depth) : undefined,
     draft: searchParams.get('draft') === 'true',

--- a/packages/payload/src/cache/createDatabaseCache.ts
+++ b/packages/payload/src/cache/createDatabaseCache.ts
@@ -100,7 +100,7 @@ const getTTLResolver = (options: DatabaseCacheOptions) => {
   if (typeof options.ttl === 'function') return options.ttl
 
   const ttlResolver: TTLResolveFunction = () => {
-    if (typeof options.ttl === 'undefined') return 3600
+    if (typeof options.ttl === 'undefined') return 3600000
 
     return options.ttl
   }

--- a/packages/payload/src/cache/createDatabaseCache.ts
+++ b/packages/payload/src/cache/createDatabaseCache.ts
@@ -1,0 +1,270 @@
+import type { TypeWithID } from '../collections/config/types.js'
+import type { Count, Find, FindGlobal, FindOne, PaginatedDocs } from '../database/types.js'
+import type { PayloadRequest, Where } from '../types/index.js'
+import type {
+  DatabaseCache,
+  DatabaseCacheOptions,
+  DatabaseCacheStorage,
+  DatabaseCachedFindArgs,
+  DatabaseCachedFindGlobalArgs,
+  DatabaseCachedFindOneArgs,
+  InvalidateCacheFunction,
+  TTLResolveFunction,
+} from './types.js'
+
+const getCacheHitLogger = ({
+  message,
+  operation,
+  options: { logging },
+  req,
+}: {
+  message: string
+  operation: string
+  options: DatabaseCacheOptions
+  req: PayloadRequest
+}) => {
+  if (!logging)
+    return {
+      log: () => {},
+      setCacheSkip: () => {},
+    }
+
+  const startTime = Date.now()
+  let cacheHit = true
+
+  const log = () => {
+    const executionTime = Date.now() - startTime
+    req.payload.logger.info(
+      `Cache: ${cacheHit ? 'HIT' : ' SKIP'}, operation: ${operation}, ${message} (${executionTime} MS)`,
+    )
+  }
+
+  return {
+    log,
+    setCacheSkip: () => (cacheHit = false),
+  }
+}
+
+type SanitizedCacheIndex = {
+  field: string
+  value: string
+}
+
+const sanitizeCachedIndexesFromWhere = (
+  cacheIndexes: string[],
+  where: Where = {},
+): SanitizedCacheIndex[] => {
+  let sanitizedIndexes: SanitizedCacheIndex[] = []
+
+  cacheIndexes.forEach((field) => {
+    if (where[field]) {
+      const value = where[field]['equals']
+
+      if (value) sanitizedIndexes.push({ field, value })
+    }
+  })
+
+  where.and?.forEach((and) => {
+    sanitizedIndexes = [...sanitizedIndexes, ...sanitizeCachedIndexesFromWhere(cacheIndexes, and)]
+  })
+
+  where.or?.forEach((or) => {
+    sanitizedIndexes = [...sanitizedIndexes, ...sanitizeCachedIndexesFromWhere(cacheIndexes, or)]
+  })
+
+  return sanitizedIndexes
+}
+
+const tagsWithDraft = (tags: string[], draft?: 'all' | boolean): string[] => {
+  let resolvedTags: string[] = []
+
+  if (draft) {
+    const draftTags = tags.map((tag) => `${tag}-${draft}`)
+
+    resolvedTags = [...draftTags]
+
+    if (draft === 'all') resolvedTags = [...resolvedTags, ...tags]
+  } else resolvedTags = tags
+
+  return resolvedTags
+}
+
+const generateFindOneTags = (indexes: SanitizedCacheIndex[], draft?: 'all' | boolean) => {
+  return tagsWithDraft(
+    indexes.map((index) => `${index.field}-${index.value}`),
+    draft,
+  )
+}
+
+const getTTLResolver = (options: DatabaseCacheOptions) => {
+  if (typeof options.ttl === 'function') return options.ttl
+
+  const ttlResolver: TTLResolveFunction = () => {
+    if (typeof options.ttl === 'undefined') return 3600
+
+    return options.ttl
+  }
+
+  return ttlResolver
+}
+
+export const createDatabaseCache = ({
+  options = {},
+  storage: adapter,
+}: {
+  options: DatabaseCacheOptions
+  storage: DatabaseCacheStorage
+}): DatabaseCache => {
+  const invalidateCache: InvalidateCacheFunction = async (req, { args, draft, operation }) => {
+    if (operation === 'updateGlobal') {
+      return adapter.invalidateTags(tagsWithDraft([`find-global-${args.slug}`], draft))
+    }
+
+    await adapter.invalidateTags(tagsWithDraft([`find-many-${args.collection}`], draft))
+
+    if (operation === 'create') return
+
+    const cachedIndexes = req.payload.collections[args.collection].config.cacheIndexes
+
+    const indexes = sanitizeCachedIndexesFromWhere(cachedIndexes, args.where)
+
+    await adapter.invalidateTags(generateFindOneTags(indexes, draft))
+  }
+
+  const ttl = getTTLResolver(options)
+
+  return {
+    ...adapter,
+    count: async (args) => {
+      const { collection, req, where } = args
+      const keyParts: string[] = ['count', collection, JSON.stringify(where), req.locale]
+
+      const cacheHitLogger = getCacheHitLogger({
+        message: `collection: ${collection}`,
+        operation: 'count',
+        options,
+        req,
+      })
+
+      const cachedCount = adapter.cacheFn<Count>(
+        (args) => {
+          cacheHitLogger.setCacheSkip()
+          return req.payload.db.count(args)
+        },
+        keyParts,
+        [`find-many-${collection}`],
+        ttl({ operation: 'count', operationArgs: args }),
+      )
+
+      const result = await cachedCount(args)
+
+      cacheHitLogger.log()
+
+      return result
+    },
+    find: async <T = TypeWithID>(args: DatabaseCachedFindArgs): Promise<PaginatedDocs<T>> => {
+      const { collection, draft, limit, page, pagination, req, sort, where } = args
+
+      const keyParts: string[] = [
+        'find',
+        collection,
+        JSON.stringify(where),
+        req.locale,
+        sort,
+        JSON.stringify([limit, pagination, page]),
+      ]
+
+      const cacheHitLogger = getCacheHitLogger({
+        message: `collection: ${collection}`,
+        operation: 'find',
+        options,
+        req,
+      })
+
+      const cachedFind = adapter.cacheFn<Find>(
+        (args) => {
+          cacheHitLogger.setCacheSkip()
+          return draft ? req.payload.db.queryDrafts(args) : req.payload.db.find(args)
+        },
+        keyParts,
+        tagsWithDraft([`find-many-${collection}`], draft),
+        ttl({ draft, operation: 'find', operationArgs: args }),
+      )
+
+      const result = await cachedFind(args)
+
+      cacheHitLogger.log()
+
+      return result as PaginatedDocs<T>
+    },
+    findGlobal: async <T extends Record<string, unknown>>(
+      args: DatabaseCachedFindGlobalArgs,
+    ): Promise<T> => {
+      const { slug, draft, req } = args
+
+      const keyParts: string[] = [slug, req.locale]
+
+      const cacheHitLogger = getCacheHitLogger({
+        message: `global: ${slug}`,
+        operation: 'findGlobal',
+        options,
+        req,
+      })
+
+      const cachedFindGlobal = adapter.cacheFn<FindGlobal>(
+        (args) => {
+          cacheHitLogger.setCacheSkip()
+          return req.payload.db.findGlobal(args)
+        },
+        keyParts,
+        tagsWithDraft([`find-global-${slug}`], draft),
+        ttl({ draft, operation: 'findGlobal', operationArgs: args }),
+      )
+
+      const result = await cachedFindGlobal(args)
+
+      cacheHitLogger.log()
+
+      return result
+    },
+    findOne: async <T = TypeWithID>(args: DatabaseCachedFindOneArgs): Promise<T | null> => {
+      const { collection, draft, req, where } = args
+
+      const cacheIndexes = req.payload.collections[collection].config.cacheIndexes
+
+      const keyParts: string[] = [
+        'findOne',
+        collection,
+        JSON.stringify(where),
+        req.locale,
+        req.locale,
+      ]
+
+      const sanitizedCachedIndexes = sanitizeCachedIndexesFromWhere(cacheIndexes, where)
+
+      const cacheHitLogger = getCacheHitLogger({
+        message: `collection: ${collection}, indexes: ${sanitizedCachedIndexes.map((index) => `${index.field}: ${index.value}`).join(', ')}`,
+        operation: `findOne`,
+        options,
+        req,
+      })
+
+      const cachedFind = adapter.cacheFn<FindOne>(
+        (args) => {
+          cacheHitLogger.setCacheSkip()
+          return req.payload.db.findOne(args)
+        },
+        keyParts,
+        generateFindOneTags(sanitizedCachedIndexes, draft),
+        ttl({ draft, operation: 'findOne', operationArgs: args }),
+      )
+
+      const result = await cachedFind(args)
+
+      cacheHitLogger.log()
+
+      return result as T | null
+    },
+    invalidateCache,
+  }
+}

--- a/packages/payload/src/cache/in-memory-database-cache/InMemoryDatabaseCacheStorage.ts
+++ b/packages/payload/src/cache/in-memory-database-cache/InMemoryDatabaseCacheStorage.ts
@@ -1,0 +1,54 @@
+import type { DatabaseCacheOptions, DatabaseCacheStorage } from '../types.js'
+
+import { createDatabaseCache } from '../createDatabaseCache.js'
+
+export class InMemoryDatabaseCacheStorage implements DatabaseCacheStorage {
+  private cache = new Map<string, { expiresAt: null | number; tags: string[]; value: unknown }>()
+
+  private get(key: string) {
+    const cachedItem = this.cache.get(key)
+    if (!cachedItem) return null
+
+    if (cachedItem.expiresAt && Date.now() > cachedItem.expiresAt) {
+      this.cache.delete(key)
+      return null
+    }
+
+    return cachedItem.value
+  }
+
+  cacheFn<T extends (...args: unknown[]) => Promise<unknown>>(
+    callback: T,
+    keyParts: string[],
+    tags: string[],
+    ttl?: number,
+  ): T {
+    const key = keyParts.join(',')
+
+    const cachedFn = async (...args: unknown[]) => {
+      const cachedValue = this.get(key)
+
+      if (cachedValue) return cachedValue
+
+      const result = await callback(...args)
+
+      const expiresAt = ttl ? Date.now() + ttl : null
+
+      this.cache.set(key, { expiresAt, tags, value: result })
+
+      return result
+    }
+
+    return cachedFn as T
+  }
+
+  invalidateTags(tags: string[]): void {
+    this.cache.forEach((value, key) => {
+      if (value.tags.some((tag) => tags.includes(tag))) this.cache.delete(key)
+    })
+  }
+}
+
+export const inMemoryDatabaseCache = (options: DatabaseCacheOptions) => {
+  return createDatabaseCache({ options, storage: new InMemoryDatabaseCacheStorage() })
+}

--- a/packages/payload/src/cache/in-memory-database-cache/index.ts
+++ b/packages/payload/src/cache/in-memory-database-cache/index.ts
@@ -1,0 +1,13 @@
+import type { DatabaseCacheOptions } from '../types.js'
+
+import { createDatabaseCache } from '../createDatabaseCache.js'
+import { InMemoryDatabaseCacheStorage } from './InMemoryDatabaseCacheStorage.js'
+
+export const inMemoryDatabaseCache = (options: DatabaseCacheOptions) => {
+  return createDatabaseCache({
+    options: {
+      ...options,
+    },
+    storage: new InMemoryDatabaseCacheStorage(),
+  })
+}

--- a/packages/payload/src/cache/types.ts
+++ b/packages/payload/src/cache/types.ts
@@ -94,6 +94,6 @@ export type DatabaseCacheOptions = {
   /** @default false */
   logging?: boolean
 
-  /** @default 3600  */
+  /** @default 3600000 - '1 hour'  */
   ttl?: false | number
 }

--- a/packages/payload/src/cache/types.ts
+++ b/packages/payload/src/cache/types.ts
@@ -1,0 +1,99 @@
+import type { TypeWithID } from '../collections/config/types.js'
+import type {
+  Count,
+  CountArgs,
+  CreateArgs,
+  DeleteManyArgs,
+  DeleteOneArgs,
+  FindArgs,
+  FindGlobalArgs,
+  FindOneArgs,
+  PaginatedDocs,
+  QueryDraftsArgs,
+  UpdateGlobalArgs,
+  UpdateOneArgs,
+} from '../database/types.js'
+import type { PayloadRequest } from '../types/index.js'
+
+type Callback = (...args: unknown[]) => Promise<unknown>
+
+export type TTLResolveFunction = (
+  args: { draft?: boolean } & (
+    | {
+        operation: 'count'
+        operationArgs: CountArgs
+      }
+    | {
+        operation: 'find'
+        operationArgs: FindArgs
+      }
+    | {
+        operation: 'findGlobal'
+        operationArgs: FindGlobalArgs
+      }
+    | {
+        operation: 'findOne'
+        operationArgs: FindOneArgs
+      }
+  ),
+) => false | number
+
+export type DatabaseCacheStorage = {
+  cacheFn<T extends Callback>(
+    callback: T,
+    keyParts: string[],
+    tags: string[],
+    ttl?: TTLResolveFunction | false | number,
+  ): T
+  invalidateTags(tags: string[]): Promise<void> | void
+}
+
+export type InvalidateCacheFunction = (
+  req: PayloadRequest,
+  options: { draft?: 'all' | boolean } & (
+    | {
+        args: CreateArgs
+        operation: 'create'
+      }
+    | {
+        args: DeleteManyArgs
+        operation: 'deleteMany'
+      }
+    | {
+        args: DeleteOneArgs
+        operation: 'deleteOne'
+      }
+    | {
+        args: UpdateGlobalArgs
+        operation: 'updateGlobal'
+      }
+    | {
+        args: UpdateOneArgs
+        operation: 'updateOne'
+      }
+  ),
+) => Promise<void>
+
+type WithDraft<T extends Record<string, unknown>> = { draft?: boolean } & T
+
+export type DatabaseCachedFindArgs = WithDraft<FindArgs>
+
+export type DatabaseCachedFindGlobalArgs = WithDraft<FindGlobalArgs>
+
+export type DatabaseCachedFindOneArgs = WithDraft<FindOneArgs>
+
+export type DatabaseCache = {
+  count: Count
+  find: <T = TypeWithID>(args: WithDraft<FindArgs>) => Promise<PaginatedDocs<T>>
+  findGlobal: <T extends Record<string, unknown>>(args: WithDraft<FindGlobalArgs>) => Promise<T>
+  findOne: <T = TypeWithID>(args: WithDraft<FindOneArgs>) => Promise<T | null>
+  invalidateCache: InvalidateCacheFunction
+} & DatabaseCacheStorage
+
+export type DatabaseCacheOptions = {
+  /** @default false */
+  logging?: boolean
+
+  /** @default 3600  */
+  ttl?: false | number
+}

--- a/packages/payload/src/cache/types.ts
+++ b/packages/payload/src/cache/types.ts
@@ -9,7 +9,6 @@ import type {
   FindGlobalArgs,
   FindOneArgs,
   PaginatedDocs,
-  QueryDraftsArgs,
   UpdateGlobalArgs,
   UpdateOneArgs,
 } from '../database/types.js'
@@ -43,7 +42,7 @@ export type DatabaseCacheStorage = {
     callback: T,
     keyParts: string[],
     tags: string[],
-    ttl?: TTLResolveFunction | false | number,
+    ttl?: false | number,
   ): T
   invalidateTags(tags: string[]): Promise<void> | void
 }
@@ -95,5 +94,5 @@ export type DatabaseCacheOptions = {
   logging?: boolean
 
   /** @default 3600000 - '1 hour'  */
-  ttl?: false | number
+  ttl?: TTLResolveFunction | false | number
 }

--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -10,6 +10,7 @@ import mergeBaseFields from '../../fields/mergeBaseFields.js'
 import { getBaseUploadFields } from '../../uploads/getBaseFields.js'
 import { deepMergeWithReactComponents } from '../../utilities/deepMerge.js'
 import { formatLabels } from '../../utilities/formatLabels.js'
+import { getFieldsCacheIndexes } from '../../utilities/getFieldsCacheIndexes.js'
 import baseVersionFields from '../../versions/baseFields.js'
 import { versionDefaults } from '../../versions/defaults.js'
 import { authDefaults, defaults, loginWithUsernameDefaults } from './defaults.js'
@@ -81,6 +82,14 @@ export const sanitizeCollection = async (
   }
 
   sanitized.labels = sanitized.labels || formatLabels(sanitized.slug)
+
+  const cacheIndexes = getFieldsCacheIndexes(collection.fields)
+
+  if (!cacheIndexes.includes('id')) {
+    cacheIndexes.push('id')
+  }
+
+  ;(sanitized as SanitizedCollectionConfig).cacheIndexes = cacheIndexes
 
   if (sanitized.versions) {
     if (sanitized.versions === true) sanitized.versions = { drafts: false }

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -479,6 +479,7 @@ export interface SanitizedCollectionConfig
     'auth' | 'endpoints' | 'fields' | 'upload' | 'versions'
   > {
   auth: Auth
+  cacheIndexes: string[]
   endpoints: Endpoint[] | false
   fields: Field[]
   upload: SanitizedUploadConfig

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -55,6 +55,7 @@ const batchAndLoadDocs =
         overrideAccess,
         showHiddenFields,
         draft,
+        cache,
       ] = JSON.parse(key)
 
       const batchKeyArray = [
@@ -67,6 +68,7 @@ const batchAndLoadDocs =
         overrideAccess,
         showHiddenFields,
         draft,
+        cache,
       ]
 
       const batchKey = JSON.stringify(batchKeyArray)
@@ -101,11 +103,13 @@ const batchAndLoadDocs =
         overrideAccess,
         showHiddenFields,
         draft,
+        cache,
       ] = JSON.parse(batchKey)
 
       req.transactionID = transactionID
 
       const result = await payload.find({
+        cache,
         collection,
         currentDepth,
         depth,
@@ -129,6 +133,7 @@ const batchAndLoadDocs =
 
       result.docs.forEach((doc) => {
         const docKey = createDataloaderCacheKey({
+          cache,
           collectionSlug: collection,
           currentDepth,
           depth,
@@ -157,6 +162,7 @@ const batchAndLoadDocs =
 export const getDataLoader = (req: PayloadRequest) => new DataLoader(batchAndLoadDocs(req))
 
 type CreateCacheKeyArgs = {
+  cache?: boolean
   collectionSlug: string
   currentDepth: number
   depth: number
@@ -169,6 +175,7 @@ type CreateCacheKeyArgs = {
   transactionID: Promise<number | string> | number | string
 }
 export const createDataloaderCacheKey = ({
+  cache,
   collectionSlug,
   currentDepth,
   depth,
@@ -191,4 +198,5 @@ export const createDataloaderCacheKey = ({
     overrideAccess,
     showHiddenFields,
     draft,
+    cache,
   ])

--- a/packages/payload/src/collections/operations/count.ts
+++ b/packages/payload/src/collections/operations/count.ts
@@ -1,5 +1,5 @@
 import type { AccessResult } from '../../config/types.js'
-import type { CollectionSlug } from '../../index.js'
+import type { CollectionSlug, CountArgs } from '../../index.js'
 import type { PayloadRequest, Where } from '../../types/index.js'
 import type { Collection } from '../config/types.js'
 
@@ -10,6 +10,7 @@ import { killTransaction } from '../../utilities/killTransaction.js'
 import { buildAfterOperation } from './utils.js'
 
 export type Arguments = {
+  cache?: boolean
   collection: Collection
   disableErrors?: boolean
   overrideAccess?: boolean
@@ -41,6 +42,7 @@ export const countOperation = async <TSlug extends CollectionSlug>(
     }, Promise.resolve())
 
     const {
+      cache = false,
       collection: { config: collectionConfig },
       disableErrors,
       overrideAccess,
@@ -77,11 +79,10 @@ export const countOperation = async <TSlug extends CollectionSlug>(
       where,
     })
 
-    result = await payload.db.count({
-      collection: collectionConfig.slug,
-      req,
-      where: fullWhere,
-    })
+    const dbArgs: CountArgs = { collection: collectionConfig.slug, req, where: fullWhere }
+
+    if (cache) result = await payload.cache.count(dbArgs)
+    else result = await payload.db.count(dbArgs)
 
     // /////////////////////////////////////
     // afterOperation - Collection

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
 
-import type { CollectionSlug, JsonObject } from '../../index.js'
+import type { CollectionSlug, CreateArgs, JsonObject } from '../../index.js'
 import type { Document, PayloadRequest } from '../../types/index.js'
 import type {
   AfterChangeHook,
@@ -236,11 +236,14 @@ export const createOperation = async <TSlug extends CollectionSlug>(
         req,
       })
     } else {
-      doc = await payload.db.create({
+      const createArgs: CreateArgs = {
         collection: collectionConfig.slug,
         data: resultWithLocales,
         req,
-      })
+      }
+      doc = await payload.db.create(createArgs)
+
+      await payload.cache.invalidateCache(req, { args: createArgs, draft, operation: 'create' })
     }
 
     const verificationToken = doc._verificationToken

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -1,7 +1,7 @@
 import httpStatus from 'http-status'
 
 import type { AccessResult } from '../../config/types.js'
-import type { CollectionSlug } from '../../index.js'
+import type { CollectionSlug, DeleteOneArgs } from '../../index.js'
 import type { PayloadRequest, Where } from '../../types/index.js'
 import type { BeforeOperationHook, Collection, DataFromCollectionSlug } from '../config/types.js'
 
@@ -157,7 +157,7 @@ export const deleteOperation = async <TSlug extends CollectionSlug>(
         // Delete document
         // /////////////////////////////////////
 
-        await payload.db.deleteOne({
+        const deleteArgs: DeleteOneArgs = {
           collection: collectionConfig.slug,
           req,
           where: {
@@ -165,6 +165,14 @@ export const deleteOperation = async <TSlug extends CollectionSlug>(
               equals: id,
             },
           },
+        }
+
+        await payload.db.deleteOne(deleteArgs)
+
+        await payload.cache.invalidateCache(req, {
+          args: deleteArgs,
+          draft: 'all',
+          operation: 'deleteOne',
         })
 
         // /////////////////////////////////////

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug } from '../../index.js'
+import type { CollectionSlug, DeleteOneArgs } from '../../index.js'
 import type { PayloadRequest } from '../../types/index.js'
 import type { BeforeOperationHook, Collection, DataFromCollectionSlug } from '../config/types.js'
 
@@ -126,14 +126,22 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug>(
       })
     }
 
+    const deleteArgs: DeleteOneArgs = {
+      collection: collectionConfig.slug,
+      req,
+      where: { id: { equals: id } },
+    }
+
     // /////////////////////////////////////
     // Delete document
     // /////////////////////////////////////
 
-    let result: DataFromCollectionSlug<TSlug> = await req.payload.db.deleteOne({
-      collection: collectionConfig.slug,
-      req,
-      where: { id: { equals: id } },
+    let result: DataFromCollectionSlug<TSlug> = await req.payload.db.deleteOne(deleteArgs)
+
+    await payload.cache.invalidateCache(req, {
+      args: deleteArgs,
+      draft: 'all',
+      operation: 'deleteOne',
     })
 
     // /////////////////////////////////////

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -1,7 +1,7 @@
 import type { AccessResult } from '../../config/types.js'
 import type { FindArgs, PaginatedDocs, QueryDraftsArgs } from '../../database/types.js'
 import type { CollectionSlug } from '../../index.js'
-import type { PayloadRequest, Where } from '../../types/index.js'
+import type { Payload, PayloadRequest, Where } from '../../types/index.js'
 import type { Collection, DataFromCollectionSlug } from '../config/types.js'
 
 import executeAccess from '../../auth/executeAccess.js'

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -205,6 +205,7 @@ export const findOperation = async <TSlug extends CollectionSlug>(
       docs: await Promise.all(
         result.docs.map(async (doc) =>
           afterRead<DataFromCollectionSlug<TSlug>>({
+            cache,
             collection: collectionConfig,
             context: req.context,
             currentDepth,

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -1,5 +1,5 @@
 import type { AccessResult } from '../../config/types.js'
-import type { PaginatedDocs } from '../../database/types.js'
+import type { FindArgs, PaginatedDocs, QueryDraftsArgs } from '../../database/types.js'
 import type { CollectionSlug } from '../../index.js'
 import type { PayloadRequest, Where } from '../../types/index.js'
 import type { Collection, DataFromCollectionSlug } from '../config/types.js'
@@ -15,6 +15,7 @@ import { getQueryDraftsSort } from '../../versions/drafts/getQueryDraftsSort.js'
 import { buildAfterOperation } from './utils.js'
 
 export type Arguments = {
+  cache?: boolean
   collection: Collection
   currentDepth?: number
   depth?: number
@@ -54,6 +55,7 @@ export const findOperation = async <TSlug extends CollectionSlug>(
     }, Promise.resolve())
 
     const {
+      cache,
       collection: { config: collectionConfig },
       collection,
       currentDepth,
@@ -120,7 +122,7 @@ export const findOperation = async <TSlug extends CollectionSlug>(
         where: fullWhere,
       })
 
-      result = await payload.db.queryDrafts<DataFromCollectionSlug<TSlug>>({
+      const args: QueryDraftsArgs = {
         collection: collectionConfig.slug,
         limit: sanitizedLimit,
         locale,
@@ -129,7 +131,10 @@ export const findOperation = async <TSlug extends CollectionSlug>(
         req,
         sort: getQueryDraftsSort(sort),
         where: fullWhere,
-      })
+      }
+
+      if (cache) result = await payload.cache.find({ ...args, draft: true })
+      else result = await payload.db.queryDrafts<DataFromCollectionSlug<TSlug>>(args)
     } else {
       await validateQueryPaths({
         collectionConfig,
@@ -138,7 +143,7 @@ export const findOperation = async <TSlug extends CollectionSlug>(
         where,
       })
 
-      result = await payload.db.find<DataFromCollectionSlug<TSlug>>({
+      const args: FindArgs = {
         collection: collectionConfig.slug,
         limit: sanitizedLimit,
         locale,
@@ -147,7 +152,20 @@ export const findOperation = async <TSlug extends CollectionSlug>(
         req,
         sort,
         where: fullWhere,
-      })
+      }
+
+      if (cache) result = await payload.cache.find(args)
+      else
+        result = await payload.db.find<DataFromCollectionSlug<TSlug>>({
+          collection: collectionConfig.slug,
+          limit: sanitizedLimit,
+          locale,
+          page: sanitizedPage,
+          pagination,
+          req,
+          sort,
+          where: fullWhere,
+        })
     }
 
     // /////////////////////////////////////

--- a/packages/payload/src/collections/operations/local/count.ts
+++ b/packages/payload/src/collections/operations/local/count.ts
@@ -6,6 +6,7 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { countOperation } from '../count.js'
 
 export type Options<TSlug extends CollectionSlug> = {
+  cache?: boolean
   collection: TSlug
   /**
    * context, which will then be passed to req.context, which can be read by hooks
@@ -24,7 +25,13 @@ export default async function countLocal<TSlug extends CollectionSlug>(
   payload: Payload,
   options: Options<TSlug>,
 ): Promise<{ totalDocs: number }> {
-  const { collection: collectionSlug, disableErrors, overrideAccess = true, where } = options
+  const {
+    cache = false,
+    collection: collectionSlug,
+    disableErrors,
+    overrideAccess = true,
+    where,
+  } = options
 
   const collection = payload.collections[collectionSlug]
 
@@ -35,6 +42,7 @@ export default async function countLocal<TSlug extends CollectionSlug>(
   }
 
   return countOperation<TSlug>({
+    cache,
     collection,
     disableErrors,
     overrideAccess,

--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -8,6 +8,7 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findOperation } from '../find.js'
 
 export type Options<TSlug extends CollectionSlug> = {
+  cache?: boolean
   collection: TSlug
   /**
    * context, which will then be passed to req.context, which can be read by hooks
@@ -35,6 +36,7 @@ export async function findLocal<TSlug extends CollectionSlug>(
   options: Options<TSlug>,
 ): Promise<PaginatedDocs<DataFromCollectionSlug<TSlug>>> {
   const {
+    cache = false,
     collection: collectionSlug,
     currentDepth,
     depth,
@@ -58,6 +60,7 @@ export async function findLocal<TSlug extends CollectionSlug>(
   }
 
   return findOperation<TSlug>({
+    cache,
     collection,
     currentDepth,
     depth,

--- a/packages/payload/src/collections/operations/local/findByID.ts
+++ b/packages/payload/src/collections/operations/local/findByID.ts
@@ -7,6 +7,7 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findByIDOperation } from '../findByID.js'
 
 export type Options<TSlug extends CollectionSlug> = {
+  cache?: boolean
   collection: TSlug
   /**
    * context, which will then be passed to req.context, which can be read by hooks
@@ -31,6 +32,7 @@ export default async function findByIDLocal<TSlug extends CollectionSlug>(
 ): Promise<DataFromCollectionSlug<TSlug>> {
   const {
     id,
+    cache = false,
     collection: collectionSlug,
     currentDepth,
     depth,
@@ -50,6 +52,7 @@ export default async function findByIDLocal<TSlug extends CollectionSlug>(
 
   return findByIDOperation<TSlug>({
     id,
+    cache,
     collection,
     currentDepth,
     depth,

--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -10,6 +10,7 @@ import type {
 export type ServerOnlyRootProperties = keyof Pick<
   SanitizedConfig,
   | 'bin'
+  | 'cache'
   | 'cors'
   | 'csrf'
   | 'custom'
@@ -61,6 +62,7 @@ export const serverOnlyConfigProperties: readonly Partial<ServerOnlyRootProperti
   'csrf',
   'email',
   'custom',
+  'cache',
   'graphQL',
   // `admin`, `onInit`, `localization`, `collections`, and `globals` are all handled separately
 ]

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -11,6 +11,7 @@ import type {
 } from './types.js'
 
 import { defaultUserCollection } from '../auth/defaultUser.js'
+import { inMemoryDatabaseCache } from '../cache/in-memory-database-cache/InMemoryDatabaseCacheStorage.js'
 import { sanitizeCollection } from '../collections/config/sanitize.js'
 import { migrationsCollection } from '../database/migrations/migrationsCollection.js'
 import { InvalidConfiguration } from '../errors/index.js'
@@ -199,6 +200,8 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
     promises.push(sanitizeFunction(config as SanitizedConfig))
   }
   await Promise.all(promises)
+
+  config.cache = incomingConfig.cache ?? inMemoryDatabaseCache({})
 
   return config as SanitizedConfig
 }

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -31,8 +31,8 @@ import type {
 import type { DatabaseAdapterResult } from '../database/types.js'
 import type { EmailAdapter, SendEmailOptions } from '../email/types.js'
 import type { GlobalConfig, Globals, SanitizedGlobalConfig } from '../globals/config/types.js'
-import type { Payload, TypedUser } from '../index.js'
-import type { PayloadRequest, Where } from '../types/index.js'
+import type { DatabaseCache, Payload, TypedUser } from '../index.js'
+import type { CacheAdapter, PayloadRequest, Where } from '../types/index.js'
 import type { PayloadLogger } from '../utilities/logger.js'
 
 /**
@@ -704,6 +704,7 @@ export type Config = {
   }
   /** Custom Payload bin scripts can be injected via the config. */
   bin?: BinScriptConfig[]
+  cache?: DatabaseCache
   /**
    * Manage the datamodel of your application
    *
@@ -886,6 +887,7 @@ export type Config = {
 }
 
 export type SanitizedConfig = {
+  cache: DatabaseCache
   collections: SanitizedCollectionConfig[]
   /** Default richtext editor to use for richText fields */
   editor?: RichTextAdapter<any, any, any>

--- a/packages/payload/src/database/createDatabaseAdapter.ts
+++ b/packages/payload/src/database/createDatabaseAdapter.ts
@@ -7,6 +7,7 @@ import type {
   RollbackTransaction,
 } from './types.js'
 
+import { createDatabaseCache } from './cache/createDatabaseCache.js'
 import { createMigration } from './migrations/createMigration.js'
 import { migrate } from './migrations/migrate.js'
 import { migrateDown } from './migrations/migrateDown.js'
@@ -43,7 +44,6 @@ export function createDatabaseAdapter<T extends BaseDatabaseAdapter>(
     migrateReset,
     migrateStatus,
     rollbackTransaction,
-
     ...args,
 
     // Ensure migrationDir is set

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -1,6 +1,7 @@
 import type { TypeWithID } from '../collections/config/types.js'
 import type { Document, Payload, PayloadRequest, Where } from '../types/index.js'
 import type { TypeWithVersion } from '../versions/types.js'
+import type { DatabaseCache } from './cache/types.js'
 
 export type { TypeWithVersion }
 
@@ -10,6 +11,7 @@ export interface BaseDatabaseAdapter {
    * @returns an identifier for the transaction or null if one cannot be established
    */
   beginTransaction?: BeginTransaction
+
   /**
    * Persist the changes made since the start of the transaction.
    */
@@ -25,8 +27,8 @@ export interface BaseDatabaseAdapter {
   create: Create
 
   createGlobal: CreateGlobal
-
   createGlobalVersion: CreateGlobalVersion
+
   /**
    * Output a migration file
    */
@@ -42,8 +44,8 @@ export interface BaseDatabaseAdapter {
   deleteMany: DeleteMany
 
   deleteOne: DeleteOne
-
   deleteVersions: DeleteVersions
+
   /**
    * Terminate the connection with the database
    */
@@ -78,16 +80,15 @@ export interface BaseDatabaseAdapter {
    * Drop the current database and run all migrate up functions
    */
   migrateFresh: (args: { forceAcceptWarning?: boolean }) => Promise<void>
-
   /**
    * Run all migration down functions before running up
    */
   migrateRefresh: () => Promise<void>
+
   /**
    * Run all migrate down functions
    */
   migrateReset: () => Promise<void>
-
   /**
    * Read the current state of migrations and output the result to show which have been run
    */
@@ -100,16 +101,17 @@ export interface BaseDatabaseAdapter {
    * The name of the database adapter
    */
   name: string
+
   /**
    * reference to the instance of payload
    */
   payload: Payload
-
   queryDrafts: QueryDrafts
   /**
    * Abort any changes since the start of the transaction.
    */
   rollbackTransaction?: RollbackTransaction
+
   /**
    * A key-value store of all sessions open (used for transactions)
    */

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -273,6 +273,7 @@ export interface FieldBase {
     update?: FieldAccess
   }
   admin?: Admin
+  cacheIndex?: boolean
   /** Extension point to add your custom data. Server only. */
   custom?: Record<string, any>
   defaultValue?: any
@@ -305,6 +306,7 @@ export interface FieldBase {
    */
   typescriptSchema?: Array<(args: { jsonSchema: JSONSchema4 }) => JSONSchema4>
   unique?: boolean
+
   validate?: Validate
 }
 

--- a/packages/payload/src/fields/hooks/afterRead/index.ts
+++ b/packages/payload/src/fields/hooks/afterRead/index.ts
@@ -6,6 +6,7 @@ import { deepCopyObjectSimple } from '../../../utilities/deepCopyObject.js'
 import { traverseFields } from './traverseFields.js'
 
 type Args<T extends JsonObject> = {
+  cache?: boolean
   collection: SanitizedCollectionConfig | null
   context: RequestContext
   currentDepth?: number
@@ -34,6 +35,7 @@ type Args<T extends JsonObject> = {
 
 export async function afterRead<T extends JsonObject>(args: Args<T>): Promise<T> {
   const {
+    cache,
     collection,
     context,
     currentDepth: incomingCurrentDepth,
@@ -63,6 +65,7 @@ export async function afterRead<T extends JsonObject>(args: Args<T>): Promise<T>
   const currentDepth = incomingCurrentDepth || 1
 
   traverseFields({
+    cache,
     collection,
     context,
     currentDepth,

--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -12,6 +12,7 @@ import { relationshipPopulationPromise } from './relationshipPopulationPromise.j
 import { traverseFields } from './traverseFields.js'
 
 type Args = {
+  cache?: boolean
   collection: SanitizedCollectionConfig | null
   context: RequestContext
   currentDepth: number
@@ -54,6 +55,7 @@ type Args = {
 // - Populate relationships
 
 export const promise = async ({
+  cache,
   collection,
   context,
   currentDepth,
@@ -291,6 +293,7 @@ export const promise = async ({
     if (field.type === 'relationship' || field.type === 'upload') {
       populationPromises.push(
         relationshipPopulationPromise({
+          cache,
           currentDepth,
           depth,
           draft,

--- a/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -5,6 +5,7 @@ import { createDataloaderCacheKey } from '../../../collections/dataloader.js'
 import { fieldHasMaxDepth, fieldSupportsMany } from '../../config/types.js'
 
 type PopulateArgs = {
+  cache?: boolean
   currentDepth: number
   data: Record<string, unknown>
   dataReference: Record<string, any>
@@ -21,6 +22,7 @@ type PopulateArgs = {
 }
 
 const populate = async ({
+  cache,
   currentDepth,
   data,
   dataReference,
@@ -56,6 +58,7 @@ const populate = async ({
     if (shouldPopulate) {
       relationshipValue = await req.payloadDataLoader.load(
         createDataloaderCacheKey({
+          cache,
           collectionSlug: relatedCollection.config.slug,
           currentDepth: currentDepth + 1,
           depth,
@@ -96,6 +99,7 @@ const populate = async ({
 }
 
 type PromiseArgs = {
+  cache?: boolean
   currentDepth: number
   depth: number
   draft: boolean
@@ -109,6 +113,7 @@ type PromiseArgs = {
 }
 
 export const relationshipPopulationPromise = async ({
+  cache,
   currentDepth,
   depth,
   draft,
@@ -136,6 +141,7 @@ export const relationshipPopulationPromise = async ({
           siblingDoc[field.name][localeKey].forEach((relatedDoc, index) => {
             const rowPromise = async () => {
               await populate({
+                cache,
                 currentDepth,
                 data: siblingDoc[field.name][localeKey][index],
                 dataReference: resultingDoc,
@@ -160,6 +166,7 @@ export const relationshipPopulationPromise = async ({
         const rowPromise = async () => {
           if (relatedDoc) {
             await populate({
+              cache,
               currentDepth,
               data: relatedDoc,
               dataReference: resultingDoc,
@@ -188,6 +195,7 @@ export const relationshipPopulationPromise = async ({
     Object.keys(siblingDoc[field.name]).forEach((localeKey) => {
       const rowPromise = async () => {
         await populate({
+          cache,
           currentDepth,
           data: siblingDoc[field.name][localeKey],
           dataReference: resultingDoc,
@@ -208,6 +216,7 @@ export const relationshipPopulationPromise = async ({
     await Promise.all(rowPromises)
   } else if (siblingDoc[field.name]) {
     await populate({
+      cache,
       currentDepth,
       data: siblingDoc[field.name],
       dataReference: resultingDoc,

--- a/packages/payload/src/fields/hooks/afterRead/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/afterRead/traverseFields.ts
@@ -6,6 +6,7 @@ import type { Field, TabAsField } from '../../config/types.js'
 import { promise } from './promise.js'
 
 type Args = {
+  cache?: boolean
   collection: SanitizedCollectionConfig | null
   context: RequestContext
   currentDepth: number
@@ -34,6 +35,7 @@ type Args = {
 }
 
 export const traverseFields = ({
+  cache,
   collection,
   context,
   currentDepth,
@@ -60,6 +62,7 @@ export const traverseFields = ({
   fields.forEach((field) => {
     fieldPromises.push(
       promise({
+        cache,
         collection,
         context,
         currentDepth,

--- a/packages/payload/src/globals/operations/local/findOne.ts
+++ b/packages/payload/src/globals/operations/local/findOne.ts
@@ -7,6 +7,7 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findOneOperation } from '../findOne.js'
 
 export type Options<TSlug extends GlobalSlug> = {
+  cache?: boolean
   context?: RequestContext
   depth?: number
   draft?: boolean
@@ -25,6 +26,7 @@ export default async function findOneLocal<TSlug extends GlobalSlug>(
 ): Promise<DataFromGlobalSlug<TSlug>> {
   const {
     slug: globalSlug,
+    cache = false,
     depth,
     draft = false,
     overrideAccess = true,
@@ -39,6 +41,7 @@ export default async function findOneLocal<TSlug extends GlobalSlug>(
 
   return findOneOperation({
     slug: globalSlug as string,
+    cache,
     depth,
     draft,
     globalConfig,

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -18,6 +18,7 @@ import type { Result as LoginResult } from './auth/operations/login.js'
 import type { Result as ResetPasswordResult } from './auth/operations/resetPassword.js'
 import type { AuthStrategy, User } from './auth/types.js'
 import type { ImportMap } from './bin/generateImportMap/index.js'
+import type { DatabaseCache } from './cache/types.js'
 import type {
   BulkOperationResult,
   Collection,
@@ -146,6 +147,8 @@ export class BasePayload {
   }
 
   authStrategies: AuthStrategy[]
+
+  cache: DatabaseCache
 
   collections: {
     [slug: string]: Collection
@@ -600,6 +603,8 @@ export class BasePayload {
       })
     }
 
+    this.cache = this.config.cache
+
     if (!options.disableOnInit) {
       if (typeof options.onInit === 'function') await options.onInit(this)
       if (typeof this.config.onInit === 'function') await this.config.onInit(this)
@@ -706,6 +711,10 @@ export { generateImportMap } from './bin/generateImportMap/index.js'
 
 export type { ImportMap } from './bin/generateImportMap/index.js'
 export { genImportMapIterateFields } from './bin/generateImportMap/iterateFields.js'
+export { createDatabaseCache } from './cache/createDatabaseCache.js'
+export { inMemoryDatabaseCache } from './cache/in-memory-database-cache/index.js'
+export type { DatabaseCache, DatabaseCacheOptions, DatabaseCacheStorage } from './cache/types.js'
+
 export type { ClientCollectionConfig } from './collections/config/client.js'
 export type {
   ServerOnlyCollectionAdminProperties,
@@ -1055,10 +1064,10 @@ export { isValidID } from './utilities/isValidID.js'
 export { default as isolateObjectProperty } from './utilities/isolateObjectProperty.js'
 export { killTransaction } from './utilities/killTransaction.js'
 export { mapAsync } from './utilities/mapAsync.js'
+export { getDependencies }
 export { mergeListSearchAndWhere } from './utilities/mergeListSearchAndWhere.js'
 export { buildVersionCollectionFields } from './versions/buildCollectionFields.js'
 export { buildVersionGlobalFields } from './versions/buildGlobalFields.js'
-export { getDependencies }
 export { versionDefaults } from './versions/defaults.js'
 export { deleteCollectionVersions } from './versions/deleteCollectionVersions.js'
 export { enforceMaxVersions } from './versions/enforceMaxVersions.js'

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -5,6 +5,7 @@ import type { TypeWithID, TypeWithTimestamps } from '../collections/config/types
 import type payload from '../index.js'
 import type { TypedLocale, TypedUser } from '../index.js'
 import type { validOperators } from './constants.js'
+
 export type { Payload as Payload } from '../index.js'
 
 export type CustomPayloadRequestProperties = {

--- a/packages/payload/src/utilities/getFieldsCacheIndexes.ts
+++ b/packages/payload/src/utilities/getFieldsCacheIndexes.ts
@@ -1,0 +1,24 @@
+import { type Field, tabHasName } from '../fields/config/types.js'
+
+export const getFieldsCacheIndexes = (fields: Field[]) => {
+  let cacheIndexes: string[] = []
+
+  fields.forEach((field) => {
+    if ('cacheIndex' in field && 'name' in field && field.cacheIndex) {
+      cacheIndexes.push(field.name)
+    }
+
+    if (field.type === 'row' || field.type === 'collapsible') {
+      cacheIndexes = [...cacheIndexes, ...getFieldsCacheIndexes(field.fields)]
+    }
+
+    if (field.type === 'tabs') {
+      field.tabs.forEach((tab) => {
+        if (tabHasName(tab)) return
+        cacheIndexes = [...cacheIndexes, ...getFieldsCacheIndexes(tab.fields)]
+      })
+    }
+  })
+
+  return cacheIndexes
+}

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -1,6 +1,7 @@
 import { BlocksFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
+import { inMemoryDatabaseCache } from 'payload'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
@@ -12,6 +13,7 @@ const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
   // ...extend config here
+  cache: inMemoryDatabaseCache({ logging: true }),
   collections: [
     PostsCollection,
     {

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -1,3 +1,4 @@
+import { nextDatabaseCache } from '@payloadcms/next/cache'
 import { BlocksFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
 import { fileURLToPath } from 'node:url'
 import path from 'path'


### PR DESCRIPTION
## Description

Adds an implementation of caching to Payload.

### Usage
Simply providing `cache: true` into args will cache the current operation:

```ts
payload.find({ cache: true, collection: 'posts' })
payload.findByID({ id: 1, cache: true, collection: 'posts' })
payload.count({ cache: true, collection: 'posts' })
payload.findGlobal({ cache: true, slug: 'header' })
```

With the REST API - query parameter `?cache=true`.

### Configuration / cache adapters

By default, if `cache` is not provided - `inMemoryDatabaseCache` will be used.
Any implemented database cache adapter accepts `logging` and `ttl` options.
Example of `logging: true` - useful for debugging
![image](https://github.com/user-attachments/assets/0c548711-4e0a-4558-b99d-6b52ed9f01b8)
![image](https://github.com/user-attachments/assets/d4522cee-4fbe-4b29-a5b8-425aa7e46071)

`ttl` - Time To Live for the cached values, by default it's 1 hour. Providing `false` will disable TTL.
```ts
import { inMemoryDatabaseCache } from 'payload'
import { nextDatabaseCache } from '@payloadcms/next/cache'

export default buildConfig({
  // ...config here
  cache: inMemoryDatabaseCache({ logging: true, ttl: 100000  }),
})

// 
export default buildConfig({
  // ...config here
  cache: nextDatabaseCache({ logging: true, ttl: 100000  }),
})
```

`inMemoryDatabaseCache` probably won't work well on a server-less envs like Vercel!

### Fields Cache Indexes
By default, only `id` field is used for revalidation of the `findOne` calls, you can provide `cacheIndex: true` to a needed field (for example a common one - slug).
```ts
 {
          name: "slug",
          type: "text",
          cacheIndex:true
}
``` 
 

The implementation as well handles the cache invalidation for us, no need to write revalidation hooks more!
That means if you're using `nextDatabaseCache` - ISR should happen automatically as well. This also includes `depth` parameter handling.

Underlying API calls `payload.db` directly and stores its result into the implemented storage.
You can use it like this:

```ts
// important to pass 'req' with 'payload' inside
payload.cache.count({collection: "posts",req, where:{}})
```



`ttl` can as well be resolved dynamically via `TTLResolveFunction`.
```ts
export type TTLResolveFunction = (
  args: { draft?: boolean } & (
    | {
        operation: 'count'
        operationArgs: CountArgs
      }
    | {
        operation: 'find'
        operationArgs: FindArgs
      }
    | {
        operation: 'findGlobal'
        operationArgs: FindGlobalArgs
      }
    | {
        operation: 'findOne'
        operationArgs: FindOneArgs
      }
  ),
) => false | number
```

 No tests / docs and probably some things don't work normally yet

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
