### PR TITLE
fix: migrations exit code

### DIFF
--- a/packages/drizzle/src/migrate.ts
+++ b/packages/drizzle/src/migrate.ts
@@ -100,5 +100,6 @@ async function runMigrationFile(payload: Payload, migration: Migration, batch: n
       err,
       msg: parseError(err, `Error running migration ${migration.name}`),
     })
+    process.exit(1)
   }
 }

--- a/packages/drizzle/src/migrateFresh.ts
+++ b/packages/drizzle/src/migrateFresh.ts
@@ -74,6 +74,7 @@ export async function migrateFresh(
         err,
         msg: parseError(err, `Error running migration ${migration.name}. Rolling back`),
       })
+      process.exit(1)
     }
   }
 }

--- a/packages/drizzle/src/migrateRefresh.ts
+++ b/packages/drizzle/src/migrateRefresh.ts
@@ -100,6 +100,7 @@ export async function migrateRefresh(this: DrizzleAdapter) {
         err,
         msg: parseError(err, `Error running migration ${migration.name}. Rolling back.`),
       })
+      process.exit(1)
     }
   }
 }


### PR DESCRIPTION
Migration command were not returning proper error codes on failure. This caused issues with CI in particular.

Fixes #7031 for 3.0