### PR TITLE
docs: removes type keyword from useFormFields import

### DIFF
--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -113,7 +113,7 @@ You can pass a Redux-like selector into the hook, which will ensure that you ret
 
 ```tsx
 'use client'
-import type { useFormFields } from '@payloadcms/ui'
+import { useFormFields } from '@payloadcms/ui'
 
 const MyComponent: React.FC = () => {
   // Get only the `amount` field state, and only cause a rerender when that field changes


### PR DESCRIPTION
## Description

Update the `Admin > Hooks > useFormFields` section in the documentation where `useFormFields` was only imported as a type instead of the hook itself.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have made corresponding changes to the documentation
