### PR TITLE
fix(next): current published version label

### DIFF
--- a/packages/next/src/views/Version/index.tsx
+++ b/packages/next/src/views/Version/index.tsx
@@ -60,12 +60,14 @@ export const VersionView: PayloadServerReactComponent<EditViewComponent> = async
         latestDraftVersion = await getLatestVersion({
           slug,
           type: 'collection',
+          parentID: id,
           payload,
           status: 'draft',
         })
         latestPublishedVersion = await getLatestVersion({
           slug,
           type: 'collection',
+          parentID: id,
           payload,
           status: 'published',
         })

--- a/packages/next/src/views/Versions/getLatestVersion.ts
+++ b/packages/next/src/views/Versions/getLatestVersion.ts
@@ -1,4 +1,4 @@
-import type { Payload } from 'payload'
+import type { Payload, Where } from 'payload'
 
 type ReturnType = {
   id: string
@@ -6,13 +6,30 @@ type ReturnType = {
 } | null
 
 type Args = {
+  parentID?: number | string
   payload: Payload
   slug: string
   status: 'draft' | 'published'
   type: 'collection' | 'global'
 }
 export async function getLatestVersion(args: Args): Promise<ReturnType> {
-  const { slug, type = 'collection', payload, status } = args
+  const { slug, type = 'collection', parentID, payload, status } = args
+
+  const and: Where[] = [
+    {
+      'version._status': {
+        equals: status,
+      },
+    },
+  ]
+
+  if (type === 'collection' && parentID) {
+    and.push({
+      parent: {
+        equals: parentID,
+      },
+    })
+  }
 
   try {
     const sharedOptions = {
@@ -20,9 +37,7 @@ export async function getLatestVersion(args: Args): Promise<ReturnType> {
       limit: 1,
       sort: '-updatedAt',
       where: {
-        'version._status': {
-          equals: status,
-        },
+        and,
       },
     }
 

--- a/packages/next/src/views/Versions/index.tsx
+++ b/packages/next/src/views/Versions/index.tsx
@@ -83,12 +83,14 @@ export const VersionsView: PayloadServerReactComponent<EditViewComponent> = asyn
         latestDraftVersion = await getLatestVersion({
           slug: collectionSlug,
           type: 'collection',
+          parentID: id,
           payload,
           status: 'draft',
         })
         latestPublishedVersion = await getLatestVersion({
           slug: collectionSlug,
           type: 'collection',
+          parentID: id,
           payload,
           status: 'published',
         })


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/8502

includes `parent` to the `getLatestVersion` query