### PR TITLE
fix: requires client field prop in server field components

### DIFF
--- a/packages/payload/src/admin/forms/Description.ts
+++ b/packages/payload/src/admin/forms/Description.ts
@@ -29,7 +29,7 @@ export type FieldDescriptionServerProps<
   TFieldServer extends Field = Field,
   TFieldClient extends ClientFieldWithOptionalType = ClientFieldWithOptionalType,
 > = {
-  clientField?: TFieldClient
+  clientField: TFieldClient
   readonly field: TFieldServer
 } & GenericDescriptionProps &
   Partial<ServerProps>

--- a/packages/payload/src/admin/forms/Error.ts
+++ b/packages/payload/src/admin/forms/Error.ts
@@ -21,7 +21,7 @@ export type FieldErrorServerProps<
   TFieldServer extends Field,
   TFieldClient extends ClientFieldWithOptionalType = ClientFieldWithOptionalType,
 > = {
-  clientField?: TFieldClient
+  clientField: TFieldClient
   readonly field: TFieldServer
 } & GenericErrorProps &
   Partial<ServerProps>

--- a/packages/payload/src/admin/forms/Label.ts
+++ b/packages/payload/src/admin/forms/Label.ts
@@ -22,7 +22,7 @@ export type FieldLabelServerProps<
   TFieldServer extends Field,
   TFieldClient extends ClientFieldWithOptionalType = ClientFieldWithOptionalType,
 > = {
-  clientField?: TFieldClient
+  clientField: TFieldClient
   readonly field: TFieldServer
 } & GenericLabelProps &
   Partial<ServerProps>


### PR DESCRIPTION
Fixes a type error when using server components for field labels, descriptions, and errors. The `clientField` prop will always exist, so the types just need to be reflective of this. Here's an example:

```tsx
import type { TextFieldServerLabelComponent } from 'payload'

import { FieldLabel } from '@payloadcms/ui'
import React from 'react'

export const MyServerFieldLabelComponent: TextFieldServerLabelComponent = ({ clientField }) => {
  return <FieldLabel field={clientField} /> // `TextFieldClientWithoutType | undefined` is not assignable to type `ClientFieldWithoutType`
}
```