### PR TITLE
fix: correct migrations sorting in `getMigrations`

### DIFF
--- a/packages/payload/src/database/migrations/getMigrations.ts
+++ b/packages/payload/src/database/migrations/getMigrations.ts
@@ -12,7 +12,7 @@ export async function getMigrations({
   const migrationQuery = await payload.find({
     collection: 'payload-migrations',
     limit: 0,
-    sort: '-batch',
+    sort: ['-batch', '-name'],
     where: {
       batch: {
         not_equals: -1,

--- a/packages/payload/src/database/migrations/getMigrations.ts
+++ b/packages/payload/src/database/migrations/getMigrations.ts
@@ -12,7 +12,7 @@ export async function getMigrations({
   const migrationQuery = await payload.find({
     collection: 'payload-migrations',
     limit: 0,
-    sort: '-name',
+    sort: '-batch',
     where: {
       batch: {
         not_equals: -1,


### PR DESCRIPTION
### What?
We sorted migrations by `-name` in `getMigrations` as by assumption from generated file names, however, it may be not true as the improved (+ unflaked, previously it failed sometimes) test for `migrate:down` can reproduce. As in result, `migrateDown` / `migrateRefresh` may execute in order different from `migrate`.

Unflakes the 'should commit multiple operations async'  test.
We shouldn't pass the same `req` that doesn't contain a transaction to different operations that execute in parallel (via `Promise.all`) without either creating a transaction before or using `isolateObjectProperty(req, 'transactionID')`. It leads to a race condition because operation can commit a wrong transaction, different from inited
