### PR TITLE
fix(cpa): write POSTGRES_URL instead of DATABASE_URI to .env for vercel postgres

### DIFF
--- a/packages/create-payload-app/src/lib/write-env-file.ts
+++ b/packages/create-payload-app/src/lib/write-env-file.ts
@@ -1,19 +1,20 @@
 import fs from 'fs-extra'
 import path from 'path'
 
-import type { CliArgs, ProjectTemplate } from '../types.js'
+import type { CliArgs, DbType, ProjectTemplate } from '../types.js'
 
 import { debug, error } from '../utils/log.js'
 
 /** Parse and swap .env.example values and write .env */
 export async function writeEnvFile(args: {
   cliArgs: CliArgs
+  databaseType?: DbType
   databaseUri: string
   payloadSecret: string
   projectDir: string
   template?: ProjectTemplate
 }): Promise<void> {
-  const { cliArgs, databaseUri, payloadSecret, projectDir, template } = args
+  const { cliArgs, databaseType, databaseUri, payloadSecret, projectDir, template } = args
 
   if (cliArgs['--dry-run']) {
     debug(`DRY RUN: .env file created`)
@@ -41,7 +42,7 @@ export async function writeEnvFile(args: {
             }
 
             const split = line.split('=')
-            const key = split[0]
+            let key = split[0]
             let value = split[1]
 
             if (
@@ -50,6 +51,9 @@ export async function writeEnvFile(args: {
               key === 'DATABASE_URI' ||
               key === 'POSTGRES_URL'
             ) {
+              if (databaseType === 'vercel-postgres') {
+                key = 'POSTGRES_URL'
+              }
               value = databaseUri
             }
             if (key === 'PAYLOAD_SECRET' || key === 'PAYLOAD_SECRET_KEY') {

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -180,6 +180,7 @@ export class Main {
 
         await writeEnvFile({
           cliArgs: this.args,
+          databaseType: dbDetails.type,
           databaseUri: dbDetails.dbUri,
           payloadSecret: generateSecret(),
           projectDir,
@@ -222,6 +223,7 @@ export class Main {
           })
           await writeEnvFile({
             cliArgs: this.args,
+            databaseType: dbDetails.type,
             databaseUri: dbDetails.dbUri,
             payloadSecret,
             projectDir,

--- a/packages/drizzle/src/postgres/createDatabase.ts
+++ b/packages/drizzle/src/postgres/createDatabase.ts
@@ -27,8 +27,9 @@ type Args = {
   schemaName?: string
 }
 export const createDatabase = async function (this: BasePostgresAdapter, args: Args = {}) {
-  // DATABASE_URL - default Vercel env
-  const connectionString = this.poolOptions?.connectionString ?? process.env.DATABASE_URL
+  // POSTGRES_URL - default Vercel env
+  const connectionString =
+    this.poolOptions?.connectionString ?? process.env.POSTGRES_URL ?? process.env.DATABASE_URL
   let managementClientConfig: ClientConfig = {}
   let dbName = args.name
   const schemaName = this.schemaName || 'public'


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/8877
Current behaviour:
`pnpx create-payload-app@beta`, select "Vercel Postgres",


`payload.config.ts`:
```ts
db: vercelPostgresAdapter({
  pool: {
    connectionString: process.env.POSTGRES_URL || '',
  },
}),
```


`.env` file:
```env
# Added by Payload
# should be POSTGRES_URL!
DATABASE_URI=postgres://postgres:<password>@127.0.0.1:5432/f 
PAYLOAD_SECRET=4415faad68a15727b4ebf582
```