### PR TITLE
fix(ui): autosave and preventLeaveWithoutSaving interfering with fetching form-state reliably

### DIFF
--- a/packages/next/src/views/Edit/Default/index.tsx
+++ b/packages/next/src/views/Edit/Default/index.tsx
@@ -113,10 +113,19 @@ export const DefaultEditView: React.FC = () => {
 
   const isLockingEnabled = lockDocumentsProp !== false
 
-  const preventLeaveWithoutSaving =
-    (!(collectionConfig?.versions?.drafts && collectionConfig?.versions?.drafts?.autosave) ||
-      !(globalConfig?.versions?.drafts && globalConfig?.versions?.drafts?.autosave)) &&
-    !disableLeaveWithoutSaving
+  let preventLeaveWithoutSaving = true
+
+  if (collectionConfig) {
+    preventLeaveWithoutSaving = !(
+      collectionConfig?.versions?.drafts && collectionConfig?.versions?.drafts?.autosave
+    )
+  } else if (globalConfig) {
+    preventLeaveWithoutSaving = !(
+      globalConfig?.versions?.drafts && globalConfig?.versions?.drafts?.autosave
+    )
+  } else if (typeof disableLeaveWithoutSaving !== 'undefined') {
+    preventLeaveWithoutSaving = !disableLeaveWithoutSaving
+  }
 
   const [isReadOnlyForIncomingUser, setIsReadOnlyForIncomingUser] = useState(false)
   const [showTakeOverModal, setShowTakeOverModal] = useState(false)

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -47,7 +47,7 @@ export const Autosave: React.FC<Props> = ({
   } = useConfig()
   const { docConfig, getVersions, versions } = useDocumentInfo()
   const { reportUpdate } = useDocumentEvents()
-  const { dispatchFields, setModified, setSubmitted } = useForm()
+  const { dispatchFields, setSubmitted } = useForm()
   const submitted = useFormSubmitted()
   const versionsConfig = docConfig?.versions
 
@@ -149,7 +149,7 @@ export const Autosave: React.FC<Props> = ({
                       entitySlug,
                       updatedAt: newDate.toISOString(),
                     })
-                    setModified(false)
+
                     void getVersions()
                   } else {
                     return res.json()
@@ -247,7 +247,6 @@ export const Autosave: React.FC<Props> = ({
     reportUpdate,
     serverURL,
     setSubmitted,
-    setModified,
     versionsConfig?.drafts,
     debouncedFields,
     submitted,


### PR DESCRIPTION
Removes the setModified call from Autosave logic and updates the `preventLeaveWithoutSaving` logic in Document info to actually disable if autosave is enabled (previously it always resolved to true)

Fixes https://github.com/payloadcms/payload/issues/8072