### PR TITLE
fix(db-mongodb): `totalDocs` with joins

### DIFF
--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -118,7 +118,6 @@ export const find: Find = async function find(
     collection,
     collectionConfig,
     joins,
-    limit,
     locale,
     query,
   })

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -115,7 +115,6 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     collection,
     collectionConfig,
     joins,
-    limit,
     locale,
     projection,
     query: versionQuery,

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -831,6 +831,28 @@ describe('Joins Field', () => {
     expect(res.group.relatedPosts.docs).toBeDefined()
     expect(res.group.camelCasePosts.docs).toBeDefined()
   })
+
+  it('should have correct totalDocs', async () => {
+    for (let i = 0; i < 50; i++) {
+      await payload.create({ collection: categoriesSlug, data: { name: 'totalDocs' } })
+    }
+
+    const count = await payload.count({
+      collection: categoriesSlug,
+      where: { name: { equals: 'totalDocs' } },
+    })
+    expect(count.totalDocs).toBe(50)
+
+    const find = await payload.find({
+      collection: categoriesSlug,
+      limit: 5,
+      where: { name: { equals: 'totalDocs' } },
+    })
+    expect(find.totalDocs).toBe(50)
+    expect(find.docs).toHaveLength(5)
+
+    await payload.delete({ collection: categoriesSlug, where: { name: { equals: 'totalDocs' } } })
+  })
 })
 
 async function createPost(overrides?: Partial<Post>, locale?: Config['locale']) {


### PR DESCRIPTION
### What?
Fixes issue with incorrect `totalDocs` value when an aggregation is used for `find`.
Previously, `limit: 5` for example always returned `totalDocs: 5`.

### Why?
`totalDocs` must be returned correctly.

### How?
Removes `$limit` from the pipeline, as `Model.aggregatePaginate` handles it by itself.
