### PR TITLE
fix: corrects schemaPath passing

### DIFF
--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -49,6 +49,13 @@ type Args = {
   validRelationships: null | string[]
 }
 
+function generateSchemaPath({ name, path = '' }: { name?: string; path?: string }): string {
+  if (!name) {
+    return path
+  }
+  return path ? `${path}.${name}` : name
+}
+
 export const sanitizeFields = async ({
   config,
   existingFieldNames = new Set(),
@@ -57,14 +64,12 @@ export const sanitizeFields = async ({
   parentIsLocalized,
   requireFieldLevelRichTextEditor = false,
   richTextSanitizationPromises,
-  schemaPath: schemaPathArg,
+  schemaPath = '',
   validRelationships,
 }: Args): Promise<Field[]> => {
   if (!fields) {
     return []
   }
-
-  let schemaPath = schemaPathArg
 
   for (let i = 0; i < fields.length; i++) {
     const field = fields[i]
@@ -248,9 +253,6 @@ export const sanitizeFields = async ({
     }
 
     if ('fields' in field && field.fields) {
-      if ('name' in field && field.name) {
-        schemaPath = `${schemaPath || ''}${schemaPath ? '.' : ''}${field.name}`
-      }
       field.fields = await sanitizeFields({
         config,
         existingFieldNames: fieldAffectsData(field) ? new Set() : existingFieldNames,
@@ -259,7 +261,10 @@ export const sanitizeFields = async ({
         parentIsLocalized: parentIsLocalized || field.localized,
         requireFieldLevelRichTextEditor,
         richTextSanitizationPromises,
-        schemaPath,
+        schemaPath: generateSchemaPath({
+          name: 'name' in field ? field.name : undefined,
+          path: schemaPath,
+        }),
         validRelationships,
       })
     }
@@ -268,7 +273,6 @@ export const sanitizeFields = async ({
       for (let j = 0; j < field.tabs.length; j++) {
         const tab = field.tabs[j]
         if (tabHasName(tab)) {
-          schemaPath = `${schemaPath || ''}${schemaPath ? '.' : ''}${tab.name}`
           if (typeof tab.label === 'undefined') {
             tab.label = toWords(tab.name)
           }
@@ -282,7 +286,10 @@ export const sanitizeFields = async ({
           parentIsLocalized: parentIsLocalized || (tabHasName(tab) && tab.localized),
           requireFieldLevelRichTextEditor,
           richTextSanitizationPromises,
-          schemaPath,
+          schemaPath: generateSchemaPath({
+            name: 'name' in tab ? tab.name : undefined,
+            path: schemaPath,
+          }),
           validRelationships,
         })
         field.tabs[j] = tab


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/8690

Fixes an issue where unrelated schema paths were being joined and passed into nested sanitizeFields function calls.
