### PR TITLE
fix(plugin-seo): threads entity slug and document config through generation fn args

### DIFF
--- a/docs/plugins/seo.mdx
+++ b/docs/plugins/seo.mdx
@@ -119,10 +119,31 @@ A function that allows you to return any meta title, including from document's c
 {
   // ...
   seoPlugin({
-    generateTitle: ({ ...docInfo, doc, locale, req }) => `Website.com — ${doc?.title}`,
+    generateTitle: ({ doc }) => `Website.com — ${doc?.title}`,
   })
 }
 ```
+
+All "generate" functions receive the following arguments:
+
+| Argument | Description |
+| --- | --- |
+| **`docConfig`** | The Collection or Global Config related to the document. |
+| **`doc`** | The data of the current document. |
+| **`locale`** | The locale of the document. |
+| **`req`** | The Payload request object containing `user`, `payload`, `i18n`, etc. |
+| **`collectionSlug`** | The slug of the collection. |
+| **`docPermissions`** | The permissions of the document. |
+| **`globalSlug`** | The slug of the global. |
+| **`hasPublishPermission`** | Whether the user has permission to publish the document. |
+| **`hasSavePermission`** | Whether the user has permission to save the document. |
+| **`id`** | The ID of the document. |
+| **`initialData`** | The initial data of the document. |
+| **`initialState`** | The initial state of the document. |
+| **`preferencesKey`**  | The preferences key of the document. |
+| **`publishedDoc`** | The published document. |
+| **`title`** | The title of the document. |
+| **`versionsCount`** | The number of versions of the document. |
 
 ##### `generateDescription`
 
@@ -133,10 +154,12 @@ A function that allows you to return any meta description, including from docume
 {
   // ...
   seoPlugin({
-    generateDescription: ({ ...docInfo, doc, locale, req }) => doc?.excerpt,
+    generateDescription: ({ doc }) => doc?.excerpt,
   })
 }
 ```
+
+For a full list of arguments, see the [`generateTitle`](#generateTitle) function.
 
 ##### `generateImage`
 
@@ -147,10 +170,12 @@ A function that allows you to return any meta image, including from document's c
 {
   // ...
   seoPlugin({
-    generateImage: ({ ...docInfo, doc, locale, req }) => doc?.featuredImage,
+    generateImage: ({ doc }) => doc?.featuredImage,
   })
 }
 ```
+
+For a full list of arguments, see the [`generateTitle`](#generateTitle) function.
 
 ##### `generateURL`
 
@@ -161,11 +186,13 @@ A function called by the search preview component to display the actual URL of y
 {
   // ...
   seoPlugin({
-    generateURL: ({ ...docInfo, doc, locale, req }) =>
-      `https://yoursite.com/${collection?.slug}/${doc?.slug}`,
+    generateURL: ({ doc, collectionSlug }) =>
+      `https://yoursite.com/${collectionSlug}/${doc?.slug}`,
   })
 }
 ```
+
+For a full list of arguments, see the [`generateTitle`](#generateTitle) function.
 
 #### `interfaceName`
 

--- a/docs/plugins/seo.mdx
+++ b/docs/plugins/seo.mdx
@@ -128,20 +128,21 @@ All "generate" functions receive the following arguments:
 
 | Argument | Description |
 | --- | --- |
-| **`docConfig`** | The Collection or Global Config related to the document. |
-| **`doc`** | The data of the current document. |
-| **`locale`** | The locale of the document. |
-| **`req`** | The Payload request object containing `user`, `payload`, `i18n`, etc. |
+| **`collectionConfig`** | The configuration of the collection. |
 | **`collectionSlug`** | The slug of the collection. |
+| **`doc`** | The data of the current document. |
 | **`docPermissions`** | The permissions of the document. |
+| **`globalConfig`** | The configuration of the global. |
 | **`globalSlug`** | The slug of the global. |
 | **`hasPublishPermission`** | Whether the user has permission to publish the document. |
 | **`hasSavePermission`** | Whether the user has permission to save the document. |
 | **`id`** | The ID of the document. |
 | **`initialData`** | The initial data of the document. |
 | **`initialState`** | The initial state of the document. |
+| **`locale`** | The locale of the document. |
 | **`preferencesKey`**  | The preferences key of the document. |
 | **`publishedDoc`** | The published document. |
+| **`req`** | The Payload request object containing `user`, `payload`, `i18n`, etc. |
 | **`title`** | The title of the document. |
 | **`versionsCount`** | The number of versions of the document. |
 

--- a/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
@@ -71,7 +71,10 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
         initialState: docInfo.initialState,
         locale: typeof locale === 'object' ? locale?.code : locale,
         title: docInfo.title,
-      } satisfies Omit<Parameters<GenerateDescription>[0], 'docConfig' | 'req'>),
+      } satisfies Omit<
+        Parameters<GenerateDescription>[0],
+        'collectionConfig' | 'globalConfig' | 'req'
+      >),
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
@@ -61,16 +61,17 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
     const genDescriptionResponse = await fetch('/api/plugin-seo/generate-description', {
       body: JSON.stringify({
         id: docInfo.id,
-        slug: docInfo.slug,
+        collectionSlug: docInfo.collectionSlug,
         doc: getData(),
         docPermissions: docInfo.docPermissions,
+        globalSlug: docInfo.globalSlug,
         hasPublishPermission: docInfo.hasPublishPermission,
         hasSavePermission: docInfo.hasSavePermission,
         initialData: docInfo.initialData,
         initialState: docInfo.initialState,
         locale: typeof locale === 'object' ? locale?.code : locale,
         title: docInfo.title,
-      } satisfies Omit<Parameters<GenerateDescription>[0], 'req'>),
+      } satisfies Omit<Parameters<GenerateDescription>[0], 'docConfig' | 'req'>),
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
@@ -68,7 +68,10 @@ export const MetaImageComponent: React.FC<MetaImageProps> = (props) => {
         initialState: docInfo.initialState,
         locale: typeof locale === 'object' ? locale?.code : locale,
         title: docInfo.title,
-      } satisfies Omit<Parameters<GenerateImage>[0], 'docConfig' | 'req'>),
+      } satisfies Omit<
+        Parameters<GenerateDescription>[0],
+        'collectionConfig' | 'globalConfig' | 'req'
+      >),
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
@@ -58,16 +58,17 @@ export const MetaImageComponent: React.FC<MetaImageProps> = (props) => {
     const genImageResponse = await fetch('/api/plugin-seo/generate-image', {
       body: JSON.stringify({
         id: docInfo.id,
-        slug: docInfo.slug,
+        collectionSlug: docInfo.collectionSlug,
         doc: getData(),
         docPermissions: docInfo.docPermissions,
+        globalSlug: docInfo.globalSlug,
         hasPublishPermission: docInfo.hasPublishPermission,
         hasSavePermission: docInfo.hasSavePermission,
         initialData: docInfo.initialData,
         initialState: docInfo.initialState,
         locale: typeof locale === 'object' ? locale?.code : locale,
         title: docInfo.title,
-      } satisfies Omit<Parameters<GenerateImage>[0], 'req'>),
+      } satisfies Omit<Parameters<GenerateImage>[0], 'docConfig' | 'req'>),
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
@@ -68,10 +68,7 @@ export const MetaImageComponent: React.FC<MetaImageProps> = (props) => {
         initialState: docInfo.initialState,
         locale: typeof locale === 'object' ? locale?.code : locale,
         title: docInfo.title,
-      } satisfies Omit<
-        Parameters<GenerateDescription>[0],
-        'collectionConfig' | 'globalConfig' | 'req'
-      >),
+      } satisfies Omit<Parameters<GenerateImage>[0], 'collectionConfig' | 'globalConfig' | 'req'>),
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
@@ -62,16 +62,17 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
     const genTitleResponse = await fetch('/api/plugin-seo/generate-title', {
       body: JSON.stringify({
         id: docInfo.id,
-        slug: docInfo.slug,
+        collectionSlug: docInfo.collectionSlug,
         doc: getData(),
         docPermissions: docInfo.docPermissions,
+        globalSlug: docInfo.globalSlug,
         hasPublishPermission: docInfo.hasPublishPermission,
         hasSavePermission: docInfo.hasSavePermission,
         initialData: docInfo.initialData,
         initialState: docInfo.initialState,
         locale: typeof locale === 'object' ? locale?.code : locale,
         title: docInfo.title,
-      } satisfies Omit<Parameters<GenerateTitle>[0], 'req'>),
+      } satisfies Omit<Parameters<GenerateTitle>[0], 'docConfig' | 'req'>),
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
@@ -72,7 +72,10 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
         initialState: docInfo.initialState,
         locale: typeof locale === 'object' ? locale?.code : locale,
         title: docInfo.title,
-      } satisfies Omit<Parameters<GenerateTitle>[0], 'docConfig' | 'req'>),
+      } satisfies Omit<
+        Parameters<GenerateDescription>[0],
+        'collectionConfig' | 'globalConfig' | 'req'
+      >),
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
@@ -72,10 +72,7 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
         initialState: docInfo.initialState,
         locale: typeof locale === 'object' ? locale?.code : locale,
         title: docInfo.title,
-      } satisfies Omit<
-        Parameters<GenerateDescription>[0],
-        'collectionConfig' | 'globalConfig' | 'req'
-      >),
+      } satisfies Omit<Parameters<GenerateTitle>[0], 'collectionConfig' | 'globalConfig' | 'req'>),
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/fields/Preview/PreviewComponent.tsx
+++ b/packages/plugin-seo/src/fields/Preview/PreviewComponent.tsx
@@ -49,15 +49,17 @@ export const PreviewComponent: React.FC<PreviewProps> = (props) => {
       const genURLResponse = await fetch('/api/plugin-seo/generate-url', {
         body: JSON.stringify({
           id: docInfo.id,
+          collectionSlug: docInfo.collectionSlug,
           doc: getData(),
           docPermissions: docInfo.docPermissions,
+          globalSlug: docInfo.globalSlug,
           hasPublishPermission: docInfo.hasPublishPermission,
           hasSavePermission: docInfo.hasSavePermission,
           initialData: docInfo.initialData,
           initialState: docInfo.initialState,
           locale: typeof locale === 'object' ? locale?.code : locale,
           title: docInfo.title,
-        } satisfies Omit<Parameters<GenerateURL>[0], 'req'>),
+        } satisfies Omit<Parameters<GenerateURL>[0], 'docConfig' | 'req'>),
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/fields/Preview/PreviewComponent.tsx
+++ b/packages/plugin-seo/src/fields/Preview/PreviewComponent.tsx
@@ -59,10 +59,7 @@ export const PreviewComponent: React.FC<PreviewProps> = (props) => {
           initialState: docInfo.initialState,
           locale: typeof locale === 'object' ? locale?.code : locale,
           title: docInfo.title,
-        } satisfies Omit<
-          Parameters<GenerateDescription>[0],
-          'collectionConfig' | 'globalConfig' | 'req'
-        >),
+        } satisfies Omit<Parameters<GenerateURL>[0], 'collectionConfig' | 'globalConfig' | 'req'>),
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/fields/Preview/PreviewComponent.tsx
+++ b/packages/plugin-seo/src/fields/Preview/PreviewComponent.tsx
@@ -59,7 +59,10 @@ export const PreviewComponent: React.FC<PreviewProps> = (props) => {
           initialState: docInfo.initialState,
           locale: typeof locale === 'object' ? locale?.code : locale,
           title: docInfo.title,
-        } satisfies Omit<Parameters<GenerateURL>[0], 'docConfig' | 'req'>),
+        } satisfies Omit<
+          Parameters<GenerateDescription>[0],
+          'collectionConfig' | 'globalConfig' | 'req'
+        >),
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json',

--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -17,6 +17,21 @@ import { OverviewField } from './fields/Overview/index.js'
 import { PreviewField } from './fields/Preview/index.js'
 import { translations } from './translations/index.js'
 
+const getEntityConfig = ({
+  collectionSlug,
+  config,
+  globalSlug,
+}: {
+  collectionSlug?: string
+  config: Config
+  globalSlug?: string
+}) =>
+  collectionSlug
+    ? config.collections?.find((c) => c.slug === collectionSlug)
+    : globalSlug
+      ? config.globals?.find((g) => g.slug === globalSlug)
+      : null
+
 export const seoPlugin =
   (pluginConfig: SEOPluginConfig) =>
   (config: Config): Config => {
@@ -138,11 +153,11 @@ export const seoPlugin =
               req.data = data
             }
 
-            const docConfig = req.data.collectionSlug
-              ? config.collections.find((c) => c.slug === req.data.collectionSlug)
-              : req.data.globalSlug
-                ? config.globals.find((g) => g.slug === req.data.globalSlug)
-                : null
+            const docConfig = getEntityConfig({
+              collectionSlug: req.data.collectionSlug,
+              config,
+              globalSlug: req.data.globalSlug,
+            })
 
             const result = pluginConfig.generateTitle
               ? await pluginConfig.generateTitle({
@@ -164,11 +179,11 @@ export const seoPlugin =
               req.data = data
             }
 
-            const docConfig = req.data.collectionSlug
-              ? config.collections.find((c) => c.slug === req.data.collectionSlug)
-              : req.data.globalSlug
-                ? config.globals.find((g) => g.slug === req.data.globalSlug)
-                : null
+            const docConfig = getEntityConfig({
+              collectionSlug: req.data.collectionSlug,
+              config,
+              globalSlug: req.data.globalSlug,
+            })
 
             const result = pluginConfig.generateDescription
               ? await pluginConfig.generateDescription({
@@ -190,11 +205,11 @@ export const seoPlugin =
               req.data = data
             }
 
-            const docConfig = req.data.collectionSlug
-              ? config.collections.find((c) => c.slug === req.data.collectionSlug)
-              : req.data.globalSlug
-                ? config.globals.find((g) => g.slug === req.data.globalSlug)
-                : null
+            const docConfig = getEntityConfig({
+              collectionSlug: req.data.collectionSlug,
+              config,
+              globalSlug: req.data.globalSlug,
+            })
 
             const result = pluginConfig.generateURL
               ? await pluginConfig.generateURL({
@@ -216,11 +231,11 @@ export const seoPlugin =
               req.data = data
             }
 
-            const docConfig = req.data.collectionSlug
-              ? config.collections.find((c) => c.slug === req.data.collectionSlug)
-              : req.data.globalSlug
-                ? config.globals.find((g) => g.slug === req.data.globalSlug)
-                : null
+            const docConfig = getEntityConfig({
+              collectionSlug: req.data.collectionSlug,
+              config,
+              globalSlug: req.data.globalSlug,
+            })
 
             const result = pluginConfig.generateImage
               ? await pluginConfig.generateImage({

--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -17,21 +17,6 @@ import { OverviewField } from './fields/Overview/index.js'
 import { PreviewField } from './fields/Preview/index.js'
 import { translations } from './translations/index.js'
 
-const getEntityConfig = ({
-  collectionSlug,
-  config,
-  globalSlug,
-}: {
-  collectionSlug?: string
-  config: Config
-  globalSlug?: string
-}) =>
-  collectionSlug
-    ? config.collections?.find((c) => c.slug === collectionSlug)
-    : globalSlug
-      ? config.globals?.find((g) => g.slug === globalSlug)
-      : null
-
 export const seoPlugin =
   (pluginConfig: SEOPluginConfig) =>
   (config: Config): Config => {
@@ -147,22 +132,24 @@ export const seoPlugin =
         ...(config.endpoints ?? []),
         {
           handler: async (req) => {
-            const data: Omit<Parameters<GenerateTitle>[0], 'docConfig' | 'req'> = await req.json()
+            const data: Omit<
+              Parameters<GenerateTitle>[0],
+              'collectionConfig' | 'globalConfig' | 'req'
+            > = await req.json()
 
             if (data) {
               req.data = data
             }
 
-            const docConfig = getEntityConfig({
-              collectionSlug: req.data.collectionSlug,
-              config,
-              globalSlug: req.data.globalSlug,
-            })
-
             const result = pluginConfig.generateTitle
               ? await pluginConfig.generateTitle({
                   ...data,
-                  docConfig,
+                  collectionConfig: req.data.collectionSlug
+                    ? config.collections?.find((c) => c.slug === req.data.collectionSlug)
+                    : null,
+                  globalConfig: req.data.globalSlug
+                    ? config.globals?.find((g) => g.slug === req.data.globalSlug)
+                    : null,
                   req,
                 } satisfies Parameters<GenerateTitle>[0])
               : ''
@@ -173,22 +160,24 @@ export const seoPlugin =
         },
         {
           handler: async (req) => {
-            const data: Omit<Parameters<GenerateTitle>[0], 'docConfig' | 'req'> = await req.json()
+            const data: Omit<
+              Parameters<GenerateTitle>[0],
+              'collectionConfig' | 'globalConfig' | 'req'
+            > = await req.json()
 
             if (data) {
               req.data = data
             }
 
-            const docConfig = getEntityConfig({
-              collectionSlug: req.data.collectionSlug,
-              config,
-              globalSlug: req.data.globalSlug,
-            })
-
             const result = pluginConfig.generateDescription
               ? await pluginConfig.generateDescription({
                   ...data,
-                  docConfig,
+                  collectionConfig: req.data.collectionSlug
+                    ? config.collections?.find((c) => c.slug === req.data.collectionSlug)
+                    : null,
+                  globalConfig: req.data.globalSlug
+                    ? config.globals?.find((g) => g.slug === req.data.globalSlug)
+                    : null,
                   req,
                 } satisfies Parameters<GenerateDescription>[0])
               : ''
@@ -199,22 +188,24 @@ export const seoPlugin =
         },
         {
           handler: async (req) => {
-            const data: Omit<Parameters<GenerateTitle>[0], 'docConfig' | 'req'> = await req.json()
+            const data: Omit<
+              Parameters<GenerateTitle>[0],
+              'collectionConfig' | 'globalConfig' | 'req'
+            > = await req.json()
 
             if (data) {
               req.data = data
             }
 
-            const docConfig = getEntityConfig({
-              collectionSlug: req.data.collectionSlug,
-              config,
-              globalSlug: req.data.globalSlug,
-            })
-
             const result = pluginConfig.generateURL
               ? await pluginConfig.generateURL({
                   ...data,
-                  docConfig,
+                  collectionConfig: req.data.collectionSlug
+                    ? config.collections?.find((c) => c.slug === req.data.collectionSlug)
+                    : null,
+                  globalConfig: req.data.globalSlug
+                    ? config.globals?.find((g) => g.slug === req.data.globalSlug)
+                    : null,
                   req,
                 } satisfies Parameters<GenerateURL>[0])
               : ''
@@ -225,22 +216,24 @@ export const seoPlugin =
         },
         {
           handler: async (req) => {
-            const data: Omit<Parameters<GenerateTitle>[0], 'docConfig' | 'req'> = await req.json()
+            const data: Omit<
+              Parameters<GenerateTitle>[0],
+              'collectionConfig' | 'globalConfig' | 'req'
+            > = await req.json()
 
             if (data) {
               req.data = data
             }
 
-            const docConfig = getEntityConfig({
-              collectionSlug: req.data.collectionSlug,
-              config,
-              globalSlug: req.data.globalSlug,
-            })
-
             const result = pluginConfig.generateImage
               ? await pluginConfig.generateImage({
                   ...data,
-                  docConfig,
+                  collectionConfig: req.data.collectionSlug
+                    ? config.collections?.find((c) => c.slug === req.data.collectionSlug)
+                    : null,
+                  globalConfig: req.data.globalSlug
+                    ? config.globals?.find((g) => g.slug === req.data.globalSlug)
+                    : null,
                   req,
                 } as Parameters<GenerateImage>[0])
               : ''

--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -132,17 +132,24 @@ export const seoPlugin =
         ...(config.endpoints ?? []),
         {
           handler: async (req) => {
-            const data = await req.json()
+            const data: Omit<Parameters<GenerateTitle>[0], 'docConfig' | 'req'> = await req.json()
 
             if (data) {
               req.data = data
             }
 
+            const docConfig = req.data.collectionSlug
+              ? config.collections.find((c) => c.slug === req.data.collectionSlug)
+              : req.data.globalSlug
+                ? config.globals.find((g) => g.slug === req.data.globalSlug)
+                : null
+
             const result = pluginConfig.generateTitle
               ? await pluginConfig.generateTitle({
-                  ...req.data,
+                  ...data,
+                  docConfig,
                   req,
-                } as unknown as Parameters<GenerateTitle>[0])
+                } satisfies Parameters<GenerateTitle>[0])
               : ''
             return new Response(JSON.stringify({ result }), { status: 200 })
           },
@@ -151,17 +158,24 @@ export const seoPlugin =
         },
         {
           handler: async (req) => {
-            const data = await req.json()
+            const data: Omit<Parameters<GenerateTitle>[0], 'docConfig' | 'req'> = await req.json()
 
             if (data) {
               req.data = data
             }
 
+            const docConfig = req.data.collectionSlug
+              ? config.collections.find((c) => c.slug === req.data.collectionSlug)
+              : req.data.globalSlug
+                ? config.globals.find((g) => g.slug === req.data.globalSlug)
+                : null
+
             const result = pluginConfig.generateDescription
               ? await pluginConfig.generateDescription({
-                  ...req.data,
+                  ...data,
+                  docConfig,
                   req,
-                } as unknown as Parameters<GenerateDescription>[0])
+                } satisfies Parameters<GenerateDescription>[0])
               : ''
             return new Response(JSON.stringify({ result }), { status: 200 })
           },
@@ -170,17 +184,24 @@ export const seoPlugin =
         },
         {
           handler: async (req) => {
-            const data = await req.json()
+            const data: Omit<Parameters<GenerateTitle>[0], 'docConfig' | 'req'> = await req.json()
 
             if (data) {
               req.data = data
             }
 
+            const docConfig = req.data.collectionSlug
+              ? config.collections.find((c) => c.slug === req.data.collectionSlug)
+              : req.data.globalSlug
+                ? config.globals.find((g) => g.slug === req.data.globalSlug)
+                : null
+
             const result = pluginConfig.generateURL
               ? await pluginConfig.generateURL({
-                  ...req.data,
+                  ...data,
+                  docConfig,
                   req,
-                } as unknown as Parameters<GenerateURL>[0])
+                } satisfies Parameters<GenerateURL>[0])
               : ''
             return new Response(JSON.stringify({ result }), { status: 200 })
           },
@@ -189,17 +210,24 @@ export const seoPlugin =
         },
         {
           handler: async (req) => {
-            const data = await req.json()
+            const data: Omit<Parameters<GenerateTitle>[0], 'docConfig' | 'req'> = await req.json()
 
             if (data) {
               req.data = data
             }
 
+            const docConfig = req.data.collectionSlug
+              ? config.collections.find((c) => c.slug === req.data.collectionSlug)
+              : req.data.globalSlug
+                ? config.globals.find((g) => g.slug === req.data.globalSlug)
+                : null
+
             const result = pluginConfig.generateImage
               ? await pluginConfig.generateImage({
-                  ...req.data,
+                  ...data,
+                  docConfig,
                   req,
-                } as unknown as Parameters<GenerateImage>[0])
+                } as Parameters<GenerateImage>[0])
               : ''
             return new Response(result, { status: 200 })
           },

--- a/packages/plugin-seo/src/types.ts
+++ b/packages/plugin-seo/src/types.ts
@@ -27,8 +27,9 @@ export type PartialDocumentInfoContext = Pick<
 
 export type GenerateTitle<T = any> = (
   args: {
+    collectionConfig?: CollectionConfig
     doc: T
-    docConfig: CollectionConfig | GlobalConfig
+    globalConfig?: GlobalConfig
     locale?: string
     req: PayloadRequest
   } & PartialDocumentInfoContext,
@@ -36,8 +37,9 @@ export type GenerateTitle<T = any> = (
 
 export type GenerateDescription<T = any> = (
   args: {
+    collectionConfig?: CollectionConfig
     doc: T
-    docConfig: CollectionConfig | GlobalConfig
+    globalConfig?: GlobalConfig
     locale?: string
     req: PayloadRequest
   } & PartialDocumentInfoContext,
@@ -45,8 +47,9 @@ export type GenerateDescription<T = any> = (
 
 export type GenerateImage<T = any> = (
   args: {
+    collectionConfig?: CollectionConfig
     doc: T
-    docConfig: CollectionConfig | GlobalConfig
+    globalConfig?: GlobalConfig
     locale?: string
     req: PayloadRequest
   } & PartialDocumentInfoContext,
@@ -54,8 +57,9 @@ export type GenerateImage<T = any> = (
 
 export type GenerateURL<T = any> = (
   args: {
+    collectionConfig?: CollectionConfig
     doc: T
-    docConfig: CollectionConfig | GlobalConfig
+    globalConfig?: GlobalConfig
     locale?: string
     req: PayloadRequest
   } & PartialDocumentInfoContext,

--- a/packages/plugin-seo/src/types.ts
+++ b/packages/plugin-seo/src/types.ts
@@ -1,9 +1,19 @@
 import type { DocumentInfoContext } from '@payloadcms/ui'
-import type { Field, PayloadRequest, TextareaField, TextField, UploadField } from 'payload'
+import type {
+  CollectionConfig,
+  Field,
+  GlobalConfig,
+  PayloadRequest,
+  TextareaField,
+  TextField,
+  UploadField,
+} from 'payload'
 
 export type PartialDocumentInfoContext = Pick<
   DocumentInfoContext,
+  | 'collectionSlug'
   | 'docPermissions'
+  | 'globalSlug'
   | 'hasPublishPermission'
   | 'hasSavePermission'
   | 'id'
@@ -11,29 +21,44 @@ export type PartialDocumentInfoContext = Pick<
   | 'initialState'
   | 'preferencesKey'
   | 'publishedDoc'
-  | 'slug'
   | 'title'
   | 'versionsCount'
 >
 
 export type GenerateTitle<T = any> = (
-  args: { doc: T; locale?: string; req: PayloadRequest } & PartialDocumentInfoContext,
+  args: {
+    doc: T
+    docConfig: CollectionConfig | GlobalConfig
+    locale?: string
+    req: PayloadRequest
+  } & PartialDocumentInfoContext,
 ) => Promise<string> | string
 
 export type GenerateDescription<T = any> = (
   args: {
     doc: T
+    docConfig: CollectionConfig | GlobalConfig
     locale?: string
     req: PayloadRequest
   } & PartialDocumentInfoContext,
 ) => Promise<string> | string
 
 export type GenerateImage<T = any> = (
-  args: { doc: T; locale?: string; req: PayloadRequest } & PartialDocumentInfoContext,
+  args: {
+    doc: T
+    docConfig: CollectionConfig | GlobalConfig
+    locale?: string
+    req: PayloadRequest
+  } & PartialDocumentInfoContext,
 ) => Promise<string> | string
 
 export type GenerateURL<T = any> = (
-  args: { doc: T; locale?: string; req: PayloadRequest } & PartialDocumentInfoContext,
+  args: {
+    doc: T
+    docConfig: CollectionConfig | GlobalConfig
+    locale?: string
+    req: PayloadRequest
+  } & PartialDocumentInfoContext,
 ) => Promise<string> | string
 
 export type SEOPluginConfig = {

--- a/packages/ui/src/providers/DocumentInfo/types.ts
+++ b/packages/ui/src/providers/DocumentInfo/types.ts
@@ -71,7 +71,6 @@ export type DocumentInfoContext = {
     fieldPreferences: { [key: string]: unknown } & Partial<InsideFieldsPreferences>,
   ) => void
   setDocumentTitle: (title: string) => void
-  slug?: string
   title: string
   unpublishedVersions?: PaginatedDocs<TypeWithVersion<any>>
   versions?: PaginatedDocs<TypeWithVersion<any>>

--- a/test/plugin-seo/config.ts
+++ b/test/plugin-seo/config.ts
@@ -17,7 +17,9 @@ import { PagesWithImportedFields } from './collections/PagesWithImportedFields.j
 import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
 
-const generateTitle: GenerateTitle<Page> = ({ doc }) => {
+const generateTitle: GenerateTitle<Page> = (args) => {
+  const { doc } = args
+  console.log(args)
   return `Website.com — ${doc?.title}`
 }
 

--- a/test/plugin-seo/config.ts
+++ b/test/plugin-seo/config.ts
@@ -17,9 +17,7 @@ import { PagesWithImportedFields } from './collections/PagesWithImportedFields.j
 import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
 
-const generateTitle: GenerateTitle<Page> = (args) => {
-  const { doc } = args
-  console.log(args)
+const generateTitle: GenerateTitle<Page> = ({ doc }) => {
   return `Website.com — ${doc?.title}`
 }
 


### PR DESCRIPTION
The `generateTitle`, `generateDescription`, `generateURL`, and `generateImage` functions in the SEO Plugin do not currently receive any args representing the document's entity. This means that within these functions, it is currently not possible to discern the _type_ of document you are working with, i.e. a collection or global. The underlying problem here was that the request made to execute these functions was threading through `slug` as `undefined`. This is because the `DocumentInfoProvider` was failing to thread this prop through context as the types suggest. Now, these functions receive their respective `collectionConfig` and `globalConfig`.

```ts
import type { GenerateTitle } from '@payloadcms/plugin-seo/types'
import type { Page } from '@/payload-types'

const generateTitle: GenerateTitle<Page> = ({
  doc,
  collectionConfig,
  globalConfig,
}) => {
  return `Website.com — ${doc?.title}`
}
```