### PR TITLE
feat: move logger configuration to Payload config

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -75,6 +75,7 @@ The following options are available:
 | **`globals`**              | An array of Globals for Payload to manage. [More details](./globals).                                                                                                                          |
 | **`cors`**                 | Cross-origin resource sharing (CORS) is a mechanism that accept incoming requests from given domains. You can also customize the `Access-Control-Allow-Headers` header. [More details](#cors). |
 | **`localization`**         | Opt-in to translate your content into multiple locales. [More details](./localization).                                                                                                        |
+| **`logger`**               | Logger options, logger options with a destination stream, or an instantiated logger instance. [More details](https://getpino.io/#/docs/api?id=options).                                        |
 | **`graphQL`**              | Manage GraphQL-specific functionality, including custom queries and mutations, query complexity limits, etc. [More details](../graphql/overview#graphql-options).                              |
 | **`cookiePrefix`**         | A string that will be prefixed to all cookies that Payload sets.                                                                                                                               |
 | **`csrf`**                 | A whitelist array of URLs to allow Payload to accept cookies from. [More details](../authentication/overview#csrf-protection).                                                                 |
@@ -263,4 +264,4 @@ The Payload Config can accept compatibility flags for running the newest version
 
 Payload localization works on a field-by-field basis. As you can nest fields within other fields, you could potentially nest a localized field within a localized field—but this would be redundant and unnecessary. There would be no reason to define a localized field within a localized parent field, given that the entire data structure from the parent field onward would be localized.
 
-By default, Payload will remove the `localized: true` property from sub-fields if a parent field is localized. Set this compatibility flag to `true` only if you have an existing Payload MongoDB database from pre-3.0, and you have nested localized fields that you would like to maintain without migrating. 
+By default, Payload will remove the `localized: true` property from sub-fields if a parent field is localized. Set this compatibility flag to `true` only if you have an existing Payload MongoDB database from pre-3.0, and you have nested localized fields that you would like to maintain without migrating.

--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -57,7 +57,6 @@ export default buildConfig({
 | `pool` \*                   | [Pool connection options](https://orm.drizzle.team/docs/quick-postgresql/node-postgres) that will be passed to Drizzle and `node-postgres` or to `@vercel/postgres`              |
 | `push`                      | Disable Drizzle's [`db push`](https://orm.drizzle.team/kit-docs/overview#prototyping-with-db-push) in development mode. By default, `push` is enabled for development mode only. |
 | `migrationDir`              | Customize the directory that migrations are stored.                                                                                                                              |
-| `logger`                    | The instance of the logger to be passed to drizzle. By default Payload's will be used.                                                                                           |
 | `schemaName` (experimental) | A string for the postgres schema to use, defaults to 'public'.                                                                                                                   |
 | `idType`                    | A string of 'serial', or 'uuid' that is used for the data type given to id columns.                                                                                              |
 | `transactionOptions`        | A PgTransactionConfig object for transactions, or set to `false` to disable using transactions. [More details](https://orm.drizzle.team/docs/transactions)                       |

--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -86,7 +86,7 @@ const typescriptRules = {
       argsIgnorePattern: '^_',
       varsIgnorePattern: '^_',
       destructuredArrayIgnorePattern: '^_',
-      caughtErrorsIgnorePattern: '^ignore',
+      caughtErrorsIgnorePattern: '^(_|ignore)',
     },
   ],
   '@typescript-eslint/no-base-to-string': 'warn',

--- a/packages/payload/src/bin/generateTypes.ts
+++ b/packages/payload/src/bin/generateTypes.ts
@@ -10,7 +10,7 @@ export async function generateTypes(
   config: SanitizedConfig,
   options?: { log: boolean },
 ): Promise<void> {
-  const logger = getLogger()
+  const logger = getLogger('payload', 'sync')
   const outputFile = process.env.PAYLOAD_TS_OUTPUT_PATH || config.typescript.outputFile
 
   const shouldLog = options?.log ?? true

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -7,7 +7,7 @@ import type {
 import type { BusboyConfig } from 'busboy'
 import type GraphQL from 'graphql'
 import type { JSONSchema4 } from 'json-schema'
-import type { DestinationStream, LoggerOptions } from 'pino'
+import type { DestinationStream, LoggerOptions, pino } from 'pino'
 import type React from 'react'
 import type { default as sharp } from 'sharp'
 import type { DeepRequired } from 'ts-essentials'
@@ -283,19 +283,6 @@ export type InitOptions = {
 
   importMap?: ImportMap
 
-  /**
-   * A previously instantiated logger instance. Must conform to the PayloadLogger interface which uses Pino
-   * This allows you to bring your own logger instance and let payload use it
-   */
-  logger?: PayloadLogger
-
-  loggerDestination?: DestinationStream
-  /**
-   * Specify options for the built-in Pino logger that Payload uses for internal logging.
-   *
-   * See Pino Docs for options: https://getpino.io/#/docs/api?id=options
-   */
-  loggerOptions?: LoggerOptions
   /**
    * A function that is called immediately following startup that receives the Payload instance as it's only argument.
    */
@@ -916,6 +903,9 @@ export type Config = {
    * @default false // disable localization
    */
   localization?: false | LocalizationConfig
+
+  logger?: 'sync' | { destination?: DestinationStream; options: pino.LoggerOptions } | PayloadLogger
+
   /**
    * The maximum allowed depth to be permitted application-wide. This setting helps prevent against malicious queries.
    *

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -905,6 +905,30 @@ export type Config = {
    */
   localization?: false | LocalizationConfig
 
+  /**
+   * Logger options, logger options with a destination stream, or an instantiated logger instance.
+   *
+   * See Pino Docs for options: https://getpino.io/#/docs/api?id=options
+   *
+   * ```ts
+   * // Logger options only
+   * logger: {
+   *   level: 'info',
+   * }
+   *
+   * // Logger options with destination stream
+   * logger: {
+   *  options: {
+   *   level: 'info',
+   *  },
+   *  destination: process.stdout
+   * },
+   *
+   * // Logger instance
+   * logger: pino({ name: 'my-logger' })
+   *
+   * ```
+   */
   logger?: 'sync' | { destination?: DestinationStream; options: pino.LoggerOptions } | PayloadLogger
 
   /**

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -894,6 +894,7 @@ export type Config = {
     afterError?: AfterErrorHook
   }
   /** i18n config settings */
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   i18n?: I18nOptions<{} | DefaultTranslationsObject> // loosen the type here to allow for custom translations
   /** Automatically index all sortable top-level fields in the database to improve sort performance and add database compatibility for Azure Cosmos and similar. */
   indexSortableFields?: boolean

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -440,9 +440,8 @@ export class BasePayload {
       throw new Error('Error: the payload config is required to initialize payload.')
     }
 
-    this.logger = getLogger('payload', options.loggerOptions, options.loggerDestination)
-
     this.config = await options.config
+    this.logger = getLogger('payload', this.config.logger)
 
     if (!this.config.secret) {
       throw new Error('Error: missing secret key. A secret key is needed to secure Payload.')

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -626,6 +626,7 @@ interface RequestContext {
   [key: string]: unknown
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface DatabaseAdapter extends BaseDatabaseAdapter {}
 export type { Payload, RequestContext }
 export type * from './admin/types.js'

--- a/packages/payload/src/utilities/logger.ts
+++ b/packages/payload/src/utilities/logger.ts
@@ -1,6 +1,12 @@
-import { type DestinationStream, type Logger, type LoggerOptions, pino } from 'pino'
+import { type Logger, pino } from 'pino'
 import { build, type PrettyOptions } from 'pino-pretty'
 
+import type { Config } from '../config/types.js'
+
+/**
+ * Payload internal logger. Uses Pino.
+ * This allows you to bring your own logger instance and let payload use it
+ */
 export type PayloadLogger = Logger
 
 const prettyOptions: PrettyOptions = {
@@ -9,34 +15,39 @@ const prettyOptions: PrettyOptions = {
   translateTime: 'SYS:HH:MM:ss',
 }
 
-export const defaultLoggerOptions: LoggerOptions = {
-  transport: {
-    options: prettyOptions,
-    target: 'pino-pretty',
-  },
-}
-
 export const prettySyncLoggerDestination = build({
   ...prettyOptions,
   destination: 1, // stdout
   sync: true,
 })
 
-export const getLogger = (
-  name = 'payload',
-  options?: LoggerOptions,
-  destination?: DestinationStream,
-): PayloadLogger => {
-  if (options) {
-    return pino(
-      {
-        name: options?.name || name,
-        enabled: process.env.DISABLE_LOGGING !== 'true',
-        ...(options || defaultLoggerOptions),
-      },
-      destination,
-    )
+export const defaultLoggerOptions = build(prettyOptions)
+
+export const getLogger = (name = 'payload', logger?: Config['logger']): PayloadLogger => {
+  if (!logger) {
+    return pino(defaultLoggerOptions)
   }
 
-  return pino(prettySyncLoggerDestination)
+  // Synchronous logger used by bin scripts
+  if (logger === 'sync') {
+    return pino(prettySyncLoggerDestination)
+  }
+
+  // Check if logger is an object
+  if ('options' in logger) {
+    const { destination, options } = logger
+
+    if (!options.name) {
+      options.name = name
+    }
+
+    if (!options.enabled) {
+      options.enabled = process.env.DISABLE_LOGGING !== 'true'
+    }
+
+    return pino(options, destination)
+  } else {
+    // Instantiated logger
+    return logger
+  }
 }


### PR DESCRIPTION
Removes `loggerOptions` and `loggerDestination` from `initOptions` (these were not able to be used anyway).

Creates new `logger` property on the Payload config.

```ts
// Logger options only
logger: {
   level: 'info',
}

// Logger options with destination stream
logger: {
   options: {
   level: 'info',
   },
   destination: process.stdout
},

// Logger instance
logger: pino({ name: 'my-logger' })
```