### PR TITLE
fix(richtext-lexical): indent regression

### DIFF
--- a/packages/richtext-lexical/src/lexical/theme/EditorTheme.scss
+++ b/packages/richtext-lexical/src/lexical/theme/EditorTheme.scss
@@ -82,7 +82,7 @@
   }
 
   &__indent {
-    --lexical-indent-base-value: base(2);
+    --lexical-indent-base-value: 40px;
   }
 
   &__textBold {


### PR DESCRIPTION
## Description

Fixes #8038, which was broken in #7817

I'm not entirely sure if this change violates the original intent of the "base" utility, which from what I understand was introduced for scalability reasons. Either way, I think it's a good idea to keep the indent at 40px all the time.

The reason for this is that browsers use 40px as the indentation setting for lists, and using that setting the indented paragraphs and headings match the lists. See https://github.com/facebook/lexical/pull/4025

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
