### PR TITLE
chore: do not use withSentryConfig for dev/e2e next config if not needed

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,5 @@
 export async function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
+  if (process.env.NEXT_RUNTIME === 'nodejs' && process.env.NEXT_PUBLIC_SENTRY_DSN) {
     await import('./sentry.server.config.js')
   }
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -42,12 +42,21 @@ const config = withBundleAnalyzer(
         '.mjs': ['.mts', '.mjs'],
       }
 
+      // Ignore sentry warnings when not wrapped with withSentryConfig
+      webpackConfig.ignoreWarnings = [
+        ...(webpackConfig.ignoreWarnings ?? []),
+        { file: /esm\/platform\/node\/instrumentation.js/ },
+        { module: /esm\/platform\/node\/instrumentation.js/ },
+      ]
+
       return webpackConfig
     },
   }),
 )
 
-export default withSentryConfig(config, {
-  telemetry: false,
-  tunnelRoute: '/monitoring-tunnel',
-})
+export default process.env.NEXT_PUBLIC_SENTRY_DSN
+  ? withSentryConfig(config, {
+      telemetry: false,
+      tunnelRoute: '/monitoring-tunnel',
+    })
+  : config


### PR DESCRIPTION
This fixes this error when executing particular e2e test with playwright extension 
<img width="347" alt="image" src="https://github.com/user-attachments/assets/5f7608fc-7896-4014-b312-a0c36f21b7d1">
