### PR TITLE
fix(docs): update access control link

### DIFF
--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -19,7 +19,7 @@ Here are some common examples of how you can use the Local API:
 - Fetching Payload data within React Server Components
 - Seeding data via Node seed scripts that you write and maintain
 - Opening custom Next.js route handlers which feature additional functionality but still rely on Payload
-- Within [Access Control](../access-control) and [Hooks](../hooks/overview)
+- Within [Access Control](../access-control/overview) and [Hooks](../hooks/overview)
 
 ## Accessing Payload
 


### PR DESCRIPTION
Corrected a non-functioning hyperlink in the access control documentation