### PR TITLE
chore(templates): use payload cloud

### DIFF
--- a/templates/_template/package.json
+++ b/templates/_template/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@payloadcms/db-mongodb": "beta",
     "@payloadcms/next": "beta",
-    "@payloadcms/plugin-cloud": "beta",
+    "@payloadcms/payload-cloud": "beta",
     "@payloadcms/richtext-lexical": "beta",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@payloadcms/db-mongodb": "beta",
     "@payloadcms/next": "beta",
-    "@payloadcms/plugin-cloud": "beta",
+    "@payloadcms/payload-cloud": "beta",
     "@payloadcms/richtext-lexical": "beta",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",

--- a/templates/website/README.md
+++ b/templates/website/README.md
@@ -165,7 +165,7 @@ Core features:
 
 ### Cache
 
-Although Next.js includes a robust set of caching strategies out of the box, Payload Cloud proxies and caches all files through Cloudflare using the [Official Cloud Plugin](https://github.com/payloadcms/plugin-cloud). This means that Next.js caching is not needed and is disabled by default. If you are hosting your app outside of Payload Cloud, you can easily reenable the Next.js caching mechanisms by removing the `no-store` directive from all fetch requests in `./src/app/_api` and then removing all instances of `export const dynamic = 'force-dynamic'` from pages files, such as `./src/app/(pages)/[slug]/page.tsx`. For more details, see the official [Next.js Caching Docs](https://nextjs.org/docs/app/building-your-application/caching).
+Although Next.js includes a robust set of caching strategies out of the box, Payload Cloud proxies and caches all files through Cloudflare using the [Official Cloud Plugin](https://www.npmjs.com/package/@payloadcms/payload-cloud). This means that Next.js caching is not needed and is disabled by default. If you are hosting your app outside of Payload Cloud, you can easily reenable the Next.js caching mechanisms by removing the `no-store` directive from all fetch requests in `./src/app/_api` and then removing all instances of `export const dynamic = 'force-dynamic'` from pages files, such as `./src/app/(pages)/[slug]/page.tsx`. For more details, see the official [Next.js Caching Docs](https://nextjs.org/docs/app/building-your-application/caching).
 
 ## Development
 

--- a/templates/website/package.json
+++ b/templates/website/package.json
@@ -21,7 +21,7 @@
     "@payloadcms/db-mongodb": "beta",
     "@payloadcms/live-preview-react": "beta",
     "@payloadcms/next": "beta",
-    "@payloadcms/plugin-cloud": "beta",
+    "@payloadcms/payload-cloud": "beta",
     "@payloadcms/plugin-form-builder": "beta",
     "@payloadcms/plugin-nested-docs": "beta",
     "@payloadcms/plugin-redirects": "beta",

--- a/templates/website/src/payload.config.ts
+++ b/templates/website/src/payload.config.ts
@@ -1,7 +1,7 @@
 // storage-adapter-import-placeholder
 import { mongooseAdapter } from '@payloadcms/db-mongodb' // database-adapter-import
 
-import { payloadCloudPlugin } from '@payloadcms/plugin-cloud'
+import { payloadCloudPlugin } from '@payloadcms/payload-cloud'
 import { formBuilderPlugin } from '@payloadcms/plugin-form-builder'
 import { nestedDocsPlugin } from '@payloadcms/plugin-nested-docs'
 import { redirectsPlugin } from '@payloadcms/plugin-redirects'

--- a/templates/with-payload-cloud/package.json
+++ b/templates/with-payload-cloud/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@payloadcms/db-mongodb": "beta",
     "@payloadcms/next": "beta",
-    "@payloadcms/plugin-cloud": "beta",
+    "@payloadcms/payload-cloud": "beta",
     "@payloadcms/richtext-lexical": "beta",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",

--- a/templates/with-payload-cloud/src/payload.config.ts
+++ b/templates/with-payload-cloud/src/payload.config.ts
@@ -1,4 +1,4 @@
-import { payloadCloudPlugin } from '@payloadcms/plugin-cloud'
+import { payloadCloudPlugin } from '@payloadcms/payload-cloud'
 import { mongooseAdapter } from '@payloadcms/db-mongodb'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import path from 'path'

--- a/templates/with-postgres/package.json
+++ b/templates/with-postgres/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@payloadcms/db-postgres": "beta",
     "@payloadcms/next": "beta",
-    "@payloadcms/plugin-cloud": "beta",
+    "@payloadcms/payload-cloud": "beta",
     "@payloadcms/richtext-lexical": "beta",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",

--- a/templates/with-vercel-mongodb/package.json
+++ b/templates/with-vercel-mongodb/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@payloadcms/db-mongodb": "beta",
     "@payloadcms/next": "beta",
-    "@payloadcms/plugin-cloud": "beta",
+    "@payloadcms/payload-cloud": "beta",
     "@payloadcms/richtext-lexical": "beta",
     "@payloadcms/storage-vercel-blob": "beta",
     "cross-env": "^7.0.3",

--- a/templates/with-vercel-postgres/package.json
+++ b/templates/with-vercel-postgres/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@payloadcms/db-vercel-postgres": "beta",
     "@payloadcms/next": "beta",
-    "@payloadcms/plugin-cloud": "beta",
+    "@payloadcms/payload-cloud": "beta",
     "@payloadcms/richtext-lexical": "beta",
     "@payloadcms/storage-vercel-blob": "beta",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
Update templates to use `@payloadcms/payload-cloud`. 

**NOTE:** This should not be merged until beta.119 is released.