### PR TITLE
fix: allow workflows to be empty or undefined

### DIFF
--- a/packages/payload/src/queues/config/jobsCollection.ts
+++ b/packages/payload/src/queues/config/jobsCollection.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig } from '../../collections/config/types.js'
 import type { Config } from '../../config/types.js'
+import type { Field } from '../../fields/config/types.js'
 
 import { runJobsEndpoint } from '../restEndpointRun.js'
 import { getJobTaskStatus } from '../utilities/getJobTaskStatus.js'
@@ -14,7 +15,7 @@ export const getDefaultJobsCollection: (config: Config) => CollectionConfig | nu
 
   const queueNames: Set<string> = new Set(['default'])
 
-  config.jobs.workflows.forEach((workflow) => {
+  config.jobs?.workflows.forEach((workflow) => {
     workflowSlugs.add(workflow.slug)
 
     if (workflow.queue) {
@@ -141,16 +142,20 @@ export const getDefaultJobsCollection: (config: Config) => CollectionConfig | nu
           },
         ],
       },
-      {
-        name: 'workflowSlug',
-        type: 'select',
-        admin: {
-          position: 'sidebar',
-        },
-        index: true,
-        options: [...workflowSlugs],
-        required: false,
-      },
+      // only include the workflowSlugs field if workflows exist
+      ...((workflowSlugs.size > 0
+        ? [
+            {
+              name: 'workflowSlug',
+              type: 'select',
+              admin: {
+                position: 'sidebar',
+              },
+              index: true,
+              options: [...workflowSlugs],
+            },
+          ]
+        : []) as Field[]),
       {
         name: 'taskSlug',
         type: 'select',

--- a/packages/payload/src/queues/config/types/index.ts
+++ b/packages/payload/src/queues/config/types/index.ts
@@ -41,5 +41,5 @@ export type JobsConfig = {
   /**
    * Define all the workflows here. Workflows orchestrate the flow of multiple tasks.
    */
-  workflows: WorkflowConfig<any>[]
+  workflows?: WorkflowConfig<any>[]
 }

--- a/packages/payload/src/queues/operations/runJobs/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/index.ts
@@ -138,7 +138,7 @@ export const runJobs = async ({
     const jobReq = isolateObjectProperty(req, 'transactionID')
 
     const workflowConfig: WorkflowConfig<WorkflowTypes> = job.workflowSlug
-      ? req.payload.config.jobs.workflows.find(({ slug }) => slug === job.workflowSlug)
+      ? req.payload.config.jobs?.workflows.find(({ slug }) => slug === job.workflowSlug)
       : {
           slug: 'singleTask',
           handler: async ({ job, tasks }) => {


### PR DESCRIPTION
### What?

- Makes `jobs.workflows` optional
- Dynamically include the `workflowSlugs` select field in the jobs collection as needed

### Why?

When configuring jobs, it should be possible to define `job` with just some simple tasks and not be forced to define workflows.

### How?

Workflows type was made optional and optional chaining is added where needed. The workflowSlugs field is added to the jobs collection if workflows are defined.

Fixes #

When using postgres, the workflowSlugs being an empty enum cause an error when drizzle fails to detect the enum already exists. This results in the error `"enum_payload_jobs_workflow_slug" already exists`. Drizzle tries to make the enum as: `enum_payload_jobs_workflow_slug as enum();` and the check for existing enums only works when it has values.