### PR TITLE
chore: use updatedAt instead of editedAt for locked documents

### DIFF
--- a/packages/next/src/elements/DocumentLocked/index.tsx
+++ b/packages/next/src/elements/DocumentLocked/index.tsx
@@ -25,13 +25,13 @@ const formatDate = (date) => {
 }
 
 export const DocumentLocked: React.FC<{
-  editedAt?: null | number
   handleGoBack: () => void
   isActive: boolean
   onReadOnly: () => void
   onTakeOver: () => void
+  updatedAt?: null | number
   user?: ClientUser
-}> = ({ editedAt, handleGoBack, isActive, onReadOnly, onTakeOver, user }) => {
+}> = ({ handleGoBack, isActive, onReadOnly, onTakeOver, updatedAt, user }) => {
   const { closeModal, openModal } = useModal()
   const { t } = useTranslation()
 
@@ -52,7 +52,7 @@ export const DocumentLocked: React.FC<{
             <strong>{user?.email ?? user?.id}</strong> {t('general:currentlyEditing')}
           </p>
           <p>
-            {t('general:editedSince')} <strong>{formatDate(editedAt)}</strong>
+            {t('general:editedSince')} <strong>{formatDate(updatedAt)}</strong>
           </p>
         </div>
         <div className={`${baseClass}__controls`}>

--- a/packages/next/src/views/Edit/Default/index.tsx
+++ b/packages/next/src/views/Edit/Default/index.tsx
@@ -421,7 +421,6 @@ export const DefaultEditView: React.FC = () => {
           {BeforeDocument}
           {isLockingEnabled && shouldShowDocumentLockedModal && !isReadOnlyForIncomingUser && (
             <DocumentLocked
-              editedAt={lastUpdateTime}
               handleGoBack={handleGoBack}
               isActive={shouldShowDocumentLockedModal}
               onReadOnly={() => {
@@ -429,6 +428,7 @@ export const DefaultEditView: React.FC = () => {
                 setShowTakeOverModal(false)
               }}
               onTakeOver={handleTakeOver}
+              updatedAt={lastUpdateTime}
               user={currentEditor}
             />
           )}

--- a/packages/payload/src/lockedDocuments/lockedDocumentsCollection.ts
+++ b/packages/payload/src/lockedDocuments/lockedDocumentsCollection.ts
@@ -15,16 +15,14 @@ export const getLockedDocumentsCollection = (config: Config): CollectionConfig =
       relationTo: [...config.collections.map((collectionConfig) => collectionConfig.slug)],
     },
     {
-      name: 'editedAt',
-      type: 'date',
-    },
-    {
       name: 'globalSlug',
       type: 'text',
+      index: true,
     },
     {
       name: 'user',
       type: 'relationship',
+      maxDepth: 1,
       relationTo: config.collections
         .filter((collectionConfig) => collectionConfig.auth)
         .map((collectionConfig) => collectionConfig.slug),

--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -193,7 +193,6 @@ const DocumentInfo: React.FC<
           // Send a patch request to update the _lastEdited info
           await requests.patch(`${serverURL}${api}/payload-locked-documents/${lockId}`, {
             body: JSON.stringify({
-              editedAt: new Date(),
               user: { relationTo: user?.collection, value: user?.id },
             }),
             headers: {

--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -265,9 +265,7 @@ export const buildFormState = async ({
           await req.payload.db.updateOne({
             id: lockedDocument.docs[0].id,
             collection: 'payload-locked-documents',
-            data: {
-              editedAt: new Date().toISOString(),
-            },
+            data: {},
             req,
           })
         }
@@ -284,7 +282,6 @@ export const buildFormState = async ({
                   value: id,
                 }
               : undefined,
-            editedAt: new Date().toISOString(),
             globalSlug: globalSlug ? globalSlug : undefined,
             user: {
               relationTo: [req.user.collection],

--- a/test/locked-documents/e2e.spec.ts
+++ b/test/locked-documents/e2e.spec.ts
@@ -98,7 +98,6 @@ describe('locked documents', () => {
             relationTo: 'posts',
             value: postDoc.id,
           },
-          editedAt: new Date().toISOString(),
           globalSlug: undefined,
           user: {
             relationTo: 'users',
@@ -318,7 +317,6 @@ describe('locked documents', () => {
             relationTo: 'posts',
             value: postDoc.id,
           },
-          editedAt: new Date().toISOString(),
           globalSlug: undefined,
           user: {
             relationTo: 'users',
@@ -422,7 +420,6 @@ describe('locked documents', () => {
             relationTo: 'posts',
             value: postDoc.id,
           },
-          editedAt: new Date().toISOString(),
           globalSlug: undefined,
           user: {
             relationTo: 'users',
@@ -512,7 +509,6 @@ describe('locked documents', () => {
             relationTo: 'posts',
             value: postDoc.id,
           },
-          editedAt: new Date().toISOString(),
           globalSlug: undefined,
           user: {
             relationTo: 'users',
@@ -784,7 +780,6 @@ describe('locked documents', () => {
         collection: lockedDocumentCollection,
         data: {
           document: undefined,
-          editedAt: new Date().toISOString(),
           globalSlug: 'menu',
           user: {
             relationTo: 'users',

--- a/test/locked-documents/payload-types.ts
+++ b/test/locked-documents/payload-types.ts
@@ -111,7 +111,6 @@ export interface PayloadLockedDocument {
     relationTo: 'users';
     value: string | User;
   };
-  editedAt?: string | null;
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
- Removes locked documents `editedAt` as it was redundant with the `updatedAt` timestamp
- Adjust stale lock tests to configure the duration down to 1 second and await it to not lose any test coverage
- DB performance changes: 
   1. Switch to payload.db.find instead of payload.find for checkDocumentLockStatus to avoid populating the user and other payload find overhead
   2. Add maxDepth: 1 to user relationship
   3. Add index to global slug