### PR TITLE
feat: add new option to disable JOI validation

### DIFF
--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -39,6 +39,7 @@ export const defaults: Omit<Config, 'db' | 'editor'> = {
     schemaOutputFile: `${typeof process?.cwd === 'function' ? process.cwd() : ''}/schema.graphql`,
   },
   hooks: {},
+  joiValidation: true,
   localization: false,
   maxDepth: 10,
   rateLimit: {

--- a/packages/payload/src/config/schema.ts
+++ b/packages/payload/src/config/schema.ts
@@ -128,6 +128,7 @@ export default joi.object({
   }),
   i18n: joi.object(),
   indexSortableFields: joi.boolean(),
+  joiValidation: joi.boolean(),
   local: joi.boolean(),
   localization: joi.alternatives().try(
     joi.object().keys({

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -149,6 +149,11 @@ export type InitOptions = {
    */
   local?: boolean
 
+  /**
+   * A previously instantiated logger instance. Must conform to the PayloadLogger interface which uses Pino
+   * This allows you to bring your own logger instance and let payload use it
+   */
+  logger?: PayloadLogger
   loggerDestination?: DestinationStream
   /**
    * Specify options for the built-in Pino logger that Payload uses for internal logging.
@@ -156,11 +161,6 @@ export type InitOptions = {
    * See Pino Docs for options: https://getpino.io/#/docs/api?id=options
    */
   loggerOptions?: LoggerOptions
-  /**
-   * A previously instantiated logger instance. Must conform to the PayloadLogger interface which uses Pino
-   * This allows you to bring your own logger instance and let payload use it
-   */
-  logger?: PayloadLogger
 
   /**
    * A function that is called immediately following startup that receives the Payload instance as it's only argument.
@@ -635,6 +635,12 @@ export type Config = {
   i18n?: i18nInitOptions
   /** Automatically index all sortable top-level fields in the database to improve sort performance and add database compatibility for Azure Cosmos and similar. */
   indexSortableFields?: boolean
+  /**
+   * Disable JOI validation
+   *
+   * @default true // enabled by default
+   */
+  joiValidation?: boolean
   /**
    * Translate your content to different languages/locales.
    *

--- a/packages/payload/src/config/validate.ts
+++ b/packages/payload/src/config/validate.ts
@@ -83,6 +83,10 @@ const validateSchema = async (
     abortEarly: false,
   })
 
+  if (!config?.joiValidation) {
+    return config
+  }
+
   const nestedErrors = [
     ...(await validateCollections(config.collections)),
     ...validateGlobals(config.globals),


### PR DESCRIPTION
## Description

Adds new option `joiValidation: boolean` to the payload config per client request. 

`joiValidation` defaults to `true`, when set to `false` it will bypass the JOI validation for all collections, globals, fields etc.

NOTE: This change is not required for v3.

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
