### PR TITLE
fix: postgres migrate args

### DIFF
--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -53,8 +53,6 @@ import type { Args, PostgresAdapter } from './types.js'
 
 import { connect } from './connect.js'
 
-export type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/drizzle/postgres'
-
 export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter> {
   const postgresIDType = args.idType || 'serial'
   const payloadIDType = postgresIDType === 'serial' ? 'number' : 'text'
@@ -160,4 +158,5 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
   }
 }
 
+export type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/drizzle/postgres'
 export { sql } from 'drizzle-orm'

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -53,7 +53,7 @@ import type { Args, PostgresAdapter } from './types.js'
 
 import { connect } from './connect.js'
 
-export { sql } from 'drizzle-orm'
+export type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/drizzle/postgres'
 
 export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter> {
   const postgresIDType = args.idType || 'serial'
@@ -159,3 +159,5 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
     init: adapter,
   }
 }
+
+export { sql } from 'drizzle-orm'


### PR DESCRIPTION
## Description

Replaces the export of `MigrateUpArgs` and `MigrateDownArgs` from `db-postgres`