### PR TITLE
chore: prevent leave without saving from appearing when not needed

### DIFF
--- a/examples/multi-tenant-single-domain/src/fields/TenantField/components/Field.client.tsx
+++ b/examples/multi-tenant-single-domain/src/fields/TenantField/components/Field.client.tsx
@@ -8,15 +8,15 @@ type Props = {
   readOnly: boolean
 }
 export function TenantFieldComponentClient({ initialValue, path, readOnly }: Props) {
-  const { formInitializing, setValue } = useField({ path })
+  const { formInitializing, setValue, value } = useField({ path })
   const hasSetInitialValue = React.useRef(false)
 
   React.useEffect(() => {
-    if (!hasSetInitialValue.current && !formInitializing && initialValue) {
+    if (!hasSetInitialValue.current && !formInitializing && initialValue && !value) {
       setValue(initialValue)
       hasSetInitialValue.current = true
     }
-  }, [initialValue, setValue, formInitializing])
+  }, [initialValue, setValue, formInitializing, value])
 
   return (
     <RelationshipField


### PR DESCRIPTION
Prevent "Leave without saving" confirmation modal from appearing when nothing has changed.
