### PR TITLE
fix: return type of `findByID` with `strict: true`

### DIFF
--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -163,9 +163,9 @@ export type SelectMode = 'exclude' | 'include'
 
 export type SelectType = SelectExcludeType | SelectIncludeType
 
-export type ApplyDisableErrors<T, DisableErrors extends boolean> = DisableErrors extends true
-  ? null | T
-  : T
+export type ApplyDisableErrors<T, DisableErrors = false> = false extends DisableErrors
+  ? T
+  : null | T
 
 export type TransformDataWithSelect<
   Data extends Record<string, any>,


### PR DESCRIPTION
### What?
Corrects the return type of `findByID` when `strict: true` / `strictNullChecks: true` is used, adds `null` to the return type _only_ when `disableErrors: true` is passed. 




![image](https://github.com/user-attachments/assets/fb59312c-6a79-457c-8d27-d2a91473bcb3)
![image](https://github.com/user-attachments/assets/2116acbf-730c-4ae6-b662-f83a40c5d9f2)
