### PR TITLE
fix(ui): text clipping on document header title with Segoe UI font

### DIFF
--- a/packages/next/src/elements/DocumentHeader/index.scss
+++ b/packages/next/src/elements/DocumentHeader/index.scss
@@ -27,7 +27,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     margin: 0;
-    padding-bottom: base(0.2);
+    padding-bottom: base(0.4);
     line-height: 1;
     vertical-align: top;
   }


### PR DESCRIPTION
## Description

Fixes text clipping that occurs on the document header title when Segoe UI font is used in the admin panel.

Before:
![localhost_3001_admin_collections_text-fields_66c4cca94e18815cbb19b475](https://github.com/user-attachments/assets/4a0819d1-a75c-4fae-a6c7-33d05f60d849)

After:
![localhost_3001_admin_collections_text-fields_66c4cca94e18815cbb19b475 (1)](https://github.com/user-attachments/assets/82fa3b58-83b5-4db4-944d-3e9fceb76ad3)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
