### PR TITLE
fix(graphql): loading of polymorphic hasMany relationships

### DIFF
--- a/packages/graphql/src/schema/buildObjectType.ts
+++ b/packages/graphql/src/schema/buildObjectType.ts
@@ -432,8 +432,11 @@ export function buildObjectType({
             const createPopulationPromise = async (relatedDoc, i) => {
               let id = relatedDoc
               let collectionSlug = field.relationTo
+              const isValidGraphQLCollection = isRelatedToManyCollections
+                ? graphQLCollections.some((collection) => collectionSlug.includes(collection.slug))
+                : graphQLCollections.some((collection) => collectionSlug === collection.slug)
 
-              if (graphQLCollections.some((collection) => collection.slug === collectionSlug)) {
+              if (isValidGraphQLCollection) {
                 if (isRelatedToManyCollections) {
                   collectionSlug = relatedDoc.relationTo
                   id = relatedDoc.value


### PR DESCRIPTION
### What?

Bug #9173

### Why?

`collectionSlug` is an array when `isRelatedToManyCollections` is true

### How?

Compare array to array

Fixes #9173

![Screenshot 2024-11-13 at 12 37 52 PM](https://github.com/user-attachments/assets/3eae497d-90d8-474a-afd0-baf69f017459)
