### PR TITLE
docs: corrects old imports

### DIFF
--- a/docs/access-control/collections.mdx
+++ b/docs/access-control/collections.mdx
@@ -79,7 +79,7 @@ Returns a boolean which allows/denies access to the `create` request.
 To add create Access Control to a Collection, use the `create` property in the [Collection Config](../collections/overview):
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const CollectionWithCreateAccess: CollectionConfig = {
   // ...

--- a/docs/access-control/fields.mdx
+++ b/docs/access-control/fields.mdx
@@ -33,7 +33,7 @@ Access Control is specific to the operation of the request.
 To add Access Control to a Field, use the `access` property in the [Field Config](../fields/overview):
 
 ```ts
-import { CollectionConfig } from 'payload';
+import type { CollectionConfig } from 'payload';
 
 export const Posts: CollectionConfig = {
   slug: 'posts',

--- a/docs/admin/collections.mdx
+++ b/docs/admin/collections.mdx
@@ -11,7 +11,7 @@ The behavior of [Collections](../configuration/collections) within the [Admin Pa
 To configure Admin Options for Collections, use the `admin` property in your Collection Config:
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const MyCollection: CollectionConfig = {
   // ...
@@ -89,7 +89,7 @@ It is possible to display a Preview Button within the Edit View of the Admin Pan
 To configure the Preview Button, set the `admin.preview` property to a function in your [Collection Config](../configuration/collections):
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Posts: CollectionConfig = {
   // ...
@@ -126,7 +126,7 @@ All Collections receive their own List View which displays a paginated list of d
 To configure pagination options, use the `admin.pagination` property in your [Collection Config](../configuration/collections):
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Posts: CollectionConfig = {
   // ...
@@ -155,7 +155,7 @@ In the List View, there is a "search" box that allows you to quickly find a docu
 To define which fields should be searched, use the `admin.listSearchableFields` property in your [Collection Config](../configuration/collections):
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Posts: CollectionConfig = {
   // ...

--- a/docs/admin/locked-documents.mdx
+++ b/docs/admin/locked-documents.mdx
@@ -29,7 +29,7 @@ The lockDocuments property exists on both the Collection Config and the Global C
 Here’s an example configuration for document locking:
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Posts: CollectionConfig = {
   slug: 'posts',

--- a/docs/admin/metadata.mdx
+++ b/docs/admin/metadata.mdx
@@ -151,7 +151,7 @@ Collection Metadata is the metadata that is applied to all pages within any give
 To customize Collection Metadata, use the `admin.meta` key within your Collection Config:
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const MyCollection: CollectionConfig = {
   // ...

--- a/docs/authentication/custom-strategies.mdx
+++ b/docs/authentication/custom-strategies.mdx
@@ -38,7 +38,7 @@ At its core a strategy simply takes information from the incoming request and re
 Your `authenticate` method should return an object containing a Payload user document and any optional headers that you'd like Payload to set for you when we return a response.
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Users: CollectionConfig = {
   slug: 'users',

--- a/docs/authentication/email.mdx
+++ b/docs/authentication/email.mdx
@@ -15,7 +15,7 @@ Email Verification forces users to prove they have access to the email address t
 To enable Email Verification, use the `auth.verify` property on your [Collection Config](../configuration/collections):
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Customers: CollectionConfig = {
   // ...
@@ -42,7 +42,7 @@ The following options are available:
 Function that accepts one argument, containing `{ req, token, user }`, that allows for overriding the HTML within emails that are sent to users indicating how to validate their account. The function should return a string that supports HTML, which can optionally be a full HTML email.
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Customers: CollectionConfig = {
   // ...
@@ -74,7 +74,7 @@ export const Customers: CollectionConfig = {
 Similarly to the above `generateEmailHTML`, you can also customize the subject of the email. The function argument are the same but you can only return a string - not HTML.
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Customers: CollectionConfig = {
   // ...
@@ -95,7 +95,7 @@ export const Customers: CollectionConfig = {
 You can customize how the Forgot Password workflow operates with the following options on the `auth.forgotPassword` property:
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Customers: CollectionConfig = {
   // ...
@@ -119,7 +119,7 @@ The following options are available:
 This function allows for overriding the HTML within emails that are sent to users attempting to reset their password. The function should return a string that supports HTML, which can be a full HTML email.
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Customers: CollectionConfig = {
   // ...
@@ -179,7 +179,7 @@ The following arguments are passed to the `generateEmailHTML` function:
 Similarly to the above `generateEmailHTML`, you can also customize the subject of the email. The function argument are the same but you can only return a string - not HTML.
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Customers: CollectionConfig = {
   // ...

--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -25,7 +25,7 @@ When Authentication is enabled on a [Collection](../configuration/collections), 
 To enable Authentication on a Collection, use the `auth` property in the [Collection Config](../configuration/collection#auth):
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Users: CollectionConfig = {
   // ...
@@ -48,7 +48,7 @@ Any [Collection](../configuration/collections) can opt-in to supporting Authenti
 To enable Authentication on a Collection, use the `auth` property in the [Collection Config](../configuration/collections):
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Admins: CollectionConfig = {
   // ...

--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -37,7 +37,7 @@ It's often best practice to write your Collections in separate files and then im
 Here is what a simple Collection Config might look like:
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Posts: CollectionConfig = {
   slug: 'posts',

--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -117,7 +117,7 @@ While Payload's built-in features come fully translated, you may also want to tr
 To do this, provide the translations wherever applicable, keyed to the language code:
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Articles: CollectionConfig = {
   slug: 'articles',

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -216,7 +216,7 @@ Cross-origin resource sharing (CORS) can be configured with either a whitelist a
 Here's an example showing how to allow incoming requests from any domain:
 
 ```ts
-import { buildConfig } from 'payload/config'
+import { buildConfig } from 'payload'
 
 export default buildConfig({
   // ...
@@ -227,7 +227,7 @@ export default buildConfig({
 Here's an example showing how to append a new header (`x-custom-header`) in `Access-Control-Allow-Headers`:
 
 ```ts
-import { buildConfig } from 'payload/config'
+import { buildConfig } from 'payload'
 
 export default buildConfig({
   // ...

--- a/docs/fields/array.mdx
+++ b/docs/fields/array.mdx
@@ -24,7 +24,7 @@ Arrays are useful for many different types of content from simple to complex, su
 To create an Array Field, set the `type` to `array` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyArrayField: Field = {
   // ...
@@ -69,7 +69,7 @@ _\* An asterisk denotes that a property is required._
 To customize the appearance and behavior of the Array Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyArrayField: Field = {
   // ...
@@ -92,7 +92,7 @@ The Array Field inherits all of the default options from the base [Field Admin C
 In this example, we have an Array Field called `slider` that contains a set of fields for a simple image slider. Each row in the array has a `title`, `image`, and `caption`. We also customize the row label to display the title if it exists, or a default label if it doesn't.
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -24,7 +24,7 @@ Blocks are a great way to create a flexible content model that can be used to bu
 To add a Blocks Field, set the `type` to `blocks` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyBlocksField: Field = {
   // ...
@@ -67,7 +67,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Blocks Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyBlocksField: Field = {
   // ...

--- a/docs/fields/checkbox.mdx
+++ b/docs/fields/checkbox.mdx
@@ -18,7 +18,7 @@ The Checkbox Field saves a boolean in the database.
 To add a Checkbox Field, set the `type` to `checkbox` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyCheckboxField: Field = {
   // ...
@@ -53,7 +53,7 @@ _\* An asterisk denotes that a property is required._
 Here is an example of a Checkbox Field in a Collection:
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/code.mdx
+++ b/docs/fields/code.mdx
@@ -19,7 +19,7 @@ The Code Field saves a string in the database, but provides the [Admin Panel](..
 To add a Code Field, set the `type` to `code` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyBlocksField: Field = {
   // ...
@@ -57,7 +57,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Code Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyCodeField: Field = {
   // ...
@@ -79,7 +79,7 @@ The Code Field inherits all of the default options from the base [Field Admin Co
 `collections/ExampleCollection.ts
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/collapsible.mdx
+++ b/docs/fields/collapsible.mdx
@@ -18,7 +18,7 @@ The Collapsible Field is presentational-only and only affects the Admin Panel. B
 To add a Collapsible Field, set the `type` to `collapsible` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyCollapsibleField: Field = {
   // ...
@@ -47,7 +47,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Collapsible Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyCollapsibleField: Field = {
   // ...
@@ -68,7 +68,7 @@ The Collapsible Field inherits all of the default options from the base [Field A
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -18,7 +18,7 @@ The Date Field saves a Date in the database and provides the [Admin Panel](../ad
 To add a Date Field, set the `type` to `date` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyDateField: Field = {
   // ...
@@ -53,7 +53,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Date Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyDateField: Field = {
   // ...
@@ -97,7 +97,7 @@ When only `pickerAppearance` is set, an equivalent format will be rendered in th
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/email.mdx
+++ b/docs/fields/email.mdx
@@ -18,7 +18,7 @@ The Email Field enforces that the value provided is a valid email address.
 To create an Email Field, set the `type` to `email` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyEmailField: Field = {
   // ...
@@ -54,7 +54,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Email Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyEmailField: Field = {
   // ...
@@ -76,7 +76,7 @@ The Email Field inherits all of the default options from the base [Field Admin C
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/group.mdx
+++ b/docs/fields/group.mdx
@@ -18,7 +18,7 @@ The Group Field allows [Fields](./overview) to be nested under a common property
 To add a Group Field, set the `type` to `group` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyGroupField: Field = {
   // ...
@@ -58,7 +58,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Group Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyGroupField: Field = {
   // ...
@@ -79,7 +79,7 @@ The Group Field inherits all of the default options from the base [Field Admin C
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/join.mdx
+++ b/docs/fields/join.mdx
@@ -30,7 +30,7 @@ collection you are joining. This will reference the collection and path of the f
 To add a Relationship Field, set the `type` to `join` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyJoinField: Field = {
   // highlight-start

--- a/docs/fields/json.mdx
+++ b/docs/fields/json.mdx
@@ -19,7 +19,7 @@ The JSON Field saves actual JSON in the database, which differs from the Code fi
 To add a JSON Field, set the `type` to `json` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyJSONField: Field = {
   // ...
@@ -56,7 +56,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the JSON Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyJSONField: Field = {
   // ...
@@ -77,7 +77,7 @@ The JSON Field inherits all of the default options from the base [Field Admin Co
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',
@@ -102,7 +102,7 @@ If you only provide a URL to a schema, Payload will fetch the desired schema if 
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',
@@ -135,7 +135,7 @@ export const ExampleCollection: CollectionConfig = {
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/number.mdx
+++ b/docs/fields/number.mdx
@@ -18,7 +18,7 @@ The Number Field stores and validates numeric entry and supports additional nume
 To add a Number Field, set the `type` to `number` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyNumberField: Field = {
   // ...
@@ -59,7 +59,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Number Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyNumberField: Field = {
   // ...
@@ -82,7 +82,7 @@ The Number Field inherits all of the default options from the base [Field Admin 
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/point.mdx
+++ b/docs/fields/point.mdx
@@ -18,7 +18,7 @@ The Point Field saves a pair of coordinates in the database and assigns an index
 To add a Point Field, set the `type` to `point` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyPointField: Field = {
   // ...
@@ -59,7 +59,7 @@ _\* An asterisk denotes that a property is required._
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/radio.mdx
+++ b/docs/fields/radio.mdx
@@ -18,7 +18,7 @@ The Radio Field allows for the selection of one value from a predefined set of p
 To add a Radio Field, set the `type` to `radio` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyRadioField: Field = {
   // ...
@@ -69,7 +69,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Radio Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyRadioField: Field = {
   // ...
@@ -90,7 +90,7 @@ The Radio Field inherits all of the default options from the base [Field Admin C
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/relationship.mdx
+++ b/docs/fields/relationship.mdx
@@ -24,7 +24,7 @@ The Relationship field is used in a variety of ways, including:
 To add a Relationship Field, set the `type` to `relationship` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyRelationshipField: Field = {
   // ...
@@ -74,7 +74,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Relationship Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyRelationshipField: Field = {
   // ...
@@ -159,7 +159,7 @@ called with an argument object with the following properties:
 ## Example
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/rich-text.mdx
+++ b/docs/fields/rich-text.mdx
@@ -63,7 +63,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Rich Text Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyRichTextField: Field = {
   // ...

--- a/docs/fields/row.mdx
+++ b/docs/fields/row.mdx
@@ -18,7 +18,7 @@ The Row Field is presentational-only and only affects the [Admin Panel](../admin
 To add a Row Field, set the `type` to `row` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyRowField: Field = {
   // ...
@@ -46,7 +46,7 @@ _\* An asterisk denotes that a property is required._
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/select.mdx
+++ b/docs/fields/select.mdx
@@ -18,7 +18,7 @@ The Select Field provides a dropdown-style interface for choosing options from a
 To add a Select Field, set the `type` to `select` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MySelectField: Field = {
   // ...
@@ -71,7 +71,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Select Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MySelectField: Field = {
   // ...
@@ -93,7 +93,7 @@ The Select Field inherits all of the default options from the base [Field Admin 
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',
@@ -156,8 +156,7 @@ You can import the existing Select component directly from Payload, then extend 
 
 ```ts
 import * as React from 'react';
-import { SelectInput, useField } from 'payload/components/forms';
-import { useAuth } from 'payload/components/utilities';
+import { SelectInput, useAuth, useField } from '@payloadcms/ui';
 
 type CustomSelectProps = {
   path: string;

--- a/docs/fields/tabs.mdx
+++ b/docs/fields/tabs.mdx
@@ -18,7 +18,7 @@ The Tabs Field is presentational-only and only affects the [Admin Panel](../admi
 To add a Tabs Field, set the `type` to `tabs` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyTabsField: Field = {
   // ...
@@ -59,7 +59,7 @@ _\* An asterisk denotes that a property is required._
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/text.mdx
+++ b/docs/fields/text.mdx
@@ -18,7 +18,7 @@ The Text Field is one of the most commonly used fields. It saves a string to the
 To add a Text Field, set the `type` to `text` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyTextField: Field = {
   // ...
@@ -59,7 +59,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Text Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyTextField: Field = {
   // ...
@@ -82,7 +82,7 @@ The Text Field inherits all of the default options from the base [Field Admin Co
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/textarea.mdx
+++ b/docs/fields/textarea.mdx
@@ -18,7 +18,7 @@ The Textarea Field is nearly identical to the [Text Field](./text) but it featur
 To add a Textarea Field, set the `type` to `textarea` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyTextareaField: Field = {
   // ...
@@ -56,7 +56,7 @@ _\* An asterisk denotes that a property is required._
 The customize the appearance and behavior of the Textarea Field in the [Admin Panel](../admin/overview), you can use the `admin` option:
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyTextareaField: Field = {
   // ...
@@ -79,7 +79,7 @@ The Textarea Field inherits all of the default options from the base [Field Admi
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/ui.mdx
+++ b/docs/fields/ui.mdx
@@ -18,7 +18,7 @@ With the UI Field, you can:
 To add a UI Field, set the `type` to `ui` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyUIField: Field = {
   // ...
@@ -44,7 +44,7 @@ _\* An asterisk denotes that a property is required._
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/fields/upload.mdx
+++ b/docs/fields/upload.mdx
@@ -25,7 +25,7 @@ caption="Admin Panel screenshot of an Upload field"
 To create an Upload Field, set the `type` to `upload` in your [Field Config](./overview):
 
 ```ts
-import type { Field } from 'payload/types'
+import type { Field } from 'payload'
 
 export const MyUploadField: Field = {
   // ...
@@ -73,7 +73,7 @@ _\* An asterisk denotes that a property is required._
 `collections/ExampleCollection.ts`
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const ExampleCollection: CollectionConfig = {
   slug: 'example-collection',

--- a/docs/plugins/nested-docs.mdx
+++ b/docs/plugins/nested-docs.mdx
@@ -177,7 +177,7 @@ You can also extend the built-in `parent` and `breadcrumbs` fields per collectio
 and `createBreadcrumbField` methods. They will merge your customizations overtop the plugin's base field configurations.
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 import { createParentField } from '@payloadcms/plugin-nested-docs/fields'
 import { createBreadcrumbsField } from '@payloadcms/plugin-nested-docs/fields'
 

--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -591,7 +591,7 @@ Each endpoint object needs to have:
 Example:
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 // a collection of 'orders' with an additional route for tracking details, reachable at /api/orders/:id/tracking
 export const Orders: CollectionConfig = {

--- a/docs/rich-text/slate.mdx
+++ b/docs/rich-text/slate.mdx
@@ -34,7 +34,7 @@ export default buildConfig({
 And here's an example for how to install the Slate editor on a field-by-field basis, while customizing its options:
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 import { slateEditor } from '@payloadcms/richtext-slate'
 
 export const Pages: CollectionConfig = {

--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -43,7 +43,7 @@ Every Payload Collection can opt-in to supporting Uploads by specifying the `upl
 </Banner>
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Media: CollectionConfig = {
   slug: 'media',
@@ -217,7 +217,7 @@ You can specify how Payload retrieves admin thumbnails for your upload-enabled C
 1. `adminThumbnail` as a **string**, equal to one of your provided image size names.
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Media: CollectionConfig = {
   slug: 'media',
@@ -246,7 +246,7 @@ export const Media: CollectionConfig = {
 2. `adminThumbnail` as a **function** that takes the document's data and sends back a full URL to load the thumbnail.
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Media: CollectionConfig = {
   slug: 'media',
@@ -267,7 +267,7 @@ Some example values are: `image/*`, `audio/*`, `video/*`, `image/png`, `applicat
 **Example mimeTypes usage:**
 
 ```ts
-import { CollectionConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Media: CollectionConfig = {
   slug: 'media',


### PR DESCRIPTION
1
`import type { Field } from 'payload/types'`
to
`import type { Field } from 'payload'`
2
`import { buildConfig } from 'payload/config'`
to
`import { buildConfig } from 'payload'`

3
```
import { SelectInput, useField } from 'payload/components/forms';
import { useAuth } from 'payload/components/utilities';
```
to
`import { SelectInput, useAuth, useField } from '@payloadcms/ui'`

4
uses `import type` for `import type { CollectionConfig } from 'payload'`