### PR TITLE
docs: specifies `defaultLocale` as a required property for localization

### DIFF
--- a/docs/configuration/localization.mdx
+++ b/docs/configuration/localization.mdx
@@ -35,7 +35,8 @@ import { buildConfig } from 'payload'
 export default buildConfig({
   // ...
   localization: {
-    locales: ['en', 'es', 'de'] // highlight-line
+    locales: ['en', 'es', 'de'] // required
+    defaultLocale: 'en', // required
   },
 })
 ```
@@ -63,7 +64,7 @@ export default buildConfig({
         rtl: true,
       },
     ],
-    defaultLocale: 'en',
+    defaultLocale: 'en', // required
     fallback: true,
   },
 })


### PR DESCRIPTION
Fixes #8567 
