### PR TITLE
fix(richtext-lexical): hover style of the button to remove blocks 

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/component/index.scss
+++ b/packages/richtext-lexical/src/features/blocks/client/component/index.scss
@@ -81,6 +81,9 @@
 
   &__removeButton.btn {
     margin: 0;
+    &:hover {
+      background-color: var(--theme-elevation-200);
+    }
   }
 
   &__block-header {


### PR DESCRIPTION
## Description

Fix #8045

Before: hover with same color as background, as in the issue description.

After (light):
![Screenshot 2024-09-10 at 9 36 21 AM](https://github.com/user-attachments/assets/260dbc69-a583-42f6-9b25-a81b8d8d4f70)

After (dark):
![Screenshot 2024-09-10 at 9 35 34 AM](https://github.com/user-attachments/assets/3606ee3c-24d6-43dd-8a0e-11d12e1fe779)


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
