### PR TITLE
fix(ui): `updatedAt` field in locked-docs collection able to be updated by non-owner

### DIFF
--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -278,7 +278,12 @@ export const buildFormState = async ({
           user: lockedDocument.docs[0]?.user?.value,
         }
 
-        if (updateLastEdited) {
+        const lockOwnerId =
+          typeof lockedDocument.docs[0]?.user?.value === 'object'
+            ? lockedDocument.docs[0]?.user?.value?.id
+            : lockedDocument.docs[0]?.user?.value
+
+        if (updateLastEdited && req.user && lockOwnerId === req.user.id) {
           await req.payload.db.updateOne({
             id: lockedDocument.docs[0].id,
             collection: 'payload-locked-documents',

--- a/packages/ui/src/utilities/buildFormState.ts
+++ b/packages/ui/src/utilities/buildFormState.ts
@@ -283,6 +283,7 @@ export const buildFormState = async ({
             ? lockedDocument.docs[0]?.user?.value?.id
             : lockedDocument.docs[0]?.user?.value
 
+        // Should only update doc if the incoming / current user is also the owner of the locked doc
         if (updateLastEdited && req.user && lockOwnerId === req.user.id) {
           await req.payload.db.updateOne({
             id: lockedDocument.docs[0].id,

--- a/test/locked-documents/collections/Posts/fields/DocumentLoaded.tsx
+++ b/test/locked-documents/collections/Posts/fields/DocumentLoaded.tsx
@@ -1,0 +1,32 @@
+'use client'
+import type { TextFieldClientProps } from 'payload'
+
+import { DatePicker, FieldLabel, useField } from '@payloadcms/ui'
+import { type FunctionComponent, useEffect, useRef } from 'react'
+
+export const DocumentLoaded: FunctionComponent<TextFieldClientProps> = ({ field: label }) => {
+  const field = useField<Date>({
+    path: 'documentLoaded',
+  })
+  const hasRun = useRef(false)
+
+  useEffect(() => {
+    if (hasRun.current || field.formInitializing) {
+      return
+    }
+    hasRun.current = true
+
+    field.setValue(new Date().toISOString())
+  }, [field])
+
+  return (
+    <div
+      style={{
+        marginBottom: '20px',
+      }}
+    >
+      <FieldLabel field={label} />
+      <DatePicker displayFormat="yyyy-MM-dd hh:mm:ss" readOnly={true} value={field.value} />
+    </div>
+  )
+}

--- a/test/locked-documents/collections/Posts/index.ts
+++ b/test/locked-documents/collections/Posts/index.ts
@@ -6,6 +6,7 @@ export const PostsCollection: CollectionConfig = {
   slug: postsSlug,
   admin: {
     useAsTitle: 'text',
+    defaultColumns: ['text', 'createdAt', 'updatedAt', '_status'],
   },
   lockDocuments: {
     duration: 180,

--- a/test/locked-documents/collections/Posts/index.ts
+++ b/test/locked-documents/collections/Posts/index.ts
@@ -15,6 +15,20 @@ export const PostsCollection: CollectionConfig = {
       name: 'text',
       type: 'text',
     },
+    {
+      name: 'documentLoaded',
+      label: 'Document loaded',
+      type: 'date',
+      admin: {
+        date: {
+          displayFormat: 'yyyy-MM-dd HH:mm:ss',
+        },
+        readOnly: true,
+        components: {
+          Field: '/collections/Posts/fields/DocumentLoaded.tsx#DocumentLoaded',
+        },
+      },
+    },
   ],
   versions: {
     drafts: true,

--- a/test/locked-documents/e2e.spec.ts
+++ b/test/locked-documents/e2e.spec.ts
@@ -714,51 +714,6 @@ describe('locked documents', () => {
       })
     })
 
-    test('should not change updatedAt date from custom field if incoming user tries to access locked doc', async () => {
-      const initialLockedDoc = await payload.find({
-        collection: lockedDocumentCollection,
-        limit: 1,
-        pagination: false,
-        where: {
-          'document.value': { equals: postDoc.id },
-        },
-      })
-
-      expect(initialLockedDoc.docs.length).toBe(1)
-
-      expect(initialLockedDoc.docs[0].updatedAt).toEqual(initialLockedDoc.docs[0].createdAt)
-
-      await page.goto(postsUrl.edit(postDoc.id))
-      await page.waitForURL(postsUrl.edit(postDoc.id))
-
-      const modalContainer = page.locator('.payload__modal-container')
-      await expect(modalContainer).toBeVisible()
-
-      // Need to wait for form-state to fire off so updateLastEdited returns true
-      // eslint-disable-next-line payload/no-wait-function
-      await wait(5000)
-
-      // Click read-only button to view doc in read-only mode
-      await page.locator('#document-locked-view-read-only').click()
-
-      // Need to wait for form-state to fire off so updateLastEdited returns true
-      // eslint-disable-next-line payload/no-wait-function
-      await wait(5000)
-
-      const lockedDoc = await payload.find({
-        collection: lockedDocumentCollection,
-        limit: 1,
-        pagination: false,
-        where: {
-          'document.value': { equals: postDoc.id },
-        },
-      })
-
-      expect(lockedDoc.docs.length).toBe(1)
-
-      expect(lockedDoc.docs[0].updatedAt).toEqual(lockedDoc.docs[0].createdAt)
-    })
-
     test('should show Document Locked modal for incoming user when entering locked document', async () => {
       const lockedDoc = await payload.find({
         collection: lockedDocumentCollection,

--- a/test/locked-documents/e2e.spec.ts
+++ b/test/locked-documents/e2e.spec.ts
@@ -714,6 +714,51 @@ describe('locked documents', () => {
       })
     })
 
+    test('should not change updatedAt date from custom field if incoming user tries to access locked doc', async () => {
+      const initialLockedDoc = await payload.find({
+        collection: lockedDocumentCollection,
+        limit: 1,
+        pagination: false,
+        where: {
+          'document.value': { equals: postDoc.id },
+        },
+      })
+
+      expect(initialLockedDoc.docs.length).toBe(1)
+
+      expect(initialLockedDoc.docs[0].updatedAt).toEqual(initialLockedDoc.docs[0].createdAt)
+
+      await page.goto(postsUrl.edit(postDoc.id))
+      await page.waitForURL(postsUrl.edit(postDoc.id))
+
+      const modalContainer = page.locator('.payload__modal-container')
+      await expect(modalContainer).toBeVisible()
+
+      // Need to wait for form-state to fire off so updateLastEdited returns true
+      // eslint-disable-next-line payload/no-wait-function
+      await wait(5000)
+
+      // Click read-only button to view doc in read-only mode
+      await page.locator('#document-locked-view-read-only').click()
+
+      // Need to wait for form-state to fire off so updateLastEdited returns true
+      // eslint-disable-next-line payload/no-wait-function
+      await wait(5000)
+
+      const lockedDoc = await payload.find({
+        collection: lockedDocumentCollection,
+        limit: 1,
+        pagination: false,
+        where: {
+          'document.value': { equals: postDoc.id },
+        },
+      })
+
+      expect(lockedDoc.docs.length).toBe(1)
+
+      expect(lockedDoc.docs[0].updatedAt).toEqual(lockedDoc.docs[0].createdAt)
+    })
+
     test('should show Document Locked modal for incoming user when entering locked document', async () => {
       const lockedDoc = await payload.find({
         collection: lockedDocumentCollection,


### PR DESCRIPTION
### What?

If you have a custom field that sets the value of the field using the `useField` hook on entry into a document - the `updatedAt` field would be updated even when a non-owner tries to enter a locked document.

### Why?

When a field is updated in the edit view - we perform an update in `form-state` to keep the doc in `payload-locked-documents` up to date with the current editing status. The above scenario would hit this update operation even on non-owner users because it was previously only checking for `updateLastEdited` (which would get hit by the `setValue` in the `useField` hook) so we also need to check to make sure the current user entering a locked doc is also the owner of the document.

### How?

When performing an update to `payload-locked-documents` in `buildFormState` - only perform the update if the current user is also the owner of the locked document otherwise skip the `update` operation.

Fixes #8781 
