### PR TITLE
docs(storage-adapters): Adds a hint for custom S3 endpoints

### DIFF
--- a/docs/upload/storage-adapters.mdx
+++ b/docs/upload/storage-adapters.mdx
@@ -102,6 +102,9 @@ export default buildConfig({
           secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
         },
         region: process.env.S3_REGION,
+        // Set to true if you are using a custom endpoint.
+        // forcePathStyle: true,
+
         // ... Other S3 configuration
       },
     }),


### PR DESCRIPTION
### What?
Adds a hint to setup nonstandard S3 endpoints

### Why?
Although this is about the AWS SDK setup, it appears to be a fairly common issue for people using payload.

### How?
Small comment in the code example

Fixes #
#4866 #8875
