### PR TITLE
fix: trim down accepted args of getPayloadHMR

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:live-preview": "turbo build --filter live-preview",
     "build:live-preview-react": "turbo build --filter live-preview-react",
     "build:live-preview-vue": "turbo build --filter live-preview-vue",
-    "build:next": "turbo build --filter next",
+    "build:next": "turbo build --filter \"@payloadcms/next\"",
     "build:payload": "turbo build --filter payload",
     "build:plugin-cloud": "turbo build --filter plugin-cloud",
     "build:plugin-cloud-storage": "turbo build --filter plugin-cloud-storage",

--- a/packages/next/src/utilities/getPayloadHMR.ts
+++ b/packages/next/src/utilities/getPayloadHMR.ts
@@ -62,7 +62,9 @@ export const reload = async (
   }
 }
 
-export const getPayloadHMR = async (options: InitOptions): Promise<Payload> => {
+export const getPayloadHMR = async (
+  options: Pick<InitOptions, 'config' | 'importMap'>,
+): Promise<Payload> => {
   if (!options?.config) {
     throw new Error('Error: the payload config is required for getPayloadHMR to work.')
   }


### PR DESCRIPTION
`getPayloadHMR`'s arg type was accepting unnecessary args that did not do anything. This was leading to confusion.

This PR trims down the accepted type.

Fixes #7832