### PR TITLE
fix(richtext-lexical): linkFeature doesn't respect admin.routes from payload.config.ts

### DIFF
--- a/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/LinkEditor/index.tsx
+++ b/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/LinkEditor/index.tsx
@@ -124,7 +124,7 @@ export function LinkEditor({ anchorElem }: { anchorElem: HTMLElement }): React.R
     } else {
       // internal link
       setLinkUrl(
-        `/admin/collections/${focusLinkParent.getFields()?.doc?.relationTo}/${
+        `${config.routes.admin === '/' ? '' : config.routes.admin}/collections/${focusLinkParent.getFields()?.doc?.relationTo}/${
           focusLinkParent.getFields()?.doc?.value
         }`,
       )


### PR DESCRIPTION
Fix #8452 