### PR TITLE
fix(richtext-slate, ui): use `PointerEvents` to show tooltips on enabled / disabled buttons

### DIFF
--- a/packages/richtext-slate/src/field/elements/Button.tsx
+++ b/packages/richtext-slate/src/field/elements/Button.tsx
@@ -54,8 +54,8 @@ export const ElementButton: React.FC<ButtonProps> = (props) => {
         .filter(Boolean)
         .join(' ')}
       onClick={onClick || defaultOnClick}
-      onMouseEnter={() => setShowTooltip(true)}
-      onMouseLeave={() => setShowTooltip(false)}
+      onPointerEnter={() => setShowTooltip(true)}
+      onPointerLeave={() => setShowTooltip(false)}
     >
       {tooltip && <Tooltip show={showTooltip}>{tooltip}</Tooltip>}
       {children}

--- a/packages/ui/src/elements/Button/index.tsx
+++ b/packages/ui/src/elements/Button/index.tsx
@@ -114,8 +114,8 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((
     className: !SubMenuPopupContent ? [classes, styleClasses].join(' ') : classes,
     disabled,
     onClick: !disabled ? handleClick : undefined,
-    onMouseEnter: tooltip ? () => setShowTooltip(true) : undefined,
-    onMouseLeave: tooltip ? () => setShowTooltip(false) : undefined,
+    onPointerEnter: tooltip ? () => setShowTooltip(true) : undefined,
+    onPointerLeave: tooltip ? () => setShowTooltip(false) : undefined,
     rel: newTab ? 'noopener noreferrer' : undefined,
     target: newTab ? '_blank' : undefined,
   }


### PR DESCRIPTION
Fixes #9005

Note: I did not replace all instances of `onMouseEnter`, just the ones that can be disabled and have `tooltip` set.