### PR TITLE
fix: handle bulk upload sequentially to prevent conflicts

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -255,6 +255,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'general:updating',
   'general:viewReadOnly',
   'general:uploading',
+  'general:uploadingBulk',
   'general:welcome',
 
   'operators:equals',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -308,6 +308,7 @@ export const arTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'تم التحديث بنجاح.',
     updating: 'جار التحديث',
     uploading: 'جار الرفع',
+    uploadingBulk: 'جاري التحميل {{current}} من {{total}}',
     user: 'المستخدم',
     username: 'اسم المستخدم',
     users: 'المستخدمين',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -311,6 +311,7 @@ export const azTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Uğurla yeniləndi.',
     updating: 'Yenilənir',
     uploading: 'Yüklənir',
+    uploadingBulk: '{{total}}-dan {{current}}-un yüklənməsi',
     user: 'İstifadəçi',
     username: 'İstifadəçi adı',
     users: 'İstifadəçilər',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -309,6 +309,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Обновен успешно.',
     updating: 'Обновява се',
     uploading: 'Качва се',
+    uploadingBulk: 'Качване на {{current}} от {{total}}',
     user: 'Потребител',
     username: 'Потребителско име',
     users: 'Потребители',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -309,6 +309,7 @@ export const csTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Úspěšně aktualizováno.',
     updating: 'Aktualizace',
     uploading: 'Nahrávání',
+    uploadingBulk: 'Nahrávání {{current}} z {{total}}',
     user: 'Uživatel',
     username: 'Uživatelské jméno',
     users: 'Uživatelé',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -308,6 +308,7 @@ export const daTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Opdateret.',
     updating: 'Opdaterer',
     uploading: 'Uploader',
+    uploadingBulk: 'Uploader {{current}} af {{total}}',
     user: 'Bruger',
     username: 'Brugernavn',
     users: 'Brugere',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -315,6 +315,7 @@ export const deTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Erfolgreich aktualisiert.',
     updating: 'Aktualisierung',
     uploading: 'Hochladen',
+    uploadingBulk: 'Hochladen von {{current}} von {{total}}',
     user: 'Benutzer',
     username: 'Benutzername',
     users: 'Benutzer',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -311,6 +311,7 @@ export const enTranslations = {
     updatedSuccessfully: 'Updated successfully.',
     updating: 'Updating',
     uploading: 'Uploading',
+    uploadingBulk: 'Uploading {{current}} of {{total}}',
     user: 'User',
     username: 'Username',
     users: 'Users',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -314,6 +314,7 @@ export const esTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Actualizado con éxito.',
     updating: 'Actualizando',
     uploading: 'Subiendo',
+    uploadingBulk: 'Subiendo {{current}} de {{total}}',
     user: 'Usuario',
     username: 'Nombre de usuario',
     users: 'Usuarios',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -309,6 +309,7 @@ export const faTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'با موفقیت به‌روز شد.',
     updating: 'در حال به‌روزرسانی',
     uploading: 'در حال بارگذاری',
+    uploadingBulk: 'بارگذاری {{current}} از {{total}}',
     user: 'کاربر',
     username: 'نام کاربری',
     users: 'کاربران',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -318,6 +318,7 @@ export const frTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Mis à jour avec succès.',
     updating: 'Mise à jour',
     uploading: 'Téléchargement',
+    uploadingBulk: 'Téléchargement de {{current}} sur {{total}}',
     user: 'Utilisateur',
     username: "Nom d'utilisateur",
     users: 'Utilisateurs',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -304,6 +304,7 @@ export const heTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'עודכן בהצלחה.',
     updating: 'מעדכן',
     uploading: 'מעלה',
+    uploadingBulk: 'מעלה {{current}} מתוך {{total}}',
     user: 'משתמש',
     username: 'שם משתמש',
     users: 'משתמשים',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -310,6 +310,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Uspješno ažurirano.',
     updating: 'Ažuriranje',
     uploading: 'Prijenos',
+    uploadingBulk: 'Prenosim {{current}} od {{total}}',
     user: 'Korisnik',
     username: 'Korisničko ime',
     users: 'Korisnici',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -312,6 +312,7 @@ export const huTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Sikeresen frissítve.',
     updating: 'Frissítés',
     uploading: 'Feltöltés',
+    uploadingBulk: 'Feltöltés: {{current}} / {{total}}',
     user: 'Felhasználó',
     username: 'Felhasználónév',
     users: 'Felhasználók',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -313,6 +313,7 @@ export const itTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Aggiornato con successo.',
     updating: 'Aggiornamento',
     uploading: 'Caricamento',
+    uploadingBulk: 'Caricamento {{current}} di {{total}}',
     user: 'Utente',
     username: 'Nome utente',
     users: 'Utenti',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -310,6 +310,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: '更新成功。',
     updating: '更新中',
     uploading: 'アップロード中',
+    uploadingBulk: '{{current}} / {{total}} をアップロード中',
     user: 'ユーザー',
     username: 'ユーザーネーム',
     users: 'ユーザー',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -309,6 +309,7 @@ export const koTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: '성공적으로 업데이트되었습니다.',
     updating: '업데이트 중',
     uploading: '업로드 중',
+    uploadingBulk: '{{current}} / {{total}} 업로드 중',
     user: '사용자',
     username: '사용자 이름',
     users: '사용자',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -313,6 +313,7 @@ export const myTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'အပ်ဒိတ်လုပ်ပြီးပါပြီ။',
     updating: 'ပြင်ဆင်ရန်',
     uploading: 'တင်ပေးနေသည်',
+    uploadingBulk: 'တင်နေသည် {{current}} ခု အမှတ်ဖြစ်သည် {{total}} ခုစုစုပေါင်းဖြင့်',
     user: 'အသုံးပြုသူ',
     username: 'Nama pengguna',
     users: 'အသုံးပြုသူများ',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -310,6 +310,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Oppdatert.',
     updating: 'Oppdatering',
     uploading: 'Opplasting',
+    uploadingBulk: 'Laster opp {{current}} av {{total}}',
     user: 'Bruker',
     username: 'Brukernavn',
     users: 'Brukere',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -312,6 +312,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Succesvol aangepast.',
     updating: 'Bijwerken',
     uploading: 'Uploaden',
+    uploadingBulk: 'Bezig met uploaden {{current}} van {{total}}',
     user: 'Gebruiker',
     username: 'Gebruikersnaam',
     users: 'Gebruikers',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -310,6 +310,7 @@ export const plTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Aktualizacja zakończona sukcesem.',
     updating: 'Aktualizacja',
     uploading: 'Przesyłanie',
+    uploadingBulk: 'Przesyłanie {{current}} z {{total}}',
     user: 'użytkownik',
     username: 'Nazwa użytkownika',
     users: 'użytkownicy',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -311,6 +311,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Atualizado com sucesso.',
     updating: 'Atualizando',
     uploading: 'Fazendo upload',
+    uploadingBulk: 'Carregando {{current}} de {{total}}',
     user: 'usuário',
     username: 'Nome de usuário',
     users: 'usuários',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -314,6 +314,7 @@ export const roTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Actualizat cu succes.',
     updating: 'Actualizare',
     uploading: 'Încărcare',
+    uploadingBulk: 'Încărcare {{current}} din {{total}}',
     user: 'Utilizator',
     username: 'Nume de utilizator',
     users: 'Utilizatori',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -309,6 +309,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Успешно ажурирано.',
     updating: 'Ажурирање',
     uploading: 'Пренос',
+    uploadingBulk: 'Отпремање {{current}} од {{total}}',
     user: 'Корисник',
     username: 'Korisničko ime',
     users: 'Корисници',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -309,6 +309,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Uspešno ažurirano.',
     updating: 'Ažuriranje',
     uploading: 'Prenos',
+    uploadingBulk: 'Otpremanje {{current}} od {{total}}',
     user: 'Korisnik',
     username: 'Korisničko ime',
     users: 'Korisnici',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -313,6 +313,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Успешно Обновлено.',
     updating: 'Обновление',
     uploading: 'Загрузка',
+    uploadingBulk: 'Загрузка {{current}} из {{total}}',
     user: 'пользователь',
     username: 'Имя пользователя',
     users: 'пользователи',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -311,6 +311,7 @@ export const skTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Úspešne aktualizované.',
     updating: 'Aktualizácia',
     uploading: 'Nahrávanie',
+    uploadingBulk: 'Nahrávanie {{current}} z {{total}}',
     user: 'Používateľ',
     username: 'Používateľské meno',
     users: 'Používatelia',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -310,6 +310,7 @@ export const slTranslations = {
     updatedSuccessfully: 'Uspešno posodobljeno.',
     updating: 'Posodabljanje',
     uploading: 'Nalaganje',
+    uploadingBulk: 'Nalaganje {{current}} od {{total}}',
     user: 'Uporabnik',
     username: 'Uporabniško ime',
     users: 'Uporabniki',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -310,6 +310,7 @@ export const svTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Uppdaterades framgångsrikt.',
     updating: 'Uppdatering',
     uploading: 'Uppladdning',
+    uploadingBulk: 'Laddar upp {{current}} av {{total}}',
     user: 'Användare',
     username: 'Användarnamn',
     users: 'Användare',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -306,6 +306,7 @@ export const thTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'แก้ไขสำเร็จ',
     updating: 'กำลังอัปเดต',
     uploading: 'กำลังอัปโหลด',
+    uploadingBulk: 'อัปโหลด {{current}} จาก {{total}}',
     user: 'ผู้ใช้',
     username: 'ชื่อผู้ใช้',
     users: 'ผู้ใช้',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -314,6 +314,7 @@ export const trTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Başarıyla güncellendi.',
     updating: 'Güncelleniyor',
     uploading: 'Yükleniyor',
+    uploadingBulk: "{{total}}'den {{current}} yükleniyor",
     user: 'kullanıcı',
     username: 'Kullanıcı Adı',
     users: 'kullanıcı',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -310,6 +310,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Успішно відредаговано.',
     updating: 'оновлення',
     uploading: 'завантаження',
+    uploadingBulk: 'Завантаження {{current}} з {{total}}',
     user: 'Користувач',
     username: "Ім'я користувача",
     users: 'Користувачі',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -308,6 +308,7 @@ export const viTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: 'Cập nhật thành công.',
     updating: 'Đang cập nhật',
     uploading: 'Đang tải lên',
+    uploadingBulk: 'Đang tải lên {{current}} trong tổng số {{total}}',
     user: 'Người dùng',
     username: 'Tên đăng nhập',
     users: 'Người dùng',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -302,6 +302,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: '更新成功。',
     updating: '更新中',
     uploading: '上传中',
+    uploadingBulk: '正在上传{{current}}，共{{total}}',
     user: '用户',
     username: '用户名',
     users: '用户',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -302,6 +302,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     updatedSuccessfully: '更新成功。',
     updating: '更新中',
     uploading: '上傳中',
+    uploadingBulk: '正在上傳 {{current}} / {{total}}',
     user: '使用者',
     username: '使用者名稱',
     users: '使用者',

--- a/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
@@ -231,7 +231,9 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
         formState: currentFormsData,
       }
       const newDocs = []
-      const promises = currentForms.map(async (form, i) => {
+
+      for (let i = 0; i < currentForms.length; i++) {
+        const form = currentForms[i]
         try {
           toggleLoadingOverlay({
             isLoading: true,
@@ -292,9 +294,7 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
           setHasSubmitted(true)
           toggleLoadingOverlay({ isLoading: false, key: 'saveAllDocs' })
         }
-      })
-
-      await Promise.all(promises)
+      }
 
       const remainingForms = currentForms.filter(({ errorCount }) => errorCount > 0)
       const successCount = Math.max(0, currentForms.length - remainingForms.length)


### PR DESCRIPTION
### What?
Uses sequential pattern for Bulk Upload instead of `Promise.all`.

### Why?
* Concurrent uploads led to filename conflicts for example when you have
`upload.png` and `upload(1).png` already and you try to upload `upload.png`
* Potentially expensive for resources, especially with high amount of files / sizes

### How?
Replaces `Promise.all` with `for` loop, adds indicator "Uploaded 2/20"  to the loading overlay.
