### PR TITLE
fix(next): safely check for `state` when creating first user

### DIFF
--- a/packages/next/src/views/CreateFirstUser/index.client.tsx
+++ b/packages/next/src/views/CreateFirstUser/index.client.tsx
@@ -54,7 +54,7 @@ export const CreateFirstUserClient: React.FC<{
       const controller = new AbortController()
       formStateAbortControllerRef.current = controller
 
-      const { state } = await getFormState({
+      const response = await getFormState({
         collectionSlug: userSlug,
         docPermissions,
         docPreferences,
@@ -64,7 +64,9 @@ export const CreateFirstUserClient: React.FC<{
         signal: controller.signal,
       })
 
-      return state
+      if (response && response.state) {
+        return response.state
+      }
     },
     [userSlug, getFormState, docPermissions, docPreferences],
   )


### PR DESCRIPTION
On createFirstUser, state from form-state was returning null.

![Screenshot 2024-11-13 at 9 58 04 AM](https://github.com/user-attachments/assets/19019e3e-09fc-42e6-9b9a-9198772d9133)

Only return `state` if response from form-state is not null.
