### PR TITLE
fix(ui): show required indicator for select fields

### DIFF
--- a/packages/ui/src/fields/Select/Input.tsx
+++ b/packages/ui/src/fields/Select/Input.tsx
@@ -33,6 +33,7 @@ export type SelectInputProps = {
   readonly options?: OptionObject[]
   readonly path: string
   readonly readOnly?: boolean
+  readonly required?: boolean
   readonly showError?: boolean
   readonly style?: React.CSSProperties
   readonly value?: string | string[]
@@ -57,6 +58,7 @@ export const SelectInput: React.FC<SelectInputProps> = (props) => {
     options,
     path,
     readOnly,
+    required,
     showError,
     style,
     value,
@@ -102,7 +104,9 @@ export const SelectInput: React.FC<SelectInputProps> = (props) => {
     >
       <RenderCustomComponent
         CustomComponent={Label}
-        Fallback={<FieldLabel label={label} localized={localized} path={path} required={false} />}
+        Fallback={
+          <FieldLabel label={label} localized={localized} path={path} required={required} />
+        }
       />
       <div className={`${fieldBaseClass}__wrap`}>
         <RenderCustomComponent

--- a/packages/ui/src/fields/Select/index.tsx
+++ b/packages/ui/src/fields/Select/index.tsx
@@ -115,6 +115,7 @@ const SelectFieldComponent: SelectFieldClientComponent = (props) => {
       options={options}
       path={path}
       readOnly={readOnly}
+      required={required}
       showError={showError}
       style={style}
       value={value as string | string[]}


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
Select field was not showing required indicator despite being marked required in config.

### Why?
To give end-user feedback when editting required select fields.

### How?
Replacing hardcoded required prop with required prop passed in from config.

[See here.](https://github.com/payloadcms/payload/blob/main/packages/ui/src/fields/Select/Input.tsx#L100)