### PR TITLE
fix(richtext-lexical): add target _blank for new-tab in linkFeature

### DIFF
--- a/packages/richtext-lexical/src/field/features/Link/index.ts
+++ b/packages/richtext-lexical/src/field/features/Link/index.ts
@@ -118,13 +118,14 @@ export const LinkFeature = (props: LinkFeatureProps): FeatureProvider => {
                   })
 
                   const rel: string = node.fields.newTab ? ' rel="noopener noreferrer"' : ''
+                  const target: string = node.fields.newTab ? ' target="_blank"' : ''
 
                   const href: string =
                     node.fields.linkType === 'custom'
                       ? node.fields.url
                       : (node.fields.doc?.value as string)
 
-                  return `<a href="${href}"${rel}>${childrenText}</a>`
+                  return `<a href="${href}"${target}${rel}>${childrenText}</a>`
                 },
                 nodeTypes: [LinkNode.getType()],
               } as HTMLConverter<SerializedLinkNode>,


### PR DESCRIPTION
FIxes #8569 

Matches the fixes in commit 23df60dba5682255ce6f60e3ee8e6901f6a70c7b (plugin-form-builder) and e0b201c810869320436ce35c66765d666882ec79 (v3)

Adds target="_blank" where the link should be in a new tab
