### PR TITLE
fix: dedupes field description functions and defers rendering static field descriptions to the client

### DIFF
--- a/docs/admin/fields.mdx
+++ b/docs/admin/fields.mdx
@@ -93,7 +93,7 @@ export const MyCollectionConfig: SanitizedCollectionConfig = {
 
 #### Description Functions
 
-Custom Descriptions can also be defined as a function. Description Functions are executed on the server and can be used to format simple descriptions based on the user's current [Locale](../configuration/localization), document data, etc.
+Custom Descriptions can also be defined as a function. Description Functions are executed on the server and can be used to format simple descriptions based on the user's current [Locale](../configuration/localization).
 
 To easily add a Description Function to a field, set the `admin.description` property to a _function_ in your [Field Config](../fields/overview):
 
@@ -119,15 +119,11 @@ All Description Functions receive the following arguments:
 
 | Argument       | Description                                                      |
 | -------------- | ---------------------------------------------------------------- |
-| **`data`**     | The initial data of the document. |
-| **`path`**     | A string representing the direct, dynamic path to the field at runtime, i.e. `myGroup.myArray.0.myField`. |
-| **`siblingData`** | The data of the field's siblings. |
 | **`t`**        | The `t` function used to internationalize the Admin Panel. [More details](../configuration/i18n) |
-| **`value`**    | The value of the field at render-time. |
 
 <Banner type="info">
   <strong>Note:</strong>
-  If you need to subscribe to live changes within your form, use must use a Description Component instead. [More details](#description).
+  If you need to subscribe to live changes within your form, use must use a Client Description Component instead. [More details](#description).
 </Banner>
 
 ## Conditional Logic

--- a/docs/admin/fields.mdx
+++ b/docs/admin/fields.mdx
@@ -119,9 +119,10 @@ All Description Functions receive the following arguments:
 
 | Argument       | Description                                                      |
 | -------------- | ---------------------------------------------------------------- |
-| **`t`**        | The `t` function used to internationalize the Admin Panel. [More details](../configuration/i18n) |
-| **`path`**     | A string representing the direct, dynamic path to the field at runtime, i.e. `myGroup.myArray.0.myField`. |
 | **`data`**     | The initial data of the document. |
+| **`path`**     | A string representing the direct, dynamic path to the field at runtime, i.e. `myGroup.myArray.0.myField`. |
+| **`siblingData`** | The data of the field's siblings. |
+| **`t`**        | The `t` function used to internationalize the Admin Panel. [More details](../configuration/i18n) |
 | **`value`**    | The value of the field at render-time. |
 
 <Banner type="info">

--- a/docs/admin/fields.mdx
+++ b/docs/admin/fields.mdx
@@ -123,7 +123,7 @@ All Description Functions receive the following arguments:
 
 <Banner type="info">
   <strong>Note:</strong>
-  If you need to subscribe to live changes within your form, use must use a Client Description Component instead. [More details](#description).
+  If you need to subscribe to live updates within your form, use a Description Component instead. [More details](#description).
 </Banner>
 
 ## Conditional Logic

--- a/docs/admin/fields.mdx
+++ b/docs/admin/fields.mdx
@@ -93,7 +93,7 @@ export const MyCollectionConfig: SanitizedCollectionConfig = {
 
 #### Description Functions
 
-Custom Descriptions can also be defined as a function. Description Functions are executed on the server and can be used to format simple descriptions based on the user's current [Locale](../configuration/localization).
+Custom Descriptions can also be defined as a function. Description Functions are executed on the server and can be used to format simple descriptions based on the user's current [Locale](../configuration/localization), document data, etc.
 
 To easily add a Description Function to a field, set the `admin.description` property to a _function_ in your [Field Config](../fields/overview):
 
@@ -120,6 +120,14 @@ All Description Functions receive the following arguments:
 | Argument       | Description                                                      |
 | -------------- | ---------------------------------------------------------------- |
 | **`t`**        | The `t` function used to internationalize the Admin Panel. [More details](../configuration/i18n) |
+| **`path`**     | A string representing the direct, dynamic path to the field at runtime, i.e. `myGroup.myArray.0.myField`. |
+| **`data`**     | The initial data of the document. |
+| **`value`**    | The value of the field at render-time. |
+
+<Banner type="info">
+  <strong>Note:</strong>
+  If you need to subscribe to live changes within your form, use must use a Description Component instead. [More details](#description).
+</Banner>
 
 ## Conditional Logic
 

--- a/packages/payload/src/admin/forms/Description.ts
+++ b/packages/payload/src/admin/forms/Description.ts
@@ -10,6 +10,7 @@ export type DescriptionFunction = <T = unknown>({
 }: {
   data: Data
   path: string
+  siblingData?: Data
   t: TFunction
   value?: T
 }) => string

--- a/packages/payload/src/admin/forms/Description.ts
+++ b/packages/payload/src/admin/forms/Description.ts
@@ -3,17 +3,8 @@ import type { TFunction } from '@payloadcms/translations'
 import type { ServerProps } from '../../config/types.js'
 import type { Field } from '../../fields/config/types.js'
 import type { ClientFieldWithOptionalType } from './Field.js'
-import type { Data } from './Form.js'
 
-export type DescriptionFunction = <T = unknown>({
-  t,
-}: {
-  data: Data
-  path: string
-  siblingData?: Data
-  t: TFunction
-  value?: T
-}) => string
+export type DescriptionFunction = ({ t }: { t: TFunction }) => string
 
 export type FieldDescriptionClientComponent<
   TFieldClient extends ClientFieldWithOptionalType = ClientFieldWithOptionalType,

--- a/packages/payload/src/admin/forms/Description.ts
+++ b/packages/payload/src/admin/forms/Description.ts
@@ -1,8 +1,18 @@
-import type { LabelFunction, ServerProps } from '../../config/types.js'
+import type { TFunction } from '@payloadcms/translations'
+
+import type { ServerProps } from '../../config/types.js'
 import type { Field } from '../../fields/config/types.js'
 import type { ClientFieldWithOptionalType } from './Field.js'
+import type { Data } from './Form.js'
 
-export type DescriptionFunction = LabelFunction
+export type DescriptionFunction = <T = unknown>({
+  t,
+}: {
+  data: Data
+  path: string
+  t: TFunction
+  value?: T
+}) => string
 
 export type FieldDescriptionClientComponent<
   TFieldClient extends ClientFieldWithOptionalType = ClientFieldWithOptionalType,

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -274,15 +274,10 @@ export const createClientField = ({
   } & ClientField
 
   if (incomingField.admin && 'description' in incomingField.admin) {
-    if (
-      typeof incomingField.admin?.description === 'string' ||
-      typeof incomingField.admin?.description === 'object'
-    ) {
+    if (typeof incomingField.admin?.description === 'function') {
+      delete (clientField as FieldWithDescription).admin.description
+    } else {
       ;(clientField as FieldWithDescription).admin.description = incomingField.admin.description
-    } else if (typeof incomingField.admin?.description === 'function') {
-      ;(clientField as FieldWithDescription).admin.description = incomingField.admin?.description({
-        t: i18n.t,
-      })
     }
   }
 

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -692,7 +692,7 @@ export type CollapsibleFieldClient = {
   Pick<CollapsibleField, 'type'>
 
 type TabBase = {
-  description?: Description
+  description?: LabelFunction | StaticDescription
   fields: Field[]
   interfaceName?: string
   saveToJWT?: boolean | string

--- a/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
@@ -208,6 +208,7 @@ export const renderField: RenderFieldMethod = ({
             description={fieldConfig.admin?.description({
               data,
               path,
+              siblingData,
               t: req.i18n.t,
               value: 'name' in fieldConfig ? formState[fieldConfig.name] : undefined,
             })}

--- a/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
@@ -206,11 +206,7 @@ export const renderField: RenderFieldMethod = ({
         fieldState.customComponents.Description = (
           <FieldDescription
             description={fieldConfig.admin?.description({
-              data,
-              path,
-              siblingData,
               t: req.i18n.t,
-              value: 'name' in fieldConfig ? formState[fieldConfig.name] : undefined,
             })}
             path={path}
           />

--- a/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
@@ -202,20 +202,19 @@ export const renderField: RenderFieldMethod = ({
 
   if (fieldConfig.admin) {
     if ('description' in fieldConfig.admin) {
-      // @TODO move this to client, only render if it is a function
-      fieldState.customComponents.Description = (
-        <FieldDescription
-          description={
-            typeof fieldConfig.admin?.description === 'string' ||
-            typeof fieldConfig.admin?.description === 'object'
-              ? fieldConfig.admin.description
-              : typeof fieldConfig.admin?.description === 'function'
-                ? fieldConfig.admin?.description({ t: req.i18n.t })
-                : ''
-          }
-          path={path}
-        />
-      )
+      if (typeof fieldConfig.admin?.description === 'function') {
+        fieldState.customComponents.Description = (
+          <FieldDescription
+            description={fieldConfig.admin?.description({
+              data,
+              path,
+              t: req.i18n.t,
+              value: 'name' in fieldConfig ? formState[fieldConfig.name] : undefined,
+            })}
+            path={path}
+          />
+        )
+      }
     }
 
     if (fieldConfig.admin?.components) {


### PR DESCRIPTION
Custom field description functions were being duplicately called in both the Client Config and form state. Static field descriptions were also being rendered in form state unnecessarily. Now, field description functions are only executed once within form state, and static descriptions are deferred to the client for rendering.