### PR TITLE
docs: correct wrong object name and useTranslation import in i18n docs

### DIFF
--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -195,7 +195,7 @@ export const customTranslations: Config['i18n']['translations'] = {
   },
 }
 
-export type CustomTranslationsObject = typeof customTranslationsObject.en
+export type CustomTranslationsObject = typeof customTranslations.en
 export type CustomTranslationsKeys = NestedKeysStripped<CustomTranslationsObject>
 ```
 
@@ -224,7 +224,7 @@ Import the shared translation types to use in your [Custom Component](../admin/c
 
 'use client'
 import type React from 'react'
-import { useTranslation } from '@payloadcms/ui/providers/Translation'
+import { useTranslation } from '@payloadcms/ui'
 
 import type { CustomTranslationsObject, CustomTranslationsKeys } from '../custom-translations'
 


### PR DESCRIPTION
Two additional corrections in i18n.mdx. In addition to that, I still think there is something wrong with the line 187 `Config['i18n']['translations']`. For more on that see discussion in https://github.com/payloadcms/payload/issues/8632.

<!--

For external contributors, please include:

- A summary of the pull request and any related issues it fixes.
- Reasoning for the changes made or any additional context that may be useful.

Ensure you have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

 -->
