### PR TITLE
docs: fixes getPayloadHMR import path

### DIFF
--- a/docs/getting-started/concepts.mdx
+++ b/docs/getting-started/concepts.mdx
@@ -68,7 +68,7 @@ Here's a quick example of a React Server Component fetching data using the Local
 ```tsx
 import React from 'react'
 import config from '@payload-config'
-import { getPayloadHMR } from '@payloadcms/next'
+import { getPayloadHMR } from '@payloadcms/next/utilities'
 
 const MyServerComponent: React.FC = () => {
   // If you're working in Next.js, and you want HMR,

--- a/docs/live-preview/server.mdx
+++ b/docs/live-preview/server.mdx
@@ -34,7 +34,7 @@ Then, render the `RefreshRouteOnSave` component anywhere in your `page.tsx`. Her
 
 ```tsx
 import { RefreshRouteOnSave } from './RefreshRouteOnSave.tsx'
-import { getPayloadHMR } from '@payloadcms/next'
+import { getPayloadHMR } from '@payloadcms/next/utilities'
 import config from '../payload.config'
 
 export default async function Page() {

--- a/examples/auth/payload/README.md
+++ b/examples/auth/payload/README.md
@@ -48,7 +48,7 @@ See the [Collections](https://payloadcms.com/docs/configuration/collections) doc
 
   ```ts
     import { headers as getHeaders } from 'next/headers.js'
-    import { getPayloadHMR } from '@payloadcms/next'
+    import { getPayloadHMR } from '@payloadcms/next/utilities'
     import config from '../../payload.config'
 
     export default async function AccountPage({ searchParams }) {

--- a/examples/live-preview/payload/README.md
+++ b/examples/live-preview/payload/README.md
@@ -107,7 +107,7 @@ Then, render `RefreshRouteOnSave` anywhere in your `page.tsx`. Here's an example
 
 ```tsx
 import { RefreshRouteOnSave } from './RefreshRouteOnSave.tsx'
-import { getPayloadHMR } from '@payloadcms/next'
+import { getPayloadHMR } from '@payloadcms/next/utilities'
 import config from '../payload.config'
 
 export default async function Page() {


### PR DESCRIPTION
When reading the new docs i found that some of them imported getPayloadHMR like this

```typescript
import { getPayloadHMR } from '@payloadcms/next'
```
but it should be 
```typescript
import { getPayloadHMR } from '@payloadcms/next/utilities'

```