### PR TITLE
fix(ui): leave without saving popup being triggered by changing the theme in the /account page

### DIFF
--- a/packages/next/src/views/Account/ToggleTheme/index.tsx
+++ b/packages/next/src/views/Account/ToggleTheme/index.tsx
@@ -16,6 +16,7 @@ export const ToggleTheme: React.FC = () => {
 
   return (
     <RadioGroupField
+      disableModifyingForm={true}
       field={{
         name: 'theme',
         label: t('general:adminTheme'),

--- a/packages/payload/src/admin/fields/Radio.ts
+++ b/packages/payload/src/admin/fields/Radio.ts
@@ -19,6 +19,10 @@ import type {
 type RadioFieldClientWithoutType = MarkOptional<RadioFieldClient, 'type'>
 
 type RadioFieldBaseClientProps = {
+  /**
+   * Threaded through to the setValue function from the form context when the value changes
+   */
+  readonly disableModifyingForm?: boolean
   readonly onChange?: OnChange
   readonly validate?: RadioFieldValidation
   readonly value?: string

--- a/packages/ui/src/fields/RadioGroup/index.tsx
+++ b/packages/ui/src/fields/RadioGroup/index.tsx
@@ -21,6 +21,7 @@ import { FieldError } from '../FieldError/index.js'
 const RadioGroupFieldComponent: RadioFieldClientComponent = (props) => {
   const {
     descriptionProps,
+    disableModifyingForm: disableModifyingFormFromProps,
     errorProps,
     field,
     field: {
@@ -126,7 +127,7 @@ const RadioGroupFieldComponent: RadioFieldClientComponent = (props) => {
                     }
 
                     if (!disabled) {
-                      setValue(optionValue)
+                      setValue(optionValue, !!disableModifyingFormFromProps)
                     }
                   }}
                   option={optionIsObject(option) ? option : { label: option, value: option }}


### PR DESCRIPTION
Fixes an annoying instance where on the /account page if you change your theme then navigate away the Leaving without save popup is triggered even though you don't need to submit a form or trigger a save in order to change your admin theme.