### PR TITLE
Refactor SEO Plugin Types for Enhanced Type Safety and Structured Document Handling

### DIFF
--- a/packages/plugin-seo/src/types.ts
+++ b/packages/plugin-seo/src/types.ts
@@ -1,32 +1,49 @@
 import type { ContextType } from 'payload/dist/admin/components/utilities/DocumentInfo/types'
-import type { Field, TextareaField, TextField, UploadField } from 'payload/dist/fields/config/types'
+import type { Field, TextareaField, TextField, UploadField, Condition, Row, Validate } from 'payload/dist/fields/config/types'
+import { Row } from 'payload/dist/admin/components/forms/Form/types';
 
-export type GenerateTitle = <T = any>(
+export type TypedFormField<VALUE> = {
+  condition?: Condition;
+  disableFormData?: boolean;
+  errorMessage?: string;
+  fieldSchema?: Field;
+  initialValue: unknown;
+  passesCondition?: boolean;
+  previousValue?: unknown;
+  rows?: Row[];
+  valid: boolean;
+  validate?: Validate;
+  value: VALUE;
+};
+export type TypedFormDocument<T = any> = {
+  [key in keyof T]: TypedFormField<T[key]>;
+}
+export type GenerateTitle<T = any> = (
   args: ContextType & { doc: T; locale?: string },
 ) => Promise<string> | string
 
-export type GenerateDescription = <T = any>(
+export type GenerateDescription<T = any> = (
   args: ContextType & {
     doc: T
     locale?: string
   },
 ) => Promise<string> | string
 
-export type GenerateImage = <T = any>(
+export type GenerateImage<T = any> = (
   args: ContextType & { doc: T; locale?: string },
 ) => Promise<string> | string
 
-export type GenerateURL = <T = any>(
+export type GenerateURL<T = any> = (
   args: ContextType & { doc: T; locale?: string },
 ) => Promise<string> | string
 
-export interface PluginConfig {
+export interface PluginConfig<T = any> {
   collections?: string[]
   fields?: Field[]
-  generateDescription?: GenerateDescription
-  generateImage?: GenerateImage
-  generateTitle?: GenerateTitle
-  generateURL?: GenerateURL
+  generateDescription?: GenerateDescription<T>
+  generateImage?: GenerateImage<T>
+  generateTitle?: GenerateTitle<T>
+  generateURL?: GenerateURL<T>
   globals?: string[]
   tabbedUI?: boolean
   fieldOverrides?: {


### PR DESCRIPTION
## Description

This pull request refactors the SEO plugin types to introduce TypedFormDocument and TypedFormField types, enhancing the type safety and flexibility of the document objects used in the SEO generation functions (GenerateTitle, GenerateDescription, GenerateImage, and GenerateURL). By replacing the generic doc type with TypedFormDocument<T>, we ensure that each field within the document is well-defined, predictable, and type-checked, reducing potential errors and improving developer experience when extending or maintaining these functions. This change is aimed at enhancing the robustness of the SEO plugin’s type definitions, making them more intuitive and aligned with the evolving architecture of the Payload CMS.

Primary Motivation was the fact that the doc param in the `generate` functions is not the type of the generated types from payload. It is a an object with FormField values. This is not readily apparent.

This also adjusts the `Generate` function types to allow for a generic to be passed in. 

From `GenerateTitle = <T = any>(`
To `GenerateTitle<T = any> = (`

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:
Honestly for these guys I can't confirm. Im running this in GitHub codebases and from the get go before any changes I could not get a build to work. But I think this is purely the codespaces env issue.

- [~] I have added tests that prove my fix is effective or that my feature works
- [~] Existing test suite passes locally with my changes
- [~] I have made corresponding changes to the documentation
