### PR TITLE
fix: duplicate with select hasMany fields

### DIFF
--- a/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
+++ b/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
@@ -68,8 +68,6 @@ const Duplicate: React.FC<Props> = ({ id, slug, collection }) => {
 
         data = baseBeforeDuplicate({ collection, data, locale })
 
-        delete data['id']
-
         if (typeof collection.admin.hooks?.beforeDuplicate === 'function') {
           data = await collection.admin.hooks.beforeDuplicate({
             collection,
@@ -77,6 +75,8 @@ const Duplicate: React.FC<Props> = ({ id, slug, collection }) => {
             locale,
           })
         }
+
+        delete data['id']
 
         if (!duplicateID) {
           if ('createdAt' in data) delete data.createdAt

--- a/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
+++ b/packages/payload/src/admin/components/elements/DuplicateDocument/index.tsx
@@ -68,6 +68,8 @@ const Duplicate: React.FC<Props> = ({ id, slug, collection }) => {
 
         data = baseBeforeDuplicate({ collection, data, locale })
 
+        delete data['id']
+
         if (typeof collection.admin.hooks?.beforeDuplicate === 'function') {
           data = await collection.admin.hooks.beforeDuplicate({
             collection,


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/6522 by not sending `id` of the _current_ document to the `post` / `patch` payload. It caused issues with Postgres and select `hasMany: true`