### PR TITLE
fix postgres idType config not honoured everywhere.

### DIFF
--- a/packages/drizzle/src/postgres/schema/build.ts
+++ b/packages/drizzle/src/postgres/schema/build.ts
@@ -13,7 +13,6 @@ import {
   index,
   integer,
   numeric,
-  serial,
   timestamp,
   unique,
   varchar,
@@ -178,7 +177,7 @@ export const buildTable = ({
 
   if (hasLocalizedField || localizedRelations.size) {
     const localeTableName = `${tableName}${adapter.localesSuffix}`
-    localesColumns.id = serial('id').primaryKey()
+    setColumnID({ adapter, columns: localesColumns })
     localesColumns._locale = adapter.enums.enum__locales('_locale').notNull()
     localesColumns._parentID = parentIDColumnMap[idColType]('_parent_id').notNull()
 
@@ -237,12 +236,13 @@ export const buildTable = ({
     if (hasManyTextField) {
       const textsTableName = `${rootTableName}_texts`
       const columns: Record<string, PgColumnBuilder> = {
-        id: serial('id').primaryKey(),
         order: integer('order').notNull(),
         parent: parentIDColumnMap[idColType]('parent_id').notNull(),
         path: varchar('path').notNull(),
         text: varchar('text'),
       }
+
+      setColumnID({ adapter, columns })
 
       if (hasLocalizedManyTextField) {
         columns.locale = adapter.enums.enum__locales('locale')
@@ -286,12 +286,13 @@ export const buildTable = ({
     if (hasManyNumberField) {
       const numbersTableName = `${rootTableName}_numbers`
       const columns: Record<string, PgColumnBuilder> = {
-        id: serial('id').primaryKey(),
         number: numeric('number'),
         order: integer('order').notNull(),
         parent: parentIDColumnMap[idColType]('parent_id').notNull(),
         path: varchar('path').notNull(),
       }
+
+      setColumnID({ adapter, columns })
 
       if (hasLocalizedManyNumberField) {
         columns.locale = adapter.enums.enum__locales('locale')
@@ -334,11 +335,12 @@ export const buildTable = ({
 
     if (relationships.size) {
       const relationshipColumns: Record<string, PgColumnBuilder> = {
-        id: serial('id').primaryKey(),
         order: integer('order'),
         parent: parentIDColumnMap[idColType]('parent_id').notNull(),
         path: varchar('path').notNull(),
       }
+
+      setColumnID({ adapter, columns })
 
       if (hasLocalizedRelationshipField) {
         relationshipColumns.locale = adapter.enums.enum__locales('locale')

--- a/packages/drizzle/src/postgres/schema/setColumnID.ts
+++ b/packages/drizzle/src/postgres/schema/setColumnID.ts
@@ -9,21 +9,23 @@ import type { BasePostgresAdapter, IDType } from '../types.js'
 type Args = {
   adapter: BasePostgresAdapter
   columns: Record<string, PgColumnBuilder>
-  fields: Field[]
+  fields?: Field[]
 }
 export const setColumnID = ({ adapter, columns, fields }: Args): IDType => {
-  const idField = flattenTopLevelFields(fields).find(
-    (field) => fieldAffectsData(field) && field.name === 'id',
-  )
-  if (idField) {
-    if (idField.type === 'number') {
-      columns.id = numeric('id').primaryKey()
-      return 'numeric'
-    }
+  if (fields) {
+    const idField = flattenTopLevelFields(fields).find(
+      (field) => fieldAffectsData(field) && field.name === 'id',
+    )
+    if (idField) {
+      if (idField.type === 'number') {
+        columns.id = numeric('id').primaryKey()
+        return 'numeric'
+      }
 
-    if (idField.type === 'text') {
-      columns.id = varchar('id').primaryKey()
-      return 'varchar'
+      if (idField.type === 'text') {
+        columns.id = varchar('id').primaryKey()
+        return 'varchar'
+      }
     }
   }
 


### PR DESCRIPTION
## Description

I initially reported on "Internal error: error: type "serial" does not exist" when setting up payload 3 beta 99 with a posgres connection to xata.io in [this discussion](https://github.com/payloadcms/payload/discussions/8096).

Later I noticed that the payload `idType` option for postgres was not respected for secondary tables like `payload_preferences_rels`. This PR patches this.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
