### PR TITLE
fix(drizzle): reuse existing joins for nested/localized fields when querying

### DIFF
--- a/packages/drizzle/src/queries/addJoinTable.ts
+++ b/packages/drizzle/src/queries/addJoinTable.ts
@@ -1,0 +1,25 @@
+import type { SQL } from 'drizzle-orm'
+import type { PgTableWithColumns } from 'drizzle-orm/pg-core'
+
+import type { GenericTable } from '../types.js'
+import type { BuildQueryJoinAliases } from './buildQuery.js'
+
+import { getNameFromDrizzleTable } from '../utilities/getNameFromDrizzleTable.js'
+
+export const addJoinTable = ({
+  type,
+  condition,
+  joins,
+  table,
+}: {
+  condition: SQL
+  joins: BuildQueryJoinAliases
+  table: GenericTable | PgTableWithColumns<any>
+  type?: 'innerJoin' | 'leftJoin' | 'rightJoin'
+}) => {
+  const name = getNameFromDrizzleTable(table)
+
+  if (!joins.some((eachJoin) => getNameFromDrizzleTable(eachJoin.table) === name)) {
+    joins.push({ type, condition, table })
+  }
+}

--- a/packages/drizzle/src/queries/buildOrderBy.ts
+++ b/packages/drizzle/src/queries/buildOrderBy.ts
@@ -55,7 +55,6 @@ export const buildOrderBy = ({
         pathSegments: sortPath.replace(/__/g, '.').split('.'),
         selectFields,
         tableName,
-        useAlias: true,
         value: sortPath,
       })
       orderBy.column = sortTable?.[sortTableColumnName]

--- a/packages/drizzle/src/utilities/getNameFromDrizzleTable.ts
+++ b/packages/drizzle/src/utilities/getNameFromDrizzleTable.ts
@@ -1,0 +1,9 @@
+import type { Table } from 'drizzle-orm'
+
+export const getNameFromDrizzleTable = (table: Table): string => {
+  const symbol = Object.getOwnPropertySymbols(table).find((symb) =>
+    symb.description.includes('Name'),
+  )
+
+  return table[symbol]
+}

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -24,6 +24,10 @@ const ArrayFields: CollectionConfig = {
           required: true,
         },
         {
+          name: 'anotherText',
+          type: 'text',
+        },
+        {
           name: 'localizedText',
           type: 'text',
           localized: true,

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1546,6 +1546,44 @@ describe('Fields', () => {
       expect(allLocales.localized.en[0].text).toStrictEqual(enText)
       expect(allLocales.localized.es[0].text).toStrictEqual(esText)
     })
+
+    it('should query by the same array', async () => {
+      const doc = await payload.create({
+        collection,
+        data: {
+          items: [
+            {
+              localizedText: 'test',
+              text: 'required',
+              anotherText: 'another',
+            },
+          ],
+          localized: [{ text: 'a' }],
+        },
+      })
+
+      const {
+        docs: [res],
+      } = await payload.find({
+        collection,
+        where: {
+          and: [
+            {
+              'items.localizedText': {
+                equals: 'test',
+              },
+            },
+            {
+              'items.anotherText': {
+                equals: 'another',
+              },
+            },
+          ],
+        },
+      })
+
+      expect(res.id).toBe(doc.id)
+    })
   })
 
   describe('group', () => {

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1562,6 +1562,7 @@ describe('Fields', () => {
         },
       })
 
+      // left join collection_items + left join collection_items_locales
       const {
         docs: [res],
       } = await payload.find({
@@ -1576,6 +1577,11 @@ describe('Fields', () => {
             {
               'items.anotherText': {
                 equals: 'another',
+              },
+            },
+            {
+              'items.text': {
+                equals: 'required',
               },
             },
           ],

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -353,6 +353,7 @@ export interface ArrayField {
   title?: string | null;
   items: {
     text: string;
+    anotherText?: string | null;
     localizedText?: string | null;
     subArray?:
       | {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/8517

Reuses existing joins instead of adding new, duplicate ones which causes:
```
Error: Alias "" is already used in this query.
```
This fix was reverted https://github.com/payloadcms/payload/pull/8396 since it's not relevant with this pattern anymore