### PR TITLE
perf: do not use deepCopyObject in validateQueryPaths for entity config

### DIFF
--- a/packages/payload/src/database/queryValidation/validateQueryPaths.ts
+++ b/packages/payload/src/database/queryValidation/validateQueryPaths.ts
@@ -6,7 +6,6 @@ import type { EntityPolicies } from './types.js'
 
 import { QueryError } from '../../errors/QueryError.js'
 import { validOperators } from '../../types/constants.js'
-import { deepCopyObject } from '../../utilities/deepCopyObject.js'
 import flattenFields from '../../utilities/flattenTopLevelFields.js'
 import { validateSearchParam } from './validateSearchParams.js'
 
@@ -67,10 +66,10 @@ export async function validateQueryPaths({
           if (validOperators.includes(operator as Operator)) {
             promises.push(
               validateSearchParam({
-                collectionConfig: deepCopyObject(collectionConfig),
+                collectionConfig,
                 errors,
                 fields: fields as Field[],
-                globalConfig: deepCopyObject(globalConfig),
+                globalConfig,
                 operator,
                 overrideAccess,
                 path,


### PR DESCRIPTION
`validateSearchParam` doesn't mutate incoming entity config, therefore there's no point of deep copying the whole entity config into it for _each_ item in `where`.