### PR TITLE
fix: corrected translation emailOrPasswordIncorrect for Danish (da)

### DIFF
--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -85,7 +85,7 @@ export const daTranslations: DefaultTranslationsObject = {
     deletingFile: 'Der opstod en fejl under sletning af filen.',
     deletingTitle:
       'Der opstod en fejl under sletningen {{title}}. Tjek din forbindelse eller prøv igen.',
-    emailOrPasswordIncorrect: 'Email eller brugernavn er forkert.',
+    emailOrPasswordIncorrect: 'Email eller adgangskode er forkert.',
     followingFieldsInvalid_one: 'Feltet er ugyldigt:',
     followingFieldsInvalid_other: 'Felterne er ugyldige:',
     incorrectCollection: 'Forkert samling',


### PR DESCRIPTION
## Description
Corrected `emailOrPasswordIncorrect` translation for Danish (da)

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.  

Type of change
- [x] fix (non-breaking change)