### PR TITLE
fix: useField incorrect initialization of errorMessage on update

### DIFF
--- a/packages/ui/src/forms/useField/index.tsx
+++ b/packages/ui/src/forms/useField/index.tsx
@@ -156,7 +156,7 @@ export const useField = <T,>(options: Options): FieldType<T> => {
           valueToValidate = getDataByPath(path)
         }
 
-        let errorMessage: string | undefined
+        let errorMessage: string | undefined = prevErrorMessage.current
         let valid: boolean | string = prevValid.current
 
         const isValid =


### PR DESCRIPTION
## Description

The `useField` hook was not properly initializing the errorMessage value when syncing form data.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
