### PR TITLE
fix(templates): proper migration file import source for vercel-postgres

### DIFF
--- a/scripts/generate-template-variations.ts
+++ b/scripts/generate-template-variations.ts
@@ -160,7 +160,15 @@ async function main() {
     })
 
     // Copy in initial migration if db is postgres. This contains user and media.
-    if (db === 'postgres') {
+    if (db === 'postgres' || db === 'vercel-postgres') {
+      // Add "ci" script to package.json
+      const packageJsonPath = path.join(destDir, 'package.json')
+      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'))
+      packageJson.scripts = packageJson.scripts || {}
+      packageJson.scripts.ci = 'payload migrate && pnpm build'
+      await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2))
+
+      // Handle copying migrations
       const migrationSrcDir = path.join(templatesDir, '_data/migrations')
       const migrationDestDir = path.join(destDir, 'src/migrations')
 
@@ -170,6 +178,20 @@ async function main() {
       }
       log(`Copying migrations from ${migrationSrcDir} to ${migrationDestDir}`)
       copyRecursiveSync(migrationSrcDir, migrationDestDir)
+
+      // Change all '@payloadcms/db-postgres' import to be '@payloadcms/db-vercel-postgres'
+      if (db === 'vercel-postgres') {
+        const migrationFiles = await fs.readdir(migrationDestDir)
+        for (const migrationFile of migrationFiles) {
+          const migrationFilePath = path.join(migrationDestDir, migrationFile)
+          const migrationFileContents = await fs.readFile(migrationFilePath, 'utf8')
+          const updatedFileContents = migrationFileContents.replaceAll(
+            '@payloadcms/db-postgres',
+            '@payloadcms/db-vercel-postgres',
+          )
+          await fs.writeFile(migrationFilePath, updatedFileContents)
+        }
+      }
     }
 
     // TODO: Email?

--- a/templates/with-postgres/package.json
+++ b/templates/with-postgres/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
+    "ci": "payload migrate && pnpm build",
     "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
     "devsafe": "rm -rf .next && cross-env NODE_OPTIONS=--no-deprecation next dev",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",

--- a/templates/with-vercel-postgres/package.json
+++ b/templates/with-vercel-postgres/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
+    "ci": "payload migrate && pnpm build",
     "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
     "devsafe": "rm -rf .next && cross-env NODE_OPTIONS=--no-deprecation next dev",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",

--- a/templates/with-vercel-postgres/src/migrations/initial.ts
+++ b/templates/with-vercel-postgres/src/migrations/initial.ts
@@ -1,6 +1,6 @@
-import type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/db-postgres'
+import type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/db-vercel-postgres'
 
-import { sql } from '@payloadcms/db-postgres'
+import { sql } from '@payloadcms/db-vercel-postgres'
 
 export async function up({ payload }: MigrateUpArgs): Promise<void> {
   await payload.db.drizzle.execute(sql`


### PR DESCRIPTION
- Add `ci` npm script properly for postgres templates
- Fix import source for migration files when using `@payloadcms/db-vercel-postgres`