### PR TITLE
fix(next): properly 404s not found documents

### DIFF
--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -75,6 +75,10 @@ export const Document: React.FC<AdminViewProps> = async ({
     req,
   })
 
+  if (!data) {
+    notFound()
+  }
+
   const { docPermissions, hasPublishPermission, hasSavePermission } = await getDocumentPermissions({
     id,
     collectionConfig,

--- a/test/admin/e2e/1/e2e.spec.ts
+++ b/test/admin/e2e/1/e2e.spec.ts
@@ -336,6 +336,20 @@ describe('admin1', () => {
   })
 
   describe('routing', () => {
+    test('should 404 not found root pages', async () => {
+      await page.goto(`${serverURL}/admin/1234`)
+      const response = await page.waitForResponse((response) => response.status() === 404)
+      expect(response).toBeTruthy()
+      await expect(page.locator('.not-found')).toContainText('Nothing found')
+    })
+
+    test('should 404 not found documents', async () => {
+      await page.goto(`${postsUrl.collection(postsCollectionSlug)}/1234`)
+      const response = await page.waitForResponse((response) => response.status() === 404)
+      expect(response).toBeTruthy()
+      await expect(page.locator('.not-found')).toContainText('Nothing found')
+    })
+
     test('should use custom logout route', async () => {
       await page.goto(`${serverURL}${adminRoutes.routes.admin}${adminRoutes.admin.routes.logout}`)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
     ],
     "paths": {
       "@payload-config": [
-        "./test/_community/config.ts"
+        "./test/admin/config.ts"
       ],
       "@payloadcms/live-preview": [
         "./packages/live-preview/src"


### PR DESCRIPTION
## Description

When navigating to non-existent documents within the admin panel, the document edit view was still being rendered along with a 200 http status code. Now they return the not found page as expected, with a corresponding 404.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
