### PR TITLE
fix(ui, richtext-lexical): corrects clickable areas on block headers

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/component/index.scss
+++ b/packages/richtext-lexical/src/features/blocks/client/component/index.scss
@@ -98,7 +98,12 @@
     width: 100%;
     overflow: hidden;
     gap: calc(var(--base) * 0.375);
-    justify-content: space-between;
+    justify-content: flex-start;
+    pointer-events: none;
+
+    & > * {
+      pointer-events: all;
+    }
   }
 
   &__block-number {

--- a/packages/ui/src/fields/Blocks/SectionTitle/index.scss
+++ b/packages/ui/src/fields/Blocks/SectionTitle/index.scss
@@ -2,7 +2,7 @@
 
 .section-title {
   position: relative;
-  width: 100%;
+  min-width: base(4);
   max-width: 100%;
   pointer-events: all;
   display: flex;


### PR DESCRIPTION
## Description

Fixes an issue where Block component section titles were taking up the entire clickable area of block headers.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
