### PR TITLE
fix(next): passes locale through requests in live preview edit view

### DIFF
--- a/packages/next/src/views/LivePreview/index.tsx
+++ b/packages/next/src/views/LivePreview/index.tsx
@@ -38,7 +38,7 @@ export const LivePreviewView: PayloadServerReactComponent<EditViewComponent> = a
         depth: 0,
         draft: true,
         fallbackLocale: false,
-        locale: locale.code,
+        locale: locale?.code,
       })
     }
 

--- a/packages/next/src/views/LivePreview/index.tsx
+++ b/packages/next/src/views/LivePreview/index.tsx
@@ -48,7 +48,7 @@ export const LivePreviewView: PayloadServerReactComponent<EditViewComponent> = a
         depth: 0,
         draft: true,
         fallbackLocale: false,
-        locale: locale.code,
+        locale: locale?.code,
       })
     }
   } catch (error) {

--- a/packages/next/src/views/LivePreview/index.tsx
+++ b/packages/next/src/views/LivePreview/index.tsx
@@ -38,6 +38,7 @@ export const LivePreviewView: PayloadServerReactComponent<EditViewComponent> = a
         depth: 0,
         draft: true,
         fallbackLocale: false,
+        locale: locale.code,
       })
     }
 
@@ -47,6 +48,7 @@ export const LivePreviewView: PayloadServerReactComponent<EditViewComponent> = a
         depth: 0,
         draft: true,
         fallbackLocale: false,
+        locale: locale.code,
       })
     }
   } catch (error) {


### PR DESCRIPTION
### What?

This makes the data lookup respect the locale of the request

### Why?

Fixes https://github.com/payloadcms/payload/issues/9293

### How?
