### PR TITLE
fix: invalid `select` type with `strictNullChecks: true`

### DIFF
--- a/packages/payload/src/utilities/addSelectGenericsToGeneratedTyoes.spec.ts
+++ b/packages/payload/src/utilities/addSelectGenericsToGeneratedTyoes.spec.ts
@@ -22,7 +22,7 @@ export interface Config {
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
-  collectionsSelect?: {
+  collectionsSelect: {
     posts: PostsSelect;
     users: UsersSelect;
     'payload-locked-documents': PayloadLockedDocumentsSelect;
@@ -33,7 +33,7 @@ export interface Config {
     defaultIDType: string;
   };
   globals: {};
-  globalsSelect?: {};
+  globalsSelect: {};
   locale: null;
   user: User & {
     collection: 'users';
@@ -295,7 +295,7 @@ export interface Config {
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
-  collectionsSelect?: {
+  collectionsSelect: {
     posts: PostsSelect<false> | PostsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -306,7 +306,7 @@ export interface Config {
     defaultIDType: string;
   };
   globals: {};
-  globalsSelect?: {};
+  globalsSelect: {};
   locale: null;
   user: User & {
     collection: 'users';

--- a/packages/payload/src/utilities/addSelectGenericsToGeneretedTypes.ts
+++ b/packages/payload/src/utilities/addSelectGenericsToGeneretedTypes.ts
@@ -10,7 +10,7 @@ export const addSelectGenericsToGeneratedTypes = ({
 
   for (const line of compiledGeneratedTypes.split('\n')) {
     let newLine = line
-    if (line === `  collectionsSelect: {` || line === `  globalsSelect?: {`) {
+    if (line === `  collectionsSelect: {` || line === `  globalsSelect: {`) {
       isCollectionsSelectToken = true
     }
 

--- a/packages/payload/src/utilities/addSelectGenericsToGeneretedTypes.ts
+++ b/packages/payload/src/utilities/addSelectGenericsToGeneretedTypes.ts
@@ -10,7 +10,7 @@ export const addSelectGenericsToGeneratedTypes = ({
 
   for (const line of compiledGeneratedTypes.split('\n')) {
     let newLine = line
-    if (line === `  collectionsSelect?: {` || line === `  globalsSelect?: {`) {
+    if (line === `  collectionsSelect: {` || line === `  globalsSelect?: {`) {
       isCollectionsSelectToken = true
     }
 

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -996,7 +996,16 @@ export function configToJSONSchema(
       locale: generateLocaleEntitySchemas(config.localization),
       user: generateAuthEntitySchemas(config.collections),
     },
-    required: ['user', 'locale', 'collections', 'globals', 'auth', 'db'],
+    required: [
+      'user',
+      'locale',
+      'collections',
+      'collectionsSelect',
+      'globalsSelect',
+      'globals',
+      'auth',
+      'db',
+    ],
     title: 'Config',
   }
   if (jobsSchemas.definitions?.size) {

--- a/templates/website/src/payload-types.ts
+++ b/templates/website/src/payload-types.ts
@@ -24,7 +24,7 @@ export interface Config {
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
-  collectionsSelect?: {
+  collectionsSelect: {
     pages: PagesSelect<false> | PagesSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
@@ -45,7 +45,7 @@ export interface Config {
     header: Header;
     footer: Footer;
   };
-  globalsSelect?: {
+  globalsSelect: {
     header: HeaderSelect<false> | HeaderSelect<true>;
     footer: FooterSelect<false> | FooterSelect<true>;
   };

--- a/test/select/payload-types.ts
+++ b/test/select/payload-types.ts
@@ -21,7 +21,7 @@ export interface Config {
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
-  collectionsSelect?: {
+  collectionsSelect: {
     posts: PostsSelect<false> | PostsSelect<true>;
     'localized-posts': LocalizedPostsSelect<false> | LocalizedPostsSelect<true>;
     'versioned-posts': VersionedPostsSelect<false> | VersionedPostsSelect<true>;
@@ -38,14 +38,14 @@ export interface Config {
   globals: {
     'global-post': GlobalPost;
   };
-  globalsSelect?: {
-    'global-post': GlobalPostSelect<false> | GlobalPostSelect<true>;
+  globalsSelect: {
+    'global-post': GlobalPostSelect;
   };
   locale: 'en' | 'de';
   user: User & {
     collection: 'users';
   };
-jobs?: {
+  jobs?: {
     tasks: unknown;
     workflows?: unknown;
   };

--- a/test/select/payload-types.ts
+++ b/test/select/payload-types.ts
@@ -39,7 +39,7 @@ export interface Config {
     'global-post': GlobalPost;
   };
   globalsSelect: {
-    'global-post': GlobalPostSelect;
+    'global-post': GlobalPostSelect<false> | GlobalPostSelect<true>;
   };
   locale: 'en' | 'de';
   user: User & {


### PR DESCRIPTION
### What?
Fixes type for the `select` property when having `strictNullChecks: true` or `strict: true` in tsconfig.

### Why?
`select` should provide autocompletion for users, at this point it doesn't work with this condtiion

### How?
Makes `collectionsSelect` and `globalsSelect` properties required in `configToJSONSchema.ts`.

Fixes https://github.com/payloadcms/payload/pull/8550#issuecomment-2452669237

