### PR TITLE
docs: append the beta tag to plugins installation command

### DIFF
--- a/docs/graphql/graphql-schema.mdx
+++ b/docs/graphql/graphql-schema.mdx
@@ -13,7 +13,7 @@ In Payload the schema is controlled by your collections and globals. All you nee
 Install `@payloadcms/graphql` as a dev dependency:
 
 ```bash
-pnpm add @payloadcms/graphql --save-dev
+pnpm add @payloadcms/graphql@beta -D
 ```
 
 Run the following command to generate the schema:

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -36,7 +36,7 @@ Forms can be as simple or complex as you need, from a basic contact form, to a m
 Install the plugin using any JavaScript package manager like [Yarn](https://yarnpkg.com), [NPM](https://npmjs.com), or [PNPM](https://pnpm.io):
 
 ```bash
-pnpm add @payloadcms/plugin-form-builder
+pnpm add @payloadcms/plugin-form-builder@beta
 ```
 
 ## Basic Usage

--- a/docs/plugins/nested-docs.mdx
+++ b/docs/plugins/nested-docs.mdx
@@ -48,7 +48,7 @@ Install the plugin using any JavaScript package manager like [Yarn](https://yarn
 or [PNPM](https://pnpm.io):
 
 ```bash
-  pnpm add @payloadcms/plugin-nested-docs
+  pnpm add @payloadcms/plugin-nested-docs@beta
 ```
 
 ## Basic Usage

--- a/docs/plugins/redirects.mdx
+++ b/docs/plugins/redirects.mdx
@@ -32,7 +32,7 @@ For example, if you have a page at `/about` and you want to change it to `/about
 Install the plugin using any JavaScript package manager like [Yarn](https://yarnpkg.com), [NPM](https://npmjs.com), or [PNPM](https://pnpm.io):
 
 ```bash
-  pnpm add @payloadcms/plugin-redirects
+  pnpm add @payloadcms/plugin-redirects@beta
 ```
 
 ## Basic Usage

--- a/docs/plugins/search.mdx
+++ b/docs/plugins/search.mdx
@@ -39,7 +39,7 @@ This plugin is a great way to implement a fast, immersive search experience such
 Install the plugin using any JavaScript package manager like [Yarn](https://yarnpkg.com), [NPM](https://npmjs.com), or [PNPM](https://pnpm.io):
 
 ```bash
-  pnpm add @payloadcms/plugin-search
+  pnpm add @payloadcms/plugin-search@beta
 ```
 
 ## Basic Usage

--- a/docs/plugins/sentry.mdx
+++ b/docs/plugins/sentry.mdx
@@ -39,7 +39,7 @@ This multi-faceted software offers a range of features that will help you manage
 Install the plugin using any JavaScript package manager like [Yarn](https://yarnpkg.com), [NPM](https://npmjs.com), or [PNPM](https://pnpm.io):
 
 ```bash
-  pnpm add @payloadcms/plugin-sentry
+  pnpm add @payloadcms/plugin-sentry@beta
 ```
 
 ## Sentry for Next.js setup

--- a/docs/plugins/seo.mdx
+++ b/docs/plugins/seo.mdx
@@ -37,7 +37,7 @@ To help you visualize what your page might look like in a search engine, a previ
 Install the plugin using any JavaScript package manager like [Yarn](https://yarnpkg.com), [NPM](https://npmjs.com), or [PNPM](https://pnpm.io):
 
 ```bash
-  pnpm add @payloadcms/plugin-seo
+  pnpm add @payloadcms/plugin-seo@beta
 ```
 
 ## Basic Usage

--- a/docs/plugins/stripe.mdx
+++ b/docs/plugins/stripe.mdx
@@ -39,7 +39,7 @@ The beauty of this plugin is the entirety of your application's content and busi
 Install the plugin using any JavaScript package manager like [Yarn](https://yarnpkg.com), [NPM](https://npmjs.com), or [PNPM](https://pnpm.io):
 
 ```bash
-  pnpm add @payloadcms/plugin-stripe
+  pnpm add @payloadcms/plugin-stripe@beta
 ```
 
 ## Basic Usage

--- a/docs/upload/storage-adapters.mdx
+++ b/docs/upload/storage-adapters.mdx
@@ -22,7 +22,7 @@ Payload offers additional storage adapters to handle file uploads. These adapter
 ### Installation
 
 ```sh
-pnpm add @payloadcms/storage-vercel-blob
+pnpm add @payloadcms/storage-vercel-blob@beta
 ```
 
 ### Usage
@@ -71,7 +71,7 @@ export default buildConfig({
 ### Installation
 
 ```sh
-pnpm add @payloadcms/storage-s3
+pnpm add @payloadcms/storage-s3@beta
 ```
 
 ### Usage
@@ -119,7 +119,7 @@ See the the [AWS SDK Package](https://github.com/aws/aws-sdk-js-v3) and [`S3Clie
 ### Installation
 
 ```sh
-pnpm add @payloadcms/storage-azure
+pnpm add @payloadcms/storage-azure@beta
 ```
 
 ### Usage
@@ -168,7 +168,7 @@ export default buildConfig({
 ### Installation
 
 ```sh
-pnpm add @payloadcms/storage-gcs
+pnpm add @payloadcms/storage-gcs@beta
 ```
 
 ### Usage
@@ -218,7 +218,7 @@ export default buildConfig({
 ### Installation
 
 ```sh
-pnpm add @payloadcms/storage-uploadthing
+pnpm add @payloadcms/storage-uploadthing@beta
 ```
 
 ### Usage
@@ -261,7 +261,7 @@ If you need to create a custom storage adapter, you can use the [`@payloadcms/pl
 
 ### Installation
 
-`pnpm add @payloadcms/plugin-cloud-storage`
+`pnpm add @payloadcms/plugin-cloud-storage@beta`
 
 ### Usage
 


### PR DESCRIPTION
Example:
```sh
pnpm add @payloadcms/plugin-sentry
```

to:

```sh
pnpm add @payloadcms/plugin-sentry@beta
```

Because of this, people can be confused with the wrong installed version. We'll change it back on stable