### PR TITLE
chore: adjust abort controller logic for server functions

### DIFF
--- a/packages/richtext-slate/src/field/elements/link/Button/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/Button/index.tsx
@@ -100,7 +100,6 @@ export const LinkButton: React.FC<{
                 data,
                 docPermissions,
                 docPreferences: await getDocPreferences(),
-                doNotAbort: true,
                 globalSlug,
                 operation: 'update',
                 renderAllFields: true,

--- a/packages/richtext-slate/src/field/elements/link/Element/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/Element/index.tsx
@@ -103,7 +103,6 @@ export const LinkElement = () => {
         data,
         docPermissions,
         docPreferences: await getDocPreferences(),
-        doNotAbort: true,
         globalSlug,
         operation: 'update',
         renderAllFields: true,

--- a/packages/richtext-slate/src/field/elements/upload/Element/UploadDrawer/index.tsx
+++ b/packages/richtext-slate/src/field/elements/upload/Element/UploadDrawer/index.tsx
@@ -77,7 +77,6 @@ export const UploadDrawer: React.FC<{
         data,
         docPermissions,
         docPreferences: await getDocPreferences(),
-        doNotAbort: true,
         globalSlug,
         operation: 'update',
         renderAllFields: true,

--- a/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerContent.tsx
@@ -81,10 +81,6 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
       }
 
       void fetchDocumentView()
-
-      return () => {
-        abortAndIgnore(controller)
-      }
     },
     [
       collectionSlug,
@@ -101,8 +97,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
 
   const onSave = useCallback<DocumentDrawerProps['onSave']>(
     (args) => {
-      const cleanup = getDocumentView(args.doc.id)
-      cleanup()
+      getDocumentView(args.doc.id)
 
       if (typeof onSaveFromProps === 'function') {
         void onSaveFromProps({
@@ -116,8 +111,7 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
 
   const onDuplicate = useCallback<DocumentDrawerProps['onDuplicate']>(
     (args) => {
-      const cleanup = getDocumentView(args.doc.id)
-      cleanup()
+      getDocumentView(args.doc.id)
 
       if (typeof onDuplicateFromProps === 'function') {
         void onDuplicateFromProps({
@@ -144,14 +138,12 @@ export const DocumentDrawerContent: React.FC<DocumentDrawerProps> = ({
   )
 
   const clearDoc = useCallback(() => {
-    const cleanup = getDocumentView()
-    cleanup()
+    getDocumentView()
   }, [getDocumentView])
 
   useEffect(() => {
     if (!DocumentView) {
-      const cleanup = getDocumentView(existingDocID)
-      return cleanup
+      getDocumentView(existingDocID)
     }
   }, [DocumentView, getDocumentView, existingDocID])
 

--- a/packages/ui/src/elements/EditMany/index.tsx
+++ b/packages/ui/src/elements/EditMany/index.tsx
@@ -4,7 +4,7 @@ import type { ClientCollectionConfig, FormState } from 'payload'
 import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
 import { useRouter } from 'next/navigation.js'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import type { FormProps } from '../../forms/Form/index.js'
 
@@ -23,6 +23,7 @@ import { useSearchParams } from '../../providers/SearchParams/index.js'
 import { SelectAllStatus, useSelection } from '../../providers/Selection/index.js'
 import { useServerFunctions } from '../../providers/ServerFunctions/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { abortAndIgnore } from '../../utilities/abortAndIgnore.js'
 import { Drawer, DrawerToggler } from '../Drawer/index.js'
 import { FieldSelect } from '../FieldSelect/index.js'
 import './index.scss'
@@ -127,6 +128,7 @@ export const EditMany: React.FC<EditManyProps> = (props) => {
   const router = useRouter()
   const [initialState, setInitialState] = useState<FormState>()
   const hasInitializedState = React.useRef(false)
+  const formStateAbortControllerRef = React.useRef<AbortController>(null)
   const { clearRouteCache } = useRouteCache()
 
   const collectionPermissions = permissions?.collections?.[slug]
@@ -135,6 +137,8 @@ export const EditMany: React.FC<EditManyProps> = (props) => {
   const drawerSlug = `edit-${slug}`
 
   React.useEffect(() => {
+    const controller = new AbortController()
+
     if (!hasInitializedState.current) {
       const getInitialState = async () => {
         const { state: result } = await getFormState({
@@ -144,6 +148,7 @@ export const EditMany: React.FC<EditManyProps> = (props) => {
           docPreferences: null,
           operation: 'update',
           schemaPath: slug,
+          signal: controller.signal,
         })
 
         setInitialState(result)
@@ -151,11 +156,20 @@ export const EditMany: React.FC<EditManyProps> = (props) => {
       }
 
       void getInitialState()
+
+      return () => {
+        abortAndIgnore(controller)
+      }
     }
   }, [apiRoute, hasInitializedState, serverURL, slug, getFormState, user, collectionPermissions])
 
   const onChange: FormProps['onChange'][0] = useCallback(
     async ({ formState: prevFormState }) => {
+      abortAndIgnore(formStateAbortControllerRef.current)
+
+      const controller = new AbortController()
+      formStateAbortControllerRef.current = controller
+
       const { state } = await getFormState({
         collectionSlug: slug,
         docPermissions: collectionPermissions,
@@ -163,12 +177,17 @@ export const EditMany: React.FC<EditManyProps> = (props) => {
         formState: prevFormState,
         operation: 'update',
         schemaPath: slug,
+        signal: controller.signal,
       })
 
       return state
     },
     [slug, getFormState, collectionPermissions],
   )
+
+  useEffect(() => {
+    abortAndIgnore(formStateAbortControllerRef.current)
+  }, [])
 
   if (selectAll === SelectAllStatus.None || !hasUpdatePermission) {
     return null

--- a/packages/ui/src/exports/shared/index.ts
+++ b/packages/ui/src/exports/shared/index.ts
@@ -7,6 +7,7 @@ export { WithServerSideProps } from '../../elements/WithServerSideProps/index.js
 export { reduceToSerializableFields } from '../../forms/Form/reduceToSerializableFields.js'
 export { PayloadIcon } from '../../graphics/Icon/index.js'
 export { PayloadLogo } from '../../graphics/Logo/index.js'
+export { abortAndIgnore } from '../../utilities/abortAndIgnore.js'
 export { requests } from '../../utilities/api.js'
 export { findLocaleFromCode } from '../../utilities/findLocaleFromCode.js'
 export { formatAdminURL } from '../../utilities/formatAdminURL.js'

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -29,6 +29,7 @@ import { useLocale } from '../../providers/Locale/index.js'
 import { useOperation } from '../../providers/Operation/index.js'
 import { useServerFunctions } from '../../providers/ServerFunctions/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
+import { abortAndIgnore } from '../../utilities/abortAndIgnore.js'
 import { requests } from '../../utilities/api.js'
 import {
   FormContext,
@@ -91,8 +92,7 @@ export const Form: React.FC<FormProps> = (props) => {
   const [submitted, setSubmitted] = useState(false)
   const formRef = useRef<HTMLFormElement>(null)
   const contextRef = useRef({} as FormContextType)
-  const abortControllerRef = useRef(new AbortController())
-  const abortControllerRef2 = useRef(new AbortController())
+  const resetFormStateAbortControllerRef = useRef<AbortController>(null)
 
   const fieldsReducer = useReducer(fieldReducer, {}, () => initialState)
 
@@ -456,16 +456,10 @@ export const Form: React.FC<FormProps> = (props) => {
 
   const reset = useCallback(
     async (data: unknown) => {
-      if (abortControllerRef.current) {
-        try {
-          abortControllerRef.current.abort()
-        } catch (error) {
-          // swallow error
-        }
-      }
+      abortAndIgnore(resetFormStateAbortControllerRef.current)
 
-      const abortController = new AbortController()
-      abortControllerRef.current = abortController
+      const controller = new AbortController()
+      resetFormStateAbortControllerRef.current = controller
 
       const docPreferences = await getDocPreferences()
 
@@ -479,7 +473,7 @@ export const Form: React.FC<FormProps> = (props) => {
         operation,
         renderAllFields: true,
         schemaPath: collectionSlug ? collectionSlug : globalSlug,
-        signal: abortController.signal,
+        signal: controller.signal,
       })
 
       contextRef.current = { ...initContextState } as FormContextType
@@ -548,27 +542,9 @@ export const Form: React.FC<FormProps> = (props) => {
     [dispatchFields, getDataByPath],
   )
 
-  // clean on unmount
   useEffect(() => {
-    const re1 = abortControllerRef.current
-    const re2 = abortControllerRef2.current
-
     return () => {
-      if (re1) {
-        try {
-          re1.abort()
-        } catch (_err) {
-          // swallow error
-        }
-      }
-
-      if (re2) {
-        try {
-          re2.abort()
-        } catch (_err) {
-          // swallow error
-        }
-      }
+      abortAndIgnore(resetFormStateAbortControllerRef.current)
     }
   }, [])
 

--- a/packages/ui/src/providers/ServerFunctions/index.tsx
+++ b/packages/ui/src/providers/ServerFunctions/index.tsx
@@ -6,14 +6,13 @@ import type {
   ServerFunctionClient,
 } from 'payload'
 
-import React, { createContext, useCallback, useEffect, useRef } from 'react'
+import React, { createContext, useCallback } from 'react'
 
 import type { buildFormStateHandler } from '../../utilities/buildFormState.js'
 import type { buildTableStateHandler } from '../../utilities/buildTableState.js'
 
 type GetFormStateClient = (
   args: {
-    doNotAbort?: boolean
     signal?: AbortSignal
   } & Omit<BuildFormStateArgs, 'clientConfig' | 'req'>,
 ) => ReturnType<typeof buildFormStateHandler>
@@ -28,7 +27,6 @@ type RenderDocument = (args: {
   collectionSlug: string
   disableActions?: boolean
   docID?: number | string
-  doNotAbort?: boolean
   drawerSlug?: string
   initialData?: Data
   redirectAfterDelete?: boolean
@@ -69,10 +67,6 @@ export const ServerFunctionsProvider: React.FC<{
     throw new Error('ServerFunctionsProvider requires a serverFunction prop')
   }
 
-  // This is the local abort controller, to abort requests when the _provider_ itself unmounts, etc.
-  // Each callback also accept a remote signal, to abort requests when each _component_ unmounts, etc.
-  const abortControllerRef = useRef(new AbortController())
-
   const getDocumentSlots = useCallback<GetDocumentSlots>(
     async (args) =>
       await serverFunction({
@@ -84,39 +78,16 @@ export const ServerFunctionsProvider: React.FC<{
 
   const getFormState = useCallback<GetFormStateClient>(
     async (args) => {
-      if (args?.doNotAbort) {
-        try {
-          const result = (await serverFunction({
-            name: 'form-state',
-            args,
-          })) as ReturnType<typeof buildFormStateHandler> // TODO: infer this type when `strictNullChecks` is enabled
-
-          return result
-        } catch (_err) {
-          console.error(_err) // eslint-disable-line no-console
-        }
-
-        return { state: null }
-      }
-
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort()
-      }
-
-      const abortController = new AbortController()
-      abortControllerRef.current = abortController
-      const localSignal = abortController.signal
-
       const { signal: remoteSignal, ...rest } = args || {}
 
       try {
-        if (!remoteSignal?.aborted && !localSignal?.aborted) {
+        if (!remoteSignal?.aborted) {
           const result = (await serverFunction({
             name: 'form-state',
             args: rest,
           })) as ReturnType<typeof buildFormStateHandler> // TODO: infer this type when `strictNullChecks` is enabled
 
-          if (!remoteSignal?.aborted && !localSignal?.aborted) {
+          if (!remoteSignal?.aborted) {
             return result
           }
         }
@@ -151,37 +122,16 @@ export const ServerFunctionsProvider: React.FC<{
 
   const renderDocument = useCallback<RenderDocument>(
     async (args) => {
-      if (args?.doNotAbort) {
-        try {
-          const result = (await serverFunction({
-            name: 'render-document',
-            args,
-          })) as { docID: string; Document: React.ReactNode }
-
-          return result
-        } catch (_err) {
-          console.error(_err) // eslint-disable-line no-console
-          return
-        }
-      }
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort()
-      }
-
-      const abortController = new AbortController()
-      abortControllerRef.current = abortController
-      const localSignal = abortController.signal
-
       const { signal: remoteSignal, ...rest } = args || {}
 
       try {
-        if (!remoteSignal?.aborted && !localSignal?.aborted) {
+        if (!remoteSignal?.aborted) {
           const result = (await serverFunction({
             name: 'render-document',
             args: rest,
           })) as { docID: string; Document: React.ReactNode }
 
-          if (!remoteSignal?.aborted && !localSignal?.aborted) {
+          if (!remoteSignal?.aborted) {
             return result
           }
         }
@@ -191,20 +141,6 @@ export const ServerFunctionsProvider: React.FC<{
     },
     [serverFunction],
   )
-
-  useEffect(() => {
-    const controller = abortControllerRef.current
-
-    return () => {
-      if (controller) {
-        try {
-          // controller.abort()
-        } catch (_err) {
-          // swallow error
-        }
-      }
-    }
-  }, [])
 
   return (
     <ServerFunctionsContext.Provider

--- a/packages/ui/src/providers/ServerFunctions/index.tsx
+++ b/packages/ui/src/providers/ServerFunctions/index.tsx
@@ -102,15 +102,19 @@ export const ServerFunctionsProvider: React.FC<{
 
   const getTableState = useCallback<GetTableStateClient>(
     async (args) => {
-      const { ...rest } = args || {}
+      const { signal: remoteSignal, ...rest } = args || {}
 
       try {
-        const result = (await serverFunction({
-          name: 'table-state',
-          args: rest,
-        })) as ReturnType<typeof buildTableStateHandler> // TODO: infer this type when `strictNullChecks` is enabled
+        if (!remoteSignal?.aborted) {
+          const result = (await serverFunction({
+            name: 'table-state',
+            args: rest,
+          })) as ReturnType<typeof buildTableStateHandler> // TODO: infer this type when `strictNullChecks` is enabled
 
-        return result
+          if (!remoteSignal?.aborted) {
+            return result
+          }
+        }
       } catch (_err) {
         console.error(_err) // eslint-disable-line no-console
       }

--- a/packages/ui/src/utilities/abortAndIgnore.ts
+++ b/packages/ui/src/utilities/abortAndIgnore.ts
@@ -1,0 +1,9 @@
+export function abortAndIgnore(controller: AbortController) {
+  if (controller) {
+    try {
+      controller.abort()
+    } catch (_err) {
+      // swallow error
+    }
+  }
+}

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -481,10 +481,8 @@ describe('access control', () => {
 
       await expect(page.locator('.unauthorized')).toBeVisible()
 
-      await page.goto(logoutURL)
-      await page.waitForURL(logoutURL)
-
       // Log back in for the next test
+      await page.goto(logoutURL)
       await login({
         data: {
           email: devUser.email,
@@ -528,6 +526,19 @@ describe('access control', () => {
       await page.waitForURL(unauthorizedURL)
 
       await expect(page.locator('.unauthorized')).toBeVisible()
+
+      // Log back in for the next test
+      await context.clearCookies()
+      await page.goto(logoutURL)
+      await page.waitForURL(logoutURL)
+      await login({
+        data: {
+          email: devUser.email,
+          password: devUser.password,
+        },
+        page,
+        serverURL,
+      })
     })
   })
 


### PR DESCRIPTION
### What?
Removes abort controllers that were shared globally inside the server actions provider.

### Why?
Constructing them in this way will cause different fetches using the same function to cancel one another accidentally.

These are currently causing issues when two components call server functions, even different functions, because the global ref inside was being overwritten and aborting the previous one.

### How?
Abort controllers are now created and maintained inside of their own component. Signals can be passed into functions that need them. These are useful inside of effects and functions.

You need these inside of effects so things like loading initial data can cancel the original request when React renders them twice in dev mode. 

They are also useful to cancel requests when a component unmounts.
