### PR TITLE
feat(richtext-lexical): improve upload and relationship node types

### DIFF
--- a/packages/richtext-lexical/src/features/relationship/client/components/RelationshipComponent.tsx
+++ b/packages/richtext-lexical/src/features/relationship/client/components/RelationshipComponent.tsx
@@ -39,9 +39,15 @@ type Props = {
 
 const Component: React.FC<Props> = (props) => {
   const {
-    data: { relationTo, value: id },
+    data: { relationTo, value },
     nodeKey,
   } = props
+
+  if (typeof value === 'object') {
+    throw new Error(
+      'Relationship value should be a string or number. The Lexical Relationship component should not receive the populated value object.',
+    )
+  }
 
   const relationshipElemRef = useRef<HTMLDivElement | null>(null)
 
@@ -63,12 +69,12 @@ const Component: React.FC<Props> = (props) => {
   const { i18n, t } = useTranslation()
   const [cacheBust, dispatchCacheBust] = useReducer((state) => state + 1, 0)
   const [{ data }, { setParams }] = usePayloadAPI(
-    `${serverURL}${api}/${relatedCollection.slug}/${id}`,
+    `${serverURL}${api}/${relatedCollection.slug}/${value}`,
     { initialParams },
   )
 
   const [DocumentDrawer, DocumentDrawerToggler, { closeDrawer }] = useDocumentDrawer({
-    id,
+    id: value,
     collectionSlug: relatedCollection.slug,
   })
 
@@ -153,7 +159,7 @@ const Component: React.FC<Props> = (props) => {
         </p>
         <DocumentDrawerToggler className={`${baseClass}__doc-drawer-toggler`}>
           <p className={`${baseClass}__title`}>
-            {data ? data[relatedCollection?.admin?.useAsTitle || 'id'] : id}
+            {data ? data[relatedCollection?.admin?.useAsTitle || 'id'] : value}
           </p>
         </DocumentDrawerToggler>
       </div>
@@ -188,7 +194,7 @@ const Component: React.FC<Props> = (props) => {
         </div>
       )}
 
-      {id && <DocumentDrawer onSave={updateRelationship} />}
+      {!!value && <DocumentDrawer onSave={updateRelationship} />}
     </div>
   )
 }

--- a/packages/richtext-lexical/src/features/relationship/server/nodes/RelationshipNode.tsx
+++ b/packages/richtext-lexical/src/features/relationship/server/nodes/RelationshipNode.tsx
@@ -10,15 +10,17 @@ import type {
   NodeKey,
   Spread,
 } from 'lexical'
-import type { CollectionSlug } from 'payload'
+import type { CollectionSlug, DataFromCollectionSlug } from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
 
 export type RelationshipData = {
-  relationTo: CollectionSlug
-  value: number | string
-}
+  [TCollectionSlug in CollectionSlug]: {
+    relationTo: TCollectionSlug
+    value: DataFromCollectionSlug<TCollectionSlug> | number | string
+  }
+}[CollectionSlug]
 
 export type SerializedRelationshipNode = {
   children?: never // required so that our typed editor state doesn't automatically add children

--- a/packages/richtext-lexical/src/features/upload/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/upload/client/component/index.tsx
@@ -86,6 +86,12 @@ const Component: React.FC<ElementProps> = (props) => {
     depth: editDepth,
   })
 
+  if (typeof value === 'object') {
+    throw new Error(
+      'Upload value should be a string or number. The Lexical Upload component should not receive the populated value object.',
+    )
+  }
+
   const [DocumentDrawer, DocumentDrawerToggler, { closeDrawer }] = useDocumentDrawer({
     id: value,
     collectionSlug: relatedCollection.slug,

--- a/packages/richtext-lexical/src/features/upload/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/upload/client/component/index.tsx
@@ -57,6 +57,12 @@ const Component: React.FC<ElementProps> = (props) => {
     nodeKey,
   } = props
 
+  if (typeof value === 'object') {
+    throw new Error(
+      'Upload value should be a string or number. The Lexical Upload component should not receive the populated value object.',
+    )
+  }
+
   const {
     config: {
       collections,
@@ -85,12 +91,6 @@ const Component: React.FC<ElementProps> = (props) => {
     slug: `lexical-upload-drawer-` + uuid + componentID, // There can be multiple upload components, each with their own drawer, in one single editor => separate them by componentID
     depth: editDepth,
   })
-
-  if (typeof value === 'object') {
-    throw new Error(
-      'Upload value should be a string or number. The Lexical Upload component should not receive the populated value object.',
-    )
-  }
 
   const [DocumentDrawer, DocumentDrawerToggler, { closeDrawer }] = useDocumentDrawer({
     id: value,

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -19,8 +19,10 @@ import * as React from 'react'
 export type UploadData<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
   [TCollectionSlug in CollectionSlug]: {
     fields: TUploadExtraFieldsData
+    // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
     id: string
     relationTo: TCollectionSlug
+    // Value can be just the document ID, or the full, populated document
     value: DataFromCollectionSlug<TCollectionSlug> | number | string
   }
 }[CollectionSlug]

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -8,7 +8,7 @@ import type {
   NodeKey,
   Spread,
 } from 'lexical'
-import type { CollectionSlug, JsonObject } from 'payload'
+import type { CollectionSlug, DataFromCollectionSlug, JsonObject } from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
@@ -16,12 +16,14 @@ import ObjectID from 'bson-objectid'
 import { $applyNodeReplacement } from 'lexical'
 import * as React from 'react'
 
-export type UploadData = {
-  fields: JsonObject
-  id: string
-  relationTo: CollectionSlug
-  value: number | string
-}
+export type UploadData<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
+  [TCollectionSlug in CollectionSlug]: {
+    fields: TUploadExtraFieldsData
+    id: string
+    relationTo: TCollectionSlug
+    value: DataFromCollectionSlug<TCollectionSlug> | number | string
+  }
+}[CollectionSlug]
 
 export function isGoogleDocCheckboxImg(img: HTMLImageElement): boolean {
   return (


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/7808. The types are now accurate. Previously, they would assume that upload and relationship nodes are never populated