### PR TITLE
docs: add `within` and `intersects` operators documentation

### DIFF
--- a/docs/fields/point.mdx
+++ b/docs/fields/point.mdx
@@ -73,6 +73,59 @@ export const ExampleCollection: CollectionConfig = {
 }
 ```
 
-## Querying
+## Querying - near
 
 In order to do query based on the distance to another point, you can use the `near` operator. When querying using the near operator, the returned documents will be sorted by nearest first.
+
+## Querying - within
+
+In order to do query based on whether points are within a specific area defined in GeoJSON, you can use the `within` operator.
+Example:
+```ts
+const polygon: Point[] = [
+  [9.0, 19.0], // bottom-left
+  [9.0, 21.0], // top-left
+  [11.0, 21.0], // top-right
+  [11.0, 19.0], // bottom-right
+  [9.0, 19.0], // back to starting point to close the polygon
+]
+
+payload.find({
+  collection: "points",
+  where: {
+    point: {
+      within: {
+        type: 'Polygon',
+        coordinates: [polygon],
+      },
+    },
+  },
+})
+```
+
+
+## Querying - intersects
+
+In order to do query based on whether points intersect a specific area defined in GeoJSON, you can use the `intersects` operator.
+Example:
+```ts
+const polygon: Point[] = [
+  [9.0, 19.0], // bottom-left
+  [9.0, 21.0], // top-left
+  [11.0, 21.0], // top-right
+  [11.0, 19.0], // bottom-right
+  [9.0, 19.0], // back to starting point to close the polygon
+]
+
+payload.find({
+  collection: "points",
+  where: {
+    point: {
+      intersects: {
+        type: 'Polygon',
+        coordinates: [polygon],
+      },
+    },
+  },
+})
+```

--- a/docs/queries/overview.mdx
+++ b/docs/queries/overview.mdx
@@ -37,21 +37,23 @@ _The exact query syntax will depend on the API you are using, but the concepts a
 
 The following operators are available for use in queries:
 
-| Operator             | Description                                                                                                                                                                       |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `equals`             | The value must be exactly equal.                                                                                                                                                  |
-| `not_equals`         | The query will return all documents where the value is not equal.                                                                                                                 |
-| `greater_than`       | For numeric or date-based fields.                                                                                                                                                 |
-| `greater_than_equal` | For numeric or date-based fields.                                                                                                                                                 |
-| `less_than`          | For numeric or date-based fields.                                                                                                                                                 |
-| `less_than_equal`    | For numeric or date-based fields.                                                                                                                                                 |
-| `like`               | Case-insensitive string must be present. If string of words, all words must be present, in any order.                                                                             |
-| `contains`           | Must contain the value entered, case-insensitive.                                                                                                                                 |
-| `in`                 | The value must be found within the provided comma-delimited list of values.                                                                                                       |
-| `not_in`             | The value must NOT be within the provided comma-delimited list of values.                                                                                                         |
-| `all`                | The value must contain all values provided in the comma-delimited list.                                                                                                           |
-| `exists`             | Only return documents where the value either exists (`true`) or does not exist (`false`).                                                                                         |
-| `near`               | For distance related to a [Point Field](../fields/point) comma separated as `<longitude>, <latitude>, <maxDistance in meters (nullable)>, <minDistance in meters (nullable)>`. |
+| Operator             | Description                                                                                                                                                                         |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `equals`             | The value must be exactly equal.                                                                                                                                                    |
+| `not_equals`         | The query will return all documents where the value is not equal.                                                                                                                   |
+| `greater_than`       | For numeric or date-based fields.                                                                                                                                                   |
+| `greater_than_equal` | For numeric or date-based fields.                                                                                                                                                   |
+| `less_than`          | For numeric or date-based fields.                                                                                                                                                   |
+| `less_than_equal`    | For numeric or date-based fields.                                                                                                                                                   |
+| `like`               | Case-insensitive string must be present. If string of words, all words must be present, in any order.                                                                               |
+| `contains`           | Must contain the value entered, case-insensitive.                                                                                                                                   |
+| `in`                 | The value must be found within the provided comma-delimited list of values.                                                                                                         |
+| `not_in`             | The value must NOT be within the provided comma-delimited list of values.                                                                                                           |
+| `all`                | The value must contain all values provided in the comma-delimited list.                                                                                                             |
+| `exists`             | Only return documents where the value either exists (`true`) or does not exist (`false`).                                                                                           |
+| `near`               | For distance related to a [Point Field](../fields/point) comma separated as `<longitude>, <latitude>, <maxDistance in meters (nullable)>, <minDistance in meters (nullable)>`.      |
+| `within`             | For [point fields][../fields/point] to filter documents based on whether points are inside of the given area defined in GeoJSON. [Example](../fields/point#querying---within)       |
+| `intersects`         | For [point fields][../fields/point] to filter documents based on whether points intersect with the given area  defined in GeoJSON. [Example](../fields/point#querying---intersects) |
 
 <Banner type="success">
   <strong>Tip:</strong>


### PR DESCRIPTION
Adds documentation for `within` and `intersects` operators.

#### Querying - within

In order to do query based on whether points are within a specific area defined in GeoJSON, you can use the `within` operator.
Example:
```ts
const polygon: Point[] = [
  [9.0, 19.0], // bottom-left
  [9.0, 21.0], // top-left
  [11.0, 21.0], // top-right
  [11.0, 19.0], // bottom-right
  [9.0, 19.0], // back to starting point to close the polygon
]

payload.find({
  collection: "points",
  where: {
    point: {
      within: {
        type: 'Polygon',
        coordinates: [polygon],
      },
    },
  },
})
```


#### Querying - intersects

In order to do query based on whether points intersect a specific area defined in GeoJSON, you can use the `intersects` operator.
Example:
```ts
const polygon: Point[] = [
  [9.0, 19.0], // bottom-left
  [9.0, 21.0], // top-left
  [11.0, 21.0], // top-right
  [11.0, 19.0], // bottom-right
  [9.0, 19.0], // back to starting point to close the polygon
]

payload.find({
  collection: "points",
  where: {
    point: {
      intersects: {
        type: 'Polygon',
        coordinates: [polygon],
      },
    },
  },
})
```

