### PR TITLE
feat: runInit timeout override

### DIFF
--- a/test/dev.ts
+++ b/test/dev.ts
@@ -44,7 +44,7 @@ await beforeTest()
 
 const { rootDir, adminRoute } = getNextRootDir(testSuiteArg)
 
-await safelyRunScriptFunction(runInit, 4000, testSuiteArg)
+await safelyRunScriptFunction(runInit, args.initTimeout ?? 4000, testSuiteArg)
 
 // Open the admin if the -o flag is passed
 if (args.o) {


### PR DESCRIPTION
<!--

For external contributors, please include:

- A summary of the pull request and any related issues it fixes.
- Reasoning for the changes made or any additional context that may be useful.

Ensure you have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

 -->

Fixes #8482 by enabling --initTimeout cli argument to override default of 4s. 

Allows for the following syntax:
`pnpm dev <folder> --initTimeout=<num>`