### PR TITLE
fix(drizzle): support equals polymorphic querying with object notation

### DIFF
--- a/packages/drizzle/src/queries/getTableColumnFromPath.ts
+++ b/packages/drizzle/src/queries/getTableColumnFromPath.ts
@@ -1,6 +1,13 @@
 import type { SQL } from 'drizzle-orm'
 import type { SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core'
-import type { Field, FieldAffectingData, NumberField, TabAsField, TextField } from 'payload'
+import type {
+  Field,
+  FieldAffectingData,
+  NumberField,
+  Operator,
+  TabAsField,
+  TextField,
+} from 'payload'
 
 import { and, eq, like, sql } from 'drizzle-orm'
 import { type PgTableWithColumns } from 'drizzle-orm/pg-core'
@@ -12,6 +19,7 @@ import { validate as uuidValidate } from 'uuid'
 import type { DrizzleAdapter, GenericColumn } from '../types.js'
 import type { BuildQueryJoinAliases } from './buildQuery.js'
 
+import { isPolymorphicRelationship } from '../utilities/isPolymorphicRelationship.js'
 import { getTableAlias } from './getTableAlias.js'
 
 type Constraint = {
@@ -601,6 +609,19 @@ export const getTableColumnFromPath = ({
                 }
                 return undefined
               },
+              table: aliasRelationshipTable,
+            }
+          } else if (isPolymorphicRelationship(value)) {
+            const { relationTo } = value
+
+            const relationTableName = adapter.tableNameMap.get(
+              toSnakeCase(adapter.payload.collections[relationTo].config.slug),
+            )
+
+            return {
+              constraints,
+              field,
+              rawColumn: sql.raw(`"${aliasRelationshipTableName}"."${relationTableName}_id"`),
               table: aliasRelationshipTable,
             }
           } else {

--- a/packages/drizzle/src/queries/getTableColumnFromPath.ts
+++ b/packages/drizzle/src/queries/getTableColumnFromPath.ts
@@ -1,13 +1,6 @@
 import type { SQL } from 'drizzle-orm'
 import type { SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core'
-import type {
-  Field,
-  FieldAffectingData,
-  NumberField,
-  Operator,
-  TabAsField,
-  TextField,
-} from 'payload'
+import type { Field, FieldAffectingData, NumberField, TabAsField, TextField } from 'payload'
 
 import { and, eq, like, sql } from 'drizzle-orm'
 import { type PgTableWithColumns } from 'drizzle-orm/pg-core'

--- a/packages/drizzle/src/utilities/getCollectionIdType.ts
+++ b/packages/drizzle/src/utilities/getCollectionIdType.ts
@@ -1,0 +1,20 @@
+import type { Collection } from 'payload'
+
+import type { DrizzleAdapter } from '../types.js'
+
+const typeMap: Record<string, 'number' | 'text'> = {
+  number: 'number',
+  serial: 'number',
+  text: 'text',
+  uuid: 'text',
+}
+
+export const getCollectionIdType = ({
+  adapter,
+  collection,
+}: {
+  adapter: DrizzleAdapter
+  collection: Collection
+}) => {
+  return collection.customIDType ?? typeMap[adapter.idType]
+}

--- a/packages/drizzle/src/utilities/isPolymorphicRelationship.ts
+++ b/packages/drizzle/src/utilities/isPolymorphicRelationship.ts
@@ -1,0 +1,16 @@
+import type { CollectionSlug } from 'payload'
+
+export const isPolymorphicRelationship = (
+  value: unknown,
+): value is {
+  relationTo: CollectionSlug
+  value: number | string
+} => {
+  return (
+    value &&
+    typeof value === 'object' &&
+    'relationTo' in value &&
+    typeof value.relationTo === 'string' &&
+    'value' in value
+  )
+}

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -20,7 +20,7 @@ export interface Config {
     'payload-migrations': PayloadMigration;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   globals: {
     menu: Menu;
@@ -54,7 +54,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: string;
+  id: number;
   text?: string | null;
   serverTextField?: string | null;
   richText?: {
@@ -97,7 +97,7 @@ export interface Post {
  * via the `definition` "simple".
  */
 export interface Simple {
-  id: string;
+  id: number;
   text?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -107,7 +107,7 @@ export interface Simple {
  * via the `definition` "media".
  */
 export interface Media {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -151,7 +151,7 @@ export interface Media {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -168,30 +168,30 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'posts';
-        value: string | Post;
+        value: number | Post;
       } | null)
     | ({
         relationTo: 'simple';
-        value: string | Simple;
+        value: number | Simple;
       } | null)
     | ({
         relationTo: 'media';
-        value: string | Media;
+        value: number | Media;
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null);
+  editedAt?: string | null;
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
-  editedAt?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -200,10 +200,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -223,7 +223,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -234,7 +234,7 @@ export interface PayloadMigration {
  * via the `definition` "menu".
  */
 export interface Menu {
-  id: string;
+  id: number;
   globalText?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -244,7 +244,7 @@ export interface Menu {
  * via the `definition` "custom-ts".
  */
 export interface CustomT {
-  id: string;
+  id: number;
   custom?: 'hello' | 'world';
   withDefinitionsUsage?: ObjectWithNumber[];
   json: {

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -20,7 +20,7 @@ export interface Config {
     'payload-migrations': PayloadMigration;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {
     menu: Menu;
@@ -54,7 +54,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: number;
+  id: string;
   text?: string | null;
   serverTextField?: string | null;
   richText?: {
@@ -97,7 +97,7 @@ export interface Post {
  * via the `definition` "simple".
  */
 export interface Simple {
-  id: number;
+  id: string;
   text?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -107,7 +107,7 @@ export interface Simple {
  * via the `definition` "media".
  */
 export interface Media {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -151,7 +151,7 @@ export interface Media {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -168,29 +168,29 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'posts';
-        value: number | Post;
+        value: string | Post;
       } | null)
     | ({
         relationTo: 'simple';
-        value: number | Simple;
+        value: string | Simple;
       } | null)
     | ({
         relationTo: 'media';
-        value: number | Media;
+        value: string | Media;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   editedAt?: string | null;
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -200,10 +200,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -223,7 +223,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -234,7 +234,7 @@ export interface PayloadMigration {
  * via the `definition` "menu".
  */
 export interface Menu {
-  id: number;
+  id: string;
   globalText?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -244,7 +244,7 @@ export interface Menu {
  * via the `definition` "custom-ts".
  */
 export interface CustomT {
-  id: number;
+  id: string;
   custom?: 'hello' | 'world';
   withDefinitionsUsage?: ObjectWithNumber[];
   json: {

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -8,6 +8,6 @@ process.env.PAYLOAD_PUBLIC_CLOUD_STORAGE_ADAPTER = 's3'
 process.env.NODE_OPTIONS = '--no-deprecation'
 process.env.PAYLOAD_CI_DEPENDENCY_CHECKER = 'true'
 
-const dbAdapter = process.env.PAYLOAD_DATABASE || 'sqlite'
+const dbAdapter = process.env.PAYLOAD_DATABASE || 'mongodb'
 
 generateDatabaseAdapter(dbAdapter)

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -8,6 +8,6 @@ process.env.PAYLOAD_PUBLIC_CLOUD_STORAGE_ADAPTER = 's3'
 process.env.NODE_OPTIONS = '--no-deprecation'
 process.env.PAYLOAD_CI_DEPENDENCY_CHECKER = 'true'
 
-const dbAdapter = process.env.PAYLOAD_DATABASE || 'mongodb'
+const dbAdapter = process.env.PAYLOAD_DATABASE || 'sqlite'
 
 generateDatabaseAdapter(dbAdapter)

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -1168,6 +1168,38 @@ describe('Relationships', () => {
       expect(queryOne.docs).toHaveLength(1)
       expect(queryTwo.docs).toHaveLength(1)
     })
+
+    it('should allow querying on polymorphic relationships with an object syntax', async () => {
+      const movie = await payload.create({
+        collection: 'movies',
+        data: {
+          name: 'Pulp Fiction 2',
+        },
+      })
+      await payload.create({
+        collection: polymorphicRelationshipsSlug,
+        data: {
+          polymorphic: {
+            relationTo: 'movies',
+            value: movie.id,
+          },
+        },
+      })
+
+      const res = await payload.find({
+        collection: 'polymorphic-relationships',
+        where: {
+          polymorphic: {
+            equals: {
+              relationTo: 'movies',
+              value: movie.id,
+            },
+          },
+        },
+      })
+
+      expect(res.docs).toHaveLength(1)
+    })
   })
 })
 

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -1,6 +1,6 @@
 import type { Payload, PayloadRequest } from 'payload'
 
-import { randomBytes } from 'crypto'
+import { randomBytes, randomUUID } from 'crypto'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
@@ -1199,6 +1199,19 @@ describe('Relationships', () => {
       })
 
       expect(res.docs).toHaveLength(1)
+
+      const res_2 = await payload.find({
+        collection: 'polymorphic-relationships',
+        where: {
+          polymorphic: {
+            equals: {
+              relationTo: 'movies',
+              value: payload.db.idType === 'uuid' ? randomUUID() : 99,
+            },
+          },
+        },
+      })
+      expect(res_2.docs).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
Previously, this wasn't valid in Postgres / SQLite:
```ts
const res = await payload.find({
  collection: 'polymorphic-relationships',
  where: {
    polymorphic: {
      equals: {
        relationTo: 'movies',
        value: movie.id,
      },
    },
  },
})
```

Now it works and actually in more performant way than this:
```ts
const res = await payload.find({
  collection: 'polymorphic-relationships',
  where: {
    and: [
      {
        'polymorphic.relationTo': {
          equals: 'movies',
        },
      },
      {
        'polymorphic.value': {
          equals: 'movies',
        },
      },
    ],
  },
})
``` 

Why? Because with the object notation, the output SQL is: `movies_id = 1` - checks exactly 1 column in the `*_rels` table, while with the separate query by `relationTo` and `value` we need to check against _each_ possible relationship collection with OR.