### PR TITLE
docs: update metadata icons example to use url and fix images type in table

### DIFF
--- a/docs/admin/metadata.mdx
+++ b/docs/admin/metadata.mdx
@@ -36,7 +36,7 @@ To customize Root Metadata, use the `admin.meta` key in your Payload Config:
         {
           rel: 'icon',
           type: 'image/png',
-          href: '/favicon.png',
+          url: '/favicon.png',
         },
       ],
     },
@@ -80,12 +80,12 @@ To customize icons, use the `icons` key within the `admin.meta` object in your P
         {
           rel: 'icon',
           type: 'image/png',
-          href: '/favicon.png',
+          url: '/favicon.png',
         },
         {
           rel: 'apple-touch-icon',
           type: 'image/png',
-          href: '/apple-touch-icon.png',
+          url: '/apple-touch-icon.png',
         },
       ],
     },
@@ -140,7 +140,7 @@ The following options are available for Open Graph Metadata:
 | Key | Type | Description |
 | --- | --- | --- |
 | **`description`** | `string` | The description of the Admin Panel. |
-| **`images`** | `OGImageConfig | OGImageConfig[]` | An array of image objects. |
+| **`images`** | `OGImageConfig` or `OGImageConfig[]` | An array of image objects. |
 | **`siteName`** | `string` | The name of the site. |
 | **`title`** | `string` | The title of the Admin Panel. |
 


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
Updates the examples in the [admin/metadata#root-metadata](https://payloadcms.com/docs/beta/admin/metadata#root-metadata) and [admin/metadata#icons](https://payloadcms.com/docs/beta/admin/metadata#icons) sections from using `href` to `url` and fixes the way that the `images` Type excludes the description due to `|` being parsed as column separator

### Why?
As of right now, the examples are incorrect and the `images` type bleeds into the description and omits it entirely

See image of table issue at `images`:
![image](https://github.com/user-attachments/assets/086dc44c-5c1b-4b5e-9658-521eb60fff0d)

### How?
Changes to `metadata.mdx`

Fixes #8887

Credit to @thgh for the `href` to `url` find