### PR TITLE
fix(ui): prevents `react-select` styles being injected into `hasMany` `number` fields

### DIFF
--- a/packages/ui/src/elements/ReactSelect/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/index.tsx
@@ -183,6 +183,7 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
       onMenuClose={onMenuClose}
       onMenuOpen={onMenuOpen}
       options={options}
+      unstyled={true}
       value={value}
     />
   )


### PR DESCRIPTION
Before:
![Screenshot 2024-10-14 at 1 35 16 PM](https://github.com/user-attachments/assets/0b121693-1160-493c-8c73-638394fe542e)

After:
![Screenshot 2024-10-14 at 1 35 30 PM](https://github.com/user-attachments/assets/2c73d345-30b1-49ba-826b-fb20066a2e43)
