### PR TITLE
fix(ui): wrong block indication when an error occurred

### DIFF
--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -284,7 +284,7 @@ const BlocksFieldComponent: React.FC<BlockFieldProps> = (props) => {
 
             if (blockToRender) {
               const rowErrorCount = errorPaths.filter((errorPath) =>
-                errorPath.startsWith(`${path}.${i}`),
+                errorPath.startsWith(`${path}.${i}.`),
               ).length
               return (
                 <DraggableSortableItem disabled={disabled || !isSortable} id={row.id} key={row.id}>


### PR DESCRIPTION
## Description

Fix #7914

When rendering the block at position N, it checks for any errors on a path starting with N.

So the block at position 1 received error status if block 10, 11, or 100 had an error.

Now check that the path contains the full number.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
