### PR TITLE
fix(ui): issue with tab labels not changing based on language when its a function

### DIFF
--- a/packages/payload/src/admin/elements/Tab.ts
+++ b/packages/payload/src/admin/elements/Tab.ts
@@ -42,6 +42,12 @@ export type DocumentTabConfig = {
   readonly Pill?: PayloadComponent
 }
 
+export type ClientDocumentTabConfig = {
+  condition?: never
+  isActive?: boolean
+  label?: string
+} & DocumentTabConfig
+
 export type DocumentTabComponent = PayloadComponent<{
   path: string
 }>

--- a/packages/payload/src/admin/types.ts
+++ b/packages/payload/src/admin/types.ts
@@ -11,6 +11,7 @@ export type { CustomPublishButton } from './elements/PublishButton.js'
 export type { CustomSaveButton } from './elements/SaveButton.js'
 export type { CustomSaveDraftButton } from './elements/SaveDraftButton.js'
 export type {
+  ClientDocumentTabConfig,
   DocumentTabComponent,
   DocumentTabCondition,
   DocumentTabConfig,

--- a/packages/payload/src/admin/views/types.ts
+++ b/packages/payload/src/admin/views/types.ts
@@ -8,7 +8,7 @@ import type { Locale, MetaConfig, PayloadComponent } from '../../config/types.js
 import type { SanitizedGlobalConfig } from '../../globals/config/types.js'
 import type { PayloadRequest } from '../../types/index.js'
 import type { LanguageOptions } from '../LanguageOptions.js'
-import type { MappedComponent } from '../types.js'
+import type { ClientDocumentTabConfig, MappedComponent } from '../types.js'
 
 export type AdminViewConfig = {
   Component: AdminViewComponent
@@ -23,6 +23,7 @@ export type AdminViewConfig = {
 export type MappedView = {
   actions?: MappedComponent[]
   Component: MappedComponent
+  tab?: ClientDocumentTabConfig
 }
 
 export type AdminViewProps = {

--- a/packages/ui/src/providers/Config/createClientConfig/collections.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/collections.tsx
@@ -250,15 +250,6 @@ export const createClientCollectionConfig = ({
     )
   }
 
-  // Ensure that the label in Edit view is a string, translate it if it's a function
-  if (collection?.admin?.components?.views?.edit) {
-    Object.entries(collection?.admin?.components?.views?.edit).forEach(([key, view]) => {
-      if ('tab' in view && 'label' in view.tab && typeof view.tab.label === 'function') {
-        collection.admin.components.views.edit[key].tab.label = view.tab.label({ t: i18n.t })
-      }
-    })
-  }
-
   clientCollection.admin.components.views = (
     collection?.admin?.components?.views
       ? deepCopyObjectSimple(collection?.admin?.components?.views)
@@ -313,6 +304,13 @@ export const createClientCollectionConfig = ({
           undefined,
           'collection.admin.components.views.edit.key.Component',
         )
+      }
+
+      // Ensure that the label in a tab in an Edit view is a string, translate it if it's a function
+      if ('tab' in view && 'label' in view.tab && typeof view.tab.label === 'function') {
+        clientCollection.admin.components.views.edit[key].tab.label = view.tab.label({
+          t: i18n.t,
+        })
       }
 
       if ('actions' in view && view.actions?.length) {


### PR DESCRIPTION
- Fixes https://github.com/payloadcms/payload/issues/8410
- Adds a new type for `ClientDocumentTabConfig` to make `label`, `isActive` and `condition` not readonly and not functions so that it's compatible with being set for the client config