### PR TITLE
[Website Template] getGlobal Utility does not type narrow

### DIFF
--- a/templates/website/src/app/utilities/getGlobals.ts
+++ b/templates/website/src/app/utilities/getGlobals.ts
@@ -6,7 +6,7 @@ import { unstable_cache } from 'next/cache'
 
 type Global = keyof Config['globals']
 
-async function getGlobal(slug: Global, depth = 0) {
+async function getGlobal<T extends Global>(slug: T, depth = 0) {
   const payload = await getPayloadHMR({ config: configPromise })
 
   const global = await payload.findGlobal({
@@ -20,7 +20,8 @@ async function getGlobal(slug: Global, depth = 0) {
 /**
  * Returns a unstable_cache function mapped with the cache tag for the slug
  */
-export const getCachedGlobal = (slug: Global, depth = 0) =>
-  unstable_cache(async () => getGlobal(slug, depth), [slug], {
+export function getCachedGlobal<T extends Global>(slug: T, depth = 0) {
+  return unstable_cache(async () => getGlobal(slug, depth), [slug], {
     tags: [`global_${slug}`],
   })
+}


### PR DESCRIPTION
## Description

By default when using this utility it will not automatically narrow to the type which you specified in the argument. This pull resolves this issue

Before:
![image](https://github.com/user-attachments/assets/a13cbb4a-5e34-4dd2-9330-635d986249cd)
After:
![image](https://github.com/user-attachments/assets/1bc7b247-e06f-410b-91a7-fadb5cc35340)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
