### PR TITLE
fix(richtext-lexical): html converters can populate relationships infinitely

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -115,11 +115,18 @@ export type FieldHookArgs<TData extends TypeWithID = any, TValue = any, TSibling
   /** The collection which the field belongs to. If the field belongs to a global, this will be null. */
   collection: SanitizedCollectionConfig | null
   context: RequestContext
+  /**
+   * Only available in `afterRead` hooks
+   */
+  currentDepth?: number /**
+   * Only available in `afterRead` hooks
+   */
   /** The data passed to update the document within create and update operations, and the full document itself in the afterRead hook. */
   data?: Partial<TData>
   /**
    * Only available in the `afterRead` hook.
    */
+  depth?: number
   draft?: boolean
   /** The field which the hook is running against. */
   field: FieldAffectingData

--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -204,7 +204,9 @@ export const promise = async ({
               const hookedValue = await currentHook({
                 collection,
                 context,
+                currentDepth,
                 data: doc,
+                depth,
                 draft,
                 field,
                 findMany,
@@ -231,7 +233,9 @@ export const promise = async ({
           const hookedValue = await currentHook({
             collection,
             context,
+            currentDepth,
             data: doc,
+            depth,
             draft,
             field,
             findMany,

--- a/packages/payload/src/utilities/getDataByPath.ts
+++ b/packages/payload/src/utilities/getDataByPath.ts
@@ -1,4 +1,4 @@
-import type { FormState } from 'payload'
+import type { FormState } from '../admin/types.js'
 
 import { unflatten } from './unflatten.js'
 

--- a/packages/richtext-lexical/src/features/blockquote/server/index.ts
+++ b/packages/richtext-lexical/src/features/blockquote/server/index.ts
@@ -6,8 +6,8 @@ import { QuoteNode } from '@lexical/rich-text'
 import { createServerFeature } from '../../../utilities/createServerFeature.js'
 import { convertLexicalNodesToHTML } from '../../converters/html/converter/index.js'
 import { createNode } from '../../typeUtilities.js'
-import { i18n } from './i18n.js'
 import { MarkdownTransformer } from '../markdownTransformer.js'
+import { i18n } from './i18n.js'
 
 export type SerializedQuoteNode = Spread<
   {
@@ -28,6 +28,8 @@ export const BlockquoteFeature = createServerFeature({
           html: {
             converter: async ({
               converters,
+              currentDepth,
+              depth,
               draft,
               node,
               overrideAccess,
@@ -37,6 +39,8 @@ export const BlockquoteFeature = createServerFeature({
             }) => {
               const childrenText = await convertLexicalNodesToHTML({
                 converters,
+                currentDepth,
+                depth,
                 draft,
                 lexicalNodes: node.children,
                 overrideAccess,

--- a/packages/richtext-lexical/src/features/converters/html/converter/converters/paragraph.ts
+++ b/packages/richtext-lexical/src/features/converters/html/converter/converters/paragraph.ts
@@ -5,9 +5,21 @@ import type { HTMLConverter } from '../types.js'
 import { convertLexicalNodesToHTML } from '../index.js'
 
 export const ParagraphHTMLConverter: HTMLConverter<SerializedParagraphNode> = {
-  async converter({ converters, draft, node, overrideAccess, parent, req, showHiddenFields }) {
+  async converter({
+    converters,
+    currentDepth,
+    depth,
+    draft,
+    node,
+    overrideAccess,
+    parent,
+    req,
+    showHiddenFields,
+  }) {
     const childrenText = await convertLexicalNodesToHTML({
       converters,
+      currentDepth,
+      depth,
       draft,
       lexicalNodes: node.children,
       overrideAccess,

--- a/packages/richtext-lexical/src/features/converters/html/converter/index.ts
+++ b/packages/richtext-lexical/src/features/converters/html/converter/index.ts
@@ -7,7 +7,9 @@ import type { HTMLConverter, SerializedLexicalNodeWithParent } from './types.js'
 
 export type ConvertLexicalToHTMLArgs = {
   converters: HTMLConverter[]
+  currentDepth?: number
   data: SerializedEditorState
+  depth?: number
   draft?: boolean // default false
   overrideAccess?: boolean // default false
   showHiddenFields?: boolean // default false
@@ -42,7 +44,9 @@ export type ConvertLexicalToHTMLArgs = {
 
 export async function convertLexicalToHTML({
   converters,
+  currentDepth,
   data,
+  depth,
   draft,
   overrideAccess,
   payload,
@@ -54,8 +58,18 @@ export async function convertLexicalToHTML({
       req = await createLocalReq({}, payload)
     }
 
+    if (!currentDepth) {
+      currentDepth = 0
+    }
+
+    if (!depth) {
+      depth = req?.payload?.config?.defaultDepth
+    }
+
     return await convertLexicalNodesToHTML({
       converters,
+      currentDepth,
+      depth,
       draft: draft === undefined ? false : draft,
       lexicalNodes: data?.root?.children,
       overrideAccess: overrideAccess === undefined ? false : overrideAccess,
@@ -69,6 +83,8 @@ export async function convertLexicalToHTML({
 
 export async function convertLexicalNodesToHTML({
   converters,
+  currentDepth,
+  depth,
   draft,
   lexicalNodes,
   overrideAccess,
@@ -77,6 +93,8 @@ export async function convertLexicalNodesToHTML({
   showHiddenFields,
 }: {
   converters: HTMLConverter[]
+  currentDepth: number
+  depth: number
   draft: boolean
   lexicalNodes: SerializedLexicalNode[]
   overrideAccess: boolean
@@ -100,6 +118,8 @@ export async function convertLexicalNodesToHTML({
             return await unknownConverter.converter({
               childIndex: i,
               converters,
+              currentDepth,
+              depth,
               draft,
               node,
               overrideAccess,
@@ -113,6 +133,8 @@ export async function convertLexicalNodesToHTML({
         return await converterForNode.converter({
           childIndex: i,
           converters,
+          currentDepth,
+          depth,
           draft,
           node,
           overrideAccess,

--- a/packages/richtext-lexical/src/features/converters/html/converter/types.ts
+++ b/packages/richtext-lexical/src/features/converters/html/converter/types.ts
@@ -5,6 +5,8 @@ export type HTMLConverter<T extends SerializedLexicalNode = SerializedLexicalNod
   converter: (args: {
     childIndex: number
     converters: HTMLConverter<any>[]
+    currentDepth: number
+    depth: number
     draft: boolean
     node: T
     overrideAccess: boolean

--- a/packages/richtext-lexical/src/features/converters/html/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/html/field/index.ts
@@ -162,6 +162,8 @@ export const lexicalHTML: (
       afterRead: [
         async ({
           collection,
+          currentDepth,
+          depth,
           draft,
           field,
           global,
@@ -217,7 +219,9 @@ export const lexicalHTML: (
 
           return await convertLexicalToHTML({
             converters: finalConverters,
+            currentDepth,
             data: lexicalFieldData,
+            depth,
             draft,
             overrideAccess,
             req,

--- a/packages/richtext-lexical/src/features/experimental_table/server/index.ts
+++ b/packages/richtext-lexical/src/features/experimental_table/server/index.ts
@@ -73,6 +73,8 @@ export const EXPERIMENTAL_TableFeature = createServerFeature({
             html: {
               converter: async ({
                 converters,
+                currentDepth,
+                depth,
                 draft,
                 node,
                 overrideAccess,
@@ -82,6 +84,8 @@ export const EXPERIMENTAL_TableFeature = createServerFeature({
               }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  currentDepth,
+                  depth,
                   draft,
                   lexicalNodes: node.children,
                   overrideAccess,
@@ -104,6 +108,8 @@ export const EXPERIMENTAL_TableFeature = createServerFeature({
             html: {
               converter: async ({
                 converters,
+                currentDepth,
+                depth,
                 draft,
                 node,
                 overrideAccess,
@@ -113,6 +119,8 @@ export const EXPERIMENTAL_TableFeature = createServerFeature({
               }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  currentDepth,
+                  depth,
                   draft,
                   lexicalNodes: node.children,
                   overrideAccess,
@@ -144,6 +152,8 @@ export const EXPERIMENTAL_TableFeature = createServerFeature({
             html: {
               converter: async ({
                 converters,
+                currentDepth,
+                depth,
                 draft,
                 node,
                 overrideAccess,
@@ -153,6 +163,8 @@ export const EXPERIMENTAL_TableFeature = createServerFeature({
               }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  currentDepth,
+                  depth,
                   draft,
                   lexicalNodes: node.children,
                   overrideAccess,

--- a/packages/richtext-lexical/src/features/heading/server/index.ts
+++ b/packages/richtext-lexical/src/features/heading/server/index.ts
@@ -46,6 +46,8 @@ export const HeadingFeature = createServerFeature<
             html: {
               converter: async ({
                 converters,
+                currentDepth,
+                depth,
                 draft,
                 node,
                 overrideAccess,
@@ -55,6 +57,8 @@ export const HeadingFeature = createServerFeature<
               }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  currentDepth,
+                  depth,
                   draft,
                   lexicalNodes: node.children,
                   overrideAccess,

--- a/packages/richtext-lexical/src/features/link/server/index.ts
+++ b/packages/richtext-lexical/src/features/link/server/index.ts
@@ -116,6 +116,8 @@ export const LinkFeature = createServerFeature<
             html: {
               converter: async ({
                 converters,
+                currentDepth,
+                depth,
                 draft,
                 node,
                 overrideAccess,
@@ -125,6 +127,8 @@ export const LinkFeature = createServerFeature<
               }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  currentDepth,
+                  depth,
                   draft,
                   lexicalNodes: node.children,
                   overrideAccess,
@@ -161,6 +165,8 @@ export const LinkFeature = createServerFeature<
             html: {
               converter: async ({
                 converters,
+                currentDepth,
+                depth,
                 draft,
                 node,
                 overrideAccess,
@@ -170,6 +176,8 @@ export const LinkFeature = createServerFeature<
               }) => {
                 const childrenText = await convertLexicalNodesToHTML({
                   converters,
+                  currentDepth,
+                  depth,
                   draft,
                   lexicalNodes: node.children,
                   overrideAccess,

--- a/packages/richtext-lexical/src/features/lists/htmlConverter.ts
+++ b/packages/richtext-lexical/src/features/lists/htmlConverter.ts
@@ -7,9 +7,21 @@ import type { SerializedListItemNode, SerializedListNode } from './plugin/index.
 import { convertLexicalNodesToHTML } from '../converters/html/converter/index.js'
 
 export const ListHTMLConverter: HTMLConverter<SerializedListNode> = {
-  converter: async ({ converters, draft, node, overrideAccess, parent, req, showHiddenFields }) => {
+  converter: async ({
+    converters,
+    currentDepth,
+    depth,
+    draft,
+    node,
+    overrideAccess,
+    parent,
+    req,
+    showHiddenFields,
+  }) => {
     const childrenText = await convertLexicalNodesToHTML({
       converters,
+      currentDepth,
+      depth,
       draft,
       lexicalNodes: node.children,
       overrideAccess,
@@ -27,11 +39,23 @@ export const ListHTMLConverter: HTMLConverter<SerializedListNode> = {
 }
 
 export const ListItemHTMLConverter: HTMLConverter<SerializedListItemNode> = {
-  converter: async ({ converters, draft, node, overrideAccess, parent, req, showHiddenFields }) => {
+  converter: async ({
+    converters,
+    currentDepth,
+    depth,
+    draft,
+    node,
+    overrideAccess,
+    parent,
+    req,
+    showHiddenFields,
+  }) => {
     const hasSubLists = node.children.some((child) => child.type === 'list')
 
     const childrenText = await convertLexicalNodesToHTML({
       converters,
+      currentDepth,
+      depth,
       draft,
       lexicalNodes: node.children,
       overrideAccess,

--- a/packages/richtext-lexical/src/features/upload/server/feature.server.ts
+++ b/packages/richtext-lexical/src/features/upload/server/feature.server.ts
@@ -97,7 +97,15 @@ export const UploadFeature = createServerFeature<
         createNode({
           converters: {
             html: {
-              converter: async ({ draft, node, overrideAccess, req, showHiddenFields }) => {
+              converter: async ({
+                currentDepth,
+                depth,
+                draft,
+                node,
+                overrideAccess,
+                req,
+                showHiddenFields,
+              }) => {
                 // @ts-expect-error
                 const id = node?.value?.id || node?.value // for backwards-compatibility
 
@@ -110,9 +118,9 @@ export const UploadFeature = createServerFeature<
                     await populate({
                       id,
                       collectionSlug: node.relationTo,
-                      currentDepth: 0,
+                      currentDepth,
                       data: uploadDocument,
-                      depth: 1,
+                      depth,
                       draft,
                       key: 'value',
                       overrideAccess,

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -975,8 +975,9 @@ export type * from './nodeTypes.js'
 
 export { defaultRichTextValue } from './populateGraphQL/defaultValue.js'
 
+export { populate } from './populateGraphQL/populate.js'
 export type { LexicalEditorProps, LexicalRichTextAdapter } from './types.js'
 export { createServerFeature } from './utilities/createServerFeature.js'
-export type { FieldsDrawerProps } from './utilities/fieldsDrawer/Drawer.js'
 
+export type { FieldsDrawerProps } from './utilities/fieldsDrawer/Drawer.js'
 export { upgradeLexicalData } from './utilities/upgradeLexicalData/index.js'

--- a/packages/richtext-lexical/src/lexical/utils/url.ts
+++ b/packages/richtext-lexical/src/lexical/utils/url.ts
@@ -30,6 +30,8 @@ const relativeOrAnchorRegExp = /^[\w\-./]*(?:#\w[\w-]*)?$/
  * @param url
  */
 export function validateUrlMinimal(url: string): boolean {
+  if (!url) return false
+
   return !url.includes(' ')
 }
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/7743