### PR TITLE
chore(cpa): use git tags for template urls

### DIFF
--- a/packages/create-payload-app/src/lib/constants.ts
+++ b/packages/create-payload-app/src/lib/constants.ts
@@ -1,0 +1,8 @@
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+const packageJson = JSON.parse(readFileSync(path.resolve(dirname, '../../package.json'), 'utf-8'))
+export const PACKAGE_VERSION = packageJson.version

--- a/packages/create-payload-app/src/lib/templates.ts
+++ b/packages/create-payload-app/src/lib/templates.ts
@@ -1,6 +1,7 @@
 import type { ProjectTemplate } from '../types.js'
 
 import { error, info } from '../utils/log.js'
+import { PACKAGE_VERSION } from './constants.js'
 
 export function validateTemplate(templateName: string): boolean {
   const validTemplates = getValidTemplates()
@@ -18,13 +19,13 @@ export function getValidTemplates(): ProjectTemplate[] {
       name: 'blank',
       type: 'starter',
       description: 'Blank 3.0 Template',
-      url: 'https://github.com/payloadcms/payload/templates/blank#beta',
+      url: `https://github.com/payloadcms/payload/templates/blank#v${PACKAGE_VERSION}`,
     },
     {
       name: 'website',
       type: 'starter',
       description: 'Website Template',
-      url: 'https://github.com/payloadcms/payload/templates/website#beta',
+      url: `https://github.com/payloadcms/payload/templates/website#v${PACKAGE_VERSION}`,
     },
 
     // Remove these until they have been updated for 3.0

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -8,6 +8,7 @@ import path from 'path'
 import type { CliArgs } from './types.js'
 
 import { configurePayloadConfig } from './lib/configure-payload-config.js'
+import { PACKAGE_VERSION } from './lib/constants.js'
 import { createProject } from './lib/create-project.js'
 import { generateSecret } from './lib/generate-secret.js'
 import { getPackageManager } from './lib/get-package-manager.js'
@@ -18,7 +19,7 @@ import { selectDb } from './lib/select-db.js'
 import { getValidTemplates, validateTemplate } from './lib/templates.js'
 import { updatePayloadInProject } from './lib/update-payload-in-project.js'
 import { writeEnvFile } from './lib/write-env-file.js'
-import { error, info } from './utils/log.js'
+import { debug, error, info } from './utils/log.js'
 import {
   feedbackOutro,
   helpMessage,
@@ -78,6 +79,8 @@ export class Main {
         helpMessage()
         process.exit(0)
       }
+
+      const debugFlag = this.args['--debug']
 
       // eslint-disable-next-line no-console
       console.log('\n')
@@ -199,6 +202,10 @@ export class Main {
           helpMessage()
           process.exit(1)
         }
+      }
+
+      if (debugFlag) {
+        debug(`Using templates from git tag: ${PACKAGE_VERSION}`)
       }
 
       const validTemplates = getValidTemplates()


### PR DESCRIPTION
`create-payload-app` will now use git tags when cloning down the templates instead of using latest from a branch.

The mechanism is cpa will read its own package.json version and use that as a git tag prefixed w/ `v`