### PR TITLE
perf(db-mongodb): use aggregations for relationship querying

### DIFF
--- a/packages/db-mongodb/src/countGlobalVersions.ts
+++ b/packages/db-mongodb/src/countGlobalVersions.ts
@@ -1,8 +1,10 @@
-import type { CountOptions } from 'mongodb'
+import type { PipelineStage } from 'mongoose'
 import type { CountGlobalVersions } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
+import { countDocuments } from './utilities/countDocuments.js'
+import { getCollation } from './utilities/getCollation.js'
 import { getHasNearConstraint } from './utilities/getHasNearConstraint.js'
 import { getSession } from './utilities/getSession.js'
 
@@ -15,7 +17,10 @@ export const countGlobalVersions: CountGlobalVersions = async function countGlob
 
   const hasNearConstraint = getHasNearConstraint(where)
 
+  const queryAggregation: PipelineStage[] = []
+
   const query = await Model.buildQuery({
+    aggregation: queryAggregation,
     locale,
     payload: this.payload,
     session,
@@ -25,26 +30,15 @@ export const countGlobalVersions: CountGlobalVersions = async function countGlob
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.
   const useEstimatedCount = hasNearConstraint || !query || Object.keys(query).length === 0
 
-  let result: number
-  if (useEstimatedCount) {
-    result = await Model.collection.estimatedDocumentCount()
-  } else {
-    const options: CountOptions = { session }
-
-    if (Object.keys(query).length === 0 && this.disableIndexHints !== true) {
-      // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding
-      // a hint. By default, if no hint is provided, MongoDB does not use an indexed field to count the returned documents,
-      // which makes queries very slow. This only happens when no query (filter) is provided. If one is provided, it uses
-      // the correct indexed field
-      options.hint = {
-        _id: 1,
-      }
-    }
-
-    result = await Model.collection.countDocuments(query, options)
-  }
-
   return {
-    totalDocs: result,
+    totalDocs: await countDocuments({
+      adapter: this,
+      collation: getCollation({ adapter: this, locale }),
+      collection: Model.collection,
+      query,
+      queryAggregation,
+      session,
+      useEstimatedCount,
+    }),
   }
 }

--- a/packages/db-mongodb/src/countVersions.ts
+++ b/packages/db-mongodb/src/countVersions.ts
@@ -1,8 +1,10 @@
-import type { CountOptions } from 'mongodb'
+import type { PipelineStage } from 'mongoose'
 import type { CountVersions } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
+import { countDocuments } from './utilities/countDocuments.js'
+import { getCollation } from './utilities/getCollation.js'
 import { getHasNearConstraint } from './utilities/getHasNearConstraint.js'
 import { getSession } from './utilities/getSession.js'
 
@@ -15,7 +17,10 @@ export const countVersions: CountVersions = async function countVersions(
 
   const hasNearConstraint = getHasNearConstraint(where)
 
+  const queryAggregation: PipelineStage[] = []
+
   const query = await Model.buildQuery({
+    aggregation: queryAggregation,
     locale,
     payload: this.payload,
     session,
@@ -25,26 +30,15 @@ export const countVersions: CountVersions = async function countVersions(
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.
   const useEstimatedCount = hasNearConstraint || !query || Object.keys(query).length === 0
 
-  let result: number
-  if (useEstimatedCount) {
-    result = await Model.collection.estimatedDocumentCount()
-  } else {
-    const options: CountOptions = { session }
-
-    if (this.disableIndexHints !== true) {
-      // Improve the performance of the countDocuments query which is used if useEstimatedCount is set to false by adding
-      // a hint. By default, if no hint is provided, MongoDB does not use an indexed field to count the returned documents,
-      // which makes queries very slow. This only happens when no query (filter) is provided. If one is provided, it uses
-      // the correct indexed field
-      options.hint = {
-        _id: 1,
-      }
-    }
-
-    result = await Model.collection.countDocuments(query, options)
-  }
-
   return {
-    totalDocs: result,
+    totalDocs: await countDocuments({
+      adapter: this,
+      collation: getCollation({ adapter: this, locale }),
+      collection: Model.collection,
+      query,
+      queryAggregation,
+      session,
+      useEstimatedCount,
+    }),
   }
 }

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -1,4 +1,4 @@
-import type { CollationOptions } from 'mongodb'
+import type { PipelineStage } from 'mongoose'
 import type { FindVersions } from 'payload'
 
 import { buildVersionCollectionFields } from 'payload'
@@ -8,8 +8,10 @@ import type { MongooseAdapter } from './index.js'
 import { buildSortParam } from './queries/buildSortParam.js'
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
 import { findMany } from './utilities/findMany.js'
+import { getCollation } from './utilities/getCollation.js'
 import { getHasNearConstraint } from './utilities/getHasNearConstraint.js'
 import { getSession } from './utilities/getSession.js'
+import { mergeProjections } from './utilities/mergeProjections.js'
 import { transform } from './utilities/transform.js'
 
 export const findVersions: FindVersions = async function findVersions(
@@ -34,9 +36,14 @@ export const findVersions: FindVersions = async function findVersions(
     })
   }
 
+  const queryAggregation: PipelineStage[] = []
+  const queryProjection = {}
+
   const query = await Model.buildQuery({
+    aggregation: queryAggregation,
     locale,
     payload: this.payload,
+    projection: queryProjection,
     session,
     where,
   })
@@ -45,28 +52,25 @@ export const findVersions: FindVersions = async function findVersions(
   // useEstimatedCount is faster, but not accurate, as it ignores any filters. It is thus set to true if there are no filters.
   const useEstimatedCount = hasNearConstraint || !query || Object.keys(query).length === 0
 
-  const projection = buildProjectionFromSelect({
-    adapter: this,
-    fields: versionFields,
-    select,
+  const projection = mergeProjections({
+    queryProjection,
+    selectProjection: buildProjectionFromSelect({
+      adapter: this,
+      fields: versionFields,
+      select,
+    }),
   })
-
-  const collation: CollationOptions | undefined = this.collation
-    ? {
-        locale: locale && locale !== 'all' && locale !== '*' ? locale : 'en',
-        ...this.collation,
-      }
-    : undefined
 
   const result = await findMany({
     adapter: this,
-    collation,
+    collation: getCollation({ adapter: this, locale }),
     collection: Model.collection,
     limit,
     page,
     pagination,
     projection,
     query,
+    queryAggregation,
     session,
     skip,
     sort,

--- a/packages/db-mongodb/src/init.ts
+++ b/packages/db-mongodb/src/init.ts
@@ -44,9 +44,7 @@ export const init: Init = function init(this: MongooseAdapter) {
         }),
       )
 
-      if (Object.keys(collection.joins).length > 0) {
-        versionSchema.plugin(mongooseAggregatePaginate)
-      }
+      versionSchema.plugin(mongooseAggregatePaginate)
 
       const versionCollectionName =
         this.autoPluralization === true && !collection.dbName ? undefined : versionModelName

--- a/packages/db-mongodb/src/models/buildCollectionSchema.ts
+++ b/packages/db-mongodb/src/models/buildCollectionSchema.ts
@@ -43,9 +43,7 @@ export const buildCollectionSchema = (
     .plugin<any, PaginateOptions>(paginate, { useEstimatedCount: true })
     .plugin(getBuildQueryPlugin({ collectionSlug: collection.slug }))
 
-  if (Object.keys(collection.joins).length > 0) {
-    schema.plugin(mongooseAggregatePaginate)
-  }
+  schema.plugin(mongooseAggregatePaginate)
 
   return schema
 }

--- a/packages/db-mongodb/src/queries/buildAndOrConditions.ts
+++ b/packages/db-mongodb/src/queries/buildAndOrConditions.ts
@@ -1,25 +1,27 @@
-import type { ClientSession } from 'mongodb'
+import type { PipelineStage } from 'mongoose'
 import type { FlattenedField, Payload, Where } from 'payload'
 
 import { parseParams } from './parseParams.js'
 
-export async function buildAndOrConditions({
+export function buildAndOrConditions({
+  aggregation,
   collectionSlug,
   fields,
   globalSlug,
   locale,
   payload,
-  session,
+  projection,
   where,
 }: {
+  aggregation: PipelineStage[]
   collectionSlug?: string
   fields: FlattenedField[]
   globalSlug?: string
   locale?: string
   payload: Payload
-  session?: ClientSession
+  projection?: Record<string, boolean>
   where: Where[]
-}): Promise<Record<string, unknown>[]> {
+}): Record<string, unknown>[] {
   const completedConditions = []
   // Loop over all AND / OR operations and add them to the AND / OR query param
   // Operations should come through as an array
@@ -27,13 +29,14 @@ export async function buildAndOrConditions({
   for (const condition of where) {
     // If the operation is properly formatted as an object
     if (typeof condition === 'object') {
-      const result = await parseParams({
+      const result = parseParams({
+        aggregation,
         collectionSlug,
         fields,
         globalSlug,
         locale,
         payload,
-        session,
+        projection,
         where: condition,
       })
       if (Object.keys(result).length > 0) {

--- a/packages/db-mongodb/src/queries/buildQuery.ts
+++ b/packages/db-mongodb/src/queries/buildQuery.ts
@@ -1,5 +1,8 @@
 import type { ClientSession } from 'mongodb'
+import type { PipelineStage } from 'mongoose'
 import type { FlattenedField, Payload, Where } from 'payload'
+
+import type { CollectionModel, GlobalModel } from '../types.js'
 
 import { parseParams } from './parseParams.js'
 
@@ -9,28 +12,61 @@ type GetBuildQueryPluginArgs = {
 }
 
 export type BuildQueryArgs = {
+  aggregation?: PipelineStage[]
   globalSlug?: string
   locale?: string
   payload: Payload
+  projection?: Record<string, boolean>
   session?: ClientSession
   where: Where
 }
 
 // This plugin asynchronously builds a list of Mongoose query constraints
 // which can then be used in subsequent Mongoose queries.
+// You can pass 'pipeline' to Model.buildQuery if you plan to use .aggregate() after
 export const getBuildQueryPlugin = ({
   collectionSlug,
   versionsFields,
 }: GetBuildQueryPluginArgs = {}) => {
   return function buildQueryPlugin(schema) {
     const modifiedSchema = schema
-    async function buildQuery({
-      globalSlug,
-      locale,
-      payload,
-      session,
-      where,
-    }: BuildQueryArgs): Promise<Record<string, unknown>> {
+
+    async function buildQuery(
+      this: CollectionModel | GlobalModel,
+      { aggregation, globalSlug, locale, payload, projection, session, where }: BuildQueryArgs,
+    ): Promise<Record<string, unknown>> {
+      if (!aggregation) {
+        aggregation = []
+
+        const query = await this.buildQuery({
+          aggregation,
+          globalSlug,
+          locale,
+          payload,
+          projection,
+          where,
+        })
+
+        // If there weren't any additional pipeline stages (querying by relationship fields), keep this query.
+        if (!aggregation.length) {
+          return query
+        }
+
+        aggregation.push({
+          $match: query,
+        })
+
+        aggregation.push({ $project: { _id: true } })
+
+        const result = await this.collection.aggregate(aggregation, { session }).toArray()
+
+        return {
+          _id: {
+            $in: result.map((each) => each._id),
+          },
+        }
+      }
+
       let fields = versionsFields
       if (!fields) {
         if (globalSlug) {
@@ -43,18 +79,19 @@ export const getBuildQueryPlugin = ({
         }
       }
 
-      const result = await parseParams({
+      const result = parseParams({
+        aggregation,
         collectionSlug,
         fields,
         globalSlug,
         locale,
         payload,
-        session,
         where,
       })
 
       return result
     }
+
     modifiedSchema.statics.buildQuery = buildQuery
   }
 }

--- a/packages/db-mongodb/src/queries/buildQuery.ts
+++ b/packages/db-mongodb/src/queries/buildQuery.ts
@@ -86,6 +86,7 @@ export const getBuildQueryPlugin = ({
         globalSlug,
         locale,
         payload,
+        projection,
         where,
       })
 

--- a/packages/db-mongodb/src/queries/parseParams.ts
+++ b/packages/db-mongodb/src/queries/parseParams.ts
@@ -1,5 +1,4 @@
-import type { ClientSession } from 'mongodb'
-import type { FilterQuery } from 'mongoose'
+import type { FilterQuery, PipelineStage } from 'mongoose'
 import type { FlattenedField, Operator, Payload, Where } from 'payload'
 
 import { deepMergeWithCombinedArrays } from 'payload'
@@ -8,23 +7,25 @@ import { validOperators } from 'payload/shared'
 import { buildAndOrConditions } from './buildAndOrConditions.js'
 import { buildSearchParam } from './buildSearchParams.js'
 
-export async function parseParams({
+export function parseParams({
+  aggregation,
   collectionSlug,
   fields,
   globalSlug,
   locale,
   payload,
-  session,
+  projection,
   where,
 }: {
+  aggregation: PipelineStage[]
   collectionSlug?: string
   fields: FlattenedField[]
   globalSlug?: string
   locale: string
   payload: Payload
-  session?: ClientSession
+  projection?: Record<string, boolean>
   where: Where
-}): Promise<Record<string, unknown>> {
+}): Record<string, unknown> {
   let result = {} as FilterQuery<any>
 
   if (typeof where === 'object') {
@@ -38,12 +39,14 @@ export async function parseParams({
         conditionOperator = '$or'
       }
       if (Array.isArray(condition)) {
-        const builtConditions = await buildAndOrConditions({
+        const builtConditions = buildAndOrConditions({
+          aggregation,
           collectionSlug,
           fields,
           globalSlug,
           locale,
           payload,
+          projection,
           where: condition,
         })
         if (builtConditions.length > 0) {
@@ -57,7 +60,8 @@ export async function parseParams({
         if (typeof pathOperators === 'object') {
           for (const operator of Object.keys(pathOperators)) {
             if (validOperators.includes(operator as Operator)) {
-              const searchParam = await buildSearchParam({
+              const searchParam = buildSearchParam({
+                aggregation,
                 collectionSlug,
                 fields,
                 globalSlug,
@@ -65,7 +69,7 @@ export async function parseParams({
                 locale,
                 operator,
                 payload,
-                session,
+                projection,
                 val: pathOperators[operator],
               })
 

--- a/packages/db-mongodb/src/types.ts
+++ b/packages/db-mongodb/src/types.ts
@@ -56,7 +56,7 @@ export type TypeOfIndex = {
 }
 
 export interface GlobalModel extends Model<Document> {
-  buildQuery: (query: unknown, locale?: string) => Promise<Record<string, unknown>>
+  buildQuery: (query: BuildQueryArgs) => Promise<Record<string, unknown>>
 }
 
 export type BuildSchema<TSchema> = (args: {

--- a/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
+++ b/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
@@ -1,6 +1,6 @@
 import type { ClientSession } from 'mongodb'
 import type { PipelineStage } from 'mongoose'
-import type { CollectionSlug, JoinQuery, SanitizedCollectionConfig, Where } from 'payload'
+import type { CollectionSlug, JoinQuery, SanitizedCollectionConfig } from 'payload'
 
 import type { MongooseAdapter } from '../index.js'
 
@@ -12,7 +12,7 @@ type BuildJoinAggregationArgs = {
   collectionConfig: SanitizedCollectionConfig
   joins: JoinQuery
   locale: string
-  projection?: Record<string, true>
+  projection?: Record<string, boolean>
   session?: ClientSession
   /** whether the query is from drafts */
   versions?: boolean

--- a/packages/db-mongodb/src/utilities/countDocuments.ts
+++ b/packages/db-mongodb/src/utilities/countDocuments.ts
@@ -1,0 +1,49 @@
+import type { ClientSession, CollationOptions, Collection } from 'mongodb'
+import type { PipelineStage } from 'mongoose'
+
+import type { MongooseAdapter } from '../index.js'
+
+export const countDocuments = async ({
+  adapter,
+  collation,
+  collection,
+  query,
+  queryAggregation,
+  session,
+  useEstimatedCount,
+}: {
+  adapter: MongooseAdapter
+  collation?: CollationOptions
+  collection: Collection
+  query: Record<string, unknown>
+  queryAggregation?: PipelineStage[]
+  session?: ClientSession
+  useEstimatedCount?: boolean
+}): Promise<number> => {
+  if (useEstimatedCount) {
+    return collection.estimatedDocumentCount()
+  }
+
+  const hint = adapter.disableIndexHints !== true ? { _id: 1 } : undefined
+
+  if (queryAggregation?.length) {
+    const aggregation = collection.aggregate([], { collation, hint, session })
+    for (const stage of queryAggregation) {
+      aggregation.addStage(stage)
+    }
+
+    aggregation.match(query)
+    aggregation.addStage({ $count: 'count' })
+
+    const result = await aggregation.toArray()
+
+    if (result.length) {
+      return result[0].count
+    }
+
+    // Without any documents MongoDB doesn't return even 0 element.
+    return 0
+  }
+
+  return collection.countDocuments(query, { collation, hint, session })
+}

--- a/packages/db-mongodb/src/utilities/getCollation.ts
+++ b/packages/db-mongodb/src/utilities/getCollation.ts
@@ -1,0 +1,18 @@
+import type { CollationOptions } from 'mongodb'
+
+import type { MongooseAdapter } from '../index.js'
+
+export const getCollation = ({
+  adapter,
+  locale,
+}: {
+  adapter: MongooseAdapter
+  locale?: string
+}): CollationOptions | undefined => {
+  if (adapter.collation) {
+    return {
+      locale: locale && locale !== 'all' && locale !== '*' ? locale : 'en',
+      ...adapter.collation,
+    }
+  }
+}

--- a/packages/db-mongodb/src/utilities/mergeProjections.ts
+++ b/packages/db-mongodb/src/utilities/mergeProjections.ts
@@ -1,0 +1,20 @@
+/**
+ * `queryProjection` - project with false values to remove relationship that included to $lookup .
+ * `selectProjection` contains only true values
+ */
+export const mergeProjections = ({
+  queryProjection,
+  selectProjection,
+}: {
+  queryProjection: Record<string, boolean>
+  selectProjection?: Record<string, true>
+}): Record<string, boolean> | undefined => {
+  if (!selectProjection) {
+    if (Object.keys(queryProjection).length > 0) {
+      return queryProjection
+    }
+    return
+  }
+
+  return selectProjection
+}

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -933,6 +933,59 @@ describe('Relationships', () => {
         expect(queryREST.docs[0].id).toStrictEqual(firstLevelID)
       })
 
+      it('should allow querying several times, one and two level deep', async () => {
+        const query = await payload.find({
+          collection: 'chained',
+          where: {
+            and: [
+              {
+                'relation.name': {
+                  equals: 'second',
+                },
+              },
+              {
+                'relation.relation.name': {
+                  equals: 'third',
+                },
+              },
+              {
+                'relation.relation.name': {
+                  like: 'third',
+                },
+              },
+              {
+                'relation.relation.name': {
+                  exists: true,
+                },
+              },
+              {
+                'relation.relation.name': {
+                  not_equals: 'third1',
+                },
+              },
+            ],
+          },
+        })
+
+        expect(query.docs).toHaveLength(1)
+        expect(query.docs[0].id).toStrictEqual(firstLevelID)
+
+        const queryREST = await restClient
+          .GET(`/chained`, {
+            query: {
+              where: {
+                'relation.relation.id': {
+                  equals: thirdLevelID,
+                },
+              },
+            },
+          })
+          .then((res) => res.json())
+
+        expect(queryREST.docs).toHaveLength(1)
+        expect(queryREST.docs[0].id).toStrictEqual(firstLevelID)
+      })
+
       it('should allow querying within array nesting', async () => {
         const page = await payload.create({
           collection: 'pages',


### PR DESCRIPTION
Uses lookups for relationships querying (`where { relationship.name }`) of subquerying.

Before, whenever we needed to query by a property from another document, we did this:
```ts
const result = await SubModel.find(subQuery, subQueryOptions)

const $in: unknown[] = []

result.forEach((doc) => {
  const stringID = doc._id.toString()
  $in.push(stringID)

  if (mongoose.Types.ObjectId.isValid(stringID)) {
    $in.push(doc._id)
  }
})
```

Now, we are building an aggregation with lookups to query by those!

### Benchmark
Benchmark in `test/relationships/int.ts` - before https://github.com/r1tsuu/payload/tree/bench/aggregations-before after https://github.com/r1tsuu/payload/tree/bench/aggregations-after

Run with:
```ts
pnpm exec cross-env NODE_OPTIONS="--no-deprecation" node 'node_modules/jest/bin/jest.js' '/Users/ritsu/work/payload-3/test/relationships/int.spec.ts' -c '/Users/ritsu/work/payload-3/test/jest.config.js' -t 'Relationships Querying Nested Querying should allow querying several times, one and two level deep'
```

Code that benchmark uses: https://github.com/r1tsuu/payload/blob/1b8eb31fa56a45316d520e92ddcb2f5c3800a0dd/test/relationships/int.spec.ts#L878-L926

#### Results:
##### Before:
<img width="343" alt="image" src="https://github.com/user-attachments/assets/fb1ac6fe-43f4-444b-a794-0e416fd46837">

##### After:
<img width="344" alt="image" src="https://github.com/user-attachments/assets/3d16a1b7-cfb1-4ea6-95ce-e38ac8448259">

### Additionally
- Ensures we always use the transaction when building the query. We didn't do this before for relationship querying.
- Unblocks sorting by relationships in mongodb (we support it with postgres/sqlite adapters), can implement in a separate PR.




