### PR TITLE
fix(next): initialize payload with importMap

### DIFF
--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -52,7 +52,7 @@ export const RootLayout = async ({
     headers,
   })
 
-  const payload = await getPayload({ config })
+  const payload = await getPayload({ config, importMap })
 
   const { i18n, permissions, user } = await initReq(config)
 


### PR DESCRIPTION
### What?
Custom providers could not be resolved because payload was not initialized in the Root layout with the importMap passed in from props.

### How?
Pass importMap from props into the getPayload function in the Root layout.
