### PR TITLE
fix: Revert fields using x-http-method-override

### DIFF
--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -203,15 +203,11 @@ const RelationshipFieldComponent: React.FC<RelationshipFieldProps> = (props) => 
               query.where.and.push(relationFilterOption)
             }
 
-            const response = await fetch(`${serverURL}${api}/${relation}`, {
-              body: qs.stringify(query),
+            const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(query)}`, {
               credentials: 'include',
               headers: {
                 'Accept-Language': i18n.language,
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'X-HTTP-Method-Override': 'GET',
               },
-              method: 'POST',
             })
 
             if (response.ok) {
@@ -334,15 +330,11 @@ const RelationshipFieldComponent: React.FC<RelationshipFieldProps> = (props) => 
         }
 
         if (!errorLoading) {
-          const response = await fetch(`${serverURL}${api}/${relation}`, {
-            body: qs.stringify(query),
+          const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(query)}`, {
             credentials: 'include',
             headers: {
               'Accept-Language': i18n.language,
-              'Content-Type': 'application/x-www-form-urlencoded',
-              'X-HTTP-Method-Override': 'GET',
             },
-            method: 'POST',
           })
 
           const collection = collections.find((coll) => coll.slug === relation)

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -18,6 +18,7 @@ import { useAuth } from '../../providers/Auth/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { fetchWithMethodOverride } from '../../utilities/fetchWithMethodOverride.js'
 import { FieldDescription } from '../FieldDescription/index.js'
 import { FieldError } from '../FieldError/index.js'
 import { FieldLabel } from '../FieldLabel/index.js'
@@ -203,11 +204,12 @@ const RelationshipFieldComponent: React.FC<RelationshipFieldProps> = (props) => 
               query.where.and.push(relationFilterOption)
             }
 
-            const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(query)}`, {
-              credentials: 'include',
-              headers: {
-                'Accept-Language': i18n.language,
-              },
+            const response = await fetchWithMethodOverride({
+              api,
+              language: i18n.language,
+              queryStr: qs.stringify(query),
+              relation,
+              serverURL,
             })
 
             if (response.ok) {
@@ -330,11 +332,12 @@ const RelationshipFieldComponent: React.FC<RelationshipFieldProps> = (props) => 
         }
 
         if (!errorLoading) {
-          const response = await fetch(`${serverURL}${api}/${relation}?${qs.stringify(query)}`, {
-            credentials: 'include',
-            headers: {
-              'Accept-Language': i18n.language,
-            },
+          const response = await fetchWithMethodOverride({
+            api,
+            language: i18n.language,
+            queryStr: qs.stringify(query),
+            relation,
+            serverURL,
           })
 
           const collection = collections.find((coll) => coll.slug === relation)

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -32,6 +32,7 @@ import { ShimmerEffect } from '../../elements/ShimmerEffect/index.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { fetchWithMethodOverride } from '../../utilities/fetchWithMethodOverride.js'
 import { FieldDescription } from '../FieldDescription/index.js'
 import { FieldError } from '../FieldError/index.js'
 import { FieldLabel } from '../FieldLabel/index.js'
@@ -200,11 +201,12 @@ export function UploadInput(props: UploadInputProps) {
         },
       }
 
-      const response = await fetch(`${serverURL}${api}/${relatedCollectionSlug}?${qs.stringify(query)}`, {
-        credentials: 'include',
-        headers: {
-          'Accept-Language': i18n.language,
-        },
+      const response = await fetchWithMethodOverride({
+        api,
+        language: i18n.language,
+        queryStr: qs.stringify(query),
+        relation: relatedCollectionSlug,
+        serverURL,
       })
       if (response.ok) {
         const json = await response.json()

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -200,15 +200,11 @@ export function UploadInput(props: UploadInputProps) {
         },
       }
 
-      const response = await fetch(`${serverURL}${api}/${relatedCollectionSlug}`, {
-        body: qs.stringify(query),
+      const response = await fetch(`${serverURL}${api}/${relatedCollectionSlug}?${qs.stringify(query)}`, {
         credentials: 'include',
         headers: {
           'Accept-Language': i18n.language,
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'X-HTTP-Method-Override': 'GET',
         },
-        method: 'POST',
       })
       if (response.ok) {
         const json = await response.json()

--- a/packages/ui/src/utilities/fetchWithMethodOverride.ts
+++ b/packages/ui/src/utilities/fetchWithMethodOverride.ts
@@ -1,0 +1,44 @@
+/**
+ * fetchWithMethodOverride allows us to fetch data for a large query.
+ *
+ * If the URL is larger than 2083 characters we will hit URL limits in
+ * browsers.
+ *
+ * One way to circumvent the limit is to use the header: 'X-HTTP-Method-Override' allowing us
+ * to fetch data using a POST request instead of a GET request. However some proxies
+ * disallow the use of the 'X-HTTP-Method-Override' therefore we only want to use it
+ * as a last resort.
+ */
+export async function fetchWithMethodOverride({
+  api,
+  language,
+  queryStr,
+  relation,
+  serverURL,
+}: {
+  api: string
+  language: string
+  queryStr: string
+  relation: string
+  serverURL: string
+}): Promise<Response> {
+  const baseUrl = `${serverURL}${api}/${relation}`
+
+  // The '?' query character needs to be accounted for
+  const useGet = baseUrl.length + queryStr.length + 1 < 2083
+
+  const queryURL = `${baseUrl}${useGet ? `?${queryStr}` : ''}`
+
+  return fetch(queryURL, {
+    credentials: 'include',
+    ...(!useGet && { body: queryStr }),
+    headers: {
+      'Accept-Language': language,
+      ...(!useGet && {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-HTTP-Method-Override': 'GET',
+      }),
+    },
+    method: useGet ? 'GET' : 'POST',
+  })
+}

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -622,6 +622,58 @@ describe('fields - relationship', () => {
       ).toHaveCount(15)
     })
   })
+
+  describe('field relationship with many items', () => {
+    beforeEach(async () => {
+      const relations: string[] = []
+      const batchSize = 10
+      const totalRelations = 300
+      const totalBatches = Math.ceil(totalRelations / batchSize)
+      for (let i = 0; i < totalBatches; i++) {
+        const batchPromises: Promise<RelationOne>[] = []
+        const start = i * batchSize
+        const end = Math.min(start + batchSize, totalRelations)
+
+        for (let j = start; j < end; j++) {
+          batchPromises.push(
+            payload.create({
+              collection: relationOneSlug,
+              data: {
+                name: 'relation',
+              },
+            }),
+          )
+        }
+
+        const batchRelations = await Promise.all(batchPromises)
+        relations.push(...batchRelations.map((doc) => doc.id))
+      }
+
+      await payload.update({
+        id: docWithExistingRelations.id,
+        collection: slug,
+        data: {
+          relationshipHasMany: relations,
+        },
+      })
+    })
+
+    test('should update with new relationship', async () => {
+      await page.goto(url.edit(docWithExistingRelations.id))
+
+      const field = page.locator('#field-relationshipHasMany')
+      const dropdownIndicator = field.locator('.dropdown-indicator')
+      await dropdownIndicator.click({ delay: 100 })
+
+      const options = page.locator('.rs__option')
+      await expect(options).toHaveCount(2)
+
+      await options.nth(0).click()
+      await expect(field).toContainText(relationOneDoc.id)
+
+      await saveDocAndAssert(page)
+    })
+  })
 })
 
 async function clearAllDocs(): Promise<void> {

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -622,58 +622,6 @@ describe('fields - relationship', () => {
       ).toHaveCount(15)
     })
   })
-
-  describe('field relationship with many items', () => {
-    beforeEach(async () => {
-      const relations: string[] = []
-      const batchSize = 10
-      const totalRelations = 300
-      const totalBatches = Math.ceil(totalRelations / batchSize)
-      for (let i = 0; i < totalBatches; i++) {
-        const batchPromises: Promise<RelationOne>[] = []
-        const start = i * batchSize
-        const end = Math.min(start + batchSize, totalRelations)
-
-        for (let j = start; j < end; j++) {
-          batchPromises.push(
-            payload.create({
-              collection: relationOneSlug,
-              data: {
-                name: 'relation',
-              },
-            }),
-          )
-        }
-
-        const batchRelations = await Promise.all(batchPromises)
-        relations.push(...batchRelations.map((doc) => doc.id))
-      }
-
-      await payload.update({
-        id: docWithExistingRelations.id,
-        collection: slug,
-        data: {
-          relationshipHasMany: relations,
-        },
-      })
-    })
-
-    test('should update with new relationship', async () => {
-      await page.goto(url.edit(docWithExistingRelations.id))
-
-      const field = page.locator('#field-relationshipHasMany')
-      const dropdownIndicator = field.locator('.dropdown-indicator')
-      await dropdownIndicator.click({ delay: 100 })
-
-      const options = page.locator('.rs__option')
-      await expect(options).toHaveCount(2)
-
-      await options.nth(0).click()
-      await expect(field).toContainText(relationOneDoc.id)
-
-      await saveDocAndAssert(page)
-    })
-  })
 })
 
 async function clearAllDocs(): Promise<void> {


### PR DESCRIPTION
X-HTTP-Method-Override breaks the relationship and upload field on AWS cloudfront. As well as in any network stack that filters X-HTTP-Method-Override headers. This commit addresses the discussion: #7248

X-HTTP-Method-Override was added as part of PR#6487. The X-HTTP-Method-Override can be security sensitive in some cases therefore some networks stacks remove the header.
In my case the header is removed  before the payload service ingress (Nginx) is called.

This commit reverts part of #6487, that issue might need to be opened gain if this is merged. I find it hard to understand under what scenarios the relations field and upload filed would break due to too many relations. Maybe there is a different workaround that doesn't resort to X-HTTP-Method-Override?

## Description

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

**I didn't add a test, instead I removed the old test. I figured a discussion was in order before I put more time into this.**

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
