### PR TITLE
fix: properly resolves cjs withPayload export

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -126,7 +126,7 @@
       },
       "./withPayload": {
         "import": "./dist/withPayload.js",
-        "require": "./dist/cjs/withPayload.cjs",
+        "require": "./dist/cjs/withPayload.js",
         "default": "./dist/withPayload.js"
       },
       "./layouts": {


### PR DESCRIPTION
Importing `withPayload` as CommonJS using `require` does not properly resolve. This was because the exported file path was using the `.cjs` extension instead of `.js`.