### PR TITLE
fix(useDocumentInfo): Add explicit null to types

### DIFF
--- a/packages/payload/src/admin/components/utilities/DocumentInfo/index.tsx
+++ b/packages/payload/src/admin/components/utilities/DocumentInfo/index.tsx
@@ -40,9 +40,11 @@ const DocumentInfo: React.FC<Props> = ({
   const { permissions } = useAuth()
   const { code } = useLocale()
   const { uploadEdits } = useUploadEdits()
-  const [publishedDoc, setPublishedDoc] = useState<TypeWithID & TypeWithTimestamps>(null)
-  const [versions, setVersions] = useState<PaginatedDocs<Version>>(null)
-  const [unpublishedVersions, setUnpublishedVersions] = useState<PaginatedDocs<Version>>(null)
+  const [publishedDoc, setPublishedDoc] = useState<(TypeWithID & TypeWithTimestamps) | null>(null)
+  const [versions, setVersions] = useState<PaginatedDocs<Version> | null>(null)
+  const [unpublishedVersions, setUnpublishedVersions] = useState<PaginatedDocs<Version> | null>(
+    null,
+  )
 
   const baseURL = `${serverURL}${api}`
   let slug: string

--- a/packages/payload/src/admin/components/utilities/DocumentInfo/types.ts
+++ b/packages/payload/src/admin/components/utilities/DocumentInfo/types.ts
@@ -24,11 +24,11 @@ export type ContextType = {
   global?: SanitizedGlobalConfig
   id?: number | string
   preferencesKey?: string
-  publishedDoc?: TypeWithID & TypeWithTimestamps & { _status?: string }
+  publishedDoc?: (TypeWithID & TypeWithTimestamps & { _status?: string }) | null
   setDocFieldPreferences: (field: string, fieldPreferences: { [key: string]: unknown }) => void
   slug?: string
-  unpublishedVersions?: PaginatedDocs<Version>
-  versions?: PaginatedDocs<Version>
+  unpublishedVersions?: PaginatedDocs<Version> | null
+  versions?: PaginatedDocs<Version> | null
 }
 
 export type Props = {


### PR DESCRIPTION
### What?

Added `| null` to the **type** for context props initialized to `null`.

### Why?

For code bases using a more strict typescript configuration, `null` and `undefined` (and optional fields) are different types and require handling separately. The states for these three context fields are all initialized to `null`, but their type doesn't include that. This caused runtime errors in our codebase.

### How?

Modified the type, both in the context type, and in the react setters. Notice that this change doesn't change anything in the runtime behaviour of the code, just types.
