### PR TITLE
fix: treat empty strings as null / undefined for `exists` queries

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -204,17 +204,25 @@ export const sanitizeQueryValue = ({
     formattedValue = formattedValue === 'true' || formattedValue === true
 
     // Clearable fields
-    if (['relationship', 'select', 'upload'].includes(field.type)) {
+    if (['relationship', 'select', 'text', 'upload'].includes(field.type)) {
       if (formattedValue) {
         return {
           rawQuery: {
-            $and: [{ [path]: { $exists: true } }, { [path]: { $ne: null } }],
+            $and: [
+              { [path]: { $exists: true } },
+              { [path]: { $ne: null } },
+              { [path]: { $ne: '' } },
+            ],
           },
         }
       } else {
         return {
           rawQuery: {
-            $or: [{ [path]: { $exists: false } }, { [path]: { $eq: null } }],
+            $or: [
+              { [path]: { $exists: false } },
+              { [path]: { $eq: null } },
+              { [path]: { $eq: '' } }, // Treat empty string as null / undefined
+            ],
           },
         }
       }

--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -189,22 +189,10 @@ export const sanitizeQueryValue = ({
         $regex: formattedValue.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'),
       }
     }
-  }
 
-  if (
-    (path === '_id' || path === 'parent') &&
-    operator === 'like' &&
-    formattedValue.length === 24 &&
-    !hasCustomID
-  ) {
-    formattedOperator = 'equals'
-  }
+    if (operator === 'exists') {
+      formattedValue = formattedValue === 'true' || formattedValue === true
 
-  if (operator === 'exists') {
-    formattedValue = formattedValue === 'true' || formattedValue === true
-
-    // Clearable fields
-    if (['relationship', 'select', 'text', 'upload'].includes(field.type)) {
       if (formattedValue) {
         return {
           rawQuery: {
@@ -223,6 +211,36 @@ export const sanitizeQueryValue = ({
               { [path]: { $eq: null } },
               { [path]: { $eq: '' } }, // Treat empty string as null / undefined
             ],
+          },
+        }
+      }
+    }
+  }
+
+  if (
+    (path === '_id' || path === 'parent') &&
+    operator === 'like' &&
+    formattedValue.length === 24 &&
+    !hasCustomID
+  ) {
+    formattedOperator = 'equals'
+  }
+
+  if (operator === 'exists') {
+    formattedValue = formattedValue === 'true' || formattedValue === true
+
+    // Clearable fields
+    if (['relationship', 'select', 'upload'].includes(field.type)) {
+      if (formattedValue) {
+        return {
+          rawQuery: {
+            $and: [{ [path]: { $exists: true } }, { [path]: { $ne: null } }],
+          },
+        }
+      } else {
+        return {
+          rawQuery: {
+            $or: [{ [path]: { $exists: false } }, { [path]: { $eq: null } }],
           },
         }
       }


### PR DESCRIPTION
Fixes #7714 
