### PR TITLE
chore: hoist selections

### DIFF
--- a/packages/next/src/views/List/Default/index.tsx
+++ b/packages/next/src/views/List/Default/index.tsx
@@ -127,8 +127,8 @@ export const DefaultListView: React.FC = () => {
   return (
     <div className={`${baseClass} ${baseClass}--${collectionSlug}`}>
       <SetViewActions actions={actions} />
-      <RenderComponent mappedComponent={beforeList} />
       <SelectionProvider docs={data.docs} totalDocs={data.totalDocs}>
+        <RenderComponent mappedComponent={beforeList} />
         <Gutter className={`${baseClass}__wrap`}>
           {Header || (
             <ListHeader heading={getTranslation(labels?.plural, i18n)}>
@@ -253,8 +253,8 @@ export const DefaultListView: React.FC = () => {
             </div>
           )}
         </Gutter>
+        <RenderComponent mappedComponent={afterList} />
       </SelectionProvider>
-      <RenderComponent mappedComponent={afterList} />
     </div>
   )
 }


### PR DESCRIPTION
## Description

Wraps beforeList and afterList with SelectionProvider. This is useful when your custom components would like to access the currently selected items in the list view.

- [ ] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
