### PR TITLE
docs: fix links in operators table for within and intersects

### DIFF
--- a/docs/queries/overview.mdx
+++ b/docs/queries/overview.mdx
@@ -52,8 +52,8 @@ The following operators are available for use in queries:
 | `all`                | The value must contain all values provided in the comma-delimited list.                                                                                                             |
 | `exists`             | Only return documents where the value either exists (`true`) or does not exist (`false`).                                                                                           |
 | `near`               | For distance related to a [Point Field](../fields/point) comma separated as `<longitude>, <latitude>, <maxDistance in meters (nullable)>, <minDistance in meters (nullable)>`.      |
-| `within`             | For [point fields][../fields/point] to filter documents based on whether points are inside of the given area defined in GeoJSON. [Example](../fields/point#querying---within)       |
-| `intersects`         | For [point fields][../fields/point] to filter documents based on whether points intersect with the given area  defined in GeoJSON. [Example](../fields/point#querying---intersects) |
+| `within`             | For [Point Fields](../fields/point) to filter documents based on whether points are inside of the given area defined in GeoJSON. [Example](../fields/point#querying-within)         |
+| `intersects`         | For [Point Fields](../fields/point) to filter documents based on whether points intersect with the given area  defined in GeoJSON. [Example](../fields/point#querying-intersects)   |
 
 <Banner type="success">
   <strong>Tip:</strong>


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
Fixes links in Queries/Operators table for `within` and `intersects` operator descriptions.

### Why?
So that they point to the correct destination in the docs.

### How?
Changes to `docs/queries/overview.mdx`

See here:
![image](https://github.com/user-attachments/assets/fc82a6fb-2c7c-4a1e-aa2d-128c9f5e711b)
