### PR TITLE
fix: draft version doc.updatedAt not updating

### DIFF
--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -256,7 +256,7 @@ export const createOperation = async <
     // /////////////////////////////////////
 
     if (collectionConfig.versions) {
-      const version = await saveVersion({
+      await saveVersion({
         id: result.id,
         autosave,
         collection: collectionConfig,
@@ -264,8 +264,6 @@ export const createOperation = async <
         payload,
         req,
       })
-
-      result.updatedAt = (version as Record<string, unknown>).updatedAt
     }
 
     // /////////////////////////////////////

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -256,7 +256,7 @@ export const createOperation = async <
     // /////////////////////////////////////
 
     if (collectionConfig.versions) {
-      await saveVersion({
+      const version = await saveVersion({
         id: result.id,
         autosave,
         collection: collectionConfig,
@@ -264,6 +264,8 @@ export const createOperation = async <
         payload,
         req,
       })
+
+      result.updatedAt = (version as Record<string, unknown>).updatedAt
     }
 
     // /////////////////////////////////////

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -39,6 +39,8 @@ export const saveVersion = async ({
   let createNewVersion = true
   const now = new Date().toISOString()
   const versionData = deepCopyObjectSimple(doc)
+  versionData.updatedAt = now
+
   if (draft) {
     versionData._status = 'draft'
   }

--- a/test/plugin-redirects/int.spec.ts
+++ b/test/plugin-redirects/int.spec.ts
@@ -18,12 +18,14 @@ describe('@payloadcms/plugin-redirects', () => {
   beforeAll(async () => {
     ;({ payload } = await initPayloadInt(dirname))
 
-    page = await payload.create({
+    const { id } = await payload.create({
       collection: 'pages',
       data: {
         title: 'Test',
       },
     })
+
+    page = await payload.findByID({ collection: 'pages', id })
   })
 
   afterAll(async () => {

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -2063,8 +2063,8 @@ function createDeepPost() {
   })
 }
 
-function createVersionedPost() {
-  return payload.create({
+async function createVersionedPost() {
+  const { id } = await payload.create({
     collection: 'versioned-posts',
     data: {
       number: 2,
@@ -2073,6 +2073,8 @@ function createVersionedPost() {
       blocks: [{ blockType: 'test', text: 'hela' }],
     },
   })
+
+  return payload.findByID({ collection: 'versioned-posts', id, draft: true })
 }
 
 function createPoint() {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -355,7 +355,7 @@ describe('Versions', () => {
         // createdAt from non-versions should be the same as version_createdAt in versions
         expect(fromNonVersionsTable.createdAt).toBe(latestVersionData.version.createdAt)
         // When creating new version - updatedAt should match version.updatedAt
-        expect(fromNonVersionsTable.updatedAt).toBe(latestVersionData.version.updatedAt)
+        expect(upd.updatedAt).toBe(latestVersionData.version.updatedAt)
       })
     })
 
@@ -1367,7 +1367,7 @@ describe('Versions', () => {
         // createdAt from non-versions should be the same as version_createdAt in versions
         expect(fromNonVersionsTable.createdAt).toBe(latestVersionData.version.createdAt)
         // When creating a new version - updatedAt should match
-        expect(fromNonVersionsTable.updatedAt).toBe(latestVersionData.version.updatedAt)
+        expect(upd.updatedAt).toBe(latestVersionData.version.updatedAt)
       })
     })
 

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -576,6 +576,33 @@ describe('Versions', () => {
           { id: doc.id, message: 'The following field is invalid: title' },
         ])
       })
+
+      it('should have correct updatedAt timestamps when saving drafts', async () => {
+        const created = await payload.create({
+          collection: draftCollectionSlug,
+          data: {
+            description: 'desc',
+            title: 'title',
+          },
+          draft: true,
+        })
+
+        await wait(10)
+
+        const updated = await payload.update({
+          id: created.id,
+          collection: draftCollectionSlug,
+          data: {
+            title: 'updated title',
+          },
+          draft: true,
+        })
+
+        const createdUpdatedAt = new Date(created.updatedAt)
+        const updatedUpdatedAt = new Date(updated.updatedAt)
+
+        expect(Number(updatedUpdatedAt)).toBeGreaterThan(Number(createdUpdatedAt))
+      })
     })
 
     describe('Update Many', () => {


### PR DESCRIPTION
### What?
When saving drafts the version document `updatedAt` should reflect the current time.

### Why?
The document timestamps appear incorrect.

### How?
Set the version document updatedAt time when saving versions.
