### PR TITLE
docs: fix TextFieldProps in client field component example

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -438,7 +438,7 @@ All [Field Components](./fields) automatically receive their respective Client F
 import React from 'react'
 import type { TextFieldProps } from 'payload'
 
-export const MyClientFieldComponent: TextFieldProps = ({ field: { name } }) => {
+export const MyClientFieldComponent = ({ field: { name } }: TextFieldProps) => {
   return (
     <p>
       {`This field's name is ${name}`}


### PR DESCRIPTION
## Description

Without using `React.FC<>`, the type needs to be placed on the right side of the props object.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~Existing test suite passes locally with my changes~
- [x] I have made corresponding changes to the documentation
