### PR TITLE
fix: allow specifying queue

### DIFF
--- a/packages/payload/src/queues/config/jobsCollection.ts
+++ b/packages/payload/src/queues/config/jobsCollection.ts
@@ -13,16 +13,6 @@ export const getDefaultJobsCollection: (config: Config) => CollectionConfig | nu
   const workflowSlugs: Set<string> = new Set()
   const taskSlugs: Set<string> = new Set(['inline'])
 
-  const queueNames: Set<string> = new Set(['default'])
-
-  config.jobs?.workflows.forEach((workflow) => {
-    workflowSlugs.add(workflow.slug)
-
-    if (workflow.queue) {
-      queueNames.add(workflow.queue)
-    }
-  })
-
   config.jobs.tasks.forEach((task) => {
     if (workflowSlugs.has(task.slug)) {
       throw new Error(
@@ -168,13 +158,12 @@ export const getDefaultJobsCollection: (config: Config) => CollectionConfig | nu
       },
       {
         name: 'queue',
-        type: 'select',
+        type: 'text',
         admin: {
           position: 'sidebar',
         },
         defaultValue: 'default',
         index: true,
-        options: [...queueNames],
       },
       {
         name: 'waitUntil',

--- a/packages/payload/src/queues/config/jobsCollection.ts
+++ b/packages/payload/src/queues/config/jobsCollection.ts
@@ -13,6 +13,10 @@ export const getDefaultJobsCollection: (config: Config) => CollectionConfig | nu
   const workflowSlugs: Set<string> = new Set()
   const taskSlugs: Set<string> = new Set(['inline'])
 
+  config.jobs?.workflows.forEach((workflow) => {
+    workflowSlugs.add(workflow.slug)
+  })
+
   config.jobs.tasks.forEach((task) => {
     if (workflowSlugs.has(task.slug)) {
       throw new Error(

--- a/packages/payload/src/queues/config/types/workflowTypes.ts
+++ b/packages/payload/src/queues/config/types/workflowTypes.ts
@@ -108,8 +108,9 @@ export type WorkflowConfig<TWorkflowSlugOrInput extends keyof TypedJobs['workflo
    */
   label?: string
   /**
-   * Optionally, define the queue name that this workflow should be tied to.
+   * Optionally, define the default queue name that this workflow should be tied to.
    * Defaults to "default".
+   * Can be overridden when queuing jobs via Local API.
    */
   queue?: string
   /**

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -153,6 +153,7 @@ describe('Queues', () => {
   it('ensure job retrying works', async () => {
     const job = await payload.jobs.queue({
       workflow: 'retriesTest',
+      queue: 'default',
       input: {
         message: 'hello',
       },


### PR DESCRIPTION
Allows user to specify a queue when calling `payload.jobs.queue()`. Closes #9133 