### PR TITLE
feat(db-postgres): create database automatically if it doesn't exist

### DIFF
--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -34,7 +34,7 @@ export default buildConfig({
 ## Options
 
 | Option                      | Description                                                                                                                                                                      |
-|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `pool` \*                   | [Pool connection options](https://orm.drizzle.team/docs/quick-postgresql/node-postgres) that will be passed to Drizzle and `node-postgres`.                                      |
 | `push`                      | Disable Drizzle's [`db push`](https://orm.drizzle.team/kit-docs/overview#prototyping-with-db-push) in development mode. By default, `push` is enabled for development mode only. |
 | `migrationDir`              | Customize the directory that migrations are stored.                                                                                                                              |
@@ -42,6 +42,7 @@ export default buildConfig({
 | `schemaName` (experimental) | A string for the postgres schema to use, defaults to 'public'.                                                                                                                   |
 | `idType`                    | A string of 'serial', or 'uuid' that is used for the data type given to id columns.                                                                                              |
 | `transactionOptions`        | A PgTransactionConfig object for transactions, or set to `false` to disable using transactions. [More details](https://orm.drizzle.team/docs/transactions)                       |
+| `createDatabase`            | Create the provided database automatically if it doesn't exist. Defaults to `true`.                                                                                                        |
 | `localesSuffix`             | A string appended to the end of table names for storing localized fields. Default is '_locales'.                                                                                 |
 | `relationshipsSuffix`       | A string appended to the end of table names for storing relationships. Default is '_rels'.                                                                                       |
 | `versionsSuffix`            | A string appended to the end of table names for storing versions. Defaults to '_v'.                                                                                              |

--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -85,9 +85,10 @@ export const connect: Connect = async function connect(
         await this.connect(options)
         return
       }
-    } else
+    } else {
       this.payload.logger.error(`Error: cannot connect to Postgres. Details: ${err.message}`, err)
-    this.payload.logger.error(`Error: cannot connect to Postgres. Details: ${err.message}`, err)
+    }
+
     if (typeof this.rejectInitializing === 'function') this.rejectInitializing()
     process.exit(1)
   }

--- a/packages/db-postgres/src/createDatabase.ts
+++ b/packages/db-postgres/src/createDatabase.ts
@@ -1,6 +1,6 @@
 import type { ClientConfig } from 'pg'
 
-import * as pg from 'pg'
+import pg from 'pg'
 
 import type { PostgresAdapter } from './types.js'
 

--- a/packages/db-postgres/src/createDatabase.ts
+++ b/packages/db-postgres/src/createDatabase.ts
@@ -1,6 +1,6 @@
 import type { ClientConfig } from 'pg'
 
-import { Client } from 'pg'
+import * as pg from 'pg'
 
 import type { PostgresAdapter } from './types.js'
 
@@ -25,7 +25,7 @@ export const createDatabase = async (adapter: PostgresAdapter): Promise<boolean>
     }
   }
 
-  const managementClient = new Client(managementClientConfig)
+  const managementClient = new pg.Client(managementClientConfig)
 
   try {
     await managementClient.connect()

--- a/packages/db-postgres/src/createDatabase.ts
+++ b/packages/db-postgres/src/createDatabase.ts
@@ -1,0 +1,47 @@
+import type { ClientConfig } from 'pg'
+
+import { Client } from 'pg'
+
+import type { PostgresAdapter } from './types.js'
+
+export const createDatabase = async (adapter: PostgresAdapter): Promise<boolean> => {
+  let managementClientConfig: ClientConfig = {}
+  let dbName: string
+
+  if (adapter.poolOptions.connectionString) {
+    const connectionURL = new URL(adapter.poolOptions.connectionString)
+
+    dbName = connectionURL.pathname.slice(1)
+
+    const managementConnectionURL = new URL(connectionURL)
+
+    managementConnectionURL.pathname = '/postgres'
+    managementClientConfig.connectionString = managementConnectionURL.toString()
+  } else {
+    dbName = adapter.poolOptions.database
+    managementClientConfig = {
+      ...adapter.poolOptions,
+      database: 'postgres',
+    }
+  }
+
+  const managementClient = new Client(managementClientConfig)
+
+  try {
+    await managementClient.connect()
+    await managementClient.query(`CREATE DATABASE ${dbName}`)
+
+    adapter.payload.logger.info(`Created database ${dbName}`)
+
+    return true
+  } catch (err) {
+    adapter.payload.logger.error(
+      `Error: failed to create database ${dbName}. Details: ${err.message}`,
+      err,
+    )
+
+    return false
+  } finally {
+    await managementClient.end?.()
+  }
+}

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -78,6 +78,7 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
 
     return createDatabaseAdapter<PostgresAdapter>({
       name: 'postgres',
+      createDatabase: args.createDatabase ?? true,
       defaultDrizzleSnapshot,
       drizzle: undefined,
       enums: {},

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -34,7 +34,6 @@ export type Args = {
    */
   schemaName?: string
   transactionOptions?: PgTransactionConfig | false
-
   versionsSuffix?: string
 }
 

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -11,6 +11,11 @@ import type { PgSchema, PgTableFn, PgTransactionConfig } from 'drizzle-orm/pg-co
 import type { Pool, PoolConfig } from 'pg'
 
 export type Args = {
+  /**
+   * Create the provided database if it doesn't exist
+   * @default true
+   */
+  createDatabase?: boolean
   idType?: 'serial' | 'uuid'
   localesSuffix?: string
   logger?: DrizzleConfig['logger']
@@ -29,6 +34,7 @@ export type Args = {
    */
   schemaName?: string
   transactionOptions?: PgTransactionConfig | false
+
   versionsSuffix?: string
 }
 

--- a/packages/drizzle/src/postgres/types.ts
+++ b/packages/drizzle/src/postgres/types.ts
@@ -93,6 +93,7 @@ type Schema =
 
 export type BasePostgresAdapter = {
   countDistinct: CountDistinct
+  createDatabase: boolean
   defaultDrizzleSnapshot: DrizzleSnapshotJSON
   deleteWhere: DeleteWhere
   drizzle: PostgresDB


### PR DESCRIPTION
## Description

QoL improve - adds abillity to create a database if it doesn't exist. Opt-out, most of the tools (like Prisma) do that too from my experience
https://github.com/payloadcms/payload/discussions/7734 - initially I thought to add this only in the dev mode, but don't see a reason why only there

To disable:
```ts
posgresAdapter({
  createDatabase: false
})
```

To test:
```sh
 POSTGRES_URL="postgresql://127.0.0.1:5432/some-dbt?schema=public" pnpm test:int:postgres database  
```

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
