### PR TITLE
fix: sorting by id incorrectly orders by version.id

### DIFF
--- a/packages/payload/src/versions/drafts/getQueryDraftsSort.ts
+++ b/packages/payload/src/versions/drafts/getQueryDraftsSort.ts
@@ -15,5 +15,9 @@ export const getQueryDraftsSort = (sort: string): string => {
     orderBy = sort.substring(1)
   }
 
+  if (orderBy === 'id') {
+    return `${direction}parent`
+  }
+
   return `${direction}version.${orderBy}`
 }


### PR DESCRIPTION
fixes #7187 