### PR TITLE
fix(ui): sanitize limit for preferences

### DIFF
--- a/packages/ui/src/providers/ListQuery/index.tsx
+++ b/packages/ui/src/providers/ListQuery/index.tsx
@@ -98,7 +98,7 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
       let updatePreferences = false
 
       if ('limit' in query) {
-        updatedPreferences.limit = query.limit
+        updatedPreferences.limit = Number(query.limit)
         updatePreferences = true
       }
 


### PR DESCRIPTION
### What?
Fixes the issue with passing a string `limit` value from user preferences to the mongodb `.aggregate` function.

To reproduce:

- click the list view for a collection that has a join field
- set "show per page" to 100
- reload, see this:

<img width="1001" alt="image" src="https://github.com/user-attachments/assets/86c644d1-d183-48e6-bf34-0ccac23cb114">

### Why?
When using `.aggregate`, MongoDB doesn't cast a value for the `$limit` stage to a number automatically as it's not handled by Mongoose. It's also more convenient to store this value as a number.  

### How?
Stores `limit` inside of preferences in number.

