### PR TITLE
feat(richtext-slate): add useElement hook to richtext-slate client exports

### DIFF
--- a/packages/richtext-slate/src/exports/client/index.ts
+++ b/packages/richtext-slate/src/exports/client/index.ts
@@ -62,5 +62,6 @@ export { UnderlineLeafButton } from '../../field/leaves/underline/LeafButton.js'
 
 export { UnderlineLeaf } from '../../field/leaves/underline/Underline/index.js'
 
+export { useElement } from '../../field/providers/ElementProvider.js'
 export { useLeaf } from '../../field/providers/LeafProvider.js'
 export { useSlatePlugin } from '../../utilities/useSlatePlugin.js'


### PR DESCRIPTION
I'm extending the Slate editor with a custom component and everything works great, except I have to import `useElement()` like this:

```tsx
import { useElement } from 'node_modules/.pnpm/@payloadcms+richtext-slate@3.0.0-beta.113_monaco-editor@0.51.0_next@15.0.0-canary.191_@babel+_qmdxs6s5hpzjhuopohgawpvl6i/node_modules/@payloadcms/richtext-slate/dist/field/providers/ElementProvider.js'

export function Element() {
	const { attributes, children } = useElement()
	return (
		<p {...attributes} className="rich-text-preheading">
			{children}
		</p>
	)
}
```

That's because it's not in the `@payloadcms/richtext-slate/client` module. This PR fixes this and would allow me to do:

```tsx
import { useElement } from '@payloadcms/richtext-slate/client'
```