### PR TITLE
chore: deflakes lexical e2e test

### DIFF
--- a/test/fields/collections/Lexical/e2e/blocks/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e/blocks/e2e.spec.ts
@@ -870,7 +870,8 @@ describe('lexicalBlocks', () => {
 
       // navigate to list view
       await page.locator('.step-nav a').nth(1).click()
-      await page.waitForURL('**/lexical-fields?limit=10')
+
+      await page.waitForURL(/^.*\/lexical-fields(\?.*)?$/)
 
       // Click on lexical document in list view (navigateToLexicalFields is client-side navigation which is what we need to reproduce the issue here)
       await navigateToLexicalFields(false)


### PR DESCRIPTION
This has caused me great pain. The problem with this test is that the page was waiting for a URL which includes a search query that never arrives. This moves the check into a regex pattern for a more accurate catch.