### PR TITLE
fix: allow self referencing relationships when adding new collections to config

### DIFF
--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -35,7 +35,13 @@ export const sanitizeCollection = async (
   // Sanitize fields
   // /////////////////////////////////
 
-  const validRelationships = config.collections.map((c) => c.slug) || []
+  const validRelationships = config.collections.reduce(
+    (acc, c) => {
+      acc.push(c.slug)
+      return acc
+    },
+    [collection.slug],
+  )
   const joins: SanitizedJoins = {}
   sanitized.fields = await sanitizeFields({
     collectionConfig: sanitized,


### PR DESCRIPTION
### What?
Unable to add collections to the config dynamically if they reference their own collection in a relationship field.

This was discovered while working on the folder view feature which dynamically adds collections to your config if it is enabled per collection.

### Why?
When `sanitizeCollection` runs, it takes the current config. If you are sanitizing a collection before adding it to the config, that collection cannot have any self referencing relationship fields on it otherwise it fails the validRelationships check.

### How?
Using a reducer we now initialize the validRelationships variable with the incoming collection slug.
