### PR TITLE
fix(db-postgres): handle special characters in `createDatabase`

### DIFF
--- a/packages/drizzle/src/postgres/createDatabase.ts
+++ b/packages/drizzle/src/postgres/createDatabase.ts
@@ -61,7 +61,7 @@ export const createDatabase = async function (this: BasePostgresAdapter, args: A
 
   try {
     await managementClient.connect()
-    await managementClient.query(`CREATE DATABASE ${dbName}`)
+    await managementClient.query(`CREATE DATABASE "${dbName}"`)
 
     this.payload.logger.info(`Created database "${dbName}"`)
 


### PR DESCRIPTION
### What?
Handles database name with special characters. For example: `-` - `my-awesome-app`.

### Why?
Previously, `my-awesome-app` led to this error:
```
Error: failed to create database my-awesome-app.
Details: syntax error at or near "-"
```
This can reproduced for example with `create-payload-app`, as the generated db name is based on project's name.

### How?
Wraps the query variable to quotes, `create database "my-awesome-app"` instead of `create database my-awesome-app`.