### PR TITLE
fix(db-mongodb)!: use dbName for mongodb model

### DIFF
--- a/packages/db-mongodb/src/init.ts
+++ b/packages/db-mongodb/src/init.ts
@@ -54,10 +54,12 @@ export const init: Init = function init(this: MongooseAdapter) {
       this.versions[collection.slug] = model
     }
 
+    const modelName = getDBName({ config: collection })
+
     const model = mongoose.model(
-      getDBName({ config: collection }),
+      modelName,
       schema,
-      this.autoPluralization === true ? undefined : collection.slug,
+      this.autoPluralization === true ? undefined : modelName,
     ) as CollectionModel
     this.collections[collection.slug] = model
   })

--- a/packages/db-mongodb/src/init.ts
+++ b/packages/db-mongodb/src/init.ts
@@ -45,27 +45,28 @@ export const init: Init = function init(this: MongooseAdapter) {
         versionSchema.plugin(mongooseAggregatePaginate)
       }
 
-      const model = mongoose.model(
+      const versionCollectionName =
+        this.autoPluralization === true && !collection.dbName ? undefined : versionModelName
+
+      this.versions[collection.slug] = mongoose.model(
         versionModelName,
         versionSchema,
-        this.autoPluralization === true ? undefined : versionModelName,
+        versionCollectionName,
       ) as CollectionModel
-
-      this.versions[collection.slug] = model
     }
 
     const modelName = getDBName({ config: collection })
+    const collectionName =
+      this.autoPluralization === true && !collection.dbName ? undefined : modelName
 
-    const model = mongoose.model(
+    this.collections[collection.slug] = mongoose.model(
       modelName,
       schema,
-      this.autoPluralization === true ? undefined : modelName,
+      collectionName,
     ) as CollectionModel
-    this.collections[collection.slug] = model
   })
 
-  const model = buildGlobalModel(this.payload.config)
-  this.globals = model
+  this.globals = buildGlobalModel(this.payload.config)
 
   this.payload.config.globals.forEach((global) => {
     if (global.versions) {
@@ -87,12 +88,11 @@ export const init: Init = function init(this: MongooseAdapter) {
         .plugin<any, PaginateOptions>(paginate, { useEstimatedCount: true })
         .plugin(getBuildQueryPlugin({ versionsFields: versionGlobalFields }))
 
-      const versionsModel = mongoose.model(
+      this.versions[global.slug] = mongoose.model(
         versionModelName,
         versionSchema,
         versionModelName,
       ) as CollectionModel
-      this.versions[global.slug] = versionsModel
     }
   })
 }


### PR DESCRIPTION
### What?
Uses the `collection.dbName` property for the Mongoose model, if defined.

### Why?
Currently, `collection.dbName` is used for the version name but not for the actual collection name. Additionally, `autoPluralization` modifies the `dbName` regardless. This behavior is inconsistent and contradicts the documentation.

### How?
- Utilize `collection.dbName` instead of `collection.slug`.
- Disable `autoPluralization` for collections with a defined `dbName`.

Related: https://github.com/payloadcms/payload/discussions/9058

**Breaking change:**
If a `dbName` was previously provided, it will now be used as the MongoDB collection name instead of the collection `slug`. `autoPluralization` will not be applied to `dbName`.