### PR TITLE
fix: prioritize server rendered Actions in ActionsProvider

### DIFF
--- a/packages/ui/src/providers/Actions/index.tsx
+++ b/packages/ui/src/providers/Actions/index.tsx
@@ -25,7 +25,15 @@ export const ActionsProvider: React.FC<{
   const [viewActions, setViewActions] = useState(Actions)
 
   return (
-    <ActionsContext.Provider value={{ Actions: viewActions, setViewActions }}>
+    <ActionsContext.Provider
+      value={{
+        Actions: {
+          ...viewActions,
+          ...Actions,
+        },
+        setViewActions,
+      }}
+    >
       {children}
     </ActionsContext.Provider>
   )


### PR DESCRIPTION
### What?
Actions were not being re-rendered when router.refresh was called.
[Discord Link](https://discord.com/channels/967097582721572934/1308636510203154462/1308648116031066173)

### Why?
They were stored in state and the state was persisting.

### How?
Spread the stateful actions and the Actions from props on top of the client state actions.