### PR TITLE
fix(drizzle): hasMany joins - localized, add limit and schema path to subquery

### DIFF
--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -250,7 +250,7 @@ export const traverseFields = ({
             field.localized && adapter.payload.config.localization ? adapter.localesSuffix : ''
           }`
 
-          if (!adapter.tables[joinTableName]?.[field.on]) {
+          if (field.hasMany) {
             const db = adapter.drizzle as LibSQLDatabase
             if (field.localized) {
               joinTableName = adapter.tableNameMap.get(toSnakeCase(field.collection))

--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -452,8 +452,8 @@ export const traverseFields = <T extends Record<string, unknown>>({
           } else {
             const hasNextPage = limit !== 0 && fieldData.length > limit
             fieldResult = {
-              docs: (hasNextPage ? fieldData.slice(0, limit) : fieldData).map((objOrID) => ({
-                id: typeof objOrID === 'object' ? objOrID.id : objOrID,
+              docs: (hasNextPage ? fieldData.slice(0, limit) : fieldData).map(({ id }) => ({
+                id,
               })),
               hasNextPage,
             }

--- a/packages/payload/src/fields/config/sanitizeJoinField.ts
+++ b/packages/payload/src/fields/config/sanitizeJoinField.ts
@@ -82,6 +82,8 @@ export const sanitizeJoinField = ({
 
   // override the join field localized property to use whatever the relationship field has
   field.localized = joinRelationship.localized
+  // override the join field hasMany property to use whatever the relationship field has
+  field.hasMany = joinRelationship.hasMany
 
   if (!joins[field.collection]) {
     joins[field.collection] = [join]

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1452,6 +1452,10 @@ export type JoinField = {
    */
   collection: CollectionSlug
   defaultValue?: never
+  /**
+   * This does not need to be set and will be overridden by the relationship field's hasMany property.
+   */
+  hasMany?: boolean
   hidden?: false
   index?: never
   /**

--- a/test/joins/collections/Categories.ts
+++ b/test/joins/collections/Categories.ts
@@ -56,6 +56,12 @@ export const Categories: CollectionConfig = {
       on: 'categories',
     },
     {
+      name: 'hasManyPostsLocalized',
+      type: 'join',
+      collection: postsSlug,
+      on: 'categoriesLocalized',
+    },
+    {
       name: 'group',
       type: 'group',
       fields: [

--- a/test/joins/collections/Posts.ts
+++ b/test/joins/collections/Posts.ts
@@ -30,6 +30,13 @@ export const Posts: CollectionConfig = {
       hasMany: true,
     },
     {
+      name: 'categoriesLocalized',
+      type: 'relationship',
+      relationTo: categoriesSlug,
+      hasMany: true,
+      localized: true,
+    },
+    {
       name: 'group',
       type: 'group',
       fields: [

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -58,6 +58,7 @@ export interface Post {
   upload?: (string | null) | Upload;
   category?: (string | null) | Category;
   categories?: (string | Category)[] | null;
+  categoriesLocalized?: (string | Category)[] | null;
   group?: {
     category?: (string | null) | Category;
     camelCaseCategory?: (string | null) | Category;
@@ -99,6 +100,10 @@ export interface Category {
     hasNextPage?: boolean | null;
   } | null;
   hasManyPosts?: {
+    docs?: (string | Post)[] | null;
+    hasNextPage?: boolean | null;
+  } | null;
+  hasManyPostsLocalized?: {
     docs?: (string | Post)[] | null;
     hasNextPage?: boolean | null;
   } | null;


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/8630 (when `hasMany: true` and `localized: true` on the foreign field)

Additionally:

- Adds `limit` to the subquery instead of hardcoded `11`.
- Adds the schema path `field.on` to the subquery, without this having 2 or more relationship fields to the same collection breaks joins
- Properly checks if the field is `hasMany`