### PR TITLE
docs: fix broken link on outside nextjs usage

### DIFF
--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -71,7 +71,7 @@ import config from '@payload-config'
 const payload = await getPayload({ config })
 ```
 
-Both options function in exactly the same way outside of one having HMR support and the other not. For more information about using Payload outside of Next.js, [click here](/docs/beta/local-api/outside-nextjs).
+Both options function in exactly the same way outside of one having HMR support and the other not. For more information about using Payload outside of Next.js, [click here](/docs/local-api/outside-nextjs).
 
 ## Local options available
 


### PR DESCRIPTION
This PR updates the docs link related to the usage of the Local API outside of Next.js previously resulting in a 404.