### PR TITLE
fix(cpa): detect package manager from command execution environment

### DIFF
--- a/packages/create-payload-app/src/lib/get-package-manager.ts
+++ b/packages/create-payload-app/src/lib/get-package-manager.ts
@@ -1,12 +1,8 @@
-import execa from 'execa'
 import fse from 'fs-extra'
 
 import type { CliArgs, PackageManager } from '../types.js'
 
-export async function getPackageManager(args: {
-  cliArgs?: CliArgs
-  projectDir: string
-}): Promise<PackageManager> {
+export function getPackageManager(args: { cliArgs?: CliArgs; projectDir: string }): PackageManager {
   const { cliArgs, projectDir } = args
 
   try {
@@ -19,14 +15,8 @@ export async function getPackageManager(args: {
     } else if (cliArgs?.['--use-npm'] || fse.existsSync(`${projectDir}/package-lock.json`)) {
       detected = 'npm'
     } else {
-      // Otherwise check for existing commands
-      if (await commandExists('pnpm')) {
-        detected = 'pnpm'
-      } else if (await commandExists('yarn')) {
-        detected = 'yarn'
-      } else {
-        detected = 'npm'
-      }
+      // Otherwise check the execution environment
+      detected = getEnvironmentPackageManager()
     }
 
     return detected
@@ -35,11 +25,20 @@ export async function getPackageManager(args: {
   }
 }
 
-async function commandExists(command: string): Promise<boolean> {
-  try {
-    await execa.command(`command -v ${command}`)
-    return true
-  } catch {
-    return false
+function getEnvironmentPackageManager(): PackageManager {
+  const userAgent = process.env.npm_config_user_agent || ''
+
+  if (userAgent.startsWith('yarn')) {
+    return 'yarn'
   }
+
+  if (userAgent.startsWith('pnpm')) {
+    return 'pnpm'
+  }
+
+  if (userAgent.startsWith('bun')) {
+    return 'bun'
+  }
+
+  return 'npm'
 }

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -132,7 +132,7 @@ export class Main {
         ? path.dirname(nextConfigPath)
         : path.resolve(process.cwd(), slugify(projectName))
 
-      const packageManager = await getPackageManager({ cliArgs: this.args, projectDir })
+      const packageManager = getPackageManager({ cliArgs: this.args, projectDir })
 
       if (nextConfigPath) {
         p.log.step(


### PR DESCRIPTION
## Description

Previously, on some machines this command:
`pnpx create-payload-app@beta app` created a project using `npm`, instead of `pnpm`, the same with `yarn`.

Also, the way we detected the package manager was always prioritizing `pnpm`, even if they executed the command with `yarn` / `npm`. Now we are relying only on from which package manager user executed `create-payload-app`.

The code for detection is grabbed from create-next-app https://github.com/vercel/next.js/blob/canary/packages/create-next-app/helpers/get-pkg-manager.ts

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
