### PR TITLE
fix: migrateRefresh migrates without previously ran migrations

### DIFF
--- a/packages/payload/src/database/migrations/migrateRefresh.ts
+++ b/packages/payload/src/database/migrations/migrateRefresh.ts
@@ -14,59 +14,57 @@ export async function migrateRefresh(this: BaseDatabaseAdapter) {
   const { payload } = this
   const migrationFiles = await readMigrationFiles({ payload })
 
-  const { existingMigrations, latestBatch } = await getMigrations({
+  const { existingMigrations } = await getMigrations({
     payload,
-  })
-
-  if (!existingMigrations?.length) {
-    payload.logger.info({ msg: 'No migrations to rollback.' })
-    return
-  }
-
-  payload.logger.info({
-    msg: `Rolling back batch ${latestBatch} consisting of ${existingMigrations.length} migration(s).`,
   })
 
   const req = { payload } as PayloadRequest
 
-  // Reverse order of migrations to rollback
-  existingMigrations.reverse()
+  if (existingMigrations?.length) {
+    payload.logger.info({
+      msg: `Rolling back all ${existingMigrations.length} migration(s).`,
+    })
+    // Reverse order of migrations to rollback
+    existingMigrations.reverse()
 
-  for (const migration of existingMigrations) {
-    try {
-      const migrationFile = migrationFiles.find((m) => m.name === migration.name)
-      if (!migrationFile) {
-        throw new Error(`Migration ${migration.name} not found locally.`)
-      }
+    for (const migration of existingMigrations) {
+      try {
+        const migrationFile = migrationFiles.find((m) => m.name === migration.name)
+        if (!migrationFile) {
+          throw new Error(`Migration ${migration.name} not found locally.`)
+        }
 
-      payload.logger.info({ msg: `Migrating down: ${migration.name}` })
-      const start = Date.now()
-      await initTransaction(req)
-      await migrationFile.down({ payload, req })
-      payload.logger.info({
-        msg: `Migrated down:  ${migration.name} (${Date.now() - start}ms)`,
-      })
-      await payload.delete({
-        collection: 'payload-migrations',
-        req,
-        where: {
-          name: {
-            equals: migration.name,
+        payload.logger.info({ msg: `Migrating down: ${migration.name}` })
+        const start = Date.now()
+        await initTransaction(req)
+        await migrationFile.down({ payload, req })
+        payload.logger.info({
+          msg: `Migrated down:  ${migration.name} (${Date.now() - start}ms)`,
+        })
+        await payload.delete({
+          collection: 'payload-migrations',
+          req,
+          where: {
+            name: {
+              equals: migration.name,
+            },
           },
-        },
-      })
-    } catch (err: unknown) {
-      await killTransaction(req)
-      let msg = `Error running migration ${migration.name}. Rolling back.`
-      if (err instanceof Error) {
-        msg += ` ${err.message}`
+        })
+      } catch (err: unknown) {
+        await killTransaction(req)
+        let msg = `Error running migration ${migration.name}. Rolling back.`
+        if (err instanceof Error) {
+          msg += ` ${err.message}`
+        }
+        payload.logger.error({
+          err,
+          msg,
+        })
+        process.exit(1)
       }
-      payload.logger.error({
-        err,
-        msg,
-      })
-      process.exit(1)
     }
+  } else {
+    payload.logger.info({ msg: 'No migrations to rollback.' })
   }
 
   // Run all migrate up

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -126,8 +126,14 @@ describe('database', () => {
   })
 
   describe('migrations', () => {
+    let ranFreshTest = false
+
     beforeEach(async () => {
-      if (process.env.PAYLOAD_DROP_DATABASE === 'true' && 'drizzle' in payload.db) {
+      if (
+        process.env.PAYLOAD_DROP_DATABASE === 'true' &&
+        'drizzle' in payload.db &&
+        !ranFreshTest
+      ) {
         const db = payload.db as unknown as PostgresAdapter
         await db.dropDatabase({ adapter: db })
       }
@@ -181,6 +187,7 @@ describe('database', () => {
       const migration = docs[0]
       expect(migration.name).toContain('_test')
       expect(migration.batch).toStrictEqual(1)
+      ranFreshTest = true
     })
 
     it('should run migrate:down', async () => {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -182,26 +182,36 @@ describe('database', () => {
       expect(migration.batch).toStrictEqual(1)
     })
 
-    // known issue: https://github.com/payloadcms/payload/issues/4597
-    it.skip('should run migrate:down', async () => {
+    it('should run migrate:down', async () => {
       let error
       try {
         await payload.db.migrateDown()
       } catch (e) {
         error = e
       }
+
+      const migrations = await payload.find({
+        collection: 'payload-migrations',
+      })
+
       expect(error).toBeUndefined()
+      expect(migrations.docs).toHaveLength(0)
     })
 
-    // known issue: https://github.com/payloadcms/payload/issues/4597
-    it.skip('should run migrate:refresh', async () => {
+    it('should run migrate:refresh', async () => {
       let error
       try {
         await payload.db.migrateRefresh()
       } catch (e) {
         error = e
       }
+
+      const migrations = await payload.find({
+        collection: 'payload-migrations',
+      })
+
       expect(error).toBeUndefined()
+      expect(migrations.docs).toHaveLength(1)
     })
   })
 

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'url'
 
 import { devUser } from '../credentials.js'
 import { initPayloadInt } from '../helpers/initPayloadInt.js'
+import { isMongoose } from '../helpers/isMongoose.js'
 import removeFiles from '../helpers/removeFiles.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -183,7 +184,8 @@ describe('database', () => {
     })
 
     // known issue: https://github.com/payloadcms/payload/issues/4597
-    it.skip('should run migrate:down', async () => {
+    it('should run migrate:down', async () => {
+      if (!isMongoose(payload)) {return}
       let error
       try {
         await payload.db.migrateDown()
@@ -200,7 +202,8 @@ describe('database', () => {
     })
 
     // known issue: https://github.com/payloadcms/payload/issues/4597
-    it.skip('should run migrate:refresh', async () => {
+    it('should run migrate:refresh', async () => {
+      if (!isMongoose(payload)) {return}
       let error
       try {
         await payload.db.migrateRefresh()

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -182,7 +182,8 @@ describe('database', () => {
       expect(migration.batch).toStrictEqual(1)
     })
 
-    it('should run migrate:down', async () => {
+    // known issue: https://github.com/payloadcms/payload/issues/4597
+    it.skip('should run migrate:down', async () => {
       let error
       try {
         await payload.db.migrateDown()
@@ -198,7 +199,8 @@ describe('database', () => {
       expect(migrations.docs).toHaveLength(0)
     })
 
-    it('should run migrate:refresh', async () => {
+    // known issue: https://github.com/payloadcms/payload/issues/4597
+    it.skip('should run migrate:refresh', async () => {
       let error
       try {
         await payload.db.migrateRefresh()

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -183,9 +183,11 @@ describe('database', () => {
       expect(migration.batch).toStrictEqual(1)
     })
 
-    // known issue: https://github.com/payloadcms/payload/issues/4597
     it('should run migrate:down', async () => {
-      if (!isMongoose(payload)) {return}
+      // known drizzle issue: https://github.com/payloadcms/payload/issues/4597
+      if (!isMongoose(payload)) {
+        return
+      }
       let error
       try {
         await payload.db.migrateDown()
@@ -201,9 +203,11 @@ describe('database', () => {
       expect(migrations.docs).toHaveLength(0)
     })
 
-    // known issue: https://github.com/payloadcms/payload/issues/4597
     it('should run migrate:refresh', async () => {
-      if (!isMongoose(payload)) {return}
+      // known drizzle issue: https://github.com/payloadcms/payload/issues/4597
+      if (!isMongoose(payload)) {
+        return
+      }
       let error
       try {
         await payload.db.migrateRefresh()


### PR DESCRIPTION
fix: migrateRefresh migrates without previously ran migrations
chore: adds tests for database migrate:fresh and migrate:refresh
