### PR TITLE
Fix: Add `collectionSlug` to live preview form state

### DIFF
--- a/packages/next/src/views/LivePreview/index.client.tsx
+++ b/packages/next/src/views/LivePreview/index.client.tsx
@@ -121,6 +121,7 @@ const PreviewView: React.FC<Props> = ({
         apiRoute,
         body: {
           id,
+          collectionSlug,
           docPreferences,
           formState: prevFormState,
           operation,
@@ -129,7 +130,7 @@ const PreviewView: React.FC<Props> = ({
         serverURL,
       })
     },
-    [serverURL, apiRoute, id, operation, schemaPath, getDocPreferences],
+    [serverURL, apiRoute, collectionSlug, id, operation, schemaPath, getDocPreferences],
   )
 
   return (


### PR DESCRIPTION
## Description

I was noticing that the `id` parameter is missing in the field validation hooks when using live preview, which caused my slug validation to fail, apparently it was caused by the missing `collectionSlug` arg in the form state request.


- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
