### PR TITLE
fix: list drawer relationship not displaying

### DIFF
--- a/packages/payload/src/admin/components/views/collections/List/Cell/field-types/Relationship/index.tsx
+++ b/packages/payload/src/admin/components/views/collections/List/Cell/field-types/Relationship/index.tsx
@@ -48,6 +48,11 @@ const RelationshipCell: React.FC<CellComponentProps<RelationshipField | UploadFi
               relationTo: field.relationTo,
               value: cell,
             })
+          } else if (typeof cell.id !== 'undefined' && typeof field.relationTo === 'string') {
+            formattedValues.push({
+              relationTo: field.relationTo,
+              value: cell.id,
+            })
           }
         })
       getRelationships(formattedValues)


### PR DESCRIPTION
List drawer relationships are not showing when selecting an existing upload.

Before:
![image](https://github.com/user-attachments/assets/77c68572-31d2-47f9-b754-82808cf3f01c)

After:
![Screenshot 2024-11-04 093830](https://github.com/user-attachments/assets/59f41ee0-f3de-431d-b432-e6181b5736a8)
