### PR TITLE
chore: update v3 issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
@@ -9,43 +9,38 @@ body:
       description: Want us to look into your issue faster? Follow the [reproduction-guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md) for more information.
     validations:
       required: false
-  - type: input
-    id: version
+
+  - type: textarea
     attributes:
-      label: Payload Version
-      description: What version of Payload are you running?
+      label: Environment Info
+      description: Paste output from `pnpm payload info` (>= beta.92) _or_ Payload, Node.js, and Next.js versions.
+      render: text
+      placeholder: |
+        Payload:
+        Node.js:
+        Next.js:
     validations:
       required: true
-  - type: input
-    id: node-version
-    attributes:
-      label: Node Version
-      description: What version of Node are you running?
-    validations:
-      required: true
-  - type: input
-    id: nextjs-version
-    attributes:
-      label: Next.js Version
-      description: What version of Next.js are you running?
-    validations:
-      required: true
+
   - type: textarea
     attributes:
       label: Describe the Bug
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Reproduction Steps
       description: Steps to reproduce the behavior, please provide a clear description of how to reproduce the issue, based on the linked minimal reproduction. Screenshots can be provided in the issue body below. If using code blocks, make sure that [syntax highlighting is correct](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) and double check that the rendered preview is not broken.
     validations:
       required: true
+
   - type: input
     id: adapters-plugins
     attributes:
       label: Adapters and Plugins
       description: What adapters and plugins are you using if relevant? ie. db-mongodb, db-postgres, storage-vercel-blob, etc.
+
   - type: markdown
     attributes:
       value: Before submitting the issue, go through the steps you've written down to make sure the steps provided are detailed and clear.


### PR DESCRIPTION
Mention `payload info` command when providing versions, which is now a textarea. 

Note: that individual version fields are now gone and are no longer required/enforced. We may need to come up with a better solution if issues are being submitted without this info.