### PR TITLE
fix: corrects cases of false positive identification of custom id fields

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -581,10 +581,13 @@ export class BasePayload {
     this.config.collections.forEach((collection) => {
       let customIDType = undefined
       const findCustomID: TraverseFieldsCallback = ({ field, next }) => {
-        if (['array', 'blocks'].includes(field.type)) {
-          next()
-          return
+        if (
+          ['array', 'blocks', 'group'].includes(field.type) ||
+          (field.type === 'tab' && 'name' in field)
+        ) {
+          return true
         }
+
         if (!fieldAffectsData(field)) {
           return
         }

--- a/test/database/config.ts
+++ b/test/database/config.ts
@@ -383,8 +383,45 @@ export default buildConfigWithDefaults({
             ],
           },
         },
+        {
+          name: 'title',
+          type: 'text',
+        },
       ],
       versions: { drafts: true },
+    },
+    {
+      slug: 'fake-custom-ids',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+        {
+          name: 'group',
+          type: 'group',
+          fields: [
+            {
+              name: 'id',
+              type: 'text',
+            },
+          ],
+        },
+        {
+          type: 'tabs',
+          tabs: [
+            {
+              name: 'myTab',
+              fields: [
+                {
+                  name: 'id',
+                  type: 'text',
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
     {
       slug: 'relationships-migration',

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -90,6 +90,46 @@ describe('database', () => {
 
       expect(doc.id).toBeDefined()
     })
+
+    it('should not create duplicate versions with custom id type', async () => {
+      const doc = await payload.create({
+        collection: 'custom-ids',
+        data: {
+          title: 'hey',
+        },
+      })
+
+      await payload.update({
+        collection: 'custom-ids',
+        id: doc.id,
+        data: {},
+      })
+
+      await payload.update({
+        collection: 'custom-ids',
+        id: doc.id,
+        data: {},
+      })
+
+      const versionsQuery = await payload.db.findVersions({
+        collection: 'custom-ids',
+        req: {} as PayloadRequest,
+        where: {
+          'version.title': {
+            equals: 'hey',
+          },
+          latest: {
+            equals: true,
+          },
+        },
+      })
+
+      expect(versionsQuery.totalDocs).toStrictEqual(1)
+    })
+
+    it('should not accidentally treat nested id fields as custom id', () => {
+      expect(payload.collections['fake-custom-ids'].customIDType).toBeUndefined()
+    })
   })
 
   describe('timestamps', () => {


### PR DESCRIPTION
This PR fixes cases where you may have a field called `id` within a group or a named tab, which would have incorrectly been treated as a custom ID field for the collection.

However, custom IDs need to be defined at the root level - and now Payload only respects custom IDs defined at the root level.