### PR TITLE
docs: add idType to sqlite args

### DIFF
--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -39,6 +39,7 @@ export default buildConfig({
 | `client` \*           | [Client connection options](https://orm.drizzle.team/docs/get-started-sqlite#turso) that will be passed to `createClient` from `@libsql/client`.                                 |
 | `push`                | Disable Drizzle's [`db push`](https://orm.drizzle.team/kit-docs/overview#prototyping-with-db-push) in development mode. By default, `push` is enabled for development mode only. |
 | `migrationDir`        | Customize the directory that migrations are stored.                                                                                                                              |
+| `idType`              | A string of 'serial', or 'uuid' that is used for the data type given to id columns.                                                                                              |
 | `logger`              | The instance of the logger to be passed to drizzle. By default Payload's will be used.                                                                                           |
 | `transactionOptions`  | A SQLiteTransactionConfig object for transactions, or set to `false` to disable using transactions. [More details](https://orm.drizzle.team/docs/transactions)                   |
 | `localesSuffix`       | A string appended to the end of table names for storing localized fields. Default is '_locales'.                                                                                 |
@@ -157,7 +158,7 @@ sqliteAdapter({
 })
 ```
 
-Make sure Payload doesn't overlap table names with its collections. For example, if you already have a collection with slug "users", you should either change the slug or `dbName` to change the table name for this collection. 
+Make sure Payload doesn't overlap table names with its collections. For example, if you already have a collection with slug "users", you should either change the slug or `dbName` to change the table name for this collection.
 
 
 ### afterSchemaInit

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -57,8 +57,8 @@ export type { MigrateDownArgs, MigrateUpArgs } from './types.js'
 export { sql } from 'drizzle-orm'
 
 export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
-  const postgresIDType = args.idType || 'serial'
-  const payloadIDType = postgresIDType === 'serial' ? 'number' : 'text'
+  const sqliteIDType = args.idType || 'serial'
+  const payloadIDType = sqliteIDType === 'serial' ? 'number' : 'text'
 
   function adapter({ payload }: { payload: Payload }) {
     const migrationDir = findMigrationDir(args.migrationDir)
@@ -90,7 +90,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       },
       fieldConstraints: {},
       getMigrationTemplate,
-      idType: postgresIDType,
+      idType: sqliteIDType,
       initializing,
       localesSuffix: args.localesSuffix || '_locales',
       logger: args.logger,


### PR DESCRIPTION
Resolves #8848.

`idType` is missing from the sqlite documentation, which can cause confusion when users want to use strings for the `id` column. This change moves it in parity with the postgres documentation.

It might be worth exploring how to make this documentation more explicit; `serial` and `uuid` don't immediately convey `string` or `number` formatting.