### PR TITLE
feat: remove unnecessary monaco-editor packages and upgrade @monaco-editor/react

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -84,6 +84,7 @@
     "pretest": "pnpm build"
   },
   "dependencies": {
+    "@monaco-editor/react": "4.6.0",
     "@next/env": "^15.0.0-canary.104",
     "@payloadcms/translations": "workspace:*",
     "@types/busboy": "1.5.4",
@@ -101,7 +102,6 @@
     "json-schema-to-typescript": "15.0.1",
     "jsonwebtoken": "9.0.1",
     "minimist": "1.2.8",
-    "monaco-editor": "0.38.0",
     "pino": "9.3.1",
     "pino-pretty": "11.2.1",
     "pluralize": "8.0.0",
@@ -113,7 +113,6 @@
   },
   "devDependencies": {
     "@hyrious/esbuild-plugin-commonjs": "^0.2.4",
-    "@monaco-editor/react": "4.5.1",
     "@payloadcms/eslint-config": "workspace:*",
     "@types/json-schema": "7.0.15",
     "@types/jsonwebtoken": "8.5.9",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -77,7 +77,7 @@
     "@faceless-ui/modal": "3.0.0-beta.2",
     "@faceless-ui/scroll-info": "2.0.0-beta.0",
     "@faceless-ui/window-info": "3.0.0-beta.0",
-    "@monaco-editor/react": "4.5.1",
+    "@monaco-editor/react": "4.6.0",
     "@payloadcms/translations": "workspace:*",
     "body-scroll-lock": "4.0.0-beta.0",
     "bson-objectid": "2.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -794,6 +794,9 @@ importers:
 
   packages/payload:
     dependencies:
+      '@monaco-editor/react':
+        specifier: 4.6.0
+        version: 4.6.0(monaco-editor@0.38.0)(react-dom@19.0.0-rc-06d0b89e-20240801(react@19.0.0-rc-06d0b89e-20240801))(react@19.0.0-rc-06d0b89e-20240801)
       '@next/env':
         specifier: ^15.0.0-canary.104
         version: 15.0.0-rc.0
@@ -848,9 +851,6 @@ importers:
       minimist:
         specifier: 1.2.8
         version: 1.2.8
-      monaco-editor:
-        specifier: 0.38.0
-        version: 0.38.0
       pino:
         specifier: 9.3.1
         version: 9.3.1
@@ -879,9 +879,6 @@ importers:
       '@hyrious/esbuild-plugin-commonjs':
         specifier: ^0.2.4
         version: 0.2.4(cjs-module-lexer@1.3.1)(esbuild@0.23.1)
-      '@monaco-editor/react':
-        specifier: 4.5.1
-        version: 4.5.1(monaco-editor@0.38.0)(react-dom@19.0.0-rc-06d0b89e-20240801(react@19.0.0-rc-06d0b89e-20240801))(react@19.0.0-rc-06d0b89e-20240801)
       '@payloadcms/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -1538,8 +1535,8 @@ importers:
         specifier: 3.0.0-beta.0
         version: 3.0.0-beta.0(react-dom@19.0.0-rc-06d0b89e-20240801(react@19.0.0-rc-06d0b89e-20240801))(react@19.0.0-rc-06d0b89e-20240801)
       '@monaco-editor/react':
-        specifier: 4.5.1
-        version: 4.5.1(monaco-editor@0.38.0)(react-dom@19.0.0-rc-06d0b89e-20240801(react@19.0.0-rc-06d0b89e-20240801))(react@19.0.0-rc-06d0b89e-20240801)
+        specifier: 4.6.0
+        version: 4.6.0(monaco-editor@0.38.0)(react-dom@19.0.0-rc-06d0b89e-20240801(react@19.0.0-rc-06d0b89e-20240801))(react@19.0.0-rc-06d0b89e-20240801)
       '@payloadcms/translations':
         specifier: workspace:*
         version: link:../translations
@@ -3756,8 +3753,8 @@ packages:
     peerDependencies:
       monaco-editor: '>= 0.21.0 < 1'
 
-  '@monaco-editor/react@4.5.1':
-    resolution: {integrity: sha512-NNDFdP+2HojtNhCkRfE6/D6ro6pBNihaOzMbGK84lNWzRu+CfBjwzGt4jmnqimLuqp5yE5viHS2vi+QOAnD5FQ==}
+  '@monaco-editor/react@4.6.0':
+    resolution: {integrity: sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==}
     peerDependencies:
       monaco-editor: '>= 0.25.0 < 1'
       react: 19.0.0-rc-06d0b89e-20240801
@@ -12197,7 +12194,7 @@ snapshots:
       monaco-editor: 0.38.0
       state-local: 1.0.7
 
-  '@monaco-editor/react@4.5.1(monaco-editor@0.38.0)(react-dom@19.0.0-rc-06d0b89e-20240801(react@19.0.0-rc-06d0b89e-20240801))(react@19.0.0-rc-06d0b89e-20240801)':
+  '@monaco-editor/react@4.6.0(monaco-editor@0.38.0)(react-dom@19.0.0-rc-06d0b89e-20240801(react@19.0.0-rc-06d0b89e-20240801))(react@19.0.0-rc-06d0b89e-20240801)':
     dependencies:
       '@monaco-editor/loader': 1.4.0(monaco-editor@0.38.0)
       monaco-editor: 0.38.0


### PR DESCRIPTION
This reduces the total install size of `payload` from 115 MB to 34 MB. 

We never used monaco-editor within payload - we were only using `@monaco-editor/react` which is a lot smaller.

Since we expose its types to the end user, we have to add it to our `dependencies`, not `devDependencies`.

Before: https://npmgraph.js.org/?q=payload@3.0.0-canary.1a675ae#select=exact%3Apayload%403.0.0-canary.1a675ae&zoom=w

After: https://npmgraph.js.org/?q=payload%403.0.0-canary.cdb9474#zoom=h&select=exact%3Apayload%403.0.0-canary.cdb9474