### PR TITLE
fix(db-mongodb): joins with singular collection name

### DIFF
--- a/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
+++ b/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
@@ -100,7 +100,7 @@ export const buildJoinAggregation = async ({
               $lookup: {
                 as: `${as}.docs`,
                 foreignField: `${join.field.on}${code}`,
-                from: slug,
+                from: adapter.collections[slug].collection.name,
                 localField: versions ? 'parent' : '_id',
                 pipeline,
               },
@@ -141,7 +141,7 @@ export const buildJoinAggregation = async ({
             $lookup: {
               as: `${as}.docs`,
               foreignField: `${join.field.on}${localeSuffix}`,
-              from: slug,
+              from: adapter.collections[slug].collection.name,
               localField: versions ? 'parent' : '_id',
               pipeline,
             },

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -20,7 +20,7 @@ export interface Config {
     'payload-migrations': PayloadMigration;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   globals: {
     menu: Menu;
@@ -54,7 +54,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: string;
+  id: number;
   text?: string | null;
   serverTextField?: string | null;
   richText?: {
@@ -97,7 +97,7 @@ export interface Post {
  * via the `definition` "simple".
  */
 export interface Simple {
-  id: string;
+  id: number;
   text?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -107,7 +107,7 @@ export interface Simple {
  * via the `definition` "media".
  */
 export interface Media {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -151,7 +151,7 @@ export interface Media {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -168,28 +168,28 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'posts';
-        value: string | Post;
+        value: number | Post;
       } | null)
     | ({
         relationTo: 'simple';
-        value: string | Simple;
+        value: number | Simple;
       } | null)
     | ({
         relationTo: 'media';
-        value: string | Media;
+        value: number | Media;
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -199,10 +199,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -222,7 +222,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -233,7 +233,7 @@ export interface PayloadMigration {
  * via the `definition` "menu".
  */
 export interface Menu {
-  id: string;
+  id: number;
   globalText?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -243,7 +243,7 @@ export interface Menu {
  * via the `definition` "custom-ts".
  */
 export interface CustomT {
-  id: string;
+  id: number;
   custom?: 'hello' | 'world';
   withDefinitionsUsage?: ObjectWithNumber[];
   json: {

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -20,7 +20,7 @@ export interface Config {
     'payload-migrations': PayloadMigration;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {
     menu: Menu;
@@ -54,7 +54,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: number;
+  id: string;
   text?: string | null;
   serverTextField?: string | null;
   richText?: {
@@ -97,7 +97,7 @@ export interface Post {
  * via the `definition` "simple".
  */
 export interface Simple {
-  id: number;
+  id: string;
   text?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -107,7 +107,7 @@ export interface Simple {
  * via the `definition` "media".
  */
 export interface Media {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -151,7 +151,7 @@ export interface Media {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -168,28 +168,28 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'posts';
-        value: number | Post;
+        value: string | Post;
       } | null)
     | ({
         relationTo: 'simple';
-        value: number | Simple;
+        value: string | Simple;
       } | null)
     | ({
         relationTo: 'media';
-        value: number | Media;
+        value: string | Media;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -199,10 +199,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -222,7 +222,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -233,7 +233,7 @@ export interface PayloadMigration {
  * via the `definition` "menu".
  */
 export interface Menu {
-  id: number;
+  id: string;
   globalText?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -243,7 +243,7 @@ export interface Menu {
  * via the `definition` "custom-ts".
  */
 export interface CustomT {
-  id: number;
+  id: string;
   custom?: 'hello' | 'world';
   withDefinitionsUsage?: ObjectWithNumber[];
   json: {

--- a/test/joins/collections/Categories.ts
+++ b/test/joins/collections/Categories.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
 import { categoriesSlug, postsSlug } from '../shared.js'
+import { singularSlug } from './Singular.js'
 
 export const Categories: CollectionConfig = {
   slug: categoriesSlug,
@@ -82,6 +83,12 @@ export const Categories: CollectionConfig = {
           on: 'group.camelCaseCategory',
         },
       ],
+    },
+    {
+      name: 'singulars',
+      type: 'join',
+      collection: singularSlug,
+      on: 'category',
     },
   ],
 }

--- a/test/joins/collections/Singular.ts
+++ b/test/joins/collections/Singular.ts
@@ -1,0 +1,14 @@
+import type { CollectionConfig } from 'payload'
+
+export const singularSlug = 'singular'
+
+export const Singular: CollectionConfig = {
+  slug: singularSlug,
+  fields: [
+    {
+      type: 'relationship',
+      relationTo: 'categories',
+      name: 'category',
+    },
+  ],
+}

--- a/test/joins/config.ts
+++ b/test/joins/config.ts
@@ -5,6 +5,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { Categories } from './collections/Categories.js'
 import { CategoriesVersions } from './collections/CategoriesVersions.js'
 import { Posts } from './collections/Posts.js'
+import { Singular } from './collections/Singular.js'
 import { Uploads } from './collections/Uploads.js'
 import { Versions } from './collections/Versions.js'
 import { seed } from './seed.js'
@@ -20,6 +21,7 @@ export default buildConfigWithDefaults({
     Uploads,
     Versions,
     CategoriesVersions,
+    Singular,
     {
       slug: localizedPostsSlug,
       admin: {

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -5,7 +5,7 @@ import { getFileByPath } from 'payload'
 import { fileURLToPath } from 'url'
 
 import type { NextRESTClient } from '../helpers/NextRESTClient.js'
-import type { Category, Config, Post } from './payload-types.js'
+import type { Category, Config, Post, Singular } from './payload-types.js'
 
 import { devUser } from '../credentials.js'
 import { idToString } from '../helpers/idToString.js'
@@ -603,6 +603,8 @@ describe('Joins Field', () => {
           }
         }
       }`
+
+      expect(true).toBeTruthy()
       const response = await restClient
         .GRAPHQL_POST({ body: JSON.stringify({ query }) })
         .then((res) => res.json())
@@ -626,6 +628,21 @@ describe('Joins Field', () => {
       .then((res) => res.json())
 
     expect(allCategories.totalDocs).toBe(allCategoriesByIds.totalDocs)
+  })
+
+  it('should join with singular collection name', async () => {
+    const {
+      docs: [category],
+    } = await payload.find({ collection: 'categories', limit: 1, depth: 0 })
+
+    const singular = await payload.create({
+      collection: 'singular',
+      data: { category: category.id },
+    })
+
+    const categoryWithJoins = await payload.findByID({ collection: 'categories', id: category.id })
+
+    expect((categoryWithJoins.singulars.docs[0] as Singular).id).toBe(singular.id)
   })
 })
 

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -16,6 +16,7 @@ export interface Config {
     uploads: Upload;
     versions: Version;
     'categories-versions': CategoriesVersion;
+    singular: Singular;
     'localized-posts': LocalizedPost;
     'localized-categories': LocalizedCategory;
     users: User;
@@ -119,6 +120,20 @@ export interface Category {
       hasNextPage?: boolean | null;
     } | null;
   };
+  singulars?: {
+    docs?: (string | Singular)[] | null;
+    hasNextPage?: boolean | null;
+  } | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "singular".
+ */
+export interface Singular {
+  id: string;
+  category?: (string | null) | Category;
   updatedAt: string;
   createdAt: string;
 }
@@ -216,6 +231,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'categories-versions';
         value: string | CategoriesVersion;
+      } | null)
+    | ({
+        relationTo: 'singular';
+        value: string | Singular;
       } | null)
     | ({
         relationTo: 'localized-posts';


### PR DESCRIPTION
### What?
Properly specifies `$lookup.from` when the collection name is singular.

### Why?
MongoDB can pluralize the collection name and so can be different for singular ones.

### How?
Uses the collection name from the driver directly `adapter.collections[slug].collection.name` instead of just `slug`.
