### PR TITLE
feat(next): enable reordering document tabs

### DIFF
--- a/packages/next/src/elements/DocumentHeader/Tabs/mergeTabViews.ts
+++ b/packages/next/src/elements/DocumentHeader/Tabs/mergeTabViews.ts
@@ -1,0 +1,92 @@
+import type {
+  DocumentTabComponent,
+  DocumentTabConfig,
+  EditViewConfig,
+  Permissions,
+  SanitizedCollectionConfig,
+  SanitizedConfig,
+ SanitizedGlobalConfig } from 'payload'
+
+import { getViewConfig } from './getViewConfig.js'
+
+export type MergedTabView = {
+  Component: DocumentTabComponent | null
+  index: number
+  isDefault: boolean
+  order: number
+  path: string
+  tab: DocumentTabConfig
+  tabFromConfig: DocumentTabConfig
+}
+
+export const mergeTabViews = (
+  defaultTabs: Record<string, DocumentTabConfig>,
+  customViews: EditViewConfig[],
+  collectionConfig: SanitizedCollectionConfig,
+  globalConfig: SanitizedGlobalConfig,
+  config: SanitizedConfig,
+  permissions: Permissions,
+): MergedTabView[] => {
+  const mergedTabViews: MergedTabView[] = [
+    ...Object.entries(defaultTabs).map(([name, tab], index) => {
+      const viewConfig = getViewConfig({ name, collectionConfig, globalConfig })
+      const tabFromConfig = viewConfig && 'tab' in viewConfig ? viewConfig.tab : undefined
+      const orderFromConfig =
+        viewConfig && 'tab' in viewConfig && 'order' in viewConfig.tab
+          ? viewConfig?.tab?.order
+          : tab.order
+      const { condition } = tabFromConfig || {}
+      const meetsCondition =
+        !condition ||
+        (condition && Boolean(condition({ collectionConfig, config, globalConfig, permissions })))
+
+      if (meetsCondition) {
+        return {
+          Component: null,
+          index,
+          isDefault: true,
+          order: orderFromConfig,
+          path: null,
+          tab,
+          tabFromConfig,
+        }
+      } else {
+        return null
+      }
+    }),
+    ...customViews.map((CustomView, index) => {
+      if ('tab' in CustomView) {
+        const { path, tab } = CustomView
+
+        return {
+          Component: tab.Component,
+          index,
+          isDefault: false,
+          order: tab.order,
+          path,
+          tab,
+          tabFromConfig: null,
+        }
+      } else {
+        return null
+      }
+    }),
+  ]
+
+  mergedTabViews.forEach((view) => {
+    if (!view.order) {
+      view.order = undefined
+    }
+  })
+
+  return mergedTabViews.sort((a, b) => {
+    if (a.order === undefined && b.order === undefined) {
+      return 0
+    } else if (a.order === undefined) {
+      return 1
+    } else if (b.order === undefined) {
+      return -1
+    }
+    return a.order - b.order
+  })
+}

--- a/packages/payload/src/admin/elements/Tab.ts
+++ b/packages/payload/src/admin/elements/Tab.ts
@@ -39,6 +39,7 @@ export type DocumentTabConfig = {
   readonly isActive?: ((args: { href: string }) => boolean) | boolean
   readonly label?: ((args: { t: (key: string) => string }) => string) | string
   readonly newTab?: boolean
+  readonly order?: number
   readonly Pill?: PayloadComponent
 }
 


### PR DESCRIPTION
## Description

This would allow passing in an "order" property to custom document tabs, and orders the tabs according to this order property. This corresponds to how the default tabs are ordered and provides additional customization and control over the way that custom document tabs are laid out. 

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes - cloud storage plugin fails