### PR TITLE
fix(drizzle): make migrate up and down args take full payload request instead of partial

### DIFF
--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -127,11 +127,11 @@ export type IDType = 'integer' | 'numeric' | 'text'
 
 export type MigrateUpArgs = {
   payload: Payload
-  req?: Partial<PayloadRequest>
+  req?: PayloadRequest
 }
 export type MigrateDownArgs = {
   payload: Payload
-  req?: Partial<PayloadRequest>
+  req?: PayloadRequest
 }
 
 declare module 'payload' {

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -127,11 +127,11 @@ export type IDType = 'integer' | 'numeric' | 'text'
 
 export type MigrateUpArgs = {
   payload: Payload
-  req?: PayloadRequest
+  req: PayloadRequest
 }
 export type MigrateDownArgs = {
   payload: Payload
-  req?: PayloadRequest
+  req: PayloadRequest
 }
 
 declare module 'payload' {

--- a/packages/drizzle/src/postgres/types.ts
+++ b/packages/drizzle/src/postgres/types.ts
@@ -156,5 +156,5 @@ export type PostgresDrizzleAdapter = Omit<
 
 export type IDType = 'integer' | 'numeric' | 'uuid' | 'varchar'
 
-export type MigrateUpArgs = { payload: Payload; req?: Partial<PayloadRequest> }
-export type MigrateDownArgs = { payload: Payload; req?: Partial<PayloadRequest> }
+export type MigrateUpArgs = { payload: Payload; req?: PayloadRequest }
+export type MigrateDownArgs = { payload: Payload; req?: PayloadRequest }

--- a/packages/drizzle/src/postgres/types.ts
+++ b/packages/drizzle/src/postgres/types.ts
@@ -156,5 +156,5 @@ export type PostgresDrizzleAdapter = Omit<
 
 export type IDType = 'integer' | 'numeric' | 'uuid' | 'varchar'
 
-export type MigrateUpArgs = { payload: Payload; req?: PayloadRequest }
-export type MigrateDownArgs = { payload: Payload; req?: PayloadRequest }
+export type MigrateUpArgs = { payload: Payload; req: PayloadRequest }
+export type MigrateDownArgs = { payload: Payload; req: PayloadRequest }


### PR DESCRIPTION
The arguments for migration up or down should take in full PayloadRequest instead of partial