### PR TITLE
feat: Added danish locale to datepicker

### DIFF
--- a/packages/ui/src/elements/DatePicker/getFormattedLocale.ts
+++ b/packages/ui/src/elements/DatePicker/getFormattedLocale.ts
@@ -1,6 +1,7 @@
 'use client'
 export const getFormattedLocale = (language = 'enUS') => {
   const formattedLocales = {
+    da: 'da',
     en: 'enUS',
     my: 'enUS', // Burmese is not currently supported
     ua: 'uk',


### PR DESCRIPTION
Lets the admin UI and fields use danish date notations when having danish selected as admin locale.