### PR TITLE
fix: prevent vertical scrolling on tab fields

### DIFF
--- a/packages/ui/src/fields/Tabs/index.scss
+++ b/packages/ui/src/fields/Tabs/index.scss
@@ -29,7 +29,8 @@
   }
 
   &__tabs-wrap {
-    overflow: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
     margin-bottom: $baseline;
   }
 


### PR DESCRIPTION
## Description

Prevents tabs fields from displaying vertical scrollbars in certain cases with different viewports/zoom levels.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
