### PR TITLE
chore: corrects package import paths for live preview test

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/plugin/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/plugin/index.tsx
@@ -24,7 +24,6 @@ import {
   COMMAND_PRIORITY_EDITOR,
   type RangeSelection,
 } from 'lexical'
-import { useLexicalDrawer } from 'packages/richtext-lexical/src/utilities/fieldsDrawer/useLexicalDrawer.js'
 import React, { useEffect, useState } from 'react'
 
 import type { PluginComponent } from '../../../typesClient.js'
@@ -33,6 +32,7 @@ import type { BlocksFeatureClientProps } from '../index.js'
 
 import { useEditorConfigContext } from '../../../../lexical/config/client/EditorConfigProvider.js'
 import { FieldsDrawer } from '../../../../utilities/fieldsDrawer/Drawer.js'
+import { useLexicalDrawer } from '../../../../utilities/fieldsDrawer/useLexicalDrawer.js'
 import { $createBlockNode, BlockNode } from '../nodes/BlocksNode.js'
 import { $createInlineBlockNode, $isInlineBlockNode } from '../nodes/InlineBlocksNode.js'
 import {

--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.tsx
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.tsx
@@ -16,7 +16,6 @@ import { INSERT_TABLE_COMMAND, TableNode } from '@lexical/table'
 import { mergeRegister } from '@lexical/utils'
 import { formatDrawerSlug, useEditDepth, useModal } from '@payloadcms/ui'
 import { $getSelection, $isRangeSelection, COMMAND_PRIORITY_EDITOR, createCommand } from 'lexical'
-import { useLexicalDrawer } from 'packages/richtext-lexical/src/utilities/fieldsDrawer/useLexicalDrawer.js'
 import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import * as React from 'react'
 
@@ -24,6 +23,7 @@ import type { PluginComponent } from '../../../../typesClient.js'
 
 import { useEditorConfigContext } from '../../../../../lexical/config/client/EditorConfigProvider.js'
 import { FieldsDrawer } from '../../../../../utilities/fieldsDrawer/Drawer.js'
+import { useLexicalDrawer } from '../../../../../utilities/fieldsDrawer/useLexicalDrawer.js'
 import './index.scss'
 
 export type CellContextShape = {


### PR DESCRIPTION
Corrects package import paths for live preview test.

- This would cause a import glitch when trying to run the live-preview test due to incorrect file paths.