### PR TITLE
fix: reset password link extra slash and thread admin.routes.reset property

### DIFF
--- a/packages/next/src/views/Root/getViewFromConfig.ts
+++ b/packages/next/src/views/Root/getViewFromConfig.ts
@@ -139,7 +139,7 @@ export const getViewFromConfig = ({
       break
     }
     case 2: {
-      if (segmentOne === 'reset') {
+      if (`/${segmentOne}` === config.admin.routes.reset) {
         // --> /reset/:token
         ViewToRender = {
           Component: ResetPassword,

--- a/packages/next/src/views/Root/meta.ts
+++ b/packages/next/src/views/Root/meta.ts
@@ -85,7 +85,7 @@ export const generatePageMetadata = async ({ config: configPromise, params }: Ar
       break
     }
     case 2: {
-      if (segmentOne === 'reset') {
+      if (`/${segmentOne}` === config.admin.routes.reset) {
         // --> /reset/:token
         meta = await generateResetPasswordMetadata({ config, i18n })
       }

--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -150,7 +150,7 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
           : `${protocol}//${req.headers.get('host')}`
 
       let html = `${req.t('authentication:youAreReceivingResetPassword')}
-    <a href="${serverURL}${config.routes.admin}/${config.admin.routes.reset}/${token}">${serverURL}${config.routes.admin}/${config.admin.routes.reset}/${token}</a>
+    <a href="${serverURL}${config.routes.admin}${config.admin.routes.reset}/${token}">${serverURL}${config.routes.admin}${config.admin.routes.reset}/${token}</a>
     ${req.t('authentication:youDidNotRequestPassword')}`
 
       if (typeof collectionConfig.auth.forgotPassword.generateEmailHTML === 'function') {


### PR DESCRIPTION
Removes extra slash
from: 
`http://host/admin//reset/token`
to:
`http://host/admin/reset/token`

Threads `admin.routes.reset`:
```ts
const config: Config = {
  admin: {
    routes: {
      reset: '/custom-reset',
    },
  },
}
```