### PR TITLE
fix: upload.defParamCharset: utf8 by default

### DIFF
--- a/packages/next/src/fetchAPI-multipart/index.ts
+++ b/packages/next/src/fetchAPI-multipart/index.ts
@@ -7,11 +7,11 @@ import { isEligibleRequest } from './isEligibleRequest.js'
 import { processMultipart } from './processMultipart.js'
 import { debugLog } from './utilities.js'
 
-const DEFAULT_OPTIONS = {
+const DEFAULT_OPTIONS: FetchAPIFileUploadOptions = {
   abortOnLimit: false,
   createParentPath: false,
   debug: false,
-  fileHandler: false,
+  defParamCharset: 'utf8',
   limitHandler: false,
   parseNested: false,
   preserveExtension: false,


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/8107

This has been confusing for people from countries where characters aren't latin, for example the Japanese file name:
フェニックス.png
Turns into:
 ãã§ããã¯ã¹.png  

Additionally, ensures type-safety for `DEFAULT_OPTIONS` and removes unused `fileHandler` property from there, which isn't defined in the `FetchAPIFileUploadOptions` type.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
