### PR TITLE
feat: add connection string flag `--db-uri` to main command

### DIFF
--- a/packages/create-payload-app/src/lib/select-db.ts
+++ b/packages/create-payload-app/src/lib/select-db.ts
@@ -59,8 +59,8 @@ export async function selectDb(args: CliArgs, projectName: string): Promise<DbDe
 
   const dbChoice = dbChoiceRecord[dbType]
 
-  if (args['--dbUri']) {
-    dbUri = args['--dbUri'] as string
+  if (args['--db-uri']) {
+    dbUri = args['--db-uri'] as string
     return {
       dbUri,
       type: dbChoice.value,

--- a/packages/create-payload-app/src/lib/select-db.ts
+++ b/packages/create-payload-app/src/lib/select-db.ts
@@ -24,6 +24,7 @@ const dbChoiceRecord: Record<DbType, DbChoice> = {
 
 export async function selectDb(args: CliArgs, projectName: string): Promise<DbDetails> {
   let dbType: DbType | undefined = undefined
+  let dbUri: string | undefined = undefined
   if (args['--db']) {
     if (!Object.values(dbChoiceRecord).some((dbChoice) => dbChoice.value === args['--db'])) {
       throw new Error(
@@ -57,6 +58,14 @@ export async function selectDb(args: CliArgs, projectName: string): Promise<DbDe
   }
 
   const dbChoice = dbChoiceRecord[dbType]
+
+  if (args['--dbUri']) {
+    dbUri = args['--dbUri'] as string
+    return {
+      dbUri,
+      type: dbChoice.value,
+    }
+  }
 
   const dbUriRes = await prompts(
     {

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -21,7 +21,7 @@ export class Main {
     this.args = arg(
       {
         '--db': String,
-        '--dbUri': String,
+        '--db-uri': String,
         '--help': Boolean,
         '--name': String,
         '--secret': String,

--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -21,6 +21,7 @@ export class Main {
     this.args = arg(
       {
         '--db': String,
+        '--dbUri': String,
         '--help': Boolean,
         '--name': String,
         '--secret': String,

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -3,7 +3,7 @@ import type arg from 'arg'
 export interface Args extends arg.Spec {
   '--beta': BooleanConstructor
   '--db': StringConstructor
-  '--dbUri': StringConstructor
+  '--db-uri': StringConstructor
   '--dry-run': BooleanConstructor
   '--help': BooleanConstructor
   '--name': StringConstructor

--- a/packages/create-payload-app/src/types.ts
+++ b/packages/create-payload-app/src/types.ts
@@ -3,6 +3,7 @@ import type arg from 'arg'
 export interface Args extends arg.Spec {
   '--beta': BooleanConstructor
   '--db': StringConstructor
+  '--dbUri': StringConstructor
   '--dry-run': BooleanConstructor
   '--help': BooleanConstructor
   '--name': StringConstructor

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -28,6 +28,8 @@ export function helpMessage(): string {
 
       -n     {underline my-payload-app}         Set project name
       -t     {underline template_name}          Choose specific template
+      -d     {underline database_type}          Choose specific database
+      --dbUri     {underline connection_string}          Set connection string
 
         {dim Available templates: ${formatTemplates(validTemplates)}}
 

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -29,7 +29,7 @@ export function helpMessage(): string {
       -n     {underline my-payload-app}         Set project name
       -t     {underline template_name}          Choose specific template
       -d     {underline database_type}          Choose specific database
-      --dbUri     {underline connection_string}          Set connection string
+      --db-uri     {underline connection_string}          Set connection string
 
         {dim Available templates: ${formatTemplates(validTemplates)}}
 


### PR DESCRIPTION
### What?
I have implemented  `--db-uri` flag which accepts a connection string and updated the help message.
### Why?
In CI/CD environments it's very hard to go through `create-payload-app` process without interfering with the prompt interactions. (Especially the connection string one, since it requires multiple characters deletion.)
### How?
A simple check for `--db-uri` in `packages/create-payload-app/src/lib/select-db.ts` before prompting for connection string.

Example usage:
`create-payload-app --db-uri postgresql://user:password@localhost:5432/postgres`


