### PR TITLE
fix(drizzle, ui): properly filters out number field values with the exists operator filter

### DIFF
--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -223,8 +223,11 @@ export const sanitizeQueryValue = ({
   }
 
   if (operator === 'exists') {
-    formattedValue = formattedValue === 'true' || formattedValue === true
-    if (formattedValue === false) {
+    formattedValue = val === 'true' || val === true
+
+    if (formattedValue) {
+      operator = 'exists'
+    } else {
       operator = 'isNull'
     }
   }

--- a/packages/ui/src/elements/Table/DefaultCell/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/index.tsx
@@ -133,13 +133,13 @@ export const DefaultCell: React.FC<CellComponentProps> = (props) => {
     } else {
       return (
         <WrapElement {...wrapElementProps}>
-          {(cellData === '' || typeof cellData === 'undefined') &&
+          {(cellData === '' || typeof cellData === 'undefined' || cellData === null) &&
             i18n.t('general:noLabel', {
               label: getTranslation(('label' in field ? field.label : null) || 'data', i18n),
             })}
           {typeof cellData === 'string' && cellData}
           {typeof cellData === 'number' && cellData}
-          {typeof cellData === 'object' && JSON.stringify(cellData)}
+          {typeof cellData === 'object' && cellData !== null && JSON.stringify(cellData)}
         </WrapElement>
       )
     }


### PR DESCRIPTION
Filtering by `null` `number` field values or normal values with the `exists` operator was not working in `postgres` & `sqlite`.

Was previously fixed for `mongodb` [here](https://github.com/payloadcms/payload/pull/8416)

Now fixed for `postgres` & `sqlite` adapters as well.


