### PR TITLE
fix(ui): pass correct relationTo to locked documents creation

### DIFF
--- a/packages/ui/src/utilities/handleFormStateLocking.ts
+++ b/packages/ui/src/utilities/handleFormStateLocking.ts
@@ -125,13 +125,13 @@ export const handleFormStateLocking = async ({
           data: {
             document: collectionSlug
               ? {
-                  relationTo: [collectionSlug],
+                  relationTo: collectionSlug,
                   value: id,
                 }
               : undefined,
             globalSlug: globalSlug ? globalSlug : undefined,
             user: {
-              relationTo: [req.user.collection],
+              relationTo: req.user.collection,
               value: req.user.id,
             },
           },


### PR DESCRIPTION
### What?
Relationships within `payload-locked-documents` collection were stored incorrectly with `relationTo` as an array:
<img width="316" alt="image" src="https://github.com/user-attachments/assets/f84b9807-6032-4ea2-8563-5c7d13306a4a">

Example how it should be:
<img width="405" alt="image" src="https://github.com/user-attachments/assets/80fb54fd-7c2e-4c90-bd2b-dec8e7a06040">


This additionally caused issue that `value` wasn't converted to `ObjectID`