### PR TITLE
chore(plugin-cloud): refresh session on ExpiredToken error code

### DIFF
--- a/packages/payload-cloud/src/staticHandler.ts
+++ b/packages/payload-cloud/src/staticHandler.ts
@@ -76,7 +76,7 @@ export const getStaticHandler = ({ cachingOptions, collection, debug }: Args): S
         stream.on('error', (err) => {
           req.payload.logger.error({
             err,
-            key,
+            Key,
             msg: 'Error streaming S3 object, destroying stream',
           })
           stream.destroy()
@@ -108,7 +108,7 @@ export const getStaticHandler = ({ cachingOptions, collection, debug }: Args): S
             collectionSlug: collection.slug,
             msg: `Requested file not found in cloud storage: ${params.filename}`,
             params,
-            requestedKey: key,
+            requestedKey: Key,
           })
           return new Response(null, { status: 404, statusText: 'Not Found' })
         } else if (err.name === 'NoSuchKey') {
@@ -117,7 +117,7 @@ export const getStaticHandler = ({ cachingOptions, collection, debug }: Args): S
             collectionSlug: collection.slug,
             msg: `Requested file not found in cloud storage: ${params.filename}`,
             params,
-            requestedKey: key,
+            requestedKey: Key,
           })
           return new Response(null, { status: 404, statusText: 'Not Found' })
         }

--- a/packages/payload-cloud/src/staticHandler.ts
+++ b/packages/payload-cloud/src/staticHandler.ts
@@ -76,7 +76,7 @@ export const getStaticHandler = ({ cachingOptions, collection, debug }: Args): S
         stream.on('error', (err) => {
           req.payload.logger.error({
             err,
-            Key,
+            key,
             msg: 'Error streaming S3 object, destroying stream',
           })
           stream.destroy()
@@ -108,7 +108,7 @@ export const getStaticHandler = ({ cachingOptions, collection, debug }: Args): S
             collectionSlug: collection.slug,
             msg: `Requested file not found in cloud storage: ${params.filename}`,
             params,
-            requestedKey: Key,
+            requestedKey: key,
           })
           return new Response(null, { status: 404, statusText: 'Not Found' })
         } else if (err.name === 'NoSuchKey') {
@@ -117,7 +117,7 @@ export const getStaticHandler = ({ cachingOptions, collection, debug }: Args): S
             collectionSlug: collection.slug,
             msg: `Requested file not found in cloud storage: ${params.filename}`,
             params,
-            requestedKey: Key,
+            requestedKey: key,
           })
           return new Response(null, { status: 404, statusText: 'Not Found' })
         }

--- a/packages/payload-cloud/src/utilities/getStorageClient.ts
+++ b/packages/payload-cloud/src/utilities/getStorageClient.ts
@@ -1,19 +1,13 @@
+import type * as AWS from '@aws-sdk/client-s3'
 import type { CognitoUserSession } from 'amazon-cognito-identity-js'
 
-import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity'
-import * as AWS from '@aws-sdk/client-s3'
-import { fromCognitoIdentityPool } from '@aws-sdk/credential-providers'
+import type { GetStorageClient } from './refreshSession.js'
 
-import { authAsCognitoUser } from './authAsCognitoUser.js'
+import { refreshSession } from './refreshSession.js'
 
-export type GetStorageClient = () => Promise<{
-  identityID: string
-  storageClient: AWS.S3
-}>
-
-let storageClient: AWS.S3 | null = null
-let session: CognitoUserSession | null = null
-let identityID: string
+export let storageClient: AWS.S3 | null = null
+export let session: CognitoUserSession | null = null
+export let identityID: string
 
 export const getStorageClient: GetStorageClient = async () => {
   if (storageClient && session?.isValid()) {
@@ -22,6 +16,8 @@ export const getStorageClient: GetStorageClient = async () => {
       storageClient,
     }
   }
+
+  ;({ identityID, session, storageClient } = await refreshSession())
 
   if (!process.env.PAYLOAD_CLOUD_PROJECT_ID) {
     throw new Error('PAYLOAD_CLOUD_PROJECT_ID is required')
@@ -32,34 +28,6 @@ export const getStorageClient: GetStorageClient = async () => {
   if (!process.env.PAYLOAD_CLOUD_COGNITO_IDENTITY_POOL_ID) {
     throw new Error('PAYLOAD_CLOUD_COGNITO_IDENTITY_POOL_ID is required')
   }
-
-  session = await authAsCognitoUser(
-    process.env.PAYLOAD_CLOUD_PROJECT_ID,
-    process.env.PAYLOAD_CLOUD_COGNITO_PASSWORD,
-  )
-
-  const cognitoIdentity = new CognitoIdentityClient({
-    credentials: fromCognitoIdentityPool({
-      clientConfig: {
-        region: 'us-east-1',
-      },
-      identityPoolId: process.env.PAYLOAD_CLOUD_COGNITO_IDENTITY_POOL_ID,
-      logins: {
-        [`cognito-idp.us-east-1.amazonaws.com/${process.env.PAYLOAD_CLOUD_COGNITO_USER_POOL_ID}`]:
-          session.getIdToken().getJwtToken(),
-      },
-    }),
-  })
-
-  const credentials = await cognitoIdentity.config.credentials()
-
-  // @ts-expect-error - Incorrect AWS types
-  identityID = credentials.identityId
-
-  storageClient = new AWS.S3({
-    credentials,
-    region: process.env.PAYLOAD_CLOUD_BUCKET_REGION,
-  })
 
   return {
     identityID,

--- a/packages/payload-cloud/src/utilities/refreshSession.ts
+++ b/packages/payload-cloud/src/utilities/refreshSession.ts
@@ -1,5 +1,3 @@
-import type { CognitoUserSession } from 'amazon-cognito-identity-js'
-
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity'
 import * as AWS from '@aws-sdk/client-s3'
 import { fromCognitoIdentityPool } from '@aws-sdk/credential-providers'
@@ -11,12 +9,8 @@ export type GetStorageClient = () => Promise<{
   storageClient: AWS.S3 | null
 }>
 
-export let storageClient: AWS.S3 | null = null
-export let session: CognitoUserSession | null = null
-export let identityID: string
-
 export const refreshSession = async () => {
-  session = await authAsCognitoUser(
+  const session = await authAsCognitoUser(
     process.env.PAYLOAD_CLOUD_PROJECT_ID || '',
     process.env.PAYLOAD_CLOUD_COGNITO_PASSWORD || '',
   )
@@ -37,10 +31,16 @@ export const refreshSession = async () => {
   const credentials = await cognitoIdentity.config.credentials()
 
   // @ts-expect-error - Incorrect AWS types
-  identityID = credentials.identityId
+  const identityID = credentials.identityId
 
-  storageClient = new AWS.S3({
+  const storageClient = new AWS.S3({
     credentials,
     region: process.env.PAYLOAD_CLOUD_BUCKET_REGION,
   })
+
+  return {
+    identityID,
+    session,
+    storageClient,
+  }
 }

--- a/packages/payload-cloud/src/utilities/refreshSession.ts
+++ b/packages/payload-cloud/src/utilities/refreshSession.ts
@@ -6,7 +6,7 @@ import { authAsCognitoUser } from './authAsCognitoUser.js'
 
 export type GetStorageClient = () => Promise<{
   identityID: string
-  storageClient: AWS.S3 | null
+  storageClient: AWS.S3
 }>
 
 export const refreshSession = async () => {

--- a/packages/payload-cloud/src/utilities/refreshSession.ts
+++ b/packages/payload-cloud/src/utilities/refreshSession.ts
@@ -1,0 +1,46 @@
+import type { CognitoUserSession } from 'amazon-cognito-identity-js'
+
+import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity'
+import * as AWS from '@aws-sdk/client-s3'
+import { fromCognitoIdentityPool } from '@aws-sdk/credential-providers'
+
+import { authAsCognitoUser } from './authAsCognitoUser.js'
+
+export type GetStorageClient = () => Promise<{
+  identityID: string
+  storageClient: AWS.S3 | null
+}>
+
+export let storageClient: AWS.S3 | null = null
+export let session: CognitoUserSession | null = null
+export let identityID: string
+
+export const refreshSession = async () => {
+  session = await authAsCognitoUser(
+    process.env.PAYLOAD_CLOUD_PROJECT_ID || '',
+    process.env.PAYLOAD_CLOUD_COGNITO_PASSWORD || '',
+  )
+
+  const cognitoIdentity = new CognitoIdentityClient({
+    credentials: fromCognitoIdentityPool({
+      clientConfig: {
+        region: 'us-east-1',
+      },
+      identityPoolId: process.env.PAYLOAD_CLOUD_COGNITO_IDENTITY_POOL_ID || '',
+      logins: {
+        [`cognito-idp.us-east-1.amazonaws.com/${process.env.PAYLOAD_CLOUD_COGNITO_USER_POOL_ID}`]:
+          session.getIdToken().getJwtToken(),
+      },
+    }),
+  })
+
+  const credentials = await cognitoIdentity.config.credentials()
+
+  // @ts-expect-error - Incorrect AWS types
+  identityID = credentials.identityId
+
+  storageClient = new AWS.S3({
+    credentials,
+    region: process.env.PAYLOAD_CLOUD_BUCKET_REGION,
+  })
+}


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/8404

This code will refresh the session token upon receiving an `ExpiredToken` error when `storageClient.getObject()` receives that error.

- The `Error Code` detected is determined by the error reported in the issue, and is an actual  code from [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html) for Error Responses.

- If the request fails again, the error is thrown.