### PR TITLE
fix(ui): proper permissions within version diff view

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/index.tsx
@@ -25,6 +25,7 @@ const RenderFieldsToDiff: React.FC<Props> = ({
   // typing it as `as typeof _diffComponents` here ensures the TField generics of DiffComponentProps are respected.
   // Without it, you could pass a UI field to the Tabs component, without it erroring
   const diffComponents: typeof _diffComponents = __diffComponents as typeof _diffComponents
+
   return (
     <div className={baseClass}>
       {fields?.map((field, i) => {
@@ -51,7 +52,9 @@ const RenderFieldsToDiff: React.FC<Props> = ({
               : comparison?.[fieldName]
 
             const hasPermission =
-              fieldPermissions?.[fieldName] === true || fieldPermissions?.[fieldName]?.read
+              fieldPermissions === true ||
+              fieldPermissions?.[fieldName] === true ||
+              fieldPermissions?.[fieldName]?.read
 
             const subFieldPermissions =
               fieldPermissions?.[fieldName] === true || fieldPermissions?.[fieldName]?.fields

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -317,6 +317,7 @@ describe('versions', () => {
       const versionID = await row2.locator('.cell-id').textContent()
       await page.goto(`${savedDocURL}/versions/${versionID}`)
       await page.waitForURL(`${savedDocURL}/versions/${versionID}`)
+      await expect(page.locator('.render-field-diffs')).toBeVisible()
       await page.locator('.restore-version__button').click()
       await page.locator('button:has-text("Confirm")').click()
       await page.waitForURL(savedDocURL)


### PR DESCRIPTION
Fixes #9337. The version view was not able to render its diff because of an invalid permissions lookup. This was a result of a change to how access results are returned from the API, which are now sanitized: https://github.com/payloadcms/payload/pull/7335