### PR TITLE
fix(ui): restrict file picking via upload config mimetypes

### DIFF
--- a/packages/ui/src/elements/BulkUpload/AddFilesView/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/AddFilesView/index.tsx
@@ -11,10 +11,11 @@ import './index.scss'
 const baseClass = 'bulk-upload--add-files'
 
 type Props = {
+  readonly acceptMimeTypes?: string
   readonly onCancel: () => void
   readonly onDrop: (acceptedFiles: FileList) => void
 }
-export function AddFilesView({ onCancel, onDrop }: Props) {
+export function AddFilesView({ acceptMimeTypes, onCancel, onDrop }: Props) {
   const { t } = useTranslation()
 
   const inputRef = React.useRef(null)
@@ -37,6 +38,7 @@ export function AddFilesView({ onCancel, onDrop }: Props) {
             {t('upload:selectFile')}
           </Button>
           <input
+            accept={acceptMimeTypes}
             aria-hidden="true"
             className={`${baseClass}__hidden-input`}
             hidden

--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -218,6 +218,8 @@ export const Upload: React.FC<UploadProps> = (props) => {
 
   const showFocalPoint = focalPoint && (hasImageSizes || hasResizeOptions || focalPointEnabled)
 
+  const acceptMimeTypes = uploadConfig.mimeTypes?.join(', ')
+
   return (
     <div className={[fieldBaseClass, baseClass].filter(Boolean).join(' ')}>
       <FieldError field={null} message={errorMessage} showError={showError} />
@@ -251,6 +253,7 @@ export const Upload: React.FC<UploadProps> = (props) => {
                     {t('upload:selectFile')}
                   </Button>
                   <input
+                    accept={acceptMimeTypes}
                     aria-hidden="true"
                     className={`${baseClass}__hidden-input`}
                     hidden


### PR DESCRIPTION
<!--

For external contributors, please include:

- A summary of the pull request and any related issues it fixes.
- Reasoning for the changes made or any additional context that may be useful.

Ensure you have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

 -->
fixes #8673

This PR restricts inputs with `type="file"` to only those mimetypes specified in collection upload configs. This also works for the input in `bulkUpload` and drag-and-drop capabilities by omitting dropped files if they do not conform to the upload config mimetypes. This PR also assumes that an upload config with an empty mimetype array should accept all files since the negation of that statement makes an upload collection redundant.