### PR TITLE
fix(ui): accept files with valid catchall mimetypes in bulkUpload

### DIFF
--- a/packages/ui/src/elements/BulkUpload/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/index.tsx
@@ -27,11 +27,12 @@ function DrawerContent() {
   const onDrop = React.useCallback(
     (acceptedFiles: FileList) => {
       const fileTransfer = new DataTransfer()
+      const validPatterns = uploadMimeTypes?.map((v) => v.replace('*', ''))
       for (const candidateFile of acceptedFiles) {
         if (
           uploadMimeTypes === undefined ||
           uploadMimeTypes.length === 0 ||
-          uploadMimeTypes?.includes(candidateFile.type)
+          validPatterns?.some((v) => candidateFile.type.startsWith(v))
         ) {
           fileTransfer.items.add(candidateFile)
         }


### PR DESCRIPTION
<!--

For external contributors, please include:

- A summary of the pull request and any related issues it fixes.
- Reasoning for the changes made or any additional context that may be useful.

Ensure you have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

 -->
fixes #8867

Solution for this came from existing valid mimetype validator [found here](https://github.com/payloadcms/payload/blob/beta/packages/payload/src/uploads/mimeTypeValidator.ts).