### PR TITLE
docs: fix broken links to release notes in migration guide

### DIFF
--- a/docs/migration-guide/overview.mdx
+++ b/docs/migration-guide/overview.mdx
@@ -113,7 +113,7 @@ For more details, see the [Documentation](https://payloadcms.com/docs/getting-st
 
 1. Database Adapter Migrations
 
-    If you have existing data and are using the MongoDB or Postgres adapters, you will need to run the database migrations to ensure your database schema is up-to-date. Follow the instructions from the release notes for [postgres](https://github.com/payloadcms/payload/releases/edit/v3.0.0-beta.39) or [mongodb](https://github.com/payloadcms/payload/releases/edit/v3.0.0-beta.131) depending on your chosen adapter.
+    If you have existing data and are using the MongoDB or Postgres adapters, you will need to run the database migrations to ensure your database schema is up-to-date. Follow the instructions from the release notes for [postgres](https://github.com/payloadcms/payload/releases/tag/v3.0.0-beta.39) or [mongodb](https://github.com/payloadcms/payload/releases/tag/v3.0.0-beta.131) depending on your chosen adapter.
 
 ## Breaking Changes
 


### PR DESCRIPTION
### What?
Fixed broken links in the documentation for release notes, changing from /releases/edit/ to /releases/tag/.

### Why?
The previous links were inaccessible to general users as they pointed to non-public editing pages. This update ensures users can access the release notes without permission issues.

### How?
Replaced the links for Postgres and MongoDB adapters with the correct format that points to public release pages.
