### PR TITLE
fix: redirect to inactivity route after inactivity logout

### DIFF
--- a/packages/next/src/views/Logout/LogoutClient.tsx
+++ b/packages/next/src/views/Logout/LogoutClient.tsx
@@ -18,7 +18,8 @@ export const LogoutClient: React.FC<{
 }> = (props) => {
   const { adminRoute, inactivity, redirect } = props
 
-  const [isLoggedOut, setIsLoggedOut] = React.useState<boolean | undefined>(undefined)
+  const { logOut, user } = useAuth()
+  const [isLoggedOut, setIsLoggedOut] = React.useState<boolean>(!user)
   const logOutSuccessRef = React.useRef(false)
   const [loginRoute] = React.useState(() =>
     formatAdminURL({
@@ -30,7 +31,6 @@ export const LogoutClient: React.FC<{
       }`,
     }),
   )
-  const { logOut } = useAuth()
   const { t } = useTranslation()
   const router = useRouter()
 

--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -296,6 +296,7 @@ export function AuthProvider({
 
       forceLogOut = setTimeout(() => {
         setNewUser(null)
+        redirectToInactivityRoute()
       }, forceLogOutInTimeFromNow)
     }
 


### PR DESCRIPTION
When the auth token expired, the user object was set to `null`, but the UI was left unchanged, leading to errors when the user tried to interact with the UI.

With this PR, the user is redirected to the inactivity route saying that they have been logged out.

Follow up to https://github.com/payloadcms/payload/pull/8600


With 5 seconds expiration time:

https://github.com/user-attachments/assets/30bf8e22-b964-4e9e-944c-04d065882dd4




