### PR TITLE
fix: modifying a doc with the document drawer should not affect the initial doc

### DIFF
--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -457,26 +457,25 @@ const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => 
         i18n,
       })
 
-      if (hasMany) {
-        setValue(
-          valueRef.current
-            ? (valueRef.current as Option[]).map((option) => {
-                if (option.value === args.doc.id) {
-                  return {
-                    relationTo: args.collectionConfig.slug,
-                    value: args.doc.id,
-                  }
-                }
+      const currentValue = valueRef.current
+      const docId = args.doc.id
 
-                return option
-              })
-            : null,
+      if (hasMany) {
+        const unchanged = (currentValue as Option[]).some((option) =>
+          typeof option === 'string' ? option === docId : option.value === docId,
         )
+
+        const valuesToSet = (currentValue as Option[]).map((option) =>
+          option.value === docId
+            ? { relationTo: args.collectionConfig.slug, value: docId }
+            : option,
+        )
+
+        setValue(valuesToSet, unchanged)
       } else {
-        setValue({
-          relationTo: args.collectionConfig.slug,
-          value: args.doc.id,
-        })
+        const unchanged = currentValue === docId
+
+        setValue({ relationTo: args.collectionConfig.slug, value: docId }, unchanged)
       }
     },
     [i18n, config, hasMany, setValue],

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -453,6 +453,27 @@ describe('fields - relationship', () => {
     ).toHaveCount(1)
   })
 
+  test('should update relationship from drawer without enabling save in main doc', async () => {
+    await page.goto(url.edit(docWithExistingRelations.id))
+
+    const saveButton = page.locator('#action-save')
+    await expect(saveButton).toBeDisabled()
+
+    await openDocDrawer(
+      page,
+      '#field-relationship button.relationship--single-value__drawer-toggler ',
+    )
+
+    const field = page.locator('#field-name')
+    await field.fill('Updated')
+
+    await saveButton.nth(1).click()
+    await expect(page.locator('.payload-toast-container')).toContainText('Updated successfully')
+    await page.locator('.doc-drawer__header-close').click()
+
+    await expect(saveButton).toBeDisabled()
+  })
+
   test('should allow filtering by polymorphic relationships with version drafts enabled', async () => {
     await createVersionedRelationshipFieldDoc('Without relationship')
     await createVersionedRelationshipFieldDoc('with relationship', [


### PR DESCRIPTION
Closes #9000

When you update a relationship document via the document drawer, the initial document is registering `modified: true`. We should only set modified to true on the initial document if the relationship id has changed.