### PR TITLE
chore(eslint): curly [skip-lint]

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,7 @@ export const rootEslintConfig = [
   {
     ignores: [
       ...defaultESLintIgnores,
+      'packages/eslint-*/**',
       'test/live-preview/next-app',
       'packages/**/*.spec.ts',
       'templates/**',

--- a/packages/create-payload-app/src/lib/init-next.ts
+++ b/packages/create-payload-app/src/lib/init-next.ts
@@ -169,7 +169,9 @@ async function installAndConfigurePayload(
   }
 
   const logDebug = (message: string) => {
-    if (debug) origDebug(message)
+    if (debug) {
+      origDebug(message)
+    }
   }
 
   if (!fs.existsSync(projectDir)) {

--- a/packages/create-payload-app/src/lib/parse-project-name.ts
+++ b/packages/create-payload-app/src/lib/parse-project-name.ts
@@ -4,13 +4,19 @@ import slugify from '@sindresorhus/slugify'
 import type { CliArgs } from '../types.js'
 
 export async function parseProjectName(args: CliArgs): Promise<string> {
-  if (args['--name']) return slugify(args['--name'])
-  if (args._[0]) return slugify(args._[0])
+  if (args['--name']) {
+    return slugify(args['--name'])
+  }
+  if (args._[0]) {
+    return slugify(args._[0])
+  }
 
   const projectName = await p.text({
     message: 'Project name?',
     validate: (value) => {
-      if (!value) return 'Please enter a project name.'
+      if (!value) {
+        return 'Please enter a project name.'
+      }
     },
   })
   if (p.isCancel(projectName)) {

--- a/packages/create-payload-app/src/lib/parse-template.ts
+++ b/packages/create-payload-app/src/lib/parse-template.ts
@@ -9,7 +9,9 @@ export async function parseTemplate(
   if (args['--template']) {
     const templateName = args['--template']
     const template = validTemplates.find((t) => t.name === templateName)
-    if (!template) throw new Error('Invalid template given')
+    if (!template) {
+      throw new Error('Invalid template given')
+    }
     return template
   }
 

--- a/packages/create-payload-app/src/lib/select-db.ts
+++ b/packages/create-payload-app/src/lib/select-db.ts
@@ -54,7 +54,9 @@ export async function selectDb(args: CliArgs, projectName: string): Promise<DbDe
         value: dbChoice.value,
       })),
     })
-    if (p.isCancel(dbType)) process.exit(0)
+    if (p.isCancel(dbType)) {
+      process.exit(0)
+    }
   }
 
   const dbChoice = dbChoiceRecord[dbType]
@@ -73,7 +75,9 @@ export async function selectDb(args: CliArgs, projectName: string): Promise<DbDe
       initialValue: initialDbUri,
       message: `Enter ${dbChoice.title.split(' ')[0]} connection string`, // strip beta from title
     })
-    if (p.isCancel(dbUri)) process.exit(0)
+    if (p.isCancel(dbUri)) {
+      process.exit(0)
+    }
   }
 
   return {

--- a/packages/create-payload-app/src/lib/update-payload-in-project.ts
+++ b/packages/create-payload-app/src/lib/update-payload-in-project.ts
@@ -16,7 +16,9 @@ import { installPackages } from './install-packages.js'
 export async function updatePayloadInProject(
   appDetails: NextAppDetails,
 ): Promise<{ message: string; success: boolean }> {
-  if (!appDetails.nextConfigPath) return { message: 'No Next.js config found', success: false }
+  if (!appDetails.nextConfigPath) {
+    return { message: 'No Next.js config found', success: false }
+  }
 
   const projectDir = path.dirname(appDetails.nextConfigPath)
 

--- a/packages/create-payload-app/src/lib/write-env-file.ts
+++ b/packages/create-payload-app/src/lib/write-env-file.ts
@@ -36,7 +36,9 @@ export async function writeEnvFile(args: {
           .split('\n')
           .filter((e) => e)
           .map((line) => {
-            if (line.startsWith('#') || !line.includes('=')) return line
+            if (line.startsWith('#') || !line.includes('=')) {
+              return line
+            }
 
             const split = line.split('=')
             const key = split[0]

--- a/packages/drizzle/src/find/buildFindManyArgs.ts
+++ b/packages/drizzle/src/find/buildFindManyArgs.ts
@@ -12,11 +12,11 @@ type BuildFindQueryArgs = {
   tableName: string
 }
 
-export type Result = DBQueryConfig<'many', true, any, any> & {
-  with?: DBQueryConfig<'many', true, any, any> & {
+export type Result = {
+  with?: {
     _locales?: DBQueryConfig<'many', true, any, any>
-  }
-}
+  } & DBQueryConfig<'many', true, any, any>
+} & DBQueryConfig<'many', true, any, any>
 
 // Generate the Drizzle query for findMany based on
 // a collection field structure

--- a/packages/drizzle/src/migrateDown.ts
+++ b/packages/drizzle/src/migrateDown.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax, no-await-in-loop */
 import type { PayloadRequest } from 'payload'
 
 import {

--- a/packages/drizzle/src/migrateRefresh.ts
+++ b/packages/drizzle/src/migrateRefresh.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax, no-await-in-loop */
 import type { PayloadRequest } from 'payload'
 
 import {

--- a/packages/drizzle/src/migrateReset.ts
+++ b/packages/drizzle/src/migrateReset.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax, no-await-in-loop */
 import type { PayloadRequest } from 'payload'
 
 import {

--- a/packages/drizzle/src/migrateStatus.ts
+++ b/packages/drizzle/src/migrateStatus.ts
@@ -30,7 +30,7 @@ export async function migrateStatus(this: DrizzleAdapter): Promise<void> {
     const existingMigration = existingMigrations.find((m) => m.name === migration.name)
     return {
       Name: migration.name,
-      // eslint-disable-next-line perfectionist/sort-objects
+
       Batch: existingMigration?.batch,
       Ran: existingMigration ? 'Yes' : 'No',
     }

--- a/packages/drizzle/src/queries/buildAndOrConditions.ts
+++ b/packages/drizzle/src/queries/buildAndOrConditions.ts
@@ -28,11 +28,10 @@ export async function buildAndOrConditions({
   const completedConditions = []
   // Loop over all AND / OR operations and add them to the AND / OR query param
   // Operations should come through as an array
-  // eslint-disable-next-line no-restricted-syntax
+
   for (const condition of where) {
     // If the operation is properly formatted as an object
     if (typeof condition === 'object') {
-      // eslint-disable-next-line no-await-in-loop
       const result = await parseParams({
         adapter,
         fields,

--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import type { SQL } from 'drizzle-orm'
 import type { Field, Operator, Where } from 'payload'
 

--- a/packages/drizzle/src/queries/selectDistinct.ts
+++ b/packages/drizzle/src/queries/selectDistinct.ts
@@ -5,6 +5,7 @@ import type { ChainedMethods } from '../find/chainMethods.js'
 import type {
   DrizzleAdapter,
   DrizzleTransaction,
+  GenericColumn,
   GenericPgColumn,
   TransactionPg,
   TransactionSQLite,
@@ -12,7 +13,6 @@ import type {
 import type { BuildQueryJoinAliases } from './buildQuery.js'
 
 import { chainMethods } from '../find/chainMethods.js'
-import { type GenericColumn } from '../types.js'
 
 type Args = {
   adapter: DrizzleAdapter
@@ -35,7 +35,7 @@ export const selectDistinct = ({
   selectFields,
   tableName,
   where,
-}: Args): QueryPromise<Record<string, GenericColumn> & { id: number | string }[]> => {
+}: Args): QueryPromise<{ id: number | string }[] & Record<string, GenericColumn>> => {
   if (Object.keys(joins).length > 0) {
     if (where) {
       chainedMethods.push({ args: [where], method: 'where' })

--- a/packages/drizzle/src/queryDrafts.ts
+++ b/packages/drizzle/src/queryDrafts.ts
@@ -35,7 +35,6 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
   return {
     ...result,
     docs: result.docs.map((doc) => {
-      // eslint-disable-next-line no-param-reassign
       doc = {
         id: doc.parent,
         ...doc.version,

--- a/packages/drizzle/src/transform/read/index.ts
+++ b/packages/drizzle/src/transform/read/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import type { Field, SanitizedConfig, TypeWithID } from 'payload'
 
 import type { DrizzleAdapter } from '../../types.js'

--- a/packages/drizzle/src/transform/write/index.ts
+++ b/packages/drizzle/src/transform/write/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import type { Field } from 'payload'
 
 import type { DrizzleAdapter } from '../../types.js'

--- a/packages/drizzle/src/transform/write/selects.ts
+++ b/packages/drizzle/src/transform/write/selects.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { isArrayOfRows } from '../../utilities/isArrayOfRows.js'
 
 type Args = {

--- a/packages/drizzle/src/upsertRow/insertArrays.ts
+++ b/packages/drizzle/src/upsertRow/insertArrays.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import type { ArrayRowToInsert } from '../transform/write/types.js'
 import type { DrizzleAdapter, DrizzleTransaction } from '../types.js'
 

--- a/packages/drizzle/src/upsertRow/types.ts
+++ b/packages/drizzle/src/upsertRow/types.ts
@@ -18,18 +18,18 @@ type BaseArgs = {
   tableName: string
 }
 
-type CreateArgs = BaseArgs & {
+type CreateArgs = {
   id?: never
   operation: 'create'
   upsertTarget?: never
   where?: never
-}
+} & BaseArgs
 
-type UpdateArgs = BaseArgs & {
+type UpdateArgs = {
   id?: number | string
   operation: 'update'
   upsertTarget?: GenericColumn
   where?: SQL<unknown>
-}
+} & BaseArgs
 
 export type Args = CreateArgs | UpdateArgs

--- a/packages/drizzle/src/utilities/createBlocksMap.ts
+++ b/packages/drizzle/src/utilities/createBlocksMap.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 export type BlocksMap = {
   [path: string]: Record<string, unknown>[]
 }

--- a/packages/email-nodemailer/src/index.ts
+++ b/packages/email-nodemailer/src/index.ts
@@ -47,7 +47,9 @@ async function buildEmail(emailConfig?: NodemailerAdapterArgs): Promise<{
 }> {
   if (!emailConfig) {
     const transport = await createMockAccount(emailConfig)
-    if (!transport) throw new InvalidConfiguration('Unable to create Nodemailer test account.')
+    if (!transport) {
+      throw new InvalidConfiguration('Unable to create Nodemailer test account.')
+    }
 
     return {
       defaultFromAddress: 'info@payloadcms.com',

--- a/packages/email-nodemailer/src/plugin.spec.ts
+++ b/packages/email-nodemailer/src/plugin.spec.ts
@@ -1,7 +1,11 @@
-import { jest } from '@jest/globals'
+import type { Transporter } from 'nodemailer'
 
-import nodemailer, { Transporter } from 'nodemailer'
-import { nodemailerAdapter, NodemailerAdapterArgs } from './index.js'
+import { jest } from '@jest/globals'
+import nodemailer from 'nodemailer'
+
+import type { NodemailerAdapterArgs } from './index.js'
+
+import { nodemailerAdapter } from './index.js'
 
 const defaultArgs: NodemailerAdapterArgs = {
   defaultFromAddress: 'test@test.com',
@@ -9,7 +13,6 @@ const defaultArgs: NodemailerAdapterArgs = {
 }
 
 describe('email-nodemailer', () => {
-
   describe('transport verification', () => {
     let mockedVerify: jest.Mock<Transporter['verify']>
     let mockTransport: Transporter
@@ -18,20 +21,21 @@ describe('email-nodemailer', () => {
       mockedVerify = jest.fn<Transporter['verify']>()
       mockTransport = nodemailer.createTransport({
         name: 'existing-transport',
-        // eslint-disable-next-line @typescript-eslint/require-await
+        // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-misused-promises
         send: async (mail) => {
+          // eslint-disable-next-line no-console
           console.log('mock send', mail)
         },
-        version: '0.0.1',
         verify: mockedVerify,
+        version: '0.0.1',
       })
     })
 
     it('should be invoked when skipVerify = false', async () => {
       await nodemailerAdapter({
         ...defaultArgs,
-        transport: mockTransport,
         skipVerify: false,
+        transport: mockTransport,
       })
 
       expect(mockedVerify.mock.calls).toHaveLength(1)
@@ -40,8 +44,8 @@ describe('email-nodemailer', () => {
     it('should be invoked when skipVerify is undefined', async () => {
       await nodemailerAdapter({
         ...defaultArgs,
-        transport: mockTransport,
         skipVerify: false,
+        transport: mockTransport,
       })
 
       expect(mockedVerify.mock.calls).toHaveLength(1)
@@ -50,8 +54,8 @@ describe('email-nodemailer', () => {
     it('should not be invoked when skipVerify = true', async () => {
       await nodemailerAdapter({
         ...defaultArgs,
-        transport: mockTransport,
         skipVerify: true,
+        transport: mockTransport,
       })
 
       expect(mockedVerify.mock.calls).toHaveLength(0)

--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -14,6 +14,7 @@ import { deepMerge } from './deepMerge.js'
 const baseRules = {
   // This rule makes no sense when overriding class methods. This is used a lot in richtext-lexical.
   'class-methods-use-this': 'off',
+  curly: ['warn', 'all'],
   'arrow-body-style': 0,
   'import-x/prefer-default-export': 'off',
   'no-restricted-exports': ['warn', { restrictDefaultExports: { direct: true } }],

--- a/packages/graphql/src/resolvers/auth/resetPassword.ts
+++ b/packages/graphql/src/resolvers/auth/resetPassword.ts
@@ -6,8 +6,12 @@ import type { Context } from '../types.js'
 
 function resetPasswordResolver(collection: Collection): any {
   async function resolver(_, args, context: Context) {
-    if (args.locale) context.req.locale = args.locale
-    if (args.fallbackLocale) context.req.fallbackLocale = args.fallbackLocale
+    if (args.locale) {
+      context.req.locale = args.locale
+    }
+    if (args.fallbackLocale) {
+      context.req.fallbackLocale = args.fallbackLocale
+    }
 
     const options = {
       api: 'GraphQL',

--- a/packages/graphql/src/resolvers/auth/verifyEmail.ts
+++ b/packages/graphql/src/resolvers/auth/verifyEmail.ts
@@ -6,8 +6,12 @@ import type { Context } from '../types.js'
 
 function verifyEmailResolver(collection: Collection) {
   async function resolver(_, args, context: Context) {
-    if (args.locale) context.req.locale = args.locale
-    if (args.fallbackLocale) context.req.fallbackLocale = args.fallbackLocale
+    if (args.locale) {
+      context.req.locale = args.locale
+    }
+    if (args.fallbackLocale) {
+      context.req.fallbackLocale = args.fallbackLocale
+    }
 
     const options = {
       api: 'GraphQL',

--- a/packages/graphql/src/resolvers/collections/delete.ts
+++ b/packages/graphql/src/resolvers/collections/delete.ts
@@ -28,7 +28,9 @@ export function getDeleteResolver<TSlug extends CollectionSlug>(
     req = isolateObjectProperty(req, 'fallbackLocale')
     req.locale = args.locale || locale
     req.fallbackLocale = args.fallbackLocale || fallbackLocale
-    if (!req.query) req.query = {}
+    if (!req.query) {
+      req.query = {}
+    }
 
     const draft: boolean =
       args.draft ?? req.query?.draft === 'false'
@@ -36,7 +38,9 @@ export function getDeleteResolver<TSlug extends CollectionSlug>(
         : req.query?.draft === 'true'
           ? true
           : undefined
-    if (typeof draft === 'boolean') req.query.draft = String(draft)
+    if (typeof draft === 'boolean') {
+      req.query.draft = String(draft)
+    }
 
     context.req = req
 

--- a/packages/graphql/src/resolvers/collections/find.ts
+++ b/packages/graphql/src/resolvers/collections/find.ts
@@ -31,7 +31,9 @@ export function findResolver(collection: Collection): Resolver {
     req = isolateObjectProperty(req, ['locale', 'fallbackLocale', 'transactionID'])
     req.locale = args.locale || locale
     req.fallbackLocale = args.fallbackLocale || fallbackLocale
-    if (!req.query) req.query = {}
+    if (!req.query) {
+      req.query = {}
+    }
 
     const draft: boolean =
       args.draft ?? req.query?.draft === 'false'
@@ -39,7 +41,9 @@ export function findResolver(collection: Collection): Resolver {
         : req.query?.draft === 'true'
           ? true
           : undefined
-    if (typeof draft === 'boolean') req.query.draft = String(draft)
+    if (typeof draft === 'boolean') {
+      req.query.draft = String(draft)
+    }
 
     context.req = req
 

--- a/packages/graphql/src/resolvers/collections/findByID.ts
+++ b/packages/graphql/src/resolvers/collections/findByID.ts
@@ -28,7 +28,9 @@ export function findByIDResolver<TSlug extends CollectionSlug>(
     req = isolateObjectProperty(req, 'fallbackLocale')
     req.locale = args.locale || locale
     req.fallbackLocale = args.fallbackLocale || fallbackLocale
-    if (!req.query) req.query = {}
+    if (!req.query) {
+      req.query = {}
+    }
 
     const draft: boolean =
       args.draft ?? req.query?.draft === 'false'
@@ -36,7 +38,9 @@ export function findByIDResolver<TSlug extends CollectionSlug>(
         : req.query?.draft === 'true'
           ? true
           : undefined
-    if (typeof draft === 'boolean') req.query.draft = String(draft)
+    if (typeof draft === 'boolean') {
+      req.query.draft = String(draft)
+    }
 
     context.req = req
 

--- a/packages/graphql/src/resolvers/collections/findVersions.ts
+++ b/packages/graphql/src/resolvers/collections/findVersions.ts
@@ -29,7 +29,9 @@ export function findVersionsResolver(collection: Collection): Resolver {
     req = isolateObjectProperty(req, 'fallbackLocale')
     req.locale = args.locale || locale
     req.fallbackLocale = args.fallbackLocale || fallbackLocale
-    if (!req.query) req.query = {}
+    if (!req.query) {
+      req.query = {}
+    }
 
     const draft: boolean =
       args.draft ?? req.query?.draft === 'false'
@@ -37,7 +39,9 @@ export function findVersionsResolver(collection: Collection): Resolver {
         : req.query?.draft === 'true'
           ? true
           : undefined
-    if (typeof draft === 'boolean') req.query.draft = String(draft)
+    if (typeof draft === 'boolean') {
+      req.query.draft = String(draft)
+    }
 
     context.req = req
 

--- a/packages/graphql/src/resolvers/collections/update.ts
+++ b/packages/graphql/src/resolvers/collections/update.ts
@@ -30,7 +30,9 @@ export function updateResolver<TSlug extends CollectionSlug>(
     req = isolateObjectProperty(req, 'fallbackLocale')
     req.locale = args.locale || locale
     req.fallbackLocale = args.fallbackLocale || fallbackLocale
-    if (!req.query) req.query = {}
+    if (!req.query) {
+      req.query = {}
+    }
 
     const draft: boolean =
       args.draft ?? req.query?.draft === 'false'
@@ -38,7 +40,9 @@ export function updateResolver<TSlug extends CollectionSlug>(
         : req.query?.draft === 'true'
           ? true
           : undefined
-    if (typeof draft === 'boolean') req.query.draft = String(draft)
+    if (typeof draft === 'boolean') {
+      req.query.draft = String(draft)
+    }
 
     context.req = req
 

--- a/packages/graphql/src/resolvers/globals/findOne.ts
+++ b/packages/graphql/src/resolvers/globals/findOne.ts
@@ -6,8 +6,12 @@ import type { Context } from '../types.js'
 
 export default function findOneResolver(globalConfig: SanitizedGlobalConfig): Document {
   return async function resolver(_, args, context: Context) {
-    if (args.locale) context.req.locale = args.locale
-    if (args.fallbackLocale) context.req.fallbackLocale = args.fallbackLocale
+    if (args.locale) {
+      context.req.locale = args.locale
+    }
+    if (args.fallbackLocale) {
+      context.req.fallbackLocale = args.fallbackLocale
+    }
 
     const { slug } = globalConfig
 

--- a/packages/graphql/src/resolvers/globals/findVersionByID.ts
+++ b/packages/graphql/src/resolvers/globals/findVersionByID.ts
@@ -19,8 +19,12 @@ export type Resolver = (
 
 export default function findVersionByIDResolver(globalConfig: SanitizedGlobalConfig): Resolver {
   return async function resolver(_, args, context: Context) {
-    if (args.locale) context.req.locale = args.locale
-    if (args.fallbackLocale) context.req.fallbackLocale = args.fallbackLocale
+    if (args.locale) {
+      context.req.locale = args.locale
+    }
+    if (args.fallbackLocale) {
+      context.req.fallbackLocale = args.fallbackLocale
+    }
 
     const options = {
       id: args.id,

--- a/packages/graphql/src/resolvers/globals/update.ts
+++ b/packages/graphql/src/resolvers/globals/update.ts
@@ -22,8 +22,12 @@ export default function updateResolver<TSlug extends GlobalSlug>(
   globalConfig: SanitizedGlobalConfig,
 ): Resolver<TSlug> {
   return async function resolver(_, args, context: Context) {
-    if (args.locale) context.req.locale = args.locale
-    if (args.fallbackLocale) context.req.fallbackLocale = args.fallbackLocale
+    if (args.locale) {
+      context.req.locale = args.locale
+    }
+    if (args.fallbackLocale) {
+      context.req.fallbackLocale = args.fallbackLocale
+    }
 
     const { slug } = globalConfig
 

--- a/packages/graphql/src/schema/buildMutationInputType.ts
+++ b/packages/graphql/src/schema/buildMutationInputType.ts
@@ -97,7 +97,9 @@ export function buildMutationInputType({
         parentName: fullName,
       })
 
-      if (!type) return inputObjectTypeConfig
+      if (!type) {
+        return inputObjectTypeConfig
+      }
 
       type = new GraphQLList(withNullableType(field, type, forceNullable))
       return {
@@ -120,7 +122,9 @@ export function buildMutationInputType({
     collapsible: (inputObjectTypeConfig: InputObjectTypeConfig, field: CollapsibleField) =>
       field.fields.reduce((acc, subField: CollapsibleField) => {
         const addSubField = fieldToSchemaMap[subField.type]
-        if (addSubField) return addSubField(acc, subField)
+        if (addSubField) {
+          return addSubField(acc, subField)
+        }
         return acc
       }, inputObjectTypeConfig),
     date: (inputObjectTypeConfig: InputObjectTypeConfig, field: DateField) => ({
@@ -142,9 +146,13 @@ export function buildMutationInputType({
         parentName: fullName,
       })
 
-      if (!type) return inputObjectTypeConfig
+      if (!type) {
+        return inputObjectTypeConfig
+      }
 
-      if (requiresAtLeastOneField) type = new GraphQLNonNull(type)
+      if (requiresAtLeastOneField) {
+        type = new GraphQLNonNull(type)
+      }
       return {
         ...inputObjectTypeConfig,
         [field.name]: { type },
@@ -227,7 +235,9 @@ export function buildMutationInputType({
     row: (inputObjectTypeConfig: InputObjectTypeConfig, field: RowField) =>
       field.fields.reduce((acc, subField: Field) => {
         const addSubField = fieldToSchemaMap[subField.type]
-        if (addSubField) return addSubField(acc, subField)
+        if (addSubField) {
+          return addSubField(acc, subField)
+        }
         return acc
       }, inputObjectTypeConfig),
     select: (inputObjectTypeConfig: InputObjectTypeConfig, field: SelectField) => {
@@ -274,9 +284,13 @@ export function buildMutationInputType({
             parentName: fullName,
           })
 
-          if (!type) return acc
+          if (!type) {
+            return acc
+          }
 
-          if (requiresAtLeastOneField) type = new GraphQLNonNull(type)
+          if (requiresAtLeastOneField) {
+            type = new GraphQLNonNull(type)
+          }
           return {
             ...acc,
             [tab.name]: { type },
@@ -287,7 +301,9 @@ export function buildMutationInputType({
           ...acc,
           ...tab.fields.reduce((subFieldSchema, subField) => {
             const addSubField = fieldToSchemaMap[subField.type]
-            if (addSubField) return addSubField(subFieldSchema, subField)
+            if (addSubField) {
+              return addSubField(subFieldSchema, subField)
+            }
             return subFieldSchema
           }, acc),
         }

--- a/packages/graphql/src/schema/buildObjectType.ts
+++ b/packages/graphql/src/schema/buildObjectType.ts
@@ -704,7 +704,7 @@ export function buildObjectType({
 
               const result = await context.req.payloadDataLoader.load(
                 createDataloaderCacheKey({
-                  collectionSlug: collectionSlug as string,
+                  collectionSlug,
                   currentDepth: 0,
                   depth: 0,
                   docID: id,
@@ -751,7 +751,7 @@ export function buildObjectType({
           if (id) {
             const relatedDocument = await context.req.payloadDataLoader.load(
               createDataloaderCacheKey({
-                collectionSlug: relatedCollectionSlug as string,
+                collectionSlug: relatedCollectionSlug,
                 currentDepth: 0,
                 depth: 0,
                 docID: id,

--- a/packages/graphql/src/schema/buildObjectType.ts
+++ b/packages/graphql/src/schema/buildObjectType.ts
@@ -184,7 +184,9 @@ export function buildObjectType({
     collapsible: (objectTypeConfig: ObjectTypeConfig, field: CollapsibleField) =>
       field.fields.reduce((objectTypeConfigWithCollapsibleFields, subField) => {
         const addSubField = fieldToSchemaMap[subField.type]
-        if (addSubField) return addSubField(objectTypeConfigWithCollapsibleFields, subField)
+        if (addSubField) {
+          return addSubField(objectTypeConfigWithCollapsibleFields, subField)
+        }
         return objectTypeConfigWithCollapsibleFields
       }, objectTypeConfig),
     date: (objectTypeConfig: ObjectTypeConfig, field: DateField) => ({
@@ -472,7 +474,9 @@ export function buildObjectType({
         },
         async resolve(parent, args, context: Context) {
           let depth = config.defaultDepth
-          if (typeof args.depth !== 'undefined') depth = args.depth
+          if (typeof args.depth !== 'undefined') {
+            depth = args.depth
+          }
           if (!field?.editor) {
             throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
           }
@@ -519,7 +523,9 @@ export function buildObjectType({
     row: (objectTypeConfig: ObjectTypeConfig, field: RowField) =>
       field.fields.reduce((objectTypeConfigWithRowFields, subField) => {
         const addSubField = fieldToSchemaMap[subField.type]
-        if (addSubField) return addSubField(objectTypeConfigWithRowFields, subField)
+        if (addSubField) {
+          return addSubField(objectTypeConfigWithRowFields, subField)
+        }
         return objectTypeConfigWithRowFields
       }, objectTypeConfig),
     select: (objectTypeConfig: ObjectTypeConfig, field: SelectField) => {
@@ -573,7 +579,9 @@ export function buildObjectType({
           ...tabSchema,
           ...tab.fields.reduce((subFieldSchema, subField) => {
             const addSubField = fieldToSchemaMap[subField.type]
-            if (addSubField) return addSubField(subFieldSchema, subField)
+            if (addSubField) {
+              return addSubField(subFieldSchema, subField)
+            }
             return subFieldSchema
           }, tabSchema),
         }

--- a/packages/graphql/src/schema/buildPoliciesType.ts
+++ b/packages/graphql/src/schema/buildPoliciesType.ts
@@ -148,7 +148,9 @@ export function buildPolicyType(args: BuildPolicyType): GraphQLObjectType {
 
   let operations = []
 
-  if (graphQL === false) return null
+  if (graphQL === false) {
+    return null
+  }
 
   if (type === 'collection') {
     operations = ['create', 'read', 'update', 'delete']

--- a/packages/graphql/src/schema/initCollections.ts
+++ b/packages/graphql/src/schema/initCollections.ts
@@ -57,7 +57,9 @@ function initCollectionsGraphQL({ config, graphqlResult }: InitCollectionsGraphQ
       config: { fields, graphQL = {} as SanitizedCollectionConfig['graphQL'], versions },
     } = collection
 
-    if (!graphQL) return
+    if (!graphQL) {
+      return
+    }
 
     let singularName
     let pluralName

--- a/packages/graphql/src/schema/initGlobals.ts
+++ b/packages/graphql/src/schema/initGlobals.ts
@@ -36,7 +36,9 @@ function initGlobalsGraphQL({ config, graphqlResult }: InitGlobalsGraphQLArgs): 
 
     const forceNullableObjectType = Boolean(versions?.drafts)
 
-    if (!graphqlResult.globals.graphQL) graphqlResult.globals.graphQL = {}
+    if (!graphqlResult.globals.graphQL) {
+      graphqlResult.globals.graphQL = {}
+    }
 
     const updateMutationInputType = buildMutationInputType({
       name: formattedName,

--- a/packages/graphql/src/schema/withOperators.ts
+++ b/packages/graphql/src/schema/withOperators.ts
@@ -263,7 +263,9 @@ export const withOperators = (
   field: FieldAffectingData,
   parentName: string,
 ): GraphQLInputObjectType => {
-  if (!defaults?.[field.type]) throw new Error(`Error: ${field.type} has no defaults configured.`)
+  if (!defaults?.[field.type]) {
+    throw new Error(`Error: ${field.type} has no defaults configured.`)
+  }
 
   const name = `${combineParentName(parentName, field.name)}_operator`
 

--- a/packages/next/babel.config.cjs
+++ b/packages/next/babel.config.cjs
@@ -4,7 +4,10 @@ const fs = require('fs')
 const ReactCompilerConfig = {
   sources: (filename) => {
     const isInNodeModules = filename.includes('node_modules')
-    if (isInNodeModules || ( !filename.endsWith('.tsx') && !filename.endsWith('.jsx') && !filename.endsWith('.js'))) {
+    if (
+      isInNodeModules ||
+      (!filename.endsWith('.tsx') && !filename.endsWith('.jsx') && !filename.endsWith('.js'))
+    ) {
       return false
     }
 

--- a/packages/next/src/elements/DocumentHeader/Tabs/index.tsx
+++ b/packages/next/src/elements/DocumentHeader/Tabs/index.tsx
@@ -40,9 +40,13 @@ export const DocumentTabs: React.FC<{
               // if no `order`, append the view to the end
               // TODO: open `order` to the config and merge `defaultViews` with `customViews`
               ?.sort(([, a], [, b]) => {
-                if (a.order === undefined && b.order === undefined) return 0
-                else if (a.order === undefined) return 1
-                else if (b.order === undefined) return -1
+                if (a.order === undefined && b.order === undefined) {
+                  return 0
+                } else if (a.order === undefined) {
+                  return 1
+                } else if (b.order === undefined) {
+                  return -1
+                }
                 return a.order - b.order
               })
               ?.map(([name, tab], index) => {

--- a/packages/next/src/elements/DocumentHeader/Tabs/tabs/VersionsPill/index.tsx
+++ b/packages/next/src/elements/DocumentHeader/Tabs/tabs/VersionsPill/index.tsx
@@ -12,7 +12,7 @@ export const VersionsPill: React.FC = () => {
   // documents that are version enabled _always_ have at least one version
   const hasVersions = versions?.totalDocs > 0
 
-  if (hasVersions)
+  if (hasVersions) {
     return (
       <span
         className={[`${baseClass}__count`, hasVersions ? `${baseClass}__count--has-count` : '']
@@ -22,4 +22,5 @@ export const VersionsPill: React.FC = () => {
         {versions.totalDocs.toString()}
       </span>
     )
+  }
 }

--- a/packages/next/src/elements/LeaveWithoutSaving/index.tsx
+++ b/packages/next/src/elements/LeaveWithoutSaving/index.tsx
@@ -25,8 +25,11 @@ const Component: React.FC<{
   // }, [modalState, isActive, onCancel])
 
   useEffect(() => {
-    if (isActive) openModal(modalSlug)
-    else closeModal(modalSlug)
+    if (isActive) {
+      openModal(modalSlug)
+    } else {
+      closeModal(modalSlug)
+    }
   }, [isActive, openModal, closeModal])
 
   return (

--- a/packages/next/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
+++ b/packages/next/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
@@ -145,7 +145,9 @@ export const usePreventLeave = ({
 
   useEffect(() => {
     if (hasAccepted && cancelledURL.current) {
-      if (onAccept) onAccept()
+      if (onAccept) {
+        onAccept()
+      }
       router.push(cancelledURL.current)
     }
   }, [hasAccepted, onAccept, router])

--- a/packages/next/src/fetchAPI-multipart/handlers.ts
+++ b/packages/next/src/fetchAPI-multipart/handlers.ts
@@ -55,7 +55,9 @@ export const tempFileHandler: Handler = (options, fieldname, filename) => {
     complete: () => {
       completed = true
       debugLog(options, `Upload ${fieldname}->${filename} completed, bytes:${fileSize}.`)
-      if (writeStream instanceof WriteStream) writeStream.end()
+      if (writeStream instanceof WriteStream) {
+        writeStream.end()
+      }
       // Return empty buff since data was uploaded into a temp file.
       return Buffer.concat([])
     },

--- a/packages/next/src/fetchAPI-multipart/processNested.ts
+++ b/packages/next/src/fetchAPI-multipart/processNested.ts
@@ -1,7 +1,9 @@
 import { isSafeFromPollution } from './utilities.js'
 
 export const processNested = function (data) {
-  if (!data || data.length < 1) return Object.create(null)
+  if (!data || data.length < 1) {
+    return Object.create(null)
+  }
 
   const d = Object.create(null),
     keys = Object.keys(data)
@@ -23,7 +25,9 @@ export const processNested = function (data) {
       if (index >= keyParts.length - 1) {
         current[k] = value
       } else {
-        if (!current[k]) current[k] = !keyParts[index + 1] ? [] : Object.create(null)
+        if (!current[k]) {
+          current[k] = !keyParts[index + 1] ? [] : Object.create(null)
+        }
         current = current[k]
       }
     }

--- a/packages/next/src/fetchAPI-multipart/uploadTimer.ts
+++ b/packages/next/src/fetchAPI-multipart/uploadTimer.ts
@@ -15,7 +15,9 @@ export const createUploadTimer: CreateUploadTimer = (timeout = 0, callback = () 
 
   const set = () => {
     // Do not start a timer if zero timeout or it hasn't been set.
-    if (!timeout) return false
+    if (!timeout) {
+      return false
+    }
     clear()
     timer = setTimeout(callback, timeout)
     return true

--- a/packages/next/src/fetchAPI-multipart/utilities.ts
+++ b/packages/next/src/fetchAPI-multipart/utilities.ts
@@ -18,7 +18,9 @@ let tempCounter = 0
  */
 export const debugLog = (options: FetchAPIFileUploadOptions, msg: string) => {
   const opts = options || {}
-  if (!opts.debug) return false
+  if (!opts.debug) {
+    return false
+  }
   console.log(`Next-file-upload: ${msg}`) // eslint-disable-line
   return true
 }
@@ -84,7 +86,9 @@ export const isSafeFromPollution: IsSafeFromPollution = (base, key) => {
 type BuildFields = (instance: any, field: string, value: any) => any
 export const buildFields: BuildFields = (instance, field, value) => {
   // Do nothing if value is not set.
-  if (value === null || value === undefined) return instance
+  if (value === null || value === undefined) {
+    return instance
+  }
   instance = instance || Object.create(null)
 
   if (!isSafeFromPollution(instance, field)) {
@@ -110,11 +114,15 @@ export const buildFields: BuildFields = (instance, field, value) => {
  */
 type CheckAndMakeDir = (fileUploadOptions: FetchAPIFileUploadOptions, filePath: string) => boolean
 export const checkAndMakeDir: CheckAndMakeDir = (fileUploadOptions, filePath) => {
-  if (!fileUploadOptions.createParentPath) return false
+  if (!fileUploadOptions.createParentPath) {
+    return false
+  }
   // Check whether folder for the file exists.
   const parentPath = path.dirname(filePath)
   // Create folder if it doesn't exist.
-  if (!fs.existsSync(parentPath)) fs.mkdirSync(parentPath, { recursive: true })
+  if (!fs.existsSync(parentPath)) {
+    fs.mkdirSync(parentPath, { recursive: true })
+  }
   // Checks folder again and return a results.
   return fs.existsSync(parentPath)
 }
@@ -134,7 +142,9 @@ const copyFile: CopyFile = (src, dst, callback) => {
   // cbCalled flag and runCb helps to run cb only once.
   let cbCalled = false
   const runCb = (err?: Error) => {
-    if (cbCalled) return
+    if (cbCalled) {
+      return
+    }
     cbCalled = true
     callback(err)
   }
@@ -247,14 +257,18 @@ export const parseFileNameExtension: ParseFileNameExtension = (preserveExtension
     name: fileName,
     extension: '',
   }
-  if (!preserveExtension) return defaultResult
+  if (!preserveExtension) {
+    return defaultResult
+  }
 
   // Define maximum extension length
   const maxExtLength =
     typeof preserveExtension === 'boolean' ? MAX_EXTENSION_LENGTH : preserveExtension
 
   const nameParts = fileName.split('.')
-  if (nameParts.length < 2) return defaultResult
+  if (nameParts.length < 2) {
+    return defaultResult
+  }
 
   let extension = nameParts.pop()
   if (extension.length > maxExtLength && maxExtLength > 0) {
@@ -274,13 +288,17 @@ export const parseFileNameExtension: ParseFileNameExtension = (preserveExtension
 type ParseFileName = (opts: FetchAPIFileUploadOptions, fileName: string) => string
 export const parseFileName: ParseFileName = (opts, fileName) => {
   // Check fileName argument
-  if (!fileName || typeof fileName !== 'string') return getTempFilename()
+  if (!fileName || typeof fileName !== 'string') {
+    return getTempFilename()
+  }
   // Cut off file name if it's length more then 255.
   let parsedName = fileName.length <= 255 ? fileName : fileName.substr(0, 255)
   // Decode file name if uriDecodeFileNames option set true.
   parsedName = uriDecodeFileName(opts, parsedName)
   // Stop parsing file name if safeFileNames options hasn't been set.
-  if (!opts.safeFileNames) return parsedName
+  if (!opts.safeFileNames) {
+    return parsedName
+  }
   // Set regular expression for the file name.
   const nameRegex =
     typeof opts.safeFileNames === 'object' && opts.safeFileNames instanceof RegExp
@@ -288,8 +306,9 @@ export const parseFileName: ParseFileName = (opts, fileName) => {
       : SAFE_FILE_NAME_REGEX
   // Parse file name extension.
   const parsedFileName = parseFileNameExtension(opts.preserveExtension, parsedName)
-  if (parsedFileName.extension.length)
+  if (parsedFileName.extension.length) {
     parsedFileName.extension = '.' + parsedFileName.extension.replace(nameRegex, '')
+  }
 
   return parsedFileName.name.replace(nameRegex, '').concat(parsedFileName.extension)
 }

--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -137,7 +137,7 @@ export const RootLayout = async ({
       )?.docs?.[0]
     : null
 
-  const isNavOpen = (navPreferences?.value as any)?.open ?? true
+  const isNavOpen = navPreferences?.value?.open ?? true
 
   return (
     <html data-theme={theme} dir={dir} lang={languageCode}>

--- a/packages/next/src/routes/rest/collections/updateByID.ts
+++ b/packages/next/src/routes/rest/collections/updateByID.ts
@@ -35,8 +35,12 @@ export const updateByID: CollectionRouteHandlerWithID = async ({
 
   let message = req.t('general:updatedSuccessfully')
 
-  if (draft) message = req.t('version:draftSavedSuccessfully')
-  if (autosave) message = req.t('version:autosavedSuccessfully')
+  if (draft) {
+    message = req.t('version:draftSavedSuccessfully')
+  }
+  if (autosave) {
+    message = req.t('version:autosavedSuccessfully')
+  }
 
   return Response.json(
     {

--- a/packages/next/src/routes/rest/files/checkFileAccess.ts
+++ b/packages/next/src/routes/rest/files/checkFileAccess.ts
@@ -15,7 +15,9 @@ export async function checkFileAccess({
 }): Promise<Response | TypeWithID> {
   const { config } = collection
   const disableEndpoints = endpointsAreDisabled({ endpoints: config.endpoints, request: req })
-  if (disableEndpoints) return disableEndpoints
+  if (disableEndpoints) {
+    return disableEndpoints
+  }
 
   const accessResult = await executeAccess({ isReadingStaticFile: true, req }, config.access.read)
 

--- a/packages/next/src/routes/rest/files/getFile.ts
+++ b/packages/next/src/routes/rest/files/getFile.ts
@@ -33,7 +33,9 @@ export const getFile = async ({ collection, filename, req }: Args): Promise<Resp
       req,
     })
 
-    if (accessResult instanceof Response) return accessResult
+    if (accessResult instanceof Response) {
+      return accessResult
+    }
 
     if (collection.config.upload.handlers?.length) {
       let customResponse = null
@@ -47,7 +49,9 @@ export const getFile = async ({ collection, filename, req }: Args): Promise<Resp
         })
       }
 
-      if (customResponse instanceof Response) return customResponse
+      if (customResponse instanceof Response) {
+        return customResponse
+      }
     }
 
     const fileDir = collection.config.upload?.staticDir || collection.config.slug

--- a/packages/next/src/routes/rest/globals/update.ts
+++ b/packages/next/src/routes/rest/globals/update.ts
@@ -24,8 +24,12 @@ export const update: GlobalRouteHandler = async ({ globalConfig, req }) => {
 
   let message = req.t('general:updatedSuccessfully')
 
-  if (draft) message = req.t('version:draftSavedSuccessfully')
-  if (autosave) message = req.t('version:autosavedSuccessfully')
+  if (draft) {
+    message = req.t('version:draftSavedSuccessfully')
+  }
+  if (autosave) {
+    message = req.t('version:autosavedSuccessfully')
+  }
 
   return Response.json(
     {

--- a/packages/next/src/routes/rest/index.ts
+++ b/packages/next/src/routes/rest/index.ts
@@ -246,7 +246,9 @@ export const GET =
         request,
       })
 
-      if (disableEndpoints) return disableEndpoints
+      if (disableEndpoints) {
+        return disableEndpoints
+      }
 
       collection = req.payload.collections?.[slug1]
 
@@ -256,7 +258,9 @@ export const GET =
           endpoints: collection.config.endpoints,
           request,
         })
-        if (disableEndpoints) return disableEndpoints
+        if (disableEndpoints) {
+          return disableEndpoints
+        }
 
         const customEndpointResponse = await handleCustomEndpoints({
           endpoints: collection.config.endpoints,
@@ -327,7 +331,9 @@ export const GET =
           endpoints: globalConfig.endpoints,
           request,
         })
-        if (disableEndpoints) return disableEndpoints
+        if (disableEndpoints) {
+          return disableEndpoints
+        }
 
         const customEndpointResponse = await handleCustomEndpoints({
           endpoints: globalConfig.endpoints,
@@ -403,7 +409,9 @@ export const GET =
         req,
       })
 
-      if (customEndpointResponse) return customEndpointResponse
+      if (customEndpointResponse) {
+        return customEndpointResponse
+      }
 
       return RouteNotFoundResponse({
         slug,
@@ -445,7 +453,9 @@ export const POST =
         request,
       })
 
-      if (disableEndpoints) return disableEndpoints
+      if (disableEndpoints) {
+        return disableEndpoints
+      }
 
       if (collection) {
         req.routeParams.collection = slug1
@@ -453,7 +463,9 @@ export const POST =
           endpoints: collection.config.endpoints,
           request,
         })
-        if (disableEndpoints) return disableEndpoints
+        if (disableEndpoints) {
+          return disableEndpoints
+        }
 
         const customEndpointResponse = await handleCustomEndpoints({
           endpoints: collection.config.endpoints,
@@ -516,7 +528,9 @@ export const POST =
           endpoints: globalConfig.endpoints,
           request,
         })
-        if (disableEndpoints) return disableEndpoints
+        if (disableEndpoints) {
+          return disableEndpoints
+        }
 
         const customEndpointResponse = await handleCustomEndpoints({
           endpoints: globalConfig.endpoints,
@@ -585,7 +599,9 @@ export const POST =
         req,
       })
 
-      if (customEndpointResponse) return customEndpointResponse
+      if (customEndpointResponse) {
+        return customEndpointResponse
+      }
 
       return RouteNotFoundResponse({
         slug,
@@ -620,7 +636,9 @@ export const DELETE =
         endpoints: req.payload.config.endpoints,
         request,
       })
-      if (disableEndpoints) return disableEndpoints
+      if (disableEndpoints) {
+        return disableEndpoints
+      }
 
       if (collection) {
         req.routeParams.collection = slug1
@@ -629,7 +647,9 @@ export const DELETE =
           endpoints: collection.config.endpoints,
           request,
         })
-        if (disableEndpoints) return disableEndpoints
+        if (disableEndpoints) {
+          return disableEndpoints
+        }
 
         const customEndpointResponse = await handleCustomEndpoints({
           endpoints: collection.config.endpoints,
@@ -679,7 +699,9 @@ export const DELETE =
         req,
       })
 
-      if (customEndpointResponse) return customEndpointResponse
+      if (customEndpointResponse) {
+        return customEndpointResponse
+      }
 
       return RouteNotFoundResponse({
         slug,
@@ -714,7 +736,9 @@ export const PATCH =
         endpoints: req.payload.config.endpoints,
         request,
       })
-      if (disableEndpoints) return disableEndpoints
+      if (disableEndpoints) {
+        return disableEndpoints
+      }
 
       if (collection) {
         req.routeParams.collection = slug1
@@ -723,7 +747,9 @@ export const PATCH =
           endpoints: collection.config.endpoints,
           request,
         })
-        if (disableEndpoints) return disableEndpoints
+        if (disableEndpoints) {
+          return disableEndpoints
+        }
 
         const customEndpointResponse = await handleCustomEndpoints({
           endpoints: collection.config.endpoints,
@@ -774,7 +800,9 @@ export const PATCH =
         req,
       })
 
-      if (customEndpointResponse) return customEndpointResponse
+      if (customEndpointResponse) {
+        return customEndpointResponse
+      }
 
       return RouteNotFoundResponse({
         slug,

--- a/packages/next/src/routes/rest/utilities/sanitizeCollectionID.ts
+++ b/packages/next/src/routes/rest/utilities/sanitizeCollectionID.ts
@@ -14,10 +14,14 @@ export const sanitizeCollectionID = ({ id, collectionSlug, payload }: Args): num
   let shouldSanitize = Boolean(payload.db.defaultIDType === 'number')
 
   // UNLESS the customIDType for this collection is text.... then we leave it
-  if (shouldSanitize && collection.customIDType === 'text') shouldSanitize = false
+  if (shouldSanitize && collection.customIDType === 'text') {
+    shouldSanitize = false
+  }
 
   // If we still should sanitize, parse float
-  if (shouldSanitize) sanitizedID = parseFloat(sanitizedID)
+  if (shouldSanitize) {
+    sanitizedID = parseFloat(sanitizedID)
+  }
 
   return sanitizedID
 }

--- a/packages/next/src/templates/Default/Wrapper/index.scss
+++ b/packages/next/src/templates/Default/Wrapper/index.scss
@@ -15,7 +15,6 @@
   }
 
   &--nav-open {
-
     .template-default {
       &__nav-overlay {
         transition: opacity var(--nav-trans-time) linear;

--- a/packages/next/src/utilities/addLocalesToRequest.ts
+++ b/packages/next/src/utilities/addLocalesToRequest.ts
@@ -31,8 +31,12 @@ export function addLocalesToRequestFromData(req: PayloadRequest): void {
       localization: config.localization,
     })
 
-    if (locale) req.locale = locale
-    if (fallbackLocale) req.fallbackLocale = fallbackLocale
+    if (locale) {
+      req.locale = locale
+    }
+    if (fallbackLocale) {
+      req.fallbackLocale = fallbackLocale
+    }
   }
 }
 

--- a/packages/next/src/utilities/createPayloadRequest.ts
+++ b/packages/next/src/utilities/createPayloadRequest.ts
@@ -69,8 +69,12 @@ export const createPayloadRequest = async ({
     fallbackLocale = locales.fallbackLocale
 
     // Override if query params are present, in order to respect HTTP method override
-    if (query.locale) locale = query.locale
-    if (query?.['fallback-locale']) fallbackLocale = query['fallback-locale']
+    if (query.locale) {
+      locale = query.locale
+    }
+    if (query?.['fallback-locale']) {
+      fallbackLocale = query['fallback-locale']
+    }
   }
 
   const customRequest: CustomPayloadRequestProperties = {
@@ -110,7 +114,9 @@ export const createPayloadRequest = async ({
 
   req.user = user
 
-  if (responseHeaders) req.responseHeaders = responseHeaders
+  if (responseHeaders) {
+    req.responseHeaders = responseHeaders
+  }
 
   return req
 }

--- a/packages/next/src/utilities/initPage/handleAuthRedirect.ts
+++ b/packages/next/src/utilities/initPage/handleAuthRedirect.ts
@@ -23,7 +23,9 @@ export const handleAuthRedirect = ({
   } = config
 
   if (!isAdminAuthRoute({ adminRoute, config, route })) {
-    if (searchParams && 'redirect' in searchParams) delete searchParams.redirect
+    if (searchParams && 'redirect' in searchParams) {
+      delete searchParams.redirect
+    }
 
     const redirectRoute = encodeURIComponent(
       route + Object.keys(searchParams ?? {}).length

--- a/packages/next/src/utilities/initPage/index.ts
+++ b/packages/next/src/utilities/initPage/index.ts
@@ -117,7 +117,9 @@ export const initPage = async ({
 
     locale = findLocaleFromCode(localization, localeCode)
 
-    if (!locale) locale = findLocaleFromCode(localization, defaultLocaleCode)
+    if (!locale) {
+      locale = findLocaleFromCode(localization, defaultLocaleCode)
+    }
     req.locale = locale.code
   }
 

--- a/packages/next/src/utilities/timestamp.ts
+++ b/packages/next/src/utilities/timestamp.ts
@@ -1,5 +1,7 @@
 export const timestamp = (label: string) => {
-  if (!process.env.PAYLOAD_TIME) process.env.PAYLOAD_TIME = String(new Date().getTime())
+  if (!process.env.PAYLOAD_TIME) {
+    process.env.PAYLOAD_TIME = String(new Date().getTime())
+  }
   const now = new Date()
   console.log(`[${now.getTime() - Number(process.env.PAYLOAD_TIME)}ms] ${label}`)
 }

--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -1,6 +1,11 @@
 import type { AdminViewProps } from 'payload'
 
-import { DocumentInfoProvider, EditDepthProvider, HydrateAuthProvider, RenderComponent } from '@payloadcms/ui'
+import {
+  DocumentInfoProvider,
+  EditDepthProvider,
+  HydrateAuthProvider,
+  RenderComponent,
+} from '@payloadcms/ui'
 import { getCreateMappedComponent } from '@payloadcms/ui/shared'
 import { notFound } from 'next/navigation.js'
 import React from 'react'
@@ -92,16 +97,15 @@ export const Account: React.FC<AdminViewProps> = async ({
         isEditing
       >
         <EditDepthProvider depth={1}>
-
-        <DocumentHeader
-          collectionConfig={collectionConfig}
-          hideTabs
-          i18n={i18n}
-          payload={payload}
-          permissions={permissions}
-        />
-        <HydrateAuthProvider permissions={permissions} />
-        <RenderComponent mappedComponent={mappedAccountComponent} />
+          <DocumentHeader
+            collectionConfig={collectionConfig}
+            hideTabs
+            i18n={i18n}
+            payload={payload}
+            permissions={permissions}
+          />
+          <HydrateAuthProvider permissions={permissions} />
+          <RenderComponent mappedComponent={mappedAccountComponent} />
           <AccountClient />
         </EditDepthProvider>
       </DocumentInfoProvider>

--- a/packages/next/src/views/Edit/Default/SetDocumentStepNav/index.tsx
+++ b/packages/next/src/views/Edit/Default/SetDocumentStepNav/index.tsx
@@ -91,7 +91,9 @@ export const SetDocumentStepNav: React.FC<{
         })
       }
 
-      if (drawerDepth <= 1) setStepNav(nav)
+      if (drawerDepth <= 1) {
+        setStepNav(nav)
+      }
     }
   }, [
     setStepNav,

--- a/packages/next/src/views/Edit/Default/index.tsx
+++ b/packages/next/src/views/Edit/Default/index.tsx
@@ -95,8 +95,12 @@ export const DefaultEditView: React.FC = () => {
 
   const classes = [baseClass, id && `${baseClass}--is-editing`]
 
-  if (globalSlug) classes.push(`global-edit--${globalSlug}`)
-  if (collectionSlug) classes.push(`collection-edit--${collectionSlug}`)
+  if (globalSlug) {
+    classes.push(`global-edit--${globalSlug}`)
+  }
+  if (collectionSlug) {
+    classes.push(`collection-edit--${collectionSlug}`)
+  }
 
   const [schemaPath, setSchemaPath] = React.useState(() => {
     if (operation === 'create' && auth && !auth.disableLocalStrategy) {

--- a/packages/next/src/views/LivePreview/Context/index.tsx
+++ b/packages/next/src/views/LivePreview/Context/index.tsx
@@ -146,7 +146,9 @@ export const LivePreviewProvider: React.FC<LivePreviewProviderProps> = ({
     (type: 'iframe' | 'popup') => {
       setAppIsReady(false)
       setPreviewWindowType(type)
-      if (type === 'popup') openPopupWindow()
+      if (type === 'popup') {
+        openPopupWindow()
+      }
     },
     [openPopupWindow],
   )

--- a/packages/next/src/views/LivePreview/Device/index.tsx
+++ b/packages/next/src/views/LivePreview/Device/index.tsx
@@ -54,8 +54,11 @@ export const DeviceContainer: React.FC<{
       if (deviceIsLargerThanFrame) {
         if (zoom > 1) {
           const differenceFromDeviceToFrame = measuredDeviceSize.width - outerFrameSize.width
-          if (differenceFromDeviceToFrame < 0) x = `${differenceFromDeviceToFrame / 2}px`
-          else x = '0'
+          if (differenceFromDeviceToFrame < 0) {
+            x = `${differenceFromDeviceToFrame / 2}px`
+          } else {
+            x = '0'
+          }
         } else {
           x = '0'
         }

--- a/packages/next/src/views/LivePreview/Toolbar/SizeInput/index.tsx
+++ b/packages/next/src/views/LivePreview/Toolbar/SizeInput/index.tsx
@@ -24,7 +24,9 @@ export const PreviewFrameSizeInput: React.FC<{
     (e: React.ChangeEvent<HTMLInputElement>) => {
       let newValue = Number(e.target.value)
 
-      if (newValue < 0) newValue = 0
+      if (newValue < 0) {
+        newValue = 0
+      }
 
       setInternalState(newValue)
       setBreakpoint('custom')
@@ -46,8 +48,11 @@ export const PreviewFrameSizeInput: React.FC<{
   // so we need to take the measurements provided by `actualDeviceSize` and sync internal state
   useEffect(() => {
     if (breakpoint === 'responsive' && measuredDeviceSize) {
-      if (axis === 'x') setInternalState(Number(measuredDeviceSize.width.toFixed(0)) * zoom)
-      else setInternalState(Number(measuredDeviceSize.height.toFixed(0)) * zoom)
+      if (axis === 'x') {
+        setInternalState(Number(measuredDeviceSize.width.toFixed(0)) * zoom)
+      } else {
+        setInternalState(Number(measuredDeviceSize.height.toFixed(0)) * zoom)
+      }
     }
 
     if (breakpoint !== 'responsive' && size) {

--- a/packages/next/src/views/Login/LoginForm/index.tsx
+++ b/packages/next/src/views/Login/LoginForm/index.tsx
@@ -40,8 +40,12 @@ export const LoginForm: React.FC<{
   const canLoginWithUsername = authOptions.loginWithUsername
 
   const [loginType] = React.useState<LoginFieldProps['type']>(() => {
-    if (canLoginWithEmail && canLoginWithUsername) return 'emailOrUsername'
-    if (canLoginWithUsername) return 'username'
+    if (canLoginWithEmail && canLoginWithUsername) {
+      return 'emailOrUsername'
+    }
+    if (canLoginWithUsername) {
+      return 'username'
+    }
     return 'email'
   })
 

--- a/packages/next/src/views/Root/isPathMatchingRoute.ts
+++ b/packages/next/src/views/Root/isPathMatchingRoute.ts
@@ -25,6 +25,10 @@ export const isPathMatchingRoute = ({
   const match = regex.exec(currentRoute)
   const viewRoute = match?.[0] || viewPath
 
-  if (exact) return currentRoute === viewRoute
-  if (!exact) return viewRoute.startsWith(currentRoute)
+  if (exact) {
+    return currentRoute === viewRoute
+  }
+  if (!exact) {
+    return viewRoute.startsWith(currentRoute)
+  }
 }

--- a/packages/next/src/views/Verify/index.tsx
+++ b/packages/next/src/views/Verify/index.tsx
@@ -43,7 +43,9 @@ export const Verify: React.FC<AdminViewProps> = async ({
     return redirect(formatAdminURL({ adminRoute, path: '/login' }))
   } catch (e) {
     // already verified
-    if (e?.status === 202) redirect(formatAdminURL({ adminRoute, path: '/login' }))
+    if (e?.status === 202) {
+      redirect(formatAdminURL({ adminRoute, path: '/login' }))
+    }
     textToRender = req.t('authentication:unableToVerify')
   }
 

--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Iterable/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Iterable/index.tsx
@@ -43,7 +43,9 @@ const Iterable: React.FC<DiffComponentProps> = ({
 
             let fields: ClientField[] = []
 
-            if (field.type === 'array' && 'fields' in field) fields = field.fields
+            if (field.type === 'array' && 'fields' in field) {
+              fields = field.fields
+            }
 
             if (field.type === 'blocks') {
               fields = [

--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Select/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Select/index.tsx
@@ -55,7 +55,9 @@ const Select: React.FC<DiffComponentProps<SelectFieldClient>> = ({
 }) => {
   let placeholder = ''
 
-  if (version === comparison) placeholder = `[${i18n.t('general:noValue')}]`
+  if (version === comparison) {
+    placeholder = `[${i18n.t('general:noValue')}]`
+  }
 
   const options = 'options' in field && field.options
 

--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Text/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Text/index.tsx
@@ -24,14 +24,20 @@ const Text: React.FC<DiffComponentProps<TextFieldClient>> = ({
 }) => {
   let placeholder = ''
 
-  if (version === comparison) placeholder = `[${i18n.t('general:noValue')}]`
+  if (version === comparison) {
+    placeholder = `[${i18n.t('general:noValue')}]`
+  }
 
   let versionToRender = version
   let comparisonToRender = comparison
 
   if (isRichText) {
-    if (typeof version === 'object') versionToRender = JSON.stringify(version, null, 2)
-    if (typeof comparison === 'object') comparisonToRender = JSON.stringify(comparison, null, 2)
+    if (typeof version === 'object') {
+      versionToRender = JSON.stringify(version, null, 2)
+    }
+    if (typeof comparison === 'object') {
+      comparisonToRender = JSON.stringify(comparison, null, 2)
+    }
   }
 
   return (

--- a/packages/next/src/views/Version/RenderFieldsToDiff/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/index.tsx
@@ -29,7 +29,9 @@ const RenderFieldsToDiff: React.FC<Props> = ({
   return (
     <div className={baseClass}>
       {fields?.map((field, i) => {
-        if ('name' in field && field.name === 'id') return null
+        if ('name' in field && field.name === 'id') {
+          return null
+        }
 
         const Component = diffComponents[field.type]
 
@@ -53,7 +55,9 @@ const RenderFieldsToDiff: React.FC<Props> = ({
 
             const subFieldPermissions = fieldPermissions?.[fieldName]?.fields
 
-            if (hasPermission === false) return null
+            if (hasPermission === false) {
+              return null
+            }
 
             const baseCellProps: FieldDiffProps = {
               comparison: comparisonValue,

--- a/packages/next/src/views/Version/SelectComparison/index.tsx
+++ b/packages/next/src/views/Version/SelectComparison/index.tsx
@@ -48,7 +48,9 @@ export const SelectComparison: React.FC<Props> = (props) => {
 
   const getResults = useCallback(
     async ({ lastLoadedPage: lastLoadedPageArg }) => {
-      if (loadedAllOptionsRef.current) return
+      if (loadedAllOptionsRef.current) {
+        return
+      }
       const query: {
         [key: string]: unknown
         where: Where

--- a/packages/next/src/views/Version/SelectLocales/index.tsx
+++ b/packages/next/src/views/Version/SelectLocales/index.tsx
@@ -14,7 +14,9 @@ export const SelectLocales: React.FC<Props> = ({ onChange, options, value }) => 
 
   const format = (items) => {
     return items.map((item) => {
-      if (typeof item.label === 'string') return item
+      if (typeof item.label === 'string') {
+        return item
+      }
       if (typeof item.label !== 'string' && item.label[code]) {
         return {
           label: item.label[code],

--- a/packages/next/src/views/Versions/cells/CreatedAt/index.tsx
+++ b/packages/next/src/views/Versions/cells/CreatedAt/index.tsx
@@ -32,17 +32,19 @@ export const CreatedAtCell: React.FC<CreatedAtCellProps> = ({
 
   let to: string
 
-  if (collectionSlug)
+  if (collectionSlug) {
     to = formatAdminURL({
       adminRoute,
       path: `/collections/${collectionSlug}/${docID}/versions/${versionID}`,
     })
+  }
 
-  if (globalSlug)
+  if (globalSlug) {
     to = formatAdminURL({
       adminRoute,
       path: `/globals/${globalSlug}/versions/${versionID}`,
     })
+  }
 
   return (
     <Link href={to}>

--- a/packages/payload/src/auth/executeAccess.ts
+++ b/packages/payload/src/auth/executeAccess.ts
@@ -23,7 +23,9 @@ const executeAccess = async (
     })
 
     if (!result) {
-      if (!disableErrors) throw new Forbidden(req.t)
+      if (!disableErrors) {
+        throw new Forbidden(req.t)
+      }
     }
 
     return result
@@ -33,7 +35,9 @@ const executeAccess = async (
     return true
   }
 
-  if (!disableErrors) throw new Forbidden(req.t)
+  if (!disableErrors) {
+    throw new Forbidden(req.t)
+  }
   return false
 }
 

--- a/packages/payload/src/auth/getAuthFields.ts
+++ b/packages/payload/src/auth/getAuthFields.ts
@@ -32,7 +32,9 @@ export const getBaseAuthFields = (authConfig: IncomingAuthType): Field[] => {
     }
 
     authFields.push(emailField)
-    if (usernameField) authFields.push(usernameField)
+    if (usernameField) {
+      authFields.push(usernameField)
+    }
 
     authFields.push(...baseAuthFields)
 

--- a/packages/payload/src/auth/isLocked.ts
+++ b/packages/payload/src/auth/isLocked.ts
@@ -1,5 +1,7 @@
 const isLocked = (date: number): boolean => {
-  if (!date) return false
+  if (!date) {
+    return false
+  }
   return date > Date.now()
 }
 export default isLocked

--- a/packages/payload/src/auth/operations/auth.ts
+++ b/packages/payload/src/auth/operations/auth.ts
@@ -39,7 +39,9 @@ export const auth = async (args: Required<AuthArgs>): Promise<AuthResult> => {
       req,
     })
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return {
       permissions,

--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -128,7 +128,9 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
     // We don't want to indicate specifically that an email was not found,
     // as doing so could lead to the exposure of registered emails.
     // Therefore, we prefer to fail silently.
-    if (!user) return null
+    if (!user) {
+      return null
+    }
 
     user.resetPasswordToken = token
     user.resetPasswordExpiration = new Date(expiration || Date.now() + 3600000).toISOString() // 1 hour
@@ -197,7 +199,9 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
       result: token,
     })
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return token
   } catch (error: unknown) {

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -202,7 +202,9 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
         })
       }
 
-      if (shouldCommit) await commitTransaction(req)
+      if (shouldCommit) {
+        await commitTransaction(req)
+      }
 
       throw new AuthenticationError(req.t)
     }
@@ -332,7 +334,9 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     // Return results
     // /////////////////////////////////////
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/auth/operations/logout.ts
+++ b/packages/payload/src/auth/operations/logout.ts
@@ -18,9 +18,12 @@ export const logoutOperation = async (incomingArgs: Arguments): Promise<boolean>
     req,
   } = incomingArgs
 
-  if (!user) throw new APIError('No User', httpStatus.BAD_REQUEST)
-  if (user.collection !== collectionConfig.slug)
+  if (!user) {
+    throw new APIError('No User', httpStatus.BAD_REQUEST)
+  }
+  if (user.collection !== collectionConfig.slug) {
     throw new APIError('Incorrect collection', httpStatus.FORBIDDEN)
+  }
 
   await collectionConfig.hooks.afterLogout.reduce(async (priorHook, hook) => {
     await priorHook

--- a/packages/payload/src/auth/operations/me.ts
+++ b/packages/payload/src/auth/operations/me.ts
@@ -69,8 +69,12 @@ export const meOperation = async (args: Arguments): Promise<MeOperationResult> =
 
       if (currentToken) {
         const decoded = jwt.decode(currentToken) as jwt.JwtPayload
-        if (decoded) result.exp = decoded.exp
-        if (!collection.config.auth.removeTokenFromResponses) result.token = currentToken
+        if (decoded) {
+          result.exp = decoded.exp
+        }
+        if (!collection.config.auth.removeTokenFromResponses) {
+          result.token = currentToken
+        }
       }
     }
   }

--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -62,7 +62,9 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
       },
     } = args
 
-    if (!args.req.user) throw new Forbidden(args.req.t)
+    if (!args.req.user) {
+      throw new Forbidden(args.req.t)
+    }
 
     const parsedURL = url.parse(args.req.url)
     const isGraphQL = parsedURL.pathname === config.routes.graphQL
@@ -143,7 +145,9 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
     // Return results
     // /////////////////////////////////////
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/auth/operations/registerFirstUser.ts
+++ b/packages/payload/src/auth/operations/registerFirstUser.ts
@@ -58,7 +58,9 @@ export const registerFirstUserOperation = async <TSlug extends CollectionSlug>(
       req,
     })
 
-    if (doc) throw new Forbidden(req.t)
+    if (doc) {
+      throw new Forbidden(req.t)
+    }
 
     // /////////////////////////////////////
     // Register first user
@@ -93,7 +95,9 @@ export const registerFirstUserOperation = async <TSlug extends CollectionSlug>(
       req,
     })
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return {
       exp,

--- a/packages/payload/src/auth/operations/resetPassword.ts
+++ b/packages/payload/src/auth/operations/resetPassword.ts
@@ -64,7 +64,9 @@ export const resetPasswordOperation = async (args: Arguments): Promise<Result> =
       },
     })
 
-    if (!user) throw new APIError('Token is either invalid or has expired.', httpStatus.FORBIDDEN)
+    if (!user) {
+      throw new APIError('Token is either invalid or has expired.', httpStatus.FORBIDDEN)
+    }
 
     // TODO: replace this method
     const { hash, salt } = await generatePasswordSaltHash({
@@ -108,7 +110,9 @@ export const resetPasswordOperation = async (args: Arguments): Promise<Result> =
       overrideAccess,
       req,
     })
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     const result = {
       token,

--- a/packages/payload/src/auth/operations/unlock.ts
+++ b/packages/payload/src/auth/operations/unlock.ts
@@ -102,7 +102,9 @@ export const unlockOperation = async <TSlug extends CollectionSlug>(
       result = null
     }
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/auth/operations/verifyEmail.ts
+++ b/packages/payload/src/auth/operations/verifyEmail.ts
@@ -31,9 +31,12 @@ export const verifyEmailOperation = async (args: Args): Promise<boolean> => {
       },
     })
 
-    if (!user) throw new APIError('Verification token is invalid.', httpStatus.FORBIDDEN)
-    if (user && user._verified === true)
+    if (!user) {
+      throw new APIError('Verification token is invalid.', httpStatus.FORBIDDEN)
+    }
+    if (user && user._verified === true) {
       throw new APIError('This account has already been activated.', httpStatus.ACCEPTED)
+    }
 
     await req.payload.db.updateOne({
       id: user.id,
@@ -46,7 +49,9 @@ export const verifyEmailOperation = async (args: Args): Promise<boolean> => {
       req,
     })
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return true
   } catch (error: unknown) {

--- a/packages/payload/src/auth/strategies/local/authenticate.ts
+++ b/packages/payload/src/auth/strategies/local/authenticate.ts
@@ -17,7 +17,9 @@ export const authenticateLocalStrategy = async ({ doc, password }: Args): Promis
     if (typeof salt === 'string' && typeof hash === 'string') {
       const res = await new Promise<Doc | null>((resolve, reject) => {
         crypto.pbkdf2(password, salt, 25000, 512, 'sha256', (e, hashBuffer) => {
-          if (e) reject(null)
+          if (e) {
+            reject(null)
+          }
 
           if (scmp(hashBuffer, Buffer.from(hash, 'hex'))) {
             resolve(doc)

--- a/packages/payload/src/auth/strategies/local/register.ts
+++ b/packages/payload/src/auth/strategies/local/register.ts
@@ -78,7 +78,9 @@ export const registerLocalStrategy = async ({
   const { hash, salt } = await generatePasswordSaltHash({ collection, password, req })
 
   const sanitizedDoc = { ...doc }
-  if (sanitizedDoc.password) delete sanitizedDoc.password
+  if (sanitizedDoc.password) {
+    delete sanitizedDoc.password
+  }
 
   return payload.db.create({
     collection: collection.slug,

--- a/packages/payload/src/auth/strategies/local/resetLoginAttempts.ts
+++ b/packages/payload/src/auth/strategies/local/resetLoginAttempts.ts
@@ -15,7 +15,9 @@ export const resetLoginAttempts = async ({
   payload,
   req,
 }: Args): Promise<void> => {
-  if (!('lockUntil' in doc && typeof doc.lockUntil === 'string') || doc.loginAttempts === 0) return
+  if (!('lockUntil' in doc && typeof doc.lockUntil === 'string') || doc.loginAttempts === 0) {
+    return
+  }
   await payload.update({
     id: doc.id,
     collection: collection.slug,

--- a/packages/payload/src/bin/generateTypes.ts
+++ b/packages/payload/src/bin/generateTypes.ts
@@ -15,7 +15,9 @@ export async function generateTypes(
 
   const shouldLog = options?.log ?? true
 
-  if (shouldLog) logger.info('Compiling TS types for Collections and Globals...')
+  if (shouldLog) {
+    logger.info('Compiling TS types for Collections and Globals...')
+  }
 
   const jsonSchema = configToJSONSchema(config, config.db.defaultIDType)
 
@@ -54,5 +56,7 @@ export async function generateTypes(
   }
 
   fs.writeFileSync(outputFile, compiled)
-  if (shouldLog) logger.info(`Types written to ${outputFile}`)
+  if (shouldLog) {
+    logger.info(`Types written to ${outputFile}`)
+  }
 }

--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -51,7 +51,9 @@ export const bin = async () => {
   const configPath = findConfig()
   const configPromise = await import(pathToFileURL(configPath).toString())
   let config = await configPromise
-  if (config.default) config = await config.default
+  if (config.default) {
+    config = await config.default
+  }
 
   const userBinScript = Array.isArray(config.bin)
     ? config.bin.find(({ key }) => key === script)

--- a/packages/payload/src/collections/config/reservedFieldNames.spec.ts
+++ b/packages/payload/src/collections/config/reservedFieldNames.spec.ts
@@ -77,12 +77,12 @@ describe('reservedFieldNames - collections -', () => {
   describe('auth -', () => {
     const collectionWithAuth: CollectionConfig = {
       slug: 'collection-with-auth',
-      fields: [],
       auth: {
-        verify: true,
-        useAPIKey: true,
         loginWithUsername: true,
+        useAPIKey: true,
+        verify: true,
       },
+      fields: [],
     }
 
     it('should throw on hash', async () => {

--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -50,8 +50,12 @@ export const sanitizeCollection = async (
     let hasCreatedAt = null
     sanitized.fields.some((field) => {
       if (fieldAffectsData(field)) {
-        if (field.name === 'updatedAt') hasUpdatedAt = true
-        if (field.name === 'createdAt') hasCreatedAt = true
+        if (field.name === 'updatedAt') {
+          hasUpdatedAt = true
+        }
+        if (field.name === 'createdAt') {
+          hasCreatedAt = true
+        }
       }
       return hasCreatedAt && hasUpdatedAt
     })
@@ -84,7 +88,9 @@ export const sanitizeCollection = async (
   sanitized.labels = sanitized.labels || formatLabels(sanitized.slug)
 
   if (sanitized.versions) {
-    if (sanitized.versions === true) sanitized.versions = { drafts: false }
+    if (sanitized.versions === true) {
+      sanitized.versions = { drafts: false }
+    }
 
     if (sanitized.timestamps === false) {
       throw new TimestampsRequired(collection)
@@ -113,7 +119,9 @@ export const sanitizeCollection = async (
   }
 
   if (sanitized.upload) {
-    if (sanitized.upload === true) sanitized.upload = {}
+    if (sanitized.upload === true) {
+      sanitized.upload = {}
+    }
 
     // sanitize fields for reserved names
     sanitizeUploadFields(sanitized.fields, sanitized)

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -75,7 +75,9 @@ const batchAndLoadDocs =
 
       let sanitizedID: number | string = id
 
-      if (idType === 'number') sanitizedID = parseFloat(id)
+      if (idType === 'number') {
+        sanitizedID = parseFloat(id)
+      }
 
       if (isValidID(sanitizedID, idType)) {
         return {

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -364,7 +364,9 @@ export const createOperation = async <TSlug extends CollectionSlug>(
     // Return results
     // /////////////////////////////////////
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -261,7 +261,9 @@ export const deleteOperation = async <TSlug extends CollectionSlug>(
       result,
     })
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -102,8 +102,12 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug>(
       where: combineQueries({ id: { equals: id } }, accessResults),
     })
 
-    if (!docToDelete && !hasWhereAccess) throw new NotFound(req.t)
-    if (!docToDelete && hasWhereAccess) throw new Forbidden(req.t)
+    if (!docToDelete && !hasWhereAccess) {
+      throw new NotFound(req.t)
+    }
+    if (!docToDelete && hasWhereAccess) {
+      throw new Forbidden(req.t)
+    }
 
     await deleteAssociatedFiles({
       collectionConfig,
@@ -213,7 +217,9 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug>(
     // 8. Return results
     // /////////////////////////////////////
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/duplicate.ts
+++ b/packages/payload/src/collections/operations/duplicate.ts
@@ -101,8 +101,12 @@ export const duplicateOperation = async <TSlug extends CollectionSlug>(
       req,
     })
 
-    if (!docWithLocales && !hasWherePolicy) throw new NotFound(req.t)
-    if (!docWithLocales && hasWherePolicy) throw new Forbidden(req.t)
+    if (!docWithLocales && !hasWherePolicy) {
+      throw new NotFound(req.t)
+    }
+    if (!docWithLocales && hasWherePolicy) {
+      throw new Forbidden(req.t)
+    }
 
     // remove the createdAt timestamp and id to rely on the db to set the default it
     delete docWithLocales.createdAt
@@ -324,7 +328,9 @@ export const duplicateOperation = async <TSlug extends CollectionSlug>(
     // Return results
     // /////////////////////////////////////
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -68,7 +68,9 @@ export const findByIDOperation = async <TSlug extends CollectionSlug>(
       : true
 
     // If errors are disabled, and access returns false, return null
-    if (accessResult === false) return null
+    if (accessResult === false) {
+      return null
+    }
 
     const findOneArgs: FindOneArgs = {
       collection: collectionConfig.slug,
@@ -83,7 +85,9 @@ export const findByIDOperation = async <TSlug extends CollectionSlug>(
     // Find by ID
     // /////////////////////////////////////
 
-    if (!findOneArgs.where.and[0].id) throw new NotFound(t)
+    if (!findOneArgs.where.and[0].id) {
+      throw new NotFound(t)
+    }
 
     let result: DataFromCollectionSlug<TSlug> = await req.payload.db.findOne(findOneArgs)
 

--- a/packages/payload/src/collections/operations/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/findVersionByID.ts
@@ -50,7 +50,9 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
       : true
 
     // If errors are disabled, and access returns false, return null
-    if (accessResults === false) return null
+    if (accessResults === false) {
+      return null
+    }
 
     const hasWhereAccess = typeof accessResults === 'object'
 
@@ -73,8 +75,12 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
 
     if (!result) {
       if (!disableErrors) {
-        if (!hasWhereAccess) throw new NotFound(req.t)
-        if (hasWhereAccess) throw new Forbidden(req.t)
+        if (!hasWhereAccess) {
+          throw new NotFound(req.t)
+        }
+        if (hasWhereAccess) {
+          throw new Forbidden(req.t)
+        }
       }
 
       return null

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -87,8 +87,12 @@ export const restoreVersionOperation = async <TData extends TypeWithID = any>(
 
     const doc = await req.payload.db.findOne(findOneArgs)
 
-    if (!doc && !hasWherePolicy) throw new NotFound(req.t)
-    if (!doc && hasWherePolicy) throw new Forbidden(req.t)
+    if (!doc && !hasWherePolicy) {
+      throw new NotFound(req.t)
+    }
+    if (!doc && hasWherePolicy) {
+      throw new Forbidden(req.t)
+    }
 
     // /////////////////////////////////////
     // fetch previousDoc

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -428,7 +428,9 @@ export const updateOperation = async <TSlug extends CollectionSlug>(
       result,
     })
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -127,8 +127,12 @@ export const updateByIDOperation = async <TSlug extends CollectionSlug>(
       req,
     })
 
-    if (!docWithLocales && !hasWherePolicy) throw new NotFound(req.t)
-    if (!docWithLocales && hasWherePolicy) throw new Forbidden(req.t)
+    if (!docWithLocales && !hasWherePolicy) {
+      throw new NotFound(req.t)
+    }
+    if (!docWithLocales && hasWherePolicy) {
+      throw new Forbidden(req.t)
+    }
 
     const originalDoc = await afterRead({
       collection: collectionConfig,
@@ -404,7 +408,9 @@ export const updateByIDOperation = async <TSlug extends CollectionSlug>(
     // Return results
     // /////////////////////////////////////
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/config/find.ts
+++ b/packages/payload/src/config/find.ts
@@ -71,7 +71,9 @@ export const findConfig = (): string => {
       : [configPath, srcPath, rootPath]
 
   for (const searchPath of searchPaths) {
-    if (!searchPath) continue
+    if (!searchPath) {
+      continue
+    }
 
     const configPath = findUpSync(
       (dir) => {
@@ -106,13 +108,17 @@ export const findConfig = (): string => {
       cwd: path.resolve(process.cwd(), 'dist'),
     })
 
-    if (distConfigPath) return distConfigPath
+    if (distConfigPath) {
+      return distConfigPath
+    }
   } else {
     const srcConfigPath = findUpSync(['payload.config.js', 'payload.config.ts'], {
       cwd: path.resolve(process.cwd(), 'src'),
     })
 
-    if (srcConfigPath) return srcConfigPath
+    if (srcConfigPath) {
+      return srcConfigPath
+    }
   }
 
   throw new Error(

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -173,13 +173,17 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
   }
 
   // Get deduped list of upload adapters
-  if (!config.upload) config.upload = { adapters: [] }
+  if (!config.upload) {
+    config.upload = { adapters: [] }
+  }
   config.upload.adapters = Array.from(
     new Set(config.collections.map((c) => c.upload?.adapter).filter(Boolean)),
   )
 
   // Pass through the email config as is so adapters don't break
-  if (incomingConfig.email) config.email = incomingConfig.email
+  if (incomingConfig.email) {
+    config.email = incomingConfig.email
+  }
 
   /*
     Execute richText sanitization

--- a/packages/payload/src/database/combineQueries.ts
+++ b/packages/payload/src/database/combineQueries.ts
@@ -3,14 +3,20 @@ import type { Where } from '../types/index.js'
 import { hasWhereAccessResult } from '../auth/index.js'
 
 export const combineQueries = (where: Where, access: Where | boolean): Where => {
-  if (!where && !access) return {}
+  if (!where && !access) {
+    return {}
+  }
 
   const result: Where = {
     and: [],
   }
 
-  if (where) result.and.push(where)
-  if (hasWhereAccessResult(access)) result.and.push(access)
+  if (where) {
+    result.and.push(where)
+  }
+  if (hasWhereAccessResult(access)) {
+    result.and.push(access)
+  }
 
   return result
 }

--- a/packages/payload/src/database/getLocalizedPaths.ts
+++ b/packages/payload/src/database/getLocalizedPaths.ts
@@ -154,7 +154,9 @@ export async function getLocalizedPaths({
               lastIncompletePath.fields = flattenFields(lastIncompletePath.field.fields, false)
             }
 
-            if (i + 1 === pathSegments.length) lastIncompletePath.complete = true
+            if (i + 1 === pathSegments.length) {
+              lastIncompletePath.complete = true
+            }
             lastIncompletePath.path = currentPath
           }
         }

--- a/packages/payload/src/database/migrations/readMigrationFiles.ts
+++ b/packages/payload/src/database/migrations/readMigrationFiles.ts
@@ -41,7 +41,9 @@ export const readMigrationFiles = async ({
         typeof require === 'function'
           ? await eval(`require('${filePath.replaceAll('\\', '/')}')`)
           : await eval(`import('${pathToFileURL(filePath).href}')`)
-      if ('default' in migration) migration = migration.default
+      if ('default' in migration) {
+        migration = migration.default
+      }
 
       const result: Migration = {
         name: path.basename(filePath).split('.')?.[0],

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -53,7 +53,9 @@ export const sanitizeFields = async ({
   richTextSanitizationPromises,
   validRelationships,
 }: Args): Promise<Field[]> => {
-  if (!fields) return []
+  if (!fields) {
+    return []
+  }
 
   for (let i = 0; i < fields.length; i++) {
     const field = fields[i]
@@ -62,7 +64,9 @@ export const sanitizeFields = async ({
       continue
     }
 
-    if (!field.type) throw new MissingFieldType(field)
+    if (!field.type) {
+      throw new MissingFieldType(field)
+    }
 
     // assert that field names do not contain forbidden characters
     if (fieldAffectsData(field) && field.name.includes('.')) {
@@ -160,8 +164,12 @@ export const sanitizeFields = async ({
         }
       }
 
-      if (!field.hooks) field.hooks = {}
-      if (!field.access) field.access = {}
+      if (!field.hooks) {
+        field.hooks = {}
+      }
+      if (!field.access) {
+        field.access = {}
+      }
 
       setDefaultBeforeDuplicate(field)
     }

--- a/packages/payload/src/fields/hooks/afterRead/index.ts
+++ b/packages/payload/src/fields/hooks/afterRead/index.ts
@@ -58,7 +58,9 @@ export async function afterRead<T extends JsonObject>(args: Args<T>): Promise<T>
     incomingDepth || incomingDepth === 0
       ? parseInt(String(incomingDepth), 10)
       : req.payload.config.defaultDepth
-  if (depth > req.payload.config.maxDepth) depth = req.payload.config.maxDepth
+  if (depth > req.payload.config.maxDepth) {
+    depth = req.payload.config.maxDepth
+  }
 
   const currentDepth = incomingCurrentDepth || 1
 

--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -313,7 +313,9 @@ export const promise = async ({
   switch (field.type) {
     case 'group': {
       let groupDoc = siblingDoc[field.name] as JsonObject
-      if (typeof siblingDoc[field.name] !== 'object') groupDoc = {}
+      if (typeof siblingDoc[field.name] !== 'object') {
+        groupDoc = {}
+      }
 
       traverseFields({
         collection,
@@ -524,7 +526,9 @@ export const promise = async ({
       let tabDoc = siblingDoc
       if (tabHasName(field)) {
         tabDoc = siblingDoc[field.name] as JsonObject
-        if (typeof siblingDoc[field.name] !== 'object') tabDoc = {}
+        if (typeof siblingDoc[field.name] !== 'object') {
+          tabDoc = {}
+        }
       }
 
       traverseFields({

--- a/packages/payload/src/fields/hooks/beforeChange/getExistingRowDoc.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/getExistingRowDoc.ts
@@ -10,13 +10,17 @@ export const getExistingRowDoc = (incomingRow: JsonObject, existingRows?: unknow
   if (incomingRow.id && Array.isArray(existingRows)) {
     const matchedExistingRow = existingRows.find((existingRow) => {
       if (typeof existingRow === 'object' && 'id' in existingRow) {
-        if (existingRow.id === incomingRow.id) return existingRow
+        if (existingRow.id === incomingRow.id) {
+          return existingRow
+        }
       }
 
       return false
     })
 
-    if (matchedExistingRow) return matchedExistingRow
+    if (matchedExistingRow) {
+      return matchedExistingRow
+    }
   }
 
   return {}

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -233,10 +233,15 @@ export const promise = async ({
     }
 
     case 'group': {
-      if (typeof siblingData[field.name] !== 'object') siblingData[field.name] = {}
-      if (typeof siblingDoc[field.name] !== 'object') siblingDoc[field.name] = {}
-      if (typeof siblingDocWithLocales[field.name] !== 'object')
+      if (typeof siblingData[field.name] !== 'object') {
+        siblingData[field.name] = {}
+      }
+      if (typeof siblingDoc[field.name] !== 'object') {
+        siblingDoc[field.name] = {}
+      }
+      if (typeof siblingDocWithLocales[field.name] !== 'object') {
         siblingDocWithLocales[field.name] = {}
+      }
 
       await traverseFields({
         id,
@@ -384,10 +389,15 @@ export const promise = async ({
       let tabSiblingDocWithLocales = siblingDocWithLocales
 
       if (tabHasName(field)) {
-        if (typeof siblingData[field.name] !== 'object') siblingData[field.name] = {}
-        if (typeof siblingDoc[field.name] !== 'object') siblingDoc[field.name] = {}
-        if (typeof siblingDocWithLocales[field.name] !== 'object')
+        if (typeof siblingData[field.name] !== 'object') {
+          siblingData[field.name] = {}
+        }
+        if (typeof siblingDoc[field.name] !== 'object') {
+          siblingDoc[field.name] = {}
+        }
+        if (typeof siblingDocWithLocales[field.name] !== 'object') {
           siblingDocWithLocales[field.name] = {}
+        }
 
         tabSiblingData = siblingData[field.name] as JsonObject
         tabSiblingDoc = siblingDoc[field.name] as JsonObject

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -109,9 +109,15 @@ export const promise = async <T>({
       }
 
       case 'checkbox': {
-        if (siblingData[field.name] === 'true') siblingData[field.name] = true
-        if (siblingData[field.name] === 'false') siblingData[field.name] = false
-        if (siblingData[field.name] === '') siblingData[field.name] = false
+        if (siblingData[field.name] === 'true') {
+          siblingData[field.name] = true
+        }
+        if (siblingData[field.name] === 'false') {
+          siblingData[field.name] = false
+        }
+        if (siblingData[field.name] === '') {
+          siblingData[field.name] = false
+        }
 
         break
       }
@@ -293,8 +299,12 @@ export const promise = async <T>({
   // Traverse subfields
   switch (field.type) {
     case 'group': {
-      if (typeof siblingData[field.name] !== 'object') siblingData[field.name] = {}
-      if (typeof siblingDoc[field.name] !== 'object') siblingDoc[field.name] = {}
+      if (typeof siblingData[field.name] !== 'object') {
+        siblingData[field.name] = {}
+      }
+      if (typeof siblingDoc[field.name] !== 'object') {
+        siblingDoc[field.name] = {}
+      }
 
       const groupData = siblingData[field.name] as Record<string, unknown>
       const groupDoc = siblingDoc[field.name] as Record<string, unknown>
@@ -414,8 +424,12 @@ export const promise = async <T>({
       let tabSiblingData
       let tabSiblingDoc
       if (tabHasName(field)) {
-        if (typeof siblingData[field.name] !== 'object') siblingData[field.name] = {}
-        if (typeof siblingDoc[field.name] !== 'object') siblingDoc[field.name] = {}
+        if (typeof siblingData[field.name] !== 'object') {
+          siblingData[field.name] = {}
+        }
+        if (typeof siblingDoc[field.name] !== 'object') {
+          siblingDoc[field.name] = {}
+        }
 
         tabSiblingData = siblingData[field.name] as Record<string, unknown>
         tabSiblingDoc = siblingDoc[field.name] as Record<string, unknown>

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -276,7 +276,7 @@ export const promise = async <T>({
     if (typeof siblingData[field.name] === 'undefined') {
       // If no incoming data, but existing document data is found, merge it in
       if (typeof siblingDoc[field.name] !== 'undefined') {
-        siblingData[field.name] = cloneDataFromOriginalDoc(siblingDoc[field.name] as any)
+        siblingData[field.name] = cloneDataFromOriginalDoc(siblingDoc[field.name])
 
         // Otherwise compute default value
       } else if (typeof field.defaultValue !== 'undefined') {

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -50,16 +50,24 @@ export const text: TextFieldValidation = (
   let maxLength: number
 
   if (!required) {
-    if (!value) return true
+    if (!value) {
+      return true
+    }
   }
 
   if (hasMany === true) {
     const lengthValidationResult = validateArrayLength(value, { maxRows, minRows, required, t })
-    if (typeof lengthValidationResult === 'string') return lengthValidationResult
+    if (typeof lengthValidationResult === 'string') {
+      return lengthValidationResult
+    }
   }
 
-  if (typeof config?.defaultMaxTextLength === 'number') maxLength = config.defaultMaxTextLength
-  if (typeof fieldMaxLength === 'number') maxLength = fieldMaxLength
+  if (typeof config?.defaultMaxTextLength === 'number') {
+    maxLength = config.defaultMaxTextLength
+  }
+  if (typeof fieldMaxLength === 'number') {
+    maxLength = fieldMaxLength
+  }
 
   const stringsToValidate: string[] = Array.isArray(value) ? value : [value]
 
@@ -99,8 +107,12 @@ export const password: PasswordFieldValidation = (
 ) => {
   let maxLength: number
 
-  if (typeof config?.defaultMaxTextLength === 'number') maxLength = config.defaultMaxTextLength
-  if (typeof fieldMaxLength === 'number') maxLength = fieldMaxLength
+  if (typeof config?.defaultMaxTextLength === 'number') {
+    maxLength = config.defaultMaxTextLength
+  }
+  if (typeof fieldMaxLength === 'number') {
+    maxLength = fieldMaxLength
+  }
 
   if (value && maxLength && value.length > maxLength) {
     return t('validation:shorterThanMax', { maxLength })
@@ -201,7 +213,9 @@ export const username: UsernameFieldValidation = (
     }
   }
 
-  if (typeof config?.defaultMaxTextLength === 'number') maxLength = config.defaultMaxTextLength
+  if (typeof config?.defaultMaxTextLength === 'number') {
+    maxLength = config.defaultMaxTextLength
+  }
 
   if (value && maxLength && value.length > maxLength) {
     return t('validation:shorterThanMax', { maxLength })
@@ -229,8 +243,12 @@ export const textarea: TextareaFieldValidation = (
 ) => {
   let maxLength: number
 
-  if (typeof config?.defaultMaxTextLength === 'number') maxLength = config.defaultMaxTextLength
-  if (typeof fieldMaxLength === 'number') maxLength = fieldMaxLength
+  if (typeof config?.defaultMaxTextLength === 'number') {
+    maxLength = config.defaultMaxTextLength
+  }
+  if (typeof fieldMaxLength === 'number') {
+    maxLength = fieldMaxLength
+  }
   if (value && maxLength && value.length > maxLength) {
     return t('validation:shorterThanMax', { maxLength })
   }
@@ -282,7 +300,9 @@ export const json: JSONFieldValidation = async (
   }
 
   const fetchSchema = ({ schema, uri }: Record<string, unknown>) => {
-    if (uri && schema) return schema
+    if (uri && schema) {
+      return schema
+    }
     // @ts-expect-error
     return fetch(uri)
       .then((response) => {
@@ -380,7 +400,9 @@ const validateArrayLength = (
 
   const arrayLength = Array.isArray(value) ? value.length : value || 0
 
-  if (!required && arrayLength === 0) return true
+  if (!required && arrayLength === 0) {
+    return true
+  }
 
   if (minRows && arrayLength < minRows) {
     return t('validation:requiresAtLeast', { count: minRows, label: t('general:rows') })
@@ -404,19 +426,27 @@ export const number: NumberFieldValidation = (
 ) => {
   if (hasMany === true) {
     const lengthValidationResult = validateArrayLength(value, { maxRows, minRows, required, t })
-    if (typeof lengthValidationResult === 'string') return lengthValidationResult
+    if (typeof lengthValidationResult === 'string') {
+      return lengthValidationResult
+    }
   }
 
   if (!value && !isNumber(value)) {
     // if no value is present, validate based on required
-    if (required) return t('validation:required')
-    if (!required) return true
+    if (required) {
+      return t('validation:required')
+    }
+    if (!required) {
+      return true
+    }
   }
 
   const numbersToValidate: number[] = Array.isArray(value) ? value : [value]
 
   for (const number of numbersToValidate) {
-    if (!isNumber(number)) return t('validation:enterNumber')
+    if (!isNumber(number)) {
+      return t('validation:enterNumber')
+    }
 
     const numberValue = parseFloat(number as unknown as string)
 
@@ -498,7 +528,9 @@ const validateFilterOptions: Validate<
             and: [{ id: { in: valueIDs } }],
           }
 
-          if (optionFilter && optionFilter !== true) findWhere.and.push(optionFilter)
+          if (optionFilter && optionFilter !== true) {
+            findWhere.and.push(optionFilter)
+          }
 
           if (optionFilter === false) {
             falseCollections.push(collection)
@@ -551,7 +583,9 @@ const validateFilterOptions: Validate<
         return true
       }
 
-      if (!options[collection]) return true
+      if (!options[collection]) {
+        return true
+      }
 
       return options[collection].indexOf(requestedID) === -1
     })
@@ -627,7 +661,9 @@ export const upload: UploadFieldValidation = async (value, options) => {
         requestedID = val.value
       }
 
-      if (requestedID === null) return false
+      if (requestedID === null) {
+        return false
+      }
 
       const idType =
         payload.collections[collectionSlug]?.customIDType || payload?.db?.defaultIDType || 'text'
@@ -708,7 +744,9 @@ export const relationship: RelationshipFieldValidation = async (value, options) 
         requestedID = val.value
       }
 
-      if (requestedID === null) return false
+      if (requestedID === null) {
+        return false
+      }
 
       const idType =
         payload.collections[collectionSlug]?.customIDType || payload?.db?.defaultIDType || 'text'

--- a/packages/payload/src/globals/config/sanitize.ts
+++ b/packages/payload/src/globals/config/sanitize.ts
@@ -28,18 +28,38 @@ export const sanitizeGlobals = async (
     // /////////////////////////////////
 
     global.endpoints = global.endpoints ?? []
-    if (!global.hooks) global.hooks = {}
-    if (!global.access) global.access = {}
-    if (!global.admin) global.admin = {}
+    if (!global.hooks) {
+      global.hooks = {}
+    }
+    if (!global.access) {
+      global.access = {}
+    }
+    if (!global.admin) {
+      global.admin = {}
+    }
 
-    if (!global.access.read) global.access.read = defaultAccess
-    if (!global.access.update) global.access.update = defaultAccess
+    if (!global.access.read) {
+      global.access.read = defaultAccess
+    }
+    if (!global.access.update) {
+      global.access.update = defaultAccess
+    }
 
-    if (!global.hooks.beforeValidate) global.hooks.beforeValidate = []
-    if (!global.hooks.beforeChange) global.hooks.beforeChange = []
-    if (!global.hooks.afterChange) global.hooks.afterChange = []
-    if (!global.hooks.beforeRead) global.hooks.beforeRead = []
-    if (!global.hooks.afterRead) global.hooks.afterRead = []
+    if (!global.hooks.beforeValidate) {
+      global.hooks.beforeValidate = []
+    }
+    if (!global.hooks.beforeChange) {
+      global.hooks.beforeChange = []
+    }
+    if (!global.hooks.afterChange) {
+      global.hooks.afterChange = []
+    }
+    if (!global.hooks.beforeRead) {
+      global.hooks.beforeRead = []
+    }
+    if (!global.hooks.afterRead) {
+      global.hooks.afterRead = []
+    }
 
     // Sanitize fields
     const validRelationships = collections.map((c) => c.slug) || []
@@ -52,7 +72,9 @@ export const sanitizeGlobals = async (
     })
 
     if (global.versions) {
-      if (global.versions === true) global.versions = { drafts: false }
+      if (global.versions === true) {
+        global.versions = { drafts: false }
+      }
 
       if (global.versions.drafts) {
         if (global.versions.drafts === true) {
@@ -76,7 +98,9 @@ export const sanitizeGlobals = async (
       }
     }
 
-    if (!global.custom) global.custom = {}
+    if (!global.custom) {
+      global.custom = {}
+    }
 
     // /////////////////////////////////
     // Sanitize fields
@@ -85,8 +109,12 @@ export const sanitizeGlobals = async (
     let hasCreatedAt = null
     global.fields.some((field) => {
       if (fieldAffectsData(field)) {
-        if (field.name === 'updatedAt') hasUpdatedAt = true
-        if (field.name === 'createdAt') hasCreatedAt = true
+        if (field.name === 'updatedAt') {
+          hasUpdatedAt = true
+        }
+        if (field.name === 'createdAt') {
+          hasCreatedAt = true
+        }
       }
       return hasCreatedAt && hasUpdatedAt
     })

--- a/packages/payload/src/globals/operations/docAccess.ts
+++ b/packages/payload/src/globals/operations/docAccess.ts
@@ -29,7 +29,9 @@ export const docAccessOperation = async (args: Arguments): Promise<GlobalPermiss
       operations: globalOperations,
       req,
     })
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
     return result
   } catch (e: unknown) {
     await killTransaction(req)

--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -46,7 +46,9 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
       : true
 
     // If errors are disabled, and access returns false, return null
-    if (accessResults === false) return null
+    if (accessResults === false) {
+      return null
+    }
 
     const hasWhereAccess = typeof accessResults === 'object'
 
@@ -62,13 +64,19 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
     // Find by ID
     // /////////////////////////////////////
 
-    if (!findGlobalVersionsArgs.where.and[0].id) throw new NotFound(req.t)
+    if (!findGlobalVersionsArgs.where.and[0].id) {
+      throw new NotFound(req.t)
+    }
 
     const { docs: results } = await payload.db.findGlobalVersions(findGlobalVersionsArgs)
     if (!results || results?.length === 0) {
       if (!disableErrors) {
-        if (!hasWhereAccess) throw new NotFound(req.t)
-        if (hasWhereAccess) throw new Forbidden(req.t)
+        if (!hasWhereAccess) {
+          throw new NotFound(req.t)
+        }
+        if (hasWhereAccess) {
+          throw new Forbidden(req.t)
+        }
       }
 
       return null

--- a/packages/payload/src/globals/operations/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/restoreVersion.ts
@@ -183,7 +183,9 @@ export const restoreVersionOperation = async <T extends TypeWithVersion<T> = any
         })) || result
     }, Promise.resolve())
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/globals/operations/update.ts
+++ b/packages/payload/src/globals/operations/update.ts
@@ -283,7 +283,9 @@ export const updateOperation = async <TSlug extends GlobalSlug>(
     // Return results
     // /////////////////////////////////////
 
-    if (shouldCommit) await commitTransaction(req)
+    if (shouldCommit) {
+      await commitTransaction(req)
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -461,7 +461,9 @@ export class BasePayload {
 
       let customIDType
 
-      if (customID?.type === 'number' || customID?.type === 'text') customIDType = customID.type
+      if (customID?.type === 'number' || customID?.type === 'text') {
+        customIDType = customID.type
+      }
 
       this.collections[collection.slug] = {
         config: collection,
@@ -554,8 +556,12 @@ export class BasePayload {
     }
 
     if (!options.disableOnInit) {
-      if (typeof options.onInit === 'function') await options.onInit(this)
-      if (typeof this.config.onInit === 'function') await this.config.onInit(this)
+      if (typeof options.onInit === 'function') {
+        await options.onInit(this)
+      }
+      if (typeof this.config.onInit === 'function') {
+        await this.config.onInit(this)
+      }
     }
 
     return this

--- a/packages/payload/src/preferences/operations/findOne.ts
+++ b/packages/payload/src/preferences/operations/findOne.ts
@@ -10,7 +10,9 @@ async function findOne(args: PreferenceRequest): Promise<TypedCollection['_prefe
     user,
   } = args
 
-  if (!user) return null
+  if (!user) {
+    return null
+  }
 
   const where: Where = {
     and: [

--- a/packages/payload/src/uploads/cropImage.ts
+++ b/packages/payload/src/uploads/cropImage.ts
@@ -38,7 +38,9 @@ export async function cropImage({
 
     const sharpOptions: SharpOptions = {}
 
-    if (fileIsAnimatedType) sharpOptions.animated = true
+    if (fileIsAnimatedType) {
+      sharpOptions.animated = true
+    }
 
     const formattedCropData = {
       height: Number(heightInPixels),

--- a/packages/payload/src/uploads/deleteAssociatedFiles.ts
+++ b/packages/payload/src/uploads/deleteAssociatedFiles.ts
@@ -24,7 +24,9 @@ export const deleteAssociatedFiles: (args: Args) => Promise<void> = async ({
   overrideDelete,
   req,
 }) => {
-  if (!collectionConfig.upload) return
+  if (!collectionConfig.upload) {
+    return
+  }
   if (overrideDelete || files.length > 0) {
     const { staticDir: staticPath } = collectionConfig.upload
 

--- a/packages/payload/src/uploads/docWithFilenameExists.ts
+++ b/packages/payload/src/uploads/docWithFilenameExists.ts
@@ -17,7 +17,9 @@ const docWithFilenameExists = async ({ collectionSlug, filename, req }: Args): P
       },
     },
   })
-  if (doc) return true
+  if (doc) {
+    return true
+  }
 
   return false
 }

--- a/packages/payload/src/uploads/formatFilesize.ts
+++ b/packages/payload/src/uploads/formatFilesize.ts
@@ -1,5 +1,7 @@
 export function formatFilesize(bytes: number, decimals = 0): string {
-  if (bytes === 0) return '0 bytes'
+  if (bytes === 0) {
+    return '0 bytes'
+  }
 
   const k = 1024
   const dm = decimals < 0 ? 0 : decimals

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -100,7 +100,9 @@ export const generateFileData = async <T>({
   }
 
   if (!file) {
-    if (throwOnMissingFile) throw new MissingFile(req.t)
+    if (throwOnMissingFile) {
+      throw new MissingFile(req.t)
+    }
 
     return {
       data,
@@ -133,7 +135,9 @@ export const generateFileData = async <T>({
 
     const sharpOptions: SharpOptions = {}
 
-    if (fileIsAnimatedType) sharpOptions.animated = true
+    if (fileIsAnimatedType) {
+      sharpOptions.animated = true
+    }
 
     if (sharp && (fileIsAnimatedType || fileHasAdjustments)) {
       if (file.tempFilePath) {
@@ -191,7 +195,9 @@ export const generateFileData = async <T>({
     }
 
     // Adjust SVG mime type. fromBuffer modifies it.
-    if (mime === 'application/xml' && ext === 'svg') mime = 'image/svg+xml'
+    if (mime === 'application/xml' && ext === 'svg') {
+      mime = 'image/svg+xml'
+    }
     fileData.mimeType = mime
 
     const baseFilename = sanitize(file.name.substring(0, file.name.lastIndexOf('.')) || file.name)
@@ -324,7 +330,9 @@ function parseUploadEditsFromReqOrIncomingData(args: {
       ? (req.query.uploadEdits as UploadEdits)
       : {}
 
-  if (uploadEdits.focalPoint) return uploadEdits
+  if (uploadEdits.focalPoint) {
+    return uploadEdits
+  }
 
   const incomingData = data as FileData
   const origDoc = originalDoc as FileData

--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -137,7 +137,9 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
       hooks: {
         afterRead: [
           ({ data, value }) => {
-            if (value && !data.filename) return value
+            if (value && !data.filename) {
+              return value
+            }
 
             return generateURL({
               collectionSlug: collection.slug,
@@ -199,7 +201,9 @@ export const getBaseUploadFields = ({ collection, config }: Options): Field[] =>
               hooks: {
                 afterRead: [
                   ({ data, value }) => {
-                    if (value && size.height && size.width && !data.filename) return value
+                    if (value && size.height && size.width && !data.filename) {
+                      return value
+                    }
 
                     const sizeFilename = data?.sizes?.[size.name]?.filename
 

--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -28,7 +28,9 @@ export const getExternalFile = async ({ data, req, uploadConfig }: Args): Promis
       method: 'GET',
     })
 
-    if (!res.ok) throw new APIError(`Failed to fetch file from ${fileURL}`, res.status)
+    if (!res.ok) {
+      throw new APIError(`Failed to fetch file from ${fileURL}`, res.status)
+    }
 
     const data = await res.arrayBuffer()
 

--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -178,15 +178,25 @@ const getImageResizeAction = ({
 
   const originalImageIsSmallerXOrY =
     originalImage.width < targetWidth || originalImage.height < targetHeight
-  if (fit === 'contain' || fit === 'inside') return 'resize'
-  if (!isNumber(targetHeight) && !isNumber(targetWidth)) return 'resize'
+  if (fit === 'contain' || fit === 'inside') {
+    return 'resize'
+  }
+  if (!isNumber(targetHeight) && !isNumber(targetWidth)) {
+    return 'resize'
+  }
 
   const targetAspectRatio = targetWidth / targetHeight
   const originalAspectRatio = originalImage.width / originalImage.height
-  if (originalAspectRatio === targetAspectRatio) return 'resize'
+  if (originalAspectRatio === targetAspectRatio) {
+    return 'resize'
+  }
 
-  if (withoutEnlargement && originalImageIsSmallerXOrY) return 'resize'
-  if (withoutReduction && !originalImageIsSmallerXOrY) return 'resize'
+  if (withoutEnlargement && originalImageIsSmallerXOrY) {
+    return 'resize'
+  }
+  if (withoutReduction && !originalImageIsSmallerXOrY) {
+    return 'resize'
+  }
 
   return hasFocalPoint ? 'resizeWithFocalPoint' : 'resize'
 }
@@ -274,7 +284,9 @@ export async function resizeAndTransformImageSizes({
   const fileIsAnimatedType = ['image/avif', 'image/gif', 'image/webp'].includes(file.mimetype)
   const sharpOptions: SharpOptions = {}
 
-  if (fileIsAnimatedType) sharpOptions.animated = true
+  if (fileIsAnimatedType) {
+    sharpOptions.animated = true
+  }
 
   const sharpBase: Sharp | undefined = sharp(file.tempFilePath || file.data, sharpOptions).rotate() // pass rotate() to auto-rotate based on EXIF data. https://github.com/payloadcms/payload/pull/3081
   const originalImageMeta = await sharpBase.metadata()
@@ -293,7 +305,9 @@ export async function resizeAndTransformImageSizes({
         hasFocalPoint: Boolean(incomingFocalPoint),
         imageResizeConfig,
       })
-      if (resizeAction === 'omit') return createResult({ name: imageResizeConfig.name })
+      if (resizeAction === 'omit') {
+        return createResult({ name: imageResizeConfig.name })
+      }
 
       const imageToResize = sharpBase.clone()
       let resized = imageToResize
@@ -313,8 +327,12 @@ export async function resizeAndTransformImageSizes({
           resizeHeight = Math.round(resizeWidth / originalAspectRatio)
         }
 
-        if (!resizeHeight) resizeHeight = resizeImageMeta.height
-        if (!resizeWidth) resizeWidth = resizeImageMeta.width
+        if (!resizeHeight) {
+          resizeHeight = resizeImageMeta.height
+        }
+        if (!resizeWidth) {
+          resizeWidth = resizeImageMeta.width
+        }
 
         const resizeAspectRatio = resizeWidth / resizeHeight
         const prioritizeHeight = resizeAspectRatio < originalAspectRatio
@@ -352,7 +370,9 @@ export async function resizeAndTransformImageSizes({
 
         // if the left bound is less than 0, adjust the left bound to 0
         // keeping the focus on the left
-        if (leftBound < 0) leftBound = 0
+        if (leftBound < 0) {
+          leftBound = 0
+        }
 
         const halfResizeY = resizeHeight / 2
         const yFocalCenter = resizeImageMeta.height * (incomingFocalPoint.y / 100)
@@ -367,7 +387,9 @@ export async function resizeAndTransformImageSizes({
 
         // if the top bound is less than 0, adjust the top bound to 0
         // keeping the image focus near the top
-        if (topBound < 0) topBound = 0
+        if (topBound < 0) {
+          topBound = 0
+        }
 
         resized = resized.extract({
           height: resizeHeight,

--- a/packages/payload/src/uploads/optionallyAppendMetadata.ts
+++ b/packages/payload/src/uploads/optionallyAppendMetadata.ts
@@ -22,7 +22,9 @@ export async function optionallyAppendMetadata({
   } else if (typeof withMetadata === 'function') {
     const useMetadata = await withMetadata({ metadata, req })
 
-    if (useMetadata) return sharpFile.withMetadata()
+    if (useMetadata) {
+      return sharpFile.withMetadata()
+    }
   }
 
   return sharpFile

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -17,10 +17,14 @@ import { getCollectionIDFieldTypes } from './getCollectionIDFieldTypes.js'
 
 const fieldIsRequired = (field: Field) => {
   const isConditional = Boolean(field?.admin && field?.admin?.condition)
-  if (isConditional) return false
+  if (isConditional) {
+    return false
+  }
 
   const isMarkedRequired = 'required' in field && field.required === true
-  if (fieldAffectsData(field) && isMarkedRequired) return true
+  if (fieldAffectsData(field) && isMarkedRequired) {
+    return true
+  }
 
   // if any subfields are required, this field is required
   if ('fields' in field && field.type !== 'array') {
@@ -139,7 +143,9 @@ export function withNullableJSONSchemaType(
   isRequired: boolean,
 ): JSONSchema4TypeName | JSONSchema4TypeName[] {
   const fieldTypes = [fieldType]
-  if (isRequired) return fieldType
+  if (isRequired) {
+    return fieldType
+  }
   fieldTypes.push('null')
   return fieldTypes
 }
@@ -169,7 +175,9 @@ export function fieldsToJSONSchema(
     properties: Object.fromEntries(
       fields.reduce((fieldSchemas, field) => {
         const isRequired = fieldAffectsData(field) && fieldIsRequired(field)
-        if (isRequired) requiredFieldNames.add(field.name)
+        if (isRequired) {
+          requiredFieldNames.add(field.name)
+        }
 
         let fieldSchema: JSONSchema4
 

--- a/packages/payload/src/utilities/createArrayFromCommaDelineated.ts
+++ b/packages/payload/src/utilities/createArrayFromCommaDelineated.ts
@@ -1,5 +1,7 @@
 export function createArrayFromCommaDelineated(input: string): string[] {
-  if (Array.isArray(input)) return input
+  if (Array.isArray(input)) {
+    return input
+  }
   if (input.indexOf(',') > -1) {
     return input.split(',')
   }

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -54,16 +54,16 @@ const attachFakeURLProperties = (req: PayloadRequest) => {
   if (!req.pathname) {
     req.pathname = getURLObject().pathname
   }
-  // @ts-expect-error
   if (!req.searchParams) {
+    // @ts-expect-error
     req.searchParams = getURLObject().searchParams
   }
-  // @ts-expect-error
   if (!req.origin) {
+    // @ts-expect-error
     req.origin = getURLObject().origin
   }
-  // @ts-expect-error
   if (!req?.url) {
+    // @ts-expect-error
     req.url = getURLObject().href
   }
 }
@@ -102,8 +102,8 @@ export const createLocalReq: CreateLocalReq = async (
     req?.i18n ||
     (await getLocalI18n({ config: payload.config, language: payload.config.i18n.fallbackLanguage }))
 
-  // @ts-expect-error
   if (!req.headers) {
+    // @ts-expect-error
     req.headers = new Headers()
   }
   req.context = getRequestContext(req, context)

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -32,7 +32,9 @@ const attachFakeURLProperties = (req: PayloadRequest) => {
   let urlObject
 
   function getURLObject() {
-    if (urlObject) return urlObject
+    if (urlObject) {
+      return urlObject
+    }
     const urlToUse = req?.url || req.payload.config?.serverURL || 'http://localhost'
     try {
       urlObject = new URL(urlToUse)
@@ -43,15 +45,27 @@ const attachFakeURLProperties = (req: PayloadRequest) => {
     return urlObject
   }
 
-  if (!req.host) req.host = getURLObject().host
-  if (!req.protocol) req.protocol = getURLObject().protocol
-  if (!req.pathname) req.pathname = getURLObject().pathname
+  if (!req.host) {
+    req.host = getURLObject().host
+  }
+  if (!req.protocol) {
+    req.protocol = getURLObject().protocol
+  }
+  if (!req.pathname) {
+    req.pathname = getURLObject().pathname
+  }
   // @ts-expect-error
-  if (!req.searchParams) req.searchParams = getURLObject().searchParams
+  if (!req.searchParams) {
+    req.searchParams = getURLObject().searchParams
+  }
   // @ts-expect-error
-  if (!req.origin) req.origin = getURLObject().origin
+  if (!req.origin) {
+    req.origin = getURLObject().origin
+  }
   // @ts-expect-error
-  if (!req?.url) req.url = getURLObject().href
+  if (!req?.url) {
+    req.url = getURLObject().href
+  }
 }
 
 type CreateLocalReq = (
@@ -89,7 +103,9 @@ export const createLocalReq: CreateLocalReq = async (
     (await getLocalI18n({ config: payload.config, language: payload.config.i18n.fallbackLanguage }))
 
   // @ts-expect-error
-  if (!req.headers) req.headers = new Headers()
+  if (!req.headers) {
+    req.headers = new Headers()
+  }
   req.context = getRequestContext(req, context)
   req.payloadAPI = req?.payloadAPI || 'local'
   req.payload = payload

--- a/packages/payload/src/utilities/deepCopyObject.ts
+++ b/packages/payload/src/utilities/deepCopyObject.ts
@@ -54,14 +54,20 @@ function cloneArray<T>(a: T, fn): T {
 }
 
 export const deepCopyObject = <T>(o: T): T => {
-  if (typeof o !== 'object' || o === null) return o
-  if (Array.isArray(o)) return cloneArray(o, deepCopyObject)
+  if (typeof o !== 'object' || o === null) {
+    return o
+  }
+  if (Array.isArray(o)) {
+    return cloneArray(o, deepCopyObject)
+  }
   if (o.constructor !== Object && (handler = constructorHandlers.get(o.constructor))) {
     return handler(o, deepCopyObject)
   }
   const o2 = {}
   for (const k in o) {
-    if (Object.hasOwnProperty.call(o, k) === false) continue
+    if (Object.hasOwnProperty.call(o, k) === false) {
+      continue
+    }
     const cur = o[k]
     if (typeof cur !== 'object' || cur === null) {
       o2[k as string] = cur
@@ -100,7 +106,9 @@ export function deepCopyObjectSimple<T extends JsonValue>(value: T): T {
       typeof e !== 'object' || e === null ? e : deepCopyObjectSimple(e),
     ) as T
   } else {
-    if (value instanceof Date) return new Date(value) as unknown as T
+    if (value instanceof Date) {
+      return new Date(value) as unknown as T
+    }
     const ret: { [key: string]: T } = {}
     for (const k in value) {
       const v = value[k]
@@ -115,7 +123,9 @@ export function deepCopyObjectSimple<T extends JsonValue>(value: T): T {
  * Can be used if correctness is more important than speed. Supports circular dependencies
  */
 export function deepCopyObjectComplex<T>(object: T, cache: WeakMap<any, any> = new WeakMap()): T {
-  if (object === null) return null
+  if (object === null) {
+    return null
+  }
 
   if (cache.has(object)) {
     return cache.get(object)

--- a/packages/payload/src/utilities/dependencies/versionUtils.ts
+++ b/packages/payload/src/utilities/dependencies/versionUtils.ts
@@ -16,13 +16,21 @@ function comparePreRelease(v1: string, v2: string): number {
   const num2 = extractNumbers(v2)
 
   for (let i = 0; i < Math.max(num1.length, num2.length); i++) {
-    if ((num1[i] || 0) < (num2[i] || 0)) return -1
-    if ((num1[i] || 0) > (num2[i] || 0)) return 1
+    if ((num1[i] || 0) < (num2[i] || 0)) {
+      return -1
+    }
+    if ((num1[i] || 0) > (num2[i] || 0)) {
+      return 1
+    }
   }
 
   // If numeric parts are equal, compare the whole string
-  if (v1 < v2) return -1
-  if (v1 > v2) return 1
+  if (v1 < v2) {
+    return -1
+  }
+  if (v1 > v2) {
+    return 1
+  }
   return 0
 }
 
@@ -53,15 +61,23 @@ export function compareVersions(
 
   // Compare main version parts
   for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-    if ((parts1[i] || 0) > (parts2[i] || 0)) return 'greater'
-    if ((parts1[i] || 0) < (parts2[i] || 0)) return 'lower'
+    if ((parts1[i] || 0) > (parts2[i] || 0)) {
+      return 'greater'
+    }
+    if ((parts1[i] || 0) < (parts2[i] || 0)) {
+      return 'lower'
+    }
   }
 
   // Compare pre-release parts if main versions are equal
   if (preReleases1?.length || preReleases2?.length) {
     for (let i = 0; i < Math.max(preReleases1.length, preReleases2.length); i++) {
-      if (!preReleases1[i]) return 'greater'
-      if (!preReleases2[i]) return 'lower'
+      if (!preReleases1[i]) {
+        return 'greater'
+      }
+      if (!preReleases2[i]) {
+        return 'lower'
+      }
 
       const result = comparePreRelease(preReleases1[i], preReleases2[i])
       if (result !== 0) {

--- a/packages/payload/src/utilities/getEntityPolicies.ts
+++ b/packages/payload/src/utilities/getEntityPolicies.ts
@@ -144,7 +144,9 @@ export async function getEntityPolicies<T extends Args>(args: T): Promise<Return
     await Promise.all(
       fields.map(async (field) => {
         if ('name' in field && field.name) {
-          if (!mutablePolicies[field.name]) mutablePolicies[field.name] = {}
+          if (!mutablePolicies[field.name]) {
+            mutablePolicies[field.name] = {}
+          }
 
           if ('access' in field && field.access && typeof field.access[operation] === 'function') {
             await createAccessPromise({
@@ -161,7 +163,9 @@ export async function getEntityPolicies<T extends Args>(args: T): Promise<Return
           }
 
           if ('fields' in field && field.fields) {
-            if (!mutablePolicies[field.name].fields) mutablePolicies[field.name].fields = {}
+            if (!mutablePolicies[field.name].fields) {
+              mutablePolicies[field.name].fields = {}
+            }
 
             await executeFieldPolicies({
               entityPermission,
@@ -172,7 +176,9 @@ export async function getEntityPolicies<T extends Args>(args: T): Promise<Return
           }
 
           if ('blocks' in field && field?.blocks) {
-            if (!mutablePolicies[field.name]?.blocks) mutablePolicies[field.name].blocks = {}
+            if (!mutablePolicies[field.name]?.blocks) {
+              mutablePolicies[field.name].blocks = {}
+            }
 
             await Promise.all(
               field.blocks.map(async (block) => {

--- a/packages/payload/src/utilities/getObjectDotNotation.ts
+++ b/packages/payload/src/utilities/getObjectDotNotation.ts
@@ -3,7 +3,9 @@ export const getObjectDotNotation = <T>(
   path: string,
   defaultValue?: T,
 ): T => {
-  if (!path || !obj) return defaultValue
+  if (!path || !obj) {
+    return defaultValue
+  }
   const result = path.split('.').reduce((o, i) => o?.[i], obj)
   return result === undefined ? defaultValue : (result as T)
 }

--- a/packages/payload/src/utilities/getSiblingData.ts
+++ b/packages/payload/src/utilities/getSiblingData.ts
@@ -4,7 +4,9 @@ import { reduceFieldsToValues } from './reduceFieldsToValues.js'
 import { unflatten } from './unflatten.js'
 
 export const getSiblingData = (fields: FormState, path: string): Data => {
-  if (!fields) return null
+  if (!fields) {
+    return null
+  }
 
   if (path.indexOf('.') === -1) {
     return reduceFieldsToValues(fields, true)

--- a/packages/payload/src/utilities/isValidID.ts
+++ b/packages/payload/src/utilities/isValidID.ts
@@ -15,7 +15,9 @@ export const isValidID = (
     return false
   }
 
-  if (typeof value === 'number' && !Number.isNaN(value)) return true
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return true
+  }
 
   if (type === 'ObjectID') {
     return ObjectId.isValid(String(value))

--- a/packages/payload/src/utilities/reduceFieldsToValues.ts
+++ b/packages/payload/src/utilities/reduceFieldsToValues.ts
@@ -15,7 +15,9 @@ export const reduceFieldsToValues = (
 ): Data => {
   let data = {}
 
-  if (!fields) return data
+  if (!fields) {
+    return data
+  }
 
   Object.keys(fields).forEach((key) => {
     if (ignoreDisableFormData === true || !fields[key]?.disableFormData) {

--- a/packages/payload/src/utilities/timestamp.ts
+++ b/packages/payload/src/utilities/timestamp.ts
@@ -1,5 +1,7 @@
 export const timestamp = (label) => {
-  if (!process.env.PAYLOAD_TIME) process.env.PAYLOAD_TIME = String(new Date().getTime())
+  if (!process.env.PAYLOAD_TIME) {
+    process.env.PAYLOAD_TIME = String(new Date().getTime())
+  }
   const now = new Date()
   console.log(`[${now.getTime() - Number(process.env.PAYLOAD_TIME)}ms] ${label}`)
 }

--- a/packages/payload/src/versions/drafts/getQueryDraftsSort.ts
+++ b/packages/payload/src/versions/drafts/getQueryDraftsSort.ts
@@ -3,7 +3,9 @@
  * @param sort
  */
 export const getQueryDraftsSort = (sort: string): string => {
-  if (!sort) return sort
+  if (!sort) {
+    return sort
+  }
 
   let direction = ''
   let orderBy = sort

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -32,8 +32,12 @@ export const saveVersion = async ({
   let createNewVersion = true
   const now = new Date().toISOString()
   const versionData = deepCopyObjectSimple(doc)
-  if (draft) versionData._status = 'draft'
-  if (versionData._id) delete versionData._id
+  if (draft) {
+    versionData._status = 'draft'
+  }
+  if (versionData._id) {
+    delete versionData._id
+  }
 
   try {
     if (autosave) {
@@ -124,10 +128,12 @@ export const saveVersion = async ({
   } catch (err) {
     let errorMessage: string
 
-    if (collection)
+    if (collection) {
       errorMessage = `There was an error while saving a version for the ${collection.labels.singular} with ID ${id}.`
-    if (global)
+    }
+    if (global) {
       errorMessage = `There was an error while saving a version for the global ${global.label}.`
+    }
     payload.logger.error(errorMessage)
     payload.logger.error(err)
     return
@@ -135,9 +141,12 @@ export const saveVersion = async ({
 
   let max = 100
 
-  if (collection && typeof collection.versions.maxPerDoc === 'number')
+  if (collection && typeof collection.versions.maxPerDoc === 'number') {
     max = collection.versions.maxPerDoc
-  if (global && typeof global.versions.max === 'number') max = global.versions.max
+  }
+  if (global && typeof global.versions.max === 'number') {
+    max = global.versions.max
+  }
 
   if (createNewVersion && max > 0) {
     await enforceMaxVersions({

--- a/packages/plugin-cloud-storage/src/adapters/azure/index.ts
+++ b/packages/plugin-cloud-storage/src/adapters/azure/index.ts
@@ -35,7 +35,9 @@ export const azureBlobStorageAdapter = ({
 
   let storageClient: ContainerClient | null = null
   const getStorageClient = () => {
-    if (storageClient) return storageClient
+    if (storageClient) {
+      return storageClient
+    }
     let blobServiceClient = null
     try {
       blobServiceClient = BlobServiceClient.fromConnectionString(connectionString)

--- a/packages/plugin-cloud-storage/src/adapters/gcs/index.ts
+++ b/packages/plugin-cloud-storage/src/adapters/gcs/index.ts
@@ -32,7 +32,9 @@ export const gcsAdapter =
     let storageClient: Storage | null = null
 
     const getStorageClient = (): Storage => {
-      if (storageClient) return storageClient
+      if (storageClient) {
+        return storageClient
+      }
       try {
         storageClient = new Storage(options)
       } catch (error) {

--- a/packages/plugin-cloud-storage/src/adapters/s3/index.ts
+++ b/packages/plugin-cloud-storage/src/adapters/s3/index.ts
@@ -38,7 +38,9 @@ export const s3Adapter =
     }
     let storageClient: AWS.S3 | null = null
     const getStorageClient: () => AWS.S3 = () => {
-      if (storageClient) return storageClient
+      if (storageClient) {
+        return storageClient
+      }
       try {
         storageClient = new AWS.S3(config)
       } catch (error) {

--- a/packages/plugin-cloud-storage/src/hooks/afterDelete.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterDelete.ts
@@ -19,7 +19,9 @@ export const getAfterDeleteHook = ({
       ]
 
       const promises = filesToDelete.map(async (filename) => {
-        if (filename) await adapter.handleDelete({ collection, doc, filename, req })
+        if (filename) {
+          await adapter.handleDelete({ collection, doc, filename, req })
+        }
       })
 
       await Promise.all(promises)

--- a/packages/plugin-cloud-storage/src/plugin.ts
+++ b/packages/plugin-cloud-storage/src/plugin.ts
@@ -39,7 +39,9 @@ export const cloudStoragePlugin =
             prefix: options.prefix,
           })
 
-          if (adapter.onInit) initFunctions.push(adapter.onInit)
+          if (adapter.onInit) {
+            initFunctions.push(adapter.onInit)
+          }
 
           const fields = getFields({
             adapter,
@@ -90,7 +92,9 @@ export const cloudStoragePlugin =
       }),
       onInit: async (payload) => {
         initFunctions.forEach((fn) => fn())
-        if (config.onInit) await config.onInit(payload)
+        if (config.onInit) {
+          await config.onInit(payload)
+        }
       },
     }
   }

--- a/packages/plugin-cloud/src/email.spec.ts
+++ b/packages/plugin-cloud/src/email.spec.ts
@@ -1,7 +1,6 @@
 import type { Config, Payload } from 'payload'
 
 import { jest } from '@jest/globals'
-import nodemailer from 'nodemailer'
 import { defaults } from 'payload'
 
 import { payloadCloudEmail } from './email.js'
@@ -11,24 +10,11 @@ describe('email', () => {
   const skipVerify = true
   const defaultDomain = 'test.com'
   const apiKey = 'test'
-  let createTransportSpy: jest.Spied<any>
 
   const mockedPayload: Payload = jest.fn() as unknown as Payload
 
   beforeEach(() => {
     defaultConfig = defaults as Config
-
-    createTransportSpy = jest.spyOn(nodemailer, 'createTransport').mockImplementation(() => {
-      return {
-        verify: jest.fn(),
-      } as unknown as ReturnType<typeof nodemailer.createTransport>
-    })
-
-    const createTestAccountSpy = jest.spyOn(nodemailer, 'createTestAccount').mockResolvedValue({
-      pass: 'password',
-      user: 'user',
-      web: 'ethereal.email',
-    } as unknown as nodemailer.TestAccount)
   })
 
   describe('not in Payload Cloud', () => {
@@ -76,8 +62,8 @@ describe('email', () => {
 
       const initializedEmail = email({ payload: mockedPayload })
 
-      expect(initializedEmail.defaultFromName).toEqual(defaultFromName)
-      expect(initializedEmail.defaultFromAddress).toEqual(defaultFromAddress)
+      expect(initializedEmail.defaultFromName).toStrictEqual(defaultFromName)
+      expect(initializedEmail.defaultFromAddress).toStrictEqual(defaultFromAddress)
     })
   })
 })

--- a/packages/plugin-cloud/src/email.ts
+++ b/packages/plugin-cloud/src/email.ts
@@ -12,9 +12,12 @@ export const payloadCloudEmail = async (
     return undefined
   }
 
-  if (!args.apiKey) throw new Error('apiKey must be provided to use Payload Cloud Email')
-  if (!args.defaultDomain)
+  if (!args.apiKey) {
+    throw new Error('apiKey must be provided to use Payload Cloud Email')
+  }
+  if (!args.defaultDomain) {
     throw new Error('defaultDomain must be provided to use Payload Cloud Email')
+  }
 
   // Check if already has email configuration
 

--- a/packages/plugin-cloud/src/hooks/uploadCache.ts
+++ b/packages/plugin-cloud/src/hooks/uploadCache.ts
@@ -7,7 +7,9 @@ interface Args {
 export const getCacheUploadsAfterChangeHook =
   ({ endpoint }: Args): CollectionAfterChangeHook =>
   ({ doc, operation, req }) => {
-    if (!req || !process.env.PAYLOAD_CLOUD_CACHE_KEY) return doc
+    if (!req || !process.env.PAYLOAD_CLOUD_CACHE_KEY) {
+      return doc
+    }
 
     // WARNING:
     // TODO: Test this for 3.0
@@ -24,7 +26,9 @@ export const getCacheUploadsAfterChangeHook =
 export const getCacheUploadsAfterDeleteHook =
   ({ endpoint }: Args): CollectionAfterDeleteHook =>
   ({ doc, req }) => {
-    if (!req || !process.env.PAYLOAD_CLOUD_CACHE_KEY) return doc
+    if (!req || !process.env.PAYLOAD_CLOUD_CACHE_KEY) {
+      return doc
+    }
 
     const { payloadAPI } = req
 

--- a/packages/plugin-cloud/src/plugin.spec.ts
+++ b/packages/plugin-cloud/src/plugin.spec.ts
@@ -100,8 +100,9 @@ describe('plugin', () => {
 
         const existingTransport = nodemailer.createTransport({
           name: 'existing-transport',
-          // eslint-disable-next-line @typescript-eslint/require-await
+          // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-misused-promises
           send: async (mail) => {
+            // eslint-disable-next-line no-console
             console.log('mock send', mail)
           },
           version: '0.0.1',

--- a/packages/plugin-form-builder/src/collections/FormSubmissions/index.ts
+++ b/packages/plugin-form-builder/src/collections/FormSubmissions/index.ts
@@ -22,7 +22,9 @@ export const generateSubmissionCollection = (
       required: true,
       validate: async (value, { req: { payload }, req }) => {
         /* Don't run in the client side */
-        if (!payload) return true
+        if (!payload) {
+          return true
+        }
 
         if (payload) {
           let _existingForm

--- a/packages/plugin-form-builder/src/collections/Forms/index.ts
+++ b/packages/plugin-form-builder/src/collections/Forms/index.ts
@@ -57,7 +57,9 @@ export const generateFormCollection = (formConfig: FormBuilderPluginConfig): Col
       ],
     })
 
-    if (redirect.fields[2].type !== 'row') redirect.fields[2].label = 'Custom URL'
+    if (redirect.fields[2].type !== 'row') {
+      redirect.fields[2].label = 'Custom URL'
+    }
 
     redirect.fields[2].admin = {
       condition: (_, siblingData) => siblingData?.type === 'custom',

--- a/packages/plugin-form-builder/src/utilities/replaceDoubleCurlys.ts
+++ b/packages/plugin-form-builder/src/utilities/replaceDoubleCurlys.ts
@@ -10,7 +10,9 @@ export const replaceDoubleCurlys = (str: string, variables?: EmailVariables): st
   if (str && variables) {
     return str.replace(regex, (_, variable) => {
       const foundVariable = variables.find(({ field: fieldName }) => variable === fieldName)
-      if (foundVariable) return foundVariable.value
+      if (foundVariable) {
+        return foundVariable.value
+      }
       return variable
     })
   }

--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -45,7 +45,9 @@ const resave = async ({ collection, doc, draft, pluginConfig, req }: ResaveArgs)
         collection.versions.drafts &&
         child._status === 'published'
 
-      if (!parentDocIsPublished && childIsPublished) return
+      if (!parentDocIsPublished && childIsPublished) {
+        return
+      }
 
       await req.payload.update({
         id: child.id,

--- a/packages/plugin-nested-docs/src/utilities/populateBreadcrumbs.ts
+++ b/packages/plugin-nested-docs/src/utilities/populateBreadcrumbs.ts
@@ -33,7 +33,7 @@ export const populateBreadcrumbs = async (
 
   const breadcrumbs = breadcrumbDocs.map((_, i) =>
     formatBreadcrumb(pluginConfig, collection, breadcrumbDocs.slice(0, i + 1)),
-  )  
+  )
 
   return {
     ...newData,

--- a/packages/plugin-relationship-object-ids/src/hooks/beforeChange.ts
+++ b/packages/plugin-relationship-object-ids/src/hooks/beforeChange.ts
@@ -14,7 +14,9 @@ const convertValue = ({
     (field) => fieldAffectsData(field) && field.name === 'id',
   )
 
-  if (!customIDField) return new mongoose.Types.ObjectId(value)
+  if (!customIDField) {
+    return new mongoose.Types.ObjectId(value)
+  }
 
   return value
 }

--- a/packages/plugin-sentry/src/plugin.ts
+++ b/packages/plugin-sentry/src/plugin.ts
@@ -23,7 +23,9 @@ export const sentryPlugin =
     }
 
     config.onInit = async (payload) => {
-      if (incomingConfig.onInit) await incomingConfig.onInit(payload)
+      if (incomingConfig.onInit) {
+        await incomingConfig.onInit(payload)
+      }
       startSentry(pluginOptions, payload)
     }
 

--- a/packages/plugin-sentry/src/startSentry.ts
+++ b/packages/plugin-sentry/src/startSentry.ts
@@ -11,7 +11,9 @@ export const startSentry = (pluginOptions: PluginOptions, payload: Payload): voi
   const { dsn, options } = pluginOptions
   const { express: app } = payload
 
-  if (!dsn || !app) return
+  if (!dsn || !app) {
+    return
+  }
 
   try {
     Sentry.init({

--- a/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
@@ -54,7 +54,9 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
   const { errorMessage, setValue, showError, value } = field
 
   const regenerateDescription = useCallback(async () => {
-    if (!hasGenerateDescriptionFn) return
+    if (!hasGenerateDescriptionFn) {
+      return
+    }
 
     const genDescriptionResponse = await fetch('/api/plugin-seo/generate-description', {
       body: JSON.stringify({

--- a/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
@@ -51,7 +51,9 @@ export const MetaImageComponent: React.FC<MetaImageProps> = (props) => {
   const { errorMessage, setValue, showError, value } = field
 
   const regenerateImage = useCallback(async () => {
-    if (!hasGenerateImageFn) return
+    if (!hasGenerateImageFn) {
+      return
+    }
 
     const genImageResponse = await fetch('/api/plugin-seo/generate-image', {
       body: JSON.stringify({

--- a/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
@@ -55,7 +55,9 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
   const { errorMessage, setValue, showError, value } = field
 
   const regenerateTitle = useCallback(async () => {
-    if (!hasGenerateTitleFn) return
+    if (!hasGenerateTitleFn) {
+      return
+    }
 
     const genTitleResponse = await fetch('/api/plugin-seo/generate-title', {
       body: JSON.stringify({

--- a/packages/plugin-seo/src/fields/Overview/OverviewComponent.tsx
+++ b/packages/plugin-seo/src/fields/Overview/OverviewComponent.tsx
@@ -58,10 +58,12 @@ export const OverviewComponent: React.FC<OverviewProps> = ({
   }, [getFields])
 
   useEffect(() => {
-    if (typeof metaTitle === 'string')
+    if (typeof metaTitle === 'string') {
       setTitleIsValid(metaTitle.length >= minTitle && metaTitle.length <= maxTitle)
-    if (typeof metaDesc === 'string')
+    }
+    if (typeof metaDesc === 'string') {
       setDescIsValid(metaDesc.length >= minDesc && metaDesc.length <= maxDesc)
+    }
     setImageIsValid(Boolean(metaImage))
   }, [metaTitle, metaDesc, metaImage])
 

--- a/packages/plugin-stripe/src/hooks/createNewInStripe.ts
+++ b/packages/plugin-stripe/src/hooks/createNewInStripe.ts
@@ -38,7 +38,9 @@ export const createNewInStripe: CollectionBeforeValidateHookWithArgs = async (ar
 
   if (payload) {
     if (data?.skipSync) {
-      if (logs) payload.logger.info(`Bypassing collection-level hooks.`)
+      if (logs) {
+        payload.logger.info(`Bypassing collection-level hooks.`)
+      }
     } else {
       // initialize as 'false' so that all Payload admin events sync to Stripe
       // then conditionally set to 'true' to for events that originate from webhooks
@@ -63,10 +65,11 @@ export const createNewInStripe: CollectionBeforeValidateHookWithArgs = async (ar
         syncedFields = deepen(syncedFields)
 
         if (operation === 'update') {
-          if (logs)
+          if (logs) {
             payload.logger.info(
               `A '${collectionSlug}' document has changed in Payload with ID: '${data?.id}', syncing with Stripe...`,
             )
+          }
 
           // NOTE: the Stripe document will be created in the "afterChange" hook, so create a new stripe document here if no stripeID exists
           if (!dataRef.stripeID) {
@@ -77,10 +80,11 @@ export const createNewInStripe: CollectionBeforeValidateHookWithArgs = async (ar
                 syncedFields,
               )
 
-              if (logs)
+              if (logs) {
                 payload.logger.info(
                   `✅ Successfully created new '${syncConfig.stripeResourceType}' resource in Stripe with ID: '${stripeResource.id}'.`,
                 )
+              }
 
               dataRef.stripeID = stripeResource.id
 
@@ -88,22 +92,26 @@ export const createNewInStripe: CollectionBeforeValidateHookWithArgs = async (ar
               dataRef.skipSync = true
             } catch (error: unknown) {
               const msg = error instanceof Error ? error.message : error
-              if (logs) payload.logger.error(`- Error creating Stripe document: ${msg}`)
+              if (logs) {
+                payload.logger.error(`- Error creating Stripe document: ${msg}`)
+              }
             }
           }
         }
 
         if (operation === 'create') {
-          if (logs)
+          if (logs) {
             payload.logger.info(
               `A new '${collectionSlug}' document was created in Payload with ID: '${data?.id}', syncing with Stripe...`,
             )
+          }
 
           try {
-            if (logs)
+            if (logs) {
               payload.logger.info(
                 `- Creating new '${syncConfig.stripeResourceType}' resource in Stripe...`,
               )
+            }
 
             // NOTE: Typed as "any" because the "create" method is not standard across all Stripe resources
             const stripeResource = await stripe?.[syncConfig.stripeResourceType]?.create(
@@ -111,10 +119,11 @@ export const createNewInStripe: CollectionBeforeValidateHookWithArgs = async (ar
               syncedFields,
             )
 
-            if (logs)
+            if (logs) {
               payload.logger.info(
                 `✅ Successfully created new '${syncConfig.stripeResourceType}' resource in Stripe with ID: '${stripeResource.id}'.`,
               )
+            }
 
             dataRef.stripeID = stripeResource.id
 

--- a/packages/plugin-stripe/src/hooks/deleteFromStripe.ts
+++ b/packages/plugin-stripe/src/hooks/deleteFromStripe.ts
@@ -28,13 +28,16 @@ export const deleteFromStripe: CollectionAfterDeleteHookWithArgs = async (args) 
   const { payload } = req
   const { slug: collectionSlug } = collection || {}
 
-  if (logs)
+  if (logs) {
     payload.logger.info(
       `Document with ID: '${doc?.id}' in collection: '${collectionSlug}' has been deleted, deleting from Stripe...`,
     )
+  }
 
   if (process.env.NODE_ENV !== 'test') {
-    if (logs) payload.logger.info(`- Deleting Stripe document with ID: '${doc.stripeID}'...`)
+    if (logs) {
+      payload.logger.info(`- Deleting Stripe document with ID: '${doc.stripeID}'...`)
+    }
 
     const syncConfig = sync?.find((conf) => conf.collection === collectionSlug)
 
@@ -44,15 +47,17 @@ export const deleteFromStripe: CollectionAfterDeleteHookWithArgs = async (args) 
 
         if (found) {
           await stripe?.[syncConfig.stripeResourceType]?.del(doc.stripeID)
-          if (logs)
+          if (logs) {
             payload.logger.info(
               `✅ Successfully deleted Stripe document with ID: '${doc.stripeID}'.`,
             )
+          }
         } else {
-          if (logs)
+          if (logs) {
             payload.logger.info(
               `- Stripe document with ID: '${doc.stripeID}' not found, skipping...`,
             )
+          }
         }
       } catch (error: unknown) {
         const msg = error instanceof Error ? error.message : error

--- a/packages/plugin-stripe/src/hooks/syncExistingWithStripe.ts
+++ b/packages/plugin-stripe/src/hooks/syncExistingWithStripe.ts
@@ -49,17 +49,21 @@ export const syncExistingWithStripe: CollectionBeforeChangeHookWithArgs = async 
 
         syncedFields = deepen(syncedFields)
 
-        if (logs)
+        if (logs) {
           payload.logger.info(
             `A '${collectionSlug}' document has changed in Payload with ID: '${originalDoc?._id}', syncing with Stripe...`,
           )
+        }
 
         if (!data.stripeID) {
           // NOTE: the "beforeValidate" hook populates this
-          if (logs) payload.logger.error(`- There is no Stripe ID for this document, skipping.`)
+          if (logs) {
+            payload.logger.error(`- There is no Stripe ID for this document, skipping.`)
+          }
         } else {
-          if (logs)
+          if (logs) {
             payload.logger.info(`- Syncing to Stripe resource with ID: '${data.stripeID}'...`)
+          }
 
           try {
             const stripeResource = await stripe?.[syncConfig?.stripeResourceType]?.update(
@@ -67,10 +71,11 @@ export const syncExistingWithStripe: CollectionBeforeChangeHookWithArgs = async 
               syncedFields,
             )
 
-            if (logs)
+            if (logs) {
               payload.logger.info(
                 `✅ Successfully synced Stripe resource with ID: '${stripeResource.id}'.`,
               )
+            }
           } catch (error: unknown) {
             const msg = error instanceof Error ? error.message : error
             throw new APIError(`Failed to sync document with ID: '${data.id}' to Stripe: ${msg}`)

--- a/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
+++ b/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
@@ -31,17 +31,19 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
   // }
 
   if (isNestedChange) {
-    if (logs)
+    if (logs) {
       payload.logger.info(
         `- This change occurred on a nested field of ${resourceType}. Nested fields are not yet supported in auto-sync but can be manually setup.`,
       )
+    }
   }
 
   if (!isNestedChange) {
-    if (logs)
+    if (logs) {
       payload.logger.info(
         `- A new document was created or updated in Stripe, now syncing to Payload...`,
       )
+    }
 
     const collectionSlug = syncConfig?.collection
 
@@ -79,10 +81,11 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
     })
 
     if (!foundDoc) {
-      if (logs)
+      if (logs) {
         payload.logger.info(
           `- No existing '${collectionSlug}' document found with Stripe ID: '${stripeID}', creating new...`,
         )
+      }
 
       // auth docs must use unique emails
       let authDoc = null
@@ -102,10 +105,11 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
             authDoc = authQuery.docs[0] as any
 
             if (authDoc) {
-              if (logs)
+              if (logs) {
                 payload.logger.info(
                   `- Account already exists with e-mail: ${stripeDoc.email}, updating now...`,
                 )
+              }
 
               // account exists by email, so update it instead
               try {
@@ -115,37 +119,42 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
                   data: syncedData,
                 })
 
-                if (logs)
+                if (logs) {
                   payload.logger.info(
                     `✅ Successfully updated '${collectionSlug}' document in Payload with ID: '${authDoc.id}.'`,
                   )
+                }
               } catch (err: unknown) {
                 const msg = err instanceof Error ? err.message : err
-                if (logs)
+                if (logs) {
                   payload.logger.error(
                     `- Error updating existing '${collectionSlug}' document: ${msg}`,
                   )
+                }
               }
             }
           } else {
-            if (logs)
+            if (logs) {
               payload.logger.error(
                 `No email was provided from Stripe, cannot create new '${collectionSlug}' document.`,
               )
+            }
           }
         } catch (error: unknown) {
           const msg = error instanceof Error ? error.message : error
-          if (logs)
+          if (logs) {
             payload.logger.error(`Error looking up '${collectionSlug}' document in Payload: ${msg}`)
+          }
         }
       }
 
       if (!isAuthCollection || (isAuthCollection && !authDoc)) {
         try {
-          if (logs)
+          if (logs) {
             payload.logger.info(
               `- Creating new '${collectionSlug}' document in Payload with Stripe ID: '${stripeID}'.`,
             )
+          }
 
           // generate a strong, unique password for the new user
           const password: string = uuid()
@@ -160,20 +169,24 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
             disableVerificationEmail: isAuthCollection ? true : undefined,
           })
 
-          if (logs)
+          if (logs) {
             payload.logger.info(
               `✅ Successfully created new '${collectionSlug}' document in Payload with Stripe ID: '${stripeID}'.`,
             )
+          }
         } catch (error: unknown) {
           const msg = error instanceof Error ? error.message : error
-          if (logs) payload.logger.error(`Error creating new document in Payload: ${msg}`)
+          if (logs) {
+            payload.logger.error(`Error creating new document in Payload: ${msg}`)
+          }
         }
       }
     } else {
-      if (logs)
+      if (logs) {
         payload.logger.info(
           `- Existing '${collectionSlug}' document found in Payload with Stripe ID: '${stripeID}', updating now...`,
         )
+      }
 
       try {
         await payload.update({
@@ -182,14 +195,16 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
           data: syncedData,
         })
 
-        if (logs)
+        if (logs) {
           payload.logger.info(
             `✅ Successfully updated '${collectionSlug}' document in Payload from Stripe ID: '${stripeID}'.`,
           )
+        }
       } catch (error: unknown) {
         const msg = error instanceof Error ? error.message : error
-        if (logs)
+        if (logs) {
           payload.logger.error(`Error updating '${collectionSlug}' document in Payload: ${msg}`)
+        }
       }
     }
   }

--- a/packages/plugin-stripe/src/webhooks/handleDeleted.ts
+++ b/packages/plugin-stripe/src/webhooks/handleDeleted.ts
@@ -23,17 +23,19 @@ export const handleDeleted: HandleDeleted = async (args) => {
   const isNestedDelete = eventObject !== resourceType
 
   if (isNestedDelete) {
-    if (logs)
+    if (logs) {
       payload.logger.info(
         `- This deletion occurred on a nested field of ${resourceType}. Nested fields are not yet supported.`,
       )
+    }
   }
 
   if (!isNestedDelete) {
-    if (logs)
+    if (logs) {
       payload.logger.info(
         `- A '${resourceType}' resource was deleted in Stripe, now deleting '${collectionSlug}' document in Payload with Stripe ID: '${stripeID}'...`,
       )
+    }
 
     try {
       const payloadQuery = await payload.find({
@@ -48,14 +50,17 @@ export const handleDeleted: HandleDeleted = async (args) => {
       const foundDoc = payloadQuery.docs[0] as any
 
       if (!foundDoc) {
-        if (logs)
+        if (logs) {
           payload.logger.info(
             `- Nothing to delete, no existing document found with Stripe ID: '${stripeID}'.`,
           )
+        }
       }
 
       if (foundDoc) {
-        if (logs) payload.logger.info(`- Deleting Payload document with ID: '${foundDoc.id}'...`)
+        if (logs) {
+          payload.logger.info(`- Deleting Payload document with ID: '${foundDoc.id}'...`)
+        }
 
         try {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -66,18 +71,23 @@ export const handleDeleted: HandleDeleted = async (args) => {
 
           // NOTE: the `afterDelete` hook will trigger, which will attempt to delete the document from Stripe and safely error out
           // There is no known way of preventing this from happening. In other hooks we use the `skipSync` field, but here the document is already deleted.
-          if (logs)
+          if (logs) {
             payload.logger.info(
               `- ✅ Successfully deleted Payload document with ID: '${foundDoc.id}'.`,
             )
+          }
         } catch (error: unknown) {
           const msg = error instanceof Error ? error.message : error
-          if (logs) payload.logger.error(`Error deleting document: ${msg}`)
+          if (logs) {
+            payload.logger.error(`Error deleting document: ${msg}`)
+          }
         }
       }
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : error
-      if (logs) payload.logger.error(`Error deleting document: ${msg}`)
+      if (logs) {
+        payload.logger.error(`Error deleting document: ${msg}`)
+      }
     }
   }
 }

--- a/packages/plugin-stripe/src/webhooks/index.ts
+++ b/packages/plugin-stripe/src/webhooks/index.ts
@@ -6,8 +6,9 @@ import { handleDeleted } from './handleDeleted.js'
 export const handleWebhooks: StripeWebhookHandler = (args) => {
   const { event, payload, pluginConfig } = args
 
-  if (pluginConfig?.logs)
+  if (pluginConfig?.logs) {
     payload.logger.info(`🪝 Received Stripe '${event.type}' webhook event with ID: '${event.id}'.`)
+  }
 
   // could also traverse into event.data.object.object to get the type, but that seems unreliable
   // use cli: `stripe resources` to see all available resources

--- a/packages/richtext-lexical/babel.config.cjs
+++ b/packages/richtext-lexical/babel.config.cjs
@@ -4,7 +4,10 @@ const fs = require('fs')
 const ReactCompilerConfig = {
   sources: (filename) => {
     const isInNodeModules = filename.includes('node_modules')
-    if (isInNodeModules || ( !filename.endsWith('.tsx') && !filename.endsWith('.jsx') && !filename.endsWith('.js'))) {
+    if (
+      isInNodeModules ||
+      (!filename.endsWith('.tsx') && !filename.endsWith('.jsx') && !filename.endsWith('.js'))
+    ) {
       return false
     }
 

--- a/packages/richtext-lexical/src/features/converters/html/field/index.ts
+++ b/packages/richtext-lexical/src/features/converters/html/field/index.ts
@@ -176,10 +176,11 @@ export const lexicalHTML: (
 
           const foundSiblingFields = findFieldPathAndSiblingFields(fields, [], field)
 
-          if (!foundSiblingFields)
+          if (!foundSiblingFields) {
             throw new Error(
               `Could not find sibling fields of current lexicalHTML field with name ${field?.name}`,
             )
+          }
 
           const { siblingFields } = foundSiblingFields
           const lexicalField: RichTextField<SerializedEditorState, AdapterProps> =

--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.scss
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.scss
@@ -84,7 +84,8 @@
     height: 100%;
   }
 
-  &__tableAddColumns, &__tableAddRows {
+  &__tableAddColumns,
+  &__tableAddRows {
     position: absolute;
     background-color: var(--theme-elevation-100);
     animation: table-controls 0.2s ease;
@@ -94,7 +95,8 @@
     min-height: 24px;
   }
 
-  &__tableAddColumns:after, &__tableAddRows:after {
+  &__tableAddColumns:after,
+  &__tableAddRows:after {
     background-image: url(../../../../../lexical/ui/icons/Add/index.svg);
     background-position: center;
     background-repeat: no-repeat;
@@ -108,7 +110,8 @@
     opacity: 0.4;
   }
 
-  &__tableAddColumns:hover, &__tableAddRows:hover {
+  &__tableAddColumns:hover,
+  &__tableAddRows:hover {
     background-color: var(--theme-elevation-200);
   }
 
@@ -167,7 +170,8 @@ html[data-theme='dark'] {
       background-color: var(--theme-elevation-50);
     }
 
-    &__tableAddColumns:after, &__tableAddRows:after {
+    &__tableAddColumns:after,
+    &__tableAddRows:after {
       background-image: url(../../../../../lexical/ui/icons/Add/light.svg);
     }
   }

--- a/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.tsx
+++ b/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.tsx
@@ -40,7 +40,9 @@ export function createLinkMatcherWithRegExp(
 ) {
   return (text: string) => {
     const match = regExp.exec(text)
-    if (match === null) return null
+    if (match === null) {
+      return null
+    }
     return {
       index: match.index,
       length: match[0].length,

--- a/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
@@ -386,7 +386,7 @@ function $getAncestor(
   predicate: (ancestor: LexicalNode) => boolean,
 ): LexicalNode | null {
   let parent: LexicalNode | null = node
-  while (parent !== null && (parent = parent.getParent()) !== null && !predicate(parent));
+  while (parent !== null && (parent = parent.getParent()) !== null && !predicate(parent)) {}
   return parent
 }
 

--- a/packages/richtext-lexical/src/features/toolbars/shared/ToolbarDropdown/DropDown.tsx
+++ b/packages/richtext-lexical/src/features/toolbars/shared/ToolbarDropdown/DropDown.tsx
@@ -113,7 +113,9 @@ function DropDownItems({
   )
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
-    if (items == null) return
+    if (items == null) {
+      return
+    }
 
     const { key } = event
 
@@ -125,13 +127,17 @@ function DropDownItems({
       onClose()
     } else if (key === 'ArrowUp') {
       setHighlightedItem((prev) => {
-        if (prev == null) return items[0]
+        if (prev == null) {
+          return items[0]
+        }
         const index = items.indexOf(prev) - 1
         return items[index === -1 ? items.length - 1 : index]
       })
     } else if (key === 'ArrowDown') {
       setHighlightedItem((prev) => {
-        if (prev == null) return items[0]
+        if (prev == null) {
+          return items[0]
+        }
         return items[items.indexOf(prev) + 1]
       })
     }

--- a/packages/richtext-lexical/src/features/upload/server/feature.server.ts
+++ b/packages/richtext-lexical/src/features/upload/server/feature.server.ts
@@ -81,7 +81,9 @@ export const UploadFeature = createServerFeature<
       ClientFeature: '@payloadcms/richtext-lexical/client#UploadFeatureClient',
       clientFeatureProps: clientProps,
       generateSchemaMap: ({ props }) => {
-        if (!props?.collections) return null
+        if (!props?.collections) {
+          return null
+        }
 
         const schemaMap = new Map<string, Field[]>()
 

--- a/packages/richtext-lexical/src/lexical/LexicalEditor.tsx
+++ b/packages/richtext-lexical/src/lexical/LexicalEditor.tsx
@@ -129,7 +129,9 @@ export const LexicalEditor: React.FC<
           onChange={(editorState, editor, tags) => {
             // Ignore any onChange event triggered by focus only
             if (!tags.has('focus') || tags.size > 1) {
-              if (onChange != null) onChange(editorState, editor, tags)
+              if (onChange != null) {
+                onChange(editorState, editor, tags)
+              }
             }
           }}
         />

--- a/packages/richtext-lexical/src/lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/LexicalMenu.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/SlashMenu/LexicalTypeaheadMenuPlugin/LexicalMenu.tsx
@@ -40,7 +40,9 @@ export type MenuRenderFn = (
 
 const scrollIntoViewIfNeeded = (target: HTMLElement) => {
   const typeaheadContainerNode = document.getElementById('slash-menu')
-  if (!typeaheadContainerNode) return
+  if (!typeaheadContainerNode) {
+    return
+  }
 
   const typeaheadRect = typeaheadContainerNode.getBoundingClientRect()
 

--- a/packages/richtext-lexical/src/lexical/plugins/handles/utils/doesLineHeightAffectElement.ts
+++ b/packages/richtext-lexical/src/lexical/plugins/handles/utils/doesLineHeightAffectElement.ts
@@ -20,7 +20,9 @@ const replacedElements = [
  * @param htmlElem
  */
 export function doesLineHeightAffectElement(htmlElem: HTMLElement) {
-  if (!htmlElem) return false
+  if (!htmlElem) {
+    return false
+  }
 
   // Check for replaced elements, elements that typically don't support line-height adjustments,
   // and elements without visible content

--- a/packages/richtext-lexical/src/lexical/utils/url.ts
+++ b/packages/richtext-lexical/src/lexical/utils/url.ts
@@ -8,7 +8,9 @@ export function sanitizeUrl(url: string): string {
 
   url = String(url).trim()
 
-  if (url.match(SAFE_URL_PATTERN) != null || url.match(DATA_URL_PATTERN) != null) return url
+  if (url.match(SAFE_URL_PATTERN) != null || url.match(DATA_URL_PATTERN) != null) {
+    return url
+  }
 
   return 'https://'
 }
@@ -30,7 +32,9 @@ const relativeOrAnchorRegExp = /^[\w\-./]*(?:#\w[\w-]*)?$/
  * @param url
  */
 export function validateUrlMinimal(url: string): boolean {
-  if (!url) return false
+  if (!url) {
+    return false
+  }
 
   return !url.includes(' ')
 }
@@ -41,15 +45,23 @@ export function validateUrl(url: string): boolean {
   // TODO Fix UI for link insertion; it should never default to an invalid URL such as https://.
   // Maybe show a dialog where they user can type the URL before inserting it.
 
-  if (!url) return false
+  if (!url) {
+    return false
+  }
 
-  if (url === 'https://') return true
+  if (url === 'https://') {
+    return true
+  }
 
   // This makes sure URLs starting with www. instead of https are valid too
-  if (absoluteRegExp.test(url)) return true
+  if (absoluteRegExp.test(url)) {
+    return true
+  }
 
   // Check relative or anchor links
-  if (relativeOrAnchorRegExp.test(url)) return true
+  if (relativeOrAnchorRegExp.test(url)) {
+    return true
+  }
 
   // While this doesn't allow URLs starting with www (which is why we use the regex above), it does properly handle tel: URLs
   try {

--- a/packages/richtext-slate/src/data/validation.ts
+++ b/packages/richtext-slate/src/data/validation.ts
@@ -13,7 +13,9 @@ export const richTextValidate: Validate<
   const { t } = req
   if (required) {
     const stringifiedDefaultValue = JSON.stringify(defaultRichTextValue)
-    if (value && JSON.stringify(value) !== stringifiedDefaultValue) return true
+    if (value && JSON.stringify(value) !== stringifiedDefaultValue) {
+      return true
+    }
     return t('validation:required')
   }
 

--- a/packages/richtext-slate/src/field/RichText.tsx
+++ b/packages/richtext-slate/src/field/RichText.tsx
@@ -261,7 +261,9 @@ const RichTextField: React.FC<LoadedSlateFieldProps> = (props) => {
         const isButton = child.tagName === 'BUTTON'
         const isDisabling = clickState === 'disabled'
         child.setAttribute('tabIndex', isDisabling ? '-1' : '0')
-        if (isButton) child.setAttribute('disabled', isDisabling ? 'disabled' : null)
+        if (isButton) {
+          child.setAttribute('disabled', isDisabling ? 'disabled' : null)
+        }
       })
     }
 
@@ -307,7 +309,9 @@ const RichTextField: React.FC<LoadedSlateFieldProps> = (props) => {
     }
   }
 
-  if (!valueToRender) valueToRender = defaultRichTextValue
+  if (!valueToRender) {
+    valueToRender = defaultRichTextValue
+  }
 
   return (
     <div

--- a/packages/richtext-slate/src/field/createFeatureMap.ts
+++ b/packages/richtext-slate/src/field/createFeatureMap.ts
@@ -23,8 +23,12 @@ export const createFeatureMap = (
         }
       }
 
-      if (key.startsWith('leaf.button.')) features.leaves[leafName].Button = value
-      if (key.startsWith('leaf.component.')) features.leaves[leafName].Leaf = value
+      if (key.startsWith('leaf.button.')) {
+        features.leaves[leafName].Button = value
+      }
+      if (key.startsWith('leaf.component.')) {
+        features.leaves[leafName].Leaf = value
+      }
     }
 
     if (key.startsWith('element.button.') || key.startsWith('element.component.')) {
@@ -38,8 +42,12 @@ export const createFeatureMap = (
         }
       }
 
-      if (key.startsWith('element.button.')) features.elements[elementName].Button = value
-      if (key.startsWith('element.component.')) features.elements[elementName].Element = value
+      if (key.startsWith('element.button.')) {
+        features.elements[elementName].Button = value
+      }
+      if (key.startsWith('element.component.')) {
+        features.elements[elementName].Element = value
+      }
     }
 
     if (key.startsWith('leaf.plugin.') || key.startsWith('element.plugin.')) {

--- a/packages/richtext-slate/src/field/elements/isActive.tsx
+++ b/packages/richtext-slate/src/field/elements/isActive.tsx
@@ -1,7 +1,9 @@
 import { Editor, Element } from 'slate'
 
 export const isElementActive = (editor: Editor, format: string, blockType = 'type'): boolean => {
-  if (!editor.selection) return false
+  if (!editor.selection) {
+    return false
+  }
 
   const [match] = Array.from(
     Editor.nodes(editor, {

--- a/packages/richtext-slate/src/field/elements/isLastSelectedElementEmpty.ts
+++ b/packages/richtext-slate/src/field/elements/isLastSelectedElementEmpty.ts
@@ -3,7 +3,9 @@ import { Editor, Element } from 'slate'
 import { nodeIsTextNode } from '../../types.js'
 
 export const isLastSelectedElementEmpty = (editor: Editor): boolean => {
-  if (!editor.selection) return false
+  if (!editor.selection) {
+    return false
+  }
 
   const currentlySelectedNodes = Array.from(
     Editor.nodes(editor, {

--- a/packages/richtext-slate/src/field/elements/isListActive.ts
+++ b/packages/richtext-slate/src/field/elements/isListActive.ts
@@ -3,10 +3,14 @@ import { Editor, Element } from 'slate'
 import { getCommonBlock } from './getCommonBlock.js'
 
 export const isListActive = (editor: Editor, format: string): boolean => {
-  if (!editor.selection) return false
+  if (!editor.selection) {
+    return false
+  }
   const [topmostSelectedNode, topmostSelectedNodePath] = getCommonBlock(editor)
 
-  if (Editor.isEditor(topmostSelectedNode)) return false
+  if (Editor.isEditor(topmostSelectedNode)) {
+    return false
+  }
 
   const [match] = Array.from(
     Editor.nodes(editor, {

--- a/packages/richtext-slate/src/field/elements/link/Element/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/Element/index.tsx
@@ -46,7 +46,9 @@ const insertChange = (editor, fields) => {
     url: data.url,
   }
 
-  if (data.fields) newNode.fields = data.fields
+  if (data.fields) {
+    newNode.fields = data.fields
+  }
 
   Transforms.setNodes(editor, newNode, { at: parentPath })
 
@@ -214,7 +216,9 @@ export const LinkElement = () => {
         className={[`${baseClass}__popup-toggler`].filter(Boolean).join(' ')}
         onClick={() => setRenderPopup(true)}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') setRenderPopup(true)
+          if (e.key === 'Enter') {
+            setRenderPopup(true)
+          }
         }}
         role="button"
         tabIndex={0}

--- a/packages/richtext-slate/src/field/elements/toggleList.tsx
+++ b/packages/richtext-slate/src/field/elements/toggleList.tsx
@@ -9,8 +9,12 @@ import { unwrapList } from './unwrapList.js'
 export const toggleList = (editor: Editor, format: string): void => {
   let currentListFormat: string
 
-  if (isListActive(editor, 'ol')) currentListFormat = 'ol'
-  if (isListActive(editor, 'ul')) currentListFormat = 'ul'
+  if (isListActive(editor, 'ol')) {
+    currentListFormat = 'ol'
+  }
+  if (isListActive(editor, 'ul')) {
+    currentListFormat = 'ul'
+  }
 
   // If the format is currently active,
   // remove the list

--- a/packages/richtext-slate/src/generateComponentMap.tsx
+++ b/packages/richtext-slate/src/generateComponentMap.tsx
@@ -61,11 +61,12 @@ export const getGenerateComponentMap =
         const ElementButton = element.Button
         const ElementComponent = element.Element
 
-        if (ElementButton)
+        if (ElementButton) {
           componentMap.set(
             `element.button.${element.name}`,
             createMappedComponent(ElementButton, undefined, undefined, 'slate-ElementButton'),
           )
+        }
         componentMap.set(
           `element.component.${element.name}`,
           createMappedComponent(ElementComponent, undefined, undefined, 'slate-ElementComponent'),

--- a/packages/storage-azure/src/staticHandler.ts
+++ b/packages/storage-azure/src/staticHandler.ts
@@ -26,7 +26,7 @@ export const getHandler = ({ collection, getStorageClient }: Args): StaticHandle
       )
 
       const blob = await blockBlobClient.download(start, end)
-       
+
       const response = blob._response
 
       // Manually create a ReadableStream for the web from a Node.js stream.

--- a/packages/storage-azure/src/utils/getStorageClient.ts
+++ b/packages/storage-azure/src/utils/getStorageClient.ts
@@ -9,7 +9,9 @@ let storageClient: ContainerClient | null = null
 export function getStorageClient(
   options: Pick<AzureStorageOptions, 'connectionString' | 'containerName'>,
 ): ContainerClient {
-  if (storageClient) return storageClient
+  if (storageClient) {
+    return storageClient
+  }
 
   const { connectionString, containerName } = options
 

--- a/packages/storage-gcs/src/index.ts
+++ b/packages/storage-gcs/src/index.ts
@@ -94,7 +94,9 @@ function gcsStorageInternal({ acl, bucket, options }: GcsStorageOptions): Adapte
     let storageClient: Storage | null = null
 
     const getStorageClient = (): Storage => {
-      if (storageClient) return storageClient
+      if (storageClient) {
+        return storageClient
+      }
       storageClient = new Storage(options)
       return storageClient
     }

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -106,7 +106,9 @@ function s3StorageInternal({ acl, bucket, config = {} }: S3StorageOptions): Adap
   return ({ collection, prefix }): GeneratedAdapter => {
     let storageClient: AWS.S3 | null = null
     const getStorageClient: () => AWS.S3 = () => {
-      if (storageClient) return storageClient
+      if (storageClient) {
+        return storageClient
+      }
       storageClient = new AWS.S3(config)
       return storageClient
     }

--- a/packages/storage-uploadthing/src/staticHandler.ts
+++ b/packages/storage-uploadthing/src/staticHandler.ts
@@ -39,7 +39,9 @@ export const getHandler = ({ utApi }: Args): StaticHandler => {
           where: { or },
         })
 
-        if (result) retrievedDoc = result
+        if (result) {
+          retrievedDoc = result
+        }
       }
 
       if (!retrievedDoc) {

--- a/packages/translations/scripts/translateNewKeys/sortKeys.ts
+++ b/packages/translations/scripts/translateNewKeys/sortKeys.ts
@@ -1,5 +1,7 @@
 export function sortKeys(obj: any): any {
-  if (typeof obj !== 'object' || obj === null) return obj
+  if (typeof obj !== 'object' || obj === null) {
+    return obj
+  }
 
   if (Array.isArray(obj)) {
     return obj.map(sortKeys)

--- a/packages/translations/src/importDateFNSLocale.ts
+++ b/packages/translations/src/importDateFNSLocale.ts
@@ -122,7 +122,9 @@ export const importDateFNSLocale = async (locale: string): Promise<Locale> => {
       break
   }
 
-  if (result.default) return result.default
+  if (result.default) {
+    return result.default
+  }
 
   return result as Locale
 }

--- a/packages/translations/src/utilities/init.ts
+++ b/packages/translations/src/utilities/init.ts
@@ -34,7 +34,9 @@ export const getTranslationString = <
   let keySuffix = ''
 
   const translation: string = keys.reduce((acc: any, key, index) => {
-    if (typeof acc === 'string') return acc
+    if (typeof acc === 'string') {
+      return acc
+    }
 
     if (typeof count === 'number') {
       if (count === 0 && `${key}_zero` in acc) {

--- a/packages/ui/babel.config.cjs
+++ b/packages/ui/babel.config.cjs
@@ -4,7 +4,10 @@ const fs = require('fs')
 const ReactCompilerConfig = {
   sources: (filename) => {
     const isInNodeModules = filename.includes('node_modules')
-    if (isInNodeModules || ( !filename.endsWith('.tsx') && !filename.endsWith('.jsx') && !filename.endsWith('.js'))) {
+    if (
+      isInNodeModules ||
+      (!filename.endsWith('.tsx') && !filename.endsWith('.jsx') && !filename.endsWith('.js'))
+    ) {
       return false
     }
 

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -57,8 +57,9 @@ export const Autosave: React.FC<Props> = ({
   const { i18n, t } = useTranslation()
 
   let interval = versionDefaults.autosaveInterval
-  if (versionsConfig.drafts && versionsConfig.drafts.autosave)
+  if (versionsConfig.drafts && versionsConfig.drafts.autosave) {
     interval = versionsConfig.drafts.autosave.interval
+  }
 
   const [saving, setSaving] = useState(false)
   const [lastSaved, setLastSaved] = useState<number>()
@@ -221,7 +222,9 @@ export const Autosave: React.FC<Props> = ({
     void autosave()
 
     return () => {
-      if (autosaveTimeout) clearTimeout(autosaveTimeout)
+      if (autosaveTimeout) {
+        clearTimeout(autosaveTimeout)
+      }
       if (abortController.signal) {
         try {
           abortController.abort('Autosave closed early.')

--- a/packages/ui/src/elements/Banner/index.tsx
+++ b/packages/ui/src/elements/Banner/index.tsx
@@ -52,8 +52,12 @@ export const Banner: React.FC<Props> = ({
 
   let RenderedType: React.ComponentType<RenderedTypeProps> | React.ElementType = 'div'
 
-  if (onClick && !to) RenderedType = 'button'
-  if (to) RenderedType = Link
+  if (onClick && !to) {
+    RenderedType = 'button'
+  }
+  if (to) {
+    RenderedType = Link
+  }
 
   return (
     <RenderedType className={classes} href={to || null} onClick={onClick}>

--- a/packages/ui/src/elements/BulkUpload/ActionsBar/index.scss
+++ b/packages/ui/src/elements/BulkUpload/ActionsBar/index.scss
@@ -17,21 +17,21 @@
     align-items: center;
     width: 100%;
   }
-  
+
   &__locationText {
     font-variant-numeric: tabular-nums;
     margin: 0;
   }
-  
+
   &__controls {
     display: flex;
     gap: calc(var(--base) / 2);
-    
+
     .btn {
       background-color: var(--theme-elevation-100);
       width: calc(var(--base) * 1.2);
       height: calc(var(--base) * 1.2);
-  
+
       &:hover {
         background-color: var(--theme-elevation-200);
       }

--- a/packages/ui/src/elements/BulkUpload/ActionsBar/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/ActionsBar/index.tsx
@@ -30,8 +30,11 @@ export function ActionsBar() {
             buttonStyle="none"
             onClick={() => {
               const nextIndex = activeIndex - 1
-              if (nextIndex < 0) setActiveIndex(forms.length - 1)
-              else setActiveIndex(nextIndex)
+              if (nextIndex < 0) {
+                setActiveIndex(forms.length - 1)
+              } else {
+                setActiveIndex(nextIndex)
+              }
             }}
             type="button"
           >
@@ -42,8 +45,11 @@ export function ActionsBar() {
             buttonStyle="none"
             onClick={() => {
               const nextIndex = activeIndex + 1
-              if (nextIndex === forms.length) setActiveIndex(0)
-              else setActiveIndex(nextIndex)
+              if (nextIndex === forms.length) {
+                setActiveIndex(0)
+              } else {
+                setActiveIndex(nextIndex)
+              }
             }}
             type="button"
           >

--- a/packages/ui/src/elements/BulkUpload/AddFilesView/index.scss
+++ b/packages/ui/src/elements/BulkUpload/AddFilesView/index.scss
@@ -7,7 +7,7 @@
     height: 100%;
     padding: calc(var(--base) * 2) var(--gutter-h);
   }
-  
+
   .dropzone {
     flex-direction: column;
     justify-content: center;

--- a/packages/ui/src/elements/BulkUpload/EditForm/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/EditForm/index.tsx
@@ -197,14 +197,18 @@ function ReportAllErrors() {
 
   const reportFormErrorCount = React.useCallback(
     (errorCount) => {
-      if (errorCount === errorCountRef.current) return
+      if (errorCount === errorCountRef.current) {
+        return
+      }
       setFormTotalErrorCount({ errorCount, index: activeIndex })
       errorCountRef.current = errorCount
     },
     [activeIndex, setFormTotalErrorCount],
   )
 
-  if (!docConfig) return null
+  if (!docConfig) {
+    return null
+  }
 
   return <WatchChildErrors fields={docConfig.fields} path="" setErrorCount={reportFormErrorCount} />
 }

--- a/packages/ui/src/elements/BulkUpload/FileSidebar/index.scss
+++ b/packages/ui/src/elements/BulkUpload/FileSidebar/index.scss
@@ -58,7 +58,7 @@
       border-radius: var(--style-radius-m);
     }
   }
-  
+
   &__fileRowContainer {
     --rowPadding: calc(var(--base) / 4);
     position: relative;
@@ -210,9 +210,8 @@
     height: 100%;
     opacity: 0;
     transition: opacity 100ms cubic-bezier(0, 0.2, 0.2, 1);
-
   }
-  
+
   &__showingFiles {
     .file-selections__mobileBlur {
       opacity: 1;
@@ -230,11 +229,11 @@
     &__showingFiles {
       z-index: 2;
     }
-    
+
     &__filesContainer {
       @include blur-bg;
     }
-    
+
     &__fileRowContainer {
       z-index: 1;
     }
@@ -242,7 +241,7 @@
     &__header {
       margin-top: 0;
     }
-    
+
     &__headerTopRow {
       border-top: 1px solid var(--theme-border-color);
       padding-block: calc(var(--base) * 0.8);
@@ -255,17 +254,17 @@
       padding-block: calc(var(--base) * 0.8);
       padding-inline: var(--file-gutter-h);
       border-top: 1px solid var(--theme-border-color);
-      
+
       > div {
         display: flex;
         justify-content: flex-end;
         width: 100%;
         button {
-          flex: .5;
+          flex: 0.5;
         }
       }
     }
-    
+
     &__toggler {
       padding-right: 0;
       display: block;
@@ -275,5 +274,4 @@
       margin: 0;
     }
   }
-
 }

--- a/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
@@ -327,7 +327,9 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
   )
 
   React.useEffect(() => {
-    if (!collectionSlug) return
+    if (!collectionSlug) {
+      return
+    }
     if (!hasInitializedState) {
       void initializeSharedFormState()
     }

--- a/packages/ui/src/elements/BulkUpload/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/index.tsx
@@ -25,7 +25,9 @@ function DrawerContent() {
     [addFiles],
   )
 
-  if (!collectionSlug) return null
+  if (!collectionSlug) {
+    return null
+  }
 
   if (!forms.length && !isInitializing) {
     return <AddFilesView onCancel={() => closeModal(drawerSlug)} onDrop={onDrop} />

--- a/packages/ui/src/elements/Button/index.tsx
+++ b/packages/ui/src/elements/Button/index.tsx
@@ -89,8 +89,12 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((
 
   function handleClick(event) {
     setShowTooltip(false)
-    if (type !== 'submit' && onClick) event.preventDefault()
-    if (onClick) onClick(event)
+    if (type !== 'submit' && onClick) {
+      event.preventDefault()
+    }
+    if (onClick) {
+      onClick(event)
+    }
   }
 
   const styleClasses = [
@@ -127,7 +131,9 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((
 
       let LinkTag = Link // eslint-disable-line no-case-declarations
 
-      if (disabled) LinkTag = 'div'
+      if (disabled) {
+        LinkTag = 'div'
+      }
 
       buttonElement = (
         <LinkTag {...buttonProps} href={to || url} to={to || url}>
@@ -164,7 +170,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((
       )
       break
   }
-  if (SubMenuPopupContent)
+  if (SubMenuPopupContent) {
     return (
       <div className={styleClasses}>
         {buttonElement}
@@ -180,6 +186,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((
         </Popup>
       </div>
     )
+  }
 
   return buttonElement
 })

--- a/packages/ui/src/elements/Collapsible/index.tsx
+++ b/packages/ui/src/elements/Collapsible/index.tsx
@@ -48,7 +48,9 @@ export const Collapsible: React.FC<Props> = ({
   const isCollapsed = typeof collapsedFromProps === 'boolean' ? collapsedFromProps : collapsedLocal
 
   const toggleCollapsible = React.useCallback(() => {
-    if (typeof onToggle === 'function') void onToggle(!isCollapsed)
+    if (typeof onToggle === 'function') {
+      void onToggle(!isCollapsed)
+    }
     setCollapsedLocal(!isCollapsed)
   }, [onToggle, isCollapsed])
 

--- a/packages/ui/src/elements/ColumnSelector/index.tsx
+++ b/packages/ui/src/elements/ColumnSelector/index.tsx
@@ -49,11 +49,15 @@ export const ColumnSelector: React.FC<Props> = ({ collectionSlug }) => {
       }}
     >
       {filteredColumns.map((col, i) => {
-        if (!col) return null
+        if (!col) {
+          return null
+        }
 
         const { Label, accessor, active } = col
 
-        if (col.accessor === '_select') return null
+        if (col.accessor === '_select') {
+          return null
+        }
 
         return (
           <Pill

--- a/packages/ui/src/elements/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/elements/DatePicker/DatePicker.tsx
@@ -50,11 +50,17 @@ const DatePicker: React.FC<Props> = (props) => {
 
   if (!customDisplayFormat) {
     // when no displayFormat is provided, determine format based on the picker appearance
-    if (pickerAppearance === 'default') dateFormat = 'MM/dd/yyyy'
-    else if (pickerAppearance === 'dayAndTime') dateFormat = 'MMM d, yyy h:mm a'
-    else if (pickerAppearance === 'timeOnly') dateFormat = 'h:mm a'
-    else if (pickerAppearance === 'dayOnly') dateFormat = 'MMM dd'
-    else if (pickerAppearance === 'monthOnly') dateFormat = 'MMMM'
+    if (pickerAppearance === 'default') {
+      dateFormat = 'MM/dd/yyyy'
+    } else if (pickerAppearance === 'dayAndTime') {
+      dateFormat = 'MMM d, yyy h:mm a'
+    } else if (pickerAppearance === 'timeOnly') {
+      dateFormat = 'h:mm a'
+    } else if (pickerAppearance === 'dayOnly') {
+      dateFormat = 'MMM dd'
+    } else if (pickerAppearance === 'monthOnly') {
+      dateFormat = 'MMMM'
+    }
   }
 
   const onChange = (incomingDate: Date) => {
@@ -63,7 +69,9 @@ const DatePicker: React.FC<Props> = (props) => {
       const tzOffset = incomingDate.getTimezoneOffset() / 60
       newDate.setHours(12 - tzOffset, 0)
     }
-    if (typeof onChangeFromProps === 'function') onChangeFromProps(newDate)
+    if (typeof onChangeFromProps === 'function') {
+      onChangeFromProps(newDate)
+    }
   }
 
   const dateTimePickerProps: ReactDatePickerProps = {

--- a/packages/ui/src/elements/DraggableSortable/index.tsx
+++ b/packages/ui/src/elements/DraggableSortable/index.tsx
@@ -43,7 +43,9 @@ export const DraggableSortable: React.FC<Props> = (props) => {
 
       event.activatorEvent.stopPropagation()
 
-      if (!active || !over) return
+      if (!active || !over) {
+        return
+      }
 
       if (typeof onDragEnd === 'function') {
         onDragEnd({

--- a/packages/ui/src/elements/Drawer/index.tsx
+++ b/packages/ui/src/elements/Drawer/index.tsx
@@ -31,7 +31,9 @@ export const DrawerToggler: React.FC<TogglerProps> = ({
   const handleClick = useCallback(
     (e) => {
       openModal(slug)
-      if (typeof onClick === 'function') onClick(e)
+      if (typeof onClick === 'function') {
+        onClick(e)
+      }
     },
     [openModal, slug, onClick],
   )

--- a/packages/ui/src/elements/Dropzone/index.scss
+++ b/packages/ui/src/elements/Dropzone/index.scss
@@ -4,7 +4,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  padding: calc(var(--base) * .9) var(--base);
+  padding: calc(var(--base) * 0.9) var(--base);
   background: transparent;
   border: 1px dotted var(--theme-elevation-400);
   border-radius: var(--style-radius-s);

--- a/packages/ui/src/elements/EditUpload/index.tsx
+++ b/packages/ui/src/elements/EditUpload/index.tsx
@@ -112,13 +112,19 @@ export const EditUpload: React.FC<EditUploadProps> = ({
 
   const fineTuneCrop = ({ dimension, value }: { dimension: 'height' | 'width'; value: string }) => {
     const intValue = parseInt(value)
-    if (dimension === 'width' && intValue >= uncroppedPixelWidth) return null
-    if (dimension === 'height' && intValue >= uncroppedPixelHeight) return null
+    if (dimension === 'width' && intValue >= uncroppedPixelWidth) {
+      return null
+    }
+    if (dimension === 'height' && intValue >= uncroppedPixelHeight) {
+      return null
+    }
 
     const percentage =
       100 * (intValue / (dimension === 'width' ? uncroppedPixelWidth : uncroppedPixelHeight))
 
-    if (percentage === 100 || percentage === 0) return null
+    if (percentage === 100 || percentage === 0) {
+      return null
+    }
 
     setCrop({
       ...crop,
@@ -140,13 +146,14 @@ export const EditUpload: React.FC<EditUploadProps> = ({
   }
 
   const saveEdits = () => {
-    if (typeof onSave === 'function')
+    if (typeof onSave === 'function') {
       onSave({
         crop: crop ? crop : undefined,
         focalPoint: focalPosition,
         heightInPixels: Number(heightInputRef?.current?.value ?? uncroppedPixelHeight),
         widthInPixels: Number(widthInputRef?.current?.value ?? uncroppedPixelWidth),
       })
+    }
     closeModal(editDrawerSlug)
   }
 
@@ -393,7 +400,9 @@ const DraggableElement = ({
   }
 
   const handleMouseMove = (event) => {
-    if (!isDragging) return null
+    if (!isDragging) {
+      return null
+    }
     const { x, y } = getCoordinates(event.clientX, event.clientY)
 
     setPosition({ x, y })
@@ -405,7 +414,9 @@ const DraggableElement = ({
   }
 
   React.useEffect(() => {
-    if (isDragging || !dragRef.current) return
+    if (isDragging || !dragRef.current) {
+      return
+    }
     if (checkBounds) {
       const { height, left, top, width } = dragRef.current.getBoundingClientRect()
       const { x, y } = getCoordinates(left + width / 2, top + height / 2, true)

--- a/packages/ui/src/elements/ErrorPill/index.tsx
+++ b/packages/ui/src/elements/ErrorPill/index.tsx
@@ -22,7 +22,9 @@ export const ErrorPill: React.FC<ErrorPillProps> = (props) => {
     .filter(Boolean)
     .join(' ')
 
-  if (count === 0) return null
+  if (count === 0) {
+    return null
+  }
 
   return (
     <div className={classes}>

--- a/packages/ui/src/elements/FieldSelect/index.tsx
+++ b/packages/ui/src/elements/FieldSelect/index.tsx
@@ -57,7 +57,9 @@ export const combineLabel = ({
       RenderedComponent: customLabel,
     }
 
-  if (!LabelToRender) return null
+  if (!LabelToRender) {
+    return null
+  }
 
   return (
     <Fragment>

--- a/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/ListDrawer/DrawerContent.tsx
@@ -185,11 +185,21 @@ export const ListDrawerContent: React.FC<ListDrawerProps> = ({
       }
     }
 
-    if (page) params.page = page
-    if (sort) params.sort = sort
-    if (cacheBust) params.cacheBust = cacheBust
-    if (copyOfWhere) params.where = copyOfWhere
-    if (versions?.drafts) params.draft = 'true'
+    if (page) {
+      params.page = page
+    }
+    if (sort) {
+      params.sort = sort
+    }
+    if (cacheBust) {
+      params.cacheBust = cacheBust
+    }
+    if (copyOfWhere) {
+      params.where = copyOfWhere
+    }
+    if (versions?.drafts) {
+      params.draft = 'true'
+    }
 
     setParams(params)
   }, [page, sort, where, search, cacheBust, filterOptions, selectedCollectionConfig, t, setParams])

--- a/packages/ui/src/elements/ListDrawer/index.scss
+++ b/packages/ui/src/elements/ListDrawer/index.scss
@@ -50,7 +50,7 @@
     &:focus-within:not(:focus-visible) {
       outline: none;
     }
-    
+
     &:focus-visible {
       outline: var(--accessibility-outline);
       outline-offset: var(--accessibility-outline-offset);

--- a/packages/ui/src/elements/Pagination/index.tsx
+++ b/packages/ui/src/elements/Pagination/index.tsx
@@ -52,10 +52,14 @@ export const Pagination: React.FC<PaginationProps> = (props) => {
     totalPages = null,
   } = props
 
-  if (!totalPages || totalPages <= 1) return null
+  if (!totalPages || totalPages <= 1) {
+    return null
+  }
 
   const updatePage = (page) => {
-    if (typeof onChange === 'function') onChange(page)
+    if (typeof onChange === 'function') {
+      onChange(page)
+    }
   }
 
   // Create array of integers for each page
@@ -65,7 +69,9 @@ export const Pagination: React.FC<PaginationProps> = (props) => {
   let rangeStartIndex = currentPage - 1 - numberOfNeighbors
 
   // Sanitize rangeStartIndex in case it is less than zero for safe split
-  if (rangeStartIndex <= 0) rangeStartIndex = 0
+  if (rangeStartIndex <= 0) {
+    rangeStartIndex = 0
+  }
 
   const rangeEndIndex = currentPage - 1 + numberOfNeighbors + 1
 
@@ -73,7 +79,9 @@ export const Pagination: React.FC<PaginationProps> = (props) => {
   const nodes: Node[] = pages.slice(rangeStartIndex, rangeEndIndex)
 
   // Add prev separator if necessary
-  if (currentPage - numberOfNeighbors - 1 >= 2) nodes.unshift({ type: 'Separator' })
+  if (currentPage - numberOfNeighbors - 1 >= 2) {
+    nodes.unshift({ type: 'Separator' })
+  }
   // Add first page if necessary
   if (currentPage > numberOfNeighbors + 1) {
     nodes.unshift({
@@ -87,7 +95,9 @@ export const Pagination: React.FC<PaginationProps> = (props) => {
   }
 
   // Add next separator if necessary
-  if (currentPage + numberOfNeighbors + 1 < totalPages) nodes.push({ type: 'Separator' })
+  if (currentPage + numberOfNeighbors + 1 < totalPages) {
+    nodes.push({ type: 'Separator' })
+  }
   // Add last page if necessary
   if (rangeEndIndex < totalPages) {
     nodes.push({

--- a/packages/ui/src/elements/PerPage/index.tsx
+++ b/packages/ui/src/elements/PerPage/index.tsx
@@ -54,7 +54,9 @@ export const PerPage: React.FC<PerPageProps> = ({
                 key={i}
                 onClick={() => {
                   close()
-                  if (handleChange) handleChange(limitNumber)
+                  if (handleChange) {
+                    handleChange(limitNumber)
+                  }
                 }}
               >
                 {limitNumber === limitToUse && (

--- a/packages/ui/src/elements/Pill/index.tsx
+++ b/packages/ui/src/elements/Pill/index.tsx
@@ -95,8 +95,12 @@ const StaticPill: React.FC<PillProps> = (props) => {
 
   let Element: ElementType | React.FC<RenderedTypeProps> = 'div'
 
-  if (onClick && !to) Element = 'button'
-  if (to) Element = Link
+  if (onClick && !to) {
+    Element = 'button'
+  }
+  if (to) {
+    Element = Link
+  }
 
   return (
     <Element
@@ -119,6 +123,8 @@ const StaticPill: React.FC<PillProps> = (props) => {
 export const Pill: React.FC<PillProps> = (props) => {
   const { draggable } = props
 
-  if (draggable) return <DraggablePill {...props} />
+  if (draggable) {
+    return <DraggablePill {...props} />
+  }
   return <StaticPill {...props} />
 }

--- a/packages/ui/src/elements/Popup/PopupTrigger/index.tsx
+++ b/packages/ui/src/elements/Popup/PopupTrigger/index.tsx
@@ -41,7 +41,9 @@ export const PopupTrigger: React.FC<PopupTriggerProps> = (props) => {
         className={classes}
         onClick={handleClick}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') handleClick()
+          if (e.key === 'Enter') {
+            handleClick()
+          }
         }}
         role="button"
         tabIndex={0}

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -133,7 +133,9 @@ export const Popup: React.FC<PopupProps> = (props) => {
   }, [intersectionEntry, setPosition, windowHeight])
 
   useEffect(() => {
-    if (typeof onToggleOpen === 'function') onToggleOpen(active)
+    if (typeof onToggleOpen === 'function') {
+      onToggleOpen(active)
+    }
 
     if (active) {
       document.addEventListener('mousedown', handleClickOutside)

--- a/packages/ui/src/elements/PreviewButton/usePreviewURL.tsx
+++ b/packages/ui/src/elements/PreviewButton/usePreviewURL.tsx
@@ -35,25 +35,37 @@ export const usePreviewURL = (): {
   // this will ensure the latest data is used when generating the preview URL
   const generatePreviewURL = useCallback(
     async ({ openPreviewWindow = false }) => {
-      if (isGeneratingPreviewURL.current) return
+      if (isGeneratingPreviewURL.current) {
+        return
+      }
       isGeneratingPreviewURL.current = true
 
       try {
         setIsLoading(true)
 
         let url = `${serverURL}${api}`
-        if (collectionSlug) url = `${url}/${collectionSlug}/${id}/preview`
-        if (globalSlug) url = `${url}/globals/${globalSlug}/preview`
+        if (collectionSlug) {
+          url = `${url}/${collectionSlug}/${id}/preview`
+        }
+        if (globalSlug) {
+          url = `${url}/globals/${globalSlug}/preview`
+        }
 
         const res = await fetch(`${url}${locale ? `?locale=${locale}` : ''}`)
 
-        if (!res.ok) throw new Error()
+        if (!res.ok) {
+          throw new Error()
+        }
         const newPreviewURL = await res.json()
-        if (!newPreviewURL) throw new Error()
+        if (!newPreviewURL) {
+          throw new Error()
+        }
         setPreviewURL(newPreviewURL)
         setIsLoading(false)
         isGeneratingPreviewURL.current = false
-        if (openPreviewWindow) window.open(newPreviewURL, '_blank')
+        if (openPreviewWindow) {
+          window.open(newPreviewURL, '_blank')
+        }
       } catch (err) {
         setIsLoading(false)
         isGeneratingPreviewURL.current = false

--- a/packages/ui/src/elements/PreviewSizes/index.tsx
+++ b/packages/ui/src/elements/PreviewSizes/index.tsx
@@ -16,7 +16,9 @@ type FilesSizesWithUrl = {
 }
 
 const sortSizes = (sizes: FilesSizesWithUrl, imageSizes: SanitizedUploadConfig['imageSizes']) => {
-  if (!imageSizes || imageSizes.length === 0) return sizes
+  if (!imageSizes || imageSizes.length === 0) {
+    return sizes
+  }
 
   const orderedSizes: FilesSizesWithUrl = {}
 
@@ -50,8 +52,12 @@ const PreviewSizeCard: React.FC<PreviewSizeCardProps> = ({
         .join(' ')}
       onClick={typeof onClick === 'function' ? onClick : undefined}
       onKeyDown={(e) => {
-        if (typeof onClick !== 'function') return
-        if (e.key === 'Enter') onClick()
+        if (typeof onClick !== 'function') {
+          return
+        }
+        if (e.key === 'Enter') {
+          onClick()
+        }
       }}
       role="button"
       tabIndex={0}
@@ -85,8 +91,12 @@ export const PreviewSizes: React.FC<PreviewSizesProps> = ({ doc, imageCacheTag, 
   const [selectedSize, setSelectedSize] = useState<null | string>(null)
 
   const generateImageUrl = (doc) => {
-    if (!doc.filename) return null
-    if (doc.url) return `${doc.url}${imageCacheTag ? `?${imageCacheTag}` : ''}`
+    if (!doc.filename) {
+      return null
+    }
+    if (doc.url) {
+      return `${doc.url}${imageCacheTag ? `?${imageCacheTag}` : ''}`
+    }
   }
   useEffect(() => {
     setOrderedSizes(sortSizes(sizes, imageSizes))

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -48,7 +48,9 @@ export const DefaultPublishButton: React.FC<{ label?: string }> = ({ label: labe
   const forceDisable = operation === 'update' && !modified
 
   const saveDraft = useCallback(async () => {
-    if (forceDisable) return
+    if (forceDisable) {
+      return
+    }
 
     const search = `?locale=${locale}&depth=0&fallback-locale=null&draft=true`
     let action
@@ -56,7 +58,9 @@ export const DefaultPublishButton: React.FC<{ label?: string }> = ({ label: labe
 
     if (collectionSlug) {
       action = `${serverURL}${api}/${collectionSlug}${id ? `/${id}` : ''}${search}`
-      if (id) method = 'PATCH'
+      if (id) {
+        method = 'PATCH'
+      }
     }
 
     if (globalSlug) {
@@ -90,7 +94,9 @@ export const DefaultPublishButton: React.FC<{ label?: string }> = ({ label: labe
     })
   }, [submit])
 
-  if (!hasPublishPermission) return null
+  if (!hasPublishPermission) {
+    return null
+  }
 
   return (
     <FormSubmit
@@ -110,6 +116,8 @@ type Props = {
 }
 
 export const PublishButton: React.FC<Props> = ({ CustomComponent }) => {
-  if (CustomComponent) return <RenderComponent mappedComponent={CustomComponent} />
+  if (CustomComponent) {
+    return <RenderComponent mappedComponent={CustomComponent} />
+  }
   return <DefaultPublishButton />
 }

--- a/packages/ui/src/elements/ReactSelect/DropdownIndicator/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/DropdownIndicator/index.tsx
@@ -24,7 +24,9 @@ export const DropdownIndicator: React.FC<
       ref={ref}
       {...restInnerProps}
       onKeyDown={(e) => {
-        if (e.key === 'Enter') e.key = ' '
+        if (e.key === 'Enter') {
+          e.key = ' '
+        }
       }}
       type="button"
     >

--- a/packages/ui/src/elements/ReactSelect/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/index.tsx
@@ -129,7 +129,9 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
         return
       }
     }
-    if (!value || !inputValue || inputValue.trim() === '') return
+    if (!value || !inputValue || inputValue.trim() === '') {
+      return
+    }
     if (filterOption && !filterOption(null, inputValue)) {
       return
     }

--- a/packages/ui/src/elements/SaveButton/index.tsx
+++ b/packages/ui/src/elements/SaveButton/index.tsx
@@ -56,6 +56,8 @@ type Props = {
 }
 
 export const SaveButton: React.FC<Props> = ({ CustomComponent }) => {
-  if (CustomComponent) return <RenderComponent mappedComponent={CustomComponent} />
+  if (CustomComponent) {
+    return <RenderComponent mappedComponent={CustomComponent} />
+  }
   return <DefaultSaveButton />
 }

--- a/packages/ui/src/elements/SaveDraftButton/index.tsx
+++ b/packages/ui/src/elements/SaveDraftButton/index.tsx
@@ -36,7 +36,9 @@ export const DefaultSaveDraftButton: React.FC = () => {
   const forceDisable = operation === 'update' && !modified
 
   const saveDraft = useCallback(async () => {
-    if (forceDisable) return
+    if (forceDisable) {
+      return
+    }
 
     const search = `?locale=${locale}&depth=0&fallback-locale=null&draft=true`
     let action
@@ -44,7 +46,9 @@ export const DefaultSaveDraftButton: React.FC = () => {
 
     if (collectionSlug) {
       action = `${serverURL}${api}/${collectionSlug}${id ? `/${id}` : ''}${search}`
-      if (id) method = 'PATCH'
+      if (id) {
+        method = 'PATCH'
+      }
     }
 
     if (globalSlug) {
@@ -96,6 +100,8 @@ type Props = {
 }
 
 export const SaveDraftButton: React.FC<Props> = ({ CustomComponent }) => {
-  if (CustomComponent) return <RenderComponent mappedComponent={CustomComponent} />
+  if (CustomComponent) {
+    return <RenderComponent mappedComponent={CustomComponent} />
+  }
   return <DefaultSaveDraftButton />
 }

--- a/packages/ui/src/elements/SearchFilter/index.tsx
+++ b/packages/ui/src/elements/SearchFilter/index.tsx
@@ -28,7 +28,9 @@ export const SearchFilter: React.FC<SearchFilterProps> = (props) => {
 
   useEffect(() => {
     if (debouncedSearch !== previousSearch.current) {
-      if (handleChange) handleChange(debouncedSearch)
+      if (handleChange) {
+        handleChange(debouncedSearch)
+      }
 
       previousSearch.current = debouncedSearch
     }

--- a/packages/ui/src/elements/ShimmerEffect/index.tsx
+++ b/packages/ui/src/elements/ShimmerEffect/index.tsx
@@ -55,7 +55,9 @@ export const StaggeredShimmers: React.FC<StaggeredShimmersProps> = ({
   const shimmerDelayToPass = typeof shimmerDelay === 'number' ? `${shimmerDelay}ms` : shimmerDelay
   const [hasDelayed] = useDelay(renderDelay, true)
 
-  if (!hasDelayed) return null
+  if (!hasDelayed) {
+    return null
+  }
 
   return (
     <div className={className}>

--- a/packages/ui/src/elements/SortColumn/index.tsx
+++ b/packages/ui/src/elements/SortColumn/index.tsx
@@ -31,10 +31,14 @@ export const SortColumn: React.FC<SortColumnProps> = (props) => {
   const asc = name
 
   const ascClasses = [`${baseClass}__asc`]
-  if (sort === asc) ascClasses.push(`${baseClass}--active`)
+  if (sort === asc) {
+    ascClasses.push(`${baseClass}--active`)
+  }
 
   const descClasses = [`${baseClass}__desc`]
-  if (sort === desc) descClasses.push(`${baseClass}--active`)
+  if (sort === desc) {
+    descClasses.push(`${baseClass}--active`)
+  }
 
   const setSort = useCallback(
     async (newSort: string) => {

--- a/packages/ui/src/elements/SortComplex/index.tsx
+++ b/packages/ui/src/elements/SortComplex/index.tsx
@@ -54,7 +54,9 @@ export const SortComplex: React.FC<SortComplexProps> = (props) => {
     if (sortField?.value) {
       const newSortValue = `${sortOrder.value}${sortField.value}`
 
-      if (handleChange) handleChange(newSortValue)
+      if (handleChange) {
+        handleChange(newSortValue)
+      }
 
       if (searchParams.sort !== newSortValue && modifySearchQuery) {
         const search = qs.stringify(

--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -58,9 +58,15 @@ export const buildColumnState = (args: Args): Column[] => {
     sortedFieldMap = sortedFieldMap.sort((a, b) => {
       const aIndex = sortTo.findIndex((column) => 'name' in a && column.accessor === a.name)
       const bIndex = sortTo.findIndex((column) => 'name' in b && column.accessor === b.name)
-      if (aIndex === -1 && bIndex === -1) return 0
-      if (aIndex === -1) return 1
-      if (bIndex === -1) return -1
+      if (aIndex === -1 && bIndex === -1) {
+        return 0
+      }
+      if (aIndex === -1) {
+        return 1
+      }
+      if (bIndex === -1) {
+        return -1
+      }
       return aIndex - bIndex
     })
   }

--- a/packages/ui/src/elements/TableColumns/index.tsx
+++ b/packages/ui/src/elements/TableColumns/index.tsx
@@ -91,7 +91,9 @@ export const TableColumnsProvider: React.FC<Props> = ({
     let foundFirstActive = false
     const newColumns = columns.map((col) => {
       const linkColumn = col.active && !foundFirstActive && col.accessor !== '_select'
-      if (linkColumn) foundFirstActive = true
+      if (linkColumn) {
+        foundFirstActive = true
+      }
 
       return {
         ...col,

--- a/packages/ui/src/elements/Tooltip/index.tsx
+++ b/packages/ui/src/elements/Tooltip/index.tsx
@@ -55,12 +55,16 @@ export const Tooltip: React.FC<Props> = (props) => {
     }
 
     return () => {
-      if (timerId) clearTimeout(timerId)
+      if (timerId) {
+        clearTimeout(timerId)
+      }
     }
   }, [showFromProps, delay])
 
   useEffect(() => {
-    if (staticPositioning) return
+    if (staticPositioning) {
+      return
+    }
     setPosition(intersectionEntry?.isIntersecting ? 'top' : 'bottom')
   }, [intersectionEntry, staticPositioning])
 

--- a/packages/ui/src/elements/Upload/index.scss
+++ b/packages/ui/src/elements/Upload/index.scss
@@ -97,7 +97,7 @@
 
   &__dropzoneButtons {
     display: flex;
-    gap: calc(var(--base) * .5);
+    gap: calc(var(--base) * 0.5);
   }
 
   &__orText {

--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -50,7 +50,9 @@ export const UploadActions = ({
 
   const fileTypeIsAdjustable = isImage(mimeType) && mimeType !== 'image/svg+xml'
 
-  if (!fileTypeIsAdjustable && (!customActions || customActions.length === 0)) return null
+  if (!fileTypeIsAdjustable && (!customActions || customActions.length === 0)) {
+    return null
+  }
 
   return (
     <div className={`${baseClass}__upload-actions`}>

--- a/packages/ui/src/elements/WhereBuilder/reduceClientFields.tsx
+++ b/packages/ui/src/elements/WhereBuilder/reduceClientFields.tsx
@@ -29,7 +29,9 @@ export const reduceClientFields = ({
   pathPrefix,
 }: ReduceClientFieldsArgs): FieldCondition[] => {
   return fields.reduce((reduced, field) => {
-    if (field.admin?.disableListFilter) return reduced
+    if (field.admin?.disableListFilter) {
+      return reduced
+    }
 
     if (field.type === 'tabs' && 'tabs' in field) {
       const tabs = field.tabs

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -89,8 +89,12 @@ export const ArrayFieldComponent: React.FC<ArrayFieldProps> = (props) => {
 
   // Handle labeling for Arrays, Global Arrays, and Blocks
   const getLabels = (p: ArrayFieldProps): Partial<ArrayFieldType['labels']> => {
-    if ('labels' in p && p?.labels) return p.labels
-    if ('label' in p.field && p.field.label) return { plural: undefined, singular: p.field.label }
+    if ('labels' in p && p?.labels) {
+      return p.labels
+    }
+    if ('label' in p.field && p.field.label) {
+      return { plural: undefined, singular: p.field.label }
+    }
     return { plural: t('general:rows'), singular: t('general:row') }
   }
 

--- a/packages/ui/src/fields/Blocks/BlocksDrawer/index.tsx
+++ b/packages/ui/src/fields/Blocks/BlocksDrawer/index.tsx
@@ -24,7 +24,9 @@ export type Props = {
 const baseClass = 'blocks-drawer'
 
 const getBlockLabel = (block: ClientBlock, i18n: I18nClient) => {
-  if (typeof block.labels.singular === 'string') return block.labels.singular.toLowerCase()
+  if (typeof block.labels.singular === 'string') {
+    return block.labels.singular.toLowerCase()
+  }
   if (typeof block.labels.singular === 'object') {
     return getTranslation(block.labels.singular, i18n).toLowerCase()
   }
@@ -50,7 +52,9 @@ export const BlocksDrawer: React.FC<Props> = (props) => {
 
     const matchingBlocks = blocks?.reduce((matchedBlocks, block) => {
       const blockLabel = getBlockLabel(block, i18n)
-      if (blockLabel.includes(searchTermToUse)) matchedBlocks.push(block)
+      if (blockLabel.includes(searchTermToUse)) {
+        matchedBlocks.push(block)
+      }
       return matchedBlocks
     }, [])
 

--- a/packages/ui/src/fields/Checkbox/index.tsx
+++ b/packages/ui/src/fields/Checkbox/index.tsx
@@ -76,7 +76,9 @@ const CheckboxFieldComponent: React.FC<CheckboxFieldProps> = (props) => {
   const onToggle = useCallback(() => {
     if (!disabled) {
       setValue(!value)
-      if (typeof onChangeFromProps === 'function') onChangeFromProps(!value)
+      if (typeof onChangeFromProps === 'function') {
+        onChangeFromProps(!value)
+      }
     }
   }, [onChangeFromProps, disabled, setValue, value])
 

--- a/packages/ui/src/fields/Collapsible/index.tsx
+++ b/packages/ui/src/fields/Collapsible/index.tsx
@@ -110,7 +110,9 @@ const CollapsibleFieldComponent: React.FC<CollapsibleFieldProps> = (props) => {
     void fetchInitialState()
   }, [getPreference, preferencesKey, fieldPreferencesKey, initCollapsed, path])
 
-  if (typeof collapsedOnMount !== 'boolean') return null
+  if (typeof collapsedOnMount !== 'boolean') {
+    return null
+  }
 
   const disabled = readOnlyFromProps || readOnlyFromContext || formProcessing || formInitializing
 

--- a/packages/ui/src/fields/DateTime/index.tsx
+++ b/packages/ui/src/fields/DateTime/index.tsx
@@ -99,7 +99,9 @@ const DateTimeFieldComponent: React.FC<DateFieldProps> = (props) => {
         <DatePickerField
           {...datePickerProps}
           onChange={(incomingDate) => {
-            if (!disabled) setValue(incomingDate?.toISOString() || null)
+            if (!disabled) {
+              setValue(incomingDate?.toISOString() || null)
+            }
           }}
           placeholder={getTranslation(placeholder, i18n)}
           readOnly={disabled}

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -49,8 +49,9 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
 
   const memoizedValidate = useCallback(
     (value, options) => {
-      if (typeof validate === 'function')
+      if (typeof validate === 'function') {
         return validate(value, { ...options, jsonError, required })
+      }
     },
     [validate, required, jsonError],
   )
@@ -67,7 +68,9 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
 
   const handleMount = useCallback(
     (editor, monaco) => {
-      if (!jsonSchema) return
+      if (!jsonSchema) {
+        return
+      }
 
       const existingSchemas = monaco.languages.json.jsonDefaults.diagnosticsOptions.schemas || []
       const modelUri = monaco.Uri.parse(jsonSchema.uri)
@@ -86,7 +89,9 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
 
   const handleChange = useCallback(
     (val) => {
-      if (disabled) return
+      if (disabled) {
+        return
+      }
       setStringValue(val)
 
       try {
@@ -101,7 +106,9 @@ const JSONFieldComponent: React.FC<JSONFieldProps> = (props) => {
   )
 
   useEffect(() => {
-    if (hasLoadedValue || value === undefined) return
+    if (hasLoadedValue || value === undefined) {
+      return
+    }
 
     setStringValue(
       value || initialValue ? JSON.stringify(value ? value : initialValue, null, 2) : '',

--- a/packages/ui/src/fields/RadioGroup/index.tsx
+++ b/packages/ui/src/fields/RadioGroup/index.tsx
@@ -50,8 +50,9 @@ const RadioGroupFieldComponent: React.FC<RadioFieldProps> = (props) => {
 
   const memoizedValidate = useCallback(
     (value, validationOptions) => {
-      if (typeof validate === 'function')
+      if (typeof validate === 'function') {
         return validate(value, { ...validationOptions, options, required })
+      }
     },
     [validate, options, required],
   )

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -260,7 +260,9 @@ const RelationshipFieldComponent: React.FC<RelationshipFieldProps> = (props) => 
           }
         }, Promise.resolve())
 
-        if (typeof onSuccess === 'function') onSuccess()
+        if (typeof onSuccess === 'function') {
+          onSuccess()
+        }
       }
     },
     [
@@ -466,7 +468,9 @@ const RelationshipFieldComponent: React.FC<RelationshipFieldProps> = (props) => 
 
   const valueToRender = findOptionsByValue({ options, value })
 
-  if (!Array.isArray(valueToRender) && valueToRender?.value === 'null') valueToRender.value = null
+  if (!Array.isArray(valueToRender) && valueToRender?.value === 'null') {
+    valueToRender.value = null
+  }
 
   return (
     <div
@@ -518,7 +522,9 @@ const RelationshipFieldComponent: React.FC<RelationshipFieldProps> = (props) => 
               disabled={readOnly || formProcessing || drawerIsOpen}
               filterOption={enableWordBoundarySearch ? filterOption : undefined}
               getOptionValue={(option) => {
-                if (!option) return undefined
+                if (!option) {
+                  return undefined
+                }
                 return hasMany && Array.isArray(relationTo)
                   ? `${option.relationTo}_${option.value}`
                   : option.value

--- a/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
@@ -41,7 +41,9 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
   })
 
   useEffect(() => {
-    if (typeof setDrawerIsOpen === 'function') setDrawerIsOpen(isDrawerOpen)
+    if (typeof setDrawerIsOpen === 'function') {
+      setDrawerIsOpen(isDrawerOpen)
+    }
   }, [isDrawerOpen, setDrawerIsOpen])
 
   return (

--- a/packages/ui/src/fields/Select/index.tsx
+++ b/packages/ui/src/fields/Select/index.tsx
@@ -53,8 +53,9 @@ const SelectFieldComponent: React.FC<SelectFieldProps> = (props) => {
 
   const memoizedValidate = useCallback(
     (value, validationOptions) => {
-      if (typeof validate === 'function')
+      if (typeof validate === 'function') {
         return validate(value, { ...validationOptions, hasMany, options, required })
+      }
     },
     [validate, required, hasMany, options],
   )

--- a/packages/ui/src/fields/Text/index.tsx
+++ b/packages/ui/src/fields/Text/index.tsx
@@ -55,8 +55,9 @@ const TextFieldComponent: React.FC<TextFieldProps> = (props) => {
 
   const memoizedValidate = useCallback(
     (value, options) => {
-      if (typeof validate === 'function')
+      if (typeof validate === 'function') {
         return validate(value, { ...options, maxLength, minLength, required })
+      }
     },
     [validate, minLength, maxLength, required],
   )

--- a/packages/ui/src/fields/Textarea/index.tsx
+++ b/packages/ui/src/fields/Textarea/index.tsx
@@ -64,8 +64,9 @@ const TextareaFieldComponent: React.FC<TextareaFieldProps> = (props) => {
 
   const memoizedValidate: TextareaFieldValidation = useCallback(
     (value, options) => {
-      if (typeof validate === 'function')
+      if (typeof validate === 'function') {
         return validate(value, { ...options, maxLength, minLength, required })
+      }
     },
     [validate, required, maxLength, minLength],
   )

--- a/packages/ui/src/fields/Upload/HasMany/index.tsx
+++ b/packages/ui/src/fields/Upload/HasMany/index.tsx
@@ -30,7 +30,9 @@ export function UploadComponentHasMany(props: Props) {
 
   const moveRow = React.useCallback(
     (moveFromIndex: number, moveToIndex: number) => {
-      if (moveFromIndex === moveToIndex) return
+      if (moveFromIndex === moveToIndex) {
+        return
+      }
 
       const updatedArray = [...fileDocs]
       const [item] = updatedArray.splice(moveFromIndex, 1)

--- a/packages/ui/src/fields/Upload/HasOne/index.scss
+++ b/packages/ui/src/fields/Upload/HasOne/index.scss
@@ -4,4 +4,3 @@
   position: relative;
   max-width: 100%;
 }
-

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -258,10 +258,14 @@ export function UploadInput(props: UploadInputProps) {
         dataTransfer.items.add(fileList[0])
         fileListToUse = dataTransfer.files
       }
-      if (fileListToUse) setInitialFiles(fileListToUse)
+      if (fileListToUse) {
+        setInitialFiles(fileListToUse)
+      }
       setCollectionSlug(relationTo)
       setOnSuccess(onUploadSuccess)
-      if (typeof maxRows === 'number') setMaxFiles(maxRows)
+      if (typeof maxRows === 'number') {
+        setMaxFiles(maxRows)
+      }
       openModal(drawerSlug)
     },
     [

--- a/packages/ui/src/fields/Upload/RelationshipContent/index.scss
+++ b/packages/ui/src/fields/Upload/RelationshipContent/index.scss
@@ -22,7 +22,7 @@
     flex-direction: column;
     gap: 0;
     overflow: hidden;
-    margin-right: calc(var(--base)* 2);
+    margin-right: calc(var(--base) * 2);
   }
 
   &__title {

--- a/packages/ui/src/fields/Upload/UploadCard/index.scss
+++ b/packages/ui/src/fields/Upload/UploadCard/index.scss
@@ -8,7 +8,7 @@
   gap: calc(var(--base) / 2);
 
   &--size-medium {
-    padding: calc(var(--base) * .5);
+    padding: calc(var(--base) * 0.5);
 
     .thumbnail {
       width: 40px;
@@ -18,10 +18,10 @@
 
   &--size-small {
     padding: calc(var(--base) / 3) calc(var(--base) / 2);
-    
+
     .thumbnail {
       width: 25px;
       height: 25px;
     }
-  };
+  }
 }

--- a/packages/ui/src/fields/Upload/index.scss
+++ b/packages/ui/src/fields/Upload/index.scss
@@ -22,12 +22,12 @@
     .btn .btn__content {
       gap: calc(var(--base) / 5);
     }
-    
+
     .btn__label {
       font-weight: 100;
     }
   }
-  
+
   &__dropzoneContent__orText {
     color: var(--theme-elevation-500);
     text-transform: lowercase;

--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -44,7 +44,9 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
 
     case 'REMOVE': {
       const newState = { ...state }
-      if (newState[action.path]) delete newState[action.path]
+      if (newState[action.path]) {
+        delete newState[action.path]
+      }
       return newState
     }
 
@@ -251,7 +253,9 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
       const rowsMetadata = [...(state[path].rows || [])]
 
       const duplicateRowMetadata = deepCopyObjectSimple(rowsMetadata[rowIndex])
-      if (duplicateRowMetadata.id) duplicateRowMetadata.id = new ObjectId().toHexString()
+      if (duplicateRowMetadata.id) {
+        duplicateRowMetadata.id = new ObjectId().toHexString()
+      }
 
       const duplicateRowState = deepCopyObject(rows[rowIndex])
       if (duplicateRowState.id) {

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -220,7 +220,9 @@ export const Form: React.FC<FormProps> = (props) => {
       setProcessing(true)
       setDisabled(true)
 
-      if (waitForAutocomplete) await wait(100)
+      if (waitForAutocomplete) {
+        await wait(100)
+      }
 
       // Execute server side validations
       if (Array.isArray(beforeSubmit)) {
@@ -307,9 +309,13 @@ export const Form: React.FC<FormProps> = (props) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let json: Record<string, any> = {}
 
-        if (isJSON) json = await res.json()
+        if (isJSON) {
+          json = await res.json()
+        }
         if (res.status < 400) {
-          if (typeof onSuccess === 'function') await onSuccess(json)
+          if (typeof onSuccess === 'function') {
+            await onSuccess(json)
+          }
           setSubmitted(false)
           setProcessing(false)
 
@@ -562,11 +568,15 @@ export const Form: React.FC<FormProps> = (props) => {
   }, [])
 
   useEffect(() => {
-    if (typeof disabledFromProps === 'boolean') setDisabled(disabledFromProps)
+    if (typeof disabledFromProps === 'boolean') {
+      setDisabled(disabledFromProps)
+    }
   }, [disabledFromProps])
 
   useEffect(() => {
-    if (typeof submittedFromProps === 'boolean') setSubmitted(submittedFromProps)
+    if (typeof submittedFromProps === 'boolean') {
+      setSubmitted(submittedFromProps)
+    }
   }, [submittedFromProps])
 
   useEffect(() => {
@@ -618,7 +628,9 @@ export const Form: React.FC<FormProps> = (props) => {
         }
       }
 
-      if (modified) void executeOnChange()
+      if (modified) {
+        void executeOnChange()
+      }
     },
     150,
     // Make sure we trigger this whenever modified changes (not just when `fields` changes), otherwise we will miss merging server form state for the first form update/onChange. Here's why:

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -24,7 +24,9 @@ export const mergeServerFormState = (
 
   if (existingState) {
     Object.entries(existingState).forEach(([path, newFieldState]) => {
-      if (!incomingState[path]) return
+      if (!incomingState[path]) {
+        return
+      }
 
       /**
        * Handle error paths

--- a/packages/ui/src/forms/Form/rowHelpers.ts
+++ b/packages/ui/src/forms/Form/rowHelpers.ts
@@ -15,8 +15,12 @@ export const extractRowsAndCollapsedIDs = ({
 } => {
   return rows.reduce(
     (acc, row) => {
-      if (rowID === row.id) row.collapsed = collapsed
-      if (row.collapsed) acc.collapsedIDs.push(row.id)
+      if (rowID === row.id) {
+        row.collapsed = collapsed
+      }
+      if (row.collapsed) {
+        acc.collapsedIDs.push(row.id)
+      }
       acc.updatedRows.push(row)
       return acc
     },
@@ -37,7 +41,9 @@ export const toggleAllRows = ({
   return rows.reduce(
     (acc, row) => {
       row.collapsed = collapsed
-      if (collapsed) acc.collapsedIDs.push(row.id)
+      if (collapsed) {
+        acc.collapsedIDs.push(row.id)
+      }
       acc.updatedRows.push(row)
       return acc
     },

--- a/packages/ui/src/forms/Form/rows.ts
+++ b/packages/ui/src/forms/Form/rows.ts
@@ -14,7 +14,9 @@ export const separateRows = (path: string, fields: FormState): Result => {
 
     if (fieldPath.indexOf(`${path}.`) === 0) {
       const [rowIndex] = fieldPath.replace(`${path}.`, '').split('.')
-      if (!newRows[rowIndex]) newRows[rowIndex] = {}
+      if (!newRows[rowIndex]) {
+        newRows[rowIndex] = {}
+      }
       newRows[rowIndex][fieldPath.replace(`${path}.${String(rowIndex)}.`, '')] = { ...field }
     } else {
       remainingFields[fieldPath] = field

--- a/packages/ui/src/forms/NullifyField/index.tsx
+++ b/packages/ui/src/forms/NullifyField/index.tsx
@@ -35,11 +35,17 @@ export const NullifyLocaleField: React.FC<NullifyLocaleFieldProps> = ({
 
   if (fieldValue) {
     let hideCheckbox = false
-    if (typeof fieldValue === 'number' && fieldValue > 0) hideCheckbox = true
-    if (Array.isArray(fieldValue) && fieldValue.length > 0) hideCheckbox = true
+    if (typeof fieldValue === 'number' && fieldValue > 0) {
+      hideCheckbox = true
+    }
+    if (Array.isArray(fieldValue) && fieldValue.length > 0) {
+      hideCheckbox = true
+    }
 
     if (hideCheckbox) {
-      if (checked) setChecked(false) // uncheck when field has value
+      if (checked) {
+        setChecked(false)
+      } // uncheck when field has value
       return null
     }
   }

--- a/packages/ui/src/forms/RenderFields/RenderField.tsx
+++ b/packages/ui/src/forms/RenderFields/RenderField.tsx
@@ -57,8 +57,9 @@ export const RenderField: React.FC<Props> = ({
   fieldComponentProps.readOnly = fieldComponentProps?.field?.admin?.readOnly
 
   // if parent field is `readOnly: true`, but this field is `readOnly: false`, the field should still be editable
-  if (readOnlyFromContext && fieldComponentProps.readOnly !== false)
+  if (readOnlyFromContext && fieldComponentProps.readOnly !== false) {
     fieldComponentProps.readOnly = true
+  }
 
   // if the user does not have access control to begin with, force it to be read-only
   if (permissions?.[operation]?.permission === false) {

--- a/packages/ui/src/forms/buildStateFromSchema/calculateDefaultValues/promise.ts
+++ b/packages/ui/src/forms/buildStateFromSchema/calculateDefaultValues/promise.ts
@@ -40,7 +40,9 @@ export const defaultValuePromise = async <T>({
   // Traverse subfields
   switch (field.type) {
     case 'group': {
-      if (typeof siblingData[field.name] !== 'object') siblingData[field.name] = {}
+      if (typeof siblingData[field.name] !== 'object') {
+        siblingData[field.name] = {}
+      }
 
       const groupData = siblingData[field.name] as Record<string, unknown>
 
@@ -125,7 +127,9 @@ export const defaultValuePromise = async <T>({
     case 'tab': {
       let tabSiblingData
       if (tabHasName(field)) {
-        if (typeof siblingData[field.name] !== 'object') siblingData[field.name] = {}
+        if (typeof siblingData[field.name] !== 'object') {
+          siblingData[field.name] = {}
+        }
 
         tabSiblingData = siblingData[field.name] as Record<string, unknown>
       } else {

--- a/packages/ui/src/graphics/Account/index.tsx
+++ b/packages/ui/src/graphics/Account/index.tsx
@@ -36,6 +36,10 @@ export const Account = () => {
     )
   }
 
-  if (!user?.email || avatar === 'default') return <DefaultAccountIcon active={isOnAccountPage} />
-  if (avatar === 'gravatar') return <GravatarAccountIcon />
+  if (!user?.email || avatar === 'default') {
+    return <DefaultAccountIcon active={isOnAccountPage} />
+  }
+  if (avatar === 'gravatar') {
+    return <GravatarAccountIcon />
+  }
 }

--- a/packages/ui/src/hooks/useHotkey.ts
+++ b/packages/ui/src/hooks/useHotkey.ts
@@ -93,7 +93,9 @@ export const useHotkey = (
         }
       })
 
-      if (e.code) pushToKeys(e.code)
+      if (e.code) {
+        pushToKeys(e.code)
+      }
 
       // Check for Mac and iPad
       const hasCmd = window.navigator.userAgent.includes('Mac OS X')
@@ -122,7 +124,9 @@ export const useHotkey = (
   )
 
   const keyup = useCallback((e: KeyboardEvent) => {
-    if (e.code) removeFromKeys(e.code)
+    if (e.code) {
+      removeFromKeys(e.code)
+    }
   }, [])
 
   useEffect(() => {

--- a/packages/ui/src/hooks/useIntersect.ts
+++ b/packages/ui/src/hooks/useIntersect.ts
@@ -34,7 +34,9 @@ export const useIntersect = (
     const { current: currentObserver } = observer
     currentObserver.disconnect()
 
-    if (node) currentObserver.observe(node)
+    if (node) {
+      currentObserver.observe(node)
+    }
 
     return () => currentObserver.disconnect()
   }, [node, disable])

--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -287,7 +287,9 @@ export function AuthProvider({
     }
 
     return () => {
-      if (reminder) clearTimeout(reminder)
+      if (reminder) {
+        clearTimeout(reminder)
+      }
     }
   }, [tokenExpiration, openModal])
 
@@ -308,7 +310,9 @@ export function AuthProvider({
     }
 
     return () => {
-      if (forceLogOut) clearTimeout(forceLogOut)
+      if (forceLogOut) {
+        clearTimeout(forceLogOut)
+      }
     }
   }, [tokenExpiration, closeAllModals, i18n, redirectToInactivityRoute, revokeTokenAndExpire])
 

--- a/packages/ui/src/providers/Config/createClientConfig/collections.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/collections.tsx
@@ -87,7 +87,9 @@ export const createClientCollectionConfig = ({
     if ('imageSizes' in clientCollection.upload && clientCollection.upload.imageSizes.length) {
       clientCollection.upload.imageSizes = clientCollection.upload.imageSizes.map((size) => {
         const sanitizedSize = { ...size }
-        if ('generateImageName' in sanitizedSize) delete sanitizedSize.generateImageName
+        if ('generateImageName' in sanitizedSize) {
+          delete sanitizedSize.generateImageName
+        }
         return sanitizedSize
       })
     }

--- a/packages/ui/src/providers/Config/createClientConfig/getCreateMappedComponent.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/getCreateMappedComponent.tsx
@@ -56,7 +56,9 @@ export function getCreateMappedComponent({
         }
 
         // conditionally set props here to avoid bloating the HTML with `$undefined` props
-        if (clientProps) toReturn.props = clientProps
+        if (clientProps) {
+          toReturn.props = clientProps
+        }
 
         return toReturn
       }

--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -72,7 +72,9 @@ const DocumentInfo: React.FC<
   const { uploadEdits } = useUploadEdits()
 
   const [documentTitle, setDocumentTitle] = useState(() => {
-    if (!initialDataFromProps) return ''
+    if (!initialDataFromProps) {
+      return ''
+    }
 
     return formatDocTitle({
       collectionConfig,
@@ -419,7 +421,9 @@ const DocumentInfo: React.FC<
       initialDataFromProps === undefined ||
       localeChanged
     ) {
-      if (localeChanged) prevLocale.current = locale
+      if (localeChanged) {
+        prevLocale.current = locale
+      }
 
       const getInitialState = async () => {
         setIsError(false)
@@ -443,7 +447,9 @@ const DocumentInfo: React.FC<
           const data = reduceFieldsToValues(result, true)
           setData(data)
 
-          if (localeChanged) void getDocPermissions(data)
+          if (localeChanged) {
+            void getDocPermissions(data)
+          }
 
           setInitialState(result)
         } catch (err) {
@@ -541,7 +547,9 @@ const DocumentInfo: React.FC<
     })}`
   }, [baseURL, locale, pluralType, id, slug, uploadEdits])
 
-  if (isError) notFound()
+  if (isError) {
+    notFound()
+  }
 
   const value: DocumentInfoContext = {
     ...props,

--- a/packages/ui/src/providers/ListQuery/index.tsx
+++ b/packages/ui/src/providers/ListQuery/index.tsx
@@ -76,10 +76,14 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
 
   const refineListData = React.useCallback(
     async (query: RefineOverrides) => {
-      if (!modifySearchParams) return
+      if (!modifySearchParams) {
+        return
+      }
 
       let pageQuery = 'page' in query ? query.page : currentQuery?.page
-      if ('where' in query || 'search' in query) pageQuery = '1'
+      if ('where' in query || 'search' in query) {
+        pageQuery = '1'
+      }
 
       const updatedPreferences: Record<string, unknown> = {}
       let updatePreferences = false

--- a/packages/ui/src/providers/Locale/index.tsx
+++ b/packages/ui/src/providers/Locale/index.tsx
@@ -47,7 +47,9 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode }> = ({ child
         setLocaleCode(localeToSet)
         setLocale(findLocaleFromCode(localization, localeToSet))
         try {
-          if (user) await setPreference('locale', localeToSet)
+          if (user) {
+            await setPreference('locale', localeToSet)
+          }
         } catch (error) {
           // swallow error
         }

--- a/packages/ui/src/providers/Preferences/index.tsx
+++ b/packages/ui/src/providers/Preferences/index.tsx
@@ -50,7 +50,9 @@ export const PreferencesProvider: React.FC<{ children?: React.ReactNode }> = ({ 
   const getPreference = useCallback(
     async <T = any,>(key: string): Promise<T> => {
       const prefs = preferencesRef.current
-      if (typeof prefs[key] !== 'undefined') return prefs[key]
+      if (typeof prefs[key] !== 'undefined') {
+        return prefs[key]
+      }
       const promise = new Promise((resolve: (value: T) => void) => {
         void (async () => {
           const request = await requests.get(`${serverURL}${api}/payload-preferences/${key}`, {

--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -133,7 +133,9 @@ export const buildFormState = async ({ req }: { req: PayloadRequest }): Promise<
           },
         })) as unknown as { docs: { value: DocumentPreferences }[] }
 
-        if (preferencesResult?.docs?.[0]?.value) docPreferences = preferencesResult.docs[0].value
+        if (preferencesResult?.docs?.[0]?.value) {
+          docPreferences = preferencesResult.docs[0].value
+        }
       }
 
       promises.preferences = fetchPreferences()
@@ -142,7 +144,9 @@ export const buildFormState = async ({ req }: { req: PayloadRequest }): Promise<
 
   // If there is a form state,
   // then we can deduce data from that form state
-  if (formState) data = reduceFieldsToValues(formState, true)
+  if (formState) {
+    data = reduceFieldsToValues(formState, true)
+  }
 
   // If we do not have data at this point,
   // we can fetch it. This is useful for DocumentInfoProvider

--- a/packages/ui/src/utilities/reduceFieldsToValuesWithValidation.ts
+++ b/packages/ui/src/utilities/reduceFieldsToValuesWithValidation.ts
@@ -24,12 +24,16 @@ export const reduceFieldsToValuesWithValidation = (
     valid: true,
   }
 
-  if (!fields) return state
+  if (!fields) {
+    return state
+  }
 
   Object.keys(fields).forEach((key) => {
     if (ignoreDisableFormData === true || !fields[key]?.disableFormData) {
       state.data[key] = fields[key]?.value
-      if (!fields[key].valid) state.valid = false
+      if (!fields[key].valid) {
+        state.valid = false
+      }
     }
   })
 


### PR DESCRIPTION
Now enforcing curly brackets on all if statements. Includes auto-fixer.


```ts
// ❌ Bad
if (foo) foo++;

// ✅ Good
if (foo) {
  foo++;
}
```




Note: this did not lint the `drizzle` package or any `db-*` packages. This will be done in the future.