### PR TITLE
fix: `getPayload` generate import map only in Next.js

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -6,6 +6,8 @@
 export const withPayload = (nextConfig = {}) => {
   const env = nextConfig?.env || {}
 
+  env.PAYLOAD_NEXT_INTEGRATION = 'true'
+
   if (nextConfig.experimental?.staleTimes?.dynamic) {
     console.warn(
       'Payload detected a non-zero value for the `staleTimes.dynamic` option in your Next.js config. This will slow down page transitions and may cause stale data to load within the Admin panel. To clear this warning, remove the `staleTimes.dynamic` option from your Next.js config or set it to 0. In the future, Next.js may support scoping this option to specific routes.',

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -6,8 +6,6 @@
 export const withPayload = (nextConfig = {}) => {
   const env = nextConfig?.env || {}
 
-  env.PAYLOAD_NEXT_INTEGRATION = 'true'
-
   if (nextConfig.experimental?.staleTimes?.dynamic) {
     console.warn(
       'Payload detected a non-zero value for the `staleTimes.dynamic` option in your Next.js config. This will slow down page transitions and may cause stale data to load within the Admin panel. To clear this warning, remove the `staleTimes.dynamic` option from your Next.js config or set it to 0. In the future, Next.js may support scoping this option to specific routes.',

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -773,7 +773,11 @@ export const reload = async (
   }
 
   // Generate component map
-  if (skipImportMapGeneration !== true && config.admin?.importMap?.autoGenerate !== false) {
+  if (
+    skipImportMapGeneration !== true &&
+    config.admin?.importMap?.autoGenerate !== false &&
+    process.env.PAYLOAD_NEXT_INTEGRATION === 'true'
+  ) {
     await generateImportMap(config, {
       log: true,
     })
@@ -807,7 +811,7 @@ export const getPayload = async (
       // will reach `if (cached.reload instanceof Promise) {` which then waits for the first reload to finish.
       cached.reload = new Promise((res) => (resolve = res))
       const config = await options.config
-      await reload(config, cached.payload)
+      await reload(config, cached.payload, process.env.PAYLOAD_NEXT_INTEGRATION !== 'true')
 
       resolve()
     }
@@ -839,6 +843,7 @@ export const getPayload = async (
     ) {
       try {
         const port = process.env.PORT || '3000'
+
         cached.ws = new WebSocket(
           `ws://localhost:${port}${process.env.NEXT_BASE_PATH ?? ''}/_next/webpack-hmr`,
         )

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -773,11 +773,7 @@ export const reload = async (
   }
 
   // Generate component map
-  if (
-    skipImportMapGeneration !== true &&
-    config.admin?.importMap?.autoGenerate !== false &&
-    process.env.PAYLOAD_NEXT_INTEGRATION === 'true'
-  ) {
+  if (skipImportMapGeneration !== true && config.admin?.importMap?.autoGenerate !== false) {
     await generateImportMap(config, {
       log: true,
     })
@@ -819,7 +815,6 @@ export const getPayload = async (
     if (cached.reload instanceof Promise) {
       await cached.reload
     }
-
     if (options?.importMap) {
       cached.payload.importMap = options.importMap
     }

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -807,7 +807,7 @@ export const getPayload = async (
       // will reach `if (cached.reload instanceof Promise) {` which then waits for the first reload to finish.
       cached.reload = new Promise((res) => (resolve = res))
       const config = await options.config
-      await reload(config, cached.payload, process.env.PAYLOAD_NEXT_INTEGRATION !== 'true')
+      await reload(config, cached.payload, !options.importMap)
 
       resolve()
     }


### PR DESCRIPTION
After the change with removing `getPayloadHMR`, we do generate import map even outside of Next.js, which leads to errors when using in a project without it:
![image](https://github.com/user-attachments/assets/e8dc2af6-566b-443c-a6d8-8b02e719bd30)