### PR TITLE
feat: extends Button and extracts ListHeader components

### DIFF
--- a/packages/next/src/views/List/Default/index.scss
+++ b/packages/next/src/views/List/Default/index.scss
@@ -16,7 +16,8 @@
       text-decoration: none;
     }
 
-    .btn__wrap {
+    .btn--withoutPopup,
+    .btn--withPopup {
       position: relative;
       margin: 0 0 base(0.2);
     }

--- a/packages/next/src/views/List/Default/index.scss
+++ b/packages/next/src/views/List/Default/index.scss
@@ -11,21 +11,12 @@
     }
   }
 
-  &__header {
-    display: flex;
-    align-items: flex-end;
-    flex-wrap: wrap;
-    gap: base(0.8);
-
-    h1 {
-      margin: 0;
-    }
-
+  .list-header {
     a {
       text-decoration: none;
     }
 
-    .pill {
+    .btn__wrap {
       position: relative;
       margin: 0 0 base(0.2);
     }

--- a/packages/next/src/views/List/Default/index.tsx
+++ b/packages/next/src/views/List/Default/index.tsx
@@ -13,7 +13,7 @@ import {
   ListSelection,
   Pagination,
   PerPage,
-  Pill,
+  PopupList,
   PublishMany,
   RelationshipProvider,
   RenderComponent,
@@ -108,14 +108,18 @@ export const DefaultListView: React.FC = () => {
           {Header || (
             <ListHeader heading={getTranslation(labels?.plural, i18n)}>
               {hasCreatePermission && (
-                <Pill
+                <Button
+                  Link={Link}
                   aria-label={i18n.t('general:createNewLabel', {
                     label: getTranslation(labels?.singular, i18n),
                   })}
+                  buttonStyle="pill"
+                  el="link"
+                  size="small"
                   to={newDocumentURL}
                 >
                   {i18n.t('general:createNew')}
-                </Pill>
+                </Button>
               )}
               {!smallBreak && (
                 <ListSelection label={getTranslation(collectionConfig.labels.plural, i18n)} />

--- a/packages/next/src/views/List/Default/index.tsx
+++ b/packages/next/src/views/List/Default/index.tsx
@@ -9,6 +9,7 @@ import {
   EditMany,
   Gutter,
   ListControls,
+  ListHeader,
   ListSelection,
   Pagination,
   PerPage,
@@ -104,35 +105,32 @@ export const DefaultListView: React.FC = () => {
       <RenderComponent mappedComponent={beforeList} />
       <SelectionProvider docs={data.docs} totalDocs={data.totalDocs}>
         <Gutter className={`${baseClass}__wrap`}>
-          <header className={`${baseClass}__header`}>
-            {Header || (
-              <Fragment>
-                <h1>{getTranslation(labels?.plural, i18n)}</h1>
-                {hasCreatePermission && (
-                  <Pill
-                    aria-label={i18n.t('general:createNewLabel', {
-                      label: getTranslation(labels?.singular, i18n),
-                    })}
-                    to={newDocumentURL}
-                  >
-                    {i18n.t('general:createNew')}
-                  </Pill>
-                )}
-                {!smallBreak && (
-                  <ListSelection label={getTranslation(collectionConfig.labels.plural, i18n)} />
-                )}
-                {description && (
-                  <div className={`${baseClass}__sub-header`}>
-                    <RenderComponent
-                      Component={ViewDescription}
-                      clientProps={{ description }}
-                      mappedComponent={Description}
-                    />
-                  </div>
-                )}
-              </Fragment>
-            )}
-          </header>
+          {Header || (
+            <ListHeader heading={getTranslation(labels?.plural, i18n)}>
+              {hasCreatePermission && (
+                <Pill
+                  aria-label={i18n.t('general:createNewLabel', {
+                    label: getTranslation(labels?.singular, i18n),
+                  })}
+                  to={newDocumentURL}
+                >
+                  {i18n.t('general:createNew')}
+                </Pill>
+              )}
+              {!smallBreak && (
+                <ListSelection label={getTranslation(collectionConfig.labels.plural, i18n)} />
+              )}
+              {description && (
+                <div className={`${baseClass}__sub-header`}>
+                  <RenderComponent
+                    Component={ViewDescription}
+                    clientProps={{ description }}
+                    mappedComponent={Description}
+                  />
+                </div>
+              )}
+            </ListHeader>
+          )}
           <ListControls collectionConfig={collectionConfig} fields={fields} />
           <RenderComponent mappedComponent={beforeListTable} />
           {!data.docs && (
@@ -174,7 +172,7 @@ export const DefaultListView: React.FC = () => {
                 limit={data.limit}
                 nextPage={data.nextPage}
                 numberOfNeighbors={1}
-                onChange={handlePageChange}
+                onChange={(page) => void handlePageChange(page)}
                 page={data.page}
                 prevPage={data.prevPage}
                 totalPages={data.totalPages}
@@ -189,7 +187,7 @@ export const DefaultListView: React.FC = () => {
                     {i18n.t('general:of')} {data.totalDocs}
                   </div>
                   <PerPage
-                    handleChange={handlePerPageChange}
+                    handleChange={(limit) => void handlePerPageChange(limit)}
                     limit={
                       isNumber(searchParams?.limit) ? Number(searchParams.limit) : defaultLimit
                     }

--- a/packages/ui/src/elements/Button/index.scss
+++ b/packages/ui/src/elements/Button/index.scss
@@ -111,7 +111,7 @@ a.btn {
 
   color: var(--color, inherit);
   background-color: var(--bg-color, transparent);
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--box-shado, none);
 
   .icon {
     @include color-svg(var(--color));

--- a/packages/ui/src/elements/Button/index.scss
+++ b/packages/ui/src/elements/Button/index.scss
@@ -39,7 +39,7 @@ a.btn {
       --color: var(--theme-elevation-200);
       --box-shadow: inset 0 0 0 1px var(--theme-elevation-200);
       --hover-box-shadow: inset 0 0 0 1px var(--theme-elevation-200);
-      --hover-color: var(--theme-elevation-200);
+      --hover-color: var(--color);
     }
   }
 
@@ -48,6 +48,12 @@ a.btn {
     --color: var(--theme-elevation-800);
     --hover-color: var(--color);
     --hover-bg: var(--theme-elevation-100);
+
+    &.btn--disabled {
+      --color: var(--theme-elevation-600);
+      --hover-bg: var(--bg-color);
+      --hover-color: var(--color);
+    }
   }
 }
 

--- a/packages/ui/src/elements/Button/index.scss
+++ b/packages/ui/src/elements/Button/index.scss
@@ -4,7 +4,7 @@ a.btn {
   display: inline-block;
 }
 
-.btn__wrap {
+.btn--withPopup {
   margin-block: 24px;
   .btn {
     margin: 0;
@@ -12,7 +12,85 @@ a.btn {
 }
 
 .btn {
-  background: transparent;
+  // colors
+  &--style-primary {
+    --color: var(--theme-elevation-0);
+    --bg-color: var(--theme-elevation-800);
+    --box-shadow: none;
+    --hover-bg: var(--theme-elevation-600);
+    --hover-color: var(--color);
+
+    &.btn--disabled {
+      --bg-color: var(--theme-elevation-200);
+      --color: var(--theme-elevation-800);
+      --hover-bg: var(--bg-color);
+      --hover-color: var(--color);
+    }
+  }
+
+  &--style-secondary {
+    --color: var(--theme-text);
+    --bg-color: transparent;
+    --box-shadow: inset 0 0 0 1px var(--theme-elevation-800);
+    --hover-color: var(--theme-elevation-600);
+    --hover-box-shadow: inset 0 0 0 1px var(--theme-elevation-400);
+
+    &.btn--disabled {
+      --color: var(--theme-elevation-200);
+      --box-shadow: inset 0 0 0 1px var(--theme-elevation-200);
+      --hover-box-shadow: inset 0 0 0 1px var(--theme-elevation-200);
+      --hover-color: var(--theme-elevation-200);
+    }
+  }
+
+  &--style-pill {
+    --bg-color: var(--theme-elevation-150);
+    --color: var(--theme-elevation-800);
+    --hover-color: var(--color);
+    --hover-bg: var(--theme-elevation-100);
+  }
+}
+
+.btn--withPopup {
+  .popup-button {
+    color: var(--color, inherit);
+    background-color: var(--bg-color);
+    box-shadow: var(--box-shadow);
+    border-radius: $style-radius-m;
+    border-left: 1px solid var(--theme-bg);
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    align-items: center;
+
+    &:hover,
+    &:focus-visible,
+    &:focus,
+    &:active {
+      background-color: var(--hover-bg);
+      color: var(--hover-color);
+      box-shadow: var(--hover-box-shadow);
+    }
+  }
+}
+
+.btn,
+.btn--withPopup .btn {
+  &:hover,
+  &:focus-visible,
+  &:focus,
+  &:active {
+    color: var(--hover-color);
+    box-shadow: var(--hover-box-shadow);
+    background-color: var(--hover-bg);
+  }
+}
+
+.btn--disabled,
+.btn--disabled .btn {
+  cursor: not-allowed;
+}
+
+.btn {
   border-radius: $style-radius-s;
   font-size: var(--base-body-size);
   margin-block: base(1.2);
@@ -21,10 +99,17 @@ a.btn {
   cursor: pointer;
   font-weight: normal;
   text-decoration: none;
-  color: inherit;
   transition-property: border, color, box-shadow, background;
   transition-duration: 100ms;
   transition-timing-function: cubic-bezier(0, 0.2, 0.2, 1);
+
+  color: var(--color, inherit);
+  background-color: var(--bg-color, transparent);
+  box-shadow: var(--box-shadow);
+
+  .icon {
+    @include color-svg(var(--color));
+  }
 
   &__content {
     display: flex;
@@ -54,7 +139,7 @@ a.btn {
     }
   }
 
-  &__wrap {
+  &--withPopup {
     display: flex;
   }
 
@@ -138,51 +223,9 @@ a.btn {
     }
   }
 
-  &--has-secondary-actions {
+  &--withPopup .btn {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
-  }
-
-  &--style-primary {
-    background: var(--theme-elevation-800);
-    color: var(--theme-elevation-0);
-
-    &.btn--disabled {
-      background: var(--theme-elevation-200);
-    }
-
-    &:not(.btn--disabled) {
-      &:hover,
-      &:focus-visible,
-      &:focus,
-      &:active {
-        background: var(--theme-elevation-600);
-      }
-    }
-
-    .icon {
-      @include color-svg(var(--theme-elevation-0));
-    }
-  }
-
-  &--style-secondary {
-    box-shadow: inset 0 0 0 1px var(--theme-elevation-800);
-    color: var(--theme-text);
-
-    &.btn--disabled {
-      color: var(--theme-elevation-200);
-      box-shadow: inset 0 0 0 1px var(--theme-elevation-200);
-    }
-
-    &:not(.btn--disabled) {
-      &:hover,
-      &:focus-visible,
-      &:focus,
-      &:active {
-        color: var(--theme-elevation-600);
-        box-shadow: inset 0 0 0 1px var(--theme-elevation-400);
-      }
-    }
   }
 
   &--style-icon-label,
@@ -198,40 +241,6 @@ a.btn {
 
   &--style-none {
     padding: 0;
-  }
-
-  &__chevron {
-    @include color-svg(currentColor);
-    border-radius: $style-radius-m;
-    border-left: 1px solid var(--theme-bg) !important;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    align-items: center;
-
-    .icon {
-      vertical-align: middle;
-
-      & path {
-        stroke-width: 1px;
-      }
-    }
-
-    &--disabled {
-      .popup__trigger-wrap {
-        display: none;
-      }
-    }
-
-    &--open {
-      .icon {
-        transform: rotate(180deg);
-      }
-    }
-
-    &:focus:not(:focus-visible) {
-      box-shadow: none;
-      background: var(--theme-elevation-700);
-    }
   }
 
   &:focus:not(:focus-visible) {

--- a/packages/ui/src/elements/Button/index.scss
+++ b/packages/ui/src/elements/Button/index.scss
@@ -4,6 +4,13 @@ a.btn {
   display: inline-block;
 }
 
+.btn__wrap {
+  margin-block: 24px;
+  .btn {
+    margin: 0;
+  }
+}
+
 .btn {
   background: transparent;
   border-radius: $style-radius-s;
@@ -45,6 +52,10 @@ a.btn {
     &.btn--size-small {
       padding: base(0.2);
     }
+  }
+
+  &__wrap {
+    display: flex;
   }
 
   &--has-tooltip {
@@ -127,6 +138,11 @@ a.btn {
     }
   }
 
+  &--has-secondary-actions {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
   &--style-primary {
     background: var(--theme-elevation-800);
     color: var(--theme-elevation-0);
@@ -182,6 +198,40 @@ a.btn {
 
   &--style-none {
     padding: 0;
+  }
+
+  &__chevron {
+    @include color-svg(currentColor);
+    border-radius: $style-radius-m;
+    border-left: 1px solid var(--theme-bg) !important;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    align-items: center;
+
+    .icon {
+      vertical-align: middle;
+
+      & path {
+        stroke-width: 1px;
+      }
+    }
+
+    &--disabled {
+      .popup__trigger-wrap {
+        display: none;
+      }
+    }
+
+    &--open {
+      .icon {
+        transform: rotate(180deg);
+      }
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
+      background: var(--theme-elevation-700);
+    }
   }
 
   &:focus:not(:focus-visible) {

--- a/packages/ui/src/elements/Button/index.scss
+++ b/packages/ui/src/elements/Button/index.scss
@@ -111,7 +111,7 @@ a.btn {
 
   color: var(--color, inherit);
   background-color: var(--bg-color, transparent);
-  box-shadow: var(--box-shado, none);
+  box-shadow: var(--box-shadow, none);
 
   .icon {
     @include color-svg(var(--color));

--- a/packages/ui/src/elements/Button/index.tsx
+++ b/packages/ui/src/elements/Button/index.tsx
@@ -9,6 +9,8 @@ import { LinkIcon } from '../../icons/Link/index.js'
 import { PlusIcon } from '../../icons/Plus/index.js'
 import { SwapIcon } from '../../icons/Swap/index.js'
 import { XIcon } from '../../icons/X/index.js'
+import { ButtonGroup, Button as PopupButton } from '../Popup/PopupButtonList/index.js'
+import { Popup } from '../Popup/index.js'
 import { Tooltip } from '../Tooltip/index.js'
 import './index.scss'
 
@@ -46,6 +48,47 @@ export const ButtonContents = ({ children, icon, showTooltip, tooltip }) => {
   )
 }
 
+const SecondaryActions = ({ className, disabled, secondaryActions }) => {
+  const [showSecondaryActions, setShowSecondaryActions] = React.useState<boolean>(false)
+  const multipleActions = secondaryActions.length >= 1
+
+  React.useEffect(() => {
+    if (disabled) setShowSecondaryActions(false)
+  }, [disabled])
+
+  return (
+    <Popup
+      button={<ChevronIcon />}
+      buttonClassName={[
+        className && className,
+        `${baseClass}__chevron`,
+        showSecondaryActions && `${baseClass}__chevron--open`,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      className={disabled ? `${baseClass}--popup-disabled` : ''}
+      disabled={disabled}
+      horizontalAlign="right"
+      noBackground
+      onToggleOpen={(active) => (!disabled ? setShowSecondaryActions(active) : undefined)}
+      size="large"
+      verticalAlign="bottom"
+    >
+      <ButtonGroup>
+        {multipleActions ? (
+          secondaryActions.map((action, i) => (
+            <PopupButton key={i} onClick={action.onClick}>
+              {action.label}
+            </PopupButton>
+          ))
+        ) : (
+          <PopupButton onClick={secondaryActions.onClick}>{secondaryActions.label}</PopupButton>
+        )}
+      </ButtonGroup>
+    </Popup>
+  )
+}
+
 export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((props, ref) => {
   const {
     id,
@@ -63,6 +106,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((
     newTab,
     onClick,
     round,
+    secondaryActions,
     size = 'medium',
     to,
     tooltip,
@@ -83,6 +127,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((
     size && `${baseClass}--size-${size}`,
     icon && iconPosition && `${baseClass}--icon-position-${iconPosition}`,
     tooltip && `${baseClass}--has-tooltip`,
+    secondaryActions && `${baseClass}--has-secondary-actions`,
   ]
     .filter(Boolean)
     .join(' ')
@@ -107,6 +152,8 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((
     target: newTab ? '_blank' : undefined,
   }
 
+  let buttonElement
+
   switch (el) {
     case 'link':
       if (!Link) {
@@ -114,32 +161,44 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((
         return null
       }
 
-      return (
+      buttonElement = (
         <Link {...buttonProps} href={to || url} to={to || url}>
           <ButtonContents icon={icon} showTooltip={showTooltip} tooltip={tooltip}>
             {children}
           </ButtonContents>
         </Link>
       )
+      break
 
     case 'anchor':
-      return (
+      buttonElement = (
         <a {...buttonProps} href={url} ref={ref as React.Ref<HTMLAnchorElement>}>
           <ButtonContents icon={icon} showTooltip={showTooltip} tooltip={tooltip}>
             {children}
           </ButtonContents>
         </a>
       )
+      break
 
     default:
       const Tag = el // eslint-disable-line no-case-declarations
 
-      return (
+      buttonElement = (
         <Tag ref={ref} type="submit" {...buttonProps}>
           <ButtonContents icon={icon} showTooltip={showTooltip} tooltip={tooltip}>
             {children}
           </ButtonContents>
         </Tag>
       )
+      break
   }
+  if (secondaryActions)
+    return (
+      <div className={`${baseClass}__wrap`}>
+        {buttonElement}
+        <SecondaryActions {...buttonProps} secondaryActions={secondaryActions} />
+      </div>
+    )
+
+  return buttonElement
 })

--- a/packages/ui/src/elements/Button/types.ts
+++ b/packages/ui/src/elements/Button/types.ts
@@ -1,6 +1,11 @@
 import type { ElementType, MouseEvent } from 'react'
 import type React from 'react'
 
+type secondaryAction = {
+  label: string
+  onClick: (event: MouseEvent) => void
+}
+
 export type Props = {
   Link?: React.ElementType
   'aria-label'?: string
@@ -17,6 +22,7 @@ export type Props = {
   newTab?: boolean
   onClick?: (event: MouseEvent) => void
   round?: boolean
+  secondaryActions?: secondaryAction | secondaryAction[]
   size?: 'large' | 'medium' | 'small'
   to?: string
   tooltip?: string

--- a/packages/ui/src/elements/Button/types.ts
+++ b/packages/ui/src/elements/Button/types.ts
@@ -1,16 +1,12 @@
 import type { ElementType, MouseEvent } from 'react'
 import type React from 'react'
 
-type secondaryAction = {
-  label: string
-  onClick: (event: MouseEvent) => void
-}
-
 export type Props = {
   Link?: React.ElementType
+  SubMenuPopupContent?: React.ReactNode
   'aria-label'?: string
   buttonId?: string
-  buttonStyle?: 'error' | 'icon-label' | 'none' | 'primary' | 'secondary' | 'transparent'
+  buttonStyle?: 'error' | 'icon-label' | 'none' | 'pill' | 'primary' | 'secondary' | 'transparent'
   children?: React.ReactNode
   className?: string
   disabled?: boolean
@@ -22,7 +18,6 @@ export type Props = {
   newTab?: boolean
   onClick?: (event: MouseEvent) => void
   round?: boolean
-  secondaryActions?: secondaryAction | secondaryAction[]
   size?: 'large' | 'medium' | 'small'
   to?: string
   tooltip?: string

--- a/packages/ui/src/elements/ListHeader/index.scss
+++ b/packages/ui/src/elements/ListHeader/index.scss
@@ -1,0 +1,10 @@
+.list-header {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: calc(var(--base) * 0.8);
+
+  h1 {
+    margin: 0;
+  }
+}

--- a/packages/ui/src/elements/ListHeader/index.tsx
+++ b/packages/ui/src/elements/ListHeader/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import './index.scss'
+
+const baseClass = 'list-header'
+
+type Props = {
+  children?: React.ReactNode
+  className?: string
+  heading: string
+}
+export function ListHeader({ children, className, heading }: Props) {
+  return (
+    <header className={[baseClass, className].filter(Boolean).join(' ')}>
+      <h1>{heading}</h1>
+      {children}
+    </header>
+  )
+}

--- a/packages/ui/src/elements/Popup/PopupButtonList/index.tsx
+++ b/packages/ui/src/elements/Popup/PopupButtonList/index.tsx
@@ -34,7 +34,7 @@ type MenuButtonProps = {
   className?: string
   href?: LinkProps['href']
   id?: string
-  onClick?: () => void
+  onClick?: (e?: React.MouseEvent) => void
 }
 
 export const Button: React.FC<MenuButtonProps> = ({
@@ -55,9 +55,9 @@ export const Button: React.FC<MenuButtonProps> = ({
         className={classes}
         href={href}
         id={id}
-        onClick={() => {
+        onClick={(e) => {
           if (onClick) {
-            onClick()
+            onClick(e)
           }
         }}
       >
@@ -71,9 +71,9 @@ export const Button: React.FC<MenuButtonProps> = ({
       <button
         className={classes}
         id={id}
-        onClick={() => {
+        onClick={(e) => {
           if (onClick) {
-            onClick()
+            onClick(e)
           }
         }}
         type="button"

--- a/packages/ui/src/elements/Popup/PopupTrigger/index.scss
+++ b/packages/ui/src/elements/Popup/PopupTrigger/index.scss
@@ -7,8 +7,11 @@
   font-size: inherit;
   line-height: inherit;
   font-family: inherit;
-  background: transparent;
   border: 0;
   cursor: pointer;
   display: inline-flex;
+
+  &--background {
+    background: transparent;
+  }
 }

--- a/packages/ui/src/elements/Popup/PopupTrigger/index.tsx
+++ b/packages/ui/src/elements/Popup/PopupTrigger/index.tsx
@@ -10,13 +10,22 @@ export type PopupTriggerProps = {
   button: React.ReactNode
   buttonType: 'custom' | 'default' | 'none'
   className?: string
+  disabled?: boolean
+  noBackground?: boolean
   setActive: (active: boolean) => void
 }
 
 export const PopupTrigger: React.FC<PopupTriggerProps> = (props) => {
-  const { active, button, buttonType, className, setActive } = props
+  const { active, button, buttonType, className, disabled, noBackground, setActive } = props
 
-  const classes = [baseClass, className, `${baseClass}--${buttonType}`].filter(Boolean).join(' ')
+  const classes = [
+    baseClass,
+    className,
+    `${baseClass}--${buttonType}`,
+    !noBackground && `${baseClass}--background`,
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   const handleClick = () => {
     setActive(!active)
@@ -43,7 +52,13 @@ export const PopupTrigger: React.FC<PopupTriggerProps> = (props) => {
   }
 
   return (
-    <button className={classes} onClick={() => setActive(!active)} tabIndex={0} type="button">
+    <button
+      className={classes}
+      disabled={disabled}
+      onClick={handleClick}
+      tabIndex={0}
+      type="button"
+    >
       {button}
     </button>
   )

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -21,9 +21,11 @@ export type PopupProps = {
   caret?: boolean
   children?: React.ReactNode
   className?: string
+  disabled?: boolean
   forceOpen?: boolean
   horizontalAlign?: 'center' | 'left' | 'right'
   initActive?: boolean
+  noBackground?: boolean
   onToggleOpen?: (active: boolean) => void
   render?: (any) => React.ReactNode
   showOnHover?: boolean
@@ -41,9 +43,11 @@ export const Popup: React.FC<PopupProps> = (props) => {
     caret = true,
     children,
     className,
+    disabled,
     forceOpen,
     horizontalAlign: horizontalAlignFromProps = 'left',
     initActive = false,
+    noBackground,
     onToggleOpen,
     render,
     showOnHover = false,
@@ -168,12 +172,28 @@ export const Popup: React.FC<PopupProps> = (props) => {
             onMouseLeave={() => setActive(false)}
           >
             <PopupTrigger
-              {...{ active, button, buttonType, className: buttonClassName, setActive }}
+              {...{
+                active,
+                button,
+                buttonType,
+                className: buttonClassName,
+                disabled,
+                noBackground,
+                setActive,
+              }}
             />
           </div>
         ) : (
           <PopupTrigger
-            {...{ active, button, buttonType, className: buttonClassName, setActive }}
+            {...{
+              active,
+              button,
+              buttonType,
+              className: buttonClassName,
+              disabled,
+              noBackground,
+              setActive,
+            }}
           />
         )}
       </div>

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -46,6 +46,7 @@ export { HydrateAuthProvider } from '../../elements/HydrateAuthProvider/index.js
 export { ListControls } from '../../elements/ListControls/index.js'
 export { useListDrawer } from '../../elements/ListDrawer/index.js'
 export { ListSelection } from '../../elements/ListSelection/index.js'
+export { ListHeader } from '../../elements/ListHeader/index.js'
 export { LoadingOverlayToggle } from '../../elements/Loading/index.js'
 export { FormLoadingOverlayToggle } from '../../elements/Loading/index.js'
 export { LoadingOverlay } from '../../elements/Loading/index.js'


### PR DESCRIPTION
## Description

Extracts functionality this [PR](https://github.com/payloadcms/payload/pull/7669/files#diff-a2b1253ad6d1c9dde331641afc52893d73be7d3449c25e44b81066a839fef85d). Allows the Button component to take secondary actions.

Extracts a simple ListHeader component that can be imported. Useful when creating custom views.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
