### PR TITLE
feat(db-mongodb): add support for query options in update operations

### DIFF
--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -1,7 +1,17 @@
 import type { CollationOptions, TransactionOptions } from 'mongodb'
 import type { MongoMemoryReplSet } from 'mongodb-memory-server'
 import type { ClientSession, Connection, ConnectOptions, QueryOptions } from 'mongoose'
-import type { BaseDatabaseAdapter, DatabaseAdapterObj, Payload, UpdateOneArgs } from 'payload'
+import type {
+  BaseDatabaseAdapter,
+  DatabaseAdapterObj,
+  Payload,
+  TypeWithID,
+  TypeWithVersion,
+  UpdateGlobalArgs,
+  UpdateGlobalVersionArgs,
+  UpdateOneArgs,
+  UpdateVersionArgs,
+} from 'payload'
 
 import fs from 'fs'
 import mongoose from 'mongoose'
@@ -135,7 +145,16 @@ declare module 'payload' {
     }[]
     sessions: Record<number | string, ClientSession>
     transactionOptions: TransactionOptions
+    updateGlobal: <T extends Record<string, unknown>>(
+      args: { options?: QueryOptions } & UpdateGlobalArgs<T>,
+    ) => Promise<T>
+    updateGlobalVersion: <T extends TypeWithID = TypeWithID>(
+      args: { options?: QueryOptions } & UpdateGlobalVersionArgs<T>,
+    ) => Promise<TypeWithVersion<T>>
     updateOne: (args: { options?: QueryOptions } & UpdateOneArgs) => Promise<Document>
+    updateVersion: <T extends TypeWithID = TypeWithID>(
+      args: { options?: QueryOptions } & UpdateVersionArgs<T>,
+    ) => Promise<TypeWithVersion<T>>
     versions: {
       [slug: string]: CollectionModel
     }

--- a/packages/db-mongodb/src/updateGlobal.ts
+++ b/packages/db-mongodb/src/updateGlobal.ts
@@ -1,3 +1,4 @@
+import type { QueryOptions } from 'mongoose'
 import type { PayloadRequest, UpdateGlobal } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -9,12 +10,13 @@ import { withSession } from './withSession.js'
 
 export const updateGlobal: UpdateGlobal = async function updateGlobal(
   this: MongooseAdapter,
-  { slug, data, req = {} as PayloadRequest, select },
+  { slug, data, options: optionsArgs = {}, req = {} as PayloadRequest, select },
 ) {
   const Model = this.globals
   const fields = this.payload.config.globals.find((global) => global.slug === slug).fields
 
-  const options = {
+  const options: QueryOptions = {
+    ...optionsArgs,
     ...(await withSession(this, req)),
     lean: true,
     new: true,

--- a/packages/db-mongodb/src/updateGlobalVersion.ts
+++ b/packages/db-mongodb/src/updateGlobalVersion.ts
@@ -1,3 +1,5 @@
+import type { QueryOptions } from 'mongoose'
+
 import {
   buildVersionGlobalFields,
   type PayloadRequest,
@@ -17,6 +19,7 @@ export async function updateGlobalVersion<T extends TypeWithID>(
     id,
     global: globalSlug,
     locale,
+    options: optionsArgs = {},
     req = {} as PayloadRequest,
     select,
     versionData,
@@ -30,7 +33,8 @@ export async function updateGlobalVersion<T extends TypeWithID>(
     this.payload.config.globals.find((global) => global.slug === globalSlug),
   )
 
-  const options = {
+  const options: QueryOptions = {
+    ...optionsArgs,
     ...(await withSession(this, req)),
     lean: true,
     new: true,

--- a/packages/db-mongodb/src/updateVersion.ts
+++ b/packages/db-mongodb/src/updateVersion.ts
@@ -1,3 +1,5 @@
+import type { QueryOptions } from 'mongoose'
+
 import { buildVersionCollectionFields, type PayloadRequest, type UpdateVersion } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
@@ -8,7 +10,16 @@ import { withSession } from './withSession.js'
 
 export const updateVersion: UpdateVersion = async function updateVersion(
   this: MongooseAdapter,
-  { id, collection, locale, req = {} as PayloadRequest, select, versionData, where },
+  {
+    id,
+    collection,
+    locale,
+    options: optionsArgs = {},
+    req = {} as PayloadRequest,
+    select,
+    versionData,
+    where,
+  },
 ) {
   const VersionModel = this.versions[collection]
   const whereToUse = where || { id: { equals: id } }
@@ -17,7 +28,8 @@ export const updateVersion: UpdateVersion = async function updateVersion(
     this.payload.collections[collection].config,
   )
 
-  const options = {
+  const options: QueryOptions = {
+    ...optionsArgs,
     ...(await withSession(this, req)),
     lean: true,
     new: true,

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -283,6 +283,10 @@ export type FindGlobalArgs = {
 export type UpdateGlobalVersionArgs<T = TypeWithID> = {
   global: string
   locale?: string
+  /**
+   * Additional database adapter specific options to pass to the query
+   */
+  options?: Record<string, unknown>
   req: PayloadRequest
   select?: SelectType
   versionData: T
@@ -316,6 +320,10 @@ export type CreateGlobal = <T extends Record<string, unknown> = any>(
 
 export type UpdateGlobalArgs<T extends Record<string, unknown> = any> = {
   data: T
+  /**
+   * Additional database adapter specific options to pass to the query
+   */
+  options?: Record<string, unknown>
   req: PayloadRequest
   select?: SelectType
   slug: string
@@ -380,6 +388,10 @@ export type DeleteVersions = (args: DeleteVersionsArgs) => Promise<void>
 export type UpdateVersionArgs<T = TypeWithID> = {
   collection: string
   locale?: string
+  /**
+   * Additional database adapter specific options to pass to the query
+   */
+  options?: Record<string, unknown>
   req: PayloadRequest
   select?: SelectType
   versionData: T


### PR DESCRIPTION
The mongodb adapter `updateOne` method accepts an `options` argument that allows query options to be passed to mongoose. This parameter was added in https://github.com/payloadcms/payload/pull/8397 to support the `upsert` operation.

This `options` parameter can also be useful when using the database adaptor directly without going through the local api. It is true that the Mongoose models could be used directly in such situations, but the adapter methods include a lot of useful functionality, like for instance the sanitization of document and relationship ids, so it is desirable to be able to use the adapter functions while still being able to provide mongoose query options (e.g. `{timestamps: false}`).

This PR adds the same options parameter to the other update methods of the mongodb adapter.
