### PR TITLE
fix(ui): filtering in any collection crush the app after navigating to another colleciton

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
@@ -120,7 +120,7 @@ export const Condition: React.FC<Props> = (props) => {
         type: 'client',
         Component: Select,
       }
-    : internalField.Filter || {
+    : internalField?.Filter || {
         type: 'client',
         Component: valueFields?.[internalField?.field?.type] || Text,
       }


### PR DESCRIPTION
Fix https://github.com/payloadcms/payload/issues/8198

Caused by not having ts in strict mode.
