### PR TITLE
fix(next): forgot-password unserializable translation

### DIFF
--- a/packages/next/src/views/ForgotPassword/index.client.tsx
+++ b/packages/next/src/views/ForgotPassword/index.client.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { Translation, useTranslation } from '@payloadcms/ui'
+import { formatAdminURL } from '@payloadcms/ui/shared'
+import LinkImport from 'next/link.js'
+
+const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
+
+type ForgotPasswordClientProps = {
+  readonly accountRoute: string
+  readonly adminRoute: string
+}
+
+export const ForgotPasswordClient: React.FC<ForgotPasswordClientProps> = ({
+  accountRoute,
+  adminRoute,
+}) => {
+  const { t } = useTranslation()
+
+  return (
+    <Translation
+      elements={{
+        '0': ({ children }) => (
+          <Link
+            href={formatAdminURL({
+              adminRoute,
+              path: accountRoute,
+            })}
+          >
+            {children}
+          </Link>
+        ),
+      }}
+      i18nKey="authentication:loggedInChangePassword"
+      t={t}
+    />
+  )
+}

--- a/packages/next/src/views/ForgotPassword/index.tsx
+++ b/packages/next/src/views/ForgotPassword/index.tsx
@@ -1,11 +1,12 @@
 import type { AdminViewProps } from 'payload'
 
-import { Button, Translation } from '@payloadcms/ui'
+import { Button } from '@payloadcms/ui'
 import { formatAdminURL } from '@payloadcms/ui/shared'
 import LinkImport from 'next/link.js'
 import React, { Fragment } from 'react'
 
 import { ForgotPasswordForm } from './ForgotPasswordForm/index.js'
+import { ForgotPasswordClient } from './index.client.js'
 
 export { generateForgotPasswordMetadata } from './meta.js'
 
@@ -33,22 +34,7 @@ export const ForgotPasswordView: React.FC<AdminViewProps> = ({ initPageResult })
       <Fragment>
         <h1>{i18n.t('authentication:alreadyLoggedIn')}</h1>
         <p>
-          <Translation
-            elements={{
-              '0': ({ children }) => (
-                <Link
-                  href={formatAdminURL({
-                    adminRoute,
-                    path: accountRoute,
-                  })}
-                >
-                  {children}
-                </Link>
-              ),
-            }}
-            i18nKey="authentication:loggedInChangePassword"
-            t={i18n.t}
-          />
+          <ForgotPasswordClient accountRoute={accountRoute} adminRoute={adminRoute} />
         </p>
         <br />
         <Button buttonStyle="secondary" el="link" Link={Link} size="large" to={adminRoute}>


### PR DESCRIPTION
Replaces Translation component with non-serializable `t` function causing RSC error with client component 

Closes #8349
