### PR TITLE
fix: `latest: true` version disappear on parallel writes

### DIFF
--- a/packages/db-mongodb/src/createVersion.ts
+++ b/packages/db-mongodb/src/createVersion.ts
@@ -81,7 +81,7 @@ export const createVersion: CreateVersion = async function createVersion(
         },
         {
           createdAt: {
-            $lt: new Date(doc.createdAt),
+            $lte: new Date(doc.createdAt),
           },
         },
       ],

--- a/packages/db-mongodb/src/createVersion.ts
+++ b/packages/db-mongodb/src/createVersion.ts
@@ -79,6 +79,11 @@ export const createVersion: CreateVersion = async function createVersion(
             $eq: true,
           },
         },
+        {
+          createdAt: {
+            $lt: new Date(doc.createdAt),
+          },
+        },
       ],
     },
     { $unset: { latest: 1 } },

--- a/packages/drizzle/src/createVersion.ts
+++ b/packages/drizzle/src/createVersion.ts
@@ -66,6 +66,7 @@ export async function createVersion<T extends TypeWithID>(
         SET latest = false
         WHERE ${table.id} != ${result.id}
           AND ${table.parent} = ${parent}
+          AND ${table.createdAt} < ${result.createdAt}
       `,
     })
   }

--- a/packages/drizzle/src/createVersion.ts
+++ b/packages/drizzle/src/createVersion.ts
@@ -66,7 +66,7 @@ export async function createVersion<T extends TypeWithID>(
         SET latest = false
         WHERE ${table.id} != ${result.id}
           AND ${table.parent} = ${parent}
-          AND ${table.createdAt} < ${result.createdAt}
+          AND ${table.createdAt} <= ${result.createdAt}
       `,
     })
   }


### PR DESCRIPTION
### What?
Fixes issue when on parallel writes in result you can have 0 `latest: true` versions.

### Why?
There must be always a version with `latest: true`

### How?
Ensures that we always have a version with `latest: true` by adding a filter on `createdAt < createdVersion.createdAt`. 
Instead, this _ponentially_ can lead to a situation where we have 2 versions with `latest: true`, if they were created at _the exact same time_, but this shouldn't happen in a real world scenario and it's much less problematic than not having a version with `latest: true`. 

Fixes https://github.com/payloadcms/payload/issues/5895
