### PR TITLE
fix(cpa): properly detect if pnpm exists on windows

### DIFF
--- a/packages/create-payload-app/src/lib/get-package-manager.ts
+++ b/packages/create-payload-app/src/lib/get-package-manager.ts
@@ -54,7 +54,7 @@ function getEnvironmentPackageManager(): PackageManager {
 
 async function commandExists(command: string): Promise<boolean> {
   try {
-    await execa.command(`command -v ${command}`)
+    await execa.command(process.platform === 'win32' ? `where ${command}` : `command -v ${command}`)
     return true
   } catch {
     return false


### PR DESCRIPTION
Use `where <command>` if using windows when detecting package manager