### PR TITLE
fix(db-postgres, db-sqlite): hasMany text, number, poly relationship, blocks, arrays within localized fields

### DIFF
--- a/packages/db-sqlite/src/schema/build.ts
+++ b/packages/db-sqlite/src/schema/build.ts
@@ -58,6 +58,11 @@ type Args = {
   tableName: string
   timestamps?: boolean
   versions: boolean
+  /**
+   * Tracks whether or not this table is built
+   * from the result of a localized array or block field at some point
+   */
+  withinLocalizedArrayOrBlock?: boolean
 }
 
 type Result = {
@@ -81,6 +86,7 @@ export const buildTable = ({
   tableName,
   timestamps,
   versions,
+  withinLocalizedArrayOrBlock,
 }: Args): Result => {
   const isRoot = !incomingRootTableName
   const rootTableName = incomingRootTableName || tableName
@@ -128,6 +134,7 @@ export const buildTable = ({
     rootTableIDColType: rootTableIDColType || idColType,
     rootTableName,
     versions,
+    withinLocalizedArrayOrBlock,
   })
 
   // split the relationsToBuild by localized and non-localized

--- a/packages/db-sqlite/src/schema/build.ts
+++ b/packages/db-sqlite/src/schema/build.ts
@@ -66,6 +66,9 @@ type Args = {
 }
 
 type Result = {
+  hasLocalizedManyNumberField: boolean
+  hasLocalizedManyTextField: boolean
+  hasLocalizedRelationshipField: boolean
   hasManyNumberField: 'index' | boolean
   hasManyTextField: 'index' | boolean
   relationsToBuild: RelationMap
@@ -485,5 +488,12 @@ export const buildTable = ({
     return result
   })
 
-  return { hasManyNumberField, hasManyTextField, relationsToBuild }
+  return {
+    hasLocalizedManyNumberField,
+    hasLocalizedManyTextField,
+    hasLocalizedRelationshipField,
+    hasManyNumberField,
+    hasManyTextField,
+    relationsToBuild,
+  }
 }

--- a/packages/db-sqlite/src/schema/traverseFields.ts
+++ b/packages/db-sqlite/src/schema/traverseFields.ts
@@ -52,6 +52,11 @@ type Args = {
   rootTableIDColType: IDType
   rootTableName: string
   versions: boolean
+  /**
+   * Tracks whether or not this table is built
+   * from the result of a localized array or block field at some point
+   */
+  withinLocalizedArrayOrBlock?: boolean
 }
 
 type Result = {
@@ -84,6 +89,7 @@ export const traverseFields = ({
   rootTableIDColType,
   rootTableName,
   versions,
+  withinLocalizedArrayOrBlock,
 }: Args): Result => {
   let hasLocalizedField = false
   let hasLocalizedRelationshipField = false
@@ -337,7 +343,11 @@ export const traverseFields = ({
           _parentIDIdx: (cols) => index(`${arrayTableName}_parent_id_idx`).on(cols._parentID),
         }
 
-        if (field.localized && adapter.payload.config.localization) {
+        const isLocalized =
+          Boolean(field.localized && adapter.payload.config.localization) ||
+          withinLocalizedArrayOrBlock
+
+        if (isLocalized) {
           baseColumns._locale = text('_locale', { enum: locales }).notNull()
           baseExtraConfig._localeIdx = (cols) =>
             index(`${arrayTableName}_locale_idx`).on(cols._locale)
@@ -360,6 +370,7 @@ export const traverseFields = ({
           rootTableName,
           tableName: arrayTableName,
           versions,
+          withinLocalizedArrayOrBlock: isLocalized,
         })
 
         if (subHasManyTextField) {
@@ -453,7 +464,11 @@ export const traverseFields = ({
               _pathIdx: (cols) => index(`${blockTableName}_path_idx`).on(cols._path),
             }
 
-            if (field.localized && adapter.payload.config.localization) {
+            const isLocalized =
+              Boolean(field.localized && adapter.payload.config.localization) ||
+              withinLocalizedArrayOrBlock
+
+            if (isLocalized) {
               baseColumns._locale = text('_locale', { enum: locales }).notNull()
               baseExtraConfig._localeIdx = (cols) =>
                 index(`${blockTableName}_locale_idx`).on(cols._locale)
@@ -476,6 +491,7 @@ export const traverseFields = ({
               rootTableName,
               tableName: blockTableName,
               versions,
+              withinLocalizedArrayOrBlock: isLocalized,
             })
 
             if (subHasManyTextField) {
@@ -577,6 +593,7 @@ export const traverseFields = ({
             rootTableIDColType,
             rootTableName,
             versions,
+            withinLocalizedArrayOrBlock,
           })
 
           if (groupHasLocalizedField) hasLocalizedField = true
@@ -618,6 +635,7 @@ export const traverseFields = ({
           rootTableIDColType,
           rootTableName,
           versions,
+          withinLocalizedArrayOrBlock,
         })
 
         if (groupHasLocalizedField) hasLocalizedField = true
@@ -660,6 +678,7 @@ export const traverseFields = ({
           rootTableIDColType,
           rootTableName,
           versions,
+          withinLocalizedArrayOrBlock,
         })
 
         if (tabHasLocalizedField) hasLocalizedField = true
@@ -702,6 +721,7 @@ export const traverseFields = ({
           rootTableIDColType,
           rootTableName,
           versions,
+          withinLocalizedArrayOrBlock,
         })
 
         if (rowHasLocalizedField) hasLocalizedField = true

--- a/packages/db-sqlite/src/schema/traverseFields.ts
+++ b/packages/db-sqlite/src/schema/traverseFields.ts
@@ -156,7 +156,11 @@ export const traverseFields = ({
     switch (field.type) {
       case 'text': {
         if (field.hasMany) {
-          if (field.localized) {
+          const isLocalized =
+            Boolean(field.localized && adapter.payload.config.localization) ||
+            withinLocalizedArrayOrBlock
+
+          if (isLocalized) {
             hasLocalizedManyTextField = true
           }
 
@@ -185,7 +189,11 @@ export const traverseFields = ({
 
       case 'number': {
         if (field.hasMany) {
-          if (field.localized) {
+          const isLocalized =
+            Boolean(field.localized && adapter.payload.config.localization) ||
+            withinLocalizedArrayOrBlock
+
+          if (isLocalized) {
             hasLocalizedManyNumberField = true
           }
 
@@ -261,7 +269,11 @@ export const traverseFields = ({
             parentIdx: (cols) => index(`${selectTableName}_parent_idx`).on(cols.parent),
           }
 
-          if (field.localized) {
+          const isLocalized =
+            Boolean(field.localized && adapter.payload.config.localization) ||
+            withinLocalizedArrayOrBlock
+
+          if (isLocalized) {
             baseColumns.locale = text('locale', { enum: locales }).notNull()
             baseExtraConfig.localeIdx = (cols) =>
               index(`${selectTableName}_locale_idx`).on(cols.locale)
@@ -354,6 +366,9 @@ export const traverseFields = ({
         }
 
         const {
+          hasLocalizedManyNumberField: subHasLocalizedManyNumberField,
+          hasLocalizedManyTextField: subHasLocalizedManyTextField,
+          hasLocalizedRelationshipField: subHasLocalizedRelationshipField,
           hasManyNumberField: subHasManyNumberField,
           hasManyTextField: subHasManyTextField,
           relationsToBuild: subRelationsToBuild,
@@ -372,6 +387,18 @@ export const traverseFields = ({
           versions,
           withinLocalizedArrayOrBlock: isLocalized,
         })
+
+        if (subHasLocalizedManyNumberField) {
+          hasLocalizedManyNumberField = subHasLocalizedManyNumberField
+        }
+
+        if (subHasLocalizedRelationshipField) {
+          hasLocalizedRelationshipField = subHasLocalizedRelationshipField
+        }
+
+        if (subHasLocalizedManyTextField) {
+          hasLocalizedManyTextField = subHasLocalizedManyTextField
+        }
 
         if (subHasManyTextField) {
           if (!hasManyTextField || subHasManyTextField === 'index')
@@ -475,6 +502,9 @@ export const traverseFields = ({
             }
 
             const {
+              hasLocalizedManyNumberField: subHasLocalizedManyNumberField,
+              hasLocalizedManyTextField: subHasLocalizedManyTextField,
+              hasLocalizedRelationshipField: subHasLocalizedRelationshipField,
               hasManyNumberField: subHasManyNumberField,
               hasManyTextField: subHasManyTextField,
               relationsToBuild: subRelationsToBuild,
@@ -493,6 +523,18 @@ export const traverseFields = ({
               versions,
               withinLocalizedArrayOrBlock: isLocalized,
             })
+
+            if (subHasLocalizedManyNumberField) {
+              hasLocalizedManyNumberField = subHasLocalizedManyNumberField
+            }
+
+            if (subHasLocalizedRelationshipField) {
+              hasLocalizedRelationshipField = subHasLocalizedRelationshipField
+            }
+
+            if (subHasLocalizedManyTextField) {
+              hasLocalizedManyTextField = subHasLocalizedManyTextField
+            }
 
             if (subHasManyTextField) {
               if (!hasManyTextField || subHasManyTextField === 'index')
@@ -773,7 +815,10 @@ export const traverseFields = ({
           }
           break
         }
-        if (adapter.payload.config.localization && field.localized) {
+        if (
+          Boolean(field.localized && adapter.payload.config.localization) ||
+          withinLocalizedArrayOrBlock
+        ) {
           hasLocalizedRelationshipField = true
         }
 

--- a/packages/drizzle/src/postgres/schema/build.ts
+++ b/packages/drizzle/src/postgres/schema/build.ts
@@ -54,6 +54,11 @@ type Args = {
   tableName: string
   timestamps?: boolean
   versions: boolean
+  /**
+   * Tracks whether or not this table is built
+   * from the result of a localized array or block field at some point
+   */
+  withinLocalizedArrayOrBlock?: boolean
 }
 
 type Result = {
@@ -76,6 +81,7 @@ export const buildTable = ({
   tableName,
   timestamps,
   versions,
+  withinLocalizedArrayOrBlock,
 }: Args): Result => {
   const isRoot = !incomingRootTableName
   const rootTableName = incomingRootTableName || tableName
@@ -122,6 +128,7 @@ export const buildTable = ({
     rootTableIDColType: rootTableIDColType || idColType,
     rootTableName,
     versions,
+    withinLocalizedArrayOrBlock,
   })
 
   // split the relationsToBuild by localized and non-localized

--- a/packages/drizzle/src/postgres/schema/build.ts
+++ b/packages/drizzle/src/postgres/schema/build.ts
@@ -62,6 +62,9 @@ type Args = {
 }
 
 type Result = {
+  hasLocalizedManyNumberField: boolean
+  hasLocalizedManyTextField: boolean
+  hasLocalizedRelationshipField: boolean
   hasManyNumberField: 'index' | boolean
   hasManyTextField: 'index' | boolean
   relationsToBuild: RelationMap
@@ -471,5 +474,12 @@ export const buildTable = ({
     return result
   })
 
-  return { hasManyNumberField, hasManyTextField, relationsToBuild }
+  return {
+    hasLocalizedManyNumberField,
+    hasLocalizedManyTextField,
+    hasLocalizedRelationshipField,
+    hasManyNumberField,
+    hasManyTextField,
+    relationsToBuild,
+  }
 }

--- a/packages/drizzle/src/postgres/schema/traverseFields.ts
+++ b/packages/drizzle/src/postgres/schema/traverseFields.ts
@@ -58,6 +58,11 @@ type Args = {
   rootTableIDColType: string
   rootTableName: string
   versions: boolean
+  /**
+   * Tracks whether or not this table is built
+   * from the result of a localized array or block field at some point
+   */
+  withinLocalizedArrayOrBlock?: boolean
 }
 
 type Result = {
@@ -89,6 +94,7 @@ export const traverseFields = ({
   rootTableIDColType,
   rootTableName,
   versions,
+  withinLocalizedArrayOrBlock,
 }: Args): Result => {
   const throwValidationError = true
   let hasLocalizedField = false
@@ -354,7 +360,11 @@ export const traverseFields = ({
           _parentIDIdx: (cols) => index(`${arrayTableName}_parent_id_idx`).on(cols._parentID),
         }
 
-        if (field.localized && adapter.payload.config.localization) {
+        const isLocalized =
+          Boolean(field.localized && adapter.payload.config.localization) ||
+          withinLocalizedArrayOrBlock
+
+        if (isLocalized) {
           baseColumns._locale = adapter.enums.enum__locales('_locale').notNull()
           baseExtraConfig._localeIdx = (cols) =>
             index(`${arrayTableName}_locale_idx`).on(cols._locale)
@@ -377,6 +387,7 @@ export const traverseFields = ({
           rootTableName,
           tableName: arrayTableName,
           versions,
+          withinLocalizedArrayOrBlock: isLocalized,
         })
 
         if (subHasManyTextField) {
@@ -466,7 +477,11 @@ export const traverseFields = ({
               _pathIdx: (cols) => index(`${blockTableName}_path_idx`).on(cols._path),
             }
 
-            if (field.localized && adapter.payload.config.localization) {
+            const isLocalized =
+              Boolean(field.localized && adapter.payload.config.localization) ||
+              withinLocalizedArrayOrBlock
+
+            if (isLocalized) {
               baseColumns._locale = adapter.enums.enum__locales('_locale').notNull()
               baseExtraConfig._localeIdx = (cols) =>
                 index(`${blockTableName}_locale_idx`).on(cols._locale)
@@ -489,6 +504,7 @@ export const traverseFields = ({
               rootTableName,
               tableName: blockTableName,
               versions,
+              withinLocalizedArrayOrBlock: isLocalized,
             })
 
             if (subHasManyTextField) {
@@ -589,6 +605,7 @@ export const traverseFields = ({
             rootTableIDColType,
             rootTableName,
             versions,
+            withinLocalizedArrayOrBlock,
           })
 
           if (groupHasLocalizedField) hasLocalizedField = true
@@ -629,6 +646,7 @@ export const traverseFields = ({
           rootTableIDColType,
           rootTableName,
           versions,
+          withinLocalizedArrayOrBlock,
         })
 
         if (groupHasLocalizedField) hasLocalizedField = true
@@ -670,6 +688,7 @@ export const traverseFields = ({
           rootTableIDColType,
           rootTableName,
           versions,
+          withinLocalizedArrayOrBlock,
         })
 
         if (tabHasLocalizedField) hasLocalizedField = true
@@ -711,6 +730,7 @@ export const traverseFields = ({
           rootTableIDColType,
           rootTableName,
           versions,
+          withinLocalizedArrayOrBlock,
         })
 
         if (rowHasLocalizedField) hasLocalizedField = true

--- a/packages/drizzle/src/postgres/schema/traverseFields.ts
+++ b/packages/drizzle/src/postgres/schema/traverseFields.ts
@@ -162,7 +162,11 @@ export const traverseFields = ({
     switch (field.type) {
       case 'text': {
         if (field.hasMany) {
-          if (field.localized) {
+          const isLocalized =
+            Boolean(field.localized && adapter.payload.config.localization) ||
+            withinLocalizedArrayOrBlock
+
+          if (isLocalized) {
             hasLocalizedManyTextField = true
           }
 
@@ -191,7 +195,11 @@ export const traverseFields = ({
 
       case 'number': {
         if (field.hasMany) {
-          if (field.localized) {
+          const isLocalized =
+            Boolean(field.localized && adapter.payload.config.localization) ||
+            withinLocalizedArrayOrBlock
+
+          if (isLocalized) {
             hasLocalizedManyNumberField = true
           }
 
@@ -282,7 +290,11 @@ export const traverseFields = ({
             parentIdx: (cols) => index(`${selectTableName}_parent_idx`).on(cols.parent),
           }
 
-          if (field.localized) {
+          const isLocalized =
+            Boolean(field.localized && adapter.payload.config.localization) ||
+            withinLocalizedArrayOrBlock
+
+          if (isLocalized) {
             baseColumns.locale = adapter.enums.enum__locales('locale').notNull()
             baseExtraConfig.localeIdx = (cols) =>
               index(`${selectTableName}_locale_idx`).on(cols.locale)
@@ -371,6 +383,9 @@ export const traverseFields = ({
         }
 
         const {
+          hasLocalizedManyNumberField: subHasLocalizedManyNumberField,
+          hasLocalizedManyTextField: subHasLocalizedManyTextField,
+          hasLocalizedRelationshipField: subHasLocalizedRelationshipField,
           hasManyNumberField: subHasManyNumberField,
           hasManyTextField: subHasManyTextField,
           relationsToBuild: subRelationsToBuild,
@@ -389,6 +404,18 @@ export const traverseFields = ({
           versions,
           withinLocalizedArrayOrBlock: isLocalized,
         })
+
+        if (subHasLocalizedManyNumberField) {
+          hasLocalizedManyNumberField = subHasLocalizedManyNumberField
+        }
+
+        if (subHasLocalizedRelationshipField) {
+          hasLocalizedRelationshipField = subHasLocalizedRelationshipField
+        }
+
+        if (subHasLocalizedManyTextField) {
+          hasLocalizedManyTextField = subHasLocalizedManyTextField
+        }
 
         if (subHasManyTextField) {
           if (!hasManyTextField || subHasManyTextField === 'index')
@@ -488,6 +515,9 @@ export const traverseFields = ({
             }
 
             const {
+              hasLocalizedManyNumberField: subHasLocalizedManyNumberField,
+              hasLocalizedManyTextField: subHasLocalizedManyTextField,
+              hasLocalizedRelationshipField: subHasLocalizedRelationshipField,
               hasManyNumberField: subHasManyNumberField,
               hasManyTextField: subHasManyTextField,
               relationsToBuild: subRelationsToBuild,
@@ -506,6 +536,18 @@ export const traverseFields = ({
               versions,
               withinLocalizedArrayOrBlock: isLocalized,
             })
+
+            if (subHasLocalizedManyNumberField) {
+              hasLocalizedManyNumberField = subHasLocalizedManyNumberField
+            }
+
+            if (subHasLocalizedRelationshipField) {
+              hasLocalizedRelationshipField = subHasLocalizedRelationshipField
+            }
+
+            if (subHasLocalizedManyTextField) {
+              hasLocalizedManyTextField = subHasLocalizedManyTextField
+            }
 
             if (subHasManyTextField) {
               if (!hasManyTextField || subHasManyTextField === 'index')
@@ -781,7 +823,11 @@ export const traverseFields = ({
           }
           break
         }
-        if (adapter.payload.config.localization && field.localized) {
+
+        if (
+          Boolean(field.localized && adapter.payload.config.localization) ||
+          withinLocalizedArrayOrBlock
+        ) {
           hasLocalizedRelationshipField = true
         }
 

--- a/packages/drizzle/src/transform/read/hasManyNumber.ts
+++ b/packages/drizzle/src/transform/read/hasManyNumber.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import type { NumberField } from 'payload'
 
 type Args = {
@@ -6,10 +5,29 @@ type Args = {
   locale?: string
   numberRows: Record<string, unknown>[]
   ref: Record<string, unknown>
+  withinArrayOrBlockLocale?: string
 }
 
-export const transformHasManyNumber = ({ field, locale, numberRows, ref }: Args) => {
-  const result = numberRows.map(({ number }) => number)
+export const transformHasManyNumber = ({
+  field,
+  locale,
+  numberRows,
+  ref,
+  withinArrayOrBlockLocale,
+}: Args) => {
+  let result: unknown[]
+
+  if (withinArrayOrBlockLocale) {
+    result = numberRows.reduce((acc, { locale, number }) => {
+      if (locale === withinArrayOrBlockLocale) {
+        acc.push(number)
+      }
+
+      return acc
+    }, [])
+  } else {
+    result = numberRows.map(({ number }) => number)
+  }
 
   if (locale) {
     ref[field.name][locale] = result

--- a/packages/drizzle/src/transform/read/hasManyText.ts
+++ b/packages/drizzle/src/transform/read/hasManyText.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import type { TextField } from 'payload'
 
 type Args = {
@@ -6,10 +5,29 @@ type Args = {
   locale?: string
   ref: Record<string, unknown>
   textRows: Record<string, unknown>[]
+  withinArrayOrBlockLocale?: string
 }
 
-export const transformHasManyText = ({ field, locale, ref, textRows }: Args) => {
-  const result = textRows.map(({ text }) => text)
+export const transformHasManyText = ({
+  field,
+  locale,
+  ref,
+  textRows,
+  withinArrayOrBlockLocale,
+}: Args) => {
+  let result: unknown[]
+
+  if (withinArrayOrBlockLocale) {
+    result = textRows.reduce((acc, { locale, text }) => {
+      if (locale === withinArrayOrBlockLocale) {
+        acc.push(text)
+      }
+
+      return acc
+    }, [])
+  } else {
+    result = textRows.map(({ text }) => text)
+  }
 
   if (locale) {
     ref[field.name][locale] = result

--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -360,6 +360,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
               field,
               ref: result,
               relations: relationPathMatch,
+              withinArrayOrBlockLocale,
             })
           }
           return result
@@ -394,6 +395,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
             field,
             ref: result,
             textRows: textPathMatch,
+            withinArrayOrBlockLocale,
           })
         }
 
@@ -428,6 +430,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
             field,
             numberRows: numberPathMatch,
             ref: result,
+            withinArrayOrBlockLocale,
           })
         }
 

--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -58,6 +58,10 @@ type TraverseFieldsArgs = {
    * All hasMany text fields, as returned by Drizzle, keyed on an object by field path
    */
   texts: Record<string, Record<string, unknown>[]>
+  /**
+   * Set to a locale if this group of fields is within a localized array or block.
+   */
+  withinArrayOrBlockLocale?: string
 }
 
 // Traverse fields recursively, transforming data
@@ -75,6 +79,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
   relationships,
   table,
   texts,
+  withinArrayOrBlockLocale,
 }: TraverseFieldsArgs): T => {
   const sanitizedPath = path ? `${path}.` : path
 
@@ -93,6 +98,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
         relationships,
         table,
         texts,
+        withinArrayOrBlockLocale,
       })
     }
 
@@ -114,6 +120,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
         relationships,
         table,
         texts,
+        withinArrayOrBlockLocale,
       })
     }
 
@@ -157,6 +164,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
                   relationships,
                   table: row,
                   texts,
+                  withinArrayOrBlockLocale: locale,
                 })
 
                 if ('_order' in rowResult) {
@@ -192,6 +200,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
                 relationships,
                 table: row,
                 texts,
+                withinArrayOrBlockLocale,
               })
             })
           }
@@ -237,6 +246,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
                     relationships,
                     table: row,
                     texts,
+                    withinArrayOrBlockLocale: locale,
                   })
 
                   delete blockResult._order
@@ -247,7 +257,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
               })
             })
           } else {
-            result[field.name] = blocks[blockFieldPath].map((row, i) => {
+            result[field.name] = blocks[blockFieldPath].reduce((acc, row, i) => {
               delete row._order
               if (row._uuid) {
                 row.id = row._uuid
@@ -256,24 +266,40 @@ export const traverseFields = <T extends Record<string, unknown>>({
               const block = field.blocks.find(({ slug }) => slug === row.blockType)
 
               if (block) {
-                return traverseFields<T>({
-                  adapter,
-                  blocks,
-                  config,
-                  dataRef: row,
-                  deletions,
-                  fieldPrefix: '',
-                  fields: block.fields,
-                  numbers,
-                  path: `${blockFieldPath}.${i}`,
-                  relationships,
-                  table: row,
-                  texts,
-                })
+                if (
+                  !withinArrayOrBlockLocale ||
+                  (withinArrayOrBlockLocale && withinArrayOrBlockLocale === row._locale)
+                ) {
+                  if (row._locale) {
+                    delete row._locale
+                  }
+
+                  acc.push(
+                    traverseFields<T>({
+                      adapter,
+                      blocks,
+                      config,
+                      dataRef: row,
+                      deletions,
+                      fieldPrefix: '',
+                      fields: block.fields,
+                      numbers,
+                      path: `${blockFieldPath}.${i}`,
+                      relationships,
+                      table: row,
+                      texts,
+                      withinArrayOrBlockLocale,
+                    }),
+                  )
+
+                  return acc
+                }
+              } else {
+                acc.push({})
               }
 
-              return {}
-            })
+              return acc
+            }, [])
           }
         }
 
@@ -466,6 +492,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
               relationships,
               table,
               texts,
+              withinArrayOrBlockLocale,
             })
 
             if ('_order' in ref) {

--- a/packages/drizzle/src/transform/write/array.ts
+++ b/packages/drizzle/src/transform/write/array.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import type { ArrayField } from 'payload'
 
 import type { DrizzleAdapter } from '../../types.js'
@@ -26,6 +25,11 @@ type Args = {
     [tableName: string]: Record<string, unknown>[]
   }
   texts: Record<string, unknown>[]
+  /**
+   * Set to a locale code if this set of fields is traversed within a
+   * localized array or block field
+   */
+  withinArrayOrBlockLocale?: string
 }
 
 export const transformArray = ({
@@ -43,6 +47,7 @@ export const transformArray = ({
   relationshipsToDelete,
   selects,
   texts,
+  withinArrayOrBlockLocale,
 }: Args) => {
   const newRows: ArrayRowToInsert[] = []
 
@@ -78,6 +83,10 @@ export const transformArray = ({
         newRow.row._locale = locale
       }
 
+      if (withinArrayOrBlockLocale) {
+        newRow.row._locale = withinArrayOrBlockLocale
+      }
+
       traverseFields({
         adapter,
         arrays: newRow.arrays,
@@ -97,6 +106,7 @@ export const transformArray = ({
         row: newRow.row,
         selects,
         texts,
+        withinArrayOrBlockLocale,
       })
 
       newRows.push(newRow)

--- a/packages/drizzle/src/transform/write/blocks.ts
+++ b/packages/drizzle/src/transform/write/blocks.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import type { BlockField } from 'payload'
 
 import toSnakeCase from 'to-snake-case'
@@ -26,6 +25,11 @@ type Args = {
     [tableName: string]: Record<string, unknown>[]
   }
   texts: Record<string, unknown>[]
+  /**
+   * Set to a locale code if this set of fields is traversed within a
+   * localized array or block field
+   */
+  withinArrayOrBlockLocale?: string
 }
 export const transformBlocks = ({
   adapter,
@@ -41,6 +45,7 @@ export const transformBlocks = ({
   relationshipsToDelete,
   selects,
   texts,
+  withinArrayOrBlockLocale,
 }: Args) => {
   data.forEach((blockRow, i) => {
     if (typeof blockRow.blockType !== 'string') return
@@ -60,6 +65,7 @@ export const transformBlocks = ({
     }
 
     if (field.localized && locale) newRow.row._locale = locale
+    if (withinArrayOrBlockLocale) newRow.row._locale = withinArrayOrBlockLocale
 
     const blockTableName = adapter.tableNameMap.get(`${baseTableName}_blocks_${blockType}`)
 
@@ -94,6 +100,7 @@ export const transformBlocks = ({
       row: newRow.row,
       selects,
       texts,
+      withinArrayOrBlockLocale,
     })
 
     blocks[blockType].push(newRow)

--- a/packages/drizzle/src/transform/write/traverseFields.ts
+++ b/packages/drizzle/src/transform/write/traverseFields.ts
@@ -227,7 +227,7 @@ export const traverseFields = ({
               row,
               selects,
               texts,
-              withinArrayOrBlockLocale,
+              withinArrayOrBlockLocale: localeKey,
             })
           })
         } else {
@@ -286,7 +286,7 @@ export const traverseFields = ({
                   row,
                   selects,
                   texts,
-                  withinArrayOrBlockLocale,
+                  withinArrayOrBlockLocale: localeKey,
                 })
               })
             } else {
@@ -403,6 +403,7 @@ export const traverseFields = ({
 
         transformRelationship({
           baseRow: {
+            locale: withinArrayOrBlockLocale,
             path: relationshipPath,
           },
           data: fieldData,
@@ -456,6 +457,7 @@ export const traverseFields = ({
       } else if (Array.isArray(fieldData)) {
         transformTexts({
           baseRow: {
+            locale: withinArrayOrBlockLocale,
             path: textPath,
           },
           data: fieldData,
@@ -487,6 +489,7 @@ export const traverseFields = ({
       } else if (Array.isArray(fieldData)) {
         transformNumbers({
           baseRow: {
+            locale: withinArrayOrBlockLocale,
             path: numberPath,
           },
           data: fieldData,
@@ -519,6 +522,7 @@ export const traverseFields = ({
         const newRows = transformSelects({
           id: data._uuid || data.id,
           data: data[field.name],
+          locale: withinArrayOrBlockLocale,
         })
 
         selects[selectTableName] = selects[selectTableName].concat(newRows)

--- a/packages/drizzle/src/transform/write/traverseFields.ts
+++ b/packages/drizzle/src/transform/write/traverseFields.ts
@@ -57,6 +57,11 @@ type Args = {
     [tableName: string]: Record<string, unknown>[]
   }
   texts: Record<string, unknown>[]
+  /**
+   * Set to a locale code if this set of fields is traversed within a
+   * localized array or block field
+   */
+  withinArrayOrBlockLocale?: string
 }
 
 export const traverseFields = ({
@@ -80,6 +85,7 @@ export const traverseFields = ({
   row,
   selects,
   texts,
+  withinArrayOrBlockLocale,
 }: Args) => {
   fields.forEach((field) => {
     let columnName = ''
@@ -116,6 +122,7 @@ export const traverseFields = ({
                 relationshipsToDelete,
                 selects,
                 texts,
+                withinArrayOrBlockLocale: localeKey,
               })
 
               arrays[arrayTableName] = arrays[arrayTableName].concat(newRows)
@@ -137,6 +144,7 @@ export const traverseFields = ({
           relationshipsToDelete,
           selects,
           texts,
+          withinArrayOrBlockLocale,
         })
 
         arrays[arrayTableName] = arrays[arrayTableName].concat(newRows)
@@ -168,6 +176,7 @@ export const traverseFields = ({
                 relationshipsToDelete,
                 selects,
                 texts,
+                withinArrayOrBlockLocale: localeKey,
               })
             }
           })
@@ -186,6 +195,7 @@ export const traverseFields = ({
           relationshipsToDelete,
           selects,
           texts,
+          withinArrayOrBlockLocale,
         })
       }
 
@@ -217,6 +227,7 @@ export const traverseFields = ({
               row,
               selects,
               texts,
+              withinArrayOrBlockLocale,
             })
           })
         } else {
@@ -240,6 +251,7 @@ export const traverseFields = ({
             row,
             selects,
             texts,
+            withinArrayOrBlockLocale,
           })
         }
       }
@@ -274,6 +286,7 @@ export const traverseFields = ({
                   row,
                   selects,
                   texts,
+                  withinArrayOrBlockLocale,
                 })
               })
             } else {
@@ -297,6 +310,7 @@ export const traverseFields = ({
                 row,
                 selects,
                 texts,
+                withinArrayOrBlockLocale,
               })
             }
           }
@@ -321,6 +335,7 @@ export const traverseFields = ({
             row,
             selects,
             texts,
+            withinArrayOrBlockLocale,
           })
         }
       })
@@ -347,6 +362,7 @@ export const traverseFields = ({
         row,
         selects,
         texts,
+        withinArrayOrBlockLocale,
       })
     }
 

--- a/test/localization/collections/Blocks/index.ts
+++ b/test/localization/collections/Blocks/index.ts
@@ -1,0 +1,37 @@
+import type { CollectionConfig } from 'payload'
+
+export const blocksCollectionSlug = 'blocks-fields'
+
+export const BlocksCollection: CollectionConfig = {
+  slug: blocksCollectionSlug,
+  fields: [
+    {
+      name: 'content',
+      label: 'Content',
+      type: 'blocks',
+      localized: true,
+      blocks: [
+        {
+          slug: 'blockInsideBlock',
+          fields: [
+            {
+              name: 'content',
+              type: 'blocks',
+              blocks: [
+                {
+                  slug: 'textBlock',
+                  fields: [
+                    {
+                      name: 'text',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/test/localization/collections/NestedArray/index.ts
+++ b/test/localization/collections/NestedArray/index.ts
@@ -6,6 +6,7 @@ export const NestedArray: CollectionConfig = {
     {
       name: 'arrayWithBlocks',
       type: 'array',
+      localized: true,
       fields: [
         {
           name: 'blocksWithinArray',
@@ -24,8 +25,6 @@ export const NestedArray: CollectionConfig = {
           ],
         },
       ],
-
-      localized: true,
     },
     {
       name: 'arrayWithLocalizedRelation',

--- a/test/localization/collections/NestedArray/index.ts
+++ b/test/localization/collections/NestedArray/index.ts
@@ -1,0 +1,43 @@
+import type { CollectionConfig } from 'payload'
+
+export const NestedArray: CollectionConfig = {
+  slug: 'nested-arrays',
+  fields: [
+    {
+      name: 'arrayWithBlocks',
+      type: 'array',
+      fields: [
+        {
+          name: 'blocksWithinArray',
+          type: 'blocks',
+          blocks: [
+            {
+              slug: 'someBlock',
+              fields: [
+                {
+                  name: 'relationWithinBlock',
+                  type: 'relationship',
+                  relationTo: 'localized-posts',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+
+      localized: true,
+    },
+    {
+      name: 'arrayWithLocalizedRelation',
+      type: 'array',
+      fields: [
+        {
+          name: 'localizedRelation',
+          type: 'relationship',
+          localized: true,
+          relationTo: 'localized-posts',
+        },
+      ],
+    },
+  ],
+}

--- a/test/localization/collections/NestedFields/index.ts
+++ b/test/localization/collections/NestedFields/index.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
 export const NestedFields: CollectionConfig = {
-  slug: 'nested-fields',
+  slug: 'nested-field-tables',
   fields: [
     {
       name: 'array',

--- a/test/localization/collections/NestedFields/index.ts
+++ b/test/localization/collections/NestedFields/index.ts
@@ -1,0 +1,47 @@
+import type { CollectionConfig } from 'payload'
+
+export const NestedFields: CollectionConfig = {
+  slug: 'nested-fields',
+  fields: [
+    {
+      name: 'array',
+      type: 'array',
+      localized: true,
+      fields: [
+        {
+          name: 'relation',
+          type: 'relationship',
+          relationTo: ['localized-posts'],
+        },
+        {
+          name: 'hasManyRelation',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: 'localized-posts',
+        },
+        {
+          name: 'hasManyPolyRelation',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: ['localized-posts'],
+        },
+        {
+          name: 'select',
+          type: 'select',
+          hasMany: true,
+          options: ['one', 'two', 'three'],
+        },
+        {
+          name: 'number',
+          type: 'number',
+          hasMany: true,
+        },
+        {
+          name: 'text',
+          type: 'text',
+          hasMany: true,
+        },
+      ],
+    },
+  ],
+}

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -7,7 +7,9 @@ import type { LocalizedPost } from './payload-types.js'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { ArrayCollection } from './collections/Array/index.js'
+import { BlocksCollection } from './collections/Blocks/index.js'
 import { Group } from './collections/Group/index.js'
+import { NestedArray } from './collections/NestedArray/index.js'
 import { NestedToArrayAndBlock } from './collections/NestedToArrayAndBlock/index.js'
 import { Tab } from './collections/Tab/index.js'
 import {
@@ -50,6 +52,8 @@ export default buildConfigWithDefaults({
     },
   },
   collections: [
+    BlocksCollection,
+    NestedArray,
     {
       auth: true,
       fields: [

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -10,6 +10,7 @@ import { ArrayCollection } from './collections/Array/index.js'
 import { BlocksCollection } from './collections/Blocks/index.js'
 import { Group } from './collections/Group/index.js'
 import { NestedArray } from './collections/NestedArray/index.js'
+import { NestedFields } from './collections/NestedFields/index.js'
 import { NestedToArrayAndBlock } from './collections/NestedToArrayAndBlock/index.js'
 import { Tab } from './collections/Tab/index.js'
 import {
@@ -54,6 +55,7 @@ export default buildConfigWithDefaults({
   collections: [
     BlocksCollection,
     NestedArray,
+    NestedFields,
     {
       auth: true,
       fields: [

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -1628,7 +1628,7 @@ describe('Localization', () => {
       ).docs[1]
 
       const newDoc = await payload.create({
-        collection: 'nested-fields',
+        collection: 'nested-field-tables',
         data: {
           array: [
             {
@@ -1656,7 +1656,7 @@ describe('Localization', () => {
       })
 
       await payload.update({
-        collection: 'nested-fields',
+        collection: 'nested-field-tables',
         id: newDoc.id,
         locale: 'es',
         data: {
@@ -1686,7 +1686,7 @@ describe('Localization', () => {
       })
 
       const retrieved = await payload.findByID({
-        collection: 'nested-fields',
+        collection: 'nested-field-tables',
         id: newDoc.id,
         depth: 0,
         locale: 'all',

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -1395,6 +1395,222 @@ describe('Localization', () => {
       expect(docEs.deep.blocks[0].title).toBe('hello es')
     })
   })
+
+  describe('nested blocks', () => {
+    let id
+    it('should allow creating nested blocks per locale', async () => {
+      const doc = await payload.create({
+        collection: 'blocks-fields',
+        data: {
+          content: [
+            {
+              blockType: 'blockInsideBlock',
+              content: [
+                {
+                  blockType: 'textBlock',
+                  text: 'hello',
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      id = doc.id
+
+      await payload.update({
+        collection: 'blocks-fields',
+        id,
+        locale: 'es',
+        data: {
+          content: [
+            {
+              blockType: 'blockInsideBlock',
+              content: [
+                {
+                  blockType: 'textBlock',
+                  text: 'hola',
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      const retrieved = await payload.findByID({
+        collection: 'blocks-fields',
+        id,
+        locale: 'all',
+      })
+
+      expect(retrieved.content.en[0].content).toHaveLength(1)
+      expect(retrieved.content.es[0].content).toHaveLength(1)
+    })
+  })
+
+  describe('nested arrays', () => {
+    it('should not duplicate block rows for blocks within localized array fields', async () => {
+      const randomDoc = (
+        await payload.find({
+          collection: 'localized-posts',
+          depth: 0,
+        })
+      ).docs[0]
+
+      const randomDoc2 = (
+        await payload.find({
+          collection: 'localized-posts',
+          depth: 0,
+        })
+      ).docs[1]
+
+      const blocksWithinArrayEN = [
+        {
+          blockName: '1',
+          blockType: 'someBlock',
+          relationWithinBlock: randomDoc.id,
+        },
+        {
+          blockName: '2',
+          blockType: 'someBlock',
+          relationWithinBlock: randomDoc.id,
+        },
+        {
+          blockName: '3',
+          blockType: 'someBlock',
+          relationWithinBlock: randomDoc.id,
+        },
+      ]
+
+      const blocksWithinArrayES = [
+        {
+          blockName: '1',
+          blockType: 'someBlock',
+          relationWithinBlock: randomDoc2.id,
+        },
+        {
+          blockName: '2',
+          blockType: 'someBlock',
+          relationWithinBlock: randomDoc2.id,
+        },
+        {
+          blockName: '3',
+          blockType: 'someBlock',
+          relationWithinBlock: randomDoc2.id,
+        },
+      ]
+
+      const createdEnDoc = await payload.create({
+        collection: 'nested-arrays',
+        locale: 'en',
+        depth: 0,
+        data: {
+          arrayWithBlocks: [
+            {
+              blocksWithinArray: blocksWithinArrayEN as any,
+            },
+          ],
+        },
+      })
+
+      const updatedEsDoc = await payload.update({
+        collection: 'nested-arrays',
+        id: createdEnDoc.id,
+        depth: 0,
+        locale: 'es',
+        data: {
+          arrayWithBlocks: [
+            {
+              blocksWithinArray: blocksWithinArrayES as any,
+            },
+          ],
+        },
+      })
+
+      const esArrayBlocks = updatedEsDoc.arrayWithBlocks[0].blocksWithinArray
+      // recursively remove any id field within esArrayRow
+      const removeId = (obj) => {
+        if (obj instanceof Object) {
+          delete obj.id
+          Object.values(obj).forEach(removeId)
+        }
+      }
+      removeId(esArrayBlocks)
+      removeId(createdEnDoc.arrayWithBlocks[0].blocksWithinArray)
+
+      expect(esArrayBlocks).toEqual(blocksWithinArrayES)
+      expect(createdEnDoc.arrayWithBlocks[0].blocksWithinArray).toEqual(blocksWithinArrayEN)
+
+      // pull enDoc again and make sure the update of esDoc did not mess with the data of enDoc
+      const enDoc2 = await payload.findByID({
+        id: createdEnDoc.id,
+        collection: 'nested-arrays',
+        locale: 'en',
+        depth: 0,
+      })
+      removeId(enDoc2.arrayWithBlocks[0].blocksWithinArray)
+      expect(enDoc2.arrayWithBlocks[0].blocksWithinArray).toEqual(blocksWithinArrayEN)
+    })
+
+    it('should update localized relation within unLocalized array', async () => {
+      const randomTextDoc = (
+        await payload.find({
+          collection: 'localized-posts',
+          depth: 0,
+        })
+      ).docs[0]
+      const randomTextDoc2 = (
+        await payload.find({
+          collection: 'localized-posts',
+          depth: 0,
+        })
+      ).docs[1]
+
+      const createdEnDoc = await payload.create({
+        collection: 'nested-arrays',
+        locale: 'en',
+        depth: 0,
+        data: {
+          arrayWithLocalizedRelation: [
+            {
+              localizedRelation: randomTextDoc.id,
+            },
+          ],
+        },
+      })
+
+      const updatedEsDoc = await payload.update({
+        collection: 'nested-arrays',
+        id: createdEnDoc.id,
+        depth: 0,
+        locale: 'es',
+        data: {
+          arrayWithLocalizedRelation: [
+            {
+              id: createdEnDoc.arrayWithLocalizedRelation[0].id,
+              localizedRelation: randomTextDoc2.id,
+            },
+          ],
+        },
+      })
+
+      expect(updatedEsDoc.arrayWithLocalizedRelation).toHaveLength(1)
+      expect(updatedEsDoc.arrayWithLocalizedRelation[0].localizedRelation).toBe(randomTextDoc2.id)
+
+      expect(createdEnDoc.arrayWithLocalizedRelation).toHaveLength(1)
+      expect(createdEnDoc.arrayWithLocalizedRelation[0].localizedRelation).toBe(randomTextDoc.id)
+
+      // pull enDoc again and make sure the update of esDoc did not mess with the data of enDoc
+      const enDoc2 = await payload.findByID({
+        id: createdEnDoc.id,
+        collection: 'nested-arrays',
+        locale: 'en',
+        depth: 0,
+      })
+      expect(enDoc2.arrayWithLocalizedRelation).toHaveLength(1)
+      expect(enDoc2.arrayWithLocalizedRelation[0].localizedRelation).toBe(randomTextDoc.id)
+    })
+  })
 })
 
 async function createLocalizedPost(data: {

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -13,6 +13,7 @@ export interface Config {
   collections: {
     'blocks-fields': BlocksField;
     'nested-arrays': NestedArray;
+    'nested-fields': NestedField;
     users: User;
     'localized-posts': LocalizedPost;
     'array-fields': ArrayField;
@@ -123,6 +124,34 @@ export interface LocalizedPost {
   group?: {
     children?: string | null;
   };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-fields".
+ */
+export interface NestedField {
+  id: number;
+  array?:
+    | {
+        relation?: {
+          relationTo: 'localized-posts';
+          value: number | LocalizedPost;
+        } | null;
+        hasManyRelation?: (number | LocalizedPost)[] | null;
+        hasManyPolyRelation?:
+          | {
+              relationTo: 'localized-posts';
+              value: number | LocalizedPost;
+            }[]
+          | null;
+        select?: ('one' | 'two' | 'three')[] | null;
+        number?: number[] | null;
+        text?: string[] | null;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -11,6 +11,8 @@ export interface Config {
     users: UserAuthOperations;
   };
   collections: {
+    'blocks-fields': BlocksField;
+    'nested-arrays': NestedArray;
     users: User;
     'localized-posts': LocalizedPost;
     'array-fields': ArrayField;
@@ -19,15 +21,20 @@ export interface Config {
     'relationship-localized': RelationshipLocalized;
     dummy: Dummy;
     nested: Nested;
+    groups: Group;
+    tabs: Tab;
     'localized-sort': LocalizedSort;
     'blocks-same-name': BlocksSameName;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
+  db: {
+    defaultIDType: number;
+  };
   globals: {
     'global-array': GlobalArray;
   };
-  locale: 'en' | 'es' | 'hu' | 'pt' | 'ar';
+  locale: 'en' | 'es' | 'pt' | 'ar' | 'hu';
   user: User & {
     collection: 'users';
   };
@@ -35,23 +42,97 @@ export interface Config {
 export interface UserAuthOperations {
   forgotPassword: {
     email: string;
+    password: string;
   };
   login: {
-    password: string;
     email: string;
+    password: string;
   };
   registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
     email: string;
     password: string;
   };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "blocks-fields".
+ */
+export interface BlocksField {
+  id: number;
+  content?:
+    | {
+        content?:
+          | {
+              text?: string | null;
+              id?: string | null;
+              blockName?: string | null;
+              blockType: 'textBlock';
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'blockInsideBlock';
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-arrays".
+ */
+export interface NestedArray {
+  id: number;
+  arrayWithBlocks?:
+    | {
+        blocksWithinArray?:
+          | {
+              relationWithinBlock?: (number | null) | LocalizedPost;
+              id?: string | null;
+              blockName?: string | null;
+              blockType: 'someBlock';
+            }[]
+          | null;
+        id?: string | null;
+      }[]
+    | null;
+  arrayWithLocalizedRelation?:
+    | {
+        localizedRelation?: (number | null) | LocalizedPost;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-posts".
+ */
+export interface LocalizedPost {
+  id: number;
+  title?: string | null;
+  description?: string | null;
+  localizedDescription?: string | null;
+  localizedCheckbox?: boolean | null;
+  children?: (number | LocalizedPost)[] | null;
+  group?: {
+    children?: string | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
-  relation?: (string | null) | LocalizedPost;
+  id: number;
+  relation?: (number | null) | LocalizedPost;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -65,27 +146,10 @@ export interface User {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "localized-posts".
- */
-export interface LocalizedPost {
-  id: string;
-  title?: string | null;
-  localizedDescription?: string | null;
-  description?: string | null;
-  localizedCheckbox?: boolean | null;
-  children?: (string | LocalizedPost)[] | null;
-  group?: {
-    children?: string | null;
-  };
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "array-fields".
  */
 export interface ArrayField {
-  id: string;
+  id: number;
   items?:
     | {
         text: string;
@@ -100,7 +164,7 @@ export interface ArrayField {
  * via the `definition` "localized-required".
  */
 export interface LocalizedRequired {
-  id: string;
+  id: number;
   title: string;
   layout: (
     | {
@@ -124,27 +188,27 @@ export interface LocalizedRequired {
  * via the `definition` "with-localized-relationship".
  */
 export interface WithLocalizedRelationship {
-  id: string;
-  localizedRelationship?: (string | null) | LocalizedPost;
-  localizedRelationHasManyField?: (string | LocalizedPost)[] | null;
+  id: number;
+  localizedRelationship?: (number | null) | LocalizedPost;
+  localizedRelationHasManyField?: (number | LocalizedPost)[] | null;
   localizedRelationMultiRelationTo?:
     | ({
         relationTo: 'localized-posts';
-        value: string | LocalizedPost;
+        value: number | LocalizedPost;
       } | null)
     | ({
         relationTo: 'dummy';
-        value: string | Dummy;
+        value: number | Dummy;
       } | null);
   localizedRelationMultiRelationToHasMany?:
     | (
         | {
             relationTo: 'localized-posts';
-            value: string | LocalizedPost;
+            value: number | LocalizedPost;
           }
         | {
             relationTo: 'dummy';
-            value: string | Dummy;
+            value: number | Dummy;
           }
       )[]
     | null;
@@ -156,7 +220,7 @@ export interface WithLocalizedRelationship {
  * via the `definition` "dummy".
  */
 export interface Dummy {
-  id: string;
+  id: number;
   name?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -166,33 +230,33 @@ export interface Dummy {
  * via the `definition` "relationship-localized".
  */
 export interface RelationshipLocalized {
-  id: string;
-  relationship?: (string | null) | LocalizedPost;
-  relationshipHasMany?: (string | LocalizedPost)[] | null;
+  id: number;
+  relationship?: (number | null) | LocalizedPost;
+  relationshipHasMany?: (number | LocalizedPost)[] | null;
   relationMultiRelationTo?:
     | ({
         relationTo: 'localized-posts';
-        value: string | LocalizedPost;
+        value: number | LocalizedPost;
       } | null)
     | ({
         relationTo: 'dummy';
-        value: string | Dummy;
+        value: number | Dummy;
       } | null);
   relationMultiRelationToHasMany?:
     | (
         | {
             relationTo: 'localized-posts';
-            value: string | LocalizedPost;
+            value: number | LocalizedPost;
           }
         | {
             relationTo: 'dummy';
-            value: string | Dummy;
+            value: number | Dummy;
           }
       )[]
     | null;
   arrayField?:
     | {
-        nestedRelation?: (string | null) | LocalizedPost;
+        nestedRelation?: (number | null) | LocalizedPost;
         id?: string | null;
       }[]
     | null;
@@ -204,7 +268,7 @@ export interface RelationshipLocalized {
  * via the `definition` "nested".
  */
 export interface Nested {
-  id: string;
+  id: number;
   blocks?:
     | {
         array?:
@@ -224,10 +288,72 @@ export interface Nested {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "groups".
+ */
+export interface Group {
+  id: number;
+  groupLocalized?: {
+    title?: string | null;
+  };
+  group?: {
+    title?: string | null;
+  };
+  deep?: {
+    array?:
+      | {
+          title?: string | null;
+          id?: string | null;
+        }[]
+      | null;
+    blocks?:
+      | {
+          title?: string | null;
+          id?: string | null;
+          blockName?: string | null;
+          blockType: 'first';
+        }[]
+      | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tabs".
+ */
+export interface Tab {
+  id: number;
+  tabLocalized?: {
+    title?: string | null;
+  };
+  tab?: {
+    title?: string | null;
+  };
+  deep?: {
+    array?:
+      | {
+          title?: string | null;
+          id?: string | null;
+        }[]
+      | null;
+    blocks?:
+      | {
+          title?: string | null;
+          id?: string | null;
+          blockName?: string | null;
+          blockType: 'first';
+        }[]
+      | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "localized-sort".
  */
 export interface LocalizedSort {
-  id: string;
+  id: number;
   title?: string | null;
   date?: string | null;
   updatedAt: string;
@@ -238,7 +364,7 @@ export interface LocalizedSort {
  * via the `definition` "blocks-same-name".
  */
 export interface BlocksSameName {
-  id: string;
+  id: number;
   blocks?:
     | (
         | {
@@ -263,10 +389,10 @@ export interface BlocksSameName {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -286,7 +412,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -297,7 +423,7 @@ export interface PayloadMigration {
  * via the `definition` "global-array".
  */
 export interface GlobalArray {
-  id: string;
+  id: number;
   array?:
     | {
         text?: string | null;
@@ -317,6 +443,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }


### PR DESCRIPTION
## Description

In Postgres and SQLite, localized blocks or arrays that contain other fields which may reside in a separate table were not properly storing locales in the database, and causing multiple bugs.

Fixes #7805
Fixes #7786
