### PR TITLE
docs: update database adpater installation commands to use beta version

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -54,12 +54,12 @@ To install a Database Adapter, you can run **one** of the following commands:
 
 - To install the [MongoDB Adapter](../database/mongodb), run:
     ```bash
-    pnpm i @payloadcms/db-mongodb
+    pnpm i @payloadcms/db-mongodb@beta
     ```
 
 - To install the [Postgres Adapter](../database/postgres), run:
     ```bash
-    pnpm i @payloadcms/db-postgres
+    pnpm i @payloadcms/db-postgres@beta
     ```
 
 <Banner type="success">


### PR DESCRIPTION
While following the "Adding to an existing app" instructions for the **beta** docs, I noticed that the pnpm installation commands for the database adapters were missing the `@beta` tag, which will result in errors in the project.