### PR TITLE
Add next rc 1 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,8 @@
   },
   "peerDependencies": {
     "react": "^19.0.0 || ^19.0.0-rc-3edc000d-20240926",
-    "react-dom": "^19.0.0 || ^19.0.0-rc-3edc000d-20240926"
+    "react-dom": "^19.0.0 || ^19.0.0-rc-3edc000d-20240926",
+    "next": "^15.0.0-canary.173 || ^15.0.0-rc.1"
   },
   "packageManager": "pnpm@9.7.1",
   "engines": {


### PR DESCRIPTION
<!--

For external contributors, please include:

- A summary of the pull request and any related issues it fixes.
- Reasoning for the changes made or any additional context that may be useful.

Ensure you have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

 -->

Adds next rc 1 version as peer dependency as it is more recent release than canary 173.

Currently error suggests to update dependency
![image](https://github.com/user-attachments/assets/9b70430b-3798-46d0-8051-2fe4e3696f58)

Not sure if it is enough to fix this error