### PR TITLE
fix: querying relationships by `id` path with REST

### DIFF
--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -74,6 +74,19 @@ export async function validateSearchParam({
     })
   }
   const promises = []
+
+  // Sanitize relation.otherRelation.id to relation.otherRelation
+  if (paths.at(-1)?.path === 'id') {
+    const previousField = paths.at(-2)?.field
+    if (
+      previousField &&
+      (previousField.type === 'relationship' || previousField.type === 'upload') &&
+      typeof previousField.relationTo === 'string'
+    ) {
+      paths.pop()
+    }
+  }
+
   promises.push(
     ...paths.map(async ({ collectionSlug, field, invalid, path }, i) => {
       if (invalid) {
@@ -110,6 +123,7 @@ export async function validateSearchParam({
         if (field.type === 'relationship' && Array.isArray(field.relationTo)) {
           fieldPath = fieldPath.replace('.value', '')
         }
+
         const entityType: 'collections' | 'globals' = globalConfig ? 'globals' : 'collections'
         const entitySlug = collectionSlug || globalConfig.slug
         const segments = fieldPath.split('.')

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -667,6 +667,35 @@ describe('Relationships', () => {
         expect(query.docs[0].id).toStrictEqual(firstLevelID)
       })
 
+      it('should allow querying on id two levels deep', async () => {
+        const query = await payload.find({
+          collection: 'chained',
+          where: {
+            'relation.relation.id': {
+              equals: thirdLevelID,
+            },
+          },
+        })
+
+        expect(query.docs).toHaveLength(1)
+        expect(query.docs[0].id).toStrictEqual(firstLevelID)
+
+        const queryREST = await restClient
+          .GET(`/chained`, {
+            query: {
+              where: {
+                'relation.relation.id': {
+                  equals: thirdLevelID,
+                },
+              },
+            },
+          })
+          .then((res) => res.json())
+
+        expect(queryREST.docs).toHaveLength(1)
+        expect(queryREST.docs[0].id).toStrictEqual(firstLevelID)
+      })
+
       it('should allow querying within array nesting', async () => {
         const page = await payload.create({
           collection: 'pages',

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -680,17 +680,14 @@ describe('Relationships', () => {
         expect(query.docs).toHaveLength(1)
         expect(query.docs[0].id).toStrictEqual(firstLevelID)
 
-        const queryREST = await restClient
-          .GET(`/chained`, {
-            query: {
-              where: {
-                'relation.relation.id': {
-                  equals: thirdLevelID,
-                },
-              },
+        const { result: queryREST } = await client.find({
+          slug: 'chained',
+          query: {
+            'relation.relation.id': {
+              equals: thirdLevelID,
             },
-          })
-          .then((res) => res.json())
+          },
+        })
 
         expect(queryREST.docs).toHaveLength(1)
         expect(queryREST.docs[0].id).toStrictEqual(firstLevelID)


### PR DESCRIPTION
### What?
Port of https://github.com/payloadcms/payload/pull/9013 to main

Fixes https://github.com/payloadcms/payload/issues/9008
