### PR TITLE
fix(ui): avoid calling `getTableState` from join field on create

### DIFF
--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -102,10 +102,6 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
 
   const renderTable = useCallback(
     async (docs?: PaginatedDocs['docs']) => {
-      if (disableTable) {
-        return
-      }
-
       const newQuery: ListQuery = {
         ...(query || {}),
         where: { ...(query?.where || {}) },
@@ -133,16 +129,16 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
       setColumnState(newColumnState)
       setIsLoadingTable(false)
     },
-    [getTableState, relationTo, disableTable, filterOptions, query],
+    [getTableState, relationTo, filterOptions, query],
   )
 
   useIgnoredEffect(
     () => {
-      if (!Table || query) {
+      if (!disableTable && (!Table || query)) {
         void renderTable()
       }
     },
-    [query],
+    [query, disableTable],
     [Table, renderTable],
   )
 

--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -39,6 +39,7 @@ const baseClass = 'relationship-table'
 
 type RelationshipTableComponentProps = {
   readonly allowCreate?: boolean
+  readonly disableTable?: boolean
   readonly field: JoinFieldClient
   readonly filterOptions?: Where
   readonly initialData?: PaginatedDocs
@@ -50,6 +51,7 @@ type RelationshipTableComponentProps = {
 export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (props) => {
   const {
     allowCreate = true,
+    disableTable = false,
     filterOptions,
     initialData: initialDataFromProps,
     initialDrawerData,
@@ -100,6 +102,10 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
 
   const renderTable = useCallback(
     async (docs?: PaginatedDocs['docs']) => {
+      if (disableTable) {
+        return
+      }
+
       const newQuery: ListQuery = {
         ...(query || {}),
         where: { ...(query?.where || {}) },

--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -133,7 +133,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
       setColumnState(newColumnState)
       setIsLoadingTable(false)
     },
-    [getTableState, relationTo, filterOptions, query],
+    [getTableState, relationTo, disableTable, filterOptions, query],
   )
 
   useIgnoredEffect(

--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -33,7 +33,11 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
       path,
     })
 
-  const filterOptions: Where = useMemo(() => {
+  const filterOptions: null | Where = useMemo(() => {
+    if (!docID) {
+      return null
+    }
+
     const where = {
       [on]: {
         in: [docID || ''],
@@ -54,6 +58,7 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
       {BeforeInput}
       <RelationshipTable
         allowCreate={typeof docID !== 'undefined' && allowCreate}
+        disableTable={filterOptions === null}
         field={field as JoinFieldClient}
         filterOptions={filterOptions}
         initialData={docID && value ? value : ({ docs: [] } as PaginatedDocs)}

--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -40,7 +40,7 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
 
     const where = {
       [on]: {
-        in: [docID || ''],
+        equals: docID,
       },
     }
 

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -5,7 +5,12 @@ import { reorderColumns } from 'helpers/e2e/reorderColumns.js'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 
-import { ensureCompilationIsDone, exactText, initPageConsoleErrorCatch } from '../helpers.js'
+import {
+  ensureCompilationIsDone,
+  exactText,
+  initPageConsoleErrorCatch,
+  saveDocAndAssert,
+} from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { navigateToDoc } from '../helpers/e2e/navigateToDoc.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
@@ -55,6 +60,14 @@ test.describe('Admin Panel', () => {
     await expect(joinField).toBeVisible()
     const columns = await joinField.locator('.relationship-table tbody tr').count()
     expect(columns).toBe(3)
+  })
+
+  test('should render the create page and create doc with the join field', async () => {
+    await page.goto(categoriesURL.create)
+    const nameField = page.locator('#field-name')
+    await expect(nameField).toBeVisible()
+    await nameField.fill('test category')
+    await saveDocAndAssert(page)
   })
 
   test('should render collection type in first column of relationship table', async () => {


### PR DESCRIPTION
### What?
Fixes the issue when visiting the create view with the Join Field and using postgres adapter
```
invalid input syntax for type integer: "NaN"
```
This happens because we don't have an ID yet and we send to the database:
`WHERE id = NaN`

### How?
Avoids calling  `getTableState` inside of `RelationshipTable`  if there's no ID yet, as it will always lead to the same empty result. While we _could_ avoid error directly in the database adapter, I don't think we should do that render request

Fixes https://github.com/payloadcms/payload/issues/9193