### PR TITLE
feat(payload, ui): add allowEdit config to the admin of the relationship field

### DIFF
--- a/docs/fields/relationship.mdx
+++ b/docs/fields/relationship.mdx
@@ -90,6 +90,7 @@ The Relationship Field inherits all of the default options from the base [Field 
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | **`isSortable`**               | Set to `true` if you'd like this field to be sortable within the Admin UI using drag and drop (only works when `hasMany` is set to `true`). |
 | **`allowCreate`**              | Set to `false` if you'd like to disable the ability to create new documents from within the relationship field.                             |
+| **`allowEdit`**              | Set to `false` if you'd like to disable the ability to edit documents from within the relationship field.                             |
 | **`sortOptions`**              | Define a default sorting order for the options within a Relationship field's dropdown. [More](#sortOptions)                                |
 
 ### Sort Options

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1125,6 +1125,7 @@ type SharedRelationshipPropertiesClient = FieldBaseClient &
 
 type RelationshipAdmin = {
   allowCreate?: boolean
+  allowEdit?: boolean
   components?: {
     Error?: CustomComponent<
       RelationshipFieldErrorClientComponent | RelationshipFieldErrorServerComponent

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1143,7 +1143,7 @@ type RelationshipAdminClient = {
     Label?: MappedComponent
   } & AdminClient['components']
 } & AdminClient &
-  Pick<RelationshipAdmin, 'allowCreate' | 'isSortable'>
+  Pick<RelationshipAdmin, 'allowCreate' | 'allowEdit' | 'isSortable'>
 
 export type PolymorphicRelationshipField = {
   admin?: {

--- a/packages/ui/src/elements/ReactSelect/types.ts
+++ b/packages/ui/src/elements/ReactSelect/types.ts
@@ -63,7 +63,12 @@ export type ReactSelectAdapterProps = {
   disabled?: boolean
   filterOption?:
     | ((
-        { data, label, value }: { data: Option; label: string; value: string },
+        {
+          allowEdit,
+          data,
+          label,
+          value,
+        }: { allowEdit: boolean; data: Option; label: string; value: string },
         search: string,
       ) => boolean)
     | undefined

--- a/packages/ui/src/fields/Relationship/findOptionsByValue.ts
+++ b/packages/ui/src/fields/Relationship/findOptionsByValue.ts
@@ -3,11 +3,12 @@ import type { Option } from '../../elements/ReactSelect/types.js'
 import type { OptionGroup, Value } from './types.js'
 
 type Args = {
+  allowEdit: boolean
   options: OptionGroup[]
   value: Value | Value[]
 }
 
-export const findOptionsByValue = ({ options, value }: Args): Option | Option[] => {
+export const findOptionsByValue = ({ allowEdit, options, value }: Args): Option | Option[] => {
   if (value || typeof value === 'number') {
     if (Array.isArray(value)) {
       return value.map((val) => {
@@ -25,7 +26,7 @@ export const findOptionsByValue = ({ options, value }: Args): Option | Option[] 
           }
         })
 
-        return matchedOption
+        return matchedOption ? { allowEdit, ...matchedOption } : undefined
       })
     }
 
@@ -42,7 +43,7 @@ export const findOptionsByValue = ({ options, value }: Args): Option | Option[] 
       }
     })
 
-    return matchedOption
+    return matchedOption ? { allowEdit, ...matchedOption } : undefined
   }
 
   return undefined

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -578,7 +578,13 @@ const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => 
   }, [openDrawer, currentlyOpenRelationship])
 
   const optionsByValue = findOptionsByValue({ options, value })
-  const valueToRender = optionsByValue ? { allowEdit, ...optionsByValue } : undefined
+  const valueToRender = Array.isArray(optionsByValue)
+    ? optionsByValue.map((option) => {
+        return { allowEdit, ...option }
+      })
+    : optionsByValue
+      ? { allowEdit, ...optionsByValue }
+      : undefined
 
   if (!Array.isArray(valueToRender) && valueToRender?.value === 'null') {
     valueToRender.value = null

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -577,14 +577,7 @@ const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => 
     }
   }, [openDrawer, currentlyOpenRelationship])
 
-  const optionsByValue = findOptionsByValue({ options, value })
-  const valueToRender = Array.isArray(optionsByValue)
-    ? optionsByValue.map((option) => {
-        return { allowEdit, ...option }
-      })
-    : optionsByValue
-      ? { allowEdit, ...optionsByValue }
-      : undefined
+  const valueToRender = findOptionsByValue({ allowEdit, options, value })
 
   if (!Array.isArray(valueToRender) && valueToRender?.value === 'null') {
     valueToRender.value = null

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -46,6 +46,7 @@ const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => 
       _path: pathFromProps,
       admin: {
         allowCreate = true,
+        allowEdit = true,
         className,
         description,
         isSortable = true,
@@ -576,7 +577,8 @@ const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => 
     }
   }, [openDrawer, currentlyOpenRelationship])
 
-  const valueToRender = findOptionsByValue({ options, value })
+  const optionsByValue = findOptionsByValue({ options, value })
+  const valueToRender = optionsByValue ? { allowEdit, ...optionsByValue } : undefined
 
   if (!Array.isArray(valueToRender) && valueToRender?.value === 'null') {
     valueToRender.value = null

--- a/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
@@ -44,7 +44,7 @@ export const MultiValueLabel: React.FC<
           }}
         />
       </div>
-      {relationTo && hasReadPermission && allowEdit && (
+      {relationTo && hasReadPermission && allowEdit !== false && (
         <Fragment>
           <button
             aria-label={`Edit ${label}`}

--- a/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/MultiValueLabel/index.tsx
@@ -24,7 +24,7 @@ export const MultiValueLabel: React.FC<
   } & MultiValueProps<Option>
 > = (props) => {
   const {
-    data: { label, relationTo, value },
+    data: { allowEdit, label, relationTo, value },
     selectProps: { customProps: { draggableProps, onDocumentDrawerOpen } = {} } = {},
   } = props
 
@@ -44,7 +44,7 @@ export const MultiValueLabel: React.FC<
           }}
         />
       </div>
-      {relationTo && hasReadPermission && (
+      {relationTo && hasReadPermission && allowEdit && (
         <Fragment>
           <button
             aria-label={`Edit ${label}`}

--- a/packages/ui/src/fields/Relationship/select-components/SingleValue/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/SingleValue/index.tsx
@@ -25,7 +25,7 @@ export const SingleValue: React.FC<
 > = (props) => {
   const {
     children,
-    data: { label, relationTo, value },
+    data: { allowEdit, label, relationTo, value },
     selectProps: { customProps: { onDocumentDrawerOpen } = {} } = {},
   } = props
 
@@ -39,7 +39,7 @@ export const SingleValue: React.FC<
       <div className={`${baseClass}__label`}>
         <div className={`${baseClass}__label-text`}>
           <div className={`${baseClass}__text`}>{children}</div>
-          {relationTo && hasReadPermission && (
+          {relationTo && hasReadPermission && allowEdit && (
             <Fragment>
               <button
                 aria-label={t('general:editLabel', { label })}

--- a/packages/ui/src/fields/Relationship/select-components/SingleValue/index.tsx
+++ b/packages/ui/src/fields/Relationship/select-components/SingleValue/index.tsx
@@ -39,7 +39,7 @@ export const SingleValue: React.FC<
       <div className={`${baseClass}__label`}>
         <div className={`${baseClass}__label-text`}>
           <div className={`${baseClass}__text`}>{children}</div>
-          {relationTo && hasReadPermission && allowEdit && (
+          {relationTo && hasReadPermission && allowEdit !== false && (
             <Fragment>
               <button
                 aria-label={t('general:editLabel', { label })}

--- a/packages/ui/src/fields/Relationship/types.ts
+++ b/packages/ui/src/fields/Relationship/types.ts
@@ -2,6 +2,7 @@ import type { I18nClient } from '@payloadcms/translations'
 import type { ClientCollectionConfig, ClientConfig, FilterOptionsResult } from 'payload'
 
 export type Option = {
+  allowEdit: boolean
   label: string
   options?: Option[]
   relationTo?: string

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -160,37 +160,31 @@ describe('relationship', () => {
   test('should hide relationship add new button', async () => {
     await page.goto(url.create)
     await page.waitForURL(url.create)
-    const count1 = await page
-      .locator('#relationWithAllowEditToFalse-add-new .relationship-add-new__add-button')
-      .count()
-    expect(count1).toEqual(1)
+    const locator1 = page.locator(
+      '#relationWithAllowEditToFalse-add-new .relationship-add-new__add-button',
+    )
+    await expect(locator1).toHaveCount(1)
     // expect the button to not exist in the field
-    const count2 = await page
-      .locator('#relationWithAllowCreateToFalse-add-new .relationship-add-new__add-button')
-      .count()
-    expect(count2).toEqual(0)
+    const locator2 = page.locator(
+      '#relationWithAllowCreateToFalse-add-new .relationship-add-new__add-button',
+    )
+    await expect(locator2).toHaveCount(0)
   })
 
   test('should hide relationship edit button', async () => {
     await page.goto(url.create)
     await page.waitForURL(url.create)
-    const count1 = await page
+    const locator1 = page
       .locator('#field-relationWithAllowEditToFalse')
       .getByLabel('Edit dev@payloadcms.com')
-      .count()
-    expect(count1).toEqual(0)
-    const count2 = await page
+    await expect(locator1).toHaveCount(0)
+    const locator2 = page
       .locator('#field-relationWithAllowCreateToFalse')
       .getByLabel('Edit dev@payloadcms.com')
-      .count()
-    expect(count2).toEqual(1)
-    // This is the same as count1. The reason is that I've noticed that sometimes
-    // the default value does not appear after count1 is tested IDK why.
-    const count3 = await page
-      .locator('#field-relationWithAllowEditToFalse')
-      .getByLabel('Edit dev@payloadcms.com')
-      .count()
-    expect(count3).toEqual(0)
+    await expect(locator2).toHaveCount(1)
+    // The reason why I check for locator 1 again is that I've noticed that sometimes
+    // the default value does not appear after the first locator is tested. IDK why.
+    await expect(locator1).toHaveCount(0)
   })
 
   // TODO: Flaky test in CI - fix this. https://github.com/payloadcms/payload/actions/runs/8910825395/job/24470963991

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -159,6 +159,7 @@ describe('relationship', () => {
 
   test('should hide relationship add new button', async () => {
     await page.goto(url.create)
+    await page.waitForURL(url.create)
     const count1 = await page
       .locator('#relationWithAllowEditToFalse-add-new .relationship-add-new__add-button')
       .count()
@@ -172,6 +173,7 @@ describe('relationship', () => {
 
   test('should hide relationship edit button', async () => {
     await page.goto(url.create)
+    await page.waitForURL(url.create)
     const count1 = await page
       .locator(
         '#relationWithAllowCreateToFalse button.relationship--single-value-label__drawer-toggler',

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -175,18 +175,22 @@ describe('relationship', () => {
     await page.goto(url.create)
     await page.waitForURL(url.create)
     const count1 = await page
-      .locator(
-        '#relationWithAllowCreateToFalse button.relationship--single-value-label__drawer-toggler',
-      )
+      .locator('#field-relationWithAllowEditToFalse')
+      .getByLabel('Edit dev@payloadcms.com')
       .count()
-    expect(count1).toEqual(1)
-    // expect the button to not exist in the field
+    expect(count1).toEqual(0)
     const count2 = await page
-      .locator(
-        '#relationWithAllowEditToFalse button.relationship--single-value-label__drawer-toggler',
-      )
+      .locator('#field-relationWithAllowCreateToFalse')
+      .getByLabel('Edit dev@payloadcms.com')
       .count()
-    expect(count2).toEqual(0)
+    expect(count2).toEqual(1)
+    // This is the same as count1. The reason is that I've noticed that sometimes
+    // the default value does not appear after count1 is tested IDK why.
+    const count3 = await page
+      .locator('#field-relationWithAllowEditToFalse')
+      .getByLabel('Edit dev@payloadcms.com')
+      .count()
+    expect(count3).toEqual(0)
   })
 
   // TODO: Flaky test in CI - fix this. https://github.com/payloadcms/payload/actions/runs/8910825395/job/24470963991

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -159,11 +159,32 @@ describe('relationship', () => {
 
   test('should hide relationship add new button', async () => {
     await page.goto(url.create)
-    // expect the button to not exist in the field
-    const count = await page
-      .locator('#relationToSelfSelectOnly-add-new .relationship-add-new__add-button')
+    const count1 = await page
+      .locator('#relationWithAllowEditToFalse-add-new .relationship-add-new__add-button')
       .count()
-    expect(count).toEqual(0)
+    expect(count1).toEqual(1)
+    // expect the button to not exist in the field
+    const count2 = await page
+      .locator('#relationWithAllowCreateToFalse-add-new .relationship-add-new__add-button')
+      .count()
+    expect(count2).toEqual(0)
+  })
+
+  test('should hide relationship edit button', async () => {
+    await page.goto(url.create)
+    const count1 = await page
+      .locator(
+        '#relationWithAllowCreateToFalse button.relationship--single-value-label__drawer-toggler',
+      )
+      .count()
+    expect(count1).toEqual(1)
+    // expect the button to not exist in the field
+    const count2 = await page
+      .locator(
+        '#relationWithAllowEditToFalse button.relationship--single-value-label__drawer-toggler',
+      )
+      .count()
+    expect(count2).toEqual(0)
   })
 
   // TODO: Flaky test in CI - fix this. https://github.com/payloadcms/payload/actions/runs/8910825395/job/24470963991

--- a/test/fields/collections/Relationship/index.ts
+++ b/test/fields/collections/Relationship/index.ts
@@ -38,18 +38,25 @@ const RelationshipFields: CollectionConfig = {
     },
     {
       name: 'relationToSelfSelectOnly',
-      admin: {
-        allowCreate: false,
-      },
       relationTo: relationshipFieldsSlug,
       type: 'relationship',
     },
     {
-      name: 'relationToSelfRestrictCreate',
+      name: 'relationWithAllowCreateToFalse',
+      admin: {
+        allowCreate: false,
+      },
+      defaultValue: ({ user }) => user?.id,
+      relationTo: 'users',
+      type: 'relationship',
+    },
+    {
+      name: 'relationWithAllowEditToFalse',
       admin: {
         allowEdit: false,
       },
-      relationTo: relationshipFieldsSlug,
+      defaultValue: ({ user }) => user?.id,
+      relationTo: 'users',
       type: 'relationship',
     },
     {

--- a/test/fields/collections/Relationship/index.ts
+++ b/test/fields/collections/Relationship/index.ts
@@ -45,6 +45,14 @@ const RelationshipFields: CollectionConfig = {
       type: 'relationship',
     },
     {
+      name: 'relationToSelfRestrictCreate',
+      admin: {
+        allowEdit: false,
+      },
+      relationTo: relationshipFieldsSlug,
+      type: 'relationship',
+    },
+    {
       name: 'relationWithDynamicDefault',
       defaultValue: ({ user }) => user?.id,
       relationTo: 'users',

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1140,6 +1140,7 @@ export interface RelationshipField {
     | null;
   relationToSelf?: (string | null) | RelationshipField;
   relationToSelfSelectOnly?: (string | null) | RelationshipField;
+  relationToSelfRestrictCreate?: (string | null) | RelationshipField;
   relationWithDynamicDefault?: (string | null) | User;
   relationHasManyWithDynamicDefault?: {
     relationTo: 'users';

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1140,7 +1140,8 @@ export interface RelationshipField {
     | null;
   relationToSelf?: (string | null) | RelationshipField;
   relationToSelfSelectOnly?: (string | null) | RelationshipField;
-  relationToSelfRestrictCreate?: (string | null) | RelationshipField;
+  relationWithAllowCreateToFalse?: (string | null) | User;
+  relationWithAllowEditToFalse?: (string | null) | User;
   relationWithDynamicDefault?: (string | null) | User;
   relationHasManyWithDynamicDefault?: {
     relationTo: 'users';


### PR DESCRIPTION
This PR adds a new property `allowEdit` to the admin of the relationship field. It is very similar to the existing `allowCreate`, only in this case it hides the edit icon:

<img width="796" alt="image" src="https://github.com/user-attachments/assets/bbe79bb2-db06-4ec4-b023-2f1c53330fcb">

Note: The Upload field also allows the `allowCreate` property. Its corresponding `allowEdit` analog will be implemented in a later PR.