### PR TITLE
feat(db-postgres, db-vercel-postgres): add createDatabase, create db automatically if it doesn't exist

### DIFF
--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -60,7 +60,7 @@ export default buildConfig({
 | `schemaName` (experimental) | A string for the postgres schema to use, defaults to 'public'.                                                                                                                   |
 | `idType`                    | A string of 'serial', or 'uuid' that is used for the data type given to id columns.                                                                                              |
 | `transactionOptions`        | A PgTransactionConfig object for transactions, or set to `false` to disable using transactions. [More details](https://orm.drizzle.team/docs/transactions)                       |
-| `autoDatabaseCreate`      | Create the provided database automatically if it doesn't exist. Defaults to `true`.                                                                                              |
+| `disableCreateDatabase`     | Pass `true` to disale auto database creation if it doesn't exist. Defaults to `false`.                                                                                           |
 | `localesSuffix`             | A string appended to the end of table names for storing localized fields. Default is '_locales'.                                                                                 |
 | `relationshipsSuffix`       | A string appended to the end of table names for storing relationships. Default is '_rels'.                                                                                       |
 | `versionsSuffix`            | A string appended to the end of table names for storing versions. Defaults to '_v'.                                                                                              |

--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -60,6 +60,7 @@ export default buildConfig({
 | `schemaName` (experimental) | A string for the postgres schema to use, defaults to 'public'.                                                                                                                   |
 | `idType`                    | A string of 'serial', or 'uuid' that is used for the data type given to id columns.                                                                                              |
 | `transactionOptions`        | A PgTransactionConfig object for transactions, or set to `false` to disable using transactions. [More details](https://orm.drizzle.team/docs/transactions)                       |
+| `autoDatabaseCreate`      | Create the provided database automatically if it doesn't exist. Defaults to `true`.                                                                                              |
 | `localesSuffix`             | A string appended to the end of table names for storing localized fields. Default is '_locales'.                                                                                 |
 | `relationshipsSuffix`       | A string appended to the end of table names for storing relationships. Default is '_rels'.                                                                                       |
 | `versionsSuffix`            | A string appended to the end of table names for storing versions. Defaults to '_v'.                                                                                              |

--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -76,7 +76,7 @@ export const connect: Connect = async function connect(
       }
     }
   } catch (err) {
-    if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreate) {
+    if (err.message?.match(/database .* does not exist/i) && !this.disableCreateDatabase) {
       // capitalize first char of the err msg
       this.payload.logger.info(
         `${err.message.charAt(0).toUpperCase() + err.message.slice(1)}, creating...`,

--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -77,7 +77,10 @@ export const connect: Connect = async function connect(
     }
   } catch (err) {
     if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreate) {
-      this.payload.logger.info(`Database ${err.message}, creating...`)
+      // capitalize first char of the err msg
+      this.payload.logger.info(
+        `${err.message.charAt(0).toUpperCase() + err.message.slice(1)}, creating...`,
+      )
       const isCreated = await this.createDatabase()
 
       if (isCreated) {

--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -76,7 +76,7 @@ export const connect: Connect = async function connect(
       }
     }
   } catch (err) {
-    if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreation) {
+    if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreate) {
       this.payload.logger.info(`Database does not exist, creating...`)
       const isCreated = await this.createDatabase()
 

--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -77,7 +77,7 @@ export const connect: Connect = async function connect(
     }
   } catch (err) {
     if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreate) {
-      this.payload.logger.info(`Database does not exist, creating...`)
+      this.payload.logger.info(`Database ${err.message}, creating...`)
       const isCreated = await this.createDatabase()
 
       if (isCreated) {

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -78,10 +78,10 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
     return createDatabaseAdapter<PostgresAdapter>({
       name: 'postgres',
       afterSchemaInit: args.afterSchemaInit ?? [],
-      autoDatabaseCreate: args.autoDatabaseCreate ?? true,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,
       defaultDrizzleSnapshot,
+      disableCreateDatabase: args.disableCreateDatabase ?? false,
       drizzle: undefined,
       enums: {},
       features: {

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -35,6 +35,7 @@ import {
 import {
   convertPathToJSONTraversal,
   countDistinct,
+  createDatabase,
   createJSONQuery,
   createMigration,
   defaultDrizzleSnapshot,
@@ -77,7 +78,9 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
     return createDatabaseAdapter<PostgresAdapter>({
       name: 'postgres',
       afterSchemaInit: args.afterSchemaInit ?? [],
+      autoDatabaseCreation: args.autoDatabaseCreation ?? true,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
+      createDatabase,
       defaultDrizzleSnapshot,
       drizzle: undefined,
       enums: {},

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -78,7 +78,7 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
     return createDatabaseAdapter<PostgresAdapter>({
       name: 'postgres',
       afterSchemaInit: args.afterSchemaInit ?? [],
-      autoDatabaseCreation: args.autoDatabaseCreation ?? true,
+      autoDatabaseCreate: args.autoDatabaseCreate ?? true,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,
       defaultDrizzleSnapshot,

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -19,16 +19,16 @@ export type Args = {
    */
   afterSchemaInit?: PostgresSchemaHook[]
   /**
-   * Create the provided database automatically if it doesn't exist
-   * @default true
-   */
-  autoDatabaseCreate?: boolean
-  /**
    * Transform the schema before it's built.
    * You can use it to preserve an existing database schema and if there are any collissions Payload will override them.
    * To generate Drizzle schema from the database, see [Drizzle Kit introspection](https://orm.drizzle.team/kit-docs/commands#introspect--pull)
    */
   beforeSchemaInit?: PostgresSchemaHook[]
+  /**
+   * Pass `true` to disale auto database creation if it doesn't exist.
+   * @default false
+   */
+  disableCreateDatabase?: boolean
   idType?: 'serial' | 'uuid'
   localesSuffix?: string
   logger?: DrizzleConfig['logger']

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -19,6 +19,11 @@ export type Args = {
    */
   afterSchemaInit?: PostgresSchemaHook[]
   /**
+   * Create the provided database automatically if it doesn't exist
+   * @default true
+   */
+  autoDatabaseCreation?: boolean
+  /**
    * Transform the schema before it's built.
    * You can use it to preserve an existing database schema and if there are any collissions Payload will override them.
    * To generate Drizzle schema from the database, see [Drizzle Kit introspection](https://orm.drizzle.team/kit-docs/commands#introspect--pull)

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -22,7 +22,7 @@ export type Args = {
    * Create the provided database automatically if it doesn't exist
    * @default true
    */
-  autoDatabaseCreation?: boolean
+  autoDatabaseCreate?: boolean
   /**
    * Transform the schema before it's built.
    * You can use it to preserve an existing database schema and if there are any collissions Payload will override them.

--- a/packages/db-vercel-postgres/src/connect.ts
+++ b/packages/db-vercel-postgres/src/connect.ts
@@ -40,7 +40,7 @@ export const connect: Connect = async function connect(
     }
   } catch (err) {
     if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreate) {
-      this.payload.logger.info(`Database does not exist, creating...`)
+      this.payload.logger.info(`Database ${err.message}, creating...`)
       const isCreated = await this.createDatabase()
 
       if (isCreated) {

--- a/packages/db-vercel-postgres/src/connect.ts
+++ b/packages/db-vercel-postgres/src/connect.ts
@@ -39,7 +39,7 @@ export const connect: Connect = async function connect(
       }
     }
   } catch (err) {
-    if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreation) {
+    if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreate) {
       this.payload.logger.info(`Database does not exist, creating...`)
       const isCreated = await this.createDatabase()
 

--- a/packages/db-vercel-postgres/src/connect.ts
+++ b/packages/db-vercel-postgres/src/connect.ts
@@ -40,7 +40,10 @@ export const connect: Connect = async function connect(
     }
   } catch (err) {
     if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreate) {
-      this.payload.logger.info(`Database ${err.message}, creating...`)
+      // capitalize first char of the err msg
+      this.payload.logger.info(
+        `${err.message.charAt(0).toUpperCase() + err.message.slice(1)}, creating...`,
+      )
       const isCreated = await this.createDatabase()
 
       if (isCreated) {

--- a/packages/db-vercel-postgres/src/connect.ts
+++ b/packages/db-vercel-postgres/src/connect.ts
@@ -39,7 +39,7 @@ export const connect: Connect = async function connect(
       }
     }
   } catch (err) {
-    if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreate) {
+    if (err.message?.match(/database .* does not exist/i) && !this.disableCreateDatabase) {
       // capitalize first char of the err msg
       this.payload.logger.info(
         `${err.message.charAt(0).toUpperCase() + err.message.slice(1)}, creating...`,

--- a/packages/db-vercel-postgres/src/connect.ts
+++ b/packages/db-vercel-postgres/src/connect.ts
@@ -39,7 +39,18 @@ export const connect: Connect = async function connect(
       }
     }
   } catch (err) {
-    this.payload.logger.error({ err, msg: `Error: cannot connect to Postgres: ${err.message}` })
+    if (err.message?.match(/database .* does not exist/i) && this.autoDatabaseCreation) {
+      this.payload.logger.info(`Database does not exist, creating...`)
+      const isCreated = await this.createDatabase()
+
+      if (isCreated) {
+        await this.connect(options)
+        return
+      }
+    } else {
+      this.payload.logger.error(`Error: cannot connect to Postgres. Details: ${err.message}`, err)
+    }
+
     if (typeof this.rejectInitializing === 'function') {
       this.rejectInitializing()
     }

--- a/packages/db-vercel-postgres/src/index.ts
+++ b/packages/db-vercel-postgres/src/index.ts
@@ -78,10 +78,10 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
     return createDatabaseAdapter<VercelPostgresAdapter>({
       name: 'postgres',
       afterSchemaInit: args.afterSchemaInit ?? [],
-      autoDatabaseCreate: args.autoDatabaseCreate ?? true,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,
       defaultDrizzleSnapshot,
+      disableCreateDatabase: args.disableCreateDatabase ?? false,
       drizzle: undefined,
       enums: {},
       features: {

--- a/packages/db-vercel-postgres/src/index.ts
+++ b/packages/db-vercel-postgres/src/index.ts
@@ -35,6 +35,7 @@ import {
 import {
   convertPathToJSONTraversal,
   countDistinct,
+  createDatabase,
   createJSONQuery,
   createMigration,
   defaultDrizzleSnapshot,
@@ -77,7 +78,9 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
     return createDatabaseAdapter<VercelPostgresAdapter>({
       name: 'postgres',
       afterSchemaInit: args.afterSchemaInit ?? [],
+      autoDatabaseCreation: args.autoDatabaseCreation ?? true,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
+      createDatabase,
       defaultDrizzleSnapshot,
       drizzle: undefined,
       enums: {},

--- a/packages/db-vercel-postgres/src/index.ts
+++ b/packages/db-vercel-postgres/src/index.ts
@@ -78,7 +78,7 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
     return createDatabaseAdapter<VercelPostgresAdapter>({
       name: 'postgres',
       afterSchemaInit: args.afterSchemaInit ?? [],
-      autoDatabaseCreation: args.autoDatabaseCreation ?? true,
+      autoDatabaseCreate: args.autoDatabaseCreate ?? true,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,
       defaultDrizzleSnapshot,

--- a/packages/db-vercel-postgres/src/types.ts
+++ b/packages/db-vercel-postgres/src/types.ts
@@ -19,6 +19,11 @@ export type Args = {
    */
   afterSchemaInit?: PostgresSchemaHook[]
   /**
+   * Create the provided database automatically if it doesn't exist
+   * @default true
+   */
+  autoDatabaseCreation?: boolean
+  /**
    * Transform the schema before it's built.
    * You can use it to preserve an existing database schema and if there are any collissions Payload will override them.
    * To generate Drizzle schema from the database, see [Drizzle Kit introspection](https://orm.drizzle.team/kit-docs/commands#introspect--pull)

--- a/packages/db-vercel-postgres/src/types.ts
+++ b/packages/db-vercel-postgres/src/types.ts
@@ -22,7 +22,7 @@ export type Args = {
    * Create the provided database automatically if it doesn't exist
    * @default true
    */
-  autoDatabaseCreation?: boolean
+  autoDatabaseCreate?: boolean
   /**
    * Transform the schema before it's built.
    * You can use it to preserve an existing database schema and if there are any collissions Payload will override them.

--- a/packages/db-vercel-postgres/src/types.ts
+++ b/packages/db-vercel-postgres/src/types.ts
@@ -19,17 +19,17 @@ export type Args = {
    */
   afterSchemaInit?: PostgresSchemaHook[]
   /**
-   * Create the provided database automatically if it doesn't exist
-   * @default true
-   */
-  autoDatabaseCreate?: boolean
-  /**
    * Transform the schema before it's built.
    * You can use it to preserve an existing database schema and if there are any collissions Payload will override them.
    * To generate Drizzle schema from the database, see [Drizzle Kit introspection](https://orm.drizzle.team/kit-docs/commands#introspect--pull)
    */
   beforeSchemaInit?: PostgresSchemaHook[]
   connectionString?: string
+  /**
+   * Pass `true` to disale auto database creation if it doesn't exist.
+   * @default false
+   */
+  disableCreateDatabase?: boolean
   idType?: 'serial' | 'uuid'
   localesSuffix?: string
   logger?: DrizzleConfig['logger']

--- a/packages/drizzle/src/exports/postgres.ts
+++ b/packages/drizzle/src/exports/postgres.ts
@@ -1,4 +1,5 @@
 export { countDistinct } from '../postgres/countDistinct.js'
+export { createDatabase } from '../postgres/createDatabase.js'
 export { convertPathToJSONTraversal } from '../postgres/createJSONQuery/convertPathToJSONTraversal.js'
 export { createJSONQuery } from '../postgres/createJSONQuery/index.js'
 export { createMigration } from '../postgres/createMigration.js'

--- a/packages/drizzle/src/postgres/createDatabase.ts
+++ b/packages/drizzle/src/postgres/createDatabase.ts
@@ -14,7 +14,6 @@ type Args = {
 }
 export const createDatabase = async function (this: BasePostgresAdapter, args: Args = {}) {
   // DATABASE_URL - default Vercel env
-
   const connectionString = this.poolOptions?.connectionString ?? process.env.DATABASE_URL
   let managementClientConfig: ClientConfig = {}
   let dbName = args.name

--- a/packages/drizzle/src/postgres/createDatabase.ts
+++ b/packages/drizzle/src/postgres/createDatabase.ts
@@ -1,7 +1,5 @@
 import type { ClientConfig } from 'pg'
 
-import pg from 'pg'
-
 import type { BasePostgresAdapter } from './types.js'
 
 type Args = {
@@ -16,6 +14,7 @@ type Args = {
 }
 export const createDatabase = async function (this: BasePostgresAdapter, args: Args = {}) {
   // DATABASE_URL - default Vercel env
+
   const connectionString = this.poolOptions?.connectionString ?? process.env.DATABASE_URL
   let managementClientConfig: ClientConfig = {}
   let dbName = args.name
@@ -40,6 +39,9 @@ export const createDatabase = async function (this: BasePostgresAdapter, args: A
       database: 'postgres',
     }
   }
+
+  // import pg only when createDatabase is used
+  const pg = await import('pg')
 
   const managementClient = new pg.Client(managementClientConfig)
 

--- a/packages/drizzle/src/postgres/createDatabase.ts
+++ b/packages/drizzle/src/postgres/createDatabase.ts
@@ -1,0 +1,83 @@
+import type { ClientConfig } from 'pg'
+
+import pg from 'pg'
+
+import type { BasePostgresAdapter } from './types.js'
+
+type Args = {
+  /**
+   * Name of a database, defaults to the current one
+   */
+  name?: string
+  /**
+   * Schema to create in addition to 'public'. Defaults to adapter.schemaName if exists.
+   */
+  schemaName?: string
+}
+export const createDatabase = async function (this: BasePostgresAdapter, args: Args = {}) {
+  // DATABASE_URL - default Vercel env
+  const connectionString = this.poolOptions?.connectionString ?? process.env.DATABASE_URL
+  let managementClientConfig: ClientConfig = {}
+  let dbName = args.name
+  const schemaName = this.schemaName || 'public'
+
+  if (connectionString) {
+    const connectionURL = new URL(connectionString)
+    if (!dbName) {
+      dbName = connectionURL.pathname.slice(1)
+    }
+
+    const managementConnectionURL = new URL(connectionURL)
+    managementConnectionURL.pathname = '/postgres'
+    managementClientConfig.connectionString = managementConnectionURL.toString()
+  } else {
+    if (!dbName) {
+      dbName = this.poolOptions.database
+    }
+
+    managementClientConfig = {
+      ...this.poolOptions,
+      database: 'postgres',
+    }
+  }
+
+  const managementClient = new pg.Client(managementClientConfig)
+
+  try {
+    await managementClient.connect()
+    await managementClient.query(`CREATE DATABASE ${dbName}`)
+
+    this.payload.logger.info(`Created database ${dbName}`)
+
+    if (schemaName !== 'public') {
+      const createdDatabaseClient = new pg.Client({
+        ...managementClientConfig,
+        database: dbName,
+      })
+      try {
+        await createdDatabaseClient.connect()
+
+        await createdDatabaseClient.query(`CREATE SCHEMA ${schemaName}`)
+        this.payload.logger.info(`Created schema ${schemaName}`)
+      } catch (err) {
+        this.payload.logger.error({
+          err,
+          msg: `Error: failed to create schema ${schemaName}. Details: ${err.message}`,
+        })
+      } finally {
+        await createdDatabaseClient.end()
+      }
+    }
+
+    return true
+  } catch (err) {
+    this.payload.logger.error(
+      `Error: failed to create database ${dbName}. Details: ${err.message}`,
+      err,
+    )
+
+    return false
+  } finally {
+    await managementClient.end()
+  }
+}

--- a/packages/drizzle/src/postgres/types.ts
+++ b/packages/drizzle/src/postgres/types.ts
@@ -128,12 +128,12 @@ export type PostgresSchemaHook = (
 
 export type BasePostgresAdapter = {
   afterSchemaInit: PostgresSchemaHook[]
-  autoDatabaseCreate: boolean
   beforeSchemaInit: PostgresSchemaHook[]
   countDistinct: CountDistinct
   createDatabase: CreateDatabase
   defaultDrizzleSnapshot: DrizzleSnapshotJSON
   deleteWhere: DeleteWhere
+  disableCreateDatabase: boolean
   drizzle: PostgresDB
   dropDatabase: DropDatabase
   enums: Record<string, GenericEnum>

--- a/packages/drizzle/src/postgres/types.ts
+++ b/packages/drizzle/src/postgres/types.ts
@@ -128,7 +128,7 @@ export type PostgresSchemaHook = (
 
 export type BasePostgresAdapter = {
   afterSchemaInit: PostgresSchemaHook[]
-  autoDatabaseCreation: boolean
+  autoDatabaseCreate: boolean
   beforeSchemaInit: PostgresSchemaHook[]
   countDistinct: CountDistinct
   createDatabase: CreateDatabase

--- a/packages/drizzle/src/postgres/types.ts
+++ b/packages/drizzle/src/postgres/types.ts
@@ -21,7 +21,7 @@ import type {
 } from 'drizzle-orm/pg-core'
 import type { PgTableFn } from 'drizzle-orm/pg-core/table'
 import type { Payload, PayloadRequest } from 'payload'
-import type { QueryResult } from 'pg'
+import type { ClientConfig, QueryResult } from 'pg'
 
 import type { extendDrizzleTable, Operators } from '../index.js'
 import type { BuildQueryJoinAliases, DrizzleAdapter, TransactionPg } from '../types.js'
@@ -92,6 +92,17 @@ export type Insert = (args: {
   values: Record<string, unknown> | Record<string, unknown>[]
 }) => Promise<Record<string, unknown>[]>
 
+export type CreateDatabase = (args?: {
+  /**
+   * Name of a database, defaults to the current one
+   */
+  name?: string
+  /**
+   * Schema to create in addition to 'public'. Defaults from adapter.schemaName if exists.
+   */
+  schemaName?: string
+}) => Promise<boolean>
+
 type Schema =
   | {
       enum: typeof pgEnum
@@ -117,8 +128,10 @@ export type PostgresSchemaHook = (
 
 export type BasePostgresAdapter = {
   afterSchemaInit: PostgresSchemaHook[]
+  autoDatabaseCreation: boolean
   beforeSchemaInit: PostgresSchemaHook[]
   countDistinct: CountDistinct
+  createDatabase: CreateDatabase
   defaultDrizzleSnapshot: DrizzleSnapshotJSON
   deleteWhere: DeleteWhere
   drizzle: PostgresDB
@@ -137,6 +150,7 @@ export type BasePostgresAdapter = {
   logger: DrizzleConfig['logger']
   operators: Operators
   pgSchema?: Schema
+  poolOptions?: ClientConfig
   prodMigrations?: {
     down: (args: MigrateDownArgs) => Promise<void>
     name: string


### PR DESCRIPTION
Adds `createDatabase` method to Postgres adapters which can be used either independently like this:
```ts
payload.db.createDatabase({
  name: "some-database",
  schemaName: "custom-schema"
})
```
Or
```ts
payload.db.createDatabase()
```
Which creates a database from the current configuration, this is used in `connect` if `disableDatabaesCreate` is set to `false` (default).
You can disable this behaviour with:
```ts
postgresAdapter({ disableDatabaesCreate: true })
```

Example:
<img width="470" alt="image" src="https://github.com/user-attachments/assets/8d08c79d-9672-454c-af0f-eb802f9dcd99">
