### PR TITLE
fix(db-mongodb): ensures that old versions are properly cleaned up in all cases

### DIFF
--- a/packages/db-mongodb/src/createVersion.ts
+++ b/packages/db-mongodb/src/createVersion.ts
@@ -1,4 +1,4 @@
-import { Types } from 'mongoose'
+import mongoose from 'mongoose'
 import {
   buildVersionCollectionFields,
   type CreateVersion,
@@ -57,10 +57,11 @@ export const createVersion: CreateVersion = async function createVersion(
       },
     ],
   }
-  if (data.parent instanceof Types.ObjectId) {
+
+  if (typeof data.parent === 'string' && mongoose.Types.ObjectId.isValid(data.parent)) {
     parentQuery.$or.push({
       parent: {
-        $eq: data.parent.toString(),
+        $eq: new mongoose.Types.ObjectId(data.parent),
       },
     })
   }


### PR DESCRIPTION
With the upgrade of Mongoose to 8.x, we now store (and need to enforce) relationship IDs to be stored as ObjectID.

This PR ensures that old versions are properly cleaned up no matter if you have old versions with string or ObjectID-based `parent`s.