### PR TITLE
chore: pass parentPath and parentSchemaPath to all fields

### DIFF
--- a/packages/payload/src/admin/fields/Checkbox.ts
+++ b/packages/payload/src/admin/fields/Checkbox.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -24,9 +25,8 @@ type CheckboxFieldBaseClientProps = {
   readonly id?: string
   readonly onChange?: (value: boolean) => void
   readonly partialChecked?: boolean
-  readonly path: string
   readonly validate?: CheckboxFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type CheckboxFieldClientProps = CheckboxFieldBaseClientProps &
   ClientFieldBase<CheckboxFieldClientWithoutType>

--- a/packages/payload/src/admin/fields/Code.ts
+++ b/packages/payload/src/admin/fields/Code.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -20,9 +21,8 @@ type CodeFieldClientWithoutType = MarkOptional<CodeFieldClient, 'type'>
 
 type CodeFieldBaseClientProps = {
   readonly autoComplete?: string
-  readonly path: string
   readonly validate?: CodeFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type CodeFieldClientProps = ClientFieldBase<CodeFieldClientWithoutType> &
   CodeFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Date.ts
+++ b/packages/payload/src/admin/fields/Date.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -19,9 +20,8 @@ import type {
 type DateFieldClientWithoutType = MarkOptional<DateFieldClient, 'type'>
 
 type DateFieldBaseClientProps = {
-  readonly path: string
   readonly validate?: DateFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type DateFieldClientProps = ClientFieldBase<DateFieldClientWithoutType> &
   DateFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Email.ts
+++ b/packages/payload/src/admin/fields/Email.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -19,9 +20,8 @@ import type {
 type EmailFieldClientWithoutType = MarkOptional<EmailFieldClient, 'type'>
 
 type EmailFieldBaseClientProps = {
-  readonly path: string
   readonly validate?: EmailFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type EmailFieldClientProps = ClientFieldBase<EmailFieldClientWithoutType> &
   EmailFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Hidden.ts
+++ b/packages/payload/src/admin/fields/Hidden.ts
@@ -1,5 +1,5 @@
 import type { ClientField } from '../../fields/config/types.js'
-import type { ClientFieldBase } from '../types.js'
+import type { ClientFieldBase, FieldPaths } from '../types.js'
 
 type HiddenFieldBaseClientProps = {
   readonly disableModifyingForm?: false
@@ -8,6 +8,6 @@ type HiddenFieldBaseClientProps = {
   } & ClientField
   readonly path: string
   readonly value?: unknown
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type HiddenFieldProps = ClientFieldBase & HiddenFieldBaseClientProps

--- a/packages/payload/src/admin/fields/JSON.ts
+++ b/packages/payload/src/admin/fields/JSON.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -19,9 +20,8 @@ import type {
 type JSONFieldClientWithoutType = MarkOptional<JSONFieldClient, 'type'>
 
 type JSONFieldBaseClientProps = {
-  readonly path: string
   readonly validate?: JSONFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type JSONFieldClientProps = ClientFieldBase<JSONFieldClientWithoutType> &
   JSONFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Join.ts
+++ b/packages/payload/src/admin/fields/Join.ts
@@ -5,6 +5,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -17,9 +18,7 @@ import type {
 
 type JoinFieldClientWithoutType = MarkOptional<JoinFieldClient, 'type'>
 
-type JoinFieldBaseClientProps = {
-  readonly path: string
-}
+type JoinFieldBaseClientProps = Omit<FieldPaths, 'indexPath'>
 
 export type JoinFieldClientProps = ClientFieldBase<JoinFieldClientWithoutType> &
   JoinFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Number.ts
+++ b/packages/payload/src/admin/fields/Number.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -20,9 +21,8 @@ type NumberFieldClientWithoutType = MarkOptional<NumberFieldClient, 'type'>
 
 type NumberFieldBaseClientProps = {
   readonly onChange?: (e: number) => void
-  readonly path: string
   readonly validate?: NumberFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type NumberFieldClientProps = ClientFieldBase<NumberFieldClientWithoutType> &
   NumberFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Point.ts
+++ b/packages/payload/src/admin/fields/Point.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -19,9 +20,8 @@ import type {
 type PointFieldClientWithoutType = MarkOptional<PointFieldClient, 'type'>
 
 type PointFieldBaseClientProps = {
-  readonly path: string
   readonly validate?: PointFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type PointFieldClientProps = ClientFieldBase<PointFieldClientWithoutType> &
   PointFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Radio.ts
+++ b/packages/payload/src/admin/fields/Radio.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -24,10 +25,9 @@ type RadioFieldBaseClientProps = {
    */
   readonly disableModifyingForm?: boolean
   readonly onChange?: OnChange
-  readonly path: string
   readonly validate?: RadioFieldValidation
   readonly value?: string
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type RadioFieldClientProps = ClientFieldBase<RadioFieldClientWithoutType> &
   RadioFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Relationship.ts
+++ b/packages/payload/src/admin/fields/Relationship.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -19,9 +20,8 @@ import type {
 type RelationshipFieldClientWithoutType = MarkOptional<RelationshipFieldClient, 'type'>
 
 type RelationshipFieldBaseClientProps = {
-  readonly path: string
   readonly validate?: RelationshipFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type RelationshipFieldClientProps = ClientFieldBase<RelationshipFieldClientWithoutType> &
   RelationshipFieldBaseClientProps

--- a/packages/payload/src/admin/fields/RichText.ts
+++ b/packages/payload/src/admin/fields/RichText.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -27,9 +28,8 @@ type RichTextFieldBaseClientProps<
   TAdapterProps = any,
   TExtraProperties = object,
 > = {
-  readonly path: string
   readonly validate?: RichTextFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type RichTextFieldClientProps<
   TValue extends object = any,

--- a/packages/payload/src/admin/fields/Select.ts
+++ b/packages/payload/src/admin/fields/Select.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -20,10 +21,9 @@ type SelectFieldClientWithoutType = MarkOptional<SelectFieldClient, 'type'>
 
 type SelectFieldBaseClientProps = {
   readonly onChange?: (e: string | string[]) => void
-  readonly path: string
   readonly validate?: SelectFieldValidation
   readonly value?: string
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type SelectFieldClientProps = ClientFieldBase<SelectFieldClientWithoutType> &
   SelectFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Text.ts
+++ b/packages/payload/src/admin/fields/Text.ts
@@ -7,6 +7,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -22,9 +23,8 @@ type TextFieldClientWithoutType = MarkOptional<TextFieldClient, 'type'>
 type TextFieldBaseClientProps = {
   readonly inputRef?: React.RefObject<HTMLInputElement>
   readonly onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>
-  readonly path: string
   readonly validate?: TextFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type TextFieldClientProps = ClientFieldBase<TextFieldClientWithoutType> &
   TextFieldBaseClientProps

--- a/packages/payload/src/admin/fields/Textarea.ts
+++ b/packages/payload/src/admin/fields/Textarea.ts
@@ -7,6 +7,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -22,9 +23,8 @@ type TextareaFieldClientWithoutType = MarkOptional<TextareaFieldClient, 'type'>
 type TextareaFieldBaseClientProps = {
   readonly inputRef?: React.Ref<HTMLInputElement>
   readonly onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>
-  readonly path: string
   readonly validate?: TextareaFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type TextareaFieldClientProps = ClientFieldBase<TextareaFieldClientWithoutType> &
   TextareaFieldBaseClientProps

--- a/packages/payload/src/admin/fields/UI.ts
+++ b/packages/payload/src/admin/fields/UI.ts
@@ -4,15 +4,14 @@ import type { UIField, UIFieldClient } from '../../fields/config/types.js'
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../types.js'
 
 type UIFieldClientWithoutType = MarkOptional<UIFieldClient, 'type'>
 
-type UIFieldBaseClientProps = {
-  readonly path: string
-}
+type UIFieldBaseClientProps = Omit<FieldPaths, 'indexPath'>
 
 export type UIFieldClientProps = ClientFieldBase<UIFieldClientWithoutType> & UIFieldBaseClientProps
 

--- a/packages/payload/src/admin/fields/Upload.ts
+++ b/packages/payload/src/admin/fields/Upload.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -19,9 +20,8 @@ import type {
 type UploadFieldClientWithoutType = MarkOptional<UploadFieldClient, 'type'>
 
 type UploadFieldBaseClientProps = {
-  readonly path: string
   readonly validate?: UploadFieldValidation
-}
+} & Omit<FieldPaths, 'indexPath'>
 
 export type UploadFieldClientProps = ClientFieldBase<UploadFieldClientWithoutType> &
   UploadFieldBaseClientProps

--- a/packages/ui/src/fields/Checkbox/index.tsx
+++ b/packages/ui/src/fields/Checkbox/index.tsx
@@ -31,7 +31,6 @@ const CheckboxFieldComponent: CheckboxFieldClientComponent = (props) => {
     checked: checkedFromProps,
     disableFormData,
     field: {
-      name,
       admin: {
         className,
         description,

--- a/packages/ui/src/fields/Code/index.tsx
+++ b/packages/ui/src/fields/Code/index.tsx
@@ -23,7 +23,6 @@ const baseClass = 'code-field'
 const CodeFieldComponent: CodeFieldClientComponent = (props) => {
   const {
     field: {
-      name,
       admin: {
         className,
         description,

--- a/packages/ui/src/fields/DateTime/index.tsx
+++ b/packages/ui/src/fields/DateTime/index.tsx
@@ -20,7 +20,6 @@ const baseClass = 'date-time-field'
 const DateTimeFieldComponent: DateFieldClientComponent = (props) => {
   const {
     field: {
-      name,
       admin: { className, date: datePickerProps, description, placeholder, style, width } = {},
       label,
       localized,

--- a/packages/ui/src/fields/Email/index.tsx
+++ b/packages/ui/src/fields/Email/index.tsx
@@ -21,7 +21,6 @@ import './index.scss'
 const EmailFieldComponent: EmailFieldClientComponent = (props) => {
   const {
     field: {
-      name,
       admin: {
         autoComplete,
         className,

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -18,7 +18,6 @@ const baseClass = 'json-field'
 const JSONFieldComponent: JSONFieldClientComponent = (props) => {
   const {
     field: {
-      name,
       admin: { className, description, editorOptions, maxHeight, style, width } = {},
       jsonSchema,
       label,

--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -15,7 +15,6 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
   const {
     field,
     field: {
-      name,
       admin: { allowCreate },
       collection,
       label,

--- a/packages/ui/src/fields/Number/index.tsx
+++ b/packages/ui/src/fields/Number/index.tsx
@@ -21,7 +21,6 @@ import './index.scss'
 const NumberFieldComponent: NumberFieldClientComponent = (props) => {
   const {
     field: {
-      name,
       admin: {
         className,
         description,

--- a/packages/ui/src/fields/Password/index.tsx
+++ b/packages/ui/src/fields/Password/index.tsx
@@ -19,7 +19,6 @@ const PasswordFieldComponent: React.FC<PasswordFieldProps> = (props) => {
   const {
     autoComplete,
     field: {
-      name,
       admin: {
         className,
         disabled: disabledFromProps,

--- a/packages/ui/src/fields/Point/index.tsx
+++ b/packages/ui/src/fields/Point/index.tsx
@@ -19,7 +19,6 @@ const baseClass = 'point'
 export const PointFieldComponent: PointFieldClientComponent = (props) => {
   const {
     field: {
-      name,
       admin: { className, description, placeholder, step, style, width } = {},
       label,
       localized,

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -39,7 +39,6 @@ const baseClass = 'relationship'
 const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => {
   const {
     field: {
-      name,
       admin: {
         allowCreate = true,
         allowEdit = true,

--- a/packages/ui/src/fields/Text/index.tsx
+++ b/packages/ui/src/fields/Text/index.tsx
@@ -19,7 +19,6 @@ export { TextInput, TextInputProps }
 const TextFieldComponent: TextFieldClientComponent = (props) => {
   const {
     field: {
-      name,
       admin: { className, description, placeholder, rtl, style, width } = {},
       hasMany,
       label,

--- a/packages/ui/src/fields/Textarea/index.tsx
+++ b/packages/ui/src/fields/Textarea/index.tsx
@@ -20,7 +20,6 @@ export { TextareaInput, TextAreaInputProps }
 const TextareaFieldComponent: TextareaFieldClientComponent = (props) => {
   const {
     field: {
-      name,
       admin: { className, description, placeholder, rows, rtl, style, width } = {},
       label,
       localized,

--- a/packages/ui/src/fields/Upload/index.tsx
+++ b/packages/ui/src/fields/Upload/index.tsx
@@ -7,8 +7,8 @@ import React from 'react'
 import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { useConfig } from '../../providers/Config/index.js'
-import './index.scss'
 import { UploadInput } from './Input.js'
+import './index.scss'
 
 export { UploadInput } from './Input.js'
 export type { UploadInputProps } from './Input.js'
@@ -18,7 +18,6 @@ export const baseClass = 'upload'
 export function UploadComponent(props: UploadFieldClientProps) {
   const {
     field: {
-      name,
       admin: { allowCreate, className, description, isSortable, style, width } = {},
       hasMany,
       label,

--- a/packages/ui/src/forms/RenderFields/RenderField.tsx
+++ b/packages/ui/src/forms/RenderFields/RenderField.tsx
@@ -29,6 +29,14 @@ import { UIField } from '../../fields/UI/index.js'
 import { UploadField } from '../../fields/Upload/index.js'
 import { useFormFields } from '../../forms/Form/index.js'
 
+type BaseFieldProps = Omit<FieldPaths, 'indexPath'> &
+  Pick<ClientComponentProps, 'forceRender' | 'readOnly' | 'schemaPath'>
+
+type IterableFieldProps = {
+  indexPath: string
+  permissions: FieldPermissions
+} & BaseFieldProps
+
 type RenderFieldProps = {
   clientFieldConfig: ClientField
   permissions: FieldPermissions
@@ -52,89 +60,90 @@ export function RenderField({
     return Field || null
   }
 
-  const baseFieldProps: Pick<ClientComponentProps, 'forceRender' | 'readOnly' | 'schemaPath'> = {
+  const baseFieldProps: BaseFieldProps = {
     forceRender,
+    parentPath,
+    parentSchemaPath,
+    path,
     readOnly,
     schemaPath,
   }
 
-  const iterableFieldProps = {
+  const iterableFieldProps: IterableFieldProps = {
     ...baseFieldProps,
     indexPath,
-    parentPath,
-    parentSchemaPath,
     permissions,
   }
 
   if (clientFieldConfig.admin?.hidden) {
-    return <HiddenField {...baseFieldProps} field={clientFieldConfig} path={path} />
+    return <HiddenField {...baseFieldProps} />
   }
 
   switch (clientFieldConfig.type) {
     case 'array':
-      return <ArrayField {...iterableFieldProps} field={clientFieldConfig} path={path} />
+      return <ArrayField {...iterableFieldProps} field={clientFieldConfig} />
 
     case 'blocks':
-      return <BlocksField {...iterableFieldProps} field={clientFieldConfig} path={path} />
+      return <BlocksField {...iterableFieldProps} field={clientFieldConfig} />
 
     case 'checkbox':
-      return <CheckboxField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <CheckboxField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'code':
-      return <CodeField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <CodeField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'collapsible':
-      return <CollapsibleField {...iterableFieldProps} field={clientFieldConfig} path={path} />
+      return <CollapsibleField {...iterableFieldProps} field={clientFieldConfig} />
 
     case 'date':
-      return <DateTimeField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <DateTimeField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'email':
-      return <EmailField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <EmailField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'group':
-      return <GroupField {...iterableFieldProps} field={clientFieldConfig} path={path} />
+      return <GroupField {...iterableFieldProps} field={clientFieldConfig} />
 
     case 'join':
-      return <JoinField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <JoinField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'json':
-      return <JSONField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <JSONField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'number':
-      return <NumberField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <NumberField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'point':
-      return <PointField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <PointField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'radio':
-      return <RadioGroupField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <RadioGroupField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'relationship':
-      return <RelationshipField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <RelationshipField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'richText':
-      return <RichTextField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <RichTextField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'row':
       return <RowField {...iterableFieldProps} field={clientFieldConfig} />
 
     case 'select':
-      return <SelectField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <SelectField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'tabs':
-      return <TabsField {...iterableFieldProps} field={clientFieldConfig} path={path} />
+      return <TabsField {...iterableFieldProps} field={clientFieldConfig} />
 
     case 'text':
-      return <TextField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <TextField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'textarea':
-      return <TextareaField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <TextareaField {...baseFieldProps} field={clientFieldConfig} />
 
     case 'ui':
       return <UIField />
 
     case 'upload':
-      return <UploadField {...baseFieldProps} field={clientFieldConfig} path={path} />
+      return <UploadField {...baseFieldProps} field={clientFieldConfig} />
   }
 }


### PR DESCRIPTION
### What?
Ensures all fields receive parentPath, path, parentSchemaPath, schemaPath.

### Why?
Without parentPath, nested fields ie inside of an Array field have no way to determine their parents path in order to get sibling data.

### How?
Adjusts RenderField so it passes these important props.