### PR TITLE
fix: autosave potentially losing latest: true w/ race condition

### DIFF
--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -82,6 +82,8 @@ export const saveVersion = async ({
 
         const data: Record<string, unknown> = {
           createdAt: new Date(latestVersion.createdAt).toISOString(),
+          latest: true,
+          parent: id,
           updatedAt: now,
           version: {
             ...versionData,


### PR DESCRIPTION
Fixes a potential race condition where versions could lose `latest: true` and potentially also introduce a conflict with the `parent` field.

We now explicitly define these as we update versions in the `saveVersion` function.