### PR TITLE
fix: validate should not always equate valid to true

### DIFF
--- a/packages/ui/src/forms/useField/index.tsx
+++ b/packages/ui/src/forms/useField/index.tsx
@@ -69,7 +69,6 @@ export const useField = <T,>(options: Options): FieldType<T> => {
   const setValue = useCallback(
     (e, disableModifyingForm = false) => {
       const val = e && e.target ? e.target.value : e
-
       dispatchField({
         type: 'UPDATE',
         disableFormData: disableFormData || (hasRows && val > 0),
@@ -176,7 +175,9 @@ export const useField = <T,>(options: Options): FieldType<T> => {
                 } as unknown as PayloadRequest,
                 siblingData: getSiblingData(path),
               })
-            : true
+            : typeof prevErrorMessage.current === 'string'
+              ? prevErrorMessage.current
+              : prevValid.current
 
         if (typeof isValid === 'string') {
           valid = false


### PR DESCRIPTION
In some instances, form states incorrectly setting valid to true even when they should not be, just because no validate function is present.

This was apparent when using bulk upload drawers inside the multi-tenant example which inserts a custom field for the TenantSelector on documents.

Reported internally https://payloadcms.slack.com/archives/C079W6WT0R1/p1726670927732309