### PR TITLE
fix(ui) When opening drawer(like media drawer) error is written to the log

### DIFF
--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -69,7 +69,7 @@ export const buildFormState = async ({ req }: { req: PayloadRequest }): Promise<
 
   let fieldSchema: Field[]
 
-  if (schemaPathSegments.length === 1) {
+  if (schemaPathSegments?.length === 1) {
     if (req.payload.collections[schemaPath]) {
       fieldSchema = req.payload.collections[schemaPath].config.fields
     } else {


### PR DESCRIPTION
<!--

For external contributors, please include:

- A summary of the pull request and any related issues it fixes.
- Reasoning for the changes made or any additional context that may be useful.

Ensure you have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

 -->
This fixes https://github.com/payloadcms/payload/issues/7497
It's a small fix which will clear our logs at last Quoting from the issue:

When opening drawer(like media drawer) error is written to the log.
This relates to next fixed issue
[(https://github.com/payloadcms/payload/pull/7117/files)](https://github.com/payloadcms/payload/pull/7117/files)
In file:
packages/ui/src/utilities/buildFormState.ts - Lines 70-74
` const schemaPathSegments = schemaPath && schemaPath.split('.')

let fieldSchema: Field[]

if (schemaPathSegments.length === 1) {
`
What happens is the first line fixes case where schemaPath is null | undefined,
now the last line there fails of schemaPathSegments is null | undefined

It's  reported in few issues , I am not trying to resolve why next.js is not stopping the reques processing , just don't want to see it in the logs 