### PR TITLE
fix(next): respond with bad request when PATCH request has no body

### DIFF
--- a/packages/next/src/routes/rest/collections/updateByID.ts
+++ b/packages/next/src/routes/rest/collections/updateByID.ts
@@ -20,6 +20,11 @@ export const updateByID: CollectionRouteHandlerWithID = async ({
   const overrideLock = searchParams.get('overrideLock')
   const publishSpecificLocale = req.query.publishSpecificLocale as string | undefined
 
+  // NOTE: REST request body can be undefined when the request is aborted
+  if (!req.data && !req.file) {
+    return Response.json({ message: 'missing request body' }, { status: httpStatus.BAD_REQUEST })
+  }
+
   const id = sanitizeCollectionID({
     id: incomingID,
     collectionSlug: collection.config.slug,


### PR DESCRIPTION
### What?
When autosave is turned on, the PATCH request for a given collection can be aborted:
<img width="605" alt="image" src="https://github.com/user-attachments/assets/444f2c7c-e91d-41cc-a533-9727b54d96e5">
Server error:
<img width="1723" alt="image" src="https://github.com/user-attachments/assets/2280d221-304b-4803-9780-88abd4748860">


### Why?
When this happens, the request is not fully sent. Without this change, the whole update by id operation is initiated and throws an error down the line in the beforeValidate hook. After this change, the update by id operation is not initiated and no errors are thrown.

### How?
There is a simple check added if the request contains data or not. If not, a response with bad request status is returned.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
