### PR TITLE
fix(ui): safely accesses field in default filter component

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/DefaultFilter/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/DefaultFilter/index.tsx
@@ -83,7 +83,7 @@ export const DefaultFilter: React.FC<Props> = ({
       return (
         <Text
           disabled={disabled}
-          field={internalField.field as TextFieldClient}
+          field={internalField?.field as TextFieldClient}
           onChange={onChange}
           operator={operator}
           value={value}


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
In the WhereBuilder Condition DefaultFilter component, there is a switch statement that contains components to return based on the built filter in the admin ui. Having a filter built out then navigating to another collection list view causes an error to occur due to InternalField being undefined but the DefaultFilter tries to access the field on it.

### Why?
To fix unexpected `cannot access property field of undefined` errors.

### How?
Adding a conditional chaining operator.

Odd thing here is that the `Text` component where this error originates from doesn't actually make use of the passed `InternalField`. Might be worth it to take a closer look at it.

Fixes #9179