### PR TITLE
fix(ui): relationship cells in table from list drawer not shown

### DIFF
--- a/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
@@ -131,7 +131,11 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
   const isOpen = isModalOpen(drawerSlug)
   const apiURL = isOpen ? `${serverURL}${api}/${selectedCollectionConfig.slug}` : null
   const [cacheBust, dispatchCacheBust] = useReducer((state) => state + 1, 0) // used to force a re-fetch even when apiURL is unchanged
-  const [{ data, isError, isLoading: isLoadingList }, { setParams }] = usePayloadAPI(apiURL, {})
+  const [{ data, isError, isLoading: isLoadingList }, { setParams }] = usePayloadAPI(apiURL, {
+    initialParams: {
+      depth: 0,
+    },
+  })
   const moreThanOneAvailableCollection = enabledCollectionConfigs.length > 1
 
   useEffect(() => {
@@ -142,13 +146,16 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
     } = selectedCollectionConfig
     const params: {
       cacheBust?: number
+      depth?: number
       draft?: string
       limit?: number
       page?: number
       search?: string
       sort?: string
       where?: unknown
-    } = {}
+    } = {
+      depth: 0,
+    }
 
     let copyOfWhere = { ...(where || {}) }
     const filterOption = filterOptions?.[slug]


### PR DESCRIPTION
Also a nice performance improvement. The list drawer was previously fetching data with depth 1. This will cause the relationship cell to break, as it expects the relationship data to be a string/number, not a populated object with the id inside.

Now, it fetches using depth 0 - same as the normal list view