### PR TITLE
fix(ui)!: bulk selection and useSelection hook losing types of the IDs its returning

### DIFF
--- a/packages/ui/src/elements/SelectRow/index.tsx
+++ b/packages/ui/src/elements/SelectRow/index.tsx
@@ -12,22 +12,9 @@ export const SelectRow: React.FC = () => {
   const { selected, setSelection } = useSelection()
   const { rowData } = useTableCell()
 
-  const isChecked = useMemo(() => {
-    let isChecked = false
-
-    for (const [id, isSelected] of selected) {
-      if (id === rowData.id && isSelected) {
-        isChecked = true
-        break
-      }
-    }
-
-    return isChecked
-  }, [selected, rowData])
-
   return (
     <CheckboxInput
-      checked={isChecked}
+      checked={selected.get(rowData.id)}
       className={[baseClass, `${baseClass}__checkbox`].join(' ')}
       onToggle={() => setSelection(rowData.id)}
     />

--- a/packages/ui/src/elements/SelectRow/index.tsx
+++ b/packages/ui/src/elements/SelectRow/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { useTableCell } from '../../elements/Table/TableCellProvider/index.js'
 import { CheckboxInput } from '../../fields/Checkbox/Input.js'

--- a/packages/ui/src/elements/SelectRow/index.tsx
+++ b/packages/ui/src/elements/SelectRow/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { useTableCell } from '../../elements/Table/TableCellProvider/index.js'
 import { CheckboxInput } from '../../fields/Checkbox/Input.js'
@@ -12,9 +12,22 @@ export const SelectRow: React.FC = () => {
   const { selected, setSelection } = useSelection()
   const { rowData } = useTableCell()
 
+  const isChecked = useMemo(() => {
+    let isChecked = false
+
+    for (const [id, isSelected] of selected) {
+      if (id === rowData.id && isSelected) {
+        isChecked = true
+        break
+      }
+    }
+
+    return isChecked
+  }, [selected, rowData])
+
   return (
     <CheckboxInput
-      checked={selected?.[rowData?.id]}
+      checked={isChecked}
       className={[baseClass, `${baseClass}__checkbox`].join(' ')}
       onToggle={() => setSelection(rowData.id)}
     />

--- a/packages/ui/src/elements/SelectRow/index.tsx
+++ b/packages/ui/src/elements/SelectRow/index.tsx
@@ -14,7 +14,7 @@ export const SelectRow: React.FC = () => {
 
   return (
     <CheckboxInput
-      checked={selected.get(rowData.id)}
+      checked={Boolean(selected.get(rowData.id))}
       className={[baseClass, `${baseClass}__checkbox`].join(' ')}
       onToggle={() => setSelection(rowData.id)}
     />

--- a/packages/ui/src/fields/Checkbox/Input.tsx
+++ b/packages/ui/src/fields/Checkbox/Input.tsx
@@ -76,7 +76,7 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = ({
           type="checkbox"
         />
         <span
-          className={[`${inputBaseClass}__icon`, !checked && partialChecked ? 'check' : 'partial']
+          className={[`${inputBaseClass}__icon`, !checked && partialChecked ? 'partial' : 'check']
             .filter(Boolean)
             .join(' ')}
         >

--- a/packages/ui/src/fields/Checkbox/index.scss
+++ b/packages/ui/src/fields/Checkbox/index.scss
@@ -102,6 +102,19 @@
     }
   }
 
+  .checkbox-input__icon {
+    .icon--line {
+      width: 1.4rem;
+      height: 1.4rem;
+    }
+
+    &.partial {
+      svg {
+        opacity: 1;
+      }
+    }
+  }
+
   &--read-only {
     .checkbox-input__input {
       @include readOnly;

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -290,12 +290,14 @@ export function UploadInput(props: UploadInputProps) {
   // only hasMany can bulk select
   const onListBulkSelect = React.useCallback<NonNullable<ListDrawerProps['onBulkSelect']>>(
     async (docs) => {
-      const selectedDocIDs = Object.entries(docs).reduce<string[]>((acc, [docID, isSelected]) => {
+      const selectedDocIDs = []
+
+      for (const [id, isSelected] of docs) {
         if (isSelected) {
-          acc.push(docID)
+          selectedDocIDs.push(id)
         }
-        return acc
-      }, [])
+      }
+
       const loadedDocs = await populateDocs(selectedDocIDs, activeRelationTo)
       if (loadedDocs) {
         setPopulatedDocs((currentDocs) => [

--- a/packages/ui/src/providers/Selection/index.tsx
+++ b/packages/ui/src/providers/Selection/index.tsx
@@ -76,14 +76,8 @@ export const SelectionProvider: React.FC<Props> = ({ children, docs = [], totalD
 
   const setSelection = useCallback(
     (id) => {
-      let isSelected = true
-
-      for (const [key, value] of selected) {
-        if (key === id) {
-          isSelected = !value
-          break
-        }
-      }
+      const existingValue = selected.get(id)
+      const isSelected = typeof existingValue === 'boolean' ? !existingValue : true
 
       let newMap = new Map()
 

--- a/packages/ui/src/providers/Selection/index.tsx
+++ b/packages/ui/src/providers/Selection/index.tsx
@@ -30,6 +30,7 @@ const Context = createContext({} as SelectionContext)
 
 type Props = {
   readonly children: React.ReactNode
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly docs: any[]
   readonly totalDocs: number
 }
@@ -106,11 +107,17 @@ export const SelectionProvider: React.FC<Props> = ({ children, docs = [], totalD
           id: { not_equals: '' },
         }
       } else {
+        const ids = []
+
+        for (const [key, value] of selected) {
+          if (value) {
+            ids.push(key)
+          }
+        }
+
         where = {
           id: {
-            in: Object.keys(selected)
-              .filter((id) => selected[id])
-              .map((id) => id),
+            in: ids,
           },
         }
       }
@@ -141,23 +148,38 @@ export const SelectionProvider: React.FC<Props> = ({ children, docs = [], totalD
       all = false
       some = false
     } else {
-      for (const [key, value] of selected) {
+      for (const [_, value] of selected) {
         all = all && value
         some = some || value
       }
     }
 
     if (all && selected.size === docs.length) {
+      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setSelectAll(SelectAllStatus.AllInPage)
     } else if (some) {
+      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setSelectAll(SelectAllStatus.Some)
     } else {
+      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setSelectAll(SelectAllStatus.None)
     }
   }, [selectAll, selected, totalDocs, docs])
 
   useEffect(() => {
-    const newCount = selectAll === SelectAllStatus.AllAvailable ? totalDocs : selected.size
+    let newCount = 0
+
+    if (selectAll === SelectAllStatus.AllAvailable) {
+      newCount = totalDocs
+    } else {
+      for (const [_, value] of selected) {
+        if (value) {
+          newCount++
+        }
+      }
+    }
+
+    // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
     setCount(newCount)
   }, [selectAll, selected, totalDocs])
 


### PR DESCRIPTION
This PR changes the type of `selected` returned from the `useSelection` hook from the `SelectionProvider` from an object to a Map.

This fixes a bug where in some situations we lose the type of the ID which can break data entry when using postgres, due to keys being cast to strings inside of objects which doesn't happen when using a Map.

This PR also fixes a CSS bug with the checkbox when it should be partially selected.

```ts
// before
selected: Record<number | string, boolean>

// after
selected: Map<number | string, boolean>
```

This means you now need to read the data differently than before.

```ts
// before
Object.entries(selected).forEach(([key, value]) => {
  // do something
})

// after
for (const [key, value] of selected) {
  // do something
}
```