### PR TITLE
docs: fix find global anchor

### DIFF
--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -400,7 +400,7 @@ const result = await payload.verifyEmail({
 
 The following Global operations are available through the Local API:
 
-### Find
+### Find Global
 
 ```js
 // Result will be the Header Global.
@@ -415,7 +415,7 @@ const result = await payload.findGlobal({
 })
 ```
 
-### Update
+### Update Global
 
 ```js
 // Result will be the updated Header Global.


### PR DESCRIPTION
### What?

The `Find` anchor for globals is linking to the `Find` anchor for collections in the local API documentation.

### Why?

Anchors needs to be unique across the page or it will default to the first one.

### How?

Changes `Find` to `Find Global` and `Update` to `Update Global` to ensure uniqueness for anchors.

Technically `Update` was unique but it has been updated to `Update Global` for consistency.