### PR TITLE
fix: disables document locking of `payload-locked-documents`, `preferences`, & `migrations` collections

### DIFF
--- a/packages/payload/src/database/migrations/migrationsCollection.ts
+++ b/packages/payload/src/database/migrations/migrationsCollection.ts
@@ -18,4 +18,5 @@ export const migrationsCollection: CollectionConfig = {
     },
   ],
   graphQL: false,
+  lockDocuments: false,
 }

--- a/packages/payload/src/lockedDocuments/lockedDocumentsCollection.ts
+++ b/packages/payload/src/lockedDocuments/lockedDocumentsCollection.ts
@@ -29,4 +29,5 @@ export const getLockedDocumentsCollection = (config: Config): CollectionConfig =
       required: true,
     },
   ],
+  lockDocuments: false,
 })

--- a/packages/payload/src/preferences/preferencesCollection.ts
+++ b/packages/payload/src/preferences/preferencesCollection.ts
@@ -70,6 +70,7 @@ const getPreferencesCollection = (config: Config): CollectionConfig => ({
       type: 'json',
     },
   ],
+  lockDocuments: false,
 })
 
 export default getPreferencesCollection

--- a/packages/payload/src/utilities/checkDocumentLockStatus.ts
+++ b/packages/payload/src/utilities/checkDocumentLockStatus.ts
@@ -47,8 +47,12 @@ export const checkDocumentLockStatus = async ({
     throw new Error('Either collectionSlug or globalSlug must be provided.')
   }
 
+  if (!isLockingEnabled) {
+    return
+  }
+
   // Only perform lock checks if overrideLock is false and locking is enabled
-  if (!overrideLock && isLockingEnabled !== false) {
+  if (!overrideLock) {
     const defaultLockErrorMessage = collectionSlug
       ? `Document with ID ${id} is currently locked by another user and cannot be modified.`
       : `Global document with slug "${globalSlug}" is currently locked by another user and cannot be modified.`

--- a/test/locked-documents/int.spec.ts
+++ b/test/locked-documents/int.spec.ts
@@ -652,8 +652,6 @@ describe('Locked documents', () => {
       },
     })
 
-    console.log(docsFromLocksCollection.docs[0].user)
-
     expect(docsFromLocksCollection.docs).toHaveLength(1)
     expect(docsFromLocksCollection.docs[0].user.value?.id).toEqual(user.id)
   })

--- a/test/locked-documents/int.spec.ts
+++ b/test/locked-documents/int.spec.ts
@@ -611,4 +611,50 @@ describe('Locked documents', () => {
 
     expect(docsFromLocksCollection.docs).toHaveLength(0)
   })
+
+  it('should allow take over on locked doc (simulates take over modal from admin ui)', async () => {
+    const newPost7 = await payload.create({
+      collection: postsSlug,
+      data: {
+        text: 'new post 7',
+      },
+    })
+
+    const lockedDocInstance = await payload.create({
+      collection: lockedDocumentCollection,
+      data: {
+        editedAt: new Date().toISOString(),
+        user: {
+          relationTo: 'users',
+          value: user2.id,
+        },
+        document: {
+          relationTo: 'posts',
+          value: newPost7.id,
+        },
+        globalSlug: undefined,
+      },
+    })
+
+    // This is the take over action - changing the user to the current user
+    await payload.update({
+      collection: 'payload-locked-documents',
+      data: {
+        user: { relationTo: 'users', value: user?.id },
+      },
+      id: lockedDocInstance.id,
+    })
+
+    const docsFromLocksCollection = await payload.find({
+      collection: lockedDocumentCollection,
+      where: {
+        'user.value': { equals: user.id },
+      },
+    })
+
+    console.log(docsFromLocksCollection.docs[0].user)
+
+    expect(docsFromLocksCollection.docs).toHaveLength(1)
+    expect(docsFromLocksCollection.docs[0].user.value?.id).toEqual(user.id)
+  })
 })


### PR DESCRIPTION
Fixes #8589 

### Issue: 
There were problems with updating documents in `payload-locked-documents` collection i.e when "taking over" a document - a `patch` request is sent to `payload-locked-documents` to update the user (owner).

However, as a result, this `update` operation would lock that corresponding doc in `payload-locked-documents` and therefore error on the `patch` request.

### Fix:
Disable document locking entirely from `payload-locked-documents` & `preferences` & `migrations` collections


