### PR TITLE
docs: include hasMany in upload field config options

### DIFF
--- a/docs/fields/upload.mdx
+++ b/docs/fields/upload.mdx
@@ -48,6 +48,9 @@ export const MyUploadField: Field = {
 | **`name`** \*          | To be used as the property name when stored and retrieved from the database. [More](/docs/fields/overview#field-names)                                                      |
 | **`relationTo`** \*    | Provide a single collection `slug` to allow this field to accept a relation to. <strong>Note: the related collection must be configured to support Uploads.</strong>        |
 | **`filterOptions`**    | A query to filter which options appear in the UI and validate against. [More](#filtering-upload-options).                                                                   |
+| **`hasMany`**          | Boolean which, if set to true, allows this field to have many relations instead of only one.                                                                                |
+| **`minRows`**          | A number for the fewest allowed items during validation when a value is present. Used with hasMany.                                                                         |
+| **`maxRows`**          | A number for the most allowed items during validation when a value is present. Used with hasMany.                                                                           |
 | **`maxDepth`**         | Sets a number limit on iterations of related documents to populate when queried. [Depth](../queries/depth)                                                                  |
 | **`label`**            | Text used as a field label in the Admin Panel or an object with keys for each language.                                                                                     |
 | **`unique`**           | Enforce that each entry in the Collection has a unique value for this field.                                                                                                |


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
Includes `hasMany`, `minRows`, and `maxRows` in Upload field config options table.

### Why?
To be inline with the type definitions.

### How?
Changes to `docs/fields/upload.mdx`