### PR TITLE
docs: fix `defaultPopulate` docs formatting

### DIFF
--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -98,7 +98,6 @@ const getPosts = async () => {
   <strong>Reminder:</strong>
   This is the same for [Globals](../configuration/globals) using the `/api/globals` endpoint.
 </Banner>
-```
 
 
 ## `defaultPopulate` collection config property


### PR DESCRIPTION
### What?
Fixes this [here](https://payloadcms.com/docs/beta/queries/select#rest-api)
<img width="535" alt="image" src="https://github.com/user-attachments/assets/a9fec4a7-c1c2-43f3-ba36-a07505deb012">