### PR TITLE
fix(ui): description undefined error on empty tabs array

### DIFF
--- a/packages/ui/src/fields/Tabs/index.tsx
+++ b/packages/ui/src/fields/Tabs/index.tsx
@@ -112,7 +112,7 @@ const TabsFieldComponent: TabsFieldClientComponent = (props) => {
     return tabPath
   }
 
-  const activeTabDescription = activeTabConfig.description
+  const activeTabDescription = activeTabConfig?.description
   const activeTabStaticDescription =
     typeof activeTabDescription === 'function'
       ? activeTabDescription({ t: i18n.t })


### PR DESCRIPTION
<!--

For external contributors, please include:

- A summary of the pull request and any related issues it fixes.
- Reasoning for the changes made or any additional context that may be useful.

Ensure you have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

 -->
Fixes an error that occurs when `tabs` array is empty or active tab config is undefined due to missing optional chaining operator.