### PR TITLE
fix(graphql): id field non null

### DIFF
--- a/packages/graphql/src/schema/initCollections.ts
+++ b/packages/graphql/src/schema/initCollections.ts
@@ -97,7 +97,7 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
     const whereInputFields = [...fields]
 
     if (!hasIDField) {
-      baseFields.id = { type: idType }
+      baseFields.id = { type: new GraphQLNonNull(idType) }
       whereInputFields.push({
         name: 'id',
         type: config.db.defaultIDType as 'text',


### PR DESCRIPTION
Resolves #8172

## Summary

This PR addresses an issue where the`id` field in the GraphQL schema is incorrectly marked as `nullable`. The change ensures that the `id` field is set to non-nullable, which aligns with the expectation that every resource should have a non-nullable ID, especially when using UUIDs as primary keys.

### Changes
- Fix: Set the `id` field type to `GraphQLNonNull` for consistency in the GraphQL schema.

