### PR TITLE
feat!: removes Drawer reliance on EditDepth

### DIFF
--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -96,7 +96,7 @@ export const Account: React.FC<AdminViewProps> = async ({
         initialState={formState}
         isEditing
       >
-        <EditDepthProvider depth={1}>
+        <EditDepthProvider>
           <DocumentHeader
             collectionConfig={collectionConfig}
             hideTabs

--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -1,11 +1,6 @@
 import type { AdminViewProps } from 'payload'
 
-import {
-  DocumentInfoProvider,
-  EditDepthProvider,
-  HydrateAuthProvider,
-  RenderComponent,
-} from '@payloadcms/ui'
+import { DocumentInfoProvider, HydrateAuthProvider, RenderComponent } from '@payloadcms/ui'
 import { getCreateMappedComponent } from '@payloadcms/ui/shared'
 import { notFound } from 'next/navigation.js'
 import React from 'react'
@@ -96,18 +91,16 @@ export const Account: React.FC<AdminViewProps> = async ({
         initialState={formState}
         isEditing
       >
-        <EditDepthProvider>
-          <DocumentHeader
-            collectionConfig={collectionConfig}
-            hideTabs
-            i18n={i18n}
-            payload={payload}
-            permissions={permissions}
-          />
-          <HydrateAuthProvider permissions={permissions} />
-          <RenderComponent mappedComponent={mappedAccountComponent} />
-          <AccountClient />
-        </EditDepthProvider>
+        <DocumentHeader
+          collectionConfig={collectionConfig}
+          hideTabs
+          i18n={i18n}
+          payload={payload}
+          permissions={permissions}
+        />
+        <HydrateAuthProvider permissions={permissions} />
+        <RenderComponent mappedComponent={mappedAccountComponent} />
+        <AccountClient />
       </DocumentInfoProvider>
     )
   }

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -5,7 +5,7 @@ import type {
   ServerSideEditViewProps,
 } from 'payload'
 
-import { DocumentInfoProvider, EditDepthProvider, HydrateAuthProvider } from '@payloadcms/ui'
+import { DocumentInfoProvider, HydrateAuthProvider } from '@payloadcms/ui'
 import {
   formatAdminURL,
   getCreateMappedComponent,
@@ -280,7 +280,7 @@ export const Document: React.FC<AdminViewProps> = async ({
       initialData={data}
       initialState={formState}
       isEditing={isEditing}
-      key={locale?.code}
+      key={`${collectionSlug || globalSlug}${locale?.code ? `-${locale?.code}` : ''}`}
     >
       {!RootViewOverride && (
         <DocumentHeader
@@ -291,7 +291,6 @@ export const Document: React.FC<AdminViewProps> = async ({
           permissions={permissions}
         />
       )}
-      <HydrateAuthProvider permissions={permissions} />
       {/**
        * After bumping the Next.js canary to 104, and React to 19.0.0-rc-06d0b89e-20240801" we have to deepCopy the permissions object (https://github.com/payloadcms/payload/pull/7541).
        * If both HydrateClientUser and RenderCustomComponent receive the same permissions object (same object reference), we get a
@@ -300,19 +299,16 @@ export const Document: React.FC<AdminViewProps> = async ({
        *
        * // TODO: Revisit this in the future and figure out why this is happening. Might be a React/Next.js bug. We don't know why it happens, and a future React/Next version might unbreak this (keep an eye on this and remove deepCopyObjectSimple if that's the case)
        */}
-      <EditDepthProvider
-        key={`${collectionSlug || globalSlug}${locale?.code ? `-${locale?.code}` : ''}`}
-      >
-        {ErrorView ? (
-          <RenderComponent mappedComponent={ErrorView} />
-        ) : (
-          <RenderComponent
-            mappedComponent={
-              RootViewOverride ? RootViewOverride : CustomView ? CustomView : DefaultView
-            }
-          />
-        )}
-      </EditDepthProvider>
+      <HydrateAuthProvider permissions={permissions} />
+      {ErrorView ? (
+        <RenderComponent mappedComponent={ErrorView} />
+      ) : (
+        <RenderComponent
+          mappedComponent={
+            RootViewOverride ? RootViewOverride : CustomView ? CustomView : DefaultView
+          }
+        />
+      )}
     </DocumentInfoProvider>
   )
 }

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -301,7 +301,6 @@ export const Document: React.FC<AdminViewProps> = async ({
        * // TODO: Revisit this in the future and figure out why this is happening. Might be a React/Next.js bug. We don't know why it happens, and a future React/Next version might unbreak this (keep an eye on this and remove deepCopyObjectSimple if that's the case)
        */}
       <EditDepthProvider
-        depth={1}
         key={`${collectionSlug || globalSlug}${locale?.code ? `-${locale?.code}` : ''}`}
       >
         {ErrorView ? (

--- a/packages/next/src/views/Edit/Default/SetDocumentStepNav/index.tsx
+++ b/packages/next/src/views/Edit/Default/SetDocumentStepNav/index.tsx
@@ -6,7 +6,7 @@ import {
   type StepNavItem,
   useConfig,
   useDocumentInfo,
-  useEditDepth,
+  useDrawerDepth,
   useEntityVisibility,
   useStepNav,
   useTranslation,
@@ -41,12 +41,12 @@ export const SetDocumentStepNav: React.FC<{
     },
   } = useConfig()
 
-  const drawerDepth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
 
   useEffect(() => {
     const nav: StepNavItem[] = []
 
-    if (!isInitializing) {
+    if (!isInitializing && drawerDepth <= 1) {
       if (collectionSlug) {
         nav.push({
           label: getTranslation(pluralLabel, i18n),
@@ -91,9 +91,7 @@ export const SetDocumentStepNav: React.FC<{
         })
       }
 
-      if (drawerDepth <= 1) {
-        setStepNav(nav)
-      }
+      setStepNav(nav)
     }
   }, [
     setStepNav,

--- a/packages/next/src/views/Edit/Default/index.tsx
+++ b/packages/next/src/views/Edit/Default/index.tsx
@@ -14,7 +14,7 @@ import {
   useConfig,
   useDocumentEvents,
   useDocumentInfo,
-  useEditDepth,
+  useDrawerDepth,
   useUploadEdits,
 } from '@payloadcms/ui'
 import { formatAdminURL, getFormState } from '@payloadcms/ui/shared'
@@ -70,7 +70,7 @@ export const DefaultEditView: React.FC = () => {
   } = useConfig()
 
   const router = useRouter()
-  const depth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
   const params = useSearchParams()
   const { reportUpdate } = useDocumentEvents()
   const { resetUploadEdits } = useUploadEdits()
@@ -140,7 +140,7 @@ export const DefaultEditView: React.FC = () => {
         })
       }
 
-      if (!isEditing && depth < 2) {
+      if (!isEditing && drawerDepth <= 1) {
         // Redirect to the same locale if it's been set
         const redirectRoute = formatAdminURL({
           adminRoute,
@@ -158,7 +158,7 @@ export const DefaultEditView: React.FC = () => {
       id,
       entitySlug,
       user,
-      depth,
+      drawerDepth,
       collectionSlug,
       getVersions,
       isEditing,
@@ -216,7 +216,7 @@ export const DefaultEditView: React.FC = () => {
           <SetDocumentTitle
             collectionConfig={collectionConfig}
             config={config}
-            fallback={depth <= 1 ? id?.toString() : undefined}
+            fallback={drawerDepth <= 1 ? id?.toString() : undefined}
             globalConfig={globalConfig}
           />
           <DocumentControls

--- a/packages/next/src/views/Edit/index.client.tsx
+++ b/packages/next/src/views/Edit/index.client.tsx
@@ -2,13 +2,7 @@
 
 import type { ClientCollectionConfig, ClientGlobalConfig } from 'payload'
 
-import {
-  EditDepthProvider,
-  RenderComponent,
-  SetViewActions,
-  useConfig,
-  useDocumentInfo,
-} from '@payloadcms/ui'
+import { RenderComponent, SetViewActions, useConfig, useDocumentInfo } from '@payloadcms/ui'
 import React, { Fragment } from 'react'
 
 export const EditViewClient: React.FC = () => {
@@ -33,9 +27,7 @@ export const EditViewClient: React.FC = () => {
           (collectionConfig || globalConfig)?.admin?.components?.views?.edit?.default?.actions
         }
       />
-      <EditDepthProvider>
-        <RenderComponent mappedComponent={Edit} />
-      </EditDepthProvider>
+      <RenderComponent mappedComponent={Edit} />
     </Fragment>
   )
 }

--- a/packages/next/src/views/Edit/index.client.tsx
+++ b/packages/next/src/views/Edit/index.client.tsx
@@ -33,7 +33,7 @@ export const EditViewClient: React.FC = () => {
           (collectionConfig || globalConfig)?.admin?.components?.views?.edit?.default?.actions
         }
       />
-      <EditDepthProvider depth={0}>
+      <EditDepthProvider>
         <RenderComponent mappedComponent={Edit} />
       </EditDepthProvider>
     </Fragment>

--- a/packages/next/src/views/Edit/index.client.tsx
+++ b/packages/next/src/views/Edit/index.client.tsx
@@ -2,7 +2,13 @@
 
 import type { ClientCollectionConfig, ClientGlobalConfig } from 'payload'
 
-import { RenderComponent, SetViewActions, useConfig, useDocumentInfo } from '@payloadcms/ui'
+import {
+  EditDepthProvider,
+  RenderComponent,
+  SetViewActions,
+  useConfig,
+  useDocumentInfo,
+} from '@payloadcms/ui'
 import React, { Fragment } from 'react'
 
 export const EditViewClient: React.FC = () => {
@@ -27,7 +33,9 @@ export const EditViewClient: React.FC = () => {
           (collectionConfig || globalConfig)?.admin?.components?.views?.edit?.default?.actions
         }
       />
-      <RenderComponent mappedComponent={Edit} />
+      <EditDepthProvider depth={0}>
+        <RenderComponent mappedComponent={Edit} />
+      </EditDepthProvider>
     </Fragment>
   )
 }

--- a/packages/next/src/views/List/Default/index.tsx
+++ b/packages/next/src/views/List/Default/index.tsx
@@ -23,7 +23,7 @@ import {
   UnpublishMany,
   useBulkUpload,
   useConfig,
-  useEditDepth,
+  useDrawerDepth,
   useListInfo,
   useListQuery,
   useModal,
@@ -85,7 +85,7 @@ export const DefaultListView: React.FC = () => {
 
   const { i18n, t } = useTranslation()
 
-  const drawerDepth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
 
   const { setStepNav } = useStepNav()
 

--- a/packages/richtext-lexical/src/features/blocks/client/plugin/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/plugin/index.tsx
@@ -7,7 +7,7 @@ import { $insertNodeToNearestRoot, $wrapNodeInElement, mergeRegister } from '@le
 import { getTranslation } from '@payloadcms/translations'
 import {
   formatDrawerSlug,
-  useEditDepth,
+  useDrawerDepth,
   useFieldProps,
   useModal,
   useTranslation,
@@ -52,11 +52,11 @@ export const BlocksPlugin: PluginComponent<BlocksFeatureClientProps> = () => {
   const { i18n, t } = useTranslation<string, any>()
   const { schemaPath } = useFieldProps()
   const { uuid } = useEditorConfigContext()
-  const editDepth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
 
   const drawerSlug = formatDrawerSlug({
     slug: `lexical-inlineBlocks-create-` + uuid,
-    depth: editDepth,
+    depth: drawerDepth,
   })
 
   const {
@@ -140,7 +140,7 @@ export const BlocksPlugin: PluginComponent<BlocksFeatureClientProps> = () => {
             return true
           }
 
-          let rangeSelection: null | RangeSelection = null
+          let rangeSelection: RangeSelection | null = null
 
           editor.getEditorState().read(() => {
             const selection = $getSelection()

--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.tsx
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.tsx
@@ -8,6 +8,7 @@ import type {
   LexicalNode,
   RangeSelection,
 } from 'lexical'
+import type { JsonObject } from 'payload'
 import type { JSX } from 'react'
 
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
@@ -42,7 +43,7 @@ export type CellEditorConfig = Readonly<{
   theme?: EditorThemeClasses
 }>
 
-export const OPEN_TABLE_DRAWER_COMMAND: LexicalCommand<{}> = createCommand(
+export const OPEN_TABLE_DRAWER_COMMAND: LexicalCommand<JsonObject> = createCommand(
   'OPEN_EMBED_DRAWER_COMMAND',
 )
 
@@ -101,7 +102,7 @@ export const TablePlugin: PluginComponent = () => {
       editor.registerCommand(
         OPEN_TABLE_DRAWER_COMMAND,
         () => {
-          let rangeSelection: RangeSelection | null = null
+          let rangeSelection: null | RangeSelection = null
 
           editor.getEditorState().read(() => {
             const selection = $getSelection()

--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.tsx
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.tsx
@@ -14,7 +14,7 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import { TablePlugin as LexicalReactTablePlugin } from '@lexical/react/LexicalTablePlugin'
 import { INSERT_TABLE_COMMAND, TableNode } from '@lexical/table'
 import { mergeRegister } from '@lexical/utils'
-import { formatDrawerSlug, useEditDepth, useModal } from '@payloadcms/ui'
+import { formatDrawerSlug, useDrawerDepth, useModal } from '@payloadcms/ui'
 import { $getSelection, $isRangeSelection, COMMAND_PRIORITY_EDITOR, createCommand } from 'lexical'
 import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import * as React from 'react'
@@ -84,12 +84,12 @@ export const TablePlugin: PluginComponent = () => {
   const [editor] = useLexicalComposerContext()
   const cellContext = useContext(CellContext)
   const { closeModal, toggleModal } = useModal()
-  const editDepth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
   const { uuid } = useEditorConfigContext()
 
   const drawerSlug = formatDrawerSlug({
     slug: 'lexical-table-create-' + uuid,
-    depth: editDepth,
+    depth: drawerDepth,
   })
 
   useEffect(() => {
@@ -101,7 +101,7 @@ export const TablePlugin: PluginComponent = () => {
       editor.registerCommand(
         OPEN_TABLE_DRAWER_COMMAND,
         () => {
-          let rangeSelection: null | RangeSelection = null
+          let rangeSelection: RangeSelection | null = null
 
           editor.getEditorState().read(() => {
             const selection = $getSelection()
@@ -118,7 +118,7 @@ export const TablePlugin: PluginComponent = () => {
         COMMAND_PRIORITY_EDITOR,
       ),
     )
-  }, [cellContext, editor, toggleModal])
+  }, [cellContext, editor, toggleModal, drawerSlug])
 
   return (
     <React.Fragment>

--- a/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/LinkEditor/index.tsx
+++ b/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/LinkEditor/index.tsx
@@ -10,7 +10,7 @@ import {
   EditIcon,
   formatDrawerSlug,
   useConfig,
-  useEditDepth,
+  useDrawerDepth,
   useModal,
   useTranslation,
 } from '@payloadcms/ui'
@@ -53,7 +53,7 @@ export function LinkEditor({ anchorElem }: { anchorElem: HTMLElement }): React.R
   const [stateData, setStateData] = useState<{ id?: string; text: string } & LinkFields>(null)
 
   const { closeModal, toggleModal } = useModal()
-  const editDepth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
   const [isLink, setIsLink] = useState(false)
   const [selectedNodes, setSelectedNodes] = useState<LexicalNode[]>([])
 
@@ -61,7 +61,7 @@ export function LinkEditor({ anchorElem }: { anchorElem: HTMLElement }): React.R
 
   const drawerSlug = formatDrawerSlug({
     slug: `lexical-rich-text-link-` + uuid,
-    depth: editDepth,
+    depth: drawerDepth,
   })
 
   const setNotLink = useCallback(() => {

--- a/packages/richtext-lexical/src/features/upload/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/upload/client/component/index.tsx
@@ -12,7 +12,7 @@ import {
   formatDrawerSlug,
   useConfig,
   useDocumentDrawer,
-  useEditDepth,
+  useDrawerDepth,
   useModal,
   usePayloadAPI,
   useTranslation,
@@ -73,7 +73,7 @@ const Component: React.FC<ElementProps> = (props) => {
   const uploadRef = useRef<HTMLDivElement | null>(null)
   const { closeModal } = useModal()
   const { uuid } = useEditorConfigContext()
-  const editDepth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
   const [editor] = useLexicalComposerContext()
   const [isSelected, setSelected, clearSelection] = useLexicalNodeSelection(nodeKey)
 
@@ -89,7 +89,7 @@ const Component: React.FC<ElementProps> = (props) => {
 
   const drawerSlug = formatDrawerSlug({
     slug: `lexical-upload-drawer-` + uuid + componentID, // There can be multiple upload components, each with their own drawer, in one single editor => separate them by componentID
-    depth: editDepth,
+    depth: drawerDepth,
   })
 
   const [DocumentDrawer, DocumentDrawerToggler, { closeDrawer }] = useDocumentDrawer({
@@ -176,7 +176,7 @@ const Component: React.FC<ElementProps> = (props) => {
     (_, data) => {
       // Update lexical node (with key nodeKey) with new data
       editor.update(() => {
-        const uploadNode: null | UploadNode = $getNodeByKey(nodeKey)
+        const uploadNode: UploadNode | null = $getNodeByKey(nodeKey)
         if (uploadNode) {
           const newData: UploadData = {
             ...uploadNode.getData(),

--- a/packages/richtext-slate/src/field/RichText.tsx
+++ b/packages/richtext-slate/src/field/RichText.tsx
@@ -11,7 +11,7 @@ import {
   FieldError,
   FieldLabel,
   RenderComponent,
-  useEditDepth,
+  useDrawerDepth,
   useField,
   useFieldProps,
   useTranslation,
@@ -19,7 +19,7 @@ import {
 } from '@payloadcms/ui'
 import { isHotkey } from 'is-hotkey'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
-import { createEditor, Node, Element as SlateElement, Text, Transforms } from 'slate'
+import { Node, Element as SlateElement, Text, Transforms, createEditor } from 'slate'
 import { withHistory } from 'slate-history'
 import { Editable, Slate, withReact } from 'slate-react'
 
@@ -82,7 +82,7 @@ const RichTextField: React.FC<LoadedSlateFieldProps> = (props) => {
   const editorRef = useRef(null)
   const toolbarRef = useRef(null)
 
-  const drawerDepth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
   const drawerIsOpen = drawerDepth > 1
 
   const memoizedValidate = useCallback(

--- a/packages/ui/src/elements/BulkUpload/EditForm/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/EditForm/index.tsx
@@ -14,7 +14,7 @@ import { useConfig } from '../../../providers/Config/index.js'
 import { RenderComponent } from '../../../providers/Config/RenderComponent.js'
 import { useDocumentEvents } from '../../../providers/DocumentEvents/index.js'
 import { useDocumentInfo } from '../../../providers/DocumentInfo/index.js'
-import { useEditDepth } from '../../../providers/EditDepth/index.js'
+import { useDrawerDepth } from '../../../providers/DrawerDepth/index.js'
 import { OperationProvider } from '../../../providers/Operation/index.js'
 import { useUploadEdits } from '../../../providers/UploadEdits/index.js'
 import { formatAdminURL } from '../../../utilities/formatAdminURL.js'
@@ -58,7 +58,7 @@ export function EditForm({ submitted }: EditFormProps) {
   } = useConfig()
 
   const router = useRouter()
-  const depth = useEditDepth()
+  const depth = useDrawerDepth()
   const params = useSearchParams()
   const { reportUpdate } = useDocumentEvents()
   const { resetUploadEdits } = useUploadEdits()
@@ -86,7 +86,7 @@ export function EditForm({ submitted }: EditFormProps) {
         })
       }
 
-      if (!isEditing && depth < 2) {
+      if (!isEditing && depth <= 1) {
         // Redirect to the same locale if it's been set
         const redirectRoute = formatAdminURL({
           adminRoute,

--- a/packages/ui/src/elements/BulkUpload/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/index.tsx
@@ -5,7 +5,7 @@ import type { JsonObject } from 'payload'
 import { useModal } from '@faceless-ui/modal'
 import React from 'react'
 
-import { EditDepthProvider, useEditDepth } from '../../providers/EditDepth/index.js'
+import { useDrawerDepth } from '../../providers/DrawerDepth/index.js'
 import { Drawer } from '../Drawer/index.js'
 import { AddFilesView } from './AddFilesView/index.js'
 import { AddingFilesView } from './AddingFilesView/index.js'
@@ -41,17 +41,14 @@ export type BulkUploadProps = {
 }
 
 export function BulkUploadDrawer() {
-  const currentDepth = useEditDepth()
   const { drawerSlug } = useBulkUpload()
 
   return (
-    <EditDepthProvider depth={currentDepth || 1}>
-      <Drawer gutter={false} Header={null} slug={drawerSlug}>
-        <FormsManagerProvider>
-          <DrawerContent />
-        </FormsManagerProvider>
-      </Drawer>
-    </EditDepthProvider>
+    <Drawer gutter={false} Header={null} slug={drawerSlug}>
+      <FormsManagerProvider>
+        <DrawerContent />
+      </FormsManagerProvider>
+    </Drawer>
   )
 }
 
@@ -133,7 +130,7 @@ export function BulkUploadProvider({ children }: { readonly children: React.Reac
 export const useBulkUpload = () => React.useContext(Context)
 
 export function useBulkUploadDrawerSlug() {
-  const depth = useEditDepth()
+  const depth = useDrawerDepth()
 
   return `${drawerSlug}-${depth || 1}`
 }

--- a/packages/ui/src/elements/ColumnSelector/index.tsx
+++ b/packages/ui/src/elements/ColumnSelector/index.tsx
@@ -7,7 +7,7 @@ import type { Column } from '../Table/index.js'
 
 import { PlusIcon } from '../../icons/Plus/index.js'
 import { XIcon } from '../../icons/X/index.js'
-import { useEditDepth } from '../../providers/EditDepth/index.js'
+import { useDrawerDepth } from '../../providers/DrawerDepth/index.js'
 import { DraggableSortable } from '../DraggableSortable/index.js'
 import { Pill } from '../Pill/index.js'
 import { useTableColumns } from '../TableColumns/index.js'
@@ -29,7 +29,7 @@ export const ColumnSelector: React.FC<Props> = ({ collectionSlug }) => {
   const { columns, moveColumn, toggleColumn } = useTableColumns()
 
   const uuid = useId()
-  const editDepth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
 
   if (!columns) {
     return null
@@ -53,7 +53,7 @@ export const ColumnSelector: React.FC<Props> = ({ collectionSlug }) => {
           return null
         }
 
-        const { accessor, active, Label } = col
+        const { Label, accessor, active } = col
 
         if (col.accessor === '_select') {
           return null
@@ -69,7 +69,7 @@ export const ColumnSelector: React.FC<Props> = ({ collectionSlug }) => {
             draggable
             icon={active ? <XIcon /> : <PlusIcon />}
             id={accessor}
-            key={`${collectionSlug}-${col.cellProps?.field && 'name' in col.cellProps.field ? col.cellProps?.field?.name : i}${editDepth ? `-${editDepth}-` : ''}${uuid}`}
+            key={`${collectionSlug}-${col.cellProps?.field && 'name' in col.cellProps.field ? col.cellProps?.field?.name : i}${drawerDepth ? `-${drawerDepth}-` : ''}${uuid}`}
             onClick={() => {
               toggleColumn(accessor)
             }}

--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -10,7 +10,7 @@ import { XIcon } from '../../icons/X/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { RenderComponent } from '../../providers/Config/RenderComponent.js'
 import { DocumentInfoProvider, useDocumentInfo } from '../../providers/DocumentInfo/index.js'
-import { EditDepthProvider, useEditDepth } from '../../providers/EditDepth/index.js'
+import { EditDepthProvider } from '../../providers/EditDepth/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { useRelatedCollections } from '../AddNewRelation/useRelatedCollections.js'
@@ -40,7 +40,6 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   const [docID, setDocID] = useState(existingDocID)
   const [isOpen, setIsOpen] = useState(false)
   const [collectionConfig] = useRelatedCollections(collectionSlug)
-  const editDepth = useEditDepth()
 
   const Edit = collectionConfig.admin.components.views.edit.default.Component
 
@@ -109,7 +108,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
       onLoadError={onLoadError}
       onSave={onSave}
     >
-      <EditDepthProvider depth={editDepth + 1}>
+      <EditDepthProvider>
         <RenderComponent mappedComponent={Edit} />
       </EditDepthProvider>
     </DocumentInfoProvider>

--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -10,6 +10,7 @@ import { XIcon } from '../../icons/X/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { RenderComponent } from '../../providers/Config/RenderComponent.js'
 import { DocumentInfoProvider, useDocumentInfo } from '../../providers/DocumentInfo/index.js'
+import { EditDepthProvider, useEditDepth } from '../../providers/EditDepth/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { useRelatedCollections } from '../AddNewRelation/useRelatedCollections.js'
@@ -39,6 +40,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   const [docID, setDocID] = useState(existingDocID)
   const [isOpen, setIsOpen] = useState(false)
   const [collectionConfig] = useRelatedCollections(collectionSlug)
+  const editDepth = useEditDepth()
 
   const Edit = collectionConfig.admin.components.views.edit.default.Component
 
@@ -107,7 +109,9 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
       onLoadError={onLoadError}
       onSave={onSave}
     >
-      <RenderComponent mappedComponent={Edit} />
+      <EditDepthProvider depth={editDepth + 1}>
+        <RenderComponent mappedComponent={Edit} />
+      </EditDepthProvider>
     </DocumentInfoProvider>
   )
 }

--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -10,7 +10,6 @@ import { XIcon } from '../../icons/X/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { RenderComponent } from '../../providers/Config/RenderComponent.js'
 import { DocumentInfoProvider, useDocumentInfo } from '../../providers/DocumentInfo/index.js'
-import { EditDepthProvider } from '../../providers/EditDepth/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { useRelatedCollections } from '../AddNewRelation/useRelatedCollections.js'
@@ -108,9 +107,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
       onLoadError={onLoadError}
       onSave={onSave}
     >
-      <EditDepthProvider>
-        <RenderComponent mappedComponent={Edit} />
-      </EditDepthProvider>
+      <RenderComponent mappedComponent={Edit} />
     </DocumentInfoProvider>
   )
 }

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -1,30 +1,18 @@
 'use client'
 import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
-import React, { useCallback, useEffect, useId, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import type { DocumentDrawerProps, DocumentTogglerProps, UseDocumentDrawer } from './types.js'
 
-import { useEditDepth } from '../../providers/EditDepth/index.js'
+import { useDrawerDepth } from '../../providers/DrawerDepth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { useRelatedCollections } from '../AddNewRelation/useRelatedCollections.js'
-import { Drawer, DrawerToggler } from '../Drawer/index.js'
+import { Drawer, DrawerToggler, useDrawerSlug } from '../Drawer/index.js'
 import { DocumentDrawerContent } from './DrawerContent.js'
 import './index.scss'
 
 export const baseClass = 'doc-drawer'
-
-const formatDocumentDrawerSlug = ({
-  id,
-  collectionSlug,
-  depth,
-  uuid,
-}: {
-  collectionSlug: string
-  depth: number
-  id: number | string
-  uuid: string // supply when creating a new document and no id is available
-}) => `doc-drawer_${collectionSlug}_${depth}${id ? `_${id}` : ''}_${uuid}`
 
 export const DocumentDrawerToggler: React.FC<DocumentTogglerProps> = ({
   id,
@@ -64,17 +52,13 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = (props) => {
 }
 
 export const useDocumentDrawer: UseDocumentDrawer = ({ id, collectionSlug }) => {
-  const drawerDepth = useEditDepth()
-  const uuid = useId()
+  const drawerDepth = useDrawerDepth()
   const { closeModal, modalState, openModal, toggleModal } = useModal()
   const [isOpen, setIsOpen] = useState(false)
 
-  const drawerSlug = formatDocumentDrawerSlug({
-    id,
-    collectionSlug,
-    depth: drawerDepth,
-    uuid,
-  })
+  const drawerSlug = useDrawerSlug(
+    `doc-drawer_${collectionSlug}_${drawerDepth}${id ? `_${id}` : ''}`,
+  )
 
   useEffect(() => {
     setIsOpen(Boolean(modalState[drawerSlug]?.isOpen))

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -56,9 +56,7 @@ export const useDocumentDrawer: UseDocumentDrawer = ({ id, collectionSlug }) => 
   const { closeModal, modalState, openModal, toggleModal } = useModal()
   const [isOpen, setIsOpen] = useState(false)
 
-  const drawerSlug = useDrawerSlug(
-    `doc-drawer_${collectionSlug}_${drawerDepth}${id ? `_${id}` : ''}`,
-  )
+  const drawerSlug = useDrawerSlug(`doc-drawer__${collectionSlug}${id ? `_${id}` : ''}`)
 
   useEffect(() => {
     setIsOpen(Boolean(modalState[drawerSlug]?.isOpen))

--- a/packages/ui/src/elements/DocumentDrawer/types.ts
+++ b/packages/ui/src/elements/DocumentDrawer/types.ts
@@ -19,7 +19,7 @@ export type DocumentTogglerProps = {
   readonly disabled?: boolean
   readonly drawerSlug?: string
   readonly id?: string
-} & HTMLAttributes<HTMLButtonElement>
+} & Readonly<HTMLAttributes<HTMLButtonElement>>
 
 export type UseDocumentDrawer = (args: { collectionSlug: string; id?: number | string }) => [
   React.FC<Omit<DocumentDrawerProps, 'collectionSlug' | 'id'>>, // drawer

--- a/packages/ui/src/elements/Drawer/index.tsx
+++ b/packages/ui/src/elements/Drawer/index.tsx
@@ -5,8 +5,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import type { Props, TogglerProps } from './types.js'
 
 import { XIcon } from '../../icons/X/index.js'
-import { useDrawerDepth } from '../../providers/DrawerDepth/index.js'
-import { EditDepthProvider } from '../../providers/EditDepth/index.js'
+import { DrawerDepthProvider, useDrawerDepth } from '../../providers/DrawerDepth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { Gutter } from '../Gutter/index.js'
 import './index.scss'
@@ -103,7 +102,7 @@ export const Drawer: React.FC<Props> = ({
         >
           <div className={`${baseClass}__blur-bg-content`} />
           <Gutter className={`${baseClass}__content-children`} left={gutter} right={gutter}>
-            <EditDepthProvider>
+            <DrawerDepthProvider>
               {Header}
               {Header === undefined && (
                 <div className={`${baseClass}__header`}>
@@ -125,7 +124,7 @@ export const Drawer: React.FC<Props> = ({
                 </div>
               )}
               {children}
-            </EditDepthProvider>
+            </DrawerDepthProvider>
           </Gutter>
         </div>
       </Modal>

--- a/packages/ui/src/elements/Drawer/index.tsx
+++ b/packages/ui/src/elements/Drawer/index.tsx
@@ -5,7 +5,8 @@ import React, { useCallback, useEffect, useState } from 'react'
 import type { Props, TogglerProps } from './types.js'
 
 import { XIcon } from '../../icons/X/index.js'
-import { EditDepthProvider, useEditDepth } from '../../providers/EditDepth/index.js'
+import { useDrawerDepth } from '../../providers/DrawerDepth/index.js'
+import { EditDepthProvider } from '../../providers/EditDepth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { Gutter } from '../Gutter/index.js'
 import './index.scss'
@@ -56,7 +57,7 @@ export const Drawer: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation()
   const { closeModal, modalState } = useModal()
-  const drawerDepth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
 
   const [isOpen, setIsOpen] = useState(false)
   const [animateIn, setAnimateIn] = useState(false)

--- a/packages/ui/src/elements/Drawer/index.tsx
+++ b/packages/ui/src/elements/Drawer/index.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import type { Props, TogglerProps } from './types.js'
 
 import { XIcon } from '../../icons/X/index.js'
-import { EditDepthContext, useEditDepth } from '../../providers/EditDepth/index.js'
+import { EditDepthProvider, useEditDepth } from '../../providers/EditDepth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { Gutter } from '../Gutter/index.js'
 import './index.scss'
@@ -102,7 +102,7 @@ export const Drawer: React.FC<Props> = ({
         >
           <div className={`${baseClass}__blur-bg-content`} />
           <Gutter className={`${baseClass}__content-children`} left={gutter} right={gutter}>
-            <EditDepthContext.Provider value={drawerDepth + 1}>
+            <EditDepthProvider>
               {Header}
               {Header === undefined && (
                 <div className={`${baseClass}__header`}>
@@ -124,7 +124,7 @@ export const Drawer: React.FC<Props> = ({
                 </div>
               )}
               {children}
-            </EditDepthContext.Provider>
+            </EditDepthProvider>
           </Gutter>
         </div>
       </Modal>

--- a/packages/ui/src/elements/Drawer/types.ts
+++ b/packages/ui/src/elements/Drawer/types.ts
@@ -11,8 +11,8 @@ export type Props = {
 }
 
 export type TogglerProps = {
-  children: React.ReactNode
-  className?: string
-  disabled?: boolean
-  slug: string
-} & HTMLAttributes<HTMLButtonElement>
+  readonly children: React.ReactNode
+  readonly className?: string
+  readonly disabled?: boolean
+  readonly slug: string
+} & Readonly<HTMLAttributes<HTMLButtonElement>>

--- a/packages/ui/src/elements/Drawer/useDrawerSlug.tsx
+++ b/packages/ui/src/elements/Drawer/useDrawerSlug.tsx
@@ -1,14 +1,14 @@
 'use client'
 import { useId } from 'react'
 
-import { useEditDepth } from '../../providers/EditDepth/index.js'
+import { useDrawerDepth } from '../../providers/DrawerDepth/index.js'
 import { formatDrawerSlug } from './index.js'
 
 export const useDrawerSlug = (slug: string): string => {
   const uuid = useId()
-  const editDepth = useEditDepth()
+  const drawerDepth = useDrawerDepth()
   return formatDrawerSlug({
     slug: `${slug}-${uuid}`,
-    depth: editDepth,
+    depth: drawerDepth,
   })
 }

--- a/packages/ui/src/elements/FullscreenModal/index.tsx
+++ b/packages/ui/src/elements/FullscreenModal/index.tsx
@@ -4,17 +4,17 @@ import type { Modal as ModalType } from '@faceless-ui/modal'
 import { Modal } from '@faceless-ui/modal'
 import React from 'react'
 
-import { useEditDepth } from '../../providers/EditDepth/index.js'
+import { useDrawerDepth } from '../../providers/DrawerDepth/index.js'
 
 export function FullscreenModal(props: Parameters<typeof ModalType>[0]) {
-  const currentDepth = useEditDepth()
+  const currentDrawerDepth = useDrawerDepth()
 
   return (
     <Modal
       {...props}
       style={{
         ...(props.style || {}),
-        zIndex: `calc(100 + ${currentDepth || 0} + 1)`,
+        zIndex: `calc(100 + ${currentDrawerDepth || 0} + 1)`,
       }}
     />
   )

--- a/packages/ui/src/elements/ListDrawer/index.tsx
+++ b/packages/ui/src/elements/ListDrawer/index.tsx
@@ -1,26 +1,18 @@
 'use client'
 import { useModal } from '@faceless-ui/modal'
-import React, { useCallback, useEffect, useId, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import type { ListDrawerProps, ListTogglerProps, UseListDrawer } from './types.js'
 
 export * from './types.js'
 
 import { useConfig } from '../../providers/Config/index.js'
-import { useEditDepth } from '../../providers/EditDepth/index.js'
-import { Drawer, DrawerToggler } from '../Drawer/index.js'
+import { useDrawerDepth } from '../../providers/DrawerDepth/index.js'
+import { Drawer, DrawerToggler, useDrawerSlug } from '../Drawer/index.js'
 import { ListDrawerContent } from './DrawerContent.js'
 import './index.scss'
 
 export const baseClass = 'list-drawer'
-
-export const formatListDrawerSlug = ({
-  depth,
-  uuid,
-}: {
-  depth: number
-  uuid: string // supply when creating a new document and no id is available
-}) => `list-drawer_${depth}_${uuid}`
 
 export const ListDrawerToggler: React.FC<ListTogglerProps> = ({
   children,
@@ -60,16 +52,12 @@ export const useListDrawer: UseListDrawer = ({
   const {
     config: { collections },
   } = useConfig()
-  const drawerDepth = useEditDepth()
-  const uuid = useId()
+  const drawerDepth = useDrawerDepth()
   const { closeModal, modalState, openModal, toggleModal } = useModal()
   const [isOpen, setIsOpen] = useState(false)
   const [collectionSlugs, setCollectionSlugs] = useState(collectionSlugsFromProps)
 
-  const drawerSlug = formatListDrawerSlug({
-    depth: drawerDepth,
-    uuid,
-  })
+  const drawerSlug = useDrawerSlug(`list-drawer_${drawerDepth}`)
 
   useEffect(() => {
     setIsOpen(Boolean(modalState[drawerSlug]?.isOpen))

--- a/packages/ui/src/elements/ListDrawer/index.tsx
+++ b/packages/ui/src/elements/ListDrawer/index.tsx
@@ -57,7 +57,7 @@ export const useListDrawer: UseListDrawer = ({
   const [isOpen, setIsOpen] = useState(false)
   const [collectionSlugs, setCollectionSlugs] = useState(collectionSlugsFromProps)
 
-  const drawerSlug = useDrawerSlug(`list-drawer_${drawerDepth}`)
+  const drawerSlug = useDrawerSlug(`list-drawer`)
 
   useEffect(() => {
     setIsOpen(Boolean(modalState[drawerSlug]?.isOpen))

--- a/packages/ui/src/elements/ListDrawer/types.ts
+++ b/packages/ui/src/elements/ListDrawer/types.ts
@@ -19,17 +19,17 @@ export type ListDrawerProps = {
 }
 
 export type ListTogglerProps = {
-  children?: React.ReactNode
-  className?: string
-  disabled?: boolean
-  drawerSlug?: string
-} & HTMLAttributes<HTMLButtonElement>
+  readonly children?: React.ReactNode
+  readonly className?: string
+  readonly disabled?: boolean
+  readonly drawerSlug?: string
+} & Readonly<HTMLAttributes<HTMLButtonElement>>
 
 export type UseListDrawer = (args: {
-  collectionSlugs?: string[]
-  filterOptions?: FilterOptionsResult
-  selectedCollection?: string
-  uploads?: boolean // finds all collections with upload: true
+  readonly collectionSlugs?: string[]
+  readonly filterOptions?: FilterOptionsResult
+  readonly selectedCollection?: string
+  readonly uploads?: boolean // finds all collections with upload: true
 }) => [
   React.FC<Pick<ListDrawerProps, 'enableRowSelections' | 'onBulkSelect' | 'onSelect'>>, // drawer
   React.FC<Pick<ListTogglerProps, 'children' | 'className' | 'disabled'>>, // toggler

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -201,6 +201,7 @@ export { DocumentInfoProvider, useDocumentInfo } from '../../providers/DocumentI
 export type { DocumentInfoContext, DocumentInfoProps } from '../../providers/DocumentInfo/index.js'
 
 export { EditDepthProvider, useEditDepth } from '../../providers/EditDepth/index.js'
+export { DrawerDepthProvider, useDrawerDepth } from '../../providers/DrawerDepth/index.js'
 export {
   EntityVisibilityProvider,
   useEntityVisibility,

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -401,7 +401,7 @@ export function UploadInput(props: UploadInputProps) {
       loadedValueDocsRef.current = true
     }
 
-    if (!loadedValueDocsRef.current) {
+    if (!loadedValueDocsRef.current && value) {
       void loadInitialDocs()
     }
   }, [populateDocs, activeRelationTo, value])
@@ -410,7 +410,7 @@ export function UploadInput(props: UploadInputProps) {
     !readOnly &&
     (!value ||
       (hasMany && Array.isArray(value) && (typeof maxRows !== 'number' || value.length < maxRows)))
-
+  // console.log({ hasMany, populatedDocs, value })
   return (
     <div
       className={[

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -410,7 +410,7 @@ export function UploadInput(props: UploadInputProps) {
     !readOnly &&
     (!value ||
       (hasMany && Array.isArray(value) && (typeof maxRows !== 'number' || value.length < maxRows)))
-  // console.log({ hasMany, populatedDocs, value })
+
   return (
     <div
       className={[

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -25,6 +25,7 @@ import { useThrottledEffect } from '../../hooks/useThrottledEffect.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
+import { EditDepthProvider } from '../../providers/EditDepth/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useOperation } from '../../providers/Operation/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
@@ -647,26 +648,28 @@ export const Form: React.FC<FormProps> = (props) => {
       onSubmit={(e) => void contextRef.current.submit({}, e)}
       ref={formRef}
     >
-      <FormContext.Provider value={contextRef.current}>
-        <FormWatchContext.Provider
-          value={{
-            fields,
-            ...contextRef.current,
-          }}
-        >
-          <SubmittedContext.Provider value={submitted}>
-            <InitializingContext.Provider value={!isMounted || (isMounted && initializing)}>
-              <ProcessingContext.Provider value={processing}>
-                <ModifiedContext.Provider value={modified}>
-                  <FormFieldsContext.Provider value={fieldsReducer}>
-                    {children}
-                  </FormFieldsContext.Provider>
-                </ModifiedContext.Provider>
-              </ProcessingContext.Provider>
-            </InitializingContext.Provider>
-          </SubmittedContext.Provider>
-        </FormWatchContext.Provider>
-      </FormContext.Provider>
+      <EditDepthProvider>
+        <FormContext.Provider value={contextRef.current}>
+          <FormWatchContext.Provider
+            value={{
+              fields,
+              ...contextRef.current,
+            }}
+          >
+            <SubmittedContext.Provider value={submitted}>
+              <InitializingContext.Provider value={!isMounted || (isMounted && initializing)}>
+                <ProcessingContext.Provider value={processing}>
+                  <ModifiedContext.Provider value={modified}>
+                    <FormFieldsContext.Provider value={fieldsReducer}>
+                      {children}
+                    </FormFieldsContext.Provider>
+                  </ModifiedContext.Provider>
+                </ProcessingContext.Provider>
+              </InitializingContext.Provider>
+            </SubmittedContext.Provider>
+          </FormWatchContext.Provider>
+        </FormContext.Provider>
+      </EditDepthProvider>
     </form>
   )
 }

--- a/packages/ui/src/providers/DrawerDepth/index.tsx
+++ b/packages/ui/src/providers/DrawerDepth/index.tsx
@@ -1,0 +1,15 @@
+'use client'
+import React, { createContext, useContext } from 'react'
+
+export const DrawerDepthContext = createContext(0)
+
+type Props = {
+  readonly children: React.ReactNode
+}
+export function DrawerDepthProvider({ children }: Props) {
+  const parentDepth = useDrawerDepth()
+  const value = parentDepth + 1
+  return <DrawerDepthContext.Provider value={value}>{children}</DrawerDepthContext.Provider>
+}
+
+export const useDrawerDepth = (): number => useContext(DrawerDepthContext)

--- a/packages/ui/src/providers/DrawerDepth/index.tsx
+++ b/packages/ui/src/providers/DrawerDepth/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 }
 export function DrawerDepthProvider({ children }: Props) {
   const parentDepth = useDrawerDepth()
-  const value = (parentDepth || 0) + 1
+  const value = parentDepth + 1
   return <DrawerDepthContext.Provider value={value}>{children}</DrawerDepthContext.Provider>
 }
 

--- a/packages/ui/src/providers/DrawerDepth/index.tsx
+++ b/packages/ui/src/providers/DrawerDepth/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 }
 export function DrawerDepthProvider({ children }: Props) {
   const parentDepth = useDrawerDepth()
-  const value = parentDepth + 1
+  const value = (parentDepth || 0) + 1
   return <DrawerDepthContext.Provider value={value}>{children}</DrawerDepthContext.Provider>
 }
 

--- a/packages/ui/src/providers/EditDepth/index.tsx
+++ b/packages/ui/src/providers/EditDepth/index.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export function EditDepthProvider({ children }: Props) {
   const parentDepth = useContext(EditDepthContext)
-  const value = (parentDepth || 0) + 1
+  const value = parentDepth + 1
   return <EditDepthContext.Provider value={value}>{children}</EditDepthContext.Provider>
 }
 

--- a/packages/ui/src/providers/EditDepth/index.tsx
+++ b/packages/ui/src/providers/EditDepth/index.tsx
@@ -5,11 +5,12 @@ export const EditDepthContext = createContext(0)
 
 type Props = {
   readonly children: React.ReactNode
-  readonly depth: number
 }
 
-export function EditDepthProvider({ children, depth = 1 }: Props) {
-  return <EditDepthContext.Provider value={depth}>{children}</EditDepthContext.Provider>
+export function EditDepthProvider({ children }: Props) {
+  const parentDepth = useContext(EditDepthContext)
+  const value = (parentDepth || 0) + 1
+  return <EditDepthContext.Provider value={value}>{children}</EditDepthContext.Provider>
 }
 
 export const useEditDepth = (): number => useContext(EditDepthContext)

--- a/packages/ui/src/providers/EditDepth/index.tsx
+++ b/packages/ui/src/providers/EditDepth/index.tsx
@@ -9,6 +9,7 @@ type Props = {
 
 export function EditDepthProvider({ children }: Props) {
   const parentDepth = useContext(EditDepthContext)
+  console.log({ parentDepth })
   const value = parentDepth + 1
   return <EditDepthContext.Provider value={value}>{children}</EditDepthContext.Provider>
 }

--- a/packages/ui/src/providers/EditDepth/index.tsx
+++ b/packages/ui/src/providers/EditDepth/index.tsx
@@ -3,9 +3,13 @@ import React, { createContext, useContext } from 'react'
 
 export const EditDepthContext = createContext(0)
 
-export const EditDepthProvider: React.FC<{ children: React.ReactNode; depth: number }> = ({
-  children,
-  depth,
-}) => <EditDepthContext.Provider value={depth}>{children}</EditDepthContext.Provider>
+type Props = {
+  readonly children: React.ReactNode
+  readonly depth: number
+}
+
+export function EditDepthProvider({ children, depth = 1 }: Props) {
+  return <EditDepthContext.Provider value={depth}>{children}</EditDepthContext.Provider>
+}
 
 export const useEditDepth = (): number => useContext(EditDepthContext)

--- a/packages/ui/src/providers/EditDepth/index.tsx
+++ b/packages/ui/src/providers/EditDepth/index.tsx
@@ -8,8 +8,7 @@ type Props = {
 }
 
 export function EditDepthProvider({ children }: Props) {
-  const parentDepth = useContext(EditDepthContext)
-  console.log({ parentDepth })
+  const parentDepth = useEditDepth()
   const value = parentDepth + 1
   return <EditDepthContext.Provider value={value}>{children}</EditDepthContext.Provider>
 }

--- a/packages/ui/src/providers/Root/index.tsx
+++ b/packages/ui/src/providers/Root/index.tsx
@@ -5,7 +5,7 @@ import type { ClientConfig, LanguageOptions, Permissions, User } from 'payload'
 import { ModalContainer, ModalProvider } from '@faceless-ui/modal'
 import { ScrollInfoProvider } from '@faceless-ui/scroll-info'
 import { WindowInfoProvider } from '@faceless-ui/window-info'
-import React, { Fragment } from 'react'
+import React from 'react'
 
 import type { Theme } from '../Theme/index.js'
 
@@ -14,6 +14,7 @@ import { NavProvider } from '../../elements/Nav/context.js'
 import { StayLoggedInModal } from '../../elements/StayLoggedIn/index.js'
 import { StepNavProvider } from '../../elements/StepNav/index.js'
 import { fieldComponents } from '../../fields/index.js'
+import { DrawerDepthProvider } from '../../providers/DrawerDepth/index.js'
 import { ActionsProvider } from '../Actions/index.js'
 import { AuthProvider } from '../Auth/index.js'
 import { ClientFunctionProvider } from '../ClientFunction/index.js'
@@ -59,7 +60,7 @@ export const RootProvider: React.FC<Props> = ({
   user,
 }) => {
   return (
-    <Fragment>
+    <DrawerDepthProvider>
       <RouteCache>
         <ConfigProvider config={config}>
           <FieldComponentsProvider fieldComponents={fieldComponents}>
@@ -116,6 +117,6 @@ export const RootProvider: React.FC<Props> = ({
         </ConfigProvider>
       </RouteCache>
       <ToastContainer />
-    </Fragment>
+    </DrawerDepthProvider>
   )
 }

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -282,7 +282,9 @@ describe('access control', () => {
 
       await expect(addDocButton).toBeVisible()
       await addDocButton.click()
-      const documentDrawer = page.locator(`[id^=doc-drawer_${createNotUpdateCollectionSlug}_1_]`)
+      const documentDrawer = page.locator(
+        `[id^=drawer_1_doc-drawer__${createNotUpdateCollectionSlug}]`,
+      )
       await expect(documentDrawer).toBeVisible()
       await expect(documentDrawer.locator('#action-save')).toBeVisible()
       await documentDrawer.locator('#field-name').fill('name')
@@ -339,7 +341,7 @@ describe('access control', () => {
           '#userRestrictedDocs-add-new button.relationship-add-new__add-button.doc-drawer__toggler',
         )
         await addDocButton.click()
-        const documentDrawer = page.locator('[id^=doc-drawer_user-restricted-collection_1_]')
+        const documentDrawer = page.locator('[id^=drawer_1_doc-drawer__user-restricted-collection]')
         await expect(documentDrawer).toBeVisible()
         await documentDrawer.locator('#field-name').fill('anonymous@email.com')
         await documentDrawer.locator('#action-save').click()
@@ -348,7 +350,9 @@ describe('access control', () => {
         await documentDrawer.locator('button.doc-drawer__header-close').click()
         await expect(documentDrawer).toBeHidden()
         await addDocButton.click()
-        const documentDrawer2 = page.locator('[id^=doc-drawer_user-restricted-collection_1_]')
+        const documentDrawer2 = page.locator(
+          '[id^=drawer_1_doc-drawer__user-restricted-collection]',
+        )
         await expect(documentDrawer2).toBeVisible()
         await documentDrawer2.locator('#field-name').fill('dev@payloadcms.com')
         await documentDrawer2.locator('#action-save').click()

--- a/test/admin/e2e/1/e2e.spec.ts
+++ b/test/admin/e2e/1/e2e.spec.ts
@@ -981,7 +981,7 @@ describe('admin1', () => {
         )
         .click()
       await wait(500)
-      const drawer1Content = page.locator('[id^=doc-drawer_posts_1_] .drawer__content')
+      const drawer1Content = page.locator('[id^=drawer_1_doc-drawer__posts] .drawer__content')
       await expect(drawer1Content).toBeVisible()
       const drawerLeft = await drawer1Content.boundingBox().then((box) => box.x)
       await drawer1Content
@@ -989,7 +989,7 @@ describe('admin1', () => {
           '.field-type.relationship .relationship--single-value__drawer-toggler.doc-drawer__toggler',
         )
         .click()
-      const drawer2Content = page.locator('[id^=doc-drawer_posts_2_] .drawer__content')
+      const drawer2Content = page.locator('[id^=drawer_2_doc-drawer__posts] .drawer__content')
       await expect(drawer2Content).toBeVisible()
       const drawer2Left = await drawer2Content.boundingBox().then((box) => box.x)
       expect(drawer2Left > drawerLeft).toBe(true)

--- a/test/admin/e2e/2/e2e.spec.ts
+++ b/test/admin/e2e/2/e2e.spec.ts
@@ -508,18 +508,18 @@ describe('admin2', () => {
 
         await openDocDrawer(page, '.rich-text .list-drawer__toggler')
 
-        const listDrawer = page.locator('[id^=list-drawer_1_]')
+        const listDrawer = page.locator('[id^=drawer_1_list-drawer]')
         await expect(listDrawer).toBeVisible()
 
         const collectionSelector = page.locator(
-          '[id^=list-drawer_1_] .list-drawer__select-collection.react-select',
+          '[id^=drawer_1_list-drawer] .list-drawer__select-collection.react-select',
         )
 
         // select the "Post" collection
         await collectionSelector.click()
         await page
           .locator(
-            '[id^=list-drawer_1_] .list-drawer__select-collection.react-select .rs__option',
+            '[id^=drawer_1_list-drawer] .list-drawer__select-collection.react-select .rs__option',
             {
               hasText: exactText('Post'),
             },
@@ -527,7 +527,9 @@ describe('admin2', () => {
           .click()
 
         // open the column controls
-        const columnSelector = page.locator('[id^=list-drawer_1_] .list-controls__toggle-columns')
+        const columnSelector = page.locator(
+          '[id^=drawer_1_list-drawer] .list-controls__toggle-columns',
+        )
         await columnSelector.click()
         // wait until the column toggle UI is visible and fully expanded
         await expect(page.locator('.list-controls__columns.rah-static--height-auto')).toBeVisible()
@@ -536,7 +538,7 @@ describe('admin2', () => {
         await expect(
           page
             .locator(
-              '[id^=list-drawer_1_] .list-controls .column-selector .column-selector__column',
+              '[id^=drawer_1_list-drawer] .list-controls .column-selector .column-selector__column',
             )
             .first(),
         ).toHaveText('Number')
@@ -547,13 +549,15 @@ describe('admin2', () => {
 
         // Open the drawer
         await openDocDrawer(page, '.rich-text .list-drawer__toggler')
-        const listDrawer = page.locator('[id^=list-drawer_1_]')
+        const listDrawer = page.locator('[id^=drawer_1_list-drawer]')
         await expect(listDrawer).toBeVisible()
 
         const collectionSelector = page.locator(
-          '[id^=list-drawer_1_] .list-drawer__select-collection.react-select',
+          '[id^=drawer_1_list-drawer] .list-drawer__select-collection.react-select',
         )
-        const columnSelector = page.locator('[id^=list-drawer_1_] .list-controls__toggle-columns')
+        const columnSelector = page.locator(
+          '[id^=drawer_1_list-drawer] .list-controls__toggle-columns',
+        )
 
         // open the column controls
         await columnSelector.click()
@@ -563,7 +567,7 @@ describe('admin2', () => {
         // deselect the "id" column
         await page
           .locator(
-            '[id^=list-drawer_1_] .list-controls .column-selector .column-selector__column',
+            '[id^=drawer_1_list-drawer] .list-controls .column-selector .column-selector__column',
             {
               hasText: exactText('ID'),
             },
@@ -574,7 +578,7 @@ describe('admin2', () => {
         await collectionSelector.click()
         await page
           .locator(
-            '[id^=list-drawer_1_] .list-drawer__select-collection.react-select .rs__option',
+            '[id^=drawer_1_list-drawer] .list-drawer__select-collection.react-select .rs__option',
             {
               hasText: exactText('Post'),
             },
@@ -584,7 +588,7 @@ describe('admin2', () => {
         // deselect the "number" column
         await page
           .locator(
-            '[id^=list-drawer_1_] .list-controls .column-selector .column-selector__column',
+            '[id^=drawer_1_list-drawer] .list-controls .column-selector .column-selector__column',
             {
               hasText: exactText('Number'),
             },
@@ -595,7 +599,7 @@ describe('admin2', () => {
         await collectionSelector.click()
         await page
           .locator(
-            '[id^=list-drawer_1_] .list-drawer__select-collection.react-select .rs__option',
+            '[id^=drawer_1_list-drawer] .list-drawer__select-collection.react-select .rs__option',
             {
               hasText: exactText('User'),
             },
@@ -606,7 +610,7 @@ describe('admin2', () => {
         await expect(
           page
             .locator(
-              '[id^=list-drawer_1_] .list-controls .column-selector .column-selector__column',
+              '[id^=drawer_1_list-drawer] .list-controls .column-selector .column-selector__column',
             )
             .first(),
         ).not.toHaveClass('column-selector__column--active')
@@ -616,7 +620,7 @@ describe('admin2', () => {
 
         await page
           .locator(
-            '[id^=list-drawer_1_] .list-drawer__select-collection.react-select .rs__option',
+            '[id^=drawer_1_list-drawer] .list-drawer__select-collection.react-select .rs__option',
             {
               hasText: exactText('Post'),
             },
@@ -627,7 +631,7 @@ describe('admin2', () => {
         await expect(
           page
             .locator(
-              '[id^=list-drawer_1_] .list-controls .column-selector .column-selector__column',
+              '[id^=drawer_1_list-drawer] .list-controls .column-selector .column-selector__column',
             )
             .first(),
         ).not.toHaveClass('column-selector__column--active')

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -410,14 +410,14 @@ describe('fields - relationship', () => {
       '#field-relationshipReadOnly button.relationship--single-value__drawer-toggler.doc-drawer__toggler',
     )
 
-    const documentDrawer = page.locator('[id^=doc-drawer_relation-one_1_]')
+    const documentDrawer = page.locator('[id^=drawer_1_doc-drawer__relation-one]')
     await expect(documentDrawer).toBeVisible()
   })
 
   test('should open document drawer and append newly created docs onto the parent field', async () => {
     await page.goto(url.edit(docWithExistingRelations.id))
     await openCreateDocDrawer(page, '#field-relationshipHasMany')
-    const documentDrawer = page.locator('[id^=doc-drawer_relation-one_1_]')
+    const documentDrawer = page.locator('[id^=drawer_1_doc-drawer__relation-one]')
     await expect(documentDrawer).toBeVisible()
     const drawerField = documentDrawer.locator('#field-name')
     await drawerField.fill('Newly created document')

--- a/test/fields/collections/Lexical/e2e/blocks/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e/blocks/e2e.spec.ts
@@ -541,7 +541,7 @@ describe('lexicalBlocks', () => {
         await wait(300)
         await chooseExistingUploadButton.click()
         await wait(500) // wait for drawer form state to initialize (it's a flake)
-        const uploadListDrawer = page.locator('dialog[id^=list-drawer_1_]').first() // IDs starting with list-drawer_1_ (there's some other symbol after the underscore)
+        const uploadListDrawer = page.locator('dialog[id^=drawer_1_list-drawer]').first() // IDs starting with drawer_1_list-drawer (there's some other symbol after the underscore)
         await expect(uploadListDrawer).toBeVisible()
         await wait(300)
 

--- a/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
@@ -387,7 +387,7 @@ describe('lexicalMain', () => {
     await expect(slashMenuPopover).toBeHidden()
 
     await wait(500) // wait for drawer form state to initialize (it's a flake)
-    const uploadListDrawer = page.locator('dialog[id^=list-drawer_1_]').first() // IDs starting with list-drawer_1_ (there's some other symbol after the underscore)
+    const uploadListDrawer = page.locator('dialog[id^=drawer_1_list-drawer]').first() // IDs starting with drawer_1_list-drawer (there's some other symbol after the underscore)
     await expect(uploadListDrawer).toBeVisible()
     await wait(500)
 
@@ -405,7 +405,7 @@ describe('lexicalMain', () => {
     ).toBeVisible()
 
     await uploadListDrawer.getByText('Create New').first().click()
-    const createUploadDrawer = page.locator('dialog[id^=drawer_1_doc-drawer__uploads2]').first() // IDs starting with list-drawer_1_ (there's some other symbol after the underscore)
+    const createUploadDrawer = page.locator('dialog[id^=drawer_1_doc-drawer__uploads2]').first() // IDs starting with drawer_1_list-drawer (there's some other symbol after the underscore)
     await expect(createUploadDrawer).toBeVisible()
     await wait(500)
 
@@ -466,7 +466,7 @@ describe('lexicalMain', () => {
     await expect(slashMenuPopover).toBeHidden()
 
     await wait(500) // wait for drawer form state to initialize (it's a flake)
-    const uploadListDrawer = page.locator('dialog[id^=list-drawer_1_]').first() // IDs starting with list-drawer_1_ (there's some other symbol after the underscore)
+    const uploadListDrawer = page.locator('dialog[id^=drawer_1_list-drawer]').first() // IDs starting with drawer_1_list-drawer (there's some other symbol after the underscore)
     await expect(uploadListDrawer).toBeVisible()
     await wait(500)
 

--- a/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
@@ -405,7 +405,7 @@ describe('lexicalMain', () => {
     ).toBeVisible()
 
     await uploadListDrawer.getByText('Create New').first().click()
-    const createUploadDrawer = page.locator('dialog[id^=doc-drawer_uploads2_]').first() // IDs starting with list-drawer_1_ (there's some other symbol after the underscore)
+    const createUploadDrawer = page.locator('dialog[id^=drawer_1_doc-drawer__uploads2]').first() // IDs starting with list-drawer_1_ (there's some other symbol after the underscore)
     await expect(createUploadDrawer).toBeVisible()
     await wait(500)
 

--- a/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
@@ -405,7 +405,7 @@ describe('lexicalMain', () => {
     ).toBeVisible()
 
     await uploadListDrawer.getByText('Create New').first().click()
-    const createUploadDrawer = page.locator('dialog[id^=drawer_1_doc-drawer__uploads2]').first() // IDs starting with drawer_1_list-drawer (there's some other symbol after the underscore)
+    const createUploadDrawer = page.locator('dialog[id^=drawer_2_doc-drawer__uploads2]').first() // IDs starting with drawer_1_list-drawer (there's some other symbol after the underscore)
     await expect(createUploadDrawer).toBeVisible()
     await wait(500)
 

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -87,7 +87,7 @@ describe('relationship', () => {
     await textField.fill(textValue)
     await page.locator('[id^=drawer_1_doc-drawer__text-fields] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
-    await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click()
+    await page.locator('[id^=close-drawer__drawer_1_doc-drawer__text-fields]').click()
     await expect(
       page.locator('#field-relationship .relationship--single-value__text'),
     ).toContainText(textValue)
@@ -125,7 +125,7 @@ describe('relationship', () => {
     // Save then close the second modal
     await page.locator('[id^=drawer_2_doc-drawer__relationship-fields] #action-save').click()
     await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('create')
-    await page.locator('[id^=close-drawer__doc-drawer_relationship-fields_2_]').click()
+    await page.locator('[id^=close-drawer__drawer_2_doc-drawer__relationship-fields]').click()
 
     // Assert that the first modal is still open and the value matches
     await expect(page.locator('[id^=drawer_1_doc-drawer__relationship-fields]')).toBeVisible()
@@ -138,7 +138,7 @@ describe('relationship', () => {
     // Save then close the first modal
     await page.locator('[id^=drawer_1_doc-drawer__relationship-fields] #action-save').click()
     await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('create')
-    await page.locator('[id^=close-drawer__doc-drawer_relationship-fields_1_]').click()
+    await page.locator('[id^=close-drawer__drawer_1_doc-drawer__relationship-fields]').click()
 
     // Expect the original field to have a value filled
     await expect(
@@ -251,7 +251,7 @@ describe('relationship', () => {
 
     await page.locator('[id^=drawer_1_doc-drawer__text-fields] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
-    await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click()
+    await page.locator('[id^=close-drawer__drawer_1_doc-drawer__text-fields]').click()
     await page.locator('#action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
 
@@ -264,7 +264,7 @@ describe('relationship', () => {
     // Save and close the drawer
     await page.locator('[id^=drawer_1_doc-drawer__text-fields] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
-    await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click()
+    await page.locator('[id^=close-drawer__drawer_1_doc-drawer__text-fields]').click()
 
     // Now open the drawer again to edit the `text` field _using the keyboard_
     // Mimic real user behavior by typing into the field with spaces and backspaces
@@ -288,7 +288,7 @@ describe('relationship', () => {
     await page.locator('[id^=drawer_1_doc-drawer__text-fields] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
     // close drawer
-    await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click()
+    await page.locator('[id^=close-drawer__drawer_1_doc-drawer__text-fields]').click()
     // save document and reload
     await page.locator('#action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -118,7 +118,7 @@ describe('relationship', () => {
     await page.locator('[id^=drawer_2_doc-drawer__relationship-fields] #field-relationship').click()
     await page
       .locator(
-        '[id^=drawer_q_collection__relationship-fields] .rs__option:has-text("Seeded text document")',
+        '[id^=drawer_2_doc-drawer__relationship-fields] .rs__option:has-text("Seeded text document")',
       )
       .click()
 

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -85,7 +85,7 @@ describe('relationship', () => {
     await expect(textField).toBeEnabled()
     const textValue = 'hello'
     await textField.fill(textValue)
-    await page.locator('[id^=doc-drawer_text-fields_1_] #action-save').click()
+    await page.locator('[id^=drawer_1_doc-drawer__text-fields] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
     await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click()
     await expect(
@@ -102,41 +102,41 @@ describe('relationship', () => {
     await openCreateDocDrawer(page, '#field-relationToSelf')
 
     // Fill first modal's required relationship field
-    await page.locator('[id^=doc-drawer_relationship-fields_1_] #field-relationship').click()
+    await page.locator('[id^=drawer_1_doc-drawer__relationship-fields] #field-relationship').click()
     await page
       .locator(
-        '[id^=doc-drawer_relationship-fields_1_] .rs__option:has-text("Seeded text document")',
+        '[id^=drawer_1_doc-drawer__relationship-fields] .rs__option:has-text("Seeded text document")',
       )
       .click()
 
     const secondModalButton = page.locator(
-      '[id^=doc-drawer_relationship-fields_1_] #relationToSelf-add-new button',
+      '[id^=drawer_1_doc-drawer__relationship-fields] #relationToSelf-add-new button',
     )
     await secondModalButton.click()
 
     // Fill second modal's required relationship field
-    await page.locator('[id^=doc-drawer_relationship-fields_2_] #field-relationship').click()
+    await page.locator('[id^=drawer_2_doc-drawer__relationship-fields] #field-relationship').click()
     await page
       .locator(
-        '[id^=doc-drawer_relationship-fields_2_] .rs__option:has-text("Seeded text document")',
+        '[id^=drawer_q_collection__relationship-fields] .rs__option:has-text("Seeded text document")',
       )
       .click()
 
     // Save then close the second modal
-    await page.locator('[id^=doc-drawer_relationship-fields_2_] #action-save').click()
+    await page.locator('[id^=drawer_2_doc-drawer__relationship-fields] #action-save').click()
     await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('create')
     await page.locator('[id^=close-drawer__doc-drawer_relationship-fields_2_]').click()
 
     // Assert that the first modal is still open and the value matches
-    await expect(page.locator('[id^=doc-drawer_relationship-fields_1_]')).toBeVisible()
+    await expect(page.locator('[id^=drawer_1_doc-drawer__relationship-fields]')).toBeVisible()
     await expect(
       page.locator(
-        '[id^=doc-drawer_relationship-fields_1_] #field-relationToSelf .relationship--single-value__text',
+        '[id^=drawer_1_doc-drawer__relationship-fields] #field-relationToSelf .relationship--single-value__text',
       ),
     ).toBeVisible() // TODO: use '.toContainText('doc_id')' with the doc in the second modal
 
     // Save then close the first modal
-    await page.locator('[id^=doc-drawer_relationship-fields_1_] #action-save').click()
+    await page.locator('[id^=drawer_1_doc-drawer__relationship-fields] #action-save').click()
     await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('create')
     await page.locator('[id^=close-drawer__doc-drawer_relationship-fields_1_]').click()
 
@@ -249,7 +249,7 @@ describe('relationship', () => {
 
     await page.locator('.drawer__content #field-text').fill('something')
 
-    await page.locator('[id^=doc-drawer_text-fields_1_] #action-save').click()
+    await page.locator('[id^=drawer_1_doc-drawer__text-fields] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
     await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click()
     await page.locator('#action-save').click()
@@ -262,7 +262,7 @@ describe('relationship', () => {
     await page.locator('.drawer__content #field-text').fill(value)
 
     // Save and close the drawer
-    await page.locator('[id^=doc-drawer_text-fields_1_] #action-save').click()
+    await page.locator('[id^=drawer_1_doc-drawer__text-fields] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
     await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click()
 
@@ -272,20 +272,20 @@ describe('relationship', () => {
     await page
       .locator('#field-relationshipHasMany button.relationship--multi-value-label__drawer-toggler')
       .click()
-    await page.locator('[id^=doc-drawer_text-fields_1_] #field-text').click()
+    await page.locator('[id^=drawer_1_doc-drawer__text-fields] #field-text').click()
     await page.keyboard.down('1')
     await page.keyboard.type('23')
-    await expect(page.locator('[id^=doc-drawer_text-fields_1_] #field-text')).toHaveValue(
+    await expect(page.locator('[id^=drawer_1_doc-drawer__text-fields] #field-text')).toHaveValue(
       `${value}123`,
     )
     await page.keyboard.type('4567')
     await page.keyboard.press('Backspace')
-    await expect(page.locator('[id^=doc-drawer_text-fields_1_] #field-text')).toHaveValue(
+    await expect(page.locator('[id^=drawer_1_doc-drawer__text-fields] #field-text')).toHaveValue(
       `${value}123456`,
     )
 
     // save drawer
-    await page.locator('[id^=doc-drawer_text-fields_1_] #action-save').click()
+    await page.locator('[id^=drawer_1_doc-drawer__text-fields] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
     // close drawer
     await page.locator('[id^=close-drawer__doc-drawer_text-fields_1_]').click()

--- a/test/fields/collections/RichText/e2e.spec.ts
+++ b/test/fields/collections/RichText/e2e.spec.ts
@@ -217,7 +217,7 @@ describe('Rich Text', () => {
       await button.click()
 
       // check that the search is on the `name` field of the `text-fields` collection
-      const drawer = page.locator('[id^=list-drawer_1_]')
+      const drawer = page.locator('[id^=drawer_1_list-drawer]')
 
       await expect(drawer.locator('.search-filter__input')).toHaveAttribute(
         'placeholder',

--- a/test/fields/collections/RichText/e2e.spec.ts
+++ b/test/fields/collections/RichText/e2e.spec.ts
@@ -383,7 +383,7 @@ describe('Rich Text', () => {
 
       await button.click()
 
-      const documentDrawer = page.locator('[id^=doc-drawer_uploads_1_]')
+      const documentDrawer = page.locator('[id^=drawer_1_doc-drawer__uploads]')
       await expect(documentDrawer).toBeVisible()
     })
 
@@ -396,7 +396,7 @@ describe('Rich Text', () => {
 
       await button.click()
 
-      const documentDrawer = page.locator('[id^=doc-drawer_text-fields_1_]')
+      const documentDrawer = page.locator('[id^=drawer_1_doc-drawer__text-fields]')
       await expect(documentDrawer).toBeVisible()
     })
 

--- a/test/fields/collections/Upload/e2e.spec.ts
+++ b/test/fields/collections/Upload/e2e.spec.ts
@@ -130,12 +130,12 @@ describe('Upload', () => {
     await openDocDrawer(page, '#field-media .upload__createNewToggler')
 
     await page
-      .locator('[id^=doc-drawer_uploads_1_] .file-field__upload input[type="file"]')
+      .locator('[id^=drawer_1_doc-drawer__uploads] .file-field__upload input[type="file"]')
       .setInputFiles(path.resolve(dirname, './uploads/payload.png'))
     await expect(
-      page.locator('[id^=doc-drawer_uploads_1_] .file-field__upload .file-field__filename'),
+      page.locator('[id^=drawer_1_doc-drawer__uploads] .file-field__upload .file-field__filename'),
     ).toHaveValue('payload.png')
-    await page.locator('[id^=doc-drawer_uploads_1_] #action-save').click()
+    await page.locator('[id^=drawer_1_doc-drawer__uploads] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
 
     // Assert that the media field has the png upload
@@ -159,12 +159,12 @@ describe('Upload', () => {
     await openDocDrawer(page, '#field-media .upload__createNewToggler')
 
     await page
-      .locator('[id^=doc-drawer_uploads_1_] .file-field__upload input[type="file"]')
+      .locator('[id^=drawer_1_doc-drawer__uploads] .file-field__upload input[type="file"]')
       .setInputFiles(path.resolve(dirname, './uploads/payload.png'))
     await expect(
-      page.locator('[id^=doc-drawer_uploads_1_] .file-field__upload .file-field__filename'),
+      page.locator('[id^=drawer_1_doc-drawer__uploads] .file-field__upload .file-field__filename'),
     ).toHaveValue('payload.png')
-    await page.locator('[id^=doc-drawer_uploads_1_] .file-field__edit').click()
+    await page.locator('[id^=drawer_1_doc-drawer__uploads] .file-field__edit').click()
     await page
       .locator('[id^=edit-upload] .edit-upload__input input[name="Width (px)"]')
       .nth(1)
@@ -174,7 +174,7 @@ describe('Upload', () => {
       .nth(1)
       .fill('200')
     await page.locator('[id^=edit-upload] button:has-text("Apply Changes")').nth(1).click()
-    await page.locator('[id^=doc-drawer_uploads_1_] #action-save').click()
+    await page.locator('[id^=drawer_1_doc-drawer__uploads] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
 
     // Assert that the media field has the png upload
@@ -199,12 +199,12 @@ describe('Upload', () => {
     await wait(1000)
 
     await page
-      .locator('[id^=doc-drawer_uploads_1_] .file-field__upload input[type="file"]')
+      .locator('[id^=drawer_1_doc-drawer__uploads] .file-field__upload input[type="file"]')
       .setInputFiles(path.resolve(dirname, './uploads/payload.png'))
     await expect(
-      page.locator('[id^=doc-drawer_uploads_1_] .file-field__upload .file-field__filename'),
+      page.locator('[id^=drawer_1_doc-drawer__uploads] .file-field__upload .file-field__filename'),
     ).toHaveValue('payload.png')
-    await page.locator('[id^=doc-drawer_uploads_1_] #action-save').click()
+    await page.locator('[id^=drawer_1_doc-drawer__uploads] #action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
     await page.locator('.field-type.upload .upload-relationship-details__remove').click()
   })

--- a/test/fields/collections/Upload/e2e.spec.ts
+++ b/test/fields/collections/Upload/e2e.spec.ts
@@ -214,7 +214,7 @@ describe('Upload', () => {
 
     await openDocDrawer(page, '.field-type.upload .upload__listToggler')
 
-    const jpgImages = page.locator('[id^=list-drawer_1_] .upload-gallery img[src$=".jpg"]')
+    const jpgImages = page.locator('[id^=drawer_1_list-drawer] .upload-gallery img[src$=".jpg"]')
     await expect
       .poll(async () => await jpgImages.count(), { timeout: POLL_TOPASS_TIMEOUT })
       .toEqual(0)

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -305,13 +305,13 @@ describe('uploads', () => {
     await expect(listDrawer).toBeVisible()
 
     await openDocDrawer(page, 'button.list-drawer__create-new-button.doc-drawer__toggler')
-    await expect(page.locator('[id^=doc-drawer_media_2_]')).toBeVisible()
+    await expect(page.locator('[id^=drawer_2_doc-drawer__media]')).toBeVisible()
 
     // upload an image and try to select it
     await page
-      .locator('[id^=doc-drawer_media_2_] .file-field__upload input[type="file"]')
+      .locator('[id^=drawer_2_doc-drawer__media] .file-field__upload input[type="file"]')
       .setInputFiles(path.resolve(dirname, './image.png'))
-    await page.locator('[id^=doc-drawer_media_2_] button#action-save').click()
+    await page.locator('[id^=drawer_2_doc-drawer__media] button#action-save').click()
     await expect(page.locator('.payload-toast-container .toast-success')).toContainText(
       'successfully',
     )

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -301,7 +301,7 @@ describe('uploads', () => {
 
     await openDocDrawer(page, '#field-audio  .upload__listToggler')
 
-    const listDrawer = page.locator('[id^=list-drawer_1_]')
+    const listDrawer = page.locator('[id^=drawer_1_list-drawer]')
     await expect(listDrawer).toBeVisible()
 
     await openDocDrawer(page, 'button.list-drawer__create-new-button.doc-drawer__toggler')
@@ -336,7 +336,7 @@ describe('uploads', () => {
 
     await openDocDrawer(page, '.upload__listToggler')
 
-    const listDrawer = page.locator('[id^=list-drawer_1_]')
+    const listDrawer = page.locator('[id^=drawer_1_list-drawer]')
     await expect(listDrawer).toBeVisible()
 
     await expect(listDrawer.locator('tbody tr')).toHaveCount(1)


### PR DESCRIPTION
- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Description

This change separates Drawers reliance on EditDepth, and instead uses a new DrawerDepth provider so you can differentiate between the two.

Rendering an `<EditDepthProvider>` should not change the style of Drawers. Rendering a `<DrawerDepthProvider>` should. The indentation for drawers should be automatic, no need to set the depth of the drawer by reading the parent drawer depth and adding 1.

`<DrawerDepthProvider>` and the `<EditDepthProvider>` no longer take a `depth` parameter. They are self-contained and will self-increment their own depth based on their parent (which is based on its parent, etc etc up the tree).

**Note:** it seems like semantically, it would make more sense if `<EditDepthProvider>` was renamed to `<FormDepthProvider>`.

## **BREAKING CHANGES**
_This only applies to custom usage of Drawers in custom components_
- EditDepthProvider no longer takes a `depth` prop
- If you were rendering a EditDepthProvider around your Drawer so the Drawer would have the left indent, you no longer need to do that, so you can remove the EditDepthProvider
- Drawer Slugs (only important if you were targeting them with CSS or JS)
  - Document Drawer
    - previous: `doc-drawer_${collectionSlug}_${depth}_${docID}`
    - new: `drawer-${depth}_doc-drawer__${collectionSlug}_${docID}`
  - List Drawer
    - previous: `list-drawer_${depth}_${uuid}`
    - new: `drawer-${depth}_list-drawer`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
