### PR TITLE
fix(richtext-lexical): incorrect error check in TableActionMenu

### DIFF
--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TableActionMenuPlugin/index.tsx
@@ -70,7 +70,7 @@ function isTableSelectionRectangular(selection: TableSelection): boolean {
     const node = nodes[i]
     if ($isTableCellNode(node)) {
       const row = node.getParentOrThrow()
-      if ($isTableRowNode(row)) {
+      if (!$isTableRowNode(row)) {
         throw new Error('Expected CellNode to have a RowNode parent')
       }
       if (currentRow !== row) {


### PR DESCRIPTION
## Description

Fixes #7961 and #8021

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
