### PR TITLE
fix(plugin-form-builder): use escapeHTML on submission data in serializeLexical

### DIFF
--- a/packages/plugin-form-builder/src/utilities/lexical/converters/link.ts
+++ b/packages/plugin-form-builder/src/utilities/lexical/converters/link.ts
@@ -1,3 +1,5 @@
+import escapeHTML from 'escape-html'
+
 import type { HTMLConverter } from '../types'
 
 import { replaceDoubleCurlys } from '../../replaceDoubleCurlys'
@@ -22,7 +24,7 @@ export const LinkHTMLConverter: HTMLConverter<any> = {
       node.fields.linkType === 'custom' ? node.fields.url : node.fields.doc?.value?.id
 
     if (submissionData) {
-      href = replaceDoubleCurlys(href, submissionData)
+      href = escapeHTML(replaceDoubleCurlys(href, submissionData))
     }
 
     return `<a href="${href}"${target}${rel}>${childrenText}</a>`

--- a/packages/plugin-form-builder/src/utilities/lexical/converters/text.ts
+++ b/packages/plugin-form-builder/src/utilities/lexical/converters/text.ts
@@ -1,3 +1,5 @@
+import escapeHTML from 'escape-html'
+
 import type { HTMLConverter } from '../types'
 
 import { replaceDoubleCurlys } from '../../replaceDoubleCurlys'
@@ -8,7 +10,7 @@ export const TextHTMLConverter: HTMLConverter<any> = {
     let text = node.text
 
     if (submissionData) {
-      text = replaceDoubleCurlys(text, submissionData)
+      text = escapeHTML(replaceDoubleCurlys(text, submissionData))
     }
 
     if (node.format & NodeFormat.IS_BOLD) {


### PR DESCRIPTION
## Description

Fixes #8109 
Note this should also be merge in payload/beta!

- [X] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing test suite passes locally with my changes
