### PR TITLE
fix(ui): properly retrieves singular labels for array field rows

### DIFF
--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -96,6 +96,9 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
     if ('labels' in p && p?.labels) {
       return p.labels
     }
+    if ('labels' in p.field && p.field.labels) {
+      return { plural: p.field.labels?.plural, singular: p.field.labels?.singular }
+    }
     if ('label' in p.field && p.field.label) {
       return { plural: undefined, singular: p.field.label }
     }

--- a/test/fields/collections/Array/e2e.spec.ts
+++ b/test/fields/collections/Array/e2e.spec.ts
@@ -112,6 +112,11 @@ describe('Array', () => {
     )
   })
 
+  test('should show singular label for array rows', async () => {
+    await page.goto(url.create)
+    await expect(page.locator('#field-items #items-row-0 .row-label')).toContainText('Item 01')
+  })
+
   describe('row manipulation', () => {
     test('should add, remove and duplicate rows', async () => {
       const assertText0 = 'array row 1'


### PR DESCRIPTION
## Description

`singular` labels were not being used for array rows - this PR updates the array field to properly retrieve the correct label

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
