### PR TITLE
fix(ui): number field not being able to clear out the field's value

### DIFF
--- a/packages/ui/src/fields/Number/index.tsx
+++ b/packages/ui/src/fields/Number/index.tsx
@@ -78,7 +78,7 @@ const NumberFieldComponent: NumberFieldClientComponent = (props) => {
       let newVal = val
 
       if (Number.isNaN(val)) {
-        newVal = undefined
+        newVal = null
       }
 
       if (typeof onChangeFromProps === 'function') {

--- a/test/fields/collections/Number/e2e.spec.ts
+++ b/test/fields/collections/Number/e2e.spec.ts
@@ -138,4 +138,16 @@ describe('Number', () => {
       'The following field is invalid: withMinRows',
     )
   })
+
+  test('should keep data removed on save if deleted', async () => {
+    const input = 1
+    await page.goto(url.create)
+    const field = page.locator('#field-number')
+    await field.fill(String(input))
+    await saveDocAndAssert(page)
+    await expect(field).toHaveValue(String(input))
+    await field.fill('')
+    await saveDocAndAssert(page)
+    await expect(field).toHaveValue('')
+  })
 })


### PR DESCRIPTION
Fixes #7780 

Fixes a bug where the number field won't save data if it's being removed entirely (should be null) instead of changed to another value.