### PR TITLE
fix(cpa): match vercel postgres db type with package name

### DIFF
--- a/packages/create-payload-app/src/lib/replacements.ts
+++ b/packages/create-payload-app/src/lib/replacements.ts
@@ -57,7 +57,7 @@ export const dbReplacements: Record<DbType, DbAdapterReplacement> = {
   mongodb: mongodbReplacement,
   postgres: postgresReplacement,
   sqlite: sqliteReplacement,
-  vercelPostgres: vercelPostgresReplacement,
+  'vercel-postgres': vercelPostgresReplacement,
 }
 
 type StorageAdapterReplacement = {

--- a/packages/create-payload-app/src/lib/select-db.ts
+++ b/packages/create-payload-app/src/lib/select-db.ts
@@ -27,10 +27,10 @@ const dbChoiceRecord: Record<DbType, DbChoice> = {
     title: 'SQLite (beta)',
     value: 'sqlite',
   },
-  vercelPostgres: {
+  'vercel-postgres': {
     dbConnectionPrefix: 'postgres://postgres:<password>@127.0.0.1:5432/',
     title: 'Vercel Postgres (beta)',
-    value: 'vercelPostgres',
+    value: 'vercel-postgres',
   },
 }
 

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -58,7 +58,7 @@ interface Template {
 
 export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn'
 
-export type DbType = 'mongodb' | 'postgres' | 'sqlite' | 'vercelPostgres'
+export type DbType = 'mongodb' | 'postgres' | 'sqlite' | 'vercel-postgres'
 
 export type DbDetails = {
   dbUri: string


### PR DESCRIPTION
## Description

Fixes the bug I reported in https://github.com/payloadcms/payload/issues/8139 where the casing of the defined value (camelCase) of Vercel's Postgres database adapter does not match the casing of the package (kebab-case).

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
