### PR TITLE
feat(richtext-lexical)!: immediately return provided features in richtext adapter, so that they are available in the unsanitized config

### DIFF
--- a/packages/graphql/src/schema/buildObjectType.ts
+++ b/packages/graphql/src/schema/buildObjectType.ts
@@ -550,7 +550,7 @@ export function buildObjectType({
             throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
           }
 
-          if (typeof field?.editor === 'function') {
+          if ('adapter' in field.editor) {
             throw new Error('Attempted to access unsanitized rich text editor.')
           }
 

--- a/packages/payload/src/admin/RichText.ts
+++ b/packages/payload/src/admin/RichText.ts
@@ -1,19 +1,13 @@
-import type { GenericLanguages, I18n, I18nClient } from '@payloadcms/translations'
+import type { GenericLanguages, I18n } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
 
-import type { ImportMap } from '../bin/generateImportMap/index.js'
 import type { SanitizedCollectionConfig, TypeWithID } from '../collections/config/types.js'
 import type { Config, PayloadComponent, SanitizedConfig } from '../config/types.js'
 import type { ValidationFieldError } from '../errors/ValidationError.js'
-import type {
-  FieldAffectingData,
-  RichTextField,
-  RichTextFieldClient,
-  Validate,
-} from '../fields/config/types.js'
+import type { FieldAffectingData, RichTextField, Validate } from '../fields/config/types.js'
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'
 import type { RequestContext } from '../index.js'
-import type { JsonObject, Payload, PayloadRequest, PopulateType } from '../types/index.js'
+import type { JsonObject, PayloadRequest, PopulateType } from '../types/index.js'
 import type { RichTextFieldClientProps } from './fields/RichText.js'
 import type { FieldSchemaMap } from './types.js'
 
@@ -258,19 +252,21 @@ export type RichTextAdapterProvider<
   Value extends object = object,
   AdapterProps = any,
   ExtraFieldProperties = {},
-> = ({
-  config,
-  isRoot,
-  parentIsLocalized,
-}: {
-  config: SanitizedConfig
-  /**
-   * Whether or not this is the root richText editor, defined in the payload.config.ts.
-   *
-   * @default false
-   */
-  isRoot?: boolean
-  parentIsLocalized: boolean
-}) =>
-  | Promise<RichTextAdapter<Value, AdapterProps, ExtraFieldProperties>>
-  | RichTextAdapter<Value, AdapterProps, ExtraFieldProperties>
+> = {
+  adapter: ({
+    config,
+    isRoot,
+    parentIsLocalized,
+  }: {
+    config: SanitizedConfig
+    /**
+     * Whether or not this is the root richText editor, defined in the payload.config.ts.
+     *
+     * @default false
+     */
+    isRoot?: boolean
+    parentIsLocalized: boolean
+  }) =>
+    | Promise<RichTextAdapter<Value, AdapterProps, ExtraFieldProperties>>
+    | RichTextAdapter<Value, AdapterProps, ExtraFieldProperties>
+}

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -213,8 +213,8 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
   /*
     Execute richText sanitization
    */
-  if (typeof incomingConfig.editor === 'function') {
-    config.editor = await incomingConfig.editor({
+  if (incomingConfig.editor && 'adapter' in incomingConfig.editor) {
+    config.editor = await incomingConfig.editor.adapter({
       config: config as SanitizedConfig,
       isRoot: true,
       parentIsLocalized: false,

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -212,7 +212,7 @@ export const createClientField = ({
         throw new MissingEditorProp(incomingField) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
 
-      if (typeof incomingField?.editor === 'function') {
+      if ('adapter' in incomingField.editor) {
         throw new Error('Attempted to access unsanitized rich text editor.')
       }
 

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -205,15 +205,20 @@ export const sanitizeFields = async ({
           }
         }
 
-        if (typeof field.editor === 'function') {
-          field.editor = await field.editor({
+        if (field.editor && 'adapter' in field.editor) {
+          field.editor = await field.editor.adapter({
             config: _config,
             isRoot: requireFieldLevelRichTextEditor,
             parentIsLocalized: parentIsLocalized || field.localized,
           })
         }
 
-        if (field.editor.i18n && Object.keys(field.editor.i18n).length >= 0) {
+        if (
+          field.editor &&
+          !('adapter' in field.editor) &&
+          field.editor.i18n &&
+          Object.keys(field.editor.i18n).length >= 0
+        ) {
           config.i18n.translations = deepMergeSimple(config.i18n.translations, field.editor.i18n)
         }
       }

--- a/packages/payload/src/fields/hooks/afterChange/promise.ts
+++ b/packages/payload/src/fields/hooks/afterChange/promise.ts
@@ -211,7 +211,7 @@ export const promise = async ({
       if (!field?.editor) {
         throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
-      if (typeof field?.editor === 'function') {
+      if ('adapter' in field.editor) {
         throw new Error('Attempted to access unsanitized rich text editor.')
       }
 

--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -196,7 +196,7 @@ export const promise = async ({
       if (!field?.editor) {
         throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
-      if (typeof field?.editor === 'function') {
+      if ('adapter' in field.editor) {
         throw new Error('Attempted to access unsanitized rich text editor.')
       }
 
@@ -610,7 +610,7 @@ export const promise = async ({
       if (!field?.editor) {
         throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
-      if (typeof field?.editor === 'function') {
+      if ('adapter' in field.editor) {
         throw new Error('Attempted to access unsanitized rich text editor.')
       }
 

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -369,7 +369,7 @@ export const promise = async ({
       if (!field?.editor) {
         throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
-      if (typeof field?.editor === 'function') {
+      if ('adapter' in field.editor) {
         throw new Error('Attempted to access unsanitized rich text editor.')
       }
 

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -431,7 +431,7 @@ export const promise = async <T>({
       if (!field?.editor) {
         throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
-      if (typeof field?.editor === 'function') {
+      if ('adapter' in field.editor) {
         throw new Error('Attempted to access unsanitized rich text editor.')
       }
 

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -395,7 +395,7 @@ export const richText: RichTextFieldValidation = async (value, options) => {
   if (!options?.editor) {
     throw new Error('richText field has no editor property.')
   }
-  if (typeof options?.editor === 'function') {
+  if ('adapter' in options.editor) {
     throw new Error('Attempted to access unsanitized rich text editor.')
   }
 

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -525,7 +525,7 @@ export function fieldsToJSONSchema(
             if (!field?.editor) {
               throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
             }
-            if (typeof field.editor === 'function') {
+            if ('adapter' in field.editor) {
               throw new Error('Attempted to access unsanitized rich text editor.')
             }
             if (field.editor.outputSchema) {

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -34,788 +34,806 @@ import { getGenerateSchemaMap } from './utilities/generateSchemaMap.js'
 import { recurseNodeTree } from './utilities/recurseNodeTree.js'
 import { richTextValidateHOC } from './validate/index.js'
 
-let defaultSanitizedServerEditorConfig: null | SanitizedServerEditorConfig = null
+let cachedDefaultSanitizedServerEditorConfig: null | SanitizedServerEditorConfig = null
 let checkedDependencies = false
 
 export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapterProvider {
-  return async ({ config, isRoot, parentIsLocalized }) => {
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      process.env.PAYLOAD_DISABLE_DEPENDENCY_CHECKER !== 'true' &&
-      !checkedDependencies
-    ) {
-      checkedDependencies = true
-      await checkDependencies({
-        dependencyGroups: [
-          {
-            name: 'lexical',
-            dependencies: [
-              'lexical',
-              '@lexical/headless',
-              '@lexical/link',
-              '@lexical/list',
-              '@lexical/mark',
-              '@lexical/markdown',
-              '@lexical/react',
-              '@lexical/rich-text',
-              '@lexical/selection',
-              '@lexical/utils',
-            ],
-            targetVersion: '0.20.0',
-          },
-        ],
-      })
-    }
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.PAYLOAD_DISABLE_DEPENDENCY_CHECKER !== 'true' &&
+    !checkedDependencies
+  ) {
+    checkedDependencies = true
+    void checkDependencies({
+      dependencyGroups: [
+        {
+          name: 'lexical',
+          dependencies: [
+            'lexical',
+            '@lexical/headless',
+            '@lexical/link',
+            '@lexical/list',
+            '@lexical/mark',
+            '@lexical/markdown',
+            '@lexical/react',
+            '@lexical/rich-text',
+            '@lexical/selection',
+            '@lexical/utils',
+          ],
+          targetVersion: '0.20.0',
+        },
+      ],
+    })
+  }
+  const hasConfiguration = props?.features || props?.lexical
 
-    let features: FeatureProviderServer<any, any, any>[] = []
-    let resolvedFeatureMap: ResolvedServerFeatureMap
+  const enabledFeatures: LexicalEditorProps['features'] = hasConfiguration
+    ? props?.features
+    : defaultEditorFeatures
 
-    let finalSanitizedEditorConfig: SanitizedServerEditorConfig // For server only
-    if (!props || (!props.features && !props.lexical)) {
-      if (!defaultSanitizedServerEditorConfig) {
-        defaultSanitizedServerEditorConfig = await sanitizeServerEditorConfig(
-          defaultEditorConfig,
+  return {
+    adapter: async ({ config, isRoot, parentIsLocalized }) => {
+      let features: FeatureProviderServer<any, any, any>[] = []
+      let resolvedFeatureMap: ResolvedServerFeatureMap
+
+      let finalSanitizedEditorConfig: SanitizedServerEditorConfig // For server only
+      if (!hasConfiguration) {
+        if (!cachedDefaultSanitizedServerEditorConfig) {
+          cachedDefaultSanitizedServerEditorConfig = await sanitizeServerEditorConfig(
+            defaultEditorConfig,
+            config,
+            parentIsLocalized,
+          )
+          features = deepCopyObject(defaultEditorFeatures)
+        }
+
+        finalSanitizedEditorConfig = deepCopyObject(cachedDefaultSanitizedServerEditorConfig)
+
+        resolvedFeatureMap = finalSanitizedEditorConfig.resolvedFeatureMap
+      } else {
+        const rootEditor = config.editor
+        let rootEditorFeatures: FeatureProviderServer<unknown, unknown, unknown>[] = []
+        if (typeof rootEditor === 'object' && 'features' in rootEditor) {
+          rootEditorFeatures = (rootEditor as LexicalRichTextAdapter).features
+        }
+
+        features =
+          props.features && typeof props.features === 'function'
+            ? props.features({
+                defaultFeatures: deepCopyObject(defaultEditorFeatures),
+                rootFeatures: rootEditorFeatures,
+              })
+            : (props.features as FeatureProviderServer<unknown, unknown, unknown>[])
+        if (!features) {
+          features = deepCopyObject(defaultEditorFeatures)
+        }
+
+        const lexical = props.lexical ?? deepCopyObjectSimple(defaultEditorConfig.lexical)!
+
+        resolvedFeatureMap = await loadFeatures({
           config,
+          isRoot,
           parentIsLocalized,
-        )
-        features = deepCopyObject(defaultEditorFeatures)
-      }
-
-      finalSanitizedEditorConfig = deepCopyObject(defaultSanitizedServerEditorConfig)
-
-      resolvedFeatureMap = finalSanitizedEditorConfig.resolvedFeatureMap
-    } else {
-      const rootEditor = config.editor
-      let rootEditorFeatures: FeatureProviderServer<unknown, unknown, unknown>[] = []
-      if (typeof rootEditor === 'object' && 'features' in rootEditor) {
-        rootEditorFeatures = (rootEditor as LexicalRichTextAdapter).features
-      }
-
-      features =
-        props.features && typeof props.features === 'function'
-          ? props.features({
-              defaultFeatures: deepCopyObject(defaultEditorFeatures),
-              rootFeatures: rootEditorFeatures,
-            })
-          : (props.features as FeatureProviderServer<unknown, unknown, unknown>[])
-      if (!features) {
-        features = deepCopyObject(defaultEditorFeatures)
-      }
-
-      const lexical = props.lexical ?? deepCopyObjectSimple(defaultEditorConfig.lexical)!
-
-      resolvedFeatureMap = await loadFeatures({
-        config,
-        isRoot,
-        parentIsLocalized,
-        unSanitizedEditorConfig: {
-          features,
-          lexical,
-        },
-      })
-
-      finalSanitizedEditorConfig = {
-        features: sanitizeServerFeatures(resolvedFeatureMap),
-        lexical,
-        resolvedFeatureMap,
-      }
-    }
-
-    const featureI18n = finalSanitizedEditorConfig.features.i18n
-    for (const lang in i18n) {
-      if (!featureI18n[lang]) {
-        featureI18n[lang] = {
-          lexical: {},
-        }
-      }
-
-      featureI18n[lang].lexical.general = i18n[lang]
-    }
-
-    return {
-      CellComponent: {
-        path: '@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell',
-        serverProps: {
-          admin: props?.admin,
-          sanitizedEditorConfig: finalSanitizedEditorConfig,
-        },
-      },
-      editorConfig: finalSanitizedEditorConfig,
-      features,
-      FieldComponent: {
-        path: '@payloadcms/richtext-lexical/rsc#RscEntryLexicalField',
-        serverProps: {
-          admin: props?.admin,
-          sanitizedEditorConfig: finalSanitizedEditorConfig,
-        },
-      },
-      generateImportMap: getGenerateImportMap({
-        resolvedFeatureMap,
-      }),
-      generateSchemaMap: getGenerateSchemaMap({
-        resolvedFeatureMap,
-      }),
-      graphQLPopulationPromises({
-        context,
-        currentDepth,
-        depth,
-        draft,
-        field,
-        fieldPromises,
-        findMany,
-        flattenLocales,
-        overrideAccess,
-        populationPromises,
-        req,
-        showHiddenFields,
-        siblingDoc,
-      }) {
-        // check if there are any features with nodes which have populationPromises for this field
-        if (finalSanitizedEditorConfig?.features?.graphQLPopulationPromises?.size) {
-          populateLexicalPopulationPromises({
-            context,
-            currentDepth: currentDepth ?? 0,
-            depth,
-            draft,
-            editorPopulationPromises: finalSanitizedEditorConfig.features.graphQLPopulationPromises,
-            field,
-            fieldPromises,
-            findMany,
-            flattenLocales,
-            overrideAccess,
-            populationPromises,
-            req,
-            showHiddenFields,
-            siblingDoc,
-          })
-        }
-      },
-      hooks: {
-        afterChange: [
-          async (args) => {
-            const { collection, context: _context, global, operation, path, req, schemaPath } = args
-            let { value } = args
-            if (finalSanitizedEditorConfig?.features?.hooks?.afterChange?.length) {
-              for (const hook of finalSanitizedEditorConfig.features.hooks.afterChange) {
-                value = await hook(args)
-              }
-            }
-            if (
-              !finalSanitizedEditorConfig.features.nodeHooks?.afterChange?.size &&
-              !finalSanitizedEditorConfig.features.getSubFields?.size
-            ) {
-              return value
-            }
-            const context: any = _context
-            const nodeIDMap: {
-              [key: string]: SerializedLexicalNode
-            } = {}
-
-            /**
-             * Get the originalNodeIDMap from the beforeValidate hook, which is always run before this hook.
-             */
-            const originalNodeIDMap: {
-              [key: string]: SerializedLexicalNode
-            } = context?.internal?.richText?.[path.join('.')]?.originalNodeIDMap
-
-            if (!originalNodeIDMap || !Object.keys(originalNodeIDMap).length || !value) {
-              return value
-            }
-
-            recurseNodeTree({
-              nodeIDMap,
-              nodes: (value as SerializedEditorState)?.root?.children ?? [],
-            })
-
-            // eslint-disable-next-line prefer-const
-            for (let [id, node] of Object.entries(nodeIDMap)) {
-              const afterChangeHooks = finalSanitizedEditorConfig.features.nodeHooks?.afterChange
-              const afterChangeHooksForNode = afterChangeHooks?.get(node.type)
-              if (afterChangeHooksForNode) {
-                for (const hook of afterChangeHooksForNode) {
-                  if (!originalNodeIDMap[id]) {
-                    console.warn(
-                      '(afterChange) No original node found for node with id',
-                      id,
-                      'node:',
-                      node,
-                      'path',
-                      path.join('.'),
-                    )
-                    continue
-                  }
-                  node = await hook({
-                    context,
-                    node,
-                    operation,
-                    originalNode: originalNodeIDMap[id],
-                    parentRichTextFieldPath: path,
-                    parentRichTextFieldSchemaPath: schemaPath,
-                    req,
-                  })
-                }
-              }
-              const subFieldFn = finalSanitizedEditorConfig.features.getSubFields?.get(node.type)
-              const subFieldDataFn = finalSanitizedEditorConfig.features.getSubFieldsData?.get(
-                node.type,
-              )
-
-              if (subFieldFn && subFieldDataFn) {
-                const subFields = subFieldFn({ node, req })
-                const data = subFieldDataFn({ node, req }) ?? {}
-                const originalData = subFieldDataFn({ node: originalNodeIDMap[id], req }) ?? {}
-
-                if (subFields?.length) {
-                  await afterChangeTraverseFields({
-                    collection,
-                    context,
-                    data: originalData,
-                    doc: data,
-                    fields: subFields,
-                    global,
-                    operation,
-                    path,
-                    previousDoc: data,
-                    previousSiblingDoc: { ...data },
-                    req,
-                    schemaPath,
-                    siblingData: originalData || {},
-                    siblingDoc: { ...data },
-                  })
-                }
-              }
-            }
-            return value
+          unSanitizedEditorConfig: {
+            features,
+            lexical,
           },
-        ],
-        afterRead: [
-          /**
-           * afterRead hooks do not receive the originalNode. Thus, they can run on all nodes, not just nodes with an ID.
-           */
-          async (args) => {
-            const {
-              collection,
-              context: context,
-              currentDepth,
+        })
+
+        finalSanitizedEditorConfig = {
+          features: sanitizeServerFeatures(resolvedFeatureMap),
+          lexical,
+          resolvedFeatureMap,
+        }
+      }
+
+      const featureI18n = finalSanitizedEditorConfig.features.i18n
+      for (const lang in i18n) {
+        if (!featureI18n[lang]) {
+          featureI18n[lang] = {
+            lexical: {},
+          }
+        }
+
+        featureI18n[lang].lexical.general = i18n[lang]
+      }
+
+      return {
+        CellComponent: {
+          path: '@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell',
+          serverProps: {
+            admin: props?.admin,
+            sanitizedEditorConfig: finalSanitizedEditorConfig,
+          },
+        },
+        editorConfig: finalSanitizedEditorConfig,
+        features,
+        FieldComponent: {
+          path: '@payloadcms/richtext-lexical/rsc#RscEntryLexicalField',
+          serverProps: {
+            admin: props?.admin,
+            sanitizedEditorConfig: finalSanitizedEditorConfig,
+          },
+        },
+        generateImportMap: getGenerateImportMap({
+          resolvedFeatureMap,
+        }),
+        generateSchemaMap: getGenerateSchemaMap({
+          resolvedFeatureMap,
+        }),
+        graphQLPopulationPromises({
+          context,
+          currentDepth,
+          depth,
+          draft,
+          field,
+          fieldPromises,
+          findMany,
+          flattenLocales,
+          overrideAccess,
+          populationPromises,
+          req,
+          showHiddenFields,
+          siblingDoc,
+        }) {
+          // check if there are any features with nodes which have populationPromises for this field
+          if (finalSanitizedEditorConfig?.features?.graphQLPopulationPromises?.size) {
+            populateLexicalPopulationPromises({
+              context,
+              currentDepth: currentDepth ?? 0,
               depth,
               draft,
-              fallbackLocale,
+              editorPopulationPromises:
+                finalSanitizedEditorConfig.features.graphQLPopulationPromises,
+              field,
               fieldPromises,
               findMany,
               flattenLocales,
-              global,
-              locale,
               overrideAccess,
-              path,
-              populate,
               populationPromises,
               req,
-              schemaPath,
               showHiddenFields,
-              triggerAccessControl,
-              triggerHooks,
-            } = args
-            let { value } = args
-
-            if (finalSanitizedEditorConfig?.features?.hooks?.afterRead?.length) {
-              for (const hook of finalSanitizedEditorConfig.features.hooks.afterRead) {
-                value = await hook(args)
-              }
-            }
-
-            if (
-              !finalSanitizedEditorConfig.features.nodeHooks?.afterRead?.size &&
-              !finalSanitizedEditorConfig.features.getSubFields?.size
-            ) {
-              return value
-            }
-            const flattenedNodes: SerializedLexicalNode[] = []
-
-            recurseNodeTree({
-              flattenedNodes,
-              nodes: (value as SerializedEditorState)?.root?.children ?? [],
+              siblingDoc,
             })
-
-            for (let node of flattenedNodes) {
-              const afterReadHooks = finalSanitizedEditorConfig.features.nodeHooks?.afterRead
-              const afterReadHooksForNode = afterReadHooks?.get(node.type)
-              if (afterReadHooksForNode) {
-                for (const hook of afterReadHooksForNode) {
-                  node = await hook({
-                    context,
-                    currentDepth: currentDepth!,
-                    depth: depth!,
-                    draft: draft!,
-                    fallbackLocale: fallbackLocale!,
-                    fieldPromises: fieldPromises!,
-                    findMany: findMany!,
-                    flattenLocales: flattenLocales!,
-                    locale: locale!,
-                    node,
-                    overrideAccess: overrideAccess!,
-                    parentRichTextFieldPath: path,
-                    parentRichTextFieldSchemaPath: schemaPath,
-                    populateArg: populate,
-                    populationPromises: populationPromises!,
-                    req,
-                    showHiddenFields: showHiddenFields!,
-                    triggerAccessControl: triggerAccessControl!,
-                    triggerHooks: triggerHooks!,
-                  })
+          }
+        },
+        hooks: {
+          afterChange: [
+            async (args) => {
+              const {
+                collection,
+                context: _context,
+                global,
+                operation,
+                path,
+                req,
+                schemaPath,
+              } = args
+              let { value } = args
+              if (finalSanitizedEditorConfig?.features?.hooks?.afterChange?.length) {
+                for (const hook of finalSanitizedEditorConfig.features.hooks.afterChange) {
+                  value = await hook(args)
                 }
               }
-              const subFieldFn = finalSanitizedEditorConfig.features.getSubFields?.get(node.type)
-              const subFieldDataFn = finalSanitizedEditorConfig.features.getSubFieldsData?.get(
-                node.type,
-              )
-
-              if (subFieldFn && subFieldDataFn) {
-                const subFields = subFieldFn({ node, req })
-                const data = subFieldDataFn({ node, req }) ?? {}
-
-                if (subFields?.length) {
-                  afterReadTraverseFields({
-                    collection,
-                    context,
-                    currentDepth: currentDepth!,
-                    depth: depth!,
-                    doc: data,
-                    draft: draft!,
-                    fallbackLocale: fallbackLocale!,
-                    fieldPromises: fieldPromises!,
-                    fields: subFields,
-                    findMany: findMany!,
-                    flattenLocales: flattenLocales!,
-                    global,
-                    locale: locale!,
-                    overrideAccess: overrideAccess!,
-                    path,
-                    populate,
-                    populationPromises: populationPromises!,
-                    req,
-                    schemaPath,
-                    showHiddenFields: showHiddenFields!,
-                    siblingDoc: data,
-                    triggerAccessControl,
-                    triggerHooks,
-                  })
-                }
+              if (
+                !finalSanitizedEditorConfig.features.nodeHooks?.afterChange?.size &&
+                !finalSanitizedEditorConfig.features.getSubFields?.size
+              ) {
+                return value
               }
-            }
+              const context: any = _context
+              const nodeIDMap: {
+                [key: string]: SerializedLexicalNode
+              } = {}
 
-            return value
-          },
-        ],
-        beforeChange: [
-          async (args) => {
-            const {
-              collection,
-              context: _context,
-              errors,
-              field,
-              global,
-              mergeLocaleActions,
-              operation,
-              path,
-              req,
-              schemaPath,
-              siblingData,
-              siblingDocWithLocales,
-              skipValidation,
-            } = args
-            let { value } = args
+              /**
+               * Get the originalNodeIDMap from the beforeValidate hook, which is always run before this hook.
+               */
+              const originalNodeIDMap: {
+                [key: string]: SerializedLexicalNode
+              } = context?.internal?.richText?.[path.join('.')]?.originalNodeIDMap
 
-            if (finalSanitizedEditorConfig?.features?.hooks?.beforeChange?.length) {
-              for (const hook of finalSanitizedEditorConfig.features.hooks.beforeChange) {
-                value = await hook(args)
+              if (!originalNodeIDMap || !Object.keys(originalNodeIDMap).length || !value) {
+                return value
               }
-            }
 
-            if (
-              !finalSanitizedEditorConfig.features.nodeHooks?.beforeChange?.size &&
-              !finalSanitizedEditorConfig.features.getSubFields?.size
-            ) {
-              return value
-            }
-
-            const context: any = _context
-            const nodeIDMap: {
-              [key: string]: SerializedLexicalNode
-            } = {}
-
-            /**
-             * Get the originalNodeIDMap from the beforeValidate hook, which is always run before this hook.
-             */
-            const originalNodeIDMap: {
-              [key: string]: SerializedLexicalNode
-            } = context?.internal?.richText?.[path.join('.')]?.originalNodeIDMap
-
-            if (!originalNodeIDMap || !Object.keys(originalNodeIDMap).length || !value) {
-              return value
-            }
-
-            const originalNodeWithLocalesIDMap: {
-              [key: string]: SerializedLexicalNode
-            } = {}
-
-            recurseNodeTree({
-              nodeIDMap,
-              nodes: (value as SerializedEditorState)?.root?.children ?? [],
-            })
-
-            if (field.name && siblingDocWithLocales?.[field.name]) {
               recurseNodeTree({
-                nodeIDMap: originalNodeWithLocalesIDMap,
-                nodes:
-                  (siblingDocWithLocales[field.name] as SerializedEditorState)?.root?.children ??
-                  [],
+                nodeIDMap,
+                nodes: (value as SerializedEditorState)?.root?.children ?? [],
               })
-            }
 
-            // eslint-disable-next-line prefer-const
-            for (let [id, node] of Object.entries(nodeIDMap)) {
-              const beforeChangeHooks = finalSanitizedEditorConfig.features.nodeHooks?.beforeChange
-              const beforeChangeHooksForNode = beforeChangeHooks?.get(node.type)
-              if (beforeChangeHooksForNode) {
-                for (const hook of beforeChangeHooksForNode) {
-                  if (!originalNodeIDMap[id]) {
-                    console.warn(
-                      '(beforeChange) No original node found for node with id',
-                      id,
-                      'node:',
+              // eslint-disable-next-line prefer-const
+              for (let [id, node] of Object.entries(nodeIDMap)) {
+                const afterChangeHooks = finalSanitizedEditorConfig.features.nodeHooks?.afterChange
+                const afterChangeHooksForNode = afterChangeHooks?.get(node.type)
+                if (afterChangeHooksForNode) {
+                  for (const hook of afterChangeHooksForNode) {
+                    if (!originalNodeIDMap[id]) {
+                      console.warn(
+                        '(afterChange) No original node found for node with id',
+                        id,
+                        'node:',
+                        node,
+                        'path',
+                        path.join('.'),
+                      )
+                      continue
+                    }
+                    node = await hook({
+                      context,
                       node,
-                      'path',
-                      path.join('.'),
-                    )
-                    continue
+                      operation,
+                      originalNode: originalNodeIDMap[id],
+                      parentRichTextFieldPath: path,
+                      parentRichTextFieldSchemaPath: schemaPath,
+                      req,
+                    })
                   }
-                  node = await hook({
-                    context,
-                    errors: errors!,
-                    mergeLocaleActions: mergeLocaleActions!,
-                    node,
-                    operation: operation!,
-                    originalNode: originalNodeIDMap[id],
-                    originalNodeWithLocales: originalNodeWithLocalesIDMap[id],
-                    parentRichTextFieldPath: path,
-                    parentRichTextFieldSchemaPath: schemaPath,
-                    req,
-                    skipValidation: skipValidation!,
-                  })
+                }
+                const subFieldFn = finalSanitizedEditorConfig.features.getSubFields?.get(node.type)
+                const subFieldDataFn = finalSanitizedEditorConfig.features.getSubFieldsData?.get(
+                  node.type,
+                )
+
+                if (subFieldFn && subFieldDataFn) {
+                  const subFields = subFieldFn({ node, req })
+                  const data = subFieldDataFn({ node, req }) ?? {}
+                  const originalData = subFieldDataFn({ node: originalNodeIDMap[id], req }) ?? {}
+
+                  if (subFields?.length) {
+                    await afterChangeTraverseFields({
+                      collection,
+                      context,
+                      data: originalData,
+                      doc: data,
+                      fields: subFields,
+                      global,
+                      operation,
+                      path,
+                      previousDoc: data,
+                      previousSiblingDoc: { ...data },
+                      req,
+                      schemaPath,
+                      siblingData: originalData || {},
+                      siblingDoc: { ...data },
+                    })
+                  }
+                }
+              }
+              return value
+            },
+          ],
+          afterRead: [
+            /**
+             * afterRead hooks do not receive the originalNode. Thus, they can run on all nodes, not just nodes with an ID.
+             */
+            async (args) => {
+              const {
+                collection,
+                context: context,
+                currentDepth,
+                depth,
+                draft,
+                fallbackLocale,
+                fieldPromises,
+                findMany,
+                flattenLocales,
+                global,
+                locale,
+                overrideAccess,
+                path,
+                populate,
+                populationPromises,
+                req,
+                schemaPath,
+                showHiddenFields,
+                triggerAccessControl,
+                triggerHooks,
+              } = args
+              let { value } = args
+
+              if (finalSanitizedEditorConfig?.features?.hooks?.afterRead?.length) {
+                for (const hook of finalSanitizedEditorConfig.features.hooks.afterRead) {
+                  value = await hook(args)
                 }
               }
 
-              const subFieldFn = finalSanitizedEditorConfig.features.getSubFields?.get(node.type)
-              const subFieldDataFn = finalSanitizedEditorConfig.features.getSubFieldsData?.get(
-                node.type,
-              )
-
-              if (subFieldFn && subFieldDataFn) {
-                const subFields = subFieldFn({ node, req })
-                const data = subFieldDataFn({ node, req }) ?? {}
-                const originalData = subFieldDataFn({ node: originalNodeIDMap[id], req }) ?? {}
-                const originalDataWithLocales =
-                  subFieldDataFn({
-                    node: originalNodeWithLocalesIDMap[id],
-                    req,
-                  }) ?? {}
-
-                if (subFields?.length) {
-                  await beforeChangeTraverseFields({
-                    id,
-                    collection,
-                    context,
-                    data,
-                    doc: originalData,
-                    docWithLocales: originalDataWithLocales ?? {},
-                    errors: errors!,
-                    fields: subFields,
-                    global,
-                    mergeLocaleActions: mergeLocaleActions!,
-                    operation: operation!,
-                    path,
-                    req,
-                    schemaPath,
-                    siblingData: data,
-                    siblingDoc: originalData,
-                    siblingDocWithLocales: originalDataWithLocales ?? {},
-                    skipValidation,
-                  })
-                }
+              if (
+                !finalSanitizedEditorConfig.features.nodeHooks?.afterRead?.size &&
+                !finalSanitizedEditorConfig.features.getSubFields?.size
+              ) {
+                return value
               }
-            }
+              const flattenedNodes: SerializedLexicalNode[] = []
 
-            /**
-             * within the beforeChange hook, id's may be re-generated.
-             * Example:
-             * 1. Seed data contains IDs for block feature blocks.
-             * 2. Those are used in beforeValidate
-             * 3. in beforeChange, those IDs are regenerated, because you cannot provide IDs during document creation. See baseIDField beforeChange hook for reasoning
-             * 4. Thus, in order for all post-beforeChange hooks to receive the correct ID, we need to update the originalNodeIDMap with the new ID's, by regenerating the nodeIDMap.
-             * The reason this is not generated for every hook, is to save on performance. We know we only really have to generate it in beforeValidate, which is the first hook,
-             * and in beforeChange, which is where modifications to the provided IDs can occur.
-             */
-            const newOriginalNodeIDMap: {
-              [key: string]: SerializedLexicalNode
-            } = {}
+              recurseNodeTree({
+                flattenedNodes,
+                nodes: (value as SerializedEditorState)?.root?.children ?? [],
+              })
 
-            const previousValue = siblingData[field.name!]
-
-            recurseNodeTree({
-              nodeIDMap: newOriginalNodeIDMap,
-              nodes: (previousValue as SerializedEditorState)?.root?.children ?? [],
-            })
-
-            if (!context.internal) {
-              // Add to context, for other hooks to use
-              context.internal = {}
-            }
-            if (!context.internal.richText) {
-              context.internal.richText = {}
-            }
-            context.internal.richText[path.join('.')] = {
-              originalNodeIDMap: newOriginalNodeIDMap,
-            }
-
-            return value
-          },
-        ],
-        beforeValidate: [
-          async (args) => {
-            const {
-              collection,
-              context,
-              global,
-              operation,
-              overrideAccess,
-              path,
-              previousValue,
-              req,
-              schemaPath,
-            } = args
-            let { value } = args
-            if (finalSanitizedEditorConfig?.features?.hooks?.beforeValidate?.length) {
-              for (const hook of finalSanitizedEditorConfig.features.hooks.beforeValidate) {
-                value = await hook(args)
-              }
-            }
-
-            // return value if there are NO hooks
-            if (
-              !finalSanitizedEditorConfig.features.nodeHooks?.beforeValidate?.size &&
-              !finalSanitizedEditorConfig.features.nodeHooks?.afterChange?.size &&
-              !finalSanitizedEditorConfig.features.nodeHooks?.beforeChange?.size &&
-              !finalSanitizedEditorConfig.features.getSubFields?.size
-            ) {
-              return value
-            }
-
-            /**
-             * beforeValidate is the first field hook which runs. This is where we can create the node map, which can then be used in the other hooks.
-             *
-             */
-
-            /**
-             * flattenedNodes contains all nodes in the editor, in the order they appear in the editor. They will be used for the following hooks:
-             * - afterRead
-             *
-             * The other hooks require nodes to have IDs, which is why those are ran only from the nodeIDMap. They require IDs because they have both doc/siblingDoc and data/siblingData, and
-             * thus require a reliable way to match new node data to old node data. Given that node positions can change in between hooks, this is only reliably possible for nodes which are saved with
-             * an ID.
-             */
-            //const flattenedNodes: SerializedLexicalNode[] = []
-
-            /**
-             * Only nodes with id's (so, nodes with hooks added to them) will be added to the nodeIDMap. They will be used for the following hooks:
-             * - afterChange
-             * - beforeChange
-             * - beforeValidate
-             *
-             * Other hooks are handled by the flattenedNodes. All nodes in the nodeIDMap are part of flattenedNodes.
-             */
-
-            const originalNodeIDMap: {
-              [key: string]: SerializedLexicalNode
-            } = {}
-
-            recurseNodeTree({
-              nodeIDMap: originalNodeIDMap,
-              nodes: (previousValue as SerializedEditorState)?.root?.children ?? [],
-            })
-
-            if (!context.internal) {
-              // Add to context, for other hooks to use
-              context.internal = {}
-            }
-            if (!(context as any).internal.richText) {
-              ;(context as any).internal.richText = {}
-            }
-            ;(context as any).internal.richText[path.join('.')] = {
-              originalNodeIDMap,
-            }
-
-            /**
-             * Now that the maps for all hooks are set up, we can run the validate hook
-             */
-            if (!finalSanitizedEditorConfig.features.nodeHooks?.beforeValidate?.size) {
-              return value
-            }
-            const nodeIDMap: {
-              [key: string]: SerializedLexicalNode
-            } = {}
-            recurseNodeTree({
-              //flattenedNodes,
-              nodeIDMap,
-              nodes: (value as SerializedEditorState)?.root?.children ?? [],
-            })
-
-            // eslint-disable-next-line prefer-const
-            for (let [id, node] of Object.entries(nodeIDMap)) {
-              const beforeValidateHooks =
-                finalSanitizedEditorConfig.features.nodeHooks.beforeValidate
-              const beforeValidateHooksForNode = beforeValidateHooks?.get(node.type)
-              if (beforeValidateHooksForNode) {
-                for (const hook of beforeValidateHooksForNode) {
-                  if (!originalNodeIDMap[id]) {
-                    console.warn(
-                      '(beforeValidate) No original node found for node with id',
-                      id,
-                      'node:',
+              for (let node of flattenedNodes) {
+                const afterReadHooks = finalSanitizedEditorConfig.features.nodeHooks?.afterRead
+                const afterReadHooksForNode = afterReadHooks?.get(node.type)
+                if (afterReadHooksForNode) {
+                  for (const hook of afterReadHooksForNode) {
+                    node = await hook({
+                      context,
+                      currentDepth: currentDepth!,
+                      depth: depth!,
+                      draft: draft!,
+                      fallbackLocale: fallbackLocale!,
+                      fieldPromises: fieldPromises!,
+                      findMany: findMany!,
+                      flattenLocales: flattenLocales!,
+                      locale: locale!,
                       node,
-                      'path',
-                      path.join('.'),
-                    )
-                    continue
+                      overrideAccess: overrideAccess!,
+                      parentRichTextFieldPath: path,
+                      parentRichTextFieldSchemaPath: schemaPath,
+                      populateArg: populate,
+                      populationPromises: populationPromises!,
+                      req,
+                      showHiddenFields: showHiddenFields!,
+                      triggerAccessControl: triggerAccessControl!,
+                      triggerHooks: triggerHooks!,
+                    })
                   }
-                  node = await hook({
-                    context,
-                    node,
-                    operation,
-                    originalNode: originalNodeIDMap[id],
-                    overrideAccess: overrideAccess!,
-                    parentRichTextFieldPath: path,
-                    parentRichTextFieldSchemaPath: schemaPath,
-                    req,
-                  })
+                }
+                const subFieldFn = finalSanitizedEditorConfig.features.getSubFields?.get(node.type)
+                const subFieldDataFn = finalSanitizedEditorConfig.features.getSubFieldsData?.get(
+                  node.type,
+                )
+
+                if (subFieldFn && subFieldDataFn) {
+                  const subFields = subFieldFn({ node, req })
+                  const data = subFieldDataFn({ node, req }) ?? {}
+
+                  if (subFields?.length) {
+                    afterReadTraverseFields({
+                      collection,
+                      context,
+                      currentDepth: currentDepth!,
+                      depth: depth!,
+                      doc: data,
+                      draft: draft!,
+                      fallbackLocale: fallbackLocale!,
+                      fieldPromises: fieldPromises!,
+                      fields: subFields,
+                      findMany: findMany!,
+                      flattenLocales: flattenLocales!,
+                      global,
+                      locale: locale!,
+                      overrideAccess: overrideAccess!,
+                      path,
+                      populate,
+                      populationPromises: populationPromises!,
+                      req,
+                      schemaPath,
+                      showHiddenFields: showHiddenFields!,
+                      siblingDoc: data,
+                      triggerAccessControl,
+                      triggerHooks,
+                    })
+                  }
                 }
               }
-              const subFieldFn = finalSanitizedEditorConfig.features.getSubFields?.get(node.type)
-              const subFieldDataFn = finalSanitizedEditorConfig.features.getSubFieldsData?.get(
-                node.type,
-              )
 
-              if (subFieldFn && subFieldDataFn) {
-                const subFields = subFieldFn({ node, req })
-                const data = subFieldDataFn({ node, req }) ?? {}
-                const originalData = subFieldDataFn({ node: originalNodeIDMap[id], req }) ?? {}
+              return value
+            },
+          ],
+          beforeChange: [
+            async (args) => {
+              const {
+                collection,
+                context: _context,
+                errors,
+                field,
+                global,
+                mergeLocaleActions,
+                operation,
+                path,
+                req,
+                schemaPath,
+                siblingData,
+                siblingDocWithLocales,
+                skipValidation,
+              } = args
+              let { value } = args
 
-                if (subFields?.length) {
-                  await beforeValidateTraverseFields({
-                    id,
-                    collection,
-                    context,
-                    data,
-                    doc: originalData,
-                    fields: subFields,
-                    global,
-                    operation,
-                    overrideAccess: overrideAccess!,
-                    path,
-                    req,
-                    schemaPath,
-                    siblingData: data,
-                    siblingDoc: originalData,
-                  })
+              if (finalSanitizedEditorConfig?.features?.hooks?.beforeChange?.length) {
+                for (const hook of finalSanitizedEditorConfig.features.hooks.beforeChange) {
+                  value = await hook(args)
                 }
               }
-            }
 
-            return value
-          },
-        ],
-      },
-      i18n: featureI18n,
-      outputSchema: ({
-        collectionIDFieldTypes,
-        config,
-        field,
-        interfaceNameDefinitions,
-        isRequired,
-      }) => {
-        let outputSchema: JSONSchema4 = {
-          // This schema matches the SerializedEditorState type so far, that it's possible to cast SerializedEditorState to this schema without any errors.
-          // In the future, we should
-          // 1) allow recursive children
-          // 2) Pass in all the different types for every node added to the editorconfig. This can be done with refs in the schema.
-          type: withNullableJSONSchemaType('object', isRequired),
-          properties: {
-            root: {
-              type: 'object',
-              additionalProperties: false,
-              properties: {
-                type: {
-                  type: 'string',
-                },
-                children: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    additionalProperties: true,
-                    properties: {
-                      type: {
-                        type: 'string',
+              if (
+                !finalSanitizedEditorConfig.features.nodeHooks?.beforeChange?.size &&
+                !finalSanitizedEditorConfig.features.getSubFields?.size
+              ) {
+                return value
+              }
+
+              const context: any = _context
+              const nodeIDMap: {
+                [key: string]: SerializedLexicalNode
+              } = {}
+
+              /**
+               * Get the originalNodeIDMap from the beforeValidate hook, which is always run before this hook.
+               */
+              const originalNodeIDMap: {
+                [key: string]: SerializedLexicalNode
+              } = context?.internal?.richText?.[path.join('.')]?.originalNodeIDMap
+
+              if (!originalNodeIDMap || !Object.keys(originalNodeIDMap).length || !value) {
+                return value
+              }
+
+              const originalNodeWithLocalesIDMap: {
+                [key: string]: SerializedLexicalNode
+              } = {}
+
+              recurseNodeTree({
+                nodeIDMap,
+                nodes: (value as SerializedEditorState)?.root?.children ?? [],
+              })
+
+              if (field.name && siblingDocWithLocales?.[field.name]) {
+                recurseNodeTree({
+                  nodeIDMap: originalNodeWithLocalesIDMap,
+                  nodes:
+                    (siblingDocWithLocales[field.name] as SerializedEditorState)?.root?.children ??
+                    [],
+                })
+              }
+
+              // eslint-disable-next-line prefer-const
+              for (let [id, node] of Object.entries(nodeIDMap)) {
+                const beforeChangeHooks =
+                  finalSanitizedEditorConfig.features.nodeHooks?.beforeChange
+                const beforeChangeHooksForNode = beforeChangeHooks?.get(node.type)
+                if (beforeChangeHooksForNode) {
+                  for (const hook of beforeChangeHooksForNode) {
+                    if (!originalNodeIDMap[id]) {
+                      console.warn(
+                        '(beforeChange) No original node found for node with id',
+                        id,
+                        'node:',
+                        node,
+                        'path',
+                        path.join('.'),
+                      )
+                      continue
+                    }
+                    node = await hook({
+                      context,
+                      errors: errors!,
+                      mergeLocaleActions: mergeLocaleActions!,
+                      node,
+                      operation: operation!,
+                      originalNode: originalNodeIDMap[id],
+                      originalNodeWithLocales: originalNodeWithLocalesIDMap[id],
+                      parentRichTextFieldPath: path,
+                      parentRichTextFieldSchemaPath: schemaPath,
+                      req,
+                      skipValidation: skipValidation!,
+                    })
+                  }
+                }
+
+                const subFieldFn = finalSanitizedEditorConfig.features.getSubFields?.get(node.type)
+                const subFieldDataFn = finalSanitizedEditorConfig.features.getSubFieldsData?.get(
+                  node.type,
+                )
+
+                if (subFieldFn && subFieldDataFn) {
+                  const subFields = subFieldFn({ node, req })
+                  const data = subFieldDataFn({ node, req }) ?? {}
+                  const originalData = subFieldDataFn({ node: originalNodeIDMap[id], req }) ?? {}
+                  const originalDataWithLocales =
+                    subFieldDataFn({
+                      node: originalNodeWithLocalesIDMap[id],
+                      req,
+                    }) ?? {}
+
+                  if (subFields?.length) {
+                    await beforeChangeTraverseFields({
+                      id,
+                      collection,
+                      context,
+                      data,
+                      doc: originalData,
+                      docWithLocales: originalDataWithLocales ?? {},
+                      errors: errors!,
+                      fields: subFields,
+                      global,
+                      mergeLocaleActions: mergeLocaleActions!,
+                      operation: operation!,
+                      path,
+                      req,
+                      schemaPath,
+                      siblingData: data,
+                      siblingDoc: originalData,
+                      siblingDocWithLocales: originalDataWithLocales ?? {},
+                      skipValidation,
+                    })
+                  }
+                }
+              }
+
+              /**
+               * within the beforeChange hook, id's may be re-generated.
+               * Example:
+               * 1. Seed data contains IDs for block feature blocks.
+               * 2. Those are used in beforeValidate
+               * 3. in beforeChange, those IDs are regenerated, because you cannot provide IDs during document creation. See baseIDField beforeChange hook for reasoning
+               * 4. Thus, in order for all post-beforeChange hooks to receive the correct ID, we need to update the originalNodeIDMap with the new ID's, by regenerating the nodeIDMap.
+               * The reason this is not generated for every hook, is to save on performance. We know we only really have to generate it in beforeValidate, which is the first hook,
+               * and in beforeChange, which is where modifications to the provided IDs can occur.
+               */
+              const newOriginalNodeIDMap: {
+                [key: string]: SerializedLexicalNode
+              } = {}
+
+              const previousValue = siblingData[field.name!]
+
+              recurseNodeTree({
+                nodeIDMap: newOriginalNodeIDMap,
+                nodes: (previousValue as SerializedEditorState)?.root?.children ?? [],
+              })
+
+              if (!context.internal) {
+                // Add to context, for other hooks to use
+                context.internal = {}
+              }
+              if (!context.internal.richText) {
+                context.internal.richText = {}
+              }
+              context.internal.richText[path.join('.')] = {
+                originalNodeIDMap: newOriginalNodeIDMap,
+              }
+
+              return value
+            },
+          ],
+          beforeValidate: [
+            async (args) => {
+              const {
+                collection,
+                context,
+                global,
+                operation,
+                overrideAccess,
+                path,
+                previousValue,
+                req,
+                schemaPath,
+              } = args
+              let { value } = args
+              if (finalSanitizedEditorConfig?.features?.hooks?.beforeValidate?.length) {
+                for (const hook of finalSanitizedEditorConfig.features.hooks.beforeValidate) {
+                  value = await hook(args)
+                }
+              }
+
+              // return value if there are NO hooks
+              if (
+                !finalSanitizedEditorConfig.features.nodeHooks?.beforeValidate?.size &&
+                !finalSanitizedEditorConfig.features.nodeHooks?.afterChange?.size &&
+                !finalSanitizedEditorConfig.features.nodeHooks?.beforeChange?.size &&
+                !finalSanitizedEditorConfig.features.getSubFields?.size
+              ) {
+                return value
+              }
+
+              /**
+               * beforeValidate is the first field hook which runs. This is where we can create the node map, which can then be used in the other hooks.
+               *
+               */
+
+              /**
+               * flattenedNodes contains all nodes in the editor, in the order they appear in the editor. They will be used for the following hooks:
+               * - afterRead
+               *
+               * The other hooks require nodes to have IDs, which is why those are ran only from the nodeIDMap. They require IDs because they have both doc/siblingDoc and data/siblingData, and
+               * thus require a reliable way to match new node data to old node data. Given that node positions can change in between hooks, this is only reliably possible for nodes which are saved with
+               * an ID.
+               */
+              //const flattenedNodes: SerializedLexicalNode[] = []
+
+              /**
+               * Only nodes with id's (so, nodes with hooks added to them) will be added to the nodeIDMap. They will be used for the following hooks:
+               * - afterChange
+               * - beforeChange
+               * - beforeValidate
+               *
+               * Other hooks are handled by the flattenedNodes. All nodes in the nodeIDMap are part of flattenedNodes.
+               */
+
+              const originalNodeIDMap: {
+                [key: string]: SerializedLexicalNode
+              } = {}
+
+              recurseNodeTree({
+                nodeIDMap: originalNodeIDMap,
+                nodes: (previousValue as SerializedEditorState)?.root?.children ?? [],
+              })
+
+              if (!context.internal) {
+                // Add to context, for other hooks to use
+                context.internal = {}
+              }
+              if (!(context.internal as any).richText) {
+                ;(context.internal as any).richText = {}
+              }
+              ;(context.internal as any).richText[path.join('.')] = {
+                originalNodeIDMap,
+              }
+
+              /**
+               * Now that the maps for all hooks are set up, we can run the validate hook
+               */
+              if (!finalSanitizedEditorConfig.features.nodeHooks?.beforeValidate?.size) {
+                return value
+              }
+              const nodeIDMap: {
+                [key: string]: SerializedLexicalNode
+              } = {}
+              recurseNodeTree({
+                //flattenedNodes,
+                nodeIDMap,
+                nodes: (value as SerializedEditorState)?.root?.children ?? [],
+              })
+
+              // eslint-disable-next-line prefer-const
+              for (let [id, node] of Object.entries(nodeIDMap)) {
+                const beforeValidateHooks =
+                  finalSanitizedEditorConfig.features.nodeHooks.beforeValidate
+                const beforeValidateHooksForNode = beforeValidateHooks?.get(node.type)
+                if (beforeValidateHooksForNode) {
+                  for (const hook of beforeValidateHooksForNode) {
+                    if (!originalNodeIDMap[id]) {
+                      console.warn(
+                        '(beforeValidate) No original node found for node with id',
+                        id,
+                        'node:',
+                        node,
+                        'path',
+                        path.join('.'),
+                      )
+                      continue
+                    }
+                    node = await hook({
+                      context,
+                      node,
+                      operation,
+                      originalNode: originalNodeIDMap[id],
+                      overrideAccess: overrideAccess!,
+                      parentRichTextFieldPath: path,
+                      parentRichTextFieldSchemaPath: schemaPath,
+                      req,
+                    })
+                  }
+                }
+                const subFieldFn = finalSanitizedEditorConfig.features.getSubFields?.get(node.type)
+                const subFieldDataFn = finalSanitizedEditorConfig.features.getSubFieldsData?.get(
+                  node.type,
+                )
+
+                if (subFieldFn && subFieldDataFn) {
+                  const subFields = subFieldFn({ node, req })
+                  const data = subFieldDataFn({ node, req }) ?? {}
+                  const originalData = subFieldDataFn({ node: originalNodeIDMap[id], req }) ?? {}
+
+                  if (subFields?.length) {
+                    await beforeValidateTraverseFields({
+                      id,
+                      collection,
+                      context,
+                      data,
+                      doc: originalData,
+                      fields: subFields,
+                      global,
+                      operation,
+                      overrideAccess: overrideAccess!,
+                      path,
+                      req,
+                      schemaPath,
+                      siblingData: data,
+                      siblingDoc: originalData,
+                    })
+                  }
+                }
+              }
+
+              return value
+            },
+          ],
+        },
+        i18n: featureI18n,
+        outputSchema: ({
+          collectionIDFieldTypes,
+          config,
+          field,
+          interfaceNameDefinitions,
+          isRequired,
+        }) => {
+          let outputSchema: JSONSchema4 = {
+            // This schema matches the SerializedEditorState type so far, that it's possible to cast SerializedEditorState to this schema without any errors.
+            // In the future, we should
+            // 1) allow recursive children
+            // 2) Pass in all the different types for every node added to the editorconfig. This can be done with refs in the schema.
+            type: withNullableJSONSchemaType('object', isRequired),
+            properties: {
+              root: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  type: {
+                    type: 'string',
+                  },
+                  children: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      additionalProperties: true,
+                      properties: {
+                        type: {
+                          type: 'string',
+                        },
+                        version: {
+                          type: 'integer',
+                        },
                       },
-                      version: {
-                        type: 'integer',
-                      },
+                      required: ['type', 'version'],
                     },
-                    required: ['type', 'version'],
+                  },
+                  direction: {
+                    oneOf: [
+                      {
+                        enum: ['ltr', 'rtl'],
+                      },
+                      {
+                        type: 'null',
+                      },
+                    ],
+                  },
+                  format: {
+                    type: 'string',
+                    enum: ['left', 'start', 'center', 'right', 'end', 'justify', ''], // ElementFormatType, since the root node is an element
+                  },
+                  indent: {
+                    type: 'integer',
+                  },
+                  version: {
+                    type: 'integer',
                   },
                 },
-                direction: {
-                  oneOf: [
-                    {
-                      enum: ['ltr', 'rtl'],
-                    },
-                    {
-                      type: 'null',
-                    },
-                  ],
-                },
-                format: {
-                  type: 'string',
-                  enum: ['left', 'start', 'center', 'right', 'end', 'justify', ''], // ElementFormatType, since the root node is an element
-                },
-                indent: {
-                  type: 'integer',
-                },
-                version: {
-                  type: 'integer',
-                },
+                required: ['children', 'direction', 'format', 'indent', 'type', 'version'],
               },
-              required: ['children', 'direction', 'format', 'indent', 'type', 'version'],
             },
-          },
-          required: ['root'],
-        }
-        for (const modifyOutputSchema of finalSanitizedEditorConfig.features.generatedTypes
-          .modifyOutputSchemas) {
-          outputSchema = modifyOutputSchema({
-            collectionIDFieldTypes,
-            config,
-            currentSchema: outputSchema,
-            field,
-            interfaceNameDefinitions,
-            isRequired,
-          })
-        }
+            required: ['root'],
+          }
+          for (const modifyOutputSchema of finalSanitizedEditorConfig.features.generatedTypes
+            .modifyOutputSchemas) {
+            outputSchema = modifyOutputSchema({
+              collectionIDFieldTypes,
+              config,
+              currentSchema: outputSchema,
+              field,
+              interfaceNameDefinitions,
+              isRequired,
+            })
+          }
 
-        return outputSchema
-      },
-      validate: richTextValidateHOC({
-        editorConfig: finalSanitizedEditorConfig,
-      }),
-    }
+          return outputSchema
+        },
+        validate: richTextValidateHOC({
+          editorConfig: finalSanitizedEditorConfig,
+        }),
+      }
+    },
+    enabledFeatures,
   }
 }
 

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -65,8 +65,8 @@ export type LexicalRichTextAdapter = {
   features: FeatureProviderServer<any, any, any>[]
 } & RichTextAdapter<SerializedEditorState, AdapterProps>
 
-export type LexicalRichTextAdapterProvider =
-  /**
+export type LexicalRichTextAdapterProvider = {
+  adapter: /**
    * This is being called during the payload sanitization process
    */
   ({
@@ -78,6 +78,13 @@ export type LexicalRichTextAdapterProvider =
     isRoot?: boolean
     parentIsLocalized: boolean
   }) => Promise<LexicalRichTextAdapter>
+  /**
+   * A list of features that are enabled in the richText editor.
+   *
+   * This will be a function if a function is passed to the `features` argument in the `lexicalEditor` function.
+   */
+  enabledFeatures: LexicalEditorProps['features']
+}
 
 export type FeatureClientSchemaMap = {
   [featureKey: string]: {

--- a/packages/richtext-lexical/src/utilities/migrateSlateToLexical/migrateDocumentFieldsRecursively.ts
+++ b/packages/richtext-lexical/src/utilities/migrateSlateToLexical/migrateDocumentFieldsRecursively.ts
@@ -73,7 +73,7 @@ export const migrateDocumentFieldsRecursively = ({
     if (field.type === 'richText' && Array.isArray(data[field.name])) {
       // Slate richText
       const editor: LexicalRichTextAdapter = field.editor as LexicalRichTextAdapter
-      if (editor && typeof editor === 'object') {
+      if (editor && !('adapter' in editor)) {
         if ('features' in editor && editor.features?.length) {
           // find slatetolexical feature
           const slateToLexicalFeature = editor.editorConfig.resolvedFeatureMap.get('slateToLexical')

--- a/packages/richtext-lexical/src/utilities/upgradeLexicalData/upgradeDocumentFieldsRecursively.ts
+++ b/packages/richtext-lexical/src/utilities/upgradeLexicalData/upgradeDocumentFieldsRecursively.ts
@@ -76,7 +76,7 @@ export const upgradeDocumentFieldsRecursively = ({
     ) {
       // Lexical richText
       const editor: LexicalRichTextAdapter = field.editor as LexicalRichTextAdapter
-      if (editor && typeof editor === 'object') {
+      if (editor && !('adapter' in editor)) {
         if ('features' in editor && editor.features?.length) {
           // Load lexical editor into lexical, then save it immediately
           const editorState = data[field.name] as SerializedEditorState

--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -207,7 +207,7 @@ export const buildColumnState = (args: Args): Column[] => {
                 throw new MissingEditorProp(_field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
               }
 
-              if (typeof _field?.editor === 'function') {
+              if ('adapter' in _field.editor) {
                 throw new Error('Attempted to access unsanitized rich text editor.')
               }
 

--- a/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
@@ -109,7 +109,7 @@ export const renderField: RenderFieldMethod = ({
         throw new MissingEditorProp(fieldConfig) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
 
-      if (typeof fieldConfig?.editor === 'function') {
+      if ('adapter' in fieldConfig.editor) {
         throw new Error('Attempted to access unsanitized rich text editor.')
       }
 

--- a/packages/ui/src/utilities/buildFieldSchemaMap/traverseFields.ts
+++ b/packages/ui/src/utilities/buildFieldSchemaMap/traverseFields.ts
@@ -81,7 +81,7 @@ export const traverseFields = ({
           throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
         }
 
-        if (typeof field.editor === 'function') {
+        if ('adapter' in field.editor) {
           throw new Error('Attempted to access unsanitized rich text editor.')
         }
 


### PR DESCRIPTION
The richtext adapter provider function now can longer be assigned to the `editor` property. Instead, it now has to be assigned to the `editor.adapter` property. This allows adapters to return additional properties alongside the adapter provider function, so that these are available in the **unsanitized** config.

The lexical richText adapter function "`lexicalEditor()`" now returns `editor.enabledFeatures` alongside the adapter - this can be used to get information about what features are enabled if you are working with the unsanitized config.

**BREAKING:**

Previously, richText adapters returned either the adapter itself, or a function returning the adapter.

Now, richText adapters can return either the adapter itself, or an object with an `adapter` property that is a function returning the adapter.

This modifies what both our slate and lexical adapters return. If you work with the editor property from the **unsanitized** config, or have your own richtext adapter, this will be breaking.