### PR TITLE
docs: change req.params to req.routeParams

### DIFF
--- a/docs/migration-guide/overview.mdx
+++ b/docs/migration-guide/overview.mdx
@@ -913,7 +913,7 @@ return <p>{t('general:cancel')}</p>
   method: 'post',
   handler: (req, res) => {
     res.json({
-      parameter: req.routeParams.parameter,
+      parameter: req.params.parameter,
       name: req.body.name,
       age: req.body.age,
     })

--- a/docs/migration-guide/overview.mdx
+++ b/docs/migration-guide/overview.mdx
@@ -913,7 +913,7 @@ return <p>{t('general:cancel')}</p>
   method: 'post',
   handler: (req, res) => {
     res.json({
-      parameter: req.params.parameter,
+      parameter: req.routeParams.parameter,
       name: req.body.name,
       age: req.body.age,
     })

--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -605,7 +605,7 @@ export const Orders: CollectionConfig = {
       path: '/:id/tracking',
       method: 'get',
       handler: async (req) => {
-        const tracking = await getTrackingInfo(req.params.id)
+        const tracking = await getTrackingInfo(req.routeParams.id)
 
         if (!tracking) {
           return Response.json({ error: 'not found' }, { status: 404})


### PR DESCRIPTION
`req.params` is an old notation, now we use `req.routeParams`