### PR TITLE
feat: add `defaultPopulate` property to collection config

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -77,7 +77,7 @@ The following options are available:
 | **`typescript`**       | An object with property `interface` as the text used in schema generation. Auto-generated from slug if not defined.                                                                                                  |
 | **`upload`**           | Specify options if you would like this Collection to support file uploads. For more, consult the [Uploads](../upload/overview) documentation.                                                                        |
 | **`versions`**         | Set to true to enable default options, or configure with object properties. [More details](../versions/overview#collection-config).                                                                                  |
-| **`defaultPopulate`**  | Specify which fields to select when this Collection is populated from another document. [More Details](../queries/select#defaultselect-collection-config-property).                                                  |
+| **`defaultPopulate`**  | Specify which fields to select when this Collection is populated from another document. [More Details](../queries/select#defaultpopulate-collection-config-property).                                                  |
 
 _\* An asterisk denotes that a property is required._
 

--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -58,7 +58,7 @@ export const Posts: CollectionConfig = {
 The following options are available:
 
 | Option                 | Description                                                                                                                                                                                                          |
-|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`admin`**            | The configuration options for the Admin Panel. [More details](../admin/collections).                                                                                                                                 |
 | **`access`**           | Provide Access Control functions to define exactly who should be able to do what with Documents in this Collection. [More details](../access-control/collections).                                                   |
 | **`auth`**             | Specify options if you would like this Collection to feature authentication. [More details](../authentication/overview).                                                                                             |
@@ -77,6 +77,7 @@ The following options are available:
 | **`typescript`**       | An object with property `interface` as the text used in schema generation. Auto-generated from slug if not defined.                                                                                                  |
 | **`upload`**           | Specify options if you would like this Collection to support file uploads. For more, consult the [Uploads](../upload/overview) documentation.                                                                        |
 | **`versions`**         | Set to true to enable default options, or configure with object properties. [More details](../versions/overview#collection-config).                                                                                  |
+| **`defaultPopulate`**  | Specify which fields to select when this Collection is populated from another document. [More Details](../queries/select#defaultselect-collection-config-property).                                                  |
 
 _\* An asterisk denotes that a property is required._
 

--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -111,7 +111,8 @@ import type { CollectionConfig } from 'payload'
 import { lexicalEditor, LinkFeature } from '@payloadcms/richtext-lexical'
 import { slateEditor } from '@payloadcms/richtext-slate'
 
-// The TSlug generic can be passed to have type safety for `defaultPopulate`. If avoided, the `defaultPopulate` type is `SelectType`.
+// The TSlug generic can be passed to have type safety for `defaultPopulate`.
+// If avoided, the `defaultPopulate` type resolves to `SelectType`.
 export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
   // Specify `select`.

--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -100,9 +100,9 @@ const getPosts = async () => {
 ```
 
 
-## `defaultSelect` collection config property
+## `defaultPopulate` collection config property
 
-The `defaultSelect` property allows you specify which fields to select when populating the collection from another document.
+The `defaultPopulate` property allows you specify which fields to select when populating the collection from another document.
 This is especially useful for links where only the `slug` is needed instead of the entire document.
 
 ```ts

--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -97,3 +97,33 @@ const getPosts = async () => {
   <strong>Reminder:</strong>
   This is the same for [Globals](../configuration/globals) using the `/api/globals` endpoint.
 </Banner>
+```
+
+
+## `defaultSelect` collection config property
+
+The `defaultSelect` property allows you specify which fields to select when populating the collection from another document.
+This is especially useful for links where only the `slug` is needed instead of the entire document.
+
+```ts
+import type { CollectionConfig } from 'payload'
+
+import { lexicalEditor, LinkFeature } from '@payloadcms/richtext-lexical'
+import { slateEditor } from '@payloadcms/richtext-slate'
+
+// The TSlug generic needs to be passed to defaultPopulate type safety.
+export const Pages: CollectionConfig<'pages'> = {
+  slug: 'pages',
+  // Specify `select`.
+  defaultPopulate: {
+    slug: true,
+  },
+  fields: [
+    {
+      name: 'slug',
+      type: 'text',
+      required: true,
+    },
+  ],
+}
+```

--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -111,7 +111,7 @@ import type { CollectionConfig } from 'payload'
 import { lexicalEditor, LinkFeature } from '@payloadcms/richtext-lexical'
 import { slateEditor } from '@payloadcms/richtext-slate'
 
-// The TSlug generic needs to be passed to defaultPopulate type safety.
+// The TSlug generic can be passed to have type safety for `defaultPopulate`. If avoided, the `defaultPopulate` type is `SelectType`.
 export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
   // Specify `select`.

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -1,5 +1,5 @@
 import type { GraphQLInputObjectType, GraphQLNonNull, GraphQLObjectType } from 'graphql'
-import type { DeepRequired, MarkOptional } from 'ts-essentials'
+import type { DeepRequired, IsAny, MarkOptional } from 'ts-essentials'
 
 import type {
   CustomPreviewButton,
@@ -382,6 +382,9 @@ export type CollectionConfig<TSlug extends CollectionSlug = any> = {
    * @WARNING: If you change this property with existing data, you will need to handle the renaming of the table in your database or by using migrations
    */
   dbName?: DBIdentifierName
+  defaultPopulate?: IsAny<SelectFromCollectionSlug<TSlug>> extends true
+    ? SelectType
+    : SelectFromCollectionSlug<TSlug>
   /**
    * Default field to sort by in collection list view
    */

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -2,7 +2,7 @@ import type { BatchLoadFn } from 'dataloader'
 
 import DataLoader from 'dataloader'
 
-import type { PayloadRequest } from '../types/index.js'
+import type { PayloadRequest, SelectType } from '../types/index.js'
 import type { TypeWithID } from './config/types.js'
 
 import { isValidID } from '../utilities/isValidID.js'
@@ -55,6 +55,7 @@ const batchAndLoadDocs =
         overrideAccess,
         showHiddenFields,
         draft,
+        select,
       ] = JSON.parse(key)
 
       const batchKeyArray = [
@@ -67,6 +68,7 @@ const batchAndLoadDocs =
         overrideAccess,
         showHiddenFields,
         draft,
+        select,
       ]
 
       const batchKey = JSON.stringify(batchKeyArray)
@@ -103,6 +105,7 @@ const batchAndLoadDocs =
         overrideAccess,
         showHiddenFields,
         draft,
+        select,
       ] = JSON.parse(batchKey)
 
       req.transactionID = transactionID
@@ -118,6 +121,7 @@ const batchAndLoadDocs =
         overrideAccess: Boolean(overrideAccess),
         pagination: false,
         req,
+        select,
         showHiddenFields: Boolean(showHiddenFields),
         where: {
           id: {
@@ -139,6 +143,7 @@ const batchAndLoadDocs =
           fallbackLocale,
           locale,
           overrideAccess,
+          select,
           showHiddenFields,
           transactionID: req.transactionID,
         })
@@ -167,6 +172,7 @@ type CreateCacheKeyArgs = {
   fallbackLocale: string
   locale: string
   overrideAccess: boolean
+  select?: SelectType
   showHiddenFields: boolean
   transactionID: number | Promise<number | string> | string
 }
@@ -179,6 +185,7 @@ export const createDataloaderCacheKey = ({
   fallbackLocale,
   locale,
   overrideAccess,
+  select,
   showHiddenFields,
   transactionID,
 }: CreateCacheKeyArgs): string =>
@@ -193,4 +200,5 @@ export const createDataloaderCacheKey = ({
     overrideAccess,
     showHiddenFields,
     draft,
+    select,
   ])

--- a/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -69,6 +69,7 @@ const populate = async ({
           fallbackLocale,
           locale,
           overrideAccess,
+          select: relatedCollection.config.defaultPopulate,
           showHiddenFields,
           transactionID: req.transactionID,
         }),

--- a/packages/richtext-lexical/src/features/relationship/server/index.ts
+++ b/packages/richtext-lexical/src/features/relationship/server/index.ts
@@ -90,6 +90,7 @@ export const RelationshipFeature = createServerFeature<
                     key: 'value',
                     overrideAccess,
                     req,
+                    select: collection.config.defaultPopulate,
                     showHiddenFields,
                   }),
                 )

--- a/packages/richtext-lexical/src/features/upload/server/feature.server.ts
+++ b/packages/richtext-lexical/src/features/upload/server/feature.server.ts
@@ -261,6 +261,7 @@ export const UploadFeature = createServerFeature<
                     key: 'value',
                     overrideAccess,
                     req,
+                    select: collection.config.defaultPopulate,
                     showHiddenFields,
                   }),
                 )

--- a/packages/richtext-lexical/src/populateGraphQL/populate.ts
+++ b/packages/richtext-lexical/src/populateGraphQL/populate.ts
@@ -1,4 +1,4 @@
-import type { PayloadRequest } from 'payload'
+import type { PayloadRequest, SelectType } from 'payload'
 
 import { createDataloaderCacheKey } from 'payload'
 
@@ -10,6 +10,7 @@ type Arguments = {
   key: number | string
   overrideAccess: boolean
   req: PayloadRequest
+  select?: SelectType
   showHiddenFields: boolean
 }
 
@@ -23,6 +24,7 @@ export const populate = async ({
   key,
   overrideAccess,
   req,
+  select,
   showHiddenFields,
 }: {
   collectionSlug: string
@@ -46,6 +48,7 @@ export const populate = async ({
       fallbackLocale: req.fallbackLocale!,
       locale: req.locale!,
       overrideAccess,
+      select,
       showHiddenFields,
       transactionID: req.transactionID!,
     }),

--- a/packages/richtext-slate/src/data/populate.ts
+++ b/packages/richtext-slate/src/data/populate.ts
@@ -1,4 +1,4 @@
-import type { Collection, Field, PayloadRequest, RichTextField } from 'payload'
+import type { Collection, Field, PayloadRequest, RichTextField, SelectType } from 'payload'
 
 import { createDataloaderCacheKey } from 'payload'
 
@@ -13,6 +13,7 @@ type Arguments = {
   key: number | string
   overrideAccess?: boolean
   req: PayloadRequest
+  select?: SelectType
   showHiddenFields: boolean
 }
 
@@ -26,6 +27,7 @@ export const populate = async ({
   key,
   overrideAccess,
   req,
+  select,
   showHiddenFields,
 }: {
   collection: Collection
@@ -44,6 +46,7 @@ export const populate = async ({
       fallbackLocale: req.locale,
       locale: req.fallbackLocale,
       overrideAccess: typeof overrideAccess === 'undefined' ? false : overrideAccess,
+      select,
       showHiddenFields,
       transactionID: req.transactionID,
     }),

--- a/packages/richtext-slate/src/data/recurseNestedFields.ts
+++ b/packages/richtext-slate/src/data/recurseNestedFields.ts
@@ -48,6 +48,7 @@ export const recurseNestedFields = ({
                     key: i,
                     overrideAccess,
                     req,
+                    select: collection.config.defaultPopulate,
                     showHiddenFields,
                   }),
                 )
@@ -69,6 +70,7 @@ export const recurseNestedFields = ({
                     key: i,
                     overrideAccess,
                     req,
+                    select: collection.config.defaultPopulate,
                     showHiddenFields,
                   }),
                 )
@@ -94,6 +96,7 @@ export const recurseNestedFields = ({
                 key: 'value',
                 overrideAccess,
                 req,
+                select: collection.config.defaultPopulate,
                 showHiddenFields,
               }),
             )
@@ -114,6 +117,7 @@ export const recurseNestedFields = ({
             key: field.name,
             overrideAccess,
             req,
+            select: collection.config.defaultPopulate,
             showHiddenFields,
           }),
         )

--- a/packages/richtext-slate/src/data/richTextRelationshipPromise.ts
+++ b/packages/richtext-slate/src/data/richTextRelationshipPromise.ts
@@ -54,6 +54,7 @@ export const recurseRichText = ({
               key: 'value',
               overrideAccess,
               req,
+              select: collection.config.defaultPopulate,
               showHiddenFields,
             }),
           )
@@ -93,6 +94,7 @@ export const recurseRichText = ({
                 key: 'value',
                 overrideAccess,
                 req,
+                select: collection.config.defaultPopulate,
                 showHiddenFields,
               }),
             )

--- a/test/select/collections/Pages/index.ts
+++ b/test/select/collections/Pages/index.ts
@@ -1,0 +1,83 @@
+import type { CollectionConfig } from 'payload'
+
+import { lexicalEditor, LinkFeature } from '@payloadcms/richtext-lexical'
+import { slateEditor } from '@payloadcms/richtext-slate'
+
+// the TSlug generic needs to be passed to defaultPopulate type safety.
+export const Pages: CollectionConfig<'pages'> = {
+  slug: 'pages',
+  // I need only slug, NOT the WHOLE CONTENT!
+  defaultPopulate: {
+    slug: true,
+  },
+  fields: [
+    {
+      name: 'content',
+      type: 'blocks',
+      blocks: [
+        {
+          slug: 'cta',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+              required: true,
+            },
+            {
+              name: 'link',
+              type: 'group',
+              fields: [
+                {
+                  name: 'docPoly',
+                  type: 'relationship',
+                  relationTo: ['pages'],
+                },
+                {
+                  name: 'doc',
+                  type: 'relationship',
+                  relationTo: 'pages',
+                },
+                {
+                  name: 'docMany',
+                  hasMany: true,
+                  type: 'relationship',
+                  relationTo: 'pages',
+                },
+                {
+                  name: 'docHasManyPoly',
+                  type: 'relationship',
+                  relationTo: ['pages'],
+                  hasMany: true,
+                },
+                {
+                  name: 'label',
+                  type: 'text',
+                  required: true,
+                },
+              ],
+            },
+            {
+              name: 'richTextLexical',
+              type: 'richText',
+              editor: lexicalEditor({
+                features({ defaultFeatures }) {
+                  return [...defaultFeatures, LinkFeature({ enabledCollections: ['pages'] })]
+                },
+              }),
+            },
+            {
+              name: 'richTextSlate',
+              type: 'richText',
+              editor: slateEditor({}),
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      required: true,
+    },
+  ],
+}

--- a/test/select/collections/Pages/index.ts
+++ b/test/select/collections/Pages/index.ts
@@ -3,7 +3,8 @@ import type { CollectionConfig } from 'payload'
 import { lexicalEditor, LinkFeature } from '@payloadcms/richtext-lexical'
 import { slateEditor } from '@payloadcms/richtext-slate'
 
-// The TSlug generic can be passed to have type safety for `defaultPopulate`. If avoided, the `defaultPopulate` type is `SelectType`.
+// The TSlug generic can be passed to have type safety for `defaultPopulate`.
+// If avoided, the `defaultPopulate` type resolves to `SelectType`.
 export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
   // I need only slug, NOT the WHOLE CONTENT!

--- a/test/select/collections/Pages/index.ts
+++ b/test/select/collections/Pages/index.ts
@@ -3,7 +3,7 @@ import type { CollectionConfig } from 'payload'
 import { lexicalEditor, LinkFeature } from '@payloadcms/richtext-lexical'
 import { slateEditor } from '@payloadcms/richtext-slate'
 
-// the TSlug generic needs to be passed to defaultPopulate type safety.
+// The TSlug generic can be passed to have type safety for `defaultPopulate`. If avoided, the `defaultPopulate` type is `SelectType`.
 export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
   // I need only slug, NOT the WHOLE CONTENT!

--- a/test/select/config.ts
+++ b/test/select/config.ts
@@ -6,6 +6,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { DeepPostsCollection } from './collections/DeepPosts/index.js'
 import { LocalizedPostsCollection } from './collections/LocalizedPosts/index.js'
+import { Pages } from './collections/Pages/index.js'
 import { PostsCollection } from './collections/Posts/index.js'
 import { VersionedPostsCollection } from './collections/VersionedPosts/index.js'
 
@@ -19,6 +20,7 @@ export default buildConfigWithDefaults({
     LocalizedPostsCollection,
     VersionedPostsCollection,
     DeepPostsCollection,
+    Pages,
   ],
   globals: [
     {

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -1662,7 +1662,7 @@ describe('Select', () => {
       expect(richTextSlateRel.value).toStrictEqual(expectedHomePage)
     })
 
-    it('rEST API - should populate with the defaultPopulate select shape', async () => {
+    it('REST API - should populate with the defaultPopulate select shape', async () => {
       const restResult = await (
         await restClient.GET(`/pages/${aboutPage.id}`, { query: { depth: 1 } })
       ).json()

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -1661,6 +1661,41 @@ describe('Select', () => {
       expect(richTextLexicalRel.value).toStrictEqual(expectedHomePage)
       expect(richTextSlateRel.value).toStrictEqual(expectedHomePage)
     })
+
+    it('rEST API - should populate with the defaultPopulate select shape', async () => {
+      const restResult = await (
+        await restClient.GET(`/pages/${aboutPage.id}`, { query: { depth: 1 } })
+      ).json()
+
+      const {
+        content: [
+          {
+            link: { doc, docHasManyPoly, docMany, docPoly },
+            richTextSlate: [richTextSlateRel],
+            richTextLexical: {
+              root: {
+                children: [richTextLexicalRel],
+              },
+            },
+          },
+        ],
+      } = restResult
+
+      expect(doc).toMatchObject(expectedHomePage)
+      expect(docMany).toMatchObject([expectedHomePage])
+      expect(docPoly).toMatchObject({
+        relationTo: 'pages',
+        value: expectedHomePage,
+      })
+      expect(docHasManyPoly).toMatchObject([
+        {
+          relationTo: 'pages',
+          value: expectedHomePage,
+        },
+      ])
+      expect(richTextLexicalRel.value).toMatchObject(expectedHomePage)
+      expect(richTextSlateRel.value).toMatchObject(expectedHomePage)
+    })
   })
 })
 

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -8,6 +8,7 @@ import type {
   DeepPost,
   GlobalPost,
   LocalizedPost,
+  Page,
   Post,
   VersionedPost,
 } from './payload-types.js'
@@ -1559,6 +1560,106 @@ describe('Select', () => {
 
         expect(res).toMatchObject(expected)
       })
+    })
+  })
+
+  describe('defaultPopulate', () => {
+    let homePage: Page
+    let aboutPage: Page
+    let expectedHomePage: { id: number | string; slug: string }
+    beforeAll(async () => {
+      homePage = await payload.create({
+        depth: 0,
+        collection: 'pages',
+        data: { content: [], slug: 'home' },
+      })
+      expectedHomePage = { id: homePage.id, slug: homePage.slug }
+      aboutPage = await payload.create({
+        depth: 0,
+        collection: 'pages',
+        data: {
+          content: [
+            {
+              blockType: 'cta',
+              richTextSlate: [
+                {
+                  type: 'relationship',
+                  relationTo: 'pages',
+                  value: { id: homePage.id },
+                },
+              ],
+              richTextLexical: {
+                root: {
+                  children: [
+                    {
+                      format: '',
+                      type: 'relationship',
+                      version: 2,
+                      relationTo: 'pages',
+                      value: homePage.id,
+                    },
+                  ],
+                  direction: 'ltr',
+                  format: '',
+                  indent: 0,
+                  type: 'root',
+                  version: 1,
+                },
+              },
+              link: {
+                doc: homePage.id,
+                docHasManyPoly: [
+                  {
+                    relationTo: 'pages',
+                    value: homePage.id,
+                  },
+                ],
+                docMany: [homePage.id],
+                docPoly: {
+                  relationTo: 'pages',
+                  value: homePage.id,
+                },
+                label: 'Visit our Home Page!',
+              },
+              title: 'Contact Us',
+            },
+          ],
+          slug: 'about',
+        },
+      })
+    })
+
+    it('local API - should populate with the defaultPopulate select shape', async () => {
+      const result = await payload.findByID({ collection: 'pages', depth: 1, id: aboutPage.id })
+
+      const {
+        content: [
+          {
+            link: { doc, docHasManyPoly, docMany, docPoly },
+            richTextSlate: [richTextSlateRel],
+            richTextLexical: {
+              root: {
+                children: [richTextLexicalRel],
+              },
+            },
+          },
+        ],
+      } = result
+
+      expect(doc).toStrictEqual(expectedHomePage)
+      expect(docMany).toStrictEqual([expectedHomePage])
+      expect(docPoly).toStrictEqual({
+        relationTo: 'pages',
+        value: expectedHomePage,
+      })
+      expect(docHasManyPoly).toStrictEqual([
+        {
+          relationTo: 'pages',
+          value: expectedHomePage,
+        },
+      ])
+      expect(richTextLexicalRel.value).toStrictEqual(expectedHomePage)
+      expect(richTextSlateRel.value).toStrictEqual(expectedHomePage)
     })
   })
 })

--- a/test/select/payload-types.ts
+++ b/test/select/payload-types.ts
@@ -15,6 +15,7 @@ export interface Config {
     'localized-posts': LocalizedPost;
     'versioned-posts': VersionedPost;
     'deep-posts': DeepPost;
+    pages: Page;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -25,6 +26,7 @@ export interface Config {
     'localized-posts': LocalizedPostsSelect<false> | LocalizedPostsSelect<true>;
     'versioned-posts': VersionedPostsSelect<false> | VersionedPostsSelect<true>;
     'deep-posts': DeepPostsSelect<false> | DeepPostsSelect<true>;
+    pages: PagesSelect<false> | PagesSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -241,6 +243,59 @@ export interface DeepPost {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pages".
+ */
+export interface Page {
+  id: string;
+  content?:
+    | {
+        title: string;
+        link: {
+          docPoly?: {
+            relationTo: 'pages';
+            value: string | Page;
+          } | null;
+          doc?: (string | null) | Page;
+          docMany?: (string | Page)[] | null;
+          docHasManyPoly?:
+            | {
+                relationTo: 'pages';
+                value: string | Page;
+              }[]
+            | null;
+          label: string;
+        };
+        richTextLexical?: {
+          root: {
+            type: string;
+            children: {
+              type: string;
+              version: number;
+              [k: string]: unknown;
+            }[];
+            direction: ('ltr' | 'rtl') | null;
+            format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+            indent: number;
+            version: number;
+          };
+          [k: string]: unknown;
+        } | null;
+        richTextSlate?:
+          | {
+              [k: string]: unknown;
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'cta';
+      }[]
+    | null;
+  slug: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -278,6 +333,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'deep-posts';
         value: string | DeepPost;
+      } | null)
+    | ({
+        relationTo: 'pages';
+        value: string | Page;
       } | null)
     | ({
         relationTo: 'users';
@@ -517,6 +576,37 @@ export interface DeepPostsSelect<T extends boolean = true> {
             };
         id?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pages_select".
+ */
+export interface PagesSelect<T extends boolean = true> {
+  content?:
+    | T
+    | {
+        cta?:
+          | T
+          | {
+              title?: T;
+              link?:
+                | T
+                | {
+                    docPoly?: T;
+                    doc?: T;
+                    docMany?: T;
+                    docHasManyPoly?: T;
+                    label?: T;
+                  };
+              richTextLexical?: T;
+              richTextSlate?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  slug?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
### What?
Adds `defaultPopulate` property to collection config that allows to specify which fields to select when the collection is populated from another document.
```ts
import type { CollectionConfig } from 'payload'

// The TSlug generic can be passed to have type safety for `defaultPopulate`.
// If avoided, the `defaultPopulate` type resolves to `SelectType`.
export const Pages: CollectionConfig<'pages'> = {
  slug: 'pages',
  // I need only slug, NOT the WHOLE CONTENT!
  defaultPopulate: {
    slug: true,
  },
  fields: [
    {
      name: 'slug',
      type: 'text',
      required: true,
    },
  ],
}
```

### Why?
This is essential for example in case of links. You don't need the whole document, which can contain large data but only the `slug`.

### How?
Implements `defaultPopulate` when populating relationships, including inside of lexical / slate rich text fields. 
