### PR TITLE
fix(ui): react select fields not increasing height when items overflow

### DIFF
--- a/packages/ui/src/elements/ReactSelect/index.scss
+++ b/packages/ui/src/elements/ReactSelect/index.scss
@@ -8,7 +8,8 @@
   .react-select {
     .rs__control {
       @include formInput;
-      padding: base(0.4) base(0.6);
+      height: auto;
+      padding: base(0.35) base(0.6);
       flex-wrap: nowrap;
     }
 


### PR DESCRIPTION
Fixes this instance 
![image](https://github.com/user-attachments/assets/b2acc493-727e-4a26-8623-de28ff1dbe3c)
