### PR TITLE
fix(db-mongodb): potential errors in `sanitizeRelationshipIDs` with `ref` being a non object

### DIFF
--- a/packages/db-mongodb/src/utilities/sanitizeRelationshipIDs.ts
+++ b/packages/db-mongodb/src/utilities/sanitizeRelationshipIDs.ts
@@ -117,14 +117,26 @@ export const sanitizeRelationshipIDs = ({
   fields,
 }: Args): Record<string, unknown> => {
   const sanitize: TraverseFieldsCallback = ({ field, ref }) => {
+    if (!ref || typeof ref !== 'object') {
+      return
+    }
+
     if (field.type === 'relationship' || field.type === 'upload') {
+      if (!ref[field.name]) {
+        return
+      }
+
       // handle localized relationships
       if (config.localization && field.localized) {
         const locales = config.localization.locales
         const fieldRef = ref[field.name]
+        if (typeof fieldRef !== 'object') {
+          return
+        }
+
         for (const { code } of locales) {
-          if (ref[field.name]?.[code]) {
-            const value = ref[field.name][code]
+          const value = ref[field.name][code]
+          if (value) {
             sanitizeRelationship({ config, field, locale: code, ref: fieldRef, value })
           }
         }


### PR DESCRIPTION
### What?
Fixes potential errors when passed to `sanitizeRelationships` `ref` could potentially be a non object (for example `string`) because of having in the database data in old structure.
```
"Cannot create property 'a' on string 'B'",
``` 

### Why?
Necessary particularly for the migration script, as it migrates everything including versions that can have outdated data.

### How?
Ensures passed `ref` is an `object`.
