### PR TITLE
fix: upload hasmany missing null check

### DIFF
--- a/packages/ui/src/fields/Upload/HasMany/index.tsx
+++ b/packages/ui/src/fields/Upload/HasMany/index.tsx
@@ -200,7 +200,7 @@ export const UploadComponentHasMany: React.FC<UploadFieldPropsWithContext<string
               ids={value}
               onDragEnd={({ moveFromIndex, moveToIndex }) => moveRow(moveFromIndex, moveToIndex)}
             >
-              {Boolean(value.length) &&
+              {Boolean(value?.length) &&
                 value.map((id, index) => {
                   const doc = fileDocs.find((doc) => doc.id === id)
                   const uploadConfig = collection?.upload
@@ -265,7 +265,7 @@ export const UploadComponentHasMany: React.FC<UploadFieldPropsWithContext<string
               </div>
             </ListDrawerToggler>
           </div>
-          {Boolean(value.length) && (
+          {Boolean(value?.length) && (
             <button
               className={`${baseClass}__clear-all`}
               onClick={() => setValue([])}


### PR DESCRIPTION
## Description

Fixes a missing null coalesce check in the Upload/HasMany component to fix TypeErrors (that I only encountered running test instances but other places had the check too)

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
