### PR TITLE
fix: bugs in versions UI with perPage, pagination and diffs not showing for tabs. publish button no longer double saves when using keyboard

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/index.tsx
@@ -100,7 +100,7 @@ const RenderFieldsToDiff: React.FC<Props> = ({
             )
           }
 
-          if (field.type === 'tabs' && 'fields' in field) {
+          if (field.type === 'tabs' && 'tabs' in field) {
             const Tabs = diffComponents.tabs
 
             return (

--- a/packages/next/src/views/Versions/index.client.tsx
+++ b/packages/next/src/views/Versions/index.client.tsx
@@ -66,7 +66,8 @@ export const VersionsViewClient: React.FC<{
               limit={data.limit}
               nextPage={data.nextPage}
               numberOfNeighbors={1}
-              onChange={() => handlePageChange}
+              // eslint-disable-next-line @typescript-eslint/no-misused-promises
+              onChange={handlePageChange}
               page={data.page}
               prevPage={data.prevPage}
               totalPages={data.totalPages}
@@ -81,7 +82,8 @@ export const VersionsViewClient: React.FC<{
                   {i18n.t('general:of')} {data.totalDocs}
                 </div>
                 <PerPage
-                  handleChange={() => handlePerPageChange}
+                  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+                  handleChange={handlePerPageChange}
                   limit={limit ? Number(limit) : 10}
                   limits={paginationLimits}
                 />

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -77,7 +77,7 @@ export const DefaultPublishButton: React.FC<{ label?: string }> = ({ label: labe
     e.preventDefault()
     e.stopPropagation()
 
-    if (saveDraft && docConfig.versions?.drafts?.autosave) {
+    if (saveDraft && docConfig.versions?.drafts && docConfig.versions?.drafts?.autosave) {
       void saveDraft()
     }
   })

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -8,29 +8,77 @@ import { useForm, useFormModified } from '../../forms/Form/context.js'
 import { FormSubmit } from '../../forms/Submit/index.js'
 import { useHotkey } from '../../hooks/useHotkey.js'
 import { RenderComponent } from '../../providers/Config/RenderComponent.js'
+import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
+import { useLocale } from '../../providers/Locale/index.js'
+import { useOperation } from '../../providers/Operation/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 
 export const DefaultPublishButton: React.FC<{ label?: string }> = ({ label: labelProp }) => {
-  const { hasPublishPermission, publishedDoc, unpublishedVersions } = useDocumentInfo()
+  const {
+    config: {
+      routes: { api },
+      serverURL,
+    },
+  } = useConfig()
+
+  const {
+    id,
+    collectionSlug,
+    docConfig,
+    globalSlug,
+    hasPublishPermission,
+    publishedDoc,
+    unpublishedVersions,
+  } = useDocumentInfo()
 
   const { submit } = useForm()
   const modified = useFormModified()
   const editDepth = useEditDepth()
+  const { code: locale } = useLocale()
 
   const { t } = useTranslation()
   const label = labelProp || t('version:publishChanges')
 
   const hasNewerVersions = unpublishedVersions?.totalDocs > 0
   const canPublish = hasPublishPermission && (modified || hasNewerVersions || !publishedDoc)
+  const operation = useOperation()
+
+  const forceDisable = operation === 'update' && !modified
+
+  const saveDraft = useCallback(async () => {
+    if (forceDisable) return
+
+    const search = `?locale=${locale}&depth=0&fallback-locale=null&draft=true`
+    let action
+    let method = 'POST'
+
+    if (collectionSlug) {
+      action = `${serverURL}${api}/${collectionSlug}${id ? `/${id}` : ''}${search}`
+      if (id) method = 'PATCH'
+    }
+
+    if (globalSlug) {
+      action = `${serverURL}${api}/globals/${globalSlug}${search}`
+    }
+
+    await submit({
+      action,
+      method,
+      overrides: {
+        _status: 'draft',
+      },
+      skipValidation: true,
+    })
+  }, [submit, collectionSlug, globalSlug, serverURL, api, locale, id, forceDisable])
 
   useHotkey({ cmdCtrlKey: true, editDepth, keyCodes: ['s'] }, (e) => {
     e.preventDefault()
     e.stopPropagation()
 
-    if (submit) {
-      void submit()
+    if (saveDraft && docConfig.versions?.drafts?.autosave) {
+      void saveDraft()
     }
   })
 


### PR DESCRIPTION
Fixes:
- issue with publish button double saving on keyboard command
- versions diffs not showing if fields are tabs https://github.com/payloadcms/payload/issues/7860
- navigation on versions not working for perPage and pagination