### PR TITLE
Use jwt.verify in stead of jwt.decode

### DIFF
--- a/templates/website/src/app/next/preview/route.ts
+++ b/templates/website/src/app/next/preview/route.ts
@@ -25,7 +25,7 @@ export async function GET(
     new Response('You are not allowed to preview this page', { status: 403 })
   }
 
-  const user = jwt.decode(token, process.env.PAYLOAD_SECRET)
+  const user = jwt.verify(token, process.env.PAYLOAD_SECRET)
 
   if (!user) {
     draftMode().disable()


### PR DESCRIPTION
## Description

This updates the example app with `jwt.verify` in stead of `jwt.decode`. The `verify` method accepts the secret, whereas the `decode` method accepts an options object, as per https://github.com/auth0/node-jsonwebtoken/tree/v9.0.1 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change



- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)


## Checklist:

N/A
