### PR TITLE
feat(plugin-seo): add Swedish translations

### DIFF
--- a/packages/plugin-seo/src/translations/index.ts
+++ b/packages/plugin-seo/src/translations/index.ts
@@ -9,6 +9,7 @@ import { it } from './it.js'
 import { nb } from './nb.js'
 import { pl } from './pl.js'
 import { ru } from './ru.js'
+import { sv } from './sv.js'
 import { uk } from './uk.js'
 
 export const translations = {
@@ -21,6 +22,7 @@ export const translations = {
   nb,
   pl,
   ru,
+  sv,
   uk,
 }
 

--- a/packages/plugin-seo/src/translations/sv.ts
+++ b/packages/plugin-seo/src/translations/sv.ts
@@ -1,0 +1,28 @@
+import type { GenericTranslationsObject } from '@payloadcms/translations'
+
+export const sv: GenericTranslationsObject = {
+  $schema: './translation-schema.json',
+  'plugin-seo': {
+    almostThere: 'Nästan klar',
+    autoGenerate: 'Skapa automatiskt',
+    bestPractices: 'bästa praxis',
+    characterCount: '{{current}}/{{minLength}}-{{maxLength}} tecken, ',
+    charactersLeftOver: '{{characters}} tecken blir över',
+    charactersToGo: '{{characters}} tecken kvar',
+    charactersTooMany: '{{characters}} tecken för mycket',
+    checksPassing: '{{current}}/{{max}} kontroller är godkända',
+    good: 'Bra',
+    imageAutoGenerationTip: 'Den automatiska processen kommer att välja en hero-bild.',
+    lengthTipDescription:
+      'Bör vara mellan {{minLength}} och {{maxLength}} tecken. För hjälp med att skriva bra metabeskrivningar, se ',
+    lengthTipTitle:
+      'Bör vara mellan {{minLength}} och {{maxLength}} tecken. För hjälp med att skriva bra metatitlar, se ',
+    missing: 'Saknas',
+    noImage: 'Ingen bild',
+    preview: 'Förhandsgranska',
+    previewDescription:
+      'Exakta resultatlistningar kan variera baserat på innehåll och sökrelevans.',
+    tooLong: 'För lång',
+    tooShort: 'För kort',
+  },
+}


### PR DESCRIPTION
### What?

Swedish text translations

### Why?

There was no Swedish before