### PR TITLE
fix: plugin-search with localization enabled

### DIFF
--- a/docs/plugins/search.mdx
+++ b/docs/plugins/search.mdx
@@ -81,6 +81,10 @@ export default config
 
 The `collections` property is an array of collection slugs to enable syncing to search. Enabled collections receive a `beforeChange` and `afterDelete` hook that creates, updates, and deletes its respective search record as it changes over time.
 
+### `localize`
+
+By default, the search plugin will add `localization: true` to the `title` field of the newly added `search` collection if you have localization enabled. If you would like to disable this behavior, you can set this to `false`.
+
 #### `defaultPriorities`
 
 This plugin automatically adds a `priority` field to the `search` collection that can be used as the `?sort=` parameter in your queries. For example, you may want to list blog posts before pages. Or you may want one specific post to always take appear first.

--- a/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/syncWithSearch.ts
@@ -30,7 +30,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
       docToSyncWith = await payload.findByID({
         id,
         collection,
-        locale: 'all',
+        locale: req.locale,
         req,
       })
     }
@@ -71,6 +71,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
             ...dataToSave,
             priority: defaultPriority,
           },
+          locale: req.locale,
           req,
         })
       }
@@ -82,6 +83,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
         const searchDocQuery = await payload.find({
           collection: searchSlug,
           depth: 0,
+          locale: req.locale,
           req,
           where: {
             'doc.relationTo': {
@@ -128,6 +130,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
                   ...dataToSave,
                   priority: foundDoc.priority || defaultPriority,
                 },
+                locale: req.locale,
                 req,
               })
             } catch (err: unknown) {
@@ -154,6 +157,7 @@ export const syncWithSearch: SyncWithSearch = async (args) => {
                 ...dataToSave,
                 priority: defaultPriority,
               },
+              locale: req.locale,
               req,
             })
           } catch (err: unknown) {

--- a/packages/plugin-search/src/Search/index.ts
+++ b/packages/plugin-search/src/Search/index.ts
@@ -11,6 +11,7 @@ export const generateSearchCollection = (pluginConfig: SearchPluginConfig): Coll
       admin: {
         readOnly: true,
       },
+      localized: pluginConfig.localize,
     },
     {
       name: 'priority',

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -14,6 +14,14 @@ export const searchPlugin =
   (config: Config): Config => {
     const { collections } = config
 
+    // If the user defines `localize` to either true or false, use that
+    // Otherwise, set it based on if their config has localization enabled or disabled
+    const shouldLocalize =
+      typeof incomingPluginConfig.localize === 'boolean'
+        ? incomingPluginConfig.localize
+        : Boolean(config.localization)
+    incomingPluginConfig.localize = shouldLocalize
+
     if (collections) {
       const pluginConfig: SearchPluginConfig = {
         // write any config defaults here

--- a/packages/plugin-search/src/types.ts
+++ b/packages/plugin-search/src/types.ts
@@ -34,6 +34,7 @@ export type SearchPluginConfig = {
     [collection: string]: ((doc: any) => number | Promise<number>) | number
   }
   deleteDrafts?: boolean
+  localize?: boolean
   searchOverrides?: { fields?: FieldsOverride } & Partial<Omit<CollectionConfig, 'fields'>>
   syncDrafts?: boolean
 }

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -193,7 +193,7 @@ describe('@payloadcms/plugin-search', () => {
     const createdDoc = await payload.create({
       collection: 'posts',
       data: {
-        _status: 'draft',
+        _status: 'published',
         title: 'test title',
         slug: 'es',
       },


### PR DESCRIPTION
The search plugin was incorrectly retrieving all locales, when it should just be retrieving the locale of the parent document that was actively being updated.