### PR TITLE
chore: attempts to fix model overwriting

### DIFF
--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -98,6 +98,7 @@ export type MongooseAdapter = {
   connection: Connection
   globals: GlobalModel
   mongoMemoryServer: MongoMemoryReplSet
+  mongoose: typeof mongoose
   prodMigrations?: {
     down: (args: MigrateDownArgs) => Promise<void>
     name: string
@@ -120,6 +121,7 @@ declare module 'payload' {
     connection: Connection
     globals: GlobalModel
     mongoMemoryServer: MongoMemoryReplSet
+    mongoose: typeof mongoose
     prodMigrations?: {
       down: (args: MigrateDownArgs) => Promise<void>
       name: string
@@ -159,6 +161,7 @@ export function mongooseAdapter({
       disableIndexHints,
       globals: undefined,
       mongoMemoryServer,
+      mongoose,
       sessions: {},
       transactionOptions: transactionOptions === false ? undefined : transactionOptions,
       url,

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -24,6 +24,7 @@ import {
   UnorderedListFeature,
   UploadFeature,
 } from '@payloadcms/richtext-lexical'
+import { healthEndpoint } from 'helpers/health.js'
 // import { slateEditor } from '@payloadcms/richtext-slate'
 import { buildConfig } from 'payload'
 import { de } from 'payload/i18n/de'
@@ -131,7 +132,7 @@ export async function buildConfigWithDefaults(
       ],
     }),
     email: testEmailAdapter,
-    endpoints: [localAPIEndpoint, reInitEndpoint],
+    endpoints: [localAPIEndpoint, reInitEndpoint, healthEndpoint],
     secret: 'TEST_SECRET',
     sharp,
     telemetry: false,

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -24,7 +24,8 @@ import {
   UnorderedListFeature,
   UploadFeature,
 } from '@payloadcms/richtext-lexical'
-import { healthEndpoint } from 'helpers/health.js'
+
+import { healthEndpoint } from './helpers/health.js'
 // import { slateEditor } from '@payloadcms/richtext-slate'
 import { buildConfig } from 'payload'
 import { de } from 'payload/i18n/de'

--- a/test/dev.ts
+++ b/test/dev.ts
@@ -93,7 +93,7 @@ process.env.PAYLOAD_DROP_DATABASE = process.env.PAYLOAD_DROP_DATABASE === 'false
 
 // fetch the admin url to force a render
 void fetch(`http://localhost:${port}${adminRoute}`)
-void fetch(`http://localhost:${port}/api/access`)
+void fetch(`http://localhost:${port}/api/health`)
 // This ensures that the next-server process is killed when this process is killed and doesn't linger around.
 process.on('SIGINT', () => {
   if (child) {

--- a/test/helpers/health.ts
+++ b/test/helpers/health.ts
@@ -1,0 +1,20 @@
+import type { Endpoint, PayloadHandler } from 'payload'
+
+import httpStatus from 'http-status'
+
+const handler: PayloadHandler = () => {
+  return Response.json(
+    {
+      message: 'Payload is running!',
+    },
+    {
+      status: httpStatus.OK,
+    },
+  )
+}
+
+export const healthEndpoint: Endpoint = {
+  path: '/health',
+  method: 'get',
+  handler,
+}

--- a/test/helpers/startMemoryDB.ts
+++ b/test/helpers/startMemoryDB.ts
@@ -1,6 +1,4 @@
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
-import mongoose from 'mongoose'
-
 // eslint-disable-next-line no-restricted-exports
 export default async () => {
   console.log('Starting memory db...')
@@ -18,7 +16,8 @@ export default async () => {
       console.log('Stopped memorydb')
     }
 
-    if (Object.keys(mongoose.models).length > 0) {
+    if (global._payload?.payload?.db?.mongoose?.models) {
+      const mongoose = global._payload?.payload?.db?.mongoose
       Object.keys(mongoose.models).map((model) => mongoose.deleteModel(model))
     }
 

--- a/test/helpers/startMemoryDB.ts
+++ b/test/helpers/startMemoryDB.ts
@@ -1,4 +1,5 @@
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
 
 // eslint-disable-next-line no-restricted-exports
 export default async () => {
@@ -10,10 +11,17 @@ export default async () => {
   process.env.NODE_OPTIONS = '--no-deprecation'
   process.env.DISABLE_PAYLOAD_HMR = 'true'
 
-  if (
-    (!process.env.PAYLOAD_DATABASE || process.env.PAYLOAD_DATABASE === 'mongodb') &&
-    !global._mongoMemoryServer
-  ) {
+  if (!process.env.PAYLOAD_DATABASE || process.env.PAYLOAD_DATABASE === 'mongodb') {
+    if (global._mongoMemoryServer) {
+      console.log('Stopping memorydb...')
+      await global._mongoMemoryServer.stop()
+      console.log('Stopped memorydb')
+    }
+
+    if (Object.keys(mongoose.models).length > 0) {
+      Object.keys(mongoose.models).map((model) => mongoose.deleteModel(model))
+    }
+
     const db = await MongoMemoryReplSet.create({
       replSet: {
         count: 3,

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -87,8 +87,6 @@ describe('versions', () => {
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
     context = await browser.newContext()
     page = await context.newPage()


### PR DESCRIPTION
Attempts to fix CI errors `Cannot overwrite model once compiled` via ensuring the memory server is stopped, models are deleted, and then re-built. 

Also introduces a `/health` endpoint for tests to leverage when forcing the `/api` endpoint to compile for the first time, rather than accessing `/api/access` which could lead to transaction issues with seeding.