### PR TITLE
fix: weaken JsonObject type to allow types from payload-types being assigned to it

### DIFF
--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -95,7 +95,7 @@ export type JsonValue = JsonArray | JsonObject | unknown //Date | JsonArray | Js
 export interface JsonArray extends Array<JsonValue> {}
 
 export interface JsonObject {
-  [key: string]: JsonValue
+  [key: string]: any
 }
 
 export type WhereField = {

--- a/packages/plugin-stripe/src/routes/rest.ts
+++ b/packages/plugin-stripe/src/routes/rest.ts
@@ -38,9 +38,7 @@ export const stripeREST = async (args: {
     }
 
     responseJSON = await stripeProxy({
-      // @ts-expect-error
       stripeArgs,
-      // @ts-expect-error
       stripeMethod,
       stripeSecretKey,
     })


### PR DESCRIPTION
This fixes that type in the website template: https://github.com/payloadcms/payload/blob/3d86bf1974af652413e7bca0535faee1a86d7d02/templates/website/src/app/components/RichText/serialize.tsx#L24

Now, JsonObject still ensures that only objects can be passed, but it's weak enough to allow non-dynamic types like the ones we generate in payload-types.

The "JSON" part of this type has no meaning anymore, as it does allow objects with functions now. However, we can still use it to signal to the user that this should be JSON-serializable. It's more clear than just using Record<string, unknown>