### PR TITLE
fix(richtext-lexical): add max-width to tables (temporary fix for overflow).

### DIFF
--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.scss
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.scss
@@ -3,6 +3,7 @@
 .LexicalEditorTheme {
   &__table {
     border-collapse: collapse;
+    max-width: 100%;
     border-spacing: 0;
     overflow-y: scroll;
     overflow-x: scroll;


### PR DESCRIPTION
This is a half-baked and temporary solution to https://github.com/payloadcms/payload/issues/8036

As I said there:
- ideally tables would have a horizontal scroll independent of the rest of the document, just like Notion does.
- the solution in this PR can make the experience of resizing columns frustrating

However, despite that drawback, it is arguably a better behavior than the current one where they can have overflow over the editor container.

Until the ideal solution is implemented, let's default to this behavior.

## Before

![image](https://github.com/user-attachments/assets/b2856a3f-4b43-45f0-a7db-00c53fe5c980)


## After
![image](https://github.com/user-attachments/assets/2f60d186-d614-4c72-968c-137820812e11)
