### PR TITLE
fix(ui): unique ids for nested rows on row duplicate to prevent errors with postgres

### DIFF
--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -263,6 +263,15 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
         duplicateRowState.id.initialValue = new ObjectId().toHexString()
       }
 
+      for (const key of Object.keys(duplicateRowState).filter((key) => key.endsWith('.id'))) {
+        const idState = duplicateRowState[key]
+
+        if (idState && typeof idState.value === 'string' && ObjectId.isValid(idState.value)) {
+          duplicateRowState[key].value = new ObjectId().toHexString()
+          duplicateRowState[key].initialValue = new ObjectId().toHexString()
+        }
+      }
+
       // If there are subfields
       if (Object.keys(duplicateRowState).length > 0) {
         // Add new object containing subfield names to unflattenedRows array

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -130,6 +130,24 @@ describe('Block fields', () => {
     expect(await blocks.count()).toEqual(4)
   })
 
+  test('should save when duplicating subblocks', async () => {
+    await page.goto(url.create)
+    const subblocksRow = page.locator('#field-blocks #blocks-row-2')
+    const rowActions = subblocksRow.locator('.collapsible__actions').first()
+    await expect(rowActions).toBeVisible()
+
+    await rowActions.locator('.array-actions__button').click()
+    const duplicateButton = rowActions.locator('.array-actions__action.array-actions__duplicate')
+    await expect(duplicateButton).toBeVisible()
+    await duplicateButton.click()
+
+    const blocks = page.locator('#field-blocks > .blocks-field__rows > div')
+    expect(await blocks.count()).toEqual(4)
+
+    await page.click('#action-save')
+    await expect(page.locator('.payload-toast-container')).toContainText('successfully')
+  })
+
   test('should use i18n block labels', async () => {
     await page.goto(url.create)
     await expect(page.locator('#field-i18nBlocks .blocks-field__header')).toContainText('Block en')


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/8784

This works for any deep level, both arrays and blocks.