### PR TITLE
perf: removes i18n.supportedLanguages from client config

### DIFF
--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -45,7 +45,8 @@ export type ClientConfig = {
   collections: ClientCollectionConfig[]
   custom?: Record<string, any>
   globals: ClientGlobalConfig[]
-} & Omit<SanitizedConfig, 'admin' | 'collections' | 'globals' | ServerOnlyRootProperties>
+  i18n?: Omit<SanitizedConfig['i18n'], 'supportedLanguages'>
+} & Omit<SanitizedConfig, 'admin' | 'collections' | 'globals' | 'i18n' | ServerOnlyRootProperties>
 
 export const serverOnlyAdminConfigProperties: readonly Partial<ServerOnlyRootAdminProperties>[] = []
 
@@ -90,6 +91,14 @@ export const createClientConfig = ({
     for (const locale of clientConfig.localization.locales) {
       delete locale.toString
     }
+  }
+
+  if (
+    'i18n' in clientConfig &&
+    'supportedLanguages' in clientConfig.i18n &&
+    clientConfig.i18n.supportedLanguages
+  ) {
+    delete clientConfig.i18n.supportedLanguages
   }
 
   if (!clientConfig.admin) {


### PR DESCRIPTION
Similar to https://github.com/payloadcms/payload/pull/9195 but specifically removing `i18n.supportedLanguages` from the client config. This is a potentially large object that does not need to be sent through the network when making RSC requests.