### PR TITLE
fix(db-postgres): preserve parent createdAt when creating a new version

### DIFF
--- a/packages/drizzle/src/createVersion.ts
+++ b/packages/drizzle/src/createVersion.ts
@@ -36,7 +36,7 @@ export async function createVersion<T extends TypeWithID>(
     version,
   }
 
-  if (collection.timestamps && 'createdAt' in version) {
+  if ('createdAt' in version) {
     data.createdAt = version.createdAt
   }
 

--- a/packages/drizzle/src/createVersion.ts
+++ b/packages/drizzle/src/createVersion.ts
@@ -29,14 +29,20 @@ export async function createVersion<T extends TypeWithID>(
     delete version.id
   }
 
+  const data: Record<string, unknown> = {
+    autosave,
+    latest: true,
+    parent,
+    version,
+  }
+
+  if (collection.timestamps && 'createdAt' in version) {
+    data.createdAt = version.createdAt
+  }
+
   const result = await upsertRow<TypeWithVersion<T>>({
     adapter: this,
-    data: {
-      autosave,
-      latest: true,
-      parent,
-      version,
-    },
+    data,
     db,
     fields: buildVersionCollectionFields(collection),
     operation: 'create',

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -2,6 +2,7 @@ import type { Payload } from 'payload'
 
 import path from 'path'
 import { ValidationError } from 'payload'
+import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
 
 import type { NextRESTClient } from '../helpers/NextRESTClient.js'
@@ -298,6 +299,23 @@ describe('Versions', () => {
         expect(draftsAscending.docs[0]).toMatchObject(
           draftsDescending.docs[draftsDescending.docs.length - 1],
         )
+      })
+
+      it('should have the same createdAt on new version create', async () => {
+        const doc = await payload.create({
+          collection: autosaveCollectionSlug,
+          data: { description: 'descr', title: 'title' },
+        })
+
+        await wait(30)
+
+        const updated = await payload.update({
+          collection: autosaveCollectionSlug,
+          id: doc.id,
+          data: {},
+        })
+
+        expect(doc.createdAt).toBe(updated.createdAt)
       })
     })
 


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/7915
- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
