### PR TITLE
fix(db-postgres): missing types for db.pool by moving @types/pg from devDependencies to dependencies

### DIFF
--- a/packages/db-postgres/package.json
+++ b/packages/db-postgres/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@payloadcms/drizzle": "workspace:*",
+    "@types/pg": "8.10.2",
     "console-table-printer": "2.11.2",
     "drizzle-kit": "0.23.2-df9e596",
     "drizzle-orm": "0.32.1",
@@ -59,7 +60,6 @@
   "devDependencies": {
     "@hyrious/esbuild-plugin-commonjs": "^0.2.4",
     "@payloadcms/eslint-config": "workspace:*",
-    "@types/pg": "8.10.2",
     "@types/to-snake-case": "1.0.0",
     "esbuild": "0.23.1",
     "payload": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       '@payloadcms/drizzle':
         specifier: workspace:*
         version: link:../drizzle
+      '@types/pg':
+        specifier: 8.10.2
+        version: 8.10.2
       console-table-printer:
         specifier: 2.11.2
         version: 2.11.2
@@ -330,9 +333,6 @@ importers:
       '@payloadcms/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
-      '@types/pg':
-        specifier: 8.10.2
-        version: 8.10.2
       '@types/to-snake-case':
         specifier: 1.0.0
         version: 1.0.0


### PR DESCRIPTION
Fixes lack of types in installed project:

![CleanShot 2024-10-04 at 19 18 58@2x](https://github.com/user-attachments/assets/e7c519ee-72fd-424b-8f6c-41032322fa5e)

Since we expose stuff from @types/pg to the end user, we need it to be installed in the end users project => move to dependencies.