### PR TITLE
fix(db-postgres): nested arrays with localized items and versions

### DIFF
--- a/packages/db-postgres/src/upsertRow/insertArrays.ts
+++ b/packages/db-postgres/src/upsertRow/insertArrays.ts
@@ -54,7 +54,10 @@ export const insertArrays = async ({ adapter, arrays, db, parentRows }: Args): P
           arrayRowLocaleData._locale = arrayRowLocale
           rowsByTable[tableName].locales.push(arrayRowLocaleData)
           if (!arrayRow.row.id) {
-            arrayRowLocaleData._getParentID = (rows) => rows[i].id
+            arrayRowLocaleData._getParentID = (rows: { _uuid: string; id: number }[]) => {
+              const { id } = rows.find((each) => each._uuid === arrayRow.row._uuid)
+              return id
+            }
           }
         })
       })

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -170,6 +170,23 @@ const ArrayFields: CollectionConfig = {
       ],
       type: 'array',
     },
+    {
+      name: 'nestedArrayLocalized',
+      type: 'array',
+      fields: [
+        {
+          type: 'array',
+          name: 'array',
+          fields: [
+            {
+              name: 'text',
+              type: 'text',
+              localized: true,
+            },
+          ],
+        },
+      ],
+    },
   ],
   slug: arrayFieldsSlug,
   versions: true,

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1115,6 +1115,61 @@ describe('Fields', () => {
       expect(result.items[0].localizedText.es).toStrictEqual('spanish')
     })
 
+    it('should create and append localized items to nested array with versions', async () => {
+      const doc = await payload.create({
+        collection,
+        data: {
+          items: [{ text: 'req' }],
+          localized: [{ text: 'req' }],
+          nestedArrayLocalized: [
+            {
+              array: [
+                {
+                  text: 'marcelo',
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      const res = await payload.update({
+        id: doc.id,
+        collection,
+        data: {
+          nestedArrayLocalized: [
+            ...doc.nestedArrayLocalized,
+            {
+              array: [
+                {
+                  text: 'alejandro',
+                },
+                {
+                  text: 'raul',
+                },
+              ],
+            },
+            {
+              array: [
+                {
+                  text: 'amigo',
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      expect(res.nestedArrayLocalized).toHaveLength(3)
+
+      expect(res.nestedArrayLocalized[0].array[0].text).toBe('marcelo')
+
+      expect(res.nestedArrayLocalized[1].array[0].text).toBe('alejandro')
+      expect(res.nestedArrayLocalized[1].array[1].text).toBe('raul')
+
+      expect(res.nestedArrayLocalized[2].array[0].text).toBe('amigo')
+    })
+
     it('should create with nested array', async () => {
       const subArrayText = 'something expected'
       const doc = await payload.create({


### PR DESCRIPTION
Port of https://github.com/payloadcms/payload/pull/8331 to 2.0

Previosuly, trying to append a new item to an array that contains another array with localized items and enabled versions led to a unique `_locale` and `_parent_id` error 
```ts
{
  name: 'nestedArrayLocalized',
  type: 'array',
  fields: [
    {
      type: 'array',
      name: 'array',
      fields: [
        {
          name: 'text',
          type: 'text',
          localized: true,
        },
      ],
    },
  ],
}
```