### PR TITLE
fix: removes transactions wrapping auth strategies and login

### DIFF
--- a/packages/payload/src/auth/operations/auth.ts
+++ b/packages/payload/src/auth/operations/auth.ts
@@ -2,8 +2,6 @@ import type { TypedUser } from '../../index.js'
 import type { PayloadRequest } from '../../types/index.js'
 import type { Permissions } from '../types.js'
 
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { executeAuthStrategies } from '../executeAuthStrategies.js'
 import { getAccessResults } from '../getAccessResults.js'
@@ -25,8 +23,6 @@ export const auth = async (args: Required<AuthArgs>): Promise<AuthResult> => {
   const { payload } = req
 
   try {
-    const shouldCommit = await initTransaction(req)
-
     const { responseHeaders, user } = await executeAuthStrategies({
       headers,
       payload,
@@ -38,10 +34,6 @@ export const auth = async (args: Required<AuthArgs>): Promise<AuthResult> => {
     const permissions = await getAccessResults({
       req,
     })
-
-    if (shouldCommit) {
-      await commitTransaction(req)
-    }
 
     return {
       permissions,

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -12,8 +12,6 @@ import type { User } from '../types.js'
 import { buildAfterOperation } from '../../collections/operations/utils.js'
 import { AuthenticationError, LockedAuth, ValidationError } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
-import { commitTransaction } from '../../utilities/commitTransaction.js'
-import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields.js'
 import { getFieldsToSign } from '../getFieldsToSign.js'
@@ -43,8 +41,6 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
   let args = incomingArgs
 
   try {
-    const shouldCommit = await initTransaction(args.req)
-
     // /////////////////////////////////////
     // beforeOperation - Collection
     // /////////////////////////////////////
@@ -202,10 +198,6 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
         })
       }
 
-      if (shouldCommit) {
-        await commitTransaction(req)
-      }
-
       throw new AuthenticationError(req.t)
     }
 
@@ -333,10 +325,6 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     // /////////////////////////////////////
     // Return results
     // /////////////////////////////////////
-
-    if (shouldCommit) {
-      await commitTransaction(req)
-    }
 
     return result
   } catch (error: unknown) {


### PR DESCRIPTION
## Description

By default all api requests are creating transactions due to the authentication stategy. This change removes transactions for auth and login requests. This should only happen when the database needs to make changes in which case the auth strategy or login lockout updates will invoke their own transactions still.

This should improve performance without any sacrifice to database consistency.

Fixes #8092 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
