### PR TITLE
perf(richtext-lexical): do not send default lexical editor config to client

### DIFF
--- a/packages/richtext-lexical/src/field/index.tsx
+++ b/packages/richtext-lexical/src/field/index.tsx
@@ -23,7 +23,7 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
     clientFeatures,
     featureClientSchemaMap,
     field,
-    lexicalEditorConfig,
+    lexicalEditorConfig = defaultEditorLexicalConfig,
     schemaPath,
   } = props
 

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -83,6 +83,8 @@ export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapte
 
       finalSanitizedEditorConfig = deepCopyObject(defaultSanitizedServerEditorConfig)
 
+      delete finalSanitizedEditorConfig.lexical // We don't want to send the default lexical editor config to the client
+
       resolvedFeatureMap = finalSanitizedEditorConfig.resolvedFeatureMap
     } else {
       const rootEditor = config.editor
@@ -116,7 +118,7 @@ export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapte
 
       finalSanitizedEditorConfig = {
         features: sanitizeServerFeatures(resolvedFeatureMap),
-        lexical,
+        lexical: props.lexical,
         resolvedFeatureMap,
       }
     }

--- a/packages/richtext-lexical/src/lexical/config/types.ts
+++ b/packages/richtext-lexical/src/lexical/config/types.ts
@@ -14,12 +14,12 @@ import type { LexicalFieldAdminProps } from '../../types.js'
 
 export type ServerEditorConfig = {
   features: FeatureProviderServer<any, any, any>[]
-  lexical?: LexicalEditorConfig
+  lexical?: LexicalEditorConfig | undefined // If undefined, the default lexical editor config will be used. This can be undefined so that we do not send the default lexical editor config to the client.
 }
 
 export type SanitizedServerEditorConfig = {
   features: SanitizedServerFeatures
-  lexical: LexicalEditorConfig
+  lexical: LexicalEditorConfig | undefined // If undefined, the default lexical editor config will be used. This can be undefined so that we do not send the default lexical editor config to the client.
   resolvedFeatureMap: ResolvedServerFeatureMap
 }
 

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -97,7 +97,7 @@ export type LexicalRichTextFieldProps = {
   }
   featureClientSchemaMap: FeatureClientSchemaMap
   initialLexicalFormState: InitialLexicalFormState
-  lexicalEditorConfig: LexicalEditorConfig
+  lexicalEditorConfig: LexicalEditorConfig | undefined // Undefined if default lexical editor config should be used
 } & Pick<ServerFieldBase, 'permissions'> &
   RichTextFieldClientProps<SerializedEditorState, AdapterProps, object>
 


### PR DESCRIPTION
We can just get the default config from the client, if the server passes undefined. This wasted bandwidth and unnecessarily increased the html size