### PR TITLE
fix(db-postgres, db-vercel-postgres): relationship migration v2-v3 dirname

### DIFF
--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -50,11 +50,16 @@ import {
   requireDrizzleKit,
 } from '@payloadcms/drizzle/postgres'
 import { pgEnum, pgSchema, pgTable } from 'drizzle-orm/pg-core'
+import path from 'path'
 import { createDatabaseAdapter, defaultBeginTransaction } from 'payload'
+import { fileURLToPath } from 'url'
 
 import type { Args, PostgresAdapter } from './types.js'
 
 import { connect } from './connect.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 
 export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter> {
   const postgresIDType = args.idType || 'serial'
@@ -88,6 +93,9 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,
       createExtensions,
+      createMigration(args) {
+        return createMigration.bind(this)({ ...args, dirname })
+      },
       defaultDrizzleSnapshot,
       disableCreateDatabase: args.disableCreateDatabase ?? false,
       drizzle: undefined,
@@ -132,7 +140,6 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       createGlobal,
       createGlobalVersion,
       createJSONQuery,
-      createMigration,
       createVersion,
       defaultIDType: payloadIDType,
       deleteMany,

--- a/packages/db-vercel-postgres/src/index.ts
+++ b/packages/db-vercel-postgres/src/index.ts
@@ -50,11 +50,16 @@ import {
   requireDrizzleKit,
 } from '@payloadcms/drizzle/postgres'
 import { pgEnum, pgSchema, pgTable } from 'drizzle-orm/pg-core'
+import path from 'path'
 import { createDatabaseAdapter, defaultBeginTransaction } from 'payload'
+import { fileURLToPath } from 'url'
 
 import type { Args, VercelPostgresAdapter } from './types.js'
 
 import { connect } from './connect.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 
 export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<VercelPostgresAdapter> {
   const postgresIDType = args.idType || 'serial'
@@ -133,7 +138,9 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
       createGlobal,
       createGlobalVersion,
       createJSONQuery,
-      createMigration,
+      createMigration(args) {
+        return createMigration.bind(this)({ ...args, dirname })
+      },
       createVersion,
       defaultIDType: payloadIDType,
       deleteMany,

--- a/packages/drizzle/src/postgres/createMigration.ts
+++ b/packages/drizzle/src/postgres/createMigration.ts
@@ -2,10 +2,8 @@ import type { CreateMigration } from 'payload'
 
 import fs from 'fs'
 import { createRequire } from 'module'
-import path from 'path'
 import { getPredefinedMigration, writeMigrationIndex } from 'payload'
 import prompts from 'prompts'
-import { fileURLToPath } from 'url'
 
 import type { BasePostgresAdapter } from './types.js'
 
@@ -16,10 +14,8 @@ const require = createRequire(import.meta.url)
 
 export const createMigration: CreateMigration = async function createMigration(
   this: BasePostgresAdapter,
-  { file, forceAcceptWarning, migrationName, payload },
+  { dirname, file, forceAcceptWarning, migrationName, payload },
 ) {
-  const filename = fileURLToPath(import.meta.url)
-  const dirname = path.dirname(filename)
   const dir = payload.db.migrationDir
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -160,6 +160,8 @@ export type Connect = (args?: ConnectArgs) => Promise<void>
 export type Destroy = () => Promise<void>
 
 export type CreateMigration = (args: {
+  /** dirname of the package, required in drizzle */
+  dirname?: string
   file?: string
   /**
    * Skips the prompt asking to create empty migrations


### PR DESCRIPTION
### What?
This command from here:
https://github.com/payloadcms/payload/pull/6339
```sh
payload migrate:create --file @payloadcms/db-postgres/relationships-v2-v3
```
stopped working after db-postgers and drizzle packages were separated 

### How?
Passes correct `dirname` to `getPredefinedMigration`

Additionally, adds support for `.js` files in `getPredefinedMigration`
