### PR TITLE
fix(payload): passes `failOn` option to sharp options

### DIFF
--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -142,7 +142,7 @@ export const generateFileData = async <T>({
       fileSupportsResize &&
       Boolean(resizeOptions || formatOptions || imageSizes || trimOptions || file.tempFilePath)
 
-    const sharpOptions: SharpOptions = {}
+    const sharpOptions: SharpOptions = { failOn: 'none' }
 
     if (fileIsAnimatedType) {
       sharpOptions.animated = true

--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -282,7 +282,7 @@ export async function resizeAndTransformImageSizes({
 
   // Determine if the file is animated
   const fileIsAnimatedType = ['image/avif', 'image/gif', 'image/webp'].includes(file.mimetype)
-  const sharpOptions: SharpOptions = {}
+  const sharpOptions: SharpOptions = { failOn: 'none' }
 
   if (fileIsAnimatedType) {
     sharpOptions.animated = true


### PR DESCRIPTION
Fixes #8606 (v3)
