### PR TITLE
fix(ui): dedupes custom id fields

### DIFF
--- a/packages/ui/src/providers/Config/createClientConfig/fields.tsx
+++ b/packages/ui/src/providers/Config/createClientConfig/fields.tsx
@@ -26,7 +26,7 @@ import type {
   TabsFieldClient,
 } from 'payload'
 
-import { deepCopyObjectSimple, MissingEditorProp } from 'payload'
+import { deepCopyObjectSimple, flattenTopLevelFields, MissingEditorProp } from 'payload'
 import { fieldAffectsData, fieldIsPresentationalOnly } from 'payload/shared'
 
 import { getComponent } from './getComponent.js'
@@ -579,7 +579,7 @@ export const createClientFields = ({
     }
   }
 
-  const hasID = newClientFields.findIndex((f) => fieldAffectsData(f) && f.name === 'id') > -1
+  const hasID = flattenTopLevelFields(fields).some((f) => fieldAffectsData(f) && f.name === 'id')
 
   if (!disableAddingID && !hasID) {
     newClientFields.push({


### PR DESCRIPTION
Setting a custom `id` field within unnamed fields causes duplicative ID fields to be appear in the client config. When a top-level `id` field is detected in your config, Payload uses that instead of injecting its default field. But when nested within unnamed fields, such as an unnamed tab, these custom `id` fields were not being found, causing the default field to be duplicately rendered into tables columns, etc.