### PR TITLE
fix(next): custom default root views

### DIFF
--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -139,6 +139,7 @@ export const Account: React.FC<AdminViewProps> = async ({
           <HydrateAuthProvider permissions={permissions} />
           <RenderServerComponent
             Component={config.admin?.components?.views?.Account?.Component}
+            Fallback={EditView}
             importMap={payload.importMap}
             serverProps={{
               i18n,
@@ -152,7 +153,6 @@ export const Account: React.FC<AdminViewProps> = async ({
               user,
             }}
           />
-          <EditView />
           <AccountClient />
         </EditDepthProvider>
       </DocumentInfoProvider>

--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -37,11 +37,7 @@ export const Account: React.FC<AdminViewProps> = async ({
   } = initPageResult
 
   const {
-    admin: {
-      components: { views: { Account: CustomAccountComponent } = {} } = {},
-      theme,
-      user: userSlug,
-    },
+    admin: { theme, user: userSlug },
     routes: { api },
     serverURL,
   } = config
@@ -142,7 +138,7 @@ export const Account: React.FC<AdminViewProps> = async ({
           />
           <HydrateAuthProvider permissions={permissions} />
           <RenderServerComponent
-            Component={CustomAccountComponent}
+            Component={config.admin?.components?.views?.Account?.Component}
             importMap={payload.importMap}
             serverProps={{
               i18n,

--- a/packages/next/src/views/Dashboard/index.tsx
+++ b/packages/next/src/views/Dashboard/index.tsx
@@ -31,8 +31,6 @@ export const Dashboard: React.FC<AdminViewProps> = async ({
     visibleEntities,
   } = initPageResult
 
-  const CustomDashboardComponent = config.admin.components?.views?.Dashboard
-
   const collections = config.collections.filter(
     (collection) =>
       permissions?.collections?.[collection.slug]?.read &&
@@ -115,7 +113,7 @@ export const Dashboard: React.FC<AdminViewProps> = async ({
           Link,
           locale,
         }}
-        Component={CustomDashboardComponent}
+        Component={config.admin?.components?.views?.Dashboard?.Component}
         Fallback={DefaultDashboard}
         importMap={payload.importMap}
         serverProps={{

--- a/packages/payload/src/bin/generateImportMap/parsePayloadComponent.ts
+++ b/packages/payload/src/bin/generateImportMap/parsePayloadComponent.ts
@@ -7,6 +7,7 @@ export function parsePayloadComponent(PayloadComponent: PayloadComponent): {
   if (!PayloadComponent) {
     return null
   }
+
   const pathAndMaybeExport =
     typeof PayloadComponent === 'string' ? PayloadComponent : PayloadComponent.path
 
@@ -14,7 +15,9 @@ export function parsePayloadComponent(PayloadComponent: PayloadComponent): {
   let exportName = 'default'
 
   if (pathAndMaybeExport?.includes('#')) {
-    ;[path, exportName] = pathAndMaybeExport.split('#')
+    const split = pathAndMaybeExport.split('#')
+    path = split[0]
+    exportName = split[1]
   } else {
     path = pathAndMaybeExport
   }

--- a/packages/payload/src/bin/generateImportMap/parsePayloadComponent.ts
+++ b/packages/payload/src/bin/generateImportMap/parsePayloadComponent.ts
@@ -15,9 +15,7 @@ export function parsePayloadComponent(PayloadComponent: PayloadComponent): {
   let exportName = 'default'
 
   if (pathAndMaybeExport?.includes('#')) {
-    const split = pathAndMaybeExport.split('#')
-    path = split[0]
-    exportName = split[1]
+    ;[path, exportName] = pathAndMaybeExport.split('#')
   } else {
     path = pathAndMaybeExport
   }


### PR DESCRIPTION
Fixes #9246. Custom default root views (account and dashboard) were not being properly thread to the custom component renderer. Custom account views were also improperly _stacking_ instead of _replacing_ the default view.

Tests for this are incoming. To properly test this we need to wrap our default root views with custom ones, so that out existing `admin` test suite can continue to work alongside tests specifically for this issue.