### PR TITLE
fix(ui): add unstyled prop to react-select so that payload styles take priority

### DIFF
--- a/packages/ui/src/elements/ReactSelect/index.scss
+++ b/packages/ui/src/elements/ReactSelect/index.scss
@@ -8,7 +8,6 @@
   .react-select {
     .rs__control {
       @include formInput;
-      height: auto;
       padding: base(0.4) base(0.6);
       flex-wrap: nowrap;
     }
@@ -45,6 +44,7 @@
     .rs__group-heading {
       color: var(--theme-elevation-800);
       padding-left: base(0.5);
+      margin-top: base(0.25);
       margin-bottom: base(0.25);
     }
 

--- a/packages/ui/src/elements/ReactSelect/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/index.tsx
@@ -106,6 +106,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
         onMenuClose={onMenuClose}
         onMenuOpen={onMenuOpen}
         options={options}
+        unstyled={true}
         value={value}
       />
     )


### PR DESCRIPTION
Adds `unstyled={true}` prop to the react-select element so that payload's styles take priority. Due to the way react-select adds its own styles (injected into the page) they were higher specificity due to not being in a layer.

Fixes this bug with our styles' specificity not being applied 
![image](https://github.com/user-attachments/assets/1cd216a4-8125-4312-949e-168c7eb96186)


Also fixes https://github.com/payloadcms/payload/issues/8507