### PR TITLE
chore: import copy icon from nested folder

### DIFF
--- a/templates/website/src/blocks/Code/CopyButton.tsx
+++ b/templates/website/src/blocks/Code/CopyButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { Button } from '@/components/ui/button'
-import { CopyIcon } from '@payloadcms/ui'
+import { CopyIcon } from '@payloadcms/ui/icons/Copy'
 import { useState } from 'react'
 
 export function CopyButton({ code }: { code: string }) {

--- a/templates/with-vercel-website/src/blocks/Code/CopyButton.tsx
+++ b/templates/with-vercel-website/src/blocks/Code/CopyButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { Button } from '@/components/ui/button'
-import { CopyIcon } from '@payloadcms/ui'
+import { CopyIcon } from '@payloadcms/ui/icons/Copy'
 import { useState } from 'react'
 
 export function CopyButton({ code }: { code: string }) {


### PR DESCRIPTION
Corrects imports in templates to go directly to `@payloadcms/ui/path-to-file` instead of using the barrel export.
