### PR TITLE
fix(ui): ensure upload field updates reflect in edit popup changes

### DIFF
--- a/packages/ui/src/fields/Upload/HasMany/index.tsx
+++ b/packages/ui/src/fields/Upload/HasMany/index.tsx
@@ -11,6 +11,8 @@ import { UploadCard } from '../UploadCard/index.js'
 
 const baseClass = 'upload upload--has-many'
 
+import type { ReloadDoc } from '../types.js'
+
 import './index.scss'
 
 type Props = {
@@ -23,10 +25,12 @@ type Props = {
   readonly onRemove?: (value) => void
   readonly onReorder?: (value) => void
   readonly readonly?: boolean
+  readonly reloadDoc: ReloadDoc
   readonly serverURL: string
 }
 export function UploadComponentHasMany(props: Props) {
-  const { className, fileDocs, isSortable, onRemove, onReorder, readonly, serverURL } = props
+  const { className, fileDocs, isSortable, onRemove, onReorder, readonly, reloadDoc, serverURL } =
+    props
 
   const moveRow = React.useCallback(
     (moveFromIndex: number, moveToIndex: number) => {
@@ -109,6 +113,7 @@ export function UploadComponentHasMany(props: Props) {
                       id={id}
                       mimeType={value?.mimeType as string}
                       onRemove={() => removeItem(index)}
+                      reloadDoc={reloadDoc}
                       src={src}
                       withMeta={false}
                       x={value?.width as number}

--- a/packages/ui/src/fields/Upload/HasOne/index.tsx
+++ b/packages/ui/src/fields/Upload/HasOne/index.tsx
@@ -4,6 +4,8 @@ import type { JsonObject } from 'payload'
 
 import React from 'react'
 
+import type { ReloadDoc } from '../types.js'
+
 import { RelationshipContent } from '../RelationshipContent/index.js'
 import { UploadCard } from '../UploadCard/index.js'
 import './index.scss'
@@ -18,11 +20,12 @@ type Props = {
   }
   readonly onRemove?: () => void
   readonly readonly?: boolean
+  readonly reloadDoc: ReloadDoc
   readonly serverURL: string
 }
 
 export function UploadComponentHasOne(props: Props) {
-  const { className, fileDoc, onRemove, readonly, serverURL } = props
+  const { className, fileDoc, onRemove, readonly, reloadDoc, serverURL } = props
   const { relationTo, value } = fileDoc
   const id = String(value?.id)
 
@@ -47,6 +50,7 @@ export function UploadComponentHasOne(props: Props) {
         id={id}
         mimeType={value?.mimeType as string}
         onRemove={onRemove}
+        reloadDoc={reloadDoc}
         src={src}
         x={value?.width as number}
         y={value?.height as number}

--- a/packages/ui/src/fields/Upload/RelationshipContent/index.tsx
+++ b/packages/ui/src/fields/Upload/RelationshipContent/index.tsx
@@ -1,7 +1,11 @@
 'use client'
 
+import type { TypeWithID } from 'payload'
+
 import { formatFilesize } from 'payload/shared'
 import React from 'react'
+
+import type { ReloadDoc } from '../types.js'
 
 import { Button } from '../../../elements/Button/index.js'
 import { useDocumentDrawer } from '../../../elements/DocumentDrawer/index.js'
@@ -21,6 +25,7 @@ type Props = {
   readonly id: number | string
   readonly mimeType: string
   readonly onRemove: () => void
+  readonly reloadDoc: ReloadDoc
   readonly src: string
   readonly withMeta?: boolean
   readonly x?: number
@@ -38,11 +43,17 @@ export function RelationshipContent(props: Props) {
     filename,
     mimeType,
     onRemove,
+    reloadDoc,
     src,
     withMeta = true,
     x,
     y,
   } = props
+
+  const onSave = React.useCallback(
+    async ({ doc }: { doc: TypeWithID }) => reloadDoc(doc.id, collectionSlug),
+    [reloadDoc, collectionSlug],
+  )
 
   const [DocumentDrawer, _, { openDrawer }] = useDocumentDrawer({
     id,
@@ -108,7 +119,7 @@ export function RelationshipContent(props: Props) {
               onClick={() => onRemove()}
             />
           ) : null}
-          <DocumentDrawer />
+          <DocumentDrawer onSave={onSave} />
         </div>
       ) : null}
     </div>

--- a/packages/ui/src/fields/Upload/types.ts
+++ b/packages/ui/src/fields/Upload/types.ts
@@ -1,0 +1,8 @@
+import type { PaginatedDocs } from 'payload'
+
+export type PopulateDocs = (
+  ids: (number | string)[],
+  relatedCollectionSlug: string,
+) => Promise<null | PaginatedDocs>
+
+export type ReloadDoc = (docID: number | string, collectionSlug: string) => Promise<void>


### PR DESCRIPTION
### What?

Any changes inside edit popup for the field with type `upload` and the `relationTo` collection does nothing in context of the field, it has affect only to collection.

I.e. when you make an edit to an uploads field in the edit drawer - after saving and existing the drawer, your new changes are not present until a refresh of the page.

### Why?

Previously, we were not performing a reload of the document fetch upon saving of the doc in the edit drawer.

### How?

Now, we perform a reload (fetch) for updated docs on save within the edit drawer.

Fixes #8837 
