### PR TITLE
fix(next): `next@15.0.3` compatibillity for turbopack warnings patch

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -14,15 +14,15 @@ export const withPayload = (nextConfig = {}) => {
   }
 
   if (process.env.PAYLOAD_PATCH_TURBOPACK_WARNINGS !== 'false') {
-    const consoleWarn = console.warn
+    const turbopackWarningText =
+      'Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.\nTry to install it into the project directory by running'
 
+    const consoleWarn = console.warn
     console.warn = (...args) => {
       // Force to disable serverExternalPackages warnings: https://github.com/vercel/next.js/issues/68805
       if (
-        typeof args[1] === 'string' &&
-        args[1].includes(
-          'Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.\nTry to install it into the project directory by running',
-        )
+        (typeof args[1] === 'string' && args[1].includes(turbopackWarningText)) ||
+        (typeof args[0] === 'string' && args[0].includes(turbopackWarningText))
       ) {
         return
       }


### PR DESCRIPTION
Added patch to `withPayload` for hiding turbopack external deps warnings from this PR https://github.com/payloadcms/payload/pull/9147 didn't work on `next@15.0.3`, now it works on both `15.0.0` and `15.0.3`.