### PR TITLE
chore: update incorrect plurality in Italian translations

### DIFF
--- a/packages/payload/src/translations/it.json
+++ b/packages/payload/src/translations/it.json
@@ -219,7 +219,7 @@
     "noFiltersSet": "Nessun filtro impostato",
     "noLabel": "<No {{label}}>",
     "noOptions": "Nessuna opzione",
-    "noResults": "Nessun {{label}} trovato. Non esiste ancora nessun {{label}} oppure nessuno corrisponde ai filtri che hai specificato sopra.",
+    "noResults": "Non abbiamo trovato {{label}}. Potrebbero non esserci {{label}}, oppure nessuno corrisponde ai filtri che hai specificato sopra.",
     "noValue": "Nessun valore",
     "none": "Nessuno",
     "notFound": "Non Trovato",


### PR DESCRIPTION
## Description

Currently the `{{label}}` in `noResults` translation is a plural.

In the italian translation, the words around `{{label}}` imply that it would be singular.

This fixes it so that the translation works for a pluralized label

Before (incorrect)

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/40c62d79-4bc6-4523-9f7c-c07808e7e79f">

ChatGPT confirming it's currently incorrect: https://chatgpt.com/share/477a3d53-d988-4416-afbf-eab4455779e2

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
