### PR TITLE
fix(drizzle)!: localized fields uniqueness per locale

### DIFF
--- a/packages/db-sqlite/src/schema/traverseFields.ts
+++ b/packages/db-sqlite/src/schema/traverseFields.ts
@@ -153,7 +153,7 @@ export const traverseFields = ({
           adapter.fieldConstraints[rootTableName][`${columnName}_idx`] = constraintValue
         }
         targetIndexes[`${newTableName}_${field.name}Idx`] = createIndex({
-          name: fieldName,
+          name: field.localized ? [fieldName, '_locale'] : fieldName,
           columnName,
           tableName: newTableName,
           unique,

--- a/packages/drizzle/src/postgres/schema/traverseFields.ts
+++ b/packages/drizzle/src/postgres/schema/traverseFields.ts
@@ -159,7 +159,7 @@ export const traverseFields = ({
           adapter.fieldConstraints[rootTableName][`${columnName}_idx`] = constraintValue
         }
         targetIndexes[`${newTableName}_${field.name}Idx`] = createIndex({
-          name: fieldName,
+          name: field.localized ? [fieldName, '_locale'] : fieldName,
           columnName,
           tableName: newTableName,
           unique,

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -111,6 +111,12 @@ export default buildConfigWithDefaults({
           ],
           type: 'group',
         },
+        {
+          name: 'unique',
+          type: 'text',
+          localized: true,
+          unique: true,
+        },
       ],
     },
     ArrayCollection,

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -1,6 +1,5 @@
-import type { Payload, Where } from 'payload'
-
 import path from 'path'
+import { type Payload, type Where } from 'payload'
 import { fileURLToPath } from 'url'
 
 import type { NextRESTClient } from '../helpers/NextRESTClient.js'
@@ -1831,6 +1830,44 @@ describe('Localization', () => {
 
       expect(retrieved.array.en[0].text).toEqual(['hello', 'goodbye'])
       expect(retrieved.array.es[0].text).toEqual(['hola', 'adios'])
+    })
+  })
+
+  describe('localized with unique', () => {
+    it('localized with unique should work for each locale', async () => {
+      await payload.create({
+        collection: 'localized-posts',
+        locale: 'ar',
+        data: {
+          unique: 'text',
+        },
+      })
+
+      await payload.create({
+        collection: 'localized-posts',
+        locale: 'en',
+        data: {
+          unique: 'text',
+        },
+      })
+
+      await payload.create({
+        collection: 'localized-posts',
+        locale: 'es',
+        data: {
+          unique: 'text',
+        },
+      })
+
+      await expect(
+        payload.create({
+          collection: 'localized-posts',
+          locale: 'en',
+          data: {
+            unique: 'text',
+          },
+        }),
+      ).rejects.toBeTruthy()
     })
   })
 })

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -26,6 +26,7 @@ export interface Config {
     tabs: Tab;
     'localized-sort': LocalizedSort;
     'blocks-same-name': BlocksSameName;
+    'localized-within-localized': LocalizedWithinLocalized;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -74,6 +75,14 @@ export interface BlocksField {
               blockType: 'textBlock';
             }[]
           | null;
+        array?:
+          | {
+              link?: {
+                label?: string | null;
+              };
+              id?: string | null;
+            }[]
+          | null;
         id?: string | null;
         blockName?: string | null;
         blockType: 'blockInsideBlock';
@@ -93,6 +102,9 @@ export interface NestedArray {
         blocksWithinArray?:
           | {
               relationWithinBlock?: (string | null) | LocalizedPost;
+              myGroup?: {
+                text?: string | null;
+              };
               id?: string | null;
               blockName?: string | null;
               blockType: 'someBlock';
@@ -109,6 +121,7 @@ export interface NestedArray {
     | null;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -124,6 +137,7 @@ export interface LocalizedPost {
   group?: {
     children?: string | null;
   };
+  unique?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -410,6 +424,35 @@ export interface BlocksSameName {
           }
       )[]
     | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-within-localized".
+ */
+export interface LocalizedWithinLocalized {
+  id: string;
+  myTab?: {
+    shouldNotBeLocalized?: string | null;
+  };
+  myArray?:
+    | {
+        shouldNotBeLocalized?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  myBlocks?:
+    | {
+        shouldNotBeLocalized?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'myBlock';
+      }[]
+    | null;
+  myGroup?: {
+    shouldNotBeLocalized?: string | null;
+  };
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
Previously, this worked with MongoDB but failed with Postgres / SQLite when the `slug` field has both `localized: true` and `unique: true`.

```ts
await payload.create({
  collection: "posts",
  locale: "en",
  data: {
    slug: "my-post"
  }
})

await payload.create({
  collection: "posts",
  locale: "de",
  data: {
    slug: "my-post"
  }
})
```

Now, we build unique constraints and indexes in combination with the _locale column. This should also improve query performance for fields with both index: true and localized: true.

### Migration steps (Postgres/SQLite only)
This change updates the database schema and requires a migration (if you have any localized fields). To apply it, run the following commands:

```sh
pnpm payload migrate:create locale_unique_indexes
pnpm payload migrate
```

Note that if you use `db.push: true` which is a default, you don't have to run `pnpm payload migrate` in the development mode, only in the production, as Payload automatically pushes the schema to your DB with it.