### PR TITLE
fix(next): returns proper document id type from init page result

### DIFF
--- a/packages/next/src/utilities/initPage/handleAdminPage.ts
+++ b/packages/next/src/utilities/initPage/handleAdminPage.ts
@@ -1,28 +1,41 @@
-import type { SanitizedCollectionConfig, SanitizedConfig, SanitizedGlobalConfig } from 'payload'
+import type {
+  Payload,
+  SanitizedCollectionConfig,
+  SanitizedConfig,
+  SanitizedGlobalConfig,
+} from 'payload'
 
 import { getRouteWithoutAdmin, isAdminRoute } from './shared.js'
 
 type Args = {
   adminRoute: string
   config: SanitizedConfig
+  defaultIDType: Payload['db']['defaultIDType']
   route: string
 }
+
 type RouteInfo = {
   collectionConfig?: SanitizedCollectionConfig
   collectionSlug?: string
-  docID?: string
+  docID?: number | string
   globalConfig?: SanitizedGlobalConfig
   globalSlug?: string
 }
 
-export function getRouteInfo({ adminRoute, config, route }: Args): RouteInfo {
+export function getRouteInfo({ adminRoute, config, defaultIDType, route }: Args): RouteInfo {
   if (isAdminRoute({ adminRoute, config, route })) {
     const routeWithoutAdmin = getRouteWithoutAdmin({ adminRoute, route })
     const routeSegments = routeWithoutAdmin.split('/').filter(Boolean)
     const [entityType, entitySlug, createOrID] = routeSegments
     const collectionSlug = entityType === 'collections' ? entitySlug : undefined
     const globalSlug = entityType === 'globals' ? entitySlug : undefined
-    const docID = collectionSlug && createOrID !== 'create' ? createOrID : undefined
+
+    const docID =
+      collectionSlug && createOrID !== 'create'
+        ? defaultIDType === 'number'
+          ? Number(createOrID)
+          : createOrID
+        : undefined
 
     let collectionConfig: SanitizedCollectionConfig | undefined
     let globalConfig: SanitizedGlobalConfig | undefined

--- a/packages/next/src/utilities/initPage/index.ts
+++ b/packages/next/src/utilities/initPage/index.ts
@@ -146,6 +146,7 @@ export const initPage = async ({
   const { collectionConfig, collectionSlug, docID, globalConfig, globalSlug } = getRouteInfo({
     adminRoute,
     config: payload.config,
+    defaultIDType: payload.db.defaultIDType,
     route,
   })
 

--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -95,7 +95,7 @@ export const Account: React.FC<AdminViewProps> = async ({
         docPermissions={docPermissions}
         hasPublishPermission={hasPublishPermission}
         hasSavePermission={hasSavePermission}
-        id={user?.id.toString()}
+        id={user?.id}
         initialData={data}
         initialState={formState}
         isEditing

--- a/packages/next/src/views/Versions/index.tsx
+++ b/packages/next/src/views/Versions/index.tsx
@@ -48,7 +48,7 @@ export const VersionsView: PayloadServerReactComponent<EditViewComponent> = asyn
   if (collectionSlug) {
     limitToUse = limitToUse || collectionConfig.admin.pagination.defaultLimit
     const whereQuery: {
-      and: Array<{ parent?: { equals: string }; snapshot?: { not_equals: boolean } }>
+      and: Array<{ parent?: { equals: number | string }; snapshot?: { not_equals: boolean } }>
     } = {
       and: [
         {

--- a/packages/payload/src/admin/views/types.ts
+++ b/packages/payload/src/admin/views/types.ts
@@ -48,7 +48,7 @@ export type VisibleEntities = {
 export type InitPageResult = {
   collectionConfig?: SanitizedCollectionConfig
   cookies: Map<string, string>
-  docID?: string
+  docID?: number | string
   globalConfig?: SanitizedGlobalConfig
   languageOptions: LanguageOptions
   locale?: Locale

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -22,7 +22,7 @@ export interface Config {
     'payload-migrations': PayloadMigration;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   globals: {};
   locale: 'en' | 'es';
@@ -53,15 +53,15 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: string;
+  id: number;
   title?: string | null;
-  upload?: (string | null) | Upload;
-  category?: (string | null) | Category;
-  categories?: (string | Category)[] | null;
-  categoriesLocalized?: (string | Category)[] | null;
+  upload?: (number | null) | Upload;
+  category?: (number | null) | Category;
+  categories?: (number | Category)[] | null;
+  categoriesLocalized?: (number | Category)[] | null;
   group?: {
-    category?: (string | null) | Category;
-    camelCaseCategory?: (string | null) | Category;
+    category?: (number | null) | Category;
+    camelCaseCategory?: (number | null) | Category;
   };
   updatedAt: string;
   createdAt: string;
@@ -71,9 +71,9 @@ export interface Post {
  * via the `definition` "uploads".
  */
 export interface Upload {
-  id: string;
+  id: number;
   relatedPosts?: {
-    docs?: (string | Post)[] | null;
+    docs?: (number | Post)[] | null;
     hasNextPage?: boolean | null;
   } | null;
   updatedAt: string;
@@ -93,27 +93,27 @@ export interface Upload {
  * via the `definition` "categories".
  */
 export interface Category {
-  id: string;
+  id: number;
   name?: string | null;
   relatedPosts?: {
-    docs?: (string | Post)[] | null;
+    docs?: (number | Post)[] | null;
     hasNextPage?: boolean | null;
   } | null;
   hasManyPosts?: {
-    docs?: (string | Post)[] | null;
+    docs?: (number | Post)[] | null;
     hasNextPage?: boolean | null;
   } | null;
   hasManyPostsLocalized?: {
-    docs?: (string | Post)[] | null;
+    docs?: (number | Post)[] | null;
     hasNextPage?: boolean | null;
   } | null;
   group?: {
     relatedPosts?: {
-      docs?: (string | Post)[] | null;
+      docs?: (number | Post)[] | null;
       hasNextPage?: boolean | null;
     } | null;
     camelCasePosts?: {
-      docs?: (string | Post)[] | null;
+      docs?: (number | Post)[] | null;
       hasNextPage?: boolean | null;
     } | null;
   };
@@ -125,9 +125,9 @@ export interface Category {
  * via the `definition` "localized-posts".
  */
 export interface LocalizedPost {
-  id: string;
+  id: number;
   title?: string | null;
-  category?: (string | null) | LocalizedCategory;
+  category?: (number | null) | LocalizedCategory;
   updatedAt: string;
   createdAt: string;
 }
@@ -136,10 +136,10 @@ export interface LocalizedPost {
  * via the `definition` "localized-categories".
  */
 export interface LocalizedCategory {
-  id: string;
+  id: number;
   name?: string | null;
   relatedPosts?: {
-    docs?: (string | LocalizedPost)[] | null;
+    docs?: (number | LocalizedPost)[] | null;
     hasNextPage?: boolean | null;
   } | null;
   updatedAt: string;
@@ -150,7 +150,7 @@ export interface LocalizedCategory {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -167,36 +167,36 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'posts';
-        value: string | Post;
+        value: number | Post;
       } | null)
     | ({
         relationTo: 'categories';
-        value: string | Category;
+        value: number | Category;
       } | null)
     | ({
         relationTo: 'uploads';
-        value: string | Upload;
+        value: number | Upload;
       } | null)
     | ({
         relationTo: 'localized-posts';
-        value: string | LocalizedPost;
+        value: number | LocalizedPost;
       } | null)
     | ({
         relationTo: 'localized-categories';
-        value: string | LocalizedCategory;
+        value: number | LocalizedCategory;
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -206,10 +206,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -229,7 +229,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;


### PR DESCRIPTION
The `initPageResult` function reads the document ID from the URL and returns it as a string. This breaks edge cases with Postgres, where the ID sent to API requests needs to be a number and not a string, such as the Join Field. The fix is to read from `db.defaultIDType` and thread the proper ID type through the document info provider.