### PR TITLE
chore: improves getLatestCollectionVersion where constraints

### DIFF
--- a/packages/payload/src/versions/drafts/appendVersionToQueryKey.ts
+++ b/packages/payload/src/versions/drafts/appendVersionToQueryKey.ts
@@ -1,6 +1,6 @@
 import type { Where } from '../../types'
 
-export const appendVersionToQueryKey = (query: Where): Where => {
+export const appendVersionToQueryKey = (query: Where = {}): Where => {
   return Object.entries(query).reduce((res, [key, val]) => {
     if (['AND', 'OR', 'and', 'or'].includes(key) && Array.isArray(val)) {
       return {

--- a/packages/payload/src/versions/getLatestCollectionVersion.ts
+++ b/packages/payload/src/versions/getLatestCollectionVersion.ts
@@ -4,7 +4,9 @@ import type { Payload } from '../payload'
 import type { PayloadRequest } from '../types'
 import type { TypeWithVersion } from './types'
 
+import { combineQueries } from '../database/combineQueries'
 import { docHasTimestamps } from '../types'
+import { appendVersionToQueryKey } from './drafts/appendVersionToQueryKey'
 
 type Args = {
   config: SanitizedCollectionConfig
@@ -30,7 +32,7 @@ export const getLatestCollectionVersion = async <T extends TypeWithID = any>({
       pagination: false,
       req,
       sort: '-updatedAt',
-      where: { parent: { equals: id } },
+      where: combineQueries(appendVersionToQueryKey(query.where), { parent: { equals: id } }),
     })
     ;[latestVersion] = docs
   }


### PR DESCRIPTION
Combine incoming query constraints with parent doc constraints within the getLatestCollectionVersion function.
