### PR TITLE
fix: migrate error on windows

### DIFF
--- a/packages/payload/src/database/migrations/readMigrationFiles.ts
+++ b/packages/payload/src/database/migrations/readMigrationFiles.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import { pathToFileURL } from 'node:url'
 import path from 'path'
 
 import type { Payload } from '../../index.js'
@@ -35,9 +36,10 @@ export const readMigrationFiles = async ({
 
   return Promise.all(
     files.map(async (filePath) => {
+      const filename = pathToFileURL(filePath)
       // eval used to circumvent errors bundling
       let migration = await eval(
-        `${typeof require === 'function' ? 'require' : 'import'}('${filePath.replaceAll('\\', '/')}')`,
+        `${typeof require === 'function' ? 'require' : 'import'}('${filename.href}')`,
       )
       if ('default' in migration) migration = migration.default
 

--- a/packages/payload/src/database/migrations/readMigrationFiles.ts
+++ b/packages/payload/src/database/migrations/readMigrationFiles.ts
@@ -36,11 +36,11 @@ export const readMigrationFiles = async ({
 
   return Promise.all(
     files.map(async (filePath) => {
-      const filename = pathToFileURL(filePath)
       // eval used to circumvent errors bundling
-      let migration = await eval(
-        `${typeof require === 'function' ? 'require' : 'import'}('${filename.href}')`,
-      )
+      let migration =
+        typeof require === 'function'
+          ? await eval(`require('${filePath.replaceAll('\\', '/')}')`)
+          : await eval(`import('${pathToFileURL(filePath).href}')`)
       if ('default' in migration) migration = migration.default
 
       const result: Migration = {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -121,24 +121,21 @@ describe('database', () => {
   })
 
   describe('migrations', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       if (process.env.PAYLOAD_DROP_DATABASE === 'true' && 'drizzle' in payload.db) {
         const db = payload.db as unknown as PostgresAdapter
         await db.dropDatabase({ adapter: db })
       }
-    })
-
-    afterAll(() => {
       removeFiles(path.join(dirname, './migrations'))
-    })
 
-    it('should run migrate:create', async () => {
       await payload.db.createMigration({
         forceAcceptWarning: true,
         migrationName: 'test',
         payload,
       })
+    })
 
+    it('should run migrate:create', () => {
       // read files names in migrationsDir
       const migrationFile = path.normalize(fs.readdirSync(payload.db.migrationDir)[0])
       expect(migrationFile).toContain('_test')


### PR DESCRIPTION
handle windows compatible file names when reading migrations