### PR TITLE
fix(db-mongodb): `select` with unnamed tabs

### DIFF
--- a/packages/db-mongodb/src/utilities/buildProjectionFromSelect.ts
+++ b/packages/db-mongodb/src/utilities/buildProjectionFromSelect.ts
@@ -6,7 +6,7 @@ import {
   type SelectType,
   type TabAsField,
 } from 'payload'
-import { fieldAffectsData, getSelectMode } from 'payload/shared'
+import { fieldAffectsData, getSelectMode, tabHasName } from 'payload/shared'
 
 import type { MongooseAdapter } from '../index.js'
 
@@ -131,9 +131,17 @@ const traverseFields = ({
 
       case 'group':
       case 'tab':
-      case 'array':
+      case 'array': {
+        let fieldSelect: SelectType
+
+        if (field.type === 'tab' && !tabHasName(field)) {
+          fieldSelect = select
+        } else {
+          fieldSelect = select[field.name] as SelectType
+        }
+
         if (field.type === 'array' && selectMode === 'include') {
-          select[field.name]['id'] = true
+          fieldSelect['id'] = true
         }
 
         traverseFields({
@@ -141,12 +149,13 @@ const traverseFields = ({
           databaseSchemaPath: fieldDatabaseSchemaPath,
           fields: field.fields,
           projection,
-          select: select[field.name] as SelectType,
+          select: fieldSelect,
           selectMode,
           withinLocalizedField: fieldWithinLocalizedField,
         })
 
         break
+      }
 
       case 'blocks': {
         const blocksSelect = select[field.name] as SelectType

--- a/test/select/collections/Posts/index.ts
+++ b/test/select/collections/Posts/index.ts
@@ -74,5 +74,36 @@ export const PostsCollection: CollectionConfig = {
         },
       ],
     },
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          name: 'tab',
+          fields: [
+            {
+              type: 'text',
+              name: 'text',
+            },
+            {
+              type: 'number',
+              name: 'number',
+            },
+          ],
+        },
+        {
+          label: 'Tab Unnamed',
+          fields: [
+            {
+              type: 'text',
+              name: 'unnamedTabText',
+            },
+            {
+              type: 'number',
+              name: 'unnamedTabNumber',
+            },
+          ],
+        },
+      ],
+    },
   ],
 }

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -129,6 +129,55 @@ describe('Select', () => {
         })
       })
 
+      it('should select all the fields inside of named tab', async () => {
+        const res = await payload.findByID({
+          collection: 'posts',
+          id: postId,
+          select: {
+            tab: true,
+          },
+        })
+
+        expect(res).toStrictEqual({
+          id: postId,
+          tab: post.tab,
+        })
+      })
+
+      it('should select text field inside of named tab', async () => {
+        const res = await payload.findByID({
+          collection: 'posts',
+          id: postId,
+          select: {
+            tab: {
+              text: true,
+            },
+          },
+        })
+
+        expect(res).toStrictEqual({
+          id: postId,
+          tab: {
+            text: post.tab.text,
+          },
+        })
+      })
+
+      it('should select text field inside of unnamed tab', async () => {
+        const res = await payload.findByID({
+          collection: 'posts',
+          id: postId,
+          select: {
+            unnamedTabText: true,
+          },
+        })
+
+        expect(res).toStrictEqual({
+          id: postId,
+          unnamedTabText: post.unnamedTabText,
+        })
+      })
+
       it('should select id as default from array', async () => {
         const res = await payload.findByID({
           collection: 'posts',
@@ -1662,7 +1711,7 @@ describe('Select', () => {
       expect(richTextSlateRel.value).toStrictEqual(expectedHomePage)
     })
 
-    it('REST API - should populate with the defaultPopulate select shape', async () => {
+    it('rEST API - should populate with the defaultPopulate select shape', async () => {
       const restResult = await (
         await restClient.GET(`/pages/${aboutPage.id}`, { query: { depth: 1 } })
       ).json()
@@ -1728,6 +1777,12 @@ function createPost() {
           number: 1,
         },
       ],
+      tab: {
+        text: 'text',
+        number: 1,
+      },
+      unnamedTabNumber: 2,
+      unnamedTabText: 'text2',
     },
   })
 }

--- a/test/select/payload-types.ts
+++ b/test/select/payload-types.ts
@@ -45,6 +45,10 @@ export interface Config {
   user: User & {
     collection: 'users';
   };
+jobs?: {
+    tasks: unknown;
+    workflows?: unknown;
+  };
 }
 export interface UserAuthOperations {
   forgotPassword: {
@@ -101,6 +105,12 @@ export interface Post {
           }
       )[]
     | null;
+  tab?: {
+    text?: string | null;
+    number?: number | null;
+  };
+  unnamedTabText?: string | null;
+  unnamedTabNumber?: number | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -424,6 +434,14 @@ export interface PostsSelect<T extends boolean = true> {
               blockName?: T;
             };
       };
+  tab?:
+    | T
+    | {
+        text?: T;
+        number?: T;
+      };
+  unnamedTabText?: T;
+  unnamedTabNumber?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
### What?
Fixes `select` handling for properties inside of unnamed tabs using the mongodb adapter.
Additionally, refactors `traverseFields` in drizzle to reuse logic from groups / collapsible or rows if unnamed. 

### Why?
`select` must work for any fields.

### How?
Fixes the `'tab'` case in `buildProjectionFromSelect` to handle when the field is an unnamed tab.
Adds extra tests for named tabs / unnamed.

