### PR TITLE
fix(next): disable turbopack serverExternalPackages warnings

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -13,20 +13,22 @@ export const withPayload = (nextConfig = {}) => {
     env.NEXT_PUBLIC_ENABLE_ROUTER_CACHE_REFRESH = 'true'
   }
 
-  const consoleWarn = console.warn
+  if (process.env.PAYLOAD_PATCH_TURBOPACK_WARNINGS !== 'false') {
+    const consoleWarn = console.warn
 
-  console.warn = (...args) => {
-    // Force to disable serverExternalPackages warnings: https://github.com/vercel/next.js/issues/68805
-    if (
-      typeof args[1] === 'string' &&
-      args[1].includes(
-        'Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.\nTry to install it into the project directory by running',
-      )
-    ) {
-      return
+    console.warn = (...args) => {
+      // Force to disable serverExternalPackages warnings: https://github.com/vercel/next.js/issues/68805
+      if (
+        typeof args[1] === 'string' &&
+        args[1].includes(
+          'Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.\nTry to install it into the project directory by running',
+        )
+      ) {
+        return
+      }
+
+      consoleWarn(...args)
     }
-
-    consoleWarn(...args)
   }
 
   const poweredByHeader = {

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -13,6 +13,22 @@ export const withPayload = (nextConfig = {}) => {
     env.NEXT_PUBLIC_ENABLE_ROUTER_CACHE_REFRESH = 'true'
   }
 
+  const consoleWarn = console.warn
+
+  console.warn = (...args) => {
+    // Force to disable serverExternalPackages warnings: https://github.com/vercel/next.js/issues/68805
+    if (
+      typeof args[1] === 'string' &&
+      args[1].includes(
+        'Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.\nTry to install it into the project directory by running',
+      )
+    ) {
+      return
+    }
+
+    consoleWarn(...args)
+  }
+
   const poweredByHeader = {
     key: 'X-Powered-By',
     value: 'Next.js, Payload',


### PR DESCRIPTION
### What?
Disables these annoying warnings when running `pnpm dev --turbo`
<img width="656" alt="image" src="https://github.com/user-attachments/assets/7d0a2990-b5fd-4f5d-a025-665e8e3a7880">
https://github.com/vercel/next.js/issues/68805

### How?
Patches `console.warn` in `withPayload.js`

Can be disabled with `PAYLOAD_PATCH_TURBOPACK_WARNINGS=false` env variable