### PR TITLE
fix!: proper casing for default root views

### DIFF
--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -138,7 +138,7 @@ export const Account: React.FC<AdminViewProps> = async ({
           />
           <HydrateAuthProvider permissions={permissions} />
           <RenderServerComponent
-            Component={config.admin?.components?.views?.Account?.Component}
+            Component={config.admin?.components?.views?.account?.Component}
             Fallback={EditView}
             importMap={payload.importMap}
             serverProps={{

--- a/packages/next/src/views/Dashboard/index.tsx
+++ b/packages/next/src/views/Dashboard/index.tsx
@@ -113,7 +113,7 @@ export const Dashboard: React.FC<AdminViewProps> = async ({
           Link,
           locale,
         }}
-        Component={config.admin?.components?.views?.Dashboard?.Component}
+        Component={config.admin?.components?.views?.dashboard?.Component}
         Fallback={DefaultDashboard}
         importMap={payload.importMap}
         serverProps={{

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -764,9 +764,9 @@ export type Config = {
         /** Add custom admin views */
         [key: string]: AdminViewConfig
         /** Replace the account screen */
-        Account?: AdminViewConfig
+        account?: AdminViewConfig
         /** Replace the admin homepage */
-        Dashboard?: AdminViewConfig
+        dashboard?: AdminViewConfig
       }
     }
     /** Extension point to add your custom data. Available in server and client. */


### PR DESCRIPTION
Custom `account` and `dashboard` views now defined as lowercase in the config. This is to maintain consistency with all other custom views throughout the config. The underlying reason for this change is that previously, you could define React Components directly on these properties. Now, these are strictly _view configuration objects_, and the property names have been adjusted in order to semantically reflect that. These two views in particular, however, were never updated accordingly.

## Breaking Changes

```diff
import { buildConfig } from 'payload'

const config = buildConfig({
  // ...
  admin: {
    components: {
      // ...
      views: {
        // ...
-       Account: ...
-       Dashboard: ...
+       account: ...
+       dashboard: ...
      },
    },
  },
})
```