### PR TITLE
fix: only add snapshot to versions query when localization is enabled

### DIFF
--- a/packages/next/src/views/Version/Default/index.tsx
+++ b/packages/next/src/views/Version/Default/index.tsx
@@ -76,6 +76,8 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
 
   const localeValues = locales && locales.map((locale) => locale.value)
 
+  const draftsEnabled = Boolean((collectionConfig || globalConfig)?.versions.drafts)
+
   return (
     <main className={baseClass}>
       <SetViewActions
@@ -118,6 +120,7 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
         <div className={`${baseClass}__controls`}>
           <SelectComparison
             baseURL={compareBaseURL}
+            draftsEnabled={draftsEnabled}
             latestDraftVersion={latestDraftVersion}
             latestPublishedVersion={latestPublishedVersion}
             onChange={setCompareValue}

--- a/packages/next/src/views/Version/SelectComparison/index.tsx
+++ b/packages/next/src/views/Version/SelectComparison/index.tsx
@@ -21,6 +21,7 @@ const baseOptions = []
 export const SelectComparison: React.FC<Props> = (props) => {
   const {
     baseURL,
+    draftsEnabled,
     latestDraftVersion,
     latestPublishedVersion,
     onChange,
@@ -32,6 +33,7 @@ export const SelectComparison: React.FC<Props> = (props) => {
   const {
     config: {
       admin: { dateFormat },
+      localization,
     },
   } = useConfig()
 
@@ -45,9 +47,6 @@ export const SelectComparison: React.FC<Props> = (props) => {
   const [errorLoading, setErrorLoading] = useState('')
   const { i18n, t } = useTranslation()
   const loadedAllOptionsRef = React.useRef(false)
-  const {
-    config: { localization },
-  } = useConfig()
 
   const getResults = useCallback(
     async ({ lastLoadedPage: lastLoadedPageArg }) => {
@@ -68,11 +67,6 @@ export const SelectComparison: React.FC<Props> = (props) => {
                 not_equals: versionID,
               },
             },
-            {
-              snapshot: {
-                not_equals: true,
-              },
-            },
           ],
         },
       }
@@ -81,6 +75,14 @@ export const SelectComparison: React.FC<Props> = (props) => {
         query.where.and.push({
           parent: {
             equals: parentID,
+          },
+        })
+      }
+
+      if (localization && draftsEnabled) {
+        query.where.and.push({
+          snapshot: {
+            not_equals: true,
           },
         })
       }

--- a/packages/next/src/views/Version/SelectComparison/types.ts
+++ b/packages/next/src/views/Version/SelectComparison/types.ts
@@ -1,9 +1,10 @@
-import type { PaginatedDocs, SanitizedCollectionConfig } from 'payload'
+import type { PaginatedDocs, SanitizedCollectionConfig, SanitizedGlobalConfig } from 'payload'
 
 import type { CompareOption } from '../Default/types.js'
 
 export type Props = {
   baseURL: string
+  draftsEnabled?: boolean
   latestDraftVersion?: string
   latestPublishedVersion?: string
   onChange: (val: CompareOption) => void

--- a/packages/next/src/views/Versions/index.tsx
+++ b/packages/next/src/views/Versions/index.tsx
@@ -59,7 +59,7 @@ export const VersionsView: PayloadServerReactComponent<EditViewComponent> = asyn
       ],
     }
 
-    if (localization) {
+    if (localization && collectionConfig?.versions?.drafts) {
       whereQuery.and.push({
         snapshot: {
           not_equals: true,
@@ -100,13 +100,14 @@ export const VersionsView: PayloadServerReactComponent<EditViewComponent> = asyn
 
   if (globalSlug) {
     limitToUse = limitToUse || 10
-    const whereQuery = localization
-      ? {
-          snapshot: {
-            not_equals: true,
-          },
-        }
-      : {}
+    const whereQuery =
+      localization && globalConfig?.versions?.drafts
+        ? {
+            snapshot: {
+              not_equals: true,
+            },
+          }
+        : {}
 
     try {
       versionsData = await payload.findGlobalVersions({

--- a/packages/next/src/views/Versions/index.tsx
+++ b/packages/next/src/views/Versions/index.tsx
@@ -35,6 +35,7 @@ export const VersionsView: PayloadServerReactComponent<EditViewComponent> = asyn
   const { limit, page, sort } = searchParams
 
   const {
+    localization,
     routes: { api: apiRoute },
     serverURL,
   } = config
@@ -46,6 +47,26 @@ export const VersionsView: PayloadServerReactComponent<EditViewComponent> = asyn
 
   if (collectionSlug) {
     limitToUse = limitToUse || collectionConfig.admin.pagination.defaultLimit
+    const whereQuery: {
+      and: Array<{ parent?: { equals: string }; snapshot?: { not_equals: boolean } }>
+    } = {
+      and: [
+        {
+          parent: {
+            equals: id,
+          },
+        },
+      ],
+    }
+
+    if (localization) {
+      whereQuery.and.push({
+        snapshot: {
+          not_equals: true,
+        },
+      })
+    }
+
     try {
       versionsData = await payload.findVersions({
         collection: collectionSlug,
@@ -56,20 +77,7 @@ export const VersionsView: PayloadServerReactComponent<EditViewComponent> = asyn
         req,
         sort: sort as string,
         user,
-        where: {
-          and: [
-            {
-              parent: {
-                equals: id,
-              },
-            },
-            {
-              snapshot: {
-                not_equals: true,
-              },
-            },
-          ],
-        },
+        where: whereQuery,
       })
       if (collectionConfig?.versions?.drafts) {
         latestDraftVersion = await getLatestVersion({
@@ -92,6 +100,14 @@ export const VersionsView: PayloadServerReactComponent<EditViewComponent> = asyn
 
   if (globalSlug) {
     limitToUse = limitToUse || 10
+    const whereQuery = localization
+      ? {
+          snapshot: {
+            not_equals: true,
+          },
+        }
+      : {}
+
     try {
       versionsData = await payload.findGlobalVersions({
         slug: globalSlug,
@@ -102,11 +118,7 @@ export const VersionsView: PayloadServerReactComponent<EditViewComponent> = asyn
         req,
         sort: sort as string,
         user,
-        where: {
-          snapshot: {
-            not_equals: true,
-          },
-        },
+        where: whereQuery,
       })
 
       if (globalConfig?.versions?.drafts) {

--- a/test/admin-root/e2e.spec.ts
+++ b/test/admin-root/e2e.spec.ts
@@ -5,7 +5,12 @@ import * as path from 'path'
 import { adminRoute } from 'shared.js'
 import { fileURLToPath } from 'url'
 
-import { ensureCompilationIsDone, initPageConsoleErrorCatch, login } from '../helpers.js'
+import {
+  ensureCompilationIsDone,
+  initPageConsoleErrorCatch,
+  login,
+  saveDocAndAssert,
+} from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
 import { TEST_TIMEOUT_LONG } from '../playwright.config.js'
@@ -54,11 +59,34 @@ test.describe('Admin Panel (Root)', () => {
     expect(pageURL).not.toContain('/admin')
   })
 
+  test('collection — renders versions list', async () => {
+    await page.goto(url.create)
+    const textField = page.locator('#field-text')
+    await textField.fill('test')
+    await saveDocAndAssert(page)
+
+    const versionsTab = page.locator('.doc-tab a[href$="/versions"]')
+    await versionsTab.click()
+    const firstRow = page.locator('tbody .row-1')
+    await expect(firstRow).toBeVisible()
+  })
+
   test('global — navigates to edit view', async () => {
     await page.goto(url.global('menu'))
     const pageURL = page.url()
     expect(pageURL).toBe(url.global('menu'))
     expect(pageURL).not.toContain('/admin')
+  })
+
+  test('global — renders versions list', async () => {
+    await page.goto(url.global('menu'))
+    const textField = page.locator('#field-globalText')
+    await textField.fill('test')
+    await saveDocAndAssert(page)
+
+    await page.goto(`${url.global('menu')}/versions`)
+    const firstRow = page.locator('tbody .row-1')
+    await expect(firstRow).toBeVisible()
   })
 
   test('ui - should render default payload favicons', async () => {

--- a/test/admin-root/globals/Menu/index.ts
+++ b/test/admin-root/globals/Menu/index.ts
@@ -4,6 +4,9 @@ export const menuSlug = 'menu'
 
 export const MenuGlobal: GlobalConfig = {
   slug: menuSlug,
+  versions: {
+    drafts: false,
+  },
   fields: [
     {
       name: 'globalText',


### PR DESCRIPTION
Versions list view should not query `snapshot` unless localization is enabled.

Closes https://github.com/payloadcms/payload/issues/8289