### PR TITLE
feat: add skip population of individual joins, execute access for joins, `sanitizeJoinQuery`

### DIFF
--- a/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
+++ b/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
@@ -64,6 +64,10 @@ export const buildJoinAggregation = async ({
         continue
       }
 
+      if (joins?.[join.schemaPath] === false) {
+        continue
+      }
+
       const {
         limit: limitJoin = join.field.defaultLimit ?? 10,
         sort: sortJoin = join.field.defaultSort || collectionConfig.defaultSort,
@@ -83,7 +87,7 @@ export const buildJoinAggregation = async ({
       const $match = await joinModel.buildQuery({
         locale,
         payload: adapter.payload,
-        where: combineQueries(whereJoin, join.field?.where ?? {}),
+        where: whereJoin,
       })
 
       const pipeline: Exclude<PipelineStage, PipelineStage.Merge | PipelineStage.Out>[] = [

--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -417,11 +417,17 @@ export const traverseFields = ({
             break
           }
 
+          const joinSchemaPath = `${path.replaceAll('_', '.')}${field.name}`
+
+          if (joinQuery[joinSchemaPath] === false) {
+            break
+          }
+
           const {
             limit: limitArg = field.defaultLimit ?? 10,
             sort = field.defaultSort,
             where,
-          } = joinQuery[`${path.replaceAll('_', '.')}${field.name}`] || {}
+          } = joinQuery[joinSchemaPath] || {}
           let limit = limitArg
 
           if (limit !== 0) {
@@ -442,7 +448,7 @@ export const traverseFields = ({
             locale,
             sort,
             tableName: joinCollectionTableName,
-            where: combineQueries(where, field?.where ?? {}),
+            where,
           })
 
           let subQueryWhere = buildQueryResult.where

--- a/packages/next/src/routes/rest/utilities/sanitizeJoinParams.ts
+++ b/packages/next/src/routes/rest/utilities/sanitizeJoinParams.ts
@@ -9,11 +9,13 @@ import { isNumber } from 'payload/shared'
 export const sanitizeJoinParams = (
   joins:
     | {
-        [schemaPath: string]: {
-          limit?: unknown
-          sort?: string
-          where?: unknown
-        }
+        [schemaPath: string]:
+          | {
+              limit?: unknown
+              sort?: string
+              where?: unknown
+            }
+          | false
       }
     | false = {},
 ): JoinQuery => {

--- a/packages/next/src/routes/rest/utilities/sanitizeJoinParams.ts
+++ b/packages/next/src/routes/rest/utilities/sanitizeJoinParams.ts
@@ -20,10 +20,14 @@ export const sanitizeJoinParams = (
   const joinQuery = {}
 
   Object.keys(joins).forEach((schemaPath) => {
-    joinQuery[schemaPath] = {
-      limit: isNumber(joins[schemaPath]?.limit) ? Number(joins[schemaPath].limit) : undefined,
-      sort: joins[schemaPath]?.sort ? joins[schemaPath].sort : undefined,
-      where: joins[schemaPath]?.where ? joins[schemaPath].where : undefined,
+    if (joins[schemaPath] === 'false' || joins[schemaPath] === false) {
+      joinQuery[schemaPath] = false
+    } else {
+      joinQuery[schemaPath] = {
+        limit: isNumber(joins[schemaPath]?.limit) ? Number(joins[schemaPath].limit) : undefined,
+        sort: joins[schemaPath]?.sort ? joins[schemaPath].sort : undefined,
+        where: joins[schemaPath]?.where ? joins[schemaPath].where : undefined,
+      }
     }
   })
 

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -17,6 +17,7 @@ import type {
 import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
+import { sanitizeJoinQuery } from '../../database/sanitizeJoinQuery.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
@@ -129,6 +130,13 @@ export const findOperation = async <
 
     let fullWhere = combineQueries(where, accessResult)
 
+    const sanitizedJoins = await sanitizeJoinQuery({
+      collectionConfig,
+      joins,
+      overrideAccess,
+      req,
+    })
+
     if (collectionConfig.versions?.drafts && draftsEnabled) {
       fullWhere = appendVersionToQueryKey(fullWhere)
 
@@ -142,7 +150,7 @@ export const findOperation = async <
 
       result = await payload.db.queryDrafts<DataFromCollectionSlug<TSlug>>({
         collection: collectionConfig.slug,
-        joins: req.payloadAPI === 'GraphQL' ? false : joins,
+        joins: req.payloadAPI === 'GraphQL' ? false : sanitizedJoins,
         limit: sanitizedLimit,
         locale,
         page: sanitizedPage,
@@ -155,7 +163,6 @@ export const findOperation = async <
     } else {
       await validateQueryPaths({
         collectionConfig,
-        joins,
         overrideAccess,
         req,
         where,
@@ -163,7 +170,7 @@ export const findOperation = async <
 
       result = await payload.db.find<DataFromCollectionSlug<TSlug>>({
         collection: collectionConfig.slug,
-        joins: req.payloadAPI === 'GraphQL' ? false : joins,
+        joins: req.payloadAPI === 'GraphQL' ? false : sanitizedJoins,
         limit: sanitizedLimit,
         locale,
         page: sanitizedPage,

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -14,6 +14,7 @@ import type {
 
 import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
+import { sanitizeJoinQuery } from '../../database/sanitizeJoinQuery.js'
 import { NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { validateQueryPaths } from '../../index.js'
@@ -94,9 +95,16 @@ export const findByIDOperation = async <
 
     const where = combineQueries({ id: { equals: id } }, accessResult)
 
+    const sanitizedJoins = await sanitizeJoinQuery({
+      collectionConfig,
+      joins,
+      overrideAccess,
+      req,
+    })
+
     const findOneArgs: FindOneArgs = {
       collection: collectionConfig.slug,
-      joins: req.payloadAPI === 'GraphQL' ? false : joins,
+      joins: req.payloadAPI === 'GraphQL' ? false : sanitizedJoins,
       locale,
       req: {
         transactionID: req.transactionID,
@@ -107,7 +115,6 @@ export const findByIDOperation = async <
 
     await validateQueryPaths({
       collectionConfig,
-      joins,
       overrideAccess,
       req,
       where,

--- a/packages/payload/src/database/getLocalizedPaths.ts
+++ b/packages/payload/src/database/getLocalizedPaths.ts
@@ -103,11 +103,10 @@ export async function getLocalizedPaths({
           }
 
           case 'relationship':
-          case 'upload':
-          case 'join': {
+          case 'upload': {
             // If this is a polymorphic relation,
             // We only support querying directly (no nested querying)
-            if (matchedField.type !== 'join' && Array.isArray(matchedField.relationTo)) {
+            if (typeof matchedField.relationTo !== 'string') {
               const lastSegmentIsValid =
                 ['relationTo', 'value'].includes(pathSegments[pathSegments.length - 1]) ||
                 pathSegments.length === 1 ||
@@ -130,16 +129,7 @@ export async function getLocalizedPaths({
                 .join('.')
 
               if (nestedPathToQuery) {
-                let slug: string
-                if (matchedField.type === 'join') {
-                  slug = matchedField.collection
-                } else if (
-                  // condition is only for type assertion
-                  !Array.isArray(matchedField.relationTo)
-                ) {
-                  slug = matchedField.relationTo
-                }
-                const relatedCollection = payload.collections[slug].config
+                const relatedCollection = payload.collections[matchedField.relationTo].config
 
                 const remainingPaths = await getLocalizedPaths({
                   collectionSlug: relatedCollection.slug,

--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -150,10 +150,6 @@ export async function validateSearchParam({
         // Remove top collection and reverse array
         // to work backwards from top
         const pathsToQuery = paths.slice(1).reverse()
-        let joinCollectionSlug
-        if (field.type === 'join') {
-          joinCollectionSlug = field.collection
-        }
 
         pathsToQuery.forEach(
           ({ collectionSlug: pathCollectionSlug, path: subPath }, pathToQueryIndex) => {
@@ -162,8 +158,7 @@ export async function validateSearchParam({
             if (pathToQueryIndex === 0) {
               promises.push(
                 validateQueryPaths({
-                  collectionConfig:
-                    req.payload.collections[joinCollectionSlug ?? pathCollectionSlug].config,
+                  collectionConfig: req.payload.collections[pathCollectionSlug].config,
                   errors,
                   globalConfig: undefined,
                   overrideAccess,

--- a/packages/payload/src/database/sanitizeJoinQuery.ts
+++ b/packages/payload/src/database/sanitizeJoinQuery.ts
@@ -49,6 +49,7 @@ export const sanitizeJoinQuery = async ({
 
       if (accessResult === false) {
         joinsQuery[schemaPath] = false
+        continue
       }
 
       if (!joinsQuery[schemaPath]) {
@@ -63,6 +64,10 @@ export const sanitizeJoinQuery = async ({
 
       if (field.where) {
         joinQuery.where = combineQueries(joinQuery.where, field.where)
+      }
+
+      if (typeof accessResult === 'object') {
+        joinQuery.where = combineQueries(joinQuery.where, accessResult)
       }
 
       promises.push(

--- a/packages/payload/src/database/sanitizeJoinQuery.ts
+++ b/packages/payload/src/database/sanitizeJoinQuery.ts
@@ -8,25 +8,22 @@ import { validateQueryPaths } from './queryValidation/validateQueryPaths.js'
 
 type Args = {
   collectionConfig: SanitizedCollectionConfig
-  disableErrors?: boolean
-  errors?: { path: string }[]
   joins?: JoinQuery
   overrideAccess: boolean
   req: PayloadRequest
 }
 
 /**
- *
+ * * Validates `where` for each join
+ * * Combines the access result for joined collection
+ * * Combines the default join's `where`
  */
 export const sanitizeJoinQuery = async ({
   collectionConfig,
-  disableErrors,
-  errors = [],
   joins: joinsQuery,
   overrideAccess,
   req,
 }: Args) => {
-  const promises: Promise<void>[] = []
   if (joinsQuery === false) {
     return false
   }
@@ -34,6 +31,9 @@ export const sanitizeJoinQuery = async ({
   if (!joinsQuery) {
     joinsQuery = {}
   }
+
+  const errors: { path: string }[] = []
+  const promises: Promise<void>[] = []
 
   for (const collectionSlug in collectionConfig.joins) {
     for (const { field, schemaPath } of collectionConfig.joins[collectionSlug]) {

--- a/packages/payload/src/database/sanitizeJoinQuery.ts
+++ b/packages/payload/src/database/sanitizeJoinQuery.ts
@@ -1,0 +1,87 @@
+import type { SanitizedCollectionConfig } from '../collections/config/types.js'
+import type { JoinQuery, PayloadRequest } from '../types/index.js'
+
+import executeAccess from '../auth/executeAccess.js'
+import { QueryError } from '../errors/QueryError.js'
+import { combineQueries } from './combineQueries.js'
+import { validateQueryPaths } from './queryValidation/validateQueryPaths.js'
+
+type Args = {
+  collectionConfig: SanitizedCollectionConfig
+  disableErrors?: boolean
+  errors?: { path: string }[]
+  joins?: JoinQuery
+  overrideAccess: boolean
+  req: PayloadRequest
+}
+
+/**
+ *
+ */
+export const sanitizeJoinQuery = async ({
+  collectionConfig,
+  disableErrors,
+  errors = [],
+  joins: joinsQuery,
+  overrideAccess,
+  req,
+}: Args) => {
+  const promises: Promise<void>[] = []
+  if (joinsQuery === false) {
+    return false
+  }
+
+  if (!joinsQuery) {
+    joinsQuery = {}
+  }
+
+  for (const collectionSlug in collectionConfig.joins) {
+    for (const { field, schemaPath } of collectionConfig.joins[collectionSlug]) {
+      if (joinsQuery[schemaPath] === false) {
+        continue
+      }
+
+      const joinCollectionConfig = req.payload.collections[collectionSlug].config
+
+      const accessResult = !overrideAccess
+        ? await executeAccess({ disableErrors: true, req }, joinCollectionConfig.access.read)
+        : true
+
+      if (accessResult === false) {
+        joinsQuery[schemaPath] = false
+      }
+
+      if (!joinsQuery[schemaPath]) {
+        joinsQuery[schemaPath] = {}
+      }
+
+      const joinQuery = joinsQuery[schemaPath]
+
+      if (!joinQuery.where) {
+        joinQuery.where = {}
+      }
+
+      if (field.where) {
+        joinQuery.where = combineQueries(joinQuery.where, field.where)
+      }
+
+      promises.push(
+        validateQueryPaths({
+          collectionConfig: joinCollectionConfig,
+          errors,
+          overrideAccess,
+          req,
+          where: joinQuery.where,
+        }),
+      )
+    }
+  }
+
+  await Promise.all(promises)
+
+  if (errors.length > 0) {
+    throw new QueryError(errors)
+  }
+
+  return joinsQuery
+}

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -127,11 +127,13 @@ export type Sort = Array<string> | string
  */
 export type JoinQuery =
   | {
-      [schemaPath: string]: {
-        limit?: number
-        sort?: string
-        where?: Where
-      }
+      [schemaPath: string]:
+        | {
+            limit?: number
+            sort?: string
+            where?: Where
+          }
+        | false
     }
   | false
 

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -784,6 +784,53 @@ describe('Joins Field', () => {
 
     expect((categoryWithJoins.singulars.docs[0] as Singular).id).toBe(singular.id)
   })
+
+  it('local API should not populate individual join by providing schemaPath=false', async () => {
+    const {
+      docs: [res],
+    } = await payload.find({
+      collection: categoriesSlug,
+      where: {
+        id: { equals: category.id },
+      },
+      joins: {
+        relatedPosts: false,
+      },
+    })
+
+    // removed from the result
+    expect(res.relatedPosts).toBeUndefined()
+
+    expect(res.hasManyPosts.docs).toBeDefined()
+    expect(res.hasManyPostsLocalized.docs).toBeDefined()
+    expect(res.group.relatedPosts.docs).toBeDefined()
+    expect(res.group.camelCasePosts.docs).toBeDefined()
+  })
+
+  it('rEST API should not populate individual join by providing schemaPath=false', async () => {
+    const {
+      docs: [res],
+    } = await restClient
+      .GET(`/${categoriesSlug}`, {
+        query: {
+          where: {
+            id: { equals: category.id },
+          },
+          joins: {
+            relatedPosts: false,
+          },
+        },
+      })
+      .then((res) => res.json())
+
+    // removed from the result
+    expect(res.relatedPosts).toBeUndefined()
+
+    expect(res.hasManyPosts.docs).toBeDefined()
+    expect(res.hasManyPostsLocalized.docs).toBeDefined()
+    expect(res.group.relatedPosts.docs).toBeDefined()
+    expect(res.group.camelCasePosts.docs).toBeDefined()
+  })
 })
 
 async function createPost(overrides?: Partial<Post>, locale?: Config['locale']) {


### PR DESCRIPTION
### What?
PR to https://github.com/payloadcms/payload/pull/8973

Resets all changes in `validateQueryPaths`, `validateSearchParams`, `getLocalizedPaths`
Instead uses new `sanitizeJoinQuery` that does following:
- Validates `where` for each join
- Executes access for the joined collection
- Combines join's `where` with the access result and join's default `where`
- Moves default join's `where` handling to `sanitizeJoinQuery`

Adds ability to skip population of an individual join via `joins[schemaPath] = false`. This is also used internally if `executeAccess` returned `false`.
```ts
payload.find({
  collection: categoriesSlug,
  where: {
    id: { equals: category.id },
  },
  joins: {
    relatedPosts: false,
  },
})
```
