### PR TITLE
feat(next): added range handling for file requests

### DIFF
--- a/packages/next/src/fetchAPI-stream-file/index.ts
+++ b/packages/next/src/fetchAPI-stream-file/index.ts
@@ -1,5 +1,10 @@
 import fs from 'fs'
 
+export interface StreamFileOptions {
+  end?: number
+  start?: number
+}
+
 export function iteratorToStream(iterator) {
   return new ReadableStream({
     async pull(controller) {
@@ -19,8 +24,11 @@ export async function* nodeStreamToIterator(stream: fs.ReadStream) {
   }
 }
 
-export function streamFile(path: string): ReadableStream {
-  const nodeStream = fs.createReadStream(path)
+export function streamFile(
+  path: string,
+  options?: BufferEncoding | StreamFileOptions,
+): ReadableStream {
+  const nodeStream = fs.createReadStream(path, options)
   const data: ReadableStream = iteratorToStream(nodeStreamToIterator(nodeStream))
   return data
 }


### PR DESCRIPTION
<!--
Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?


### Why?
### How?
Fixes #
-->

### What?
This adds the correct headers and start/end options to the file streaming of the nextjs endpoint for getting files from disk. 

### Why?
Right now if you request for example a video with the type "video/mp4", the browser will send the range headers, but they are ignored in the handler and thus downloads the whole video. If you have large video files, this is problematic as the user needs to wait for the whole video to download without streaming the buffered bytes.

### How?
To fix this, in the `getFile` handler it adds a check for the range header and returns the file in chunks instead of waiting for the whole file to be loaded. It also modifies the `streamFile` method to include optional options for start and end. The status code is modified to `PARTIAL_CONTENT` (206) if a range request has been detected.

### Questions
- I think this could be exploitable by making many small range requests. Is this something that is catched by the rate-limiter? 
- Is this only needed for local files? I suppose the cloud providers do this automatically?
- Maybe it's better to put this behind a separate option int the upload config for the collection? Something like `allowRangeRequests: boolean`?
