### PR TITLE
feat(storage-vercel-blob): threads cacheControlMaxAge through static handler

### DIFF
--- a/packages/storage-vercel-blob/src/index.ts
+++ b/packages/storage-vercel-blob/src/index.ts
@@ -148,7 +148,7 @@ function vercelBlobStorageInternal(
         prefix,
         token,
       }),
-      staticHandler: getStaticHandler({ baseUrl, token }, collection),
+      staticHandler: getStaticHandler({ baseUrl, token, cacheControlMaxAge }, collection),
     }
   }
 }

--- a/packages/storage-vercel-blob/src/staticHandler.ts
+++ b/packages/storage-vercel-blob/src/staticHandler.ts
@@ -8,11 +8,11 @@ import path from 'path'
 type StaticHandlerArgs = {
   baseUrl: string
   token: string
-  cacheControlMaxAge: number
+  cacheControlMaxAge?: number
 }
 
 export const getStaticHandler = (
-  { baseUrl, token, cacheControlMaxAge }: StaticHandlerArgs,
+  { baseUrl, token, cacheControlMaxAge = 0 }: StaticHandlerArgs,
   collection: CollectionConfig,
 ): StaticHandler => {
   return async (req, { params: { filename } }) => {

--- a/packages/storage-vercel-blob/src/staticHandler.ts
+++ b/packages/storage-vercel-blob/src/staticHandler.ts
@@ -41,7 +41,7 @@ export const getStaticHandler = (
           'Content-Disposition': contentDisposition,
           'Content-Length': String(size),
           'Content-Type': contentType,
-          'Cache-Control', `public, max-age=${cacheControlMaxAge}`
+          'Cache-Control': `public, max-age=${cacheControlMaxAge}`
         }),
         status: 200,
       })

--- a/packages/storage-vercel-blob/src/staticHandler.ts
+++ b/packages/storage-vercel-blob/src/staticHandler.ts
@@ -8,10 +8,11 @@ import path from 'path'
 type StaticHandlerArgs = {
   baseUrl: string
   token: string
+  cacheControlMaxAge: number
 }
 
 export const getStaticHandler = (
-  { baseUrl, token }: StaticHandlerArgs,
+  { baseUrl, token, cacheControlMaxAge }: StaticHandlerArgs,
   collection: CollectionConfig,
 ): StaticHandler => {
   return async (req, { params: { filename } }) => {
@@ -40,6 +41,7 @@ export const getStaticHandler = (
           'Content-Disposition': contentDisposition,
           'Content-Length': String(size),
           'Content-Type': contentType,
+          'Cache-Control', `public, max-age=${cacheControlMaxAge}`
         }),
         status: 200,
       })


### PR DESCRIPTION
## Description
I'm facing a issue while trying to set a cache age for vercel blob storage plugin, this way I changed to accept and set as response the cache control.

### Before changes
![image](https://github.com/user-attachments/assets/b67ee1a0-f4af-4f1f-942a-2063ec2fa5a2)
![image](https://github.com/user-attachments/assets/a3a7bce7-70be-4c06-ade6-3708f47d524c)


### After changes

![image](https://github.com/user-attachments/assets/9085193a-ef2d-4fa0-9aae-6817fe97aae0)

![image](https://github.com/user-attachments/assets/69a44948-402d-423b-873b-026be39c7501)

### Using plugin
```
vercelBlobStorage({
      enabled: true, // Optional, defaults to true
      // dev: Specify which collections should use Vercel Blob
      collections: {
        [Media.slug]: true,
      },
      // dev:Token provided by Vercel once Blob storage is added to your Vercel project
      token: process.env.BLOB_READ_WRITE_TOKEN!,
      cacheControlMaxAge: 31536000, /// the same we see
    }),
```

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
