### PR TITLE
fix(db-mongodb): id in querying with an aggregation using a comma-delimited value

### DIFF
--- a/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
+++ b/packages/db-mongodb/src/queries/sanitizeQueryValue.ts
@@ -78,7 +78,11 @@ export const sanitizeQueryValue = ({
           return { operator: formattedOperator, val: undefined }
         }
       }
-    } else if (Array.isArray(val)) {
+    } else if (Array.isArray(val) || (typeof val === 'string' && val.split(',').length > 1)) {
+      if (typeof val === 'string') {
+        formattedValue = createArrayFromCommaDelineated(val)
+      }
+
       formattedValue = formattedValue.reduce((formattedValues, inVal) => {
         const newValues = [inVal]
         if (!hasCustomID) {

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -618,7 +618,7 @@ describe('Joins Field', () => {
     })
   })
 
-  it('should work id.in querying with joins', async () => {
+  it('should work id.in command delimited querying with joins', async () => {
     const allCategories = await payload.find({ collection: 'categories', pagination: false })
 
     const allCategoriesByIds = await restClient
@@ -626,7 +626,7 @@ describe('Joins Field', () => {
         query: {
           where: {
             id: {
-              in: allCategories.docs.map((each) => each.id),
+              in: allCategories.docs.map((each) => each.id).join(','),
             },
           },
         },

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -617,6 +617,24 @@ describe('Joins Field', () => {
       expect(response.data.Category.relatedPosts.docs[0].title).toStrictEqual('test 3')
     })
   })
+
+  it('should work id.in querying with joins', async () => {
+    const allCategories = await payload.find({ collection: 'categories', pagination: false })
+
+    const allCategoriesByIds = await restClient
+      .GET(`/categories`, {
+        query: {
+          where: {
+            id: {
+              in: allCategories.docs.map((each) => each.id),
+            },
+          },
+        },
+      })
+      .then((res) => res.json())
+
+    expect(allCategories.totalDocs).toBe(allCategoriesByIds.totalDocs)
+  })
 })
 
 async function createPost(overrides?: Partial<Post>, locale?: Config['locale']) {


### PR DESCRIPTION
### What?
Fixes the issue with `in` querying when the collection has a join field.

### Why?
When using `.aggregate`, MongoDB doesn't cast a comma delimited value for the `$in` operator to an array automatically as it's not handled by Mongoose.

### How?
Sanitizes the incoming value to an array if it should.

Fixes https://github.com/payloadcms/payload/issues/8901

