### PR TITLE
fix(drizzle): expose db.drizzle.$client type

### DIFF
--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -62,7 +62,9 @@ declare module 'payload' {
     afterSchemaInit: PostgresSchemaHook[]
     beforeSchemaInit: PostgresSchemaHook[]
     beginTransaction: (options?: PgTransactionConfig) => Promise<null | number | string>
-    drizzle: PostgresDB
+    drizzle: {
+      $client: Pool
+    } & PostgresDB
     enums: Record<string, GenericEnum>
     /**
      * An object keyed on each table, with a key value pair where the constraint name is the key, followed by the dot-notation field name

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -9,7 +9,7 @@ import type {
 import type { DrizzleAdapter } from '@payloadcms/drizzle/types'
 import type { DrizzleConfig } from 'drizzle-orm'
 import type { PgSchema, PgTableFn, PgTransactionConfig } from 'drizzle-orm/pg-core'
-import type { Pool, PoolConfig } from 'pg'
+import type { Client, Pool, PoolConfig } from 'pg'
 
 export type Args = {
   /**
@@ -63,7 +63,7 @@ declare module 'payload' {
     beforeSchemaInit: PostgresSchemaHook[]
     beginTransaction: (options?: PgTransactionConfig) => Promise<null | number | string>
     drizzle: {
-      $client: Pool
+      $client: Client | Pool
     } & PostgresDB
     enums: Record<string, GenericEnum>
     /**

--- a/packages/db-sqlite/src/connect.ts
+++ b/packages/db-sqlite/src/connect.ts
@@ -1,5 +1,4 @@
 import type { DrizzleAdapter } from '@payloadcms/drizzle/types'
-import type { LibSQLDatabase } from 'drizzle-orm/libsql'
 import type { Connect } from 'payload'
 
 import { createClient } from '@libsql/client'

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -167,7 +167,9 @@ declare module 'payload' {
     extends Omit<Args, 'idType' | 'logger' | 'migrationDir' | 'pool'>,
       DrizzleAdapter {
     beginTransaction: (options?: SQLiteTransactionConfig) => Promise<null | number | string>
-    drizzle: LibSQLDatabase
+    drizzle: { $client: Client } & LibSQLDatabase<
+      Record<string, GenericRelation | GenericTable> & Record<string, unknown>
+    >
     /**
      * An object keyed on each table, with a key value pair where the constraint name is the key, followed by the dot-notation field name
      * Used for returning properly formed errors from unique fields

--- a/packages/db-vercel-postgres/src/types.ts
+++ b/packages/db-vercel-postgres/src/types.ts
@@ -7,7 +7,7 @@ import type {
   PostgresSchemaHook,
 } from '@payloadcms/drizzle/postgres'
 import type { DrizzleAdapter } from '@payloadcms/drizzle/types'
-import type { VercelPool, VercelPostgresPoolConfig } from '@vercel/postgres'
+import type { VercelClient, VercelPool, VercelPostgresPoolConfig } from '@vercel/postgres'
 import type { DrizzleConfig } from 'drizzle-orm'
 import type { PgSchema, PgTableFn, PgTransactionConfig } from 'drizzle-orm/pg-core'
 
@@ -57,7 +57,7 @@ export type Args = {
 
 export type VercelPostgresAdapter = {
   drizzle: {
-    $client: VercelPool
+    $client: VercelClient | VercelPool
   } & PostgresDB
   pool?: VercelPool
   poolOptions?: Args['pool']
@@ -71,7 +71,7 @@ declare module 'payload' {
     beforeSchemaInit: PostgresSchemaHook[]
     beginTransaction: (options?: PgTransactionConfig) => Promise<null | number | string>
     drizzle: {
-      $client: VercelPool
+      $client: VercelClient | VercelPool
     } & PostgresDB
     enums: Record<string, GenericEnum>
     /**

--- a/packages/db-vercel-postgres/src/types.ts
+++ b/packages/db-vercel-postgres/src/types.ts
@@ -56,6 +56,9 @@ export type Args = {
 }
 
 export type VercelPostgresAdapter = {
+  drizzle: {
+    $client: VercelPool
+  } & PostgresDB
   pool?: VercelPool
   poolOptions?: Args['pool']
 } & BasePostgresAdapter
@@ -67,7 +70,9 @@ declare module 'payload' {
     afterSchemaInit: PostgresSchemaHook[]
     beforeSchemaInit: PostgresSchemaHook[]
     beginTransaction: (options?: PgTransactionConfig) => Promise<null | number | string>
-    drizzle: PostgresDB
+    drizzle: {
+      $client: VercelPool
+    } & PostgresDB
     enums: Record<string, GenericEnum>
     /**
      * An object keyed on each table, with a key value pair where the constraint name is the key, followed by the dot-notation field name

--- a/packages/drizzle/src/postgres/types.ts
+++ b/packages/drizzle/src/postgres/types.ts
@@ -21,7 +21,7 @@ import type {
 } from 'drizzle-orm/pg-core'
 import type { PgTableFn } from 'drizzle-orm/pg-core/table'
 import type { Payload, PayloadRequest } from 'payload'
-import type { ClientConfig, Pool, QueryResult } from 'pg'
+import type { Client, ClientConfig, Pool, QueryResult } from 'pg'
 
 import type { extendDrizzleTable, Operators } from '../index.js'
 import type { BuildQueryJoinAliases, DrizzleAdapter, TransactionPg } from '../types.js'
@@ -135,7 +135,7 @@ export type BasePostgresAdapter = {
   deleteWhere: DeleteWhere
   disableCreateDatabase: boolean
   drizzle: {
-    $client: Pool
+    $client: Client | Pool
   } & PostgresDB
   dropDatabase: DropDatabase
   enums: Record<string, GenericEnum>

--- a/packages/drizzle/src/postgres/types.ts
+++ b/packages/drizzle/src/postgres/types.ts
@@ -21,7 +21,7 @@ import type {
 } from 'drizzle-orm/pg-core'
 import type { PgTableFn } from 'drizzle-orm/pg-core/table'
 import type { Payload, PayloadRequest } from 'payload'
-import type { ClientConfig, QueryResult } from 'pg'
+import type { ClientConfig, Pool, QueryResult } from 'pg'
 
 import type { extendDrizzleTable, Operators } from '../index.js'
 import type { BuildQueryJoinAliases, DrizzleAdapter, TransactionPg } from '../types.js'
@@ -134,7 +134,9 @@ export type BasePostgresAdapter = {
   defaultDrizzleSnapshot: DrizzleSnapshotJSON
   deleteWhere: DeleteWhere
   disableCreateDatabase: boolean
-  drizzle: PostgresDB
+  drizzle: {
+    $client: Pool
+  } & PostgresDB
   dropDatabase: DropDatabase
   enums: Record<string, GenericEnum>
   execute: Execute<unknown>


### PR DESCRIPTION
According to Drizzle[ 0.34.0](https://github.com/drizzle-team/drizzle-orm/releases/tag/0.34.0) change  
<img width="766" alt="image" src="https://github.com/user-attachments/assets/b1f3a6ac-2a0b-422d-b39d-c9ca74b207c4">
However, currently we do not expose this type 
<img width="504" alt="image" src="https://github.com/user-attachments/assets/f200ba83-30f6-49e6-a525-dc931b5d5344">
Only with SQLite the adapter itself had it, but this PR includes it to the declaration statement. 

We need this `NodePostgres & { $client }` because this is how Drizzle defines it too:
<img width="320" alt="image" src="https://github.com/user-attachments/assets/87e8ad4d-55c3-45c7-8242-f0dd82ac16e9">
