### PR TITLE
fix(db-mongodb): db.find default limit to 0

### DIFF
--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -15,7 +15,7 @@ export const find: Find = async function find(
   {
     collection,
     joins = {},
-    limit,
+    limit = 0,
     locale,
     page,
     pagination,

--- a/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
+++ b/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
@@ -111,9 +111,10 @@ export const buildJoinAggregation = async ({
                     input: `$${as}.docs`,
                   },
                 }, // Slicing the docs to match the limit
-                [`${as}.hasNextPage`]: {
-                  $gt: [{ $size: `$${as}.docs` }, limitJoin || Number.MAX_VALUE],
-                }, // Boolean indicating if more docs than limit
+                [`${as}.hasNextPage`]: limitJoin
+                  ? { $gt: [{ $size: `$${as}.docs` }, limitJoin] }
+                  : false,
+                // Boolean indicating if more docs than limit
               },
             },
           )

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -117,6 +117,9 @@ describe('Joins Field', () => {
   it('should populate joins using find', async () => {
     const result = await payload.find({
       collection: 'categories',
+      where: {
+        id: { equals: category.id },
+      },
     })
 
     const [categoryWithPosts] = result.docs
@@ -124,6 +127,29 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.group.relatedPosts.docs).toHaveLength(10)
     expect(categoryWithPosts.group.relatedPosts.docs[0]).toHaveProperty('title')
     expect(categoryWithPosts.group.relatedPosts.docs[0].title).toBe('test 14')
+  })
+
+  it('should not error when deleting documents with joins', async () => {
+    const category = await payload.create({
+      collection: 'categories',
+      data: {
+        name: 'category with post',
+      },
+    })
+
+    const post = await createPost({
+      category: category.id,
+    })
+
+    const result = await payload.delete({
+      collection: 'categories',
+      // id: category.id,
+      where: {
+        id: { equals: category.id },
+      },
+    })
+
+    expect(result.docs[0].id).toStrictEqual(category.id)
   })
 
   describe('Joins with localization', () => {


### PR DESCRIPTION
Fixes an error anytime a `db.find` is called on documents with joins without a set `limit` by defaulting the limit to 0.
