### PR TITLE
fix(plugin-nested-docs): add generics to generate function types

### DIFF
--- a/packages/plugin-nested-docs/src/types.ts
+++ b/packages/plugin-nested-docs/src/types.ts
@@ -4,14 +4,14 @@ export interface Breadcrumb {
   url?: string
 }
 
-export type GenerateURL = (
-  docs: Array<Record<string, unknown>>,
-  currentDoc: Record<string, unknown>,
+export type GenerateURL<T = Record<string, unknown>> = (
+  docs: Array<T>,
+  currentDoc: T,
 ) => string
 
-export type GenerateLabel = (
-  docs: Array<Record<string, unknown>>,
-  currentDoc: Record<string, unknown>,
+export type GenerateLabel<T = Record<string, unknown>> = (
+  docs: Array<T>,
+  currentDoc: T,
 ) => string
 
 export interface PluginConfig {


### PR DESCRIPTION
## Description

Noticed that I had to cast some types while writing the functions in the options for `@payload/plugin-nested-docs`. Took a page from `@payload/plugin-seo` and updated the types for these functions to accept generics, with a default that matches the previous type.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

### Details

Problem: can't determine return type from function param
```ts
nestedDocsPlugin({
  generateLabel: (_, doc) => doc.title,
                           // ^--- Type 'unknown' is not assignable to type 'string'.
}),
```

Fix: provide param type
New Problem: function doesn't match GenerateLabel signature
```ts
nestedDocsPlugin({
  generateLabel: (_, doc: Page) => doc.title,
// ^--- Type '(_: Record<string, unknown>[], doc: Page) => string' is not assignable to type 'GenerateLabel'.
}),
```

Temp fix: cast function
```ts
import { GenerateLabel } from '@payloadcms/plugin-nested-docs/types'
// ...
nestedDocsPlugin({
  generateLabel: ((_, doc: Page) => doc.title) as unknown as GenerateLabel,
                                               // ^-- no more ts error but ew.
}),
```

### Solution

After this type is updated, the first solution works:
```ts
nestedDocsPlugin({
  generateLabel: (_, doc: Page) => doc.title
}),
```

Alternatively a function assignment also works:
```ts
import { GenerateLabel } from '@payloadcms/plugin-nested-docs/types'
// ...
const generateLabel: GenerateLabel<Page>: (_, doc) => doc.title
nestedDocsPlugin({
  generateLabel
}),
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] ~~I have made corresponding changes to the documentation~~ No docs update required
