### PR TITLE
fix: commonjs exports missing for withPayload

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -54,7 +54,7 @@
     "build:babel": "rm -rf dist_optimized && babel dist --out-dir dist_optimized --source-maps --extensions .ts,.js,.tsx,.jsx,.cjs,.mjs && rm -rf dist && mv dist_optimized dist",
     "build:cjs": "swc ./src/withPayload.js -o ./dist/cjs/withPayload.cjs --config-file .swcrc-cjs --strip-leading-paths",
     "build:esbuild": "node bundleScss.js",
-    "build:reactcompiler": "rm -rf dist && rm -rf tsconfig.tsbuildinfo && pnpm build:swc && pnpm build:cjs && pnpm build:babel && pnpm copyfiles && pnpm build:types && pnpm build:esbuild",
+    "build:reactcompiler": "rm -rf dist && rm -rf tsconfig.tsbuildinfo && pnpm build:swc && pnpm build:babel && pnpm copyfiles && pnpm build:types && pnpm build:esbuild  && pnpm build:cjs",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "build:without_reactcompiler": "rm -rf dist && rm -rf tsconfig.tsbuildinfo && pnpm copyfiles && pnpm build:types && pnpm build:swc && pnpm build:cjs && pnpm build:esbuild",
@@ -126,7 +126,7 @@
       },
       "./withPayload": {
         "import": "./dist/withPayload.js",
-        "require": "./dist/cjs/withPayload.js",
+        "require": "./dist/cjs/withPayload.cjs",
         "default": "./dist/withPayload.js"
       },
       "./layouts": {


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/8635

`withPayload.cjs` is now correctly named in the exports

The final exports in package.json looks like this
```
"./withPayload": {
  "import": "./dist/withPayload.js",
  "require": "./dist/cjs/withPayload.cjs",
  "default": "./dist/withPayload.js"
},
```

You can now use withPayload with require inside `next.config.js` files
```
const { withPayload } = require('@payloadcms/next/withPayload')

const nextConfig = {
  // Your Next.js config here
  experimental: {
    reactCompiler: false,
  },
}

module.exports = withPayload(nextConfig)
```