### PR TITLE
feat(ui): threads collectionSlugs through useListDrawer

### DIFF
--- a/packages/ui/src/elements/ListDrawer/index.tsx
+++ b/packages/ui/src/elements/ListDrawer/index.tsx
@@ -122,13 +122,24 @@ export const useListDrawer: UseListDrawer = ({
   const MemoizedDrawerState = useMemo(
     () => ({
       closeDrawer,
+      collectionSlugs,
       drawerDepth,
       drawerSlug,
       isDrawerOpen: isOpen,
       openDrawer,
+      setCollectionSlugs,
       toggleDrawer,
     }),
-    [drawerDepth, drawerSlug, isOpen, toggleDrawer, closeDrawer, openDrawer],
+    [
+      drawerDepth,
+      drawerSlug,
+      isOpen,
+      toggleDrawer,
+      closeDrawer,
+      openDrawer,
+      setCollectionSlugs,
+      collectionSlugs,
+    ],
   )
 
   return [MemoizedDrawer, MemoizedDrawerToggler, MemoizedDrawerState]

--- a/packages/ui/src/elements/ListDrawer/types.ts
+++ b/packages/ui/src/elements/ListDrawer/types.ts
@@ -35,10 +35,12 @@ export type UseListDrawer = (args: {
   React.FC<Pick<ListTogglerProps, 'children' | 'className' | 'disabled'>>, // toggler
   {
     closeDrawer: () => void
+    collectionSlugs: string[]
     drawerDepth: number
     drawerSlug: string
     isDrawerOpen: boolean
     openDrawer: () => void
+    setCollectionSlugs: React.Dispatch<React.SetStateAction<string[]>>
     toggleDrawer: () => void
   },
 ]

--- a/packages/ui/src/elements/ListDrawer/types.ts
+++ b/packages/ui/src/elements/ListDrawer/types.ts
@@ -35,12 +35,12 @@ export type UseListDrawer = (args: {
   React.FC<Pick<ListTogglerProps, 'children' | 'className' | 'disabled'>>, // toggler
   {
     closeDrawer: () => void
-    collectionSlugs: string[]
+    collectionSlugs: SanitizedCollectionConfig['slug'][]
     drawerDepth: number
     drawerSlug: string
     isDrawerOpen: boolean
     openDrawer: () => void
-    setCollectionSlugs: React.Dispatch<React.SetStateAction<string[]>>
+    setCollectionSlugs: React.Dispatch<React.SetStateAction<SanitizedCollectionConfig['slug'][]>>
     toggleDrawer: () => void
   },
 ]


### PR DESCRIPTION
Exposes `collectionSlugs` state from the `useListDrawer` hook to control it outside of the hook. We can't use `collectionSlug` from the hook props because it's memoized inside of the hook state.

```ts
const [
  ListDrawer,
  ListDrawerToggler,
  { collectionSlugs, setCollectionSlugs },
] = useListDrawer({
});
```