### PR TITLE
fix(graphql): avoid adding extra password fields when running mutations (#8032)

### DIFF
--- a/packages/graphql/src/schema/initCollections.ts
+++ b/packages/graphql/src/schema/initCollections.ts
@@ -124,8 +124,10 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
       parentName: singularName,
     })
 
+    const mutationInputFields = [...fields]
+
     if (collectionConfig.auth && !collectionConfig.auth.disableLocalStrategy) {
-      fields.push({
+      mutationInputFields.push({
         name: 'password',
         type: 'text',
         label: 'Password',
@@ -136,7 +138,7 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
     const createMutationInputType = buildMutationInputType({
       name: singularName,
       config,
-      fields,
+      fields: mutationInputFields,
       graphqlResult,
       parentName: singularName,
     })
@@ -147,7 +149,9 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
     const updateMutationInputType = buildMutationInputType({
       name: `${singularName}Update`,
       config,
-      fields: fields.filter((field) => !(fieldAffectsData(field) && field.name === 'id')),
+      fields: mutationInputFields.filter(
+        (field) => !(fieldAffectsData(field) && field.name === 'id'),
+      ),
       forceNullable: true,
       graphqlResult,
       parentName: `${singularName}Update`,

--- a/packages/next/src/routes/graphql/handler.ts
+++ b/packages/next/src/routes/graphql/handler.ts
@@ -1,9 +1,15 @@
 import type { GraphQLError, GraphQLFormattedError } from 'graphql'
-import type { APIError, Payload, PayloadRequest, SanitizedConfig } from 'payload'
 
 import { configToSchema } from '@payloadcms/graphql'
 import { createHandler } from 'graphql-http/lib/use/fetch'
 import httpStatus from 'http-status'
+import {
+  type APIError,
+  deepCopyObject,
+  type Payload,
+  type PayloadRequest,
+  type SanitizedConfig,
+} from 'payload'
 
 import { addDataAndFileToRequest } from '../../utilities/addDataAndFileToRequest.js'
 import { addLocalesToRequestFromData } from '../../utilities/addLocalesToRequest.js'
@@ -76,7 +82,7 @@ export const getGraphql = async (config: Promise<SanitizedConfig> | SanitizedCon
   }
 
   if (!cached.promise) {
-    const resolvedConfig = await config
+    const resolvedConfig = deepCopyObject(await config)
     cached.promise = new Promise((resolve) => {
       const schema = configToSchema(resolvedConfig)
       resolve(cached.graphql || schema)

--- a/packages/next/src/routes/graphql/handler.ts
+++ b/packages/next/src/routes/graphql/handler.ts
@@ -1,15 +1,9 @@
 import type { GraphQLError, GraphQLFormattedError } from 'graphql'
+import type { APIError, Payload, PayloadRequest, SanitizedConfig } from 'payload'
 
 import { configToSchema } from '@payloadcms/graphql'
 import { createHandler } from 'graphql-http/lib/use/fetch'
 import httpStatus from 'http-status'
-import {
-  type APIError,
-  deepCopyObject,
-  type Payload,
-  type PayloadRequest,
-  type SanitizedConfig,
-} from 'payload'
 
 import { addDataAndFileToRequest } from '../../utilities/addDataAndFileToRequest.js'
 import { addLocalesToRequestFromData } from '../../utilities/addLocalesToRequest.js'
@@ -82,7 +76,7 @@ export const getGraphql = async (config: Promise<SanitizedConfig> | SanitizedCon
   }
 
   if (!cached.promise) {
-    const resolvedConfig = deepCopyObject(await config)
+    const resolvedConfig = await config
     cached.promise = new Promise((resolve) => {
       const schema = configToSchema(resolvedConfig)
       resolve(cached.graphql || schema)


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

### What?
`auth` enabled collections show "Password" fields whenever a GraphQL query is performed or the GraphQL playground is opened (see #8032)

You can reproduce this behavior by spinning up the `admin` test with PostgreSQL:
```bash
pnpm dev:postgres admin
```

Open the admin UI and navigate to the `dev@payloadcms.com` document in the `Users` collection (see screenshot below)
<img width="915" alt="image" src="https://github.com/user-attachments/assets/40624a8f-80b7-412b-b851-5e3643ffcae1">

Open the [GraphQL playground](http://localhost:3000/api/graphql-playground) 
Open the admin UI and select the user again. The password field appears multiple times.
Subsequent GraphQL playground page refreshes lead to even more password fields in the admin UI.

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/009264bd-b153-4bf7-8fc9-8e465fc27247">

The current behavior has an impact during development and even on production. Since the password field is added to the collection, payload tries to add this field to the database as well (at least I could observe at in my own project)

### Why?
In the `packages/graphql/src/schema/initCollections.ts` file, the `initCollections` function mutates the config object by adding the password field for the GraphQL schema (line 128). This mutation adds the field multiple times, depending how often you open the playground. In addition, this added field is also shown in the UI since the config object is shared (see screenshot above).

### How?
By creating a deep copy of the object, the mutation of the configuration does not leak additional fields to the UI or other parts of the code.
