### PR TITLE
fix(db-vercel-postgres): include needed pg dependency

### DIFF
--- a/packages/db-vercel-postgres/package.json
+++ b/packages/db-vercel-postgres/package.json
@@ -62,7 +62,8 @@
     "@types/pg": "8.10.2",
     "@types/to-snake-case": "1.0.0",
     "esbuild": "0.23.1",
-    "payload": "workspace:*"
+    "payload": "workspace:*",
+    "pg": "8.11.3"
   },
   "peerDependencies": {
     "payload": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,6 +428,9 @@ importers:
       payload:
         specifier: workspace:*
         version: link:../payload
+      pg:
+        specifier: 8.11.3
+        version: 8.11.3
 
   packages/drizzle:
     dependencies:


### PR DESCRIPTION
`pg` appears to be a needed dependency in order for drizzle / @vercel/postgres to build successfully.

