### PR TITLE
fix(richtext-lexical): dropdown item disabled status

### DIFF
--- a/packages/richtext-lexical/src/features/toolbars/shared/ToolbarDropdown/index.scss
+++ b/packages/richtext-lexical/src/features/toolbars/shared/ToolbarDropdown/index.scss
@@ -88,6 +88,10 @@
       &.active {
         background-color: var(--theme-elevation-100);
       }
+      &.disabled {
+        cursor: not-allowed;
+        opacity: 0.2;
+      }
 
       padding-left: 6.25px;
       padding-right: 6.25px;


### PR DESCRIPTION
## Description

It is possible to disable arbitrary items from a toolbar dropdown menu with the `isEnabled` property. In order to illustrate the changes in this PR, I have introduced the following lines in the `HeadingFeatureClient` located at `packages/richtext-lexical/src/features/heading/client/index.tsx`.

```ts
          isEnabled: () => {
            return headingSize === 'h2'
          },
```
**Before this PR**

![Screenshot 2024-09-10 at 4 50 08 PM](https://github.com/user-attachments/assets/bffe93db-9bb1-4ddd-8ca4-2cd9e37b7811)
![Screenshot 2024-09-10 at 4 50 40 PM](https://github.com/user-attachments/assets/a63d316d-bb28-4072-95c1-96b66bcdb519)

**After this PR**
![image](https://github.com/user-attachments/assets/427b2fa5-b015-4542-a632-aee094dd881b)
![image](https://github.com/user-attachments/assets/d5123d1b-c0cd-468f-a94b-bb5910dff1e9)


packages/richtext-lexical/src/features/heading/client/index.tsx


- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Existing test suite passes locally with my changes
