### PR TITLE
fix: locale selector + autosave race condition

### DIFF
--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -280,6 +280,7 @@ export const Document: React.FC<AdminViewProps> = async ({
       initialData={data}
       initialState={formState}
       isEditing={isEditing}
+      key={locale?.code}
     >
       {!RootViewOverride && (
         <DocumentHeader


### PR DESCRIPTION
## Description

Fixes a race condition where you could switch locales and have autosave trigger with old locale data.

By adding the `key` to the `Document` component, we will ensure that the entire `Document` will be un-mounted and re-mounted between locale switches.