### PR TITLE
fix(db-postgres): preserve parent createdAt when creating a new version

### DIFF
--- a/packages/db-postgres/src/createVersion.ts
+++ b/packages/db-postgres/src/createVersion.ts
@@ -28,14 +28,20 @@ export async function createVersion<T extends TypeWithID>(
   const version = { ...versionData }
   if (version.id) delete version.id
 
+  const data: Record<string, unknown> = {
+    autosave,
+    latest: true,
+    parent,
+    version,
+  }
+
+  if (collection.timestamps && 'createdAt' in version) {
+    data.createdAt = version.createdAt
+  }
+
   const result = await upsertRow<TypeWithVersion<T>>({
     adapter: this,
-    data: {
-      autosave,
-      latest: true,
-      parent,
-      version,
-    },
+    data,
     db,
     fields: buildVersionCollectionFields(collection),
     operation: 'create',

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -291,6 +291,23 @@ describe('Versions', () => {
           draftsDescending.docs[draftsDescending.docs.length - 1],
         )
       })
+
+      it('should have the same createdAt on new version create', async () => {
+        const doc = await payload.create({
+          collection: autosaveCollectionSlug,
+          data: { description: 'descr', title: 'title' },
+        })
+
+        await new Promise((resolve) => setTimeout(resolve, 30))
+
+        const updated = await payload.update({
+          collection: autosaveCollectionSlug,
+          id: doc.id,
+          data: {},
+        })
+
+        expect(doc.createdAt).toBe(updated.createdAt)
+      })
     })
 
     describe('Restore', () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/payloadcms/payload/issues/7915
Port of https://github.com/payloadcms/payload/pull/8160 to 2.0
<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
