### PR TITLE
docs: form builder number field table unformatted

### DIFF
--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -343,12 +343,12 @@ Maps to a `checkbox` input on your front-end. Used to collect a boolean value.
 Maps to a `number` input on your front-end. Used to collect a number.
 
 | Property       | Type     | Description                                          |
-| -------------- | -------- | ---------------------------------------------------- | --- | -------------- | ------ | ------------------------------- |
+| -------------- | -------- | ---------------------------------------------------- |
 | `name`         | string   | The name of the field.                               |
 | `label`        | string   | The label of the field.                              |
-| `defaultValue` | string   | The default value of the field.                      |
+| `defaultValue` | number   | The default value of the field.                      |
 | `width`        | string   | The width of the field on the front-end.             |
-| `required`     | checkbox | Whether or not the field is required when submitted. |     | `defaultValue` | number | The default value of the field. |
+| `required`     | checkbox | Whether or not the field is required when submitted. |
 
 ### Message
 


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR aims to fix an issue in the form-builder plugin page - in the `number` field table, where an issue with one of the columns makes the whole table unformatted. [See issue here](https://payloadcms.com/docs/beta/plugins/form-builder#number).

### Why?
As it stands, the whole table is being rendered without any formatting, making understanding it very difficult.

### How?
Changes to `docs/plugins/form-builder.mdx`
