### PR TITLE
docs: fix incorrect link for outside-nextjs in local-api importing it section

### DIFF
--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -145,7 +145,7 @@ Instead, we utilize component paths to reference React Components. This method e
 
 When constructing the `ClientConfig`, Payload uses the component paths as keys to fetch the corresponding React Component imports from the Import Map. It then substitutes the `PayloadComponent` with a `MappedComponent`. A `MappedComponent` includes the React Component and additional metadata, such as whether it's a server or a client component and which props it should receive. These components are then rendered through the `<RenderComponent />` component within the Payload Admin Panel.
 
-Import maps are regenerated whenever you modify any element related to component paths. This regeneration occurs at startup and whenever Hot Module Replacement (HMR) runs. If the import maps fail to regenerate during HMR, you can restart your application and execute the `payload generate:importmap` command to manually create a new import map. If you encounter any errors running this command, see the [Troubleshooting](/docs/beta/local-api/outside-nextjs#troubleshooting) section.
+Import maps are regenerated whenever you modify any element related to component paths. This regeneration occurs at startup and whenever Hot Module Replacement (HMR) runs. If the import maps fail to regenerate during HMR, you can restart your application and execute the `payload generate:importmap` command to manually create a new import map. If you encounter any errors running this command, see the [Troubleshooting](../local-api/outside-nextjs#troubleshooting) section.
 
 ### Component paths in external packages
 

--- a/docs/authentication/cookies.mdx
+++ b/docs/authentication/cookies.mdx
@@ -97,7 +97,7 @@ Cookies can cross subdomains without being considered third party cookies, for e
 
 ##### 2. Configure cookies
 
-If option 1 isn't possible, then you can get around this limitation by [configuring your cookies](https://payloadcms.com/docs/beta/authentication/overview#config-options) on your authentication collection to achieve the following setup:
+If option 1 isn't possible, then you can get around this limitation by [configuring your cookies](./overview#config-options) on your authentication collection to achieve the following setup:
 
 ```
 SameSite: None // allows the cookie to cross domains
@@ -122,7 +122,7 @@ Configuration example:
 },
 ```
 
-If you're configuring [cors](https://payloadcms.com/docs/beta/production/preventing-abuse#cross-origin-resource-sharing-cors) in your Payload config, you won't be able to use a wildcard anymore, you'll need to specify the list of allowed domains.
+If you're configuring [cors](../production/preventing-abuse#cross-origin-resource-sharing-cors) in your Payload config, you won't be able to use a wildcard anymore, you'll need to specify the list of allowed domains.
 
 
 <Banner type="success">

--- a/docs/cloud/projects.mdx
+++ b/docs/cloud/projects.mdx
@@ -84,7 +84,7 @@ export default buildConfig({
 
 ## Email
 
-Powered by [Resend](https://resend.com), Payload Cloud comes with integrated email support out of the box. No configuration is needed, and you can use `payload.sendEmail()` to send email right from your Payload app. To learn more about sending email with Payload, checkout the [Email Configuration](https://payloadcms.com/docs/email/overview) overview.
+Powered by [Resend](https://resend.com), Payload Cloud comes with integrated email support out of the box. No configuration is needed, and you can use `payload.sendEmail()` to send email right from your Payload app. To learn more about sending email with Payload, checkout the [Email Configuration](../email/overview) overview.
 
 If you are on the Pro or Enterprise plan, you can add your own custom Email domain name. From the Email page of your project’s Settings, add the domain you wish to use for email delivery. This will generate a set of DNS records. Add these records to your DNS provider and click verify to check that your records are resolving properly. Once verified, your emails will now be sent from your custom domain name.
 

--- a/docs/database/migrations.mdx
+++ b/docs/database/migrations.mdx
@@ -157,7 +157,7 @@ You can disable this setting and solely use migrations to manage your local deve
 
 For this reason, we suggest that you leave `push` as its default setting and treat your local dev database as a sandbox.
 
-For more information about push mode and prototyping in development, [click here](/docs/beta/database/postgres#prototyping-in-dev-mode).
+For more information about push mode and prototyping in development, [click here](./postgres#prototyping-in-dev-mode).
 
 The typical workflow in Payload is to build out your Payload configs, install plugins, and make progress in development mode - allowing Drizzle to push your changes to your local database for you. Once you're finished, you can create a migration.
 

--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -99,7 +99,7 @@ Alternatively, you can disable `push` and rely solely on migrations to keep your
 
 In Postgres, migrations are a fundamental aspect of working with Payload and you should become familiar with how they work.
 
-For more information about migrations, [click here](/docs/beta/database/migrations#when-to-run-migrations).
+For more information about migrations, [click here](./migrations#when-to-run-migrations).
 
 ## Drizzle schema hooks
 

--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -78,7 +78,7 @@ Alternatively, you can disable `push` and rely solely on migrations to keep your
 
 In SQLite, migrations are a fundamental aspect of working with Payload and you should become familiar with how they work.
 
-For more information about migrations, [click here](/docs/beta/database/migrations#when-to-run-migrations).
+For more information about migrations, [click here](./migrations#when-to-run-migrations).
 
 ## Drizzle schema hooks
 

--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -71,7 +71,7 @@ import config from '@payload-config'
 const payload = await getPayload({ config })
 ```
 
-Both options function in exactly the same way outside of one having HMR support and the other not. For more information about using Payload outside of Next.js, [click here](/docs/beta/local-api/outside-nextjs).
+Both options function in exactly the same way outside of one having HMR support and the other not. For more information about using Payload outside of Next.js, [click here](./outside-nextjs).
 
 ## Local options available
 

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -138,7 +138,7 @@ const beforeEmail: BeforeEmail<FormSubmission> = (emailsToSend, beforeChangePara
 
 ### `defaultToEmail`
 
-Provide a fallback for the email address to send form submissions to. If the email in form configuration does not have a to email set, this email address will be used. If this is not provided then it falls back to the `defaultFromAddress` in your [email configuration](https://payloadcms.com/docs/beta/email/overview).
+Provide a fallback for the email address to send form submissions to. If the email in form configuration does not have a to email set, this email address will be used. If this is not provided then it falls back to the `defaultFromAddress` in your [email configuration](../email/overview).
 
 ```ts
 // payload.config.ts
@@ -412,7 +412,7 @@ formBuilder({
 
 ## Email
 
-This plugin relies on the [email configuration](https://payloadcms.com/docs/beta/email/overview) defined in your payload configuration. It will read from your config and attempt to send your emails using the credentials provided.
+This plugin relies on the [email configuration](../email/overview) defined in your payload configuration. It will read from your config and attempt to send your emails using the credentials provided.
 
 ### Email formatting
 


### PR DESCRIPTION
<!--

For external contributors, please include:

- A summary of the pull request and any related issues it fixes.
- Reasoning for the changes made or any additional context that may be useful.

Ensure you have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

 -->
Currently in the `beta` docs at the  bottom of [Local API Overview Import It section](https://payloadcms.com/docs/beta/local-api/overview#importing-it) there is a link for _Outside Nextjs_ which incorrectly sends you to `/docs/beta/beta/local-api/outside-nextjs` instead of `docs/beta/local-api/outside-nextjs`.

Interestingly enough, a `Not Found` component/message is not rendered and instead you see a blank screen.