### PR TITLE
chore: clean up types for HiddenField and WatchCondition

### DIFF
--- a/packages/next/src/views/ResetPassword/ResetPasswordForm/index.tsx
+++ b/packages/next/src/views/ResetPassword/ResetPasswordForm/index.tsx
@@ -79,18 +79,7 @@ export const ResetPasswordForm: React.FC<Args> = ({ token }) => {
           schemaPath={`${userSlug}.password`}
         />
         <ConfirmPasswordField />
-        <HiddenField
-          field={{
-            name: 'token',
-            type: 'text',
-            admin: {
-              hidden: true,
-            },
-          }}
-          path="token"
-          schemaPath={`${userSlug}.token`}
-          value={token}
-        />
+        <HiddenField path="token" schemaPath={`${userSlug}.token`} value={token} />
       </div>
       <FormSubmit size="large">{i18n.t('authentication:resetPassword')}</FormSubmit>
     </Form>

--- a/packages/payload/src/admin/fields/Hidden.ts
+++ b/packages/payload/src/admin/fields/Hidden.ts
@@ -1,13 +1,8 @@
-import type { ClientField } from '../../fields/config/types.js'
-import type { ClientFieldBase } from '../types.js'
-
 type HiddenFieldBaseClientProps = {
   readonly disableModifyingForm?: false
-  readonly field?: {
-    readonly name?: string
-  } & ClientField
+  readonly field?: never
   readonly path: string
   readonly value?: unknown
 }
 
-export type HiddenFieldProps = ClientFieldBase & HiddenFieldBaseClientProps
+export type HiddenFieldProps = HiddenFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Hidden.ts
+++ b/packages/payload/src/admin/fields/Hidden.ts
@@ -1,3 +1,5 @@
+import type { ClientFieldBase } from '../types.js'
+
 type HiddenFieldBaseClientProps = {
   readonly disableModifyingForm?: false
   readonly field?: never
@@ -5,4 +7,5 @@ type HiddenFieldBaseClientProps = {
   readonly value?: unknown
 }
 
-export type HiddenFieldProps = HiddenFieldBaseClientProps
+export type HiddenFieldProps = HiddenFieldBaseClientProps &
+  Pick<ClientFieldBase, 'forceRender' | 'schemaPath'>

--- a/packages/ui/src/fields/Hidden/index.tsx
+++ b/packages/ui/src/fields/Hidden/index.tsx
@@ -12,14 +12,7 @@ import { withCondition } from '../../forms/withCondition/index.js'
  * For example, this sets the `ìd` property of a block in the Blocks field.
  */
 const HiddenFieldComponent: React.FC<HiddenFieldProps> = (props) => {
-  const {
-    disableModifyingForm = true,
-    field: { name } = {},
-    path: pathFromProps,
-    value: valueFromProps,
-  } = props
-
-  const path = pathFromProps ?? (name || '')
+  const { disableModifyingForm = true, path, value: valueFromProps } = props
 
   const { setValue, value } = useField({
     path,

--- a/packages/ui/src/fields/index.tsx
+++ b/packages/ui/src/fields/index.tsx
@@ -5,6 +5,7 @@ import type {
   GenericDescriptionProps,
   GenericErrorProps,
   GenericLabelProps,
+  HiddenFieldProps,
 } from 'payload'
 import type React from 'react'
 
@@ -43,9 +44,10 @@ import { UploadField } from './Upload/index.js'
 export * from './shared/index.js'
 
 export type FieldTypesComponents = {
-  [K in 'hidden' | 'password' | FieldTypes]: React.FC<ClientFieldBase>
+  [K in 'password' | FieldTypes]: React.FC<ClientFieldBase>
 } & {
   confirmPassword: React.FC<ConfirmPasswordFieldProps>
+  hidden: React.FC<HiddenFieldProps>
 }
 
 export const fieldComponents: FieldTypesComponents = {

--- a/packages/ui/src/forms/RenderFields/RenderField.tsx
+++ b/packages/ui/src/forms/RenderFields/RenderField.tsx
@@ -67,7 +67,7 @@ export function RenderField({
   }
 
   if (clientFieldConfig.admin?.hidden) {
-    return <HiddenField {...baseFieldProps} field={clientFieldConfig} path={path} />
+    return <HiddenField {...baseFieldProps} path={path} />
   }
 
   switch (clientFieldConfig.type) {

--- a/packages/ui/src/forms/withCondition/WatchCondition.tsx
+++ b/packages/ui/src/forms/withCondition/WatchCondition.tsx
@@ -8,13 +8,10 @@ import { useFormFields } from '../Form/context.js'
 export const WatchCondition: React.FC<{
   children: React.ReactNode
   indexPath: string
-  name?: string
-  path?: string
+  path: string
   type: FieldTypes
 }> = (props) => {
-  const { name, children, path: pathFromProps } = props
-
-  const path = typeof pathFromProps === 'string' ? pathFromProps : name
+  const { children, path } = props
 
   const field = useFormFields(([fields]) => (fields && fields?.[path]) || null)
 

--- a/packages/ui/src/forms/withCondition/WatchCondition.tsx
+++ b/packages/ui/src/forms/withCondition/WatchCondition.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { FieldTypes } from 'payload'
 
 import React, { Fragment } from 'react'
 
@@ -9,7 +8,6 @@ export const WatchCondition: React.FC<{
   children: React.ReactNode
   indexPath: string
   path: string
-  type: FieldTypes
 }> = (props) => {
   const { children, path } = props
 

--- a/packages/ui/src/forms/withCondition/index.tsx
+++ b/packages/ui/src/forms/withCondition/index.tsx
@@ -1,25 +1,19 @@
 'use client'
-import type { ClientFieldProps, FieldPaths } from 'payload'
+import type { FieldPaths } from 'payload'
 import type { MarkOptional } from 'ts-essentials'
 
 import React from 'react'
 
 import { WatchCondition } from './WatchCondition.js'
 
-export const withCondition = <
-  P extends MarkOptional<FieldPaths & Pick<ClientFieldProps, 'field'>, 'indexPath' | 'path'>,
->(
+export const withCondition = <P extends MarkOptional<FieldPaths, 'indexPath' | 'path'>>(
   Field: React.ComponentType<P>,
 ): React.FC<P> => {
   const CheckForCondition: React.FC<P> = (props) => {
-    const {
-      field: { type },
-      indexPath,
-      path,
-    } = props
+    const { indexPath, path } = props
 
     return (
-      <WatchCondition indexPath={indexPath} path={path} type={type}>
+      <WatchCondition indexPath={indexPath} path={path}>
         <Field {...props} />
       </WatchCondition>
     )

--- a/packages/ui/src/forms/withCondition/index.tsx
+++ b/packages/ui/src/forms/withCondition/index.tsx
@@ -15,15 +15,11 @@ export const withCondition = <
     const {
       field: { type },
       indexPath,
-      path: pathFromProps,
+      path,
     } = props
 
-    const name = 'name' in props.field ? props.field.name : undefined
-
-    const path = pathFromProps ?? name
-
     return (
-      <WatchCondition indexPath={indexPath} name={name} path={path} type={type}>
+      <WatchCondition indexPath={indexPath} path={path} type={type}>
         <Field {...props} />
       </WatchCondition>
     )


### PR DESCRIPTION
### What?
Aligns types for HiddenField and the WatchCondition component with the rest of the fields. Since path is required when rendering a Field component, there is no need to keep it optional in the WatchCondition component.

### Why?
Hidden fields were requiring the `field` property to be passed, but the only reason it needed it was to allow the path to fallback to name if path was not passed. But path is required so there is no need for this anymore.

This makes using the HiddenField simpler now.

### How?
Adjusts type on the HiddenField and the WatchCondition component.
