### PR TITLE
fix(ui): relationship field "add new" button styling

### DIFF
--- a/packages/ui/src/elements/AddNewRelation/index.scss
+++ b/packages/ui/src/elements/AddNewRelation/index.scss
@@ -10,13 +10,23 @@
     height: 100%;
   }
 
-  &__add-button {
+  &__add-button:not(.relationship-add-new__add-button--unstyled),
+  &__add-button:not(.relationship-add-new__add-button--unstyled).doc-drawer__toggler {
+    @include formInput;
+    margin: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
     position: relative;
+    height: 100%;
+    margin-left: -1px;
+    display: flex;
+    padding: 0 base(0.5);
+    align-items: center;
+    display: flex;
+    cursor: pointer;
   }
 
-  &__add-button--unstyled,
-  &__add-button--unstyled.doc-drawer__toggler {
-    @include formInput;
+  &__add-button {
     margin: 0;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;

--- a/packages/ui/src/elements/AddNewRelation/index.tsx
+++ b/packages/ui/src/elements/AddNewRelation/index.tsx
@@ -142,8 +142,10 @@ export const AddNewRelation: React.FC<Props> = ({
             <DocumentDrawerToggler
               className={[
                 `${baseClass}__add-button`,
-                !unstyled && `${baseClass}__add-button--styled`,
-              ].join(' ')}
+                unstyled && `${baseClass}__add-button--unstyled`,
+              ]
+                .filter(Boolean)
+                .join(' ')}
               onClick={() => setShowTooltip(false)}
               onMouseEnter={() => setShowTooltip(true)}
               onMouseLeave={() => setShowTooltip(false)}


### PR DESCRIPTION
## Description

The relationship field's "add new" button has lost its styling as a result of the introduction of the `hasMany` upload field in this PR: #7796

Old:
<img width="442" alt="Screenshot 2024-08-22 at 10 37 39 AM" src="https://github.com/user-attachments/assets/002d2c36-e992-42e5-af0f-fdaceb4ef4e4">

New:
<img width="405" alt="Screenshot 2024-08-22 at 10 39 20 AM" src="https://github.com/user-attachments/assets/1e3c9f55-86d3-45df-b1aa-75e4ae45fc48">

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.