### PR TITLE
fix: only show restore as draft option when drafts enabled

### DIFF
--- a/packages/next/src/views/Version/Restore/index.tsx
+++ b/packages/next/src/views/Version/Restore/index.tsx
@@ -36,10 +36,13 @@ const Restore: React.FC<Props> = ({
 }) => {
   const {
     config: {
+      collections,
       routes: { admin: adminRoute, api: apiRoute },
       serverURL,
     },
   } = useConfig()
+
+  const collectionConfig = collections.find((collection) => collection.slug === collectionSlug)
 
   const { toggleModal } = useModal()
   const [processing, setProcessing] = useState(false)
@@ -54,7 +57,8 @@ const Restore: React.FC<Props> = ({
 
   let fetchURL = `${serverURL}${apiRoute}`
   let redirectURL: string
-  const canRestoreAsDraft = status !== 'draft'
+
+  const canRestoreAsDraft = status !== 'draft' && collectionConfig?.versions?.drafts
 
   if (collectionSlug) {
     fetchURL = `${fetchURL}/${collectionSlug}/versions/${versionID}?draft=${draft}`


### PR DESCRIPTION
## Description

In version comparison view, the `Restore as draft` button should only be visible when `versions.drafts: true`.

Before:
<img width="1414" alt="Screenshot 2024-09-04 at 3 33 21 PM" src="https://github.com/user-attachments/assets/1f96d804-46d7-443a-99ea-7b6481839b47">

After:
<img width="1307" alt="Screenshot 2024-09-04 at 3 38 42 PM" src="https://github.com/user-attachments/assets/d2621ddd-2b14-4dab-936c-29a5521444de">


- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
