### PR TITLE
fix: graphql missing options route resulting in failed cors preflight checks in production

### DIFF
--- a/app/(payload)/api/graphql/route.ts
+++ b/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/examples/auth/payload/src/app/(payload)/api/graphql/route.ts
+++ b/examples/auth/payload/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/examples/custom-components/src/app/(payload)/api/graphql/route.ts
+++ b/examples/custom-components/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/examples/form-builder/payload/src/app/(payload)/api/graphql/route.ts
+++ b/examples/form-builder/payload/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/examples/hierarchy/src/app/(payload)/api/graphql/route.ts
+++ b/examples/hierarchy/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/examples/live-preview/payload/src/app/(payload)/api/graphql/route.ts
+++ b/examples/live-preview/payload/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/examples/multi-tenant/src/app/(payload)/api/graphql/route.ts
+++ b/examples/multi-tenant/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/examples/tailwind-shadcn-ui/src/app/(payload)/api/graphql/route.ts
+++ b/examples/tailwind-shadcn-ui/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/examples/virtual-fields/src/app/(payload)/api/graphql/route.ts
+++ b/examples/virtual-fields/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/examples/whitelabel/src/app/(payload)/api/graphql/route.ts
+++ b/examples/whitelabel/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/templates/_template/src/app/(payload)/api/graphql/route.ts
+++ b/templates/_template/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/templates/blank/src/app/(payload)/api/graphql/route.ts
+++ b/templates/blank/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/templates/vercel-postgres/src/app/(payload)/api/graphql/route.ts
+++ b/templates/vercel-postgres/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/templates/website/src/app/(payload)/api/graphql/route.ts
+++ b/templates/website/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/templates/with-payload-cloud/src/app/(payload)/api/graphql/route.ts
+++ b/templates/with-payload-cloud/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/templates/with-postgres/src/app/(payload)/api/graphql/route.ts
+++ b/templates/with-postgres/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/templates/with-vercel-mongodb/src/app/(payload)/api/graphql/route.ts
+++ b/templates/with-vercel-mongodb/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/templates/with-vercel-postgres/src/app/(payload)/api/graphql/route.ts
+++ b/templates/with-vercel-postgres/src/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/test/admin-root/app/(payload)/api/graphql/route.ts
+++ b/test/admin-root/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/test/app/(payload)/api/graphql/route.ts
+++ b/test/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)

--- a/test/live-preview/app/(payload)/api/graphql/route.ts
+++ b/test/live-preview/app/(payload)/api/graphql/route.ts
@@ -1,6 +1,8 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 import config from '@payload-config'
-import { GRAPHQL_POST } from '@payloadcms/next/routes/index.js'
+import { GRAPHQL_POST, REST_OPTIONS } from '@payloadcms/next/routes'
 
 export const POST = GRAPHQL_POST(config)
+
+export const OPTIONS = REST_OPTIONS(config)


### PR DESCRIPTION
GraphQL currently doesn't pass CORS checks as we don't expose an OPTIONS endpoint which is used for browser preflights.

Should also fix situations like this https://github.com/payloadcms/payload/issues/8974