### PR TITLE
fix(next, ui): ensures `selectAll` in the list view ignores locked documents

### DIFF
--- a/packages/next/src/routes/rest/collections/delete.ts
+++ b/packages/next/src/routes/rest/collections/delete.ts
@@ -10,14 +10,16 @@ import type { CollectionRouteHandler } from '../types.js'
 import { headersWithCors } from '../../../utilities/headersWithCors.js'
 
 export const deleteDoc: CollectionRouteHandler = async ({ collection, req }) => {
-  const { depth, where } = req.query as {
+  const { depth, overrideLock, where } = req.query as {
     depth?: string
+    overrideLock?: string
     where?: Where
   }
 
   const result = await deleteOperation({
     collection,
     depth: isNumber(depth) ? Number(depth) : undefined,
+    overrideLock: Boolean(overrideLock === 'true'),
     req,
     where,
   })

--- a/packages/next/src/routes/rest/collections/deleteByID.ts
+++ b/packages/next/src/routes/rest/collections/deleteByID.ts
@@ -14,6 +14,7 @@ export const deleteByID: CollectionRouteHandlerWithID = async ({
 }) => {
   const { searchParams } = req
   const depth = searchParams.get('depth')
+  const overrideLock = searchParams.get('overrideLock')
 
   const id = sanitizeCollectionID({
     id: incomingID,
@@ -25,6 +26,7 @@ export const deleteByID: CollectionRouteHandlerWithID = async ({
     id,
     collection,
     depth: isNumber(depth) ? depth : undefined,
+    overrideLock: Boolean(overrideLock === 'true'),
     req,
   })
 

--- a/packages/next/src/routes/rest/collections/update.ts
+++ b/packages/next/src/routes/rest/collections/update.ts
@@ -10,10 +10,11 @@ import type { CollectionRouteHandler } from '../types.js'
 import { headersWithCors } from '../../../utilities/headersWithCors.js'
 
 export const update: CollectionRouteHandler = async ({ collection, req }) => {
-  const { depth, draft, limit, where } = req.query as {
+  const { depth, draft, limit, overrideLock, where } = req.query as {
     depth?: string
     draft?: string
     limit?: string
+    overrideLock?: string
     where?: Where
   }
 
@@ -23,6 +24,7 @@ export const update: CollectionRouteHandler = async ({ collection, req }) => {
     depth: isNumber(depth) ? Number(depth) : undefined,
     draft: draft === 'true',
     limit: isNumber(limit) ? Number(limit) : undefined,
+    overrideLock: Boolean(overrideLock === 'true'),
     req,
     where,
   })

--- a/packages/next/src/routes/rest/collections/updateByID.ts
+++ b/packages/next/src/routes/rest/collections/updateByID.ts
@@ -16,6 +16,7 @@ export const updateByID: CollectionRouteHandlerWithID = async ({
   const depth = searchParams.get('depth')
   const autosave = searchParams.get('autosave') === 'true'
   const draft = searchParams.get('draft') === 'true'
+  const overrideLock = searchParams.get('overrideLock')
   const publishSpecificLocale = req.query.publishSpecificLocale as string | undefined
 
   const id = sanitizeCollectionID({
@@ -31,6 +32,7 @@ export const updateByID: CollectionRouteHandlerWithID = async ({
     data: req.data,
     depth: isNumber(depth) ? Number(depth) : undefined,
     draft,
+    overrideLock: Boolean(overrideLock === 'true'),
     publishSpecificLocale,
     req,
   })

--- a/packages/next/src/views/Edit/Default/index.tsx
+++ b/packages/next/src/views/Edit/Default/index.tsx
@@ -343,7 +343,7 @@ export const DefaultEditView: React.FC = () => {
   const shouldShowDocumentLockedModal =
     documentIsLocked &&
     currentEditor &&
-    currentEditor.id !== user.id &&
+    currentEditor.id !== user?.id &&
     !isReadOnlyForIncomingUser &&
     !showTakeOverModal &&
     !documentLockStateRef.current?.hasShownLockedModal

--- a/packages/ui/src/elements/DeleteMany/index.tsx
+++ b/packages/ui/src/elements/DeleteMany/index.tsx
@@ -26,7 +26,7 @@ export type Props = {
 }
 
 export const DeleteMany: React.FC<Props> = (props) => {
-  const { collection: { slug, labels: { plural } } = {} } = props
+  const { collection: { slug, labels: { plural, singular } } = {} } = props
 
   const { permissions } = useAuth()
   const {
@@ -67,12 +67,13 @@ export const DeleteMany: React.FC<Props> = (props) => {
           toggleModal(modalSlug)
 
           const deletedDocs = json?.docs.length || 0
+          const successLabel = deletedDocs > 1 ? plural : singular
 
           if (res.status < 400 || deletedDocs > 0) {
             toast.success(
               t('general:deletedCountSuccessfully', {
                 count: deletedDocs,
-                label: getTranslation(plural, i18n),
+                label: getTranslation(successLabel, i18n),
               }),
             )
             if (json?.errors.length > 0) {
@@ -115,6 +116,7 @@ export const DeleteMany: React.FC<Props> = (props) => {
     router,
     selectAll,
     serverURL,
+    singular,
     slug,
     stringifyParams,
     t,

--- a/packages/ui/src/elements/DeleteMany/index.tsx
+++ b/packages/ui/src/elements/DeleteMany/index.tsx
@@ -65,8 +65,21 @@ export const DeleteMany: React.FC<Props> = (props) => {
         try {
           const json = await res.json()
           toggleModal(modalSlug)
-          if (res.status < 400) {
-            toast.success(json.message || t('general:deletedSuccessfully'))
+
+          const deletedDocs = json?.docs.length || 0
+
+          if (res.status < 400 || deletedDocs > 0) {
+            toast.success(
+              t('general:deletedCountSuccessfully', {
+                count: deletedDocs,
+                label: getTranslation(plural, i18n),
+              }),
+            )
+            if (json?.errors.length > 0) {
+              toast.error(json.message, {
+                description: json.errors.map((error) => error.message).join('\n'),
+              })
+            }
             toggleAll()
             router.replace(
               stringifyParams({
@@ -96,8 +109,9 @@ export const DeleteMany: React.FC<Props> = (props) => {
     addDefaultError,
     api,
     getQueryParams,
-    i18n.language,
+    i18n,
     modalSlug,
+    plural,
     router,
     selectAll,
     serverURL,

--- a/packages/ui/src/elements/PublishMany/index.tsx
+++ b/packages/ui/src/elements/PublishMany/index.tsx
@@ -27,7 +27,7 @@ export type PublishManyProps = {
 export const PublishMany: React.FC<PublishManyProps> = (props) => {
   const { clearRouteCache } = useRouteCache()
 
-  const { collection: { slug, labels: { plural }, versions } = {} } = props
+  const { collection: { slug, labels: { plural, singular }, versions } = {} } = props
 
   const {
     config: {
@@ -73,12 +73,13 @@ export const PublishMany: React.FC<PublishManyProps> = (props) => {
           toggleModal(modalSlug)
 
           const deletedDocs = json?.docs.length || 0
+          const successLabel = deletedDocs > 1 ? plural : singular
 
           if (res.status < 400 || deletedDocs > 0) {
             toast.success(
               t('general:updatedCountSuccessfully', {
                 count: deletedDocs,
-                label: getTranslation(plural, i18n),
+                label: getTranslation(successLabel, i18n),
               }),
             )
             if (json?.errors.length > 0) {
@@ -117,6 +118,7 @@ export const PublishMany: React.FC<PublishManyProps> = (props) => {
     plural,
     selectAll,
     serverURL,
+    singular,
     slug,
     t,
     toggleModal,

--- a/packages/ui/src/elements/PublishMany/index.tsx
+++ b/packages/ui/src/elements/PublishMany/index.tsx
@@ -71,8 +71,21 @@ export const PublishMany: React.FC<PublishManyProps> = (props) => {
         try {
           const json = await res.json()
           toggleModal(modalSlug)
-          if (res.status < 400) {
-            toast.success(t('general:updatedSuccessfully'))
+
+          const deletedDocs = json?.docs.length || 0
+
+          if (res.status < 400 || deletedDocs > 0) {
+            toast.success(
+              t('general:updatedCountSuccessfully', {
+                count: deletedDocs,
+                label: getTranslation(plural, i18n),
+              }),
+            )
+            if (json?.errors.length > 0) {
+              toast.error(json.message, {
+                description: json.errors.map((error) => error.message).join('\n'),
+              })
+            }
             router.replace(
               stringifyParams({
                 params: {
@@ -99,8 +112,9 @@ export const PublishMany: React.FC<PublishManyProps> = (props) => {
     addDefaultError,
     api,
     getQueryParams,
-    i18n.language,
+    i18n,
     modalSlug,
+    plural,
     selectAll,
     serverURL,
     slug,

--- a/packages/ui/src/elements/UnpublishMany/index.tsx
+++ b/packages/ui/src/elements/UnpublishMany/index.tsx
@@ -26,7 +26,7 @@ export type UnpublishManyProps = {
 }
 
 export const UnpublishMany: React.FC<UnpublishManyProps> = (props) => {
-  const { collection: { slug, labels: { plural }, versions } = {} } = props
+  const { collection: { slug, labels: { plural, singular }, versions } = {} } = props
 
   const {
     config: {
@@ -71,12 +71,13 @@ export const UnpublishMany: React.FC<UnpublishManyProps> = (props) => {
           toggleModal(modalSlug)
 
           const deletedDocs = json?.docs.length || 0
+          const successLabel = deletedDocs > 1 ? plural : singular
 
           if (res.status < 400 || deletedDocs > 0) {
             toast.success(
               t('general:updatedCountSuccessfully', {
                 count: deletedDocs,
-                label: getTranslation(plural, i18n),
+                label: getTranslation(successLabel, i18n),
               }),
             )
             if (json?.errors.length > 0) {
@@ -114,6 +115,7 @@ export const UnpublishMany: React.FC<UnpublishManyProps> = (props) => {
     plural,
     selectAll,
     serverURL,
+    singular,
     slug,
     t,
     toggleModal,

--- a/packages/ui/src/elements/UnpublishMany/index.tsx
+++ b/packages/ui/src/elements/UnpublishMany/index.tsx
@@ -69,8 +69,21 @@ export const UnpublishMany: React.FC<UnpublishManyProps> = (props) => {
         try {
           const json = await res.json()
           toggleModal(modalSlug)
-          if (res.status < 400) {
-            toast.success(t('general:updatedSuccessfully'))
+
+          const deletedDocs = json?.docs.length || 0
+
+          if (res.status < 400 || deletedDocs > 0) {
+            toast.success(
+              t('general:updatedCountSuccessfully', {
+                count: deletedDocs,
+                label: getTranslation(plural, i18n),
+              }),
+            )
+            if (json?.errors.length > 0) {
+              toast.error(json.message, {
+                description: json.errors.map((error) => error.message).join('\n'),
+              })
+            }
             router.replace(
               stringifyParams({
                 params: {
@@ -96,8 +109,9 @@ export const UnpublishMany: React.FC<UnpublishManyProps> = (props) => {
     addDefaultError,
     api,
     getQueryParams,
-    i18n.language,
+    i18n,
     modalSlug,
+    plural,
     selectAll,
     serverURL,
     slug,

--- a/packages/ui/src/providers/Selection/index.tsx
+++ b/packages/ui/src/providers/Selection/index.tsx
@@ -104,7 +104,7 @@ export const SelectionProvider: React.FC<Props> = ({ children, docs = [], totalD
   )
 
   const getQueryParams = useCallback(
-    (additionalParams?: Where): string => {
+    (additionalWhereParams?: Where): string => {
       let where: Where
       if (selectAll === SelectAllStatus.AllAvailable) {
         const params = searchParams?.where as Where
@@ -126,9 +126,9 @@ export const SelectionProvider: React.FC<Props> = ({ children, docs = [], totalD
           },
         }
       }
-      if (additionalParams) {
+      if (additionalWhereParams) {
         where = {
-          and: [{ ...additionalParams }, where],
+          and: [{ ...additionalWhereParams }, where],
         }
       }
       return qs.stringify(


### PR DESCRIPTION
Fixes #8783 
