### PR TITLE
fix: queues types with `strict: true`

### DIFF
--- a/packages/payload/src/queues/config/generateJobsJSONSchemas.ts
+++ b/packages/payload/src/queues/config/generateJobsJSONSchemas.ts
@@ -105,7 +105,7 @@ export function generateJobsJSONSchemas(
           required: ['input', 'output'],
         },
       },
-      required: jobsConfig.tasks.map((task) => task.slug),
+      required: [...jobsConfig.tasks.map((task) => task.slug), 'inline'],
     }
   }
 
@@ -161,7 +161,7 @@ export function generateJobsJSONSchemas(
             return [workflow.slug, toReturn]
           }),
         ),
-        required: jobsConfig.tasks.map((task) => task.slug),
+        required: jobsConfig.workflows.map((workflow) => workflow.slug),
       }
     }
   }

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -314,16 +314,13 @@ export function fieldsToJSONSchema(
           }
           case 'code':
           case 'date':
-
           case 'email':
-
           case 'textarea': {
             fieldSchema = { type: withNullableJSONSchemaType('string', isRequired) }
             break
           }
 
           case 'collapsible':
-
           case 'row': {
             const childSchema = fieldsToJSONSchema(
               collectionIDFieldTypes,
@@ -431,7 +428,6 @@ export function fieldsToJSONSchema(
           }
 
           case 'relationship':
-
           case 'upload': {
             if (Array.isArray(field.relationTo)) {
               if (field.hasMany) {
@@ -746,7 +742,6 @@ export function fieldsToSelectJSONSchema({ fields }: { fields: Field[] }): JSONS
         break
       }
       case 'collapsible':
-
       case 'row':
         schema.properties = {
           ...schema.properties,
@@ -1044,6 +1039,7 @@ export function configToJSONSchema(
       'globals',
       'auth',
       'db',
+      'jobs',
     ],
     title: 'Config',
   }
@@ -1057,7 +1053,7 @@ export function configToJSONSchema(
       type: 'object',
       additionalProperties: false,
       properties: jobsSchemas.properties,
-      required: ['tasks'],
+      required: ['tasks', 'workflows'],
     }
   }
 

--- a/test/queues/payload-types.ts
+++ b/test/queues/payload-types.ts
@@ -38,27 +38,27 @@ export interface Config {
   user: User & {
     collection: 'users';
   };
-  jobs?: {
+  jobs: {
     tasks: {
       UpdatePost: MyUpdatePostType;
       UpdatePostStep2: TaskUpdatePostStep2;
       CreateSimple: TaskCreateSimple;
       CreateSimpleWithDuplicateMessage: TaskCreateSimpleWithDuplicateMessage;
       ExternalTask: TaskExternalTask;
-      inline?: {
+      inline: {
         input: unknown;
         output: unknown;
       };
     };
-    workflows?: {
-      updatePost?: MyUpdatePostWorkflowType;
-      updatePostJSONWorkflow?: WorkflowUpdatePostJSONWorkflow;
-      retriesTest?: WorkflowRetriesTest;
-      retriesRollbackTest?: WorkflowRetriesRollbackTest;
-      retriesWorkflowLevelTest?: WorkflowRetriesWorkflowLevelTest;
-      inlineTaskTest?: WorkflowInlineTaskTest;
-      externalWorkflow?: WorkflowExternalWorkflow;
-      retriesBackoffTest?: WorkflowRetriesBackoffTest;
+    workflows: {
+      updatePost: MyUpdatePostWorkflowType;
+      updatePostJSONWorkflow: WorkflowUpdatePostJSONWorkflow;
+      retriesTest: WorkflowRetriesTest;
+      retriesRollbackTest: WorkflowRetriesRollbackTest;
+      retriesWorkflowLevelTest: WorkflowRetriesWorkflowLevelTest;
+      inlineTaskTest: WorkflowInlineTaskTest;
+      externalWorkflow: WorkflowExternalWorkflow;
+      retriesBackoffTest: WorkflowRetriesBackoffTest;
     };
   };
 }
@@ -235,7 +235,7 @@ export interface PayloadJob {
         | 'ExternalTask'
       )
     | null;
-  queue?: 'default' | null;
+  queue?: string | null;
   waitUntil?: string | null;
   processing?: boolean | null;
   updatedAt: string;


### PR DESCRIPTION
Fixes types for workflows / jobs `input` and `output` when using `strict: true` or `strictNullChecks: true` by ensuring that all properties in generates types are requried