### PR TITLE
fix: add logger to serverOnlyConfigProperties

### DIFF
--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -19,6 +19,7 @@ export type ServerOnlyRootProperties = keyof Pick<
   | 'endpoints'
   | 'graphQL'
   | 'hooks'
+  | 'logger'
   | 'onInit'
   | 'plugins'
   | 'secret'
@@ -63,5 +64,6 @@ export const serverOnlyConfigProperties: readonly Partial<ServerOnlyRootProperti
   'email',
   'custom',
   'graphQL',
+  'logger'
   // `admin`, `onInit`, `localization`, `collections`, and `globals` are all handled separately
 ]


### PR DESCRIPTION
## Description

Add `logger` field to `serverOnlyConfigProperties` to prevent it being passed to client components, which could cause issues.

### Reproduction Steps
``` typescript
// payload.config.ts

export default buildConfig({
  // ...
  logger: pino({
    name: 'test',
  }),
  // ...
})
```

![image](https://github.com/user-attachments/assets/21d155b7-3d13-4a78-9ba6-036475a6633f)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Chore (non-breaking change which does not add functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
- [ ] Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing test suite passes locally with my changes
- [ ] I have made corresponding changes to the documentation
