### PR TITLE
chore: improves getLatestCollectionVersion where constraints

### DIFF
--- a/packages/payload/src/versions/drafts/appendVersionToQueryKey.ts
+++ b/packages/payload/src/versions/drafts/appendVersionToQueryKey.ts
@@ -1,6 +1,6 @@
 import type { Where } from '../../types/index.js'
 
-export const appendVersionToQueryKey = (query: Where): Where => {
+export const appendVersionToQueryKey = (query: Where = {}): Where => {
   return Object.entries(query).reduce((res, [key, val]) => {
     if (['AND', 'and', 'OR', 'or'].includes(key) && Array.isArray(val)) {
       return {

--- a/packages/payload/src/versions/getLatestCollectionVersion.ts
+++ b/packages/payload/src/versions/getLatestCollectionVersion.ts
@@ -3,6 +3,9 @@ import type { FindOneArgs } from '../database/types.js'
 import type { Payload, PayloadRequest } from '../types/index.js'
 import type { TypeWithVersion } from './types.js'
 
+import { combineQueries } from '../database/combineQueries.js'
+import { appendVersionToQueryKey } from './drafts/appendVersionToQueryKey.js'
+
 type Args = {
   config: SanitizedCollectionConfig
   id: number | string
@@ -33,7 +36,7 @@ export const getLatestCollectionVersion = async <T extends TypeWithID = any>({
       pagination: false,
       req,
       sort: '-updatedAt',
-      where: whereQuery,
+      where: combineQueries(appendVersionToQueryKey(query.where), whereQuery),
     })
     ;[latestVersion] = docs
   }


### PR DESCRIPTION
Combine incoming query constraints with parent doc constraints within the getLatestCollectionVersion function.