### PR TITLE
Fix: Multiple preferences for the same user and entry

### DIFF
--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -9,6 +9,7 @@ import { generateImportMap } from './generateImportMap/index.js'
 import { generateTypes } from './generateTypes.js'
 import { loadEnv } from './loadEnv.js'
 import { migrate } from './migrate.js'
+import { removePreferences } from './removePreferences.js'
 
 export const bin = async () => {
   loadEnv()
@@ -73,6 +74,10 @@ export const bin = async () => {
 
   if (script === 'generate:importmap') {
     return generateImportMap(config)
+  }
+
+  if (script === 'remove:preferences') {
+    return removePreferences(config)
   }
 
   console.error(`Unknown script: "${script}".`)

--- a/packages/payload/src/bin/removePreferences.ts
+++ b/packages/payload/src/bin/removePreferences.ts
@@ -1,0 +1,22 @@
+import type { SanitizedConfig } from '../config/types.js'
+
+import { getPayload } from '../index.js'
+import { getLogger } from '../utilities/logger.js'
+
+export async function removePreferences(
+  config: SanitizedConfig,
+  options?: { log: boolean },
+): Promise<void> {
+  const logger = getLogger()
+  const shouldLog = options?.log ?? true
+  const payload = await getPayload({ config })
+
+  if (shouldLog) logger.info('Removing all user preferences...')
+
+  await payload.delete({
+    collection: 'payload-preferences',
+    where: {},
+  })
+
+  if (shouldLog) logger.info(`All user preferences removed.`)
+}

--- a/packages/payload/src/bin/removePreferences.ts
+++ b/packages/payload/src/bin/removePreferences.ts
@@ -19,4 +19,5 @@ export async function removePreferences(
   })
 
   if (shouldLog) logger.info(`All user preferences removed.`)
+  process.exit(1)
 }

--- a/packages/payload/src/preferences/operations/update.ts
+++ b/packages/payload/src/preferences/operations/update.ts
@@ -39,15 +39,20 @@ async function update(args: PreferenceUpdateRequest) {
     await executeAccess({ req }, defaultAccess)
   }
 
-  try {
-    // try/catch because we attempt to update without first reading to check if it exists first to save on db calls
+  const existingPreference = await payload.db.count({
+    collection,
+    req,
+    where: filter,
+  })
+
+  if (existingPreference.totalDocs > 0) {
     await payload.db.updateOne({
       collection,
       data: preference,
       req,
       where: filter,
     })
-  } catch (err: unknown) {
+  } else {
     await payload.db.create({
       collection,
       data: preference,


### PR DESCRIPTION
## Description

This PR add more resilience to the payload preferences update. Previously it was possible that if something goes wrong in an preferences update that multiple user preferences would exist for the same entry e.g "locale". This then has unforeseeable consequences throughout the whole application as it's unclear which of these entries will be used and updated.

This caused the following issue: #7762 

This PR also adds an CLI command to cleanup the user preferences table as there is currently no way to recover an affected Payload instance from this behaviour.

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

Possible additions / follow ups:

1. An unique constraint on payload preferences so that each user can have only one entry for each preference item.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
