### PR TITLE
docs: clarifies distinction between official and community plugins in docs

### DIFF
--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -144,6 +144,10 @@ export default addLastModified
 
 ### Available Plugins
 
-You can discover existing plugins by browsing the `payload-plugin` topic on [GitHub](https://github.com/topics/payload-plugin).
+Payload supports both official plugins, maintained by the Payload team, and community plugins, developed by external contributors.
+
+You can discover existing plugins by browsing the `payload-plugin` topic on [GitHub](https://github.com/topics/payload-plugin). These plugins offer a wide range of functionality. Some are maintained by the Payload team, while others are community-built. While we encourage users to explore them, please note that only official plugins are maintained and supported by the Payload team. For community plugins, support may vary as they are developed and maintained independently.
 
 For maintainers building plugins for others to use, please add the topic to help others find it. If you would like one to be built by the core Payload team, [open a Feature Request](https://github.com/payloadcms/payload/discussions) in our GitHub Discussions board. We would be happy to review your code and maybe feature you and your plugin where appropriate.
+
+For a list of official plugins, check the [Payload monorepo](https://github.com/payloadcms/payload/tree/main/packages).


### PR DESCRIPTION
Updated the plugins overview page to better differentiate between official Payload plugins and community plugins. 

Clarified that only official plugins are maintained and supported by the Payload team, while community plugins may have varying levels of support.