### PR TITLE
docs: fixes link to ecommerce template in nested-docs.mdx

### DIFF
--- a/docs/plugins/nested-docs.mdx
+++ b/docs/plugins/nested-docs.mdx
@@ -243,5 +243,5 @@ official [Nested Docs Plugin Example](https://github.com/payloadcms/payload/tree
 demonstrates exactly how to configure this plugin in Payload and implement it on your front-end.
 The [Templates Directory](https://github.com/payloadcms/payload/tree/main/templates) also contains an
 official [Website Template](https://github.com/payloadcms/payload/tree/main/templates/website)
-and [E-commerce Template](https://github.com/payloadcms/payload/tree/main/templates/ecommere), both of which use this
+and [E-commerce Template](https://github.com/payloadcms/payload/tree/main/templates/ecommerce), both of which use this
 plugin.


### PR DESCRIPTION
There is a typo in the E-commerce template URL in nested-docs.mdx, this fixes it.
