### PR TITLE
fix(drizzle): handle hasMany rels within join field

### DIFF
--- a/packages/drizzle/src/find/buildFindManyArgs.ts
+++ b/packages/drizzle/src/find/buildFindManyArgs.ts
@@ -36,6 +36,7 @@ export const buildFindManyArgs = ({
   tableName,
 }: BuildFindQueryArgs): Record<string, unknown> => {
   const result: Result = {
+    extras: {},
     with: {},
   }
 
@@ -44,6 +45,7 @@ export const buildFindManyArgs = ({
       id: false,
       _parentID: false,
     },
+    extras: {},
     with: {},
   }
 

--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -1,14 +1,15 @@
-import type { DBQueryConfig } from 'drizzle-orm'
+import type { LibSQLDatabase } from 'drizzle-orm/libsql'
 import type { Field, JoinQuery } from 'payload'
 
+import { and, type DBQueryConfig, eq, sql } from 'drizzle-orm'
 import { fieldAffectsData, fieldIsVirtual, tabHasName } from 'payload/shared'
 import toSnakeCase from 'to-snake-case'
 
-import type { BuildQueryJoinAliases, DrizzleAdapter } from '../types.js'
+import type { BuildQueryJoinAliases, ChainedMethods, DrizzleAdapter } from '../types.js'
 import type { Result } from './buildFindManyArgs.js'
 
-import { buildOrderBy } from '../queries/buildOrderBy.js'
 import buildQuery from '../queries/buildQuery.js'
+import { chainMethods } from './chainMethods.js'
 
 type TraverseFieldArgs = {
   _locales: Result
@@ -241,14 +242,89 @@ export const traverseFields = ({
             // get an additional document and slice it later to determine if there is a next page
             limit += 1
           }
+
           const fields = adapter.payload.collections[field.collection].config.fields
           const joinCollectionTableName = adapter.tableNameMap.get(toSnakeCase(field.collection))
-          let joinTableName = `${adapter.tableNameMap.get(toSnakeCase(field.collection))}${
+          const joinTableName = `${adapter.tableNameMap.get(toSnakeCase(field.collection))}${
             field.localized && adapter.payload.config.localization ? adapter.localesSuffix : ''
           }`
+
           if (!adapter.tables[joinTableName][field.on]) {
-            joinTableName = `${joinTableName}${adapter.relationshipsSuffix}`
+            const db = adapter.drizzle as LibSQLDatabase
+            const joinTable = `${joinTableName}${adapter.relationshipsSuffix}`
+
+            const joins: BuildQueryJoinAliases = [
+              {
+                type: 'innerJoin',
+                condition: and(
+                  eq(adapter.tables[joinTable].parent, adapter.tables[joinTableName].id),
+                  eq(
+                    sql.raw(`"${joinTable}"."${topLevelTableName}_id"`),
+                    adapter.tables[currentTableName].id,
+                  ),
+                ),
+                table: adapter.tables[joinTable],
+              },
+            ]
+
+            const { orderBy, where: subQueryWhere } = buildQuery({
+              adapter,
+              fields,
+              joins,
+              locale,
+              sort,
+              tableName: joinCollectionTableName,
+              where: {},
+            })
+
+            const chainedMethods: ChainedMethods = []
+
+            joins.forEach(({ type, condition, table }) => {
+              chainedMethods.push({
+                args: [table, condition],
+                method: type ?? 'leftJoin',
+              })
+            })
+
+            const subQuery = chainMethods({
+              methods: chainedMethods,
+              query: db
+                .select({
+                  id: adapter.tables[joinTableName].id,
+                })
+                .from(adapter.tables[joinTableName])
+                .where(subQueryWhere)
+                .orderBy(orderBy.order(orderBy.column))
+                .limit(11),
+            })
+
+            const columnName = `${path.replaceAll('.', '_')}${field.name}`
+
+            const extras = field.localized ? _locales.extras : currentArgs.extras
+
+            if (adapter.name === 'sqlite') {
+              extras[columnName] = sql`
+              COALESCE((
+                SELECT json_group_array("id")
+                FROM (
+                  ${subQuery}
+                ) AS ${sql.raw(`${columnName}_sub`)}
+              ), '[]')
+            `.as(columnName)
+            } else {
+              extras[columnName] = sql`
+              COALESCE((
+                SELECT json_agg("id")
+                FROM (
+                  ${subQuery}
+                ) AS ${sql.raw(`${columnName}_sub`)}
+              ), '[]'::json)
+            `.as(columnName)
+            }
+
+            break
           }
+
           const selectFields = {}
 
           const withJoin: DBQueryConfig<'many', true, any, any> = {
@@ -271,7 +347,7 @@ export const traverseFields = ({
             joins,
             locale,
             sort,
-            tableName: joinCollectionTableName,
+            tableName: joinTableName,
             where,
           })
           if (joinWhere) {

--- a/packages/drizzle/src/queries/buildQuery.ts
+++ b/packages/drizzle/src/queries/buildQuery.ts
@@ -10,6 +10,7 @@ import { parseParams } from './parseParams.js'
 export type BuildQueryJoinAliases = {
   condition: SQL
   table: GenericTable | PgTableWithColumns<any>
+  type?: 'innerJoin' | 'leftJoin' | 'rightJoin'
 }[]
 
 type BuildQueryArgs = {

--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -137,7 +137,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
       }
 
       const fieldName = `${fieldPrefix || ''}${field.name}`
-      const fieldData = table[fieldName]
+      let fieldData = table[fieldName]
       const localizedFieldData = {}
       const valuesToTransform: {
         ref: Record<string, unknown>
@@ -422,6 +422,11 @@ export const traverseFields = <T extends Record<string, unknown>>({
       if (field.type === 'join') {
         const { limit = 10 } = joinQuery?.[`${fieldPrefix.replaceAll('_', '.')}${field.name}`] || {}
 
+        // raw hasMany results from SQLite
+        if (typeof fieldData === 'string') {
+          fieldData = JSON.parse(fieldData)
+        }
+
         let fieldResult:
           | { docs: unknown[]; hasNextPage: boolean }
           | Record<string, { docs: unknown[]; hasNextPage: boolean }>
@@ -447,8 +452,8 @@ export const traverseFields = <T extends Record<string, unknown>>({
           } else {
             const hasNextPage = limit !== 0 && fieldData.length > limit
             fieldResult = {
-              docs: (hasNextPage ? fieldData.slice(0, limit) : fieldData).map(({ id, parent }) => ({
-                id: parent ?? id,
+              docs: (hasNextPage ? fieldData.slice(0, limit) : fieldData).map((objOrID) => ({
+                id: typeof objOrID === 'object' ? objOrID.id : objOrID,
               })),
               hasNextPage,
             }

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -418,6 +418,8 @@ describe('Relationships', () => {
             },
           })
 
+          await payload.delete({ collection: 'directors', where: {} })
+
           const director1 = await payload.create({
             collection: 'directors',
             data: {

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -400,7 +400,9 @@ describe('Relationships', () => {
 
         it('should sort by a property of a hasMany relationship', async () => {
           // no support for sort by relation in mongodb
-          if (isMongoose(payload)) {return}
+          if (isMongoose(payload)) {
+            return
+          }
 
           const movie1 = await payload.create({
             collection: 'movies',

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -433,7 +433,7 @@ describe('Relationships', () => {
             sort: '-movies.name',
           })
 
-          expect(result.docs[0].id).toStrictEqual(director1.id)
+          expect(result.docs[0].id).toStrictEqual(director2.id)
         })
 
         it('should query using "in" by hasMany relationship field', async () => {

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -17,6 +17,7 @@ import type {
 } from './payload-types.js'
 
 import { initPayloadInt } from '../helpers/initPayloadInt.js'
+import { isMongoose } from '../helpers/isMongoose.js'
 import {
   chainedRelSlug,
   customIdNumberSlug,
@@ -398,6 +399,9 @@ describe('Relationships', () => {
         })
 
         it('should sort by a property of a hasMany relationship', async () => {
+          // no support for sort by relation in mongodb
+          if (isMongoose(payload)) {return}
+
           const movie1 = await payload.create({
             collection: 'movies',
             data: {
@@ -433,7 +437,7 @@ describe('Relationships', () => {
             sort: '-movies.name',
           })
 
-          expect(result.docs[0].id).toStrictEqual(director2.id)
+          expect(result.docs[0].id).toStrictEqual(director1.id)
         })
 
         it('should query using "in" by hasMany relationship field', async () => {


### PR DESCRIPTION
Handles `hasMany` relationships from joins manually with `json_agg` / `json_group_array` instead of using drizzle because either way it seems like we can't sort the subquery that drizzle generates by column from another table