### PR TITLE
ci: auto-close issues without repro, auto-label

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
@@ -26,6 +26,33 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    attributes:
+      label: Which area(s) are affected? (Select all that apply)
+      multiple: true
+      options:
+        - 'Not sure'
+        - 'area: core'
+        - 'area: templates'
+        - 'area: ui'
+        - 'db-mongodb'
+        - 'db-postgres'
+        - 'db-sqlite'
+        - 'db-vercel-postgres'
+        - 'plugin: cloud'
+        - 'plugin: cloud-storage'
+        - 'plugin: form-builder'
+        - 'plugin: nested-docs'
+        - 'plugin: richtext-lexical'
+        - 'plugin: richtext-slate'
+        - 'plugin: search'
+        - 'plugin: sentry'
+        - 'plugin: seo'
+        - 'plugin: stripe'
+        - 'plugin: other'
+    validations:
+      required: true
+
   - type: textarea
     attributes:
       label: Environment Info
@@ -37,12 +64,6 @@ body:
         Next.js:
     validations:
       required: true
-
-  - type: input
-    id: adapters-plugins
-    attributes:
-      label: Adapters and Plugins
-      description: What adapters and plugins are you using if relevant? ie. db-mongodb, db-postgres, storage-vercel-blob, etc.
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
@@ -2,25 +2,6 @@ name: Bug Report v3
 description: Create a bug report for Payload v3 (beta)
 labels: ['status: needs-triage', 'v3']
 body:
-  - type: input
-    id: reproduction-link
-    attributes:
-      label: Link to reproduction
-      description: Want us to look into your issue faster? Follow the [reproduction-guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md) for more information.
-    validations:
-      required: false
-
-  - type: textarea
-    attributes:
-      label: Environment Info
-      description: Paste output from `pnpm payload info` (>= beta.92) _or_ Payload, Node.js, and Next.js versions.
-      render: text
-      placeholder: |
-        Payload:
-        Node.js:
-        Next.js:
-    validations:
-      required: true
 
   - type: textarea
     attributes:
@@ -28,10 +9,32 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: reproduction-link
+    attributes:
+      label: Link to the code that reproduces this issue
+      description: >-
+        Please provide a link to your reproduction. Note, if the URL is invalid (eg.: 404, or a private repository), we may close the issue.
+        Either use `npx create-payload-app@beta` or follow the [reproduction-guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md) for more information.
+    validations:
+      required: false
+
   - type: textarea
     attributes:
       label: Reproduction Steps
       description: Steps to reproduce the behavior, please provide a clear description of how to reproduce the issue, based on the linked minimal reproduction. Screenshots can be provided in the issue body below. If using code blocks, make sure that [syntax highlighting is correct](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) and double check that the rendered preview is not broken.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Environment Info
+      description: Paste output from `pnpm payload info` (>= beta.92) _or_ Payload, Node.js, and Next.js versions.
+      render: bash
+      placeholder: |
+        Payload:
+        Node.js:
+        Next.js:
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
@@ -14,10 +14,10 @@ body:
     attributes:
       label: Link to the code that reproduces this issue
       description: >-
-        Please provide a link to your reproduction. Note, if the URL is invalid (eg.: 404, or a private repository), we may close the issue.
-        Either use `npx create-payload-app@beta` or follow the [reproduction-guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md) for more information.
+        Required: Please provide a link to your reproduction. Note, if the URL is invalid (404 or a private repository), we may close the issue.
+        Either use `npx create-payload-app@beta -t blank` or follow the [reproduction-guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md) for more information.
     validations:
-      required: false
+      required: true
 
   - type: textarea
     attributes:

--- a/.github/comments/invalid-reproduction.md
+++ b/.github/comments/invalid-reproduction.md
@@ -1,0 +1,18 @@
+We cannot recreate the issue with the provided information. **Please add a reproduction in order for us to be able to investigate.**
+
+### Why was this issue marked with the `invalid-reproduction` label?
+
+To be able to investigate, we need access to a reproduction to identify what triggered the issue. We prefer a link to a public GitHub repository created with `create-payload-app@beta -t blank` or a forked/branched version of this repository with tests added (more info in the [reproduction-guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md)).
+
+To make sure the issue is resolved as quickly as possible, please make sure that the reproduction is as **minimal** as possible. This means that you should **remove unnecessary code, files, and dependencies** that do not contribute to the issue. Ensure your reproduction does not depend on secrets, 3rd party registries, private dependencies, or any other data that cannot be made public. Avoid a reproduction including a whole monorepo (unless relevant to the issue). The easier it is to reproduce the issue, the quicker we can help.
+
+Please test your reproduction against the latest version of Payload to make sure your issue has not already been fixed.
+
+### I added a link, why was it still marked?
+
+Ensure the link is pointing to a codebase that is accessible (e.g. not a private repository). "[example.com](http://example.com/)", "n/a", "will add later", etc. are not acceptable links -- we need to see a public codebase. See the above section for accepted links.
+
+### Useful Resources
+
+- [Reproduction Guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md)
+- [Contributing to Payload](https://www.youtube.com/watch?v=08Qa3ggR9rw)

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -22,11 +22,7 @@ jobs:
     steps:
       - uses: balazsorban44/nissuer@1.10.0
         with:
-          label-comments: |
-            {
-              "invalid-reproduction": ".github/comments/invalid-reproduction.md"
-            }
-          reproduction-comment: '.github/comments/invalid-link.md'
+          reproduction-comment: '.github/comments/invalid-reproduction.md'
           reproduction-blocklist: 'github.com/payloadcms/payload.*,github.com/\\w*/?$,github.com$'
           reproduction-link-section: '### Link to the code that reproduces this issue(.*)### Reproduction Steps'
           reproduction-invalid-label: 'invalid-reproduction'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -4,10 +4,6 @@ on:
   issues:
     types:
       - opened
-      - labeled
-  issue_comment:
-    types:
-      - created
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -18,13 +14,8 @@ permissions:
 jobs:
   triage:
     name: nissuer
-    if: >
-      !contains(github.event.issue.labels.*.name, 'created-by: Payload team')
     runs-on: ubuntu-latest
     steps:
-      # debug, show all labels
-      - name: Show all labels
-        run: echo "${{ toJson(github.event.issue.labels.*.name) }}"
       - uses: balazsorban44/nissuer@1.10.0
         with:
           reproduction-comment: '.github/comments/invalid-reproduction.md'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,33 @@
+name: Triage issues
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+  issue_comment:
+    types:
+      - created
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    name: Nissuer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: balazsorban44/nissuer@1.10.0
+        with:
+          label-comments: |
+            {
+              "invalid-reproduction": ".github/comments/invalid-reproduction.md",
+            }
+          reproduction-comment: '.github/comments/invalid-link.md'
+          reproduction-blocklist: 'github.com/payloadcms/payload.*,github.com/\\w*/?$,github.com$'
+          reproduction-link-section: '### Link to the code that reproduces this issue(.*)### Reproduction Steps'
+          reproduction-invalid-label: 'invalid-reproduction'
+          reproduction-issue-labels: 'status: needs-triage,'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -22,6 +22,9 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'created-by: Payload team')
     runs-on: ubuntu-latest
     steps:
+      # debug, show all labels
+      - name: Show all labels
+        run: echo "${{ toJson(github.event.issue.labels.*.name) }}"
       - uses: balazsorban44/nissuer@1.10.0
         with:
           reproduction-comment: '.github/comments/invalid-reproduction.md'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           label-comments: |
             {
-              "invalid-reproduction": ".github/comments/invalid-reproduction.md",
+              "invalid-reproduction": ".github/comments/invalid-reproduction.md"
             }
           reproduction-comment: '.github/comments/invalid-link.md'
           reproduction-blocklist: 'github.com/payloadcms/payload.*,github.com/\\w*/?$,github.com$'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: balazsorban44/nissuer@1.10.0
         with:
+          label-area-prefix: ""
+          label-area-match: "name"
+          label-area-section: 'Which area\(s\) are affected\? \(Select all that apply\)(.*)### Environment Info'
           reproduction-comment: '.github/comments/invalid-reproduction.md'
           reproduction-blocklist: 'github.com/\\w*/?$,github.com$'
           reproduction-link-section: '### Link to the code that reproduces this issue(.*)### Reproduction Steps'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,4 +1,4 @@
-name: Triage issues
+name: triage
 
 on:
   issues:
@@ -17,7 +17,9 @@ permissions:
 
 jobs:
   triage:
-    name: Nissuer
+    name: nissuer
+    if: >
+      !contains(github.event.issue.labels.*.name, 'created-by: Payload team')
     runs-on: ubuntu-latest
     steps:
       - uses: balazsorban44/nissuer@1.10.0

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: balazsorban44/nissuer@1.10.0
         with:
           reproduction-comment: '.github/comments/invalid-reproduction.md'
-          reproduction-blocklist: 'github.com/payloadcms/payload.*,github.com/\\w*/?$,github.com$'
+          reproduction-blocklist: 'github.com/\\w*/?$,github.com$'
           reproduction-link-section: '### Link to the code that reproduces this issue(.*)### Reproduction Steps'
           reproduction-invalid-label: 'invalid-reproduction'
           reproduction-issue-labels: 'status: needs-triage,'


### PR DESCRIPTION
Implement Nissuer to auto-close issues without valid reproduction and auto-label based upon selections.

**NOTE:** This does not exempt Payload team members from having a valid reproduction link.