### PR TITLE
fix: sanitizes modifyResponseHeaders from client config

### DIFF
--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -14,6 +14,15 @@ export type ServerOnlyCollectionAdminProperties = keyof Pick<
   'hidden' | 'preview'
 >
 
+export type ServerOnlyUploadProperties = keyof Pick<
+  SanitizedCollectionConfig['upload'],
+  | 'adminThumbnail'
+  | 'externalFileHeaderFilter'
+  | 'handlers'
+  | 'modifyResponseHeaders'
+  | 'withMetadata'
+>
+
 export type ClientCollectionConfig = {
   _isPreviewEnabled?: true
   admin: {

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -713,6 +713,7 @@ export type { ClientCollectionConfig } from './collections/config/client.js'
 export type {
   ServerOnlyCollectionAdminProperties,
   ServerOnlyCollectionProperties,
+  ServerOnlyUploadProperties,
 } from './collections/config/client.js'
 export type {
   AfterChangeHook as CollectionAfterChangeHook,

--- a/packages/ui/src/providers/Config/createClientConfig/collections.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/collections.tsx
@@ -11,6 +11,7 @@ import type {
   SanitizedCollectionConfig,
   ServerOnlyCollectionAdminProperties,
   ServerOnlyCollectionProperties,
+  ServerOnlyUploadProperties,
 } from 'payload'
 import type React from 'react'
 
@@ -56,6 +57,14 @@ export const createClientCollectionConfig = ({
     // are all handled separately
   ]
 
+  const serverOnlyUploadProperties: Partial<ServerOnlyUploadProperties>[] = [
+    'adminThumbnail',
+    'externalFileHeaderFilter',
+    'handlers',
+    'modifyResponseHeaders',
+    'withMetadata',
+  ]
+
   serverOnlyCollectionProperties.forEach((key) => {
     if (key in clientCollection) {
       delete clientCollection[key]
@@ -63,10 +72,11 @@ export const createClientCollectionConfig = ({
   })
 
   if ('upload' in clientCollection && typeof clientCollection.upload === 'object') {
-    delete clientCollection.upload.handlers
-    delete clientCollection.upload.adminThumbnail
-    delete clientCollection.upload.externalFileHeaderFilter
-    delete clientCollection.upload.withMetadata
+    serverOnlyUploadProperties.forEach((key) => {
+      if (key in clientCollection.upload) {
+        delete clientCollection.upload[key]
+      }
+    })
 
     if ('imageSizes' in clientCollection.upload && clientCollection.upload.imageSizes.length) {
       clientCollection.upload.imageSizes = clientCollection.upload.imageSizes.map((size) => {

--- a/packages/ui/src/providers/Config/createClientConfig/collections.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/collections.tsx
@@ -19,6 +19,30 @@ import { deepCopyObjectSimple } from 'payload'
 
 import { createClientFields } from './fields.js'
 
+const serverOnlyCollectionProperties: Partial<ServerOnlyCollectionProperties>[] = [
+  'hooks',
+  'access',
+  'endpoints',
+  'custom',
+  // `upload`
+  // `admin`
+  // are all handled separately
+]
+
+const serverOnlyUploadProperties: Partial<ServerOnlyUploadProperties>[] = [
+  'adminThumbnail',
+  'externalFileHeaderFilter',
+  'handlers',
+  'modifyResponseHeaders',
+  'withMetadata',
+]
+
+const serverOnlyCollectionAdminProperties: Partial<ServerOnlyCollectionAdminProperties>[] = [
+  'hidden',
+  'preview',
+  // `livePreview` is handled separately
+]
+
 export const createClientCollectionConfig = ({
   DefaultEditView,
   DefaultListView,
@@ -46,24 +70,6 @@ export const createClientCollectionConfig = ({
     importMap,
     payload,
   })
-
-  const serverOnlyCollectionProperties: Partial<ServerOnlyCollectionProperties>[] = [
-    'hooks',
-    'access',
-    'endpoints',
-    'custom',
-    // `upload`
-    // `admin`
-    // are all handled separately
-  ]
-
-  const serverOnlyUploadProperties: Partial<ServerOnlyUploadProperties>[] = [
-    'adminThumbnail',
-    'externalFileHeaderFilter',
-    'handlers',
-    'modifyResponseHeaders',
-    'withMetadata',
-  ]
 
   serverOnlyCollectionProperties.forEach((key) => {
     if (key in clientCollection) {
@@ -100,12 +106,6 @@ export const createClientCollectionConfig = ({
       }
     })
   }
-
-  const serverOnlyCollectionAdminProperties: Partial<ServerOnlyCollectionAdminProperties>[] = [
-    'hidden',
-    'preview',
-    // `livePreview` is handled separately
-  ]
 
   serverOnlyCollectionAdminProperties.forEach((key) => {
     if (key in clientCollection.admin) {


### PR DESCRIPTION
## Description

Sanitizes `upload.modifyResponseHeaders` from the client collection config.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
