### PR TITLE
fix(ui): removes `overflow: hidden` style from actions wrapper

### DIFF
--- a/packages/ui/src/elements/AppHeader/index.scss
+++ b/packages/ui/src/elements/AppHeader/index.scss
@@ -107,7 +107,6 @@
 
     &__actions-wrapper {
       position: relative;
-      overflow: hidden;
       display: flex;
       align-items: center;
       gap: calc(var(--base) / 2);


### PR DESCRIPTION
`Before`:
![Screenshot 2024-10-15 at 2 55 22 PM](https://github.com/user-attachments/assets/39b261c4-bb72-4497-ab47-01d430255773)

`After`:
![Screenshot 2024-10-15 at 2 55 07 PM](https://github.com/user-attachments/assets/8913479a-9e0b-4edf-baa1-130dc179af34)


