### PR TITLE
fix: reduce import map diff when config changes

### DIFF
--- a/packages/payload/src/bin/generateImportMap/index.ts
+++ b/packages/payload/src/bin/generateImportMap/index.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import fs from 'fs'
 import process from 'node:process'
 import path from 'path'
@@ -56,7 +57,8 @@ export function addPayloadComponentToImportMap({
     return
   }
 
-  const importIdentifier = exportName + '_' + Object.keys(imports).length
+  const importIdentifier =
+    exportName + '_' + crypto.createHash('md5').update(componentPath).digest('hex')
 
   // e.g. if baseDir is /test/fields and componentPath is /components/Field.tsx
   // then path needs to be /test/fields/components/Field.tsx NOT /users/username/project/test/fields/components/Field.tsx


### PR DESCRIPTION
### What?
Reduces difference in the `importMap.js` file when config changes.

### How?
Instead of appending the length, appends the hash of the path.

#### Before: 
Example of the diff when 1 component gets removed
<img width="374" alt="image" src="https://github.com/user-attachments/assets/7aff02bd-ef55-4e40-963f-1cc3890e5957">
output:
```ts
import { TestComponent as TestComponent_84 } from 'test/admin/components/TestComponent.js'
```

#### After:
Targets only necessary for this component lines:
<img width="359" alt="image" src="https://github.com/user-attachments/assets/99ba0ebd-cff4-4169-9622-e4c491e23eef">

Output:
```ts
import { TestComponent as TestComponent_d010fadde249c7cd3feed0eef58fe83c } from 'test/admin/components/TestComponent.js'
```

Fixes https://github.com/payloadcms/payload/issues/8841

