### PR TITLE
fix: drizzle init args

### DIFF
--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -66,7 +66,7 @@ export const connect: Connect = async function connect(
     }
 
     const logger = this.logger || false
-    this.drizzle = drizzle(this.pool, { logger, schema: this.schema })
+    this.drizzle = drizzle({ client: this.pool, logger, schema: this.schema })
 
     if (!hotReload) {
       if (process.env.PAYLOAD_DROP_DATABASE === 'true') {

--- a/packages/db-vercel-postgres/src/connect.ts
+++ b/packages/db-vercel-postgres/src/connect.ts
@@ -26,7 +26,8 @@ export const connect: Connect = async function connect(
     const logger = this.logger || false
     // Passed the poolOptions if provided,
     // else have vercel/postgres detect the connection string from the environment
-    this.drizzle = drizzle(this.poolOptions ? new VercelPool(this.poolOptions) : sql, {
+    this.drizzle = drizzle({
+      client: this.poolOptions ? new VercelPool(this.poolOptions) : sql,
       logger,
       schema: this.schema,
     })


### PR DESCRIPTION
Adjust drizzle init for changes in drizzle 0.35.0 https://github.com/drizzle-team/drizzle-orm/releases/tag/0.35.0

The pool/connection should now be passed as the `client` arg when initializing drizzle.

```ts
this.drizzle = drizzle({
  client: this.poolOptions ? new VercelPool(this.poolOptions) : sql,
  logger,
  schema: this.schema,
})
```

This was causing an issue where running `payload migrate` on Vercel was causing drizzle to attempt to `127.0.0.1:5432` instead of the specified environment variable in the adapter 🤔 
