### PR TITLE
chore: jest reporter log failed tests count

### DIFF
--- a/test/jest-spec-reporter.cjs
+++ b/test/jest-spec-reporter.cjs
@@ -51,7 +51,7 @@ class JestCiSpecReporter {
     console.log(
       `Executed ${numNotSkippedTests} of ${numTotalTests} (skipped ${numPendingTests}) ${testResultText} (${runDuration})`,
     )
-    console.log(`TOTAL: ${numNotSkippedTests} ${testResultText}`)
+    console.log(`TOTAL: ${numFailedTests || numNotSkippedTests} ${testResultText}`)
   }
   onTestResult(test, { testResults }) {
     testResults.forEach((result) => {


### PR DESCRIPTION
for example 3 tests passed but 1 failed, shows:
> 1 FAILED

instead of

> 4 FAILED

example of the previous behaviour
![image](https://github.com/user-attachments/assets/78c4bc76-caa4-4bf8-943f-2b6b690ce763)
![image](https://github.com/user-attachments/assets/7f261ac3-17dd-474d-87a3-47ad6cbacd68)
