### PR TITLE
fix(db-postgres, db-sqlite): joins relation name

### DIFF
--- a/packages/db-sqlite/src/schema/traverseFields.ts
+++ b/packages/db-sqlite/src/schema/traverseFields.ts
@@ -907,7 +907,7 @@ export const traverseFields = ({
           type: 'many',
           // joins are not localized on the parent table
           localized: false,
-          relationName: toSnakeCase(field.on),
+          relationName: field.on.replaceAll('.', '_'),
           target,
         })
         break

--- a/packages/drizzle/src/postgres/schema/traverseFields.ts
+++ b/packages/drizzle/src/postgres/schema/traverseFields.ts
@@ -915,7 +915,7 @@ export const traverseFields = ({
           type: 'many',
           // joins are not localized on the parent table
           localized: false,
-          relationName: toSnakeCase(field.on),
+          relationName: field.on.replaceAll('.', '_'),
           target,
         })
         break

--- a/test/joins/.gitignore
+++ b/test/joins/.gitignore
@@ -1,1 +1,1 @@
-/uploads/
+uploads

--- a/test/joins/collections/Categories.ts
+++ b/test/joins/collections/Categories.ts
@@ -60,6 +60,12 @@ export const Categories: CollectionConfig = {
           collection: postsSlug,
           on: 'group.category',
         },
+        {
+          name: 'camelCasePosts',
+          type: 'join',
+          collection: postsSlug,
+          on: 'group.camelCaseCategory',
+        },
       ],
     },
   ],

--- a/test/joins/collections/Posts.ts
+++ b/test/joins/collections/Posts.ts
@@ -32,6 +32,11 @@ export const Posts: CollectionConfig = {
           type: 'relationship',
           relationTo: categoriesSlug,
         },
+        {
+          name: 'camelCaseCategory',
+          type: 'relationship',
+          relationTo: categoriesSlug,
+        },
       ],
     },
   ],

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -68,6 +68,7 @@ describe('Joins Field', () => {
         upload: uploadedImage,
         group: {
           category: category.id,
+          camelCaseCategory: category.id,
         },
       })
     }
@@ -105,6 +106,17 @@ describe('Joins Field', () => {
     expect(docs[0].category.id).toBeDefined()
     expect(docs[0].category.name).toBeDefined()
     expect(docs[0].category.relatedPosts.docs).toHaveLength(10)
+  })
+
+  it('should populate relationships in joins with camelCase names', async () => {
+    const { docs } = await payload.find({
+      limit: 1,
+      collection: 'posts',
+    })
+
+    expect(docs[0].group.camelCaseCategory.id).toBeDefined()
+    expect(docs[0].group.camelCaseCategory.name).toBeDefined()
+    expect(docs[0].group.camelCaseCategory.group.camelCasePosts.docs).toHaveLength(10)
   })
 
   it('should populate uploads in joins', async () => {

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -59,6 +59,7 @@ export interface Post {
   category?: (string | null) | Category;
   group?: {
     category?: (string | null) | Category;
+    camelCaseCategory?: (string | null) | Category;
   };
   updatedAt: string;
   createdAt: string;
@@ -98,6 +99,10 @@ export interface Category {
   } | null;
   group?: {
     relatedPosts?: {
+      docs?: (string | Post)[] | null;
+      hasNextPage?: boolean | null;
+    } | null;
+    camelCasePosts?: {
       docs?: (string | Post)[] | null;
       hasNextPage?: boolean | null;
     } | null;


### PR DESCRIPTION
A join field on a relationship with a camelCase name would cause an error from drizzle due to the relation name not matching.