### PR TITLE
chore: improve setUser type, uses generic from useAuth

### DIFF
--- a/packages/next/src/views/CreateFirstUser/index.client.tsx
+++ b/packages/next/src/views/CreateFirstUser/index.client.tsx
@@ -1,15 +1,10 @@
 'use client'
-import type {
-  ClientCollectionConfig,
-  FormState,
-  LoginWithUsernameOptions,
-  MeOperationResult,
-} from 'payload'
+import type { FormProps, UserWithToken } from '@payloadcms/ui'
+import type { ClientCollectionConfig, FormState, LoginWithUsernameOptions } from 'payload'
 
 import {
   ConfirmPasswordField,
   Form,
-  type FormProps,
   FormSubmit,
   PasswordField,
   RenderFields,
@@ -57,7 +52,7 @@ export const CreateFirstUserClient: React.FC<{
     [apiRoute, userSlug, serverURL],
   )
 
-  const handleFirstRegister = (data: MeOperationResult) => {
+  const handleFirstRegister = (data: UserWithToken) => {
     setUser(data)
   }
 

--- a/packages/next/src/views/Login/LoginForm/index.tsx
+++ b/packages/next/src/views/Login/LoginForm/index.tsx
@@ -6,7 +6,8 @@ import React from 'react'
 const baseClass = 'login__form'
 const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.default
 
-import type { ClientUser, FormState, MeOperationResult } from 'payload'
+import type { UserWithToken } from '@payloadcms/ui'
+import type { FormState } from 'payload'
 
 import { Form, FormSubmit, PasswordField, useAuth, useConfig, useTranslation } from '@payloadcms/ui'
 import { formatAdminURL } from '@payloadcms/ui/shared'
@@ -74,7 +75,7 @@ export const LoginForm: React.FC<{
     }
   }
 
-  const handleLogin = (data: MeOperationResult) => {
+  const handleLogin = (data: UserWithToken) => {
     setUser(data)
   }
 

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -192,6 +192,7 @@ export { XIcon } from '../../icons/X/index.js'
 // providers
 export { ActionsProvider, SetViewActions, useActions } from '../../providers/Actions/index.js'
 export { AuthProvider, useAuth } from '../../providers/Auth/index.js'
+export type { UserWithToken } from '../../providers/Auth/index.js'
 export { ClientFunctionProvider, useClientFunctions } from '../../providers/ClientFunction/index.js'
 export { useAddClientFunction } from '../../providers/ClientFunction/index.js'
 export { RenderComponent } from '../../providers/Config/RenderComponent.js'

--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientUser, MeOperationResult, Permissions, User } from 'payload'
+import type { ClientUser, Permissions, User } from 'payload'
 
 import { useModal } from '@faceless-ui/modal'
 import { usePathname, useRouter } from 'next/navigation.js'
@@ -14,6 +14,12 @@ import { requests } from '../../utilities/api.js'
 import { formatAdminURL } from '../../utilities/formatAdminURL.js'
 import { useConfig } from '../Config/index.js'
 
+export type UserWithToken<T = ClientUser> = {
+  exp: number
+  token: string
+  user: T
+}
+
 export type AuthContext<T = ClientUser> = {
   fetchFullUser: () => Promise<null | User>
   logOut: () => Promise<boolean>
@@ -22,7 +28,7 @@ export type AuthContext<T = ClientUser> = {
   refreshCookieAsync: () => Promise<ClientUser>
   refreshPermissions: () => Promise<void>
   setPermissions: (permissions: Permissions) => void
-  setUser: (user: MeOperationResult | null) => void
+  setUser: (user: null | UserWithToken<T>) => void
   strategy?: string
   token?: string
   tokenExpiration?: number
@@ -97,7 +103,7 @@ export function AuthProvider({
   }, [])
 
   const setNewUser = useCallback(
-    (userResponse: MeOperationResult | null) => {
+    (userResponse: null | UserWithToken) => {
       if (userResponse?.user) {
         setUserInMemory(userResponse.user)
         setTokenInMemory(userResponse.token)
@@ -240,7 +246,7 @@ export function AuthProvider({
       })
 
       if (request.status === 200) {
-        const json: MeOperationResult = await request.json()
+        const json: UserWithToken = await request.json()
         const user = null
 
         setNewUser(json)

--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -14,9 +14,7 @@ import { requests } from '../../utilities/api.js'
 import { formatAdminURL } from '../../utilities/formatAdminURL.js'
 import { useConfig } from '../Config/index.js'
 
-export type UserResponse = MeOperationResult | null
-
-export type AuthContext = {
+export type AuthContext<T = ClientUser> = {
   fetchFullUser: () => Promise<null | User>
   logOut: () => Promise<boolean>
   permissions?: Permissions
@@ -24,11 +22,11 @@ export type AuthContext = {
   refreshCookieAsync: () => Promise<ClientUser>
   refreshPermissions: () => Promise<void>
   setPermissions: (permissions: Permissions) => void
-  setUser: (user: UserResponse) => void
+  setUser: (user: MeOperationResult | null) => void
   strategy?: string
   token?: string
   tokenExpiration?: number
-  user?: null | UserResponse['user']
+  user?: null | T
 }
 
 const Context = createContext({} as AuthContext)
@@ -99,7 +97,7 @@ export function AuthProvider({
   }, [])
 
   const setNewUser = useCallback(
-    (userResponse: UserResponse) => {
+    (userResponse: MeOperationResult | null) => {
       if (userResponse?.user) {
         setUserInMemory(userResponse.user)
         setTokenInMemory(userResponse.token)
@@ -325,4 +323,4 @@ export function AuthProvider({
   )
 }
 
-export const useAuth = (): AuthContext => useContext(Context)
+export const useAuth = <T = ClientUser,>(): AuthContext<T> => useContext(Context) as AuthContext<T>


### PR DESCRIPTION
Create specific type for create user, instead of using the MeOperation result type.

When setting a user it should still look like:
```ts
setUser({
  user: {
    id: 670524817048be0fa222fc01,
    email: dev@payloadcms.com,
    // ... other user properties
  },
  exp: 1728398351,
  token: "....eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVC...."
})
```

But before it was using the MeOperation which has other top level keys that are unnecessary.