### PR TITLE
fix(richtext-lexical): various fixes when importing mdx

### DIFF
--- a/packages/richtext-lexical/src/utilities/jsx/lexicalMarkdownCopy.ts
+++ b/packages/richtext-lexical/src/utilities/jsx/lexicalMarkdownCopy.ts
@@ -1,10 +1,4 @@
-/**
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- */
+/* eslint-disable regexp/no-unused-capturing-group */
 
 import type { ListItemNode } from '@lexical/list'
 import type {
@@ -568,9 +562,15 @@ export function normalizeMarkdown(input: string, shouldMergeAdjacentLines = fals
       continue
     }
 
+    if (
+      (CODE_START_REGEX.test(line) && !inCodeBlock) ||
+      (CODE_END_REGEX.test(line) && inCodeBlock)
+    ) {
+      inCodeBlock = !inCodeBlock
+    }
+
     // Detect the start or end of a code block
     if (CODE_START_REGEX.test(line) || CODE_END_REGEX.test(line)) {
-      inCodeBlock = !inCodeBlock
       sanitizedLines.push(line)
       continue
     }
@@ -599,7 +599,7 @@ export function normalizeMarkdown(input: string, shouldMergeAdjacentLines = fals
     ) {
       sanitizedLines.push(line)
     } else {
-      sanitizedLines[sanitizedLines.length - 1] = lastLine + line
+      sanitizedLines[sanitizedLines.length - 1] = lastLine + ' ' + line.trim()
     }
   }
 

--- a/packages/richtext-lexical/src/utilities/jsx/lexicalMarkdownCopy.ts
+++ b/packages/richtext-lexical/src/utilities/jsx/lexicalMarkdownCopy.ts
@@ -546,6 +546,8 @@ const CODE_END_REGEX = /[ \t]*```$/
 const CODE_SINGLE_LINE_REGEX = /^[ \t]*```[^`]+(?:(?:`{1,2}|`{4,})[^`]+)*```(?:[^`]|$)/
 const TABLE_ROW_REG_EXP = /^\|(.+)\|\s?$/
 const TABLE_ROW_DIVIDER_REG_EXP = /^(\| ?:?-*:? ?)+\|\s?$/
+const TAG_START_REGEX = /^[ \t]*<[a-z_][\w-]*(?:\s[^<>]*)?\/?>/i
+const TAG_END_REGEX = /^[ \t]*<\/[a-z_][\w-]*\s*>/i
 
 export function normalizeMarkdown(input: string, shouldMergeAdjacentLines = false): string {
   const lines = input.split('\n')
@@ -595,7 +597,11 @@ export function normalizeMarkdown(input: string, shouldMergeAdjacentLines = fals
       CHECK_LIST_REGEX.test(line) ||
       TABLE_ROW_REG_EXP.test(line) ||
       TABLE_ROW_DIVIDER_REG_EXP.test(line) ||
-      !shouldMergeAdjacentLines
+      !shouldMergeAdjacentLines ||
+      TAG_START_REGEX.test(line) ||
+      TAG_END_REGEX.test(line) ||
+      TAG_START_REGEX.test(lastLine) ||
+      TAG_END_REGEX.test(lastLine)
     ) {
       sanitizedLines.push(line)
     } else {

--- a/test/lexical-mdx/int.spec.ts
+++ b/test/lexical-mdx/int.spec.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from 'url'
 
 import { initPayloadInt } from '../helpers/initPayloadInt.js'
 import { postsSlug } from './collections/Posts/index.js'
-import { mdxToEditorJSON } from './mdx/hooks.js'
+import { editorJSONToMDX, mdxToEditorJSON } from './mdx/hooks.js'
 import { tableJson } from './tableJson.js'
 import { textToRichText } from './textToRichText.js'
 
@@ -974,10 +974,8 @@ no indent`,
     },
     {
       description: 'TextContainerNoTrim with nested, leftpad content',
-
       input: `
 <TextContainerNoTrim>
-
   indent 2
 
     indent 4
@@ -1411,7 +1409,7 @@ Some line [Start of link
     input,
     inputAfterConvertFromEditorJSON,
     blockNode,
-    // ignoreSpacesAndNewlines,
+    ignoreSpacesAndNewlines,
     rootChildren,
     description,
   } of INPUT_AND_OUTPUT) {
@@ -1469,37 +1467,39 @@ Some line [Start of link
       }
     })
 
-    // it(`can convert from editor JSON: ${description ?? sanitizedInput}"`, () => {
-    //   const editorState = {
-    //     root: {
-    //       children: blockNode
-    //         ? [
-    //             {
-    //               format: '',
-    //               type: 'block',
-    //               version: 2,
-    //               ...blockNode,
-    //             },
-    //           ]
-    //         : rootChildren,
-    //       format: '',
-    //       indent: 0,
-    //       type: 'root',
-    //       version: 1,
-    //     },
-    //   }
-    //   const result = editorJSONToMDX({
-    //     editorConfig,
-    //     editorState,
-    //   })
-    //   // Remove all spaces and newlines
-    //   const resultNoSpace = ignoreSpacesAndNewlines ? result.replace(/\s/g, '') : result
-    //   const inputNoSpace = ignoreSpacesAndNewlines
-    //     ? (sanitizedInputAfterConvertFromEditorJSON ?? sanitizedInput).replace(/\s/g, '')
-    //     : (sanitizedInputAfterConvertFromEditorJSON ?? sanitizedInput)
+    it(`can convert from editor JSON: ${description ?? sanitizedInput}"`, () => {
+      const editorState = {
+        root: {
+          children: blockNode
+            ? [
+                {
+                  format: '',
+                  type: 'block',
+                  version: 2,
+                  ...blockNode,
+                },
+              ]
+            : rootChildren,
+          format: '',
+          indent: 0,
+          type: 'root',
+          version: 1,
+        },
+      }
+      const result = editorJSONToMDX({
+        editorConfig,
+        editorState,
+      })
+      // Remove all spaces and newlines
+      const resultNoSpace = ignoreSpacesAndNewlines ? result.replace(/\s/g, '') : result
+      const inputNoSpace = ignoreSpacesAndNewlines
+        ? (sanitizedInputAfterConvertFromEditorJSON ?? sanitizedInput).replace(/\s/g, '')
+        : (sanitizedInputAfterConvertFromEditorJSON ?? sanitizedInput)
 
-    //   expect(resultNoSpace).toBe(inputNoSpace)
-    // })
+      console.log('resultNoSpace', resultNoSpace)
+      console.log('inputNoSpace', inputNoSpace)
+      expect(resultNoSpace).toBe(inputNoSpace)
+    })
   }
 })
 

--- a/test/lexical-mdx/int.spec.ts
+++ b/test/lexical-mdx/int.spec.ts
@@ -701,11 +701,13 @@ there4
       input: `
 <Banner>
   Some text 1 <InlineCode>code 1</InlineCode> some
+
   text 2 <InlineCode>code 2</InlineCode> some text
+
   3 <InlineCode>code 3</InlineCode> some text 4<InlineCode>code 4</InlineCode>
 </Banner>
 `,
-      description: 'Banner with inline codes, each line a linebreak, one paragraph',
+      description: 'Banner with inline codes, three paragraphs',
 
       blockNode: {
         fields: {
@@ -741,10 +743,16 @@ there4
                       type: 'text',
                       version: 1,
                     },
-                    {
-                      type: 'linebreak',
-                      version: 1,
-                    },
+                  ],
+                  format: '',
+                  indent: 0,
+                  type: 'paragraph',
+                  version: 1,
+                  textFormat: 0,
+                  textStyle: '',
+                },
+                {
+                  children: [
                     {
                       detail: 0,
                       format: 0,
@@ -771,10 +779,16 @@ there4
                       type: 'text',
                       version: 1,
                     },
-                    {
-                      type: 'linebreak',
-                      version: 1,
-                    },
+                  ],
+                  format: '',
+                  indent: 0,
+                  type: 'paragraph',
+                  version: 1,
+                  textFormat: 0,
+                  textStyle: '',
+                },
+                {
+                  children: [
                     {
                       detail: 0,
                       format: 0,
@@ -899,8 +913,11 @@ Text before banner
       input: `
 <TextContainerNoTrim>
 no indent
+
   indent 2
+
     indent 4
+
 no indent
 </TextContainerNoTrim>
 `,
@@ -908,8 +925,11 @@ no indent
         fields: {
           blockType: 'TextContainerNoTrim',
           text: `no indent
+
   indent 2
+
     indent 4
+
 no indent`,
         },
       },
@@ -920,16 +940,22 @@ no indent`,
       input: `
 <TextContainer>
 no indent
+
   indent 2
+
     indent 4
+
 no indent
 </TextContainer>
 `,
       inputAfterConvertFromEditorJSON: `
 <TextContainer>
   no indent
+
     indent 2
+
       indent 4
+
   no indent
 </TextContainer>
 `,
@@ -937,8 +963,11 @@ no indent
         fields: {
           blockType: 'TextContainer',
           text: `no indent
+
   indent 2
+
     indent 4
+
 no indent`,
         },
       },
@@ -948,9 +977,13 @@ no indent`,
 
       input: `
 <TextContainerNoTrim>
+
   indent 2
+
     indent 4
+
       indent 6
+
   indent 2
 </TextContainerNoTrim>
 `,
@@ -958,8 +991,11 @@ no indent`,
         fields: {
           blockType: 'TextContainerNoTrim',
           text: `  indent 2
+
     indent 4
+
       indent 6
+
   indent 2`,
         },
       },
@@ -969,8 +1005,11 @@ no indent`,
       input: `
 <TextContainer>
   indent 2
+
     indent 4
+
       indent 6
+
   indent 2
 </TextContainer>
 `,
@@ -978,8 +1017,11 @@ no indent`,
         fields: {
           blockType: 'TextContainer',
           text: `indent 2
+
   indent 4
+
     indent 6
+
 indent 2`,
         },
       },
@@ -1211,7 +1253,6 @@ Some text 1
       },
     },
     {
-      debugFlag: true,
       inputAfterConvertFromEditorJSON: `
 <Banner>
   Some line [Start of link line2](/some/link)
@@ -1289,11 +1330,11 @@ Some line [Start of link
 </Banner>
 `,
       input: `
-    <Banner>
-      Text text [ Link
-      ](/some/link) .
-    </Banner>
-    `,
+<Banner>
+  Text text [ Link
+  ](/some/link) .
+</Banner>
+`,
       blockNode: {
         fields: {
           blockType: 'Banner',
@@ -1364,7 +1405,7 @@ Some line [Start of link
     },
   ]
 
-  const INPUT_AND_OUTPUT: Tests = INPUT_AND_OUTPUTBase.filter((test) => test.debugFlag)
+  const INPUT_AND_OUTPUT: Tests = INPUT_AND_OUTPUTBase //.filter((test) => test.debugFlag)
 
   for (const {
     input,


### PR DESCRIPTION
**NOTE that this PR is to the `lexical-mdx-shouldMerge` branch.**

___

I had to make some fixes to `normalizeMarkdown`.

I also fixed some tests that were not considering the correct functioning of breaking lines in markdown (see https://github.com/facebook/lexical/pull/6608).

All tests now pass.