### PR TITLE
fix(ui): optimizes the relationship field by sharing a single document drawer across all values

### DIFF
--- a/packages/ui/src/elements/ReactSelect/types.ts
+++ b/packages/ui/src/elements/ReactSelect/types.ts
@@ -7,6 +7,11 @@ type CustomSelectProps = {
   disableMouseDown?: boolean
   draggableProps?: any
   droppableRef?: React.RefObject<HTMLDivElement | null>
+  onDocumentDrawerOpen: (args: {
+    collectionSlug: string
+    hasReadPermission: boolean
+    id: number | string
+  }) => void
   onSave?: DocumentDrawerProps['onSave']
   setDrawerIsOpen?: (isOpen: boolean) => void
 }

--- a/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.scss
+++ b/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.scss
@@ -21,6 +21,10 @@
   }
 
   &__drawer-toggler {
+    border: none;
+    background-color: transparent;
+    padding: 0;
+    cursor: pointer;
     position: relative;
     display: flex;
     align-items: center;

--- a/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
@@ -1,12 +1,12 @@
 'use client'
 import type { MultiValueProps } from 'react-select'
 
-import React, { Fragment, useEffect, useState } from 'react'
+import React, { Fragment, useState } from 'react'
 import { components } from 'react-select'
 
+import type { ReactSelectAdapterProps } from '../../../../elements/ReactSelect/types.js'
 import type { Option } from '../../types.js'
 
-import { useDocumentDrawer } from '../../../../elements/DocumentDrawer/index.js'
 import { Tooltip } from '../../../../elements/Tooltip/index.js'
 import { EditIcon } from '../../../../icons/Edit/index.js'
 import { useAuth } from '../../../../providers/Auth/index.js'
@@ -15,36 +15,23 @@ import './index.scss'
 
 const baseClass = 'relationship--multi-value-label'
 
-export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
+export const MultiValueLabel: React.FC<
+  {
+    selectProps: {
+      // TODO Fix this - moduleResolution 16 breaks our declare module
+      customProps: ReactSelectAdapterProps['customProps']
+    }
+  } & MultiValueProps<Option>
+> = (props) => {
   const {
     data: { label, relationTo, value },
-    selectProps: {
-      // @ts-expect-error-next-line // TODO Fix this - moduleResolution 16 breaks our declare module
-      customProps: {
-        // @ts-expect-error-next-line// TODO Fix this - moduleResolution 16 breaks our declare module
-        draggableProps,
-        // @ts-expect-error-next-line // TODO Fix this - moduleResolution 16 breaks our declare module
-        setDrawerIsOpen,
-        // onSave,
-      } = {},
-    } = {},
+    selectProps: { customProps: { draggableProps, onDocumentDrawerOpen } = {} } = {},
   } = props
 
   const { permissions } = useAuth()
   const [showTooltip, setShowTooltip] = useState(false)
   const { t } = useTranslation()
   const hasReadPermission = Boolean(permissions?.collections?.[relationTo]?.read?.permission)
-
-  const [DocumentDrawer, DocumentDrawerToggler, { isDrawerOpen }] = useDocumentDrawer({
-    id: value?.toString(),
-    collectionSlug: relationTo,
-  })
-
-  useEffect(() => {
-    if (typeof setDrawerIsOpen === 'function') {
-      setDrawerIsOpen(isDrawerOpen)
-    }
-  }, [isDrawerOpen, setDrawerIsOpen])
 
   return (
     <div className={baseClass}>
@@ -59,10 +46,17 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
       </div>
       {relationTo && hasReadPermission && (
         <Fragment>
-          <DocumentDrawerToggler
+          <button
             aria-label={`Edit ${label}`}
             className={`${baseClass}__drawer-toggler`}
-            onClick={() => setShowTooltip(false)}
+            onClick={() => {
+              setShowTooltip(false)
+              onDocumentDrawerOpen({
+                id: value,
+                collectionSlug: relationTo,
+                hasReadPermission,
+              })
+            }}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.stopPropagation()
@@ -72,13 +66,13 @@ export const MultiValueLabel: React.FC<MultiValueProps<Option>> = (props) => {
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
             onTouchEnd={(e) => e.stopPropagation()} // prevents react-select dropdown from opening
+            type="button"
           >
             <Tooltip className={`${baseClass}__tooltip`} show={showTooltip}>
               {t('general:editLabel', { label: '' })}
             </Tooltip>
             <EditIcon className={`${baseClass}__icon`} />
-          </DocumentDrawerToggler>
-          <DocumentDrawer onSave={/* onSave */ null} />
+          </button>
         </Fragment>
       )}
     </div>

--- a/packages/ui/src/fields/Relationship/select-components/SingleValue/index.scss
+++ b/packages/ui/src/fields/Relationship/select-components/SingleValue/index.scss
@@ -21,6 +21,10 @@
   }
 
   &__drawer-toggler {
+    border: none;
+    background-color: transparent;
+    padding: 0;
+    cursor: pointer;
     position: relative;
     display: inline-flex;
     align-items: center;

--- a/packages/ui/src/fields/Relationship/select-components/SingleValue/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/SingleValue/index.tsx
@@ -1,12 +1,12 @@
 'use client'
 import type { SingleValueProps } from 'react-select'
 
-import React, { Fragment, useEffect, useState } from 'react'
+import React, { Fragment, useState } from 'react'
 import { components as SelectComponents } from 'react-select'
 
+import type { ReactSelectAdapterProps } from '../../../../elements/ReactSelect/types.js'
 import type { Option } from '../../types.js'
 
-import { useDocumentDrawer } from '../../../../elements/DocumentDrawer/index.js'
 import { Tooltip } from '../../../../elements/Tooltip/index.js'
 import { EditIcon } from '../../../../icons/Edit/index.js'
 import { useAuth } from '../../../../providers/Auth/index.js'
@@ -15,29 +15,24 @@ import './index.scss'
 
 const baseClass = 'relationship--single-value'
 
-export const SingleValue: React.FC<SingleValueProps<Option>> = (props) => {
+export const SingleValue: React.FC<
+  {
+    selectProps: {
+      // TODO Fix this - moduleResolution 16 breaks our declare module
+      customProps: ReactSelectAdapterProps['customProps']
+    }
+  } & SingleValueProps<Option>
+> = (props) => {
   const {
     children,
     data: { label, relationTo, value },
-    // @ts-expect-error-next-line // TODO Fix this - moduleResolution 16 breaks our declare module
-    selectProps: { customProps: { onSave, setDrawerIsOpen } = {} } = {},
+    selectProps: { customProps: { onDocumentDrawerOpen } = {} } = {},
   } = props
 
   const [showTooltip, setShowTooltip] = useState(false)
   const { t } = useTranslation()
   const { permissions } = useAuth()
   const hasReadPermission = Boolean(permissions?.collections?.[relationTo]?.read?.permission)
-
-  const [DocumentDrawer, DocumentDrawerToggler, { isDrawerOpen }] = useDocumentDrawer({
-    id: value.toString(),
-    collectionSlug: relationTo,
-  })
-
-  useEffect(() => {
-    if (typeof setDrawerIsOpen === 'function') {
-      setDrawerIsOpen(isDrawerOpen)
-    }
-  }, [isDrawerOpen, setDrawerIsOpen])
 
   return (
     <React.Fragment>
@@ -47,10 +42,17 @@ export const SingleValue: React.FC<SingleValueProps<Option>> = (props) => {
             <div className={`${baseClass}__text`}>{children}</div>
             {relationTo && hasReadPermission && (
               <Fragment>
-                <DocumentDrawerToggler
+                <button
                   aria-label={t('general:editLabel', { label })}
                   className={`${baseClass}__drawer-toggler`}
-                  onClick={() => setShowTooltip(false)}
+                  onClick={() => {
+                    setShowTooltip(false)
+                    onDocumentDrawerOpen({
+                      id: value,
+                      collectionSlug: relationTo,
+                      hasReadPermission,
+                    })
+                  }}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {
                       e.stopPropagation()
@@ -60,17 +62,17 @@ export const SingleValue: React.FC<SingleValueProps<Option>> = (props) => {
                   onMouseEnter={() => setShowTooltip(true)}
                   onMouseLeave={() => setShowTooltip(false)}
                   onTouchEnd={(e) => e.stopPropagation()} // prevents react-select dropdown from opening
+                  type="button"
                 >
                   <Tooltip className={`${baseClass}__tooltip`} show={showTooltip}>
                     {t('general:edit')}
                   </Tooltip>
                   <EditIcon />
-                </DocumentDrawerToggler>
+                </button>
               </Fragment>
             )}
           </div>
         </div>
-        {relationTo && hasReadPermission && <DocumentDrawer onSave={onSave} />}
       </SelectComponents.SingleValue>
     </React.Fragment>
   )

--- a/test/admin/e2e/1/e2e.spec.ts
+++ b/test/admin/e2e/1/e2e.spec.ts
@@ -976,18 +976,14 @@ describe('admin1', () => {
       await page.locator('#field-title').fill(title)
       await saveDocAndAssert(page)
       await page
-        .locator(
-          '.field-type.relationship .relationship--single-value__drawer-toggler.doc-drawer__toggler',
-        )
+        .locator('.field-type.relationship .relationship--single-value__drawer-toggler')
         .click()
       await wait(500)
       const drawer1Content = page.locator('[id^=doc-drawer_posts_1_] .drawer__content')
       await expect(drawer1Content).toBeVisible()
       const drawerLeft = await drawer1Content.boundingBox().then((box) => box.x)
       await drawer1Content
-        .locator(
-          '.field-type.relationship .relationship--single-value__drawer-toggler.doc-drawer__toggler',
-        )
+        .locator('.field-type.relationship .relationship--single-value__drawer-toggler')
         .click()
       const drawer2Content = page.locator('[id^=doc-drawer_posts_2_] .drawer__content')
       await expect(drawer2Content).toBeVisible()


### PR DESCRIPTION
## Description

Currently, the relationship field's _value(s)_ each render and controls its own document drawer. This has led to `hasMany` relationships processing a potentially large number of drawers unnecessarily. But the real problem is when attempting to perform side-effects as a result of a drawer action. Currently, when you change the value of a relationship field, all drawers within are (rightfully) unmounted because the component representing the value was itself unmounted. This meant that you could not update the title of a document, for example, then update the underlying field's value, without also closing the document drawer outright. This is needed in order to support things like creating and duplicating documents within document drawers (#7679).

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
