### PR TITLE
fix: type augmentation of `RequestContext`

### DIFF
--- a/packages/payload/src/admin/RichText.ts
+++ b/packages/payload/src/admin/RichText.ts
@@ -12,7 +12,8 @@ import type {
   Validate,
 } from '../fields/config/types.js'
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'
-import type { JsonObject, Payload, PayloadRequest, RequestContext } from '../types/index.js'
+import type { RequestContext } from '../index.js'
+import type { JsonObject, Payload, PayloadRequest } from '../types/index.js'
 import type { RichTextFieldClientProps } from './fields/RichText.js'
 import type { CreateMappedComponent } from './types.js'
 

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -35,13 +35,13 @@ import type { Field, JoinField, RelationshipField, UploadField } from '../../fie
 import type {
   CollectionSlug,
   JsonObject,
+  RequestContext,
   TypedAuthOperations,
   TypedCollection,
   TypedCollectionSelect,
 } from '../../index.js'
 import type {
   PayloadRequest,
-  RequestContext,
   SelectType,
   Sort,
   TransformCollectionWithSelect,

--- a/packages/payload/src/collections/operations/local/count.ts
+++ b/packages/payload/src/collections/operations/local/count.ts
@@ -1,5 +1,5 @@
-import type { CollectionSlug, Payload, TypedLocale } from '../../../index.js'
-import type { Document, PayloadRequest, RequestContext, Where } from '../../../types/index.js'
+import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type { Document, PayloadRequest, Where } from '../../../types/index.js'
 
 import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -1,8 +1,7 @@
-import type { CollectionSlug, Payload, TypedLocale } from '../../../index.js'
+import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type {
   Document,
   PayloadRequest,
-  RequestContext,
   SelectType,
   TransformCollectionWithSelect,
 } from '../../../types/index.js'

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -1,8 +1,7 @@
-import type { CollectionSlug, Payload, TypedLocale } from '../../../index.js'
+import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type {
   Document,
   PayloadRequest,
-  RequestContext,
   SelectType,
   TransformCollectionWithSelect,
   Where,

--- a/packages/payload/src/collections/operations/local/duplicate.ts
+++ b/packages/payload/src/collections/operations/local/duplicate.ts
@@ -1,13 +1,12 @@
 import type { CollectionSlug, TypedLocale } from '../../..//index.js'
-import type { Payload } from '../../../index.js'
+import type { Payload, RequestContext } from '../../../index.js'
 import type {
   Document,
   PayloadRequest,
-  RequestContext,
   SelectType,
   TransformCollectionWithSelect,
 } from '../../../types/index.js'
-import type { DataFromCollectionSlug, SelectFromCollectionSlug } from '../../config/types.js'
+import type { SelectFromCollectionSlug } from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'

--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -1,9 +1,14 @@
 import type { PaginatedDocs } from '../../../database/types.js'
-import type { CollectionSlug, JoinQuery, Payload, TypedLocale } from '../../../index.js'
+import type {
+  CollectionSlug,
+  JoinQuery,
+  Payload,
+  RequestContext,
+  TypedLocale,
+} from '../../../index.js'
 import type {
   Document,
   PayloadRequest,
-  RequestContext,
   SelectType,
   Sort,
   TransformCollectionWithSelect,

--- a/packages/payload/src/collections/operations/local/findByID.ts
+++ b/packages/payload/src/collections/operations/local/findByID.ts
@@ -1,10 +1,16 @@
 /* eslint-disable no-restricted-exports */
-import type { CollectionSlug, JoinQuery, Payload, SelectType, TypedLocale } from '../../../index.js'
+import type {
+  CollectionSlug,
+  JoinQuery,
+  Payload,
+  RequestContext,
+  SelectType,
+  TypedLocale,
+} from '../../../index.js'
 import type {
   ApplyDisableErrors,
   Document,
   PayloadRequest,
-  RequestContext,
   TransformCollectionWithSelect,
 } from '../../../types/index.js'
 import type { SelectFromCollectionSlug } from '../../config/types.js'

--- a/packages/payload/src/collections/operations/local/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/local/findVersionByID.ts
@@ -1,5 +1,5 @@
-import type { CollectionSlug, Payload, TypedLocale } from '../../../index.js'
-import type { Document, PayloadRequest, RequestContext, SelectType } from '../../../types/index.js'
+import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type { Document, PayloadRequest, SelectType } from '../../../types/index.js'
 import type { TypeWithVersion } from '../../../versions/types.js'
 import type { DataFromCollectionSlug } from '../../config/types.js'
 

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -1,13 +1,6 @@
 import type { PaginatedDocs } from '../../../database/types.js'
-import type { CollectionSlug, Payload, TypedLocale } from '../../../index.js'
-import type {
-  Document,
-  PayloadRequest,
-  RequestContext,
-  SelectType,
-  Sort,
-  Where,
-} from '../../../types/index.js'
+import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type { Document, PayloadRequest, SelectType, Sort, Where } from '../../../types/index.js'
 import type { TypeWithVersion } from '../../../versions/types.js'
 import type { DataFromCollectionSlug } from '../../config/types.js'
 

--- a/packages/payload/src/collections/operations/local/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/local/restoreVersion.ts
@@ -1,5 +1,5 @@
-import type { CollectionSlug, Payload, TypedLocale } from '../../../index.js'
-import type { Document, PayloadRequest, RequestContext, SelectType } from '../../../types/index.js'
+import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
+import type { Document, PayloadRequest, SelectType } from '../../../types/index.js'
 import type { DataFromCollectionSlug } from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -1,10 +1,9 @@
 import type { DeepPartial } from 'ts-essentials'
 
-import type { CollectionSlug, Payload, TypedLocale } from '../../../index.js'
+import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type {
   Document,
   PayloadRequest,
-  RequestContext,
   SelectType,
   TransformCollectionWithSelect,
   Where,

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -121,11 +121,12 @@ import type {
   JSONFieldValidation,
   PointFieldValidation,
   RadioFieldValidation,
+  RequestContext,
   Sort,
   TextareaFieldValidation,
 } from '../../index.js'
 import type { DocumentPreferences } from '../../preferences/types.js'
-import type { Operation, PayloadRequest, RequestContext, Where } from '../../types/index.js'
+import type { Operation, PayloadRequest, Where } from '../../types/index.js'
 import type {
   NumberFieldManyValidation,
   NumberFieldSingleValidation,

--- a/packages/payload/src/fields/hooks/afterChange/index.ts
+++ b/packages/payload/src/fields/hooks/afterChange/index.ts
@@ -1,6 +1,7 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type { JsonObject, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 
 import { deepCopyObjectSimple } from '../../../utilities/deepCopyObject.js'
 import { traverseFields } from './traverseFields.js'

--- a/packages/payload/src/fields/hooks/afterChange/promise.ts
+++ b/packages/payload/src/fields/hooks/afterChange/promise.ts
@@ -1,7 +1,8 @@
 import type { RichTextAdapter } from '../../../admin/RichText.js'
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type { JsonObject, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 import type { Field, TabAsField } from '../../config/types.js'
 
 import { MissingEditorProp } from '../../../errors/index.js'

--- a/packages/payload/src/fields/hooks/afterChange/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/afterChange/traverseFields.ts
@@ -1,6 +1,7 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type { JsonObject, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 import type { Field, TabAsField } from '../../config/types.js'
 
 import { promise } from './promise.js'

--- a/packages/payload/src/fields/hooks/afterRead/index.ts
+++ b/packages/payload/src/fields/hooks/afterRead/index.ts
@@ -1,11 +1,7 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type {
-  JsonObject,
-  PayloadRequest,
-  RequestContext,
-  SelectType,
-} from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest, SelectType } from '../../../types/index.js'
 
 import { deepCopyObjectSimple } from '../../../utilities/deepCopyObject.js'
 import { getSelectMode } from '../../../utilities/getSelectMode.js'

--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -1,13 +1,8 @@
 import type { RichTextAdapter } from '../../../admin/RichText.js'
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type {
-  JsonObject,
-  PayloadRequest,
-  RequestContext,
-  SelectMode,
-  SelectType,
-} from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest, SelectMode, SelectType } from '../../../types/index.js'
 import type { Field, TabAsField } from '../../config/types.js'
 
 import { MissingEditorProp } from '../../../errors/index.js'

--- a/packages/payload/src/fields/hooks/afterRead/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/afterRead/traverseFields.ts
@@ -1,12 +1,7 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type {
-  JsonObject,
-  PayloadRequest,
-  RequestContext,
-  SelectMode,
-  SelectType,
-} from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest, SelectMode, SelectType } from '../../../types/index.js'
 import type { Field, TabAsField } from '../../config/types.js'
 
 import { promise } from './promise.js'

--- a/packages/payload/src/fields/hooks/beforeChange/index.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/index.ts
@@ -1,6 +1,7 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type { JsonObject, Operation, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, Operation, PayloadRequest } from '../../../types/index.js'
 
 import { ValidationError } from '../../../errors/index.js'
 import { deepCopyObjectSimple } from '../../../utilities/deepCopyObject.js'

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -1,7 +1,8 @@
 import type { RichTextAdapter } from '../../../admin/RichText.js'
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type { JsonObject, Operation, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, Operation, PayloadRequest } from '../../../types/index.js'
 import type { Field, FieldHookArgs, TabAsField, ValidateOptions } from '../../config/types.js'
 
 import { MissingEditorProp } from '../../../errors/index.js'

--- a/packages/payload/src/fields/hooks/beforeChange/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/traverseFields.ts
@@ -1,6 +1,7 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type { JsonObject, Operation, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, Operation, PayloadRequest } from '../../../types/index.js'
 import type { Field, TabAsField } from '../../config/types.js'
 
 import { promise } from './promise.js'

--- a/packages/payload/src/fields/hooks/beforeDuplicate/index.ts
+++ b/packages/payload/src/fields/hooks/beforeDuplicate/index.ts
@@ -1,5 +1,6 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
-import type { JsonObject, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 
 import { deepCopyObjectSimple } from '../../../utilities/deepCopyObject.js'
 import { traverseFields } from './traverseFields.js'

--- a/packages/payload/src/fields/hooks/beforeDuplicate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeDuplicate/promise.ts
@@ -1,5 +1,6 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
-import type { JsonObject, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 import type { Field, FieldHookArgs, TabAsField } from '../../config/types.js'
 
 import { fieldAffectsData, tabHasName } from '../../config/types.js'

--- a/packages/payload/src/fields/hooks/beforeDuplicate/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/beforeDuplicate/traverseFields.ts
@@ -1,5 +1,6 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
-import type { JsonObject, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 import type { Field, TabAsField } from '../../config/types.js'
 
 import { promise } from './promise.js'

--- a/packages/payload/src/fields/hooks/beforeValidate/index.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/index.ts
@@ -1,6 +1,7 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type { JsonObject, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 
 import { deepCopyObjectSimple } from '../../../utilities/deepCopyObject.js'
 import { traverseFields } from './traverseFields.js'

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -1,7 +1,8 @@
 import type { RichTextAdapter } from '../../../admin/RichText.js'
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type { JsonObject, JsonValue, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, JsonValue, PayloadRequest } from '../../../types/index.js'
 import type { Field, TabAsField } from '../../config/types.js'
 
 import { MissingEditorProp } from '../../../errors/index.js'

--- a/packages/payload/src/fields/hooks/beforeValidate/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/traverseFields.ts
@@ -1,6 +1,7 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type { JsonObject, PayloadRequest, RequestContext } from '../../../types/index.js'
+import type { RequestContext } from '../../../index.js'
+import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 import type { Field, TabAsField } from '../../config/types.js'
 
 import { promise } from './promise.js'

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -19,8 +19,8 @@ import type {
 } from '../../config/types.js'
 import type { DBIdentifierName } from '../../database/types.js'
 import type { Field } from '../../fields/config/types.js'
-import type { GlobalSlug, TypedGlobal, TypedGlobalSelect } from '../../index.js'
-import type { PayloadRequest, RequestContext, Where } from '../../types/index.js'
+import type { GlobalSlug, RequestContext, TypedGlobal, TypedGlobalSelect } from '../../index.js'
+import type { PayloadRequest, Where } from '../../types/index.js'
 import type { IncomingGlobalVersions, SanitizedGlobalVersions } from '../../versions/types.js'
 
 export type DataFromGlobalSlug<TSlug extends GlobalSlug> = TypedGlobal[TSlug]

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -12,6 +12,7 @@ import type {
   CollectionSlug,
   DataFromGlobalSlug,
   GlobalSlug,
+  RequestContext,
   TypedLocale,
   TypedUser,
 } from '../index.js'
@@ -93,10 +94,6 @@ export type PayloadRequest = CustomPayloadRequestProperties &
   Partial<Request> &
   PayloadRequestData &
   Required<Pick<Request, 'headers'>>
-
-export interface RequestContext {
-  [key: string]: unknown
-}
 
 export type Operator = (typeof validOperators)[number]
 

--- a/test/_community/int.spec.ts
+++ b/test/_community/int.spec.ts
@@ -54,6 +54,7 @@ describe('_Community Tests', () => {
       data: {
         text: 'LOCAL API EXAMPLE',
       },
+      context: {},
     })
 
     expect(newPost.text).toEqual('LOCAL API EXAMPLE')

--- a/test/_community/types.d.ts
+++ b/test/_community/types.d.ts
@@ -1,0 +1,9 @@
+import type { RequestContext as OriginalRequestContext } from 'payload'
+
+declare module 'payload' {
+  // Create a new interface that merges your additional fields with the original one
+  export interface RequestContext extends OriginalRequestContext {
+    myObject?: string
+    // ...
+  }
+}


### PR DESCRIPTION
### What?

Makes this to actually work
```ts
import type { RequestContext as OriginalRequestContext } from 'payload'

declare module 'payload' {
  // Create a new interface that merges your additional fields with the original one
  export interface RequestContext extends OriginalRequestContext {
    myObject?: string
    // ...
  }
}
```
<img width="502" alt="image" src="https://github.com/user-attachments/assets/38570d3c-e8a8-48aa-a57d-6d11e79394f5">


### Why?
This is described in our docs https://payloadcms.com/docs/beta/hooks/context#typescript therefore it should work.

### How?
In order to get the declaration work, we need to reuse the type from the root file `payload/src/index.js`. Additionally, removes `RequestContext` type duplication in both `payload/src/types/index.js` and `payload/src/index.js`.

Fixes https://github.com/payloadcms/payload/issues/8851
