### PR TITLE
fix: error when opening admin panel without any permissions

### DIFF
--- a/packages/payload/src/collections/operations/docAccess.ts
+++ b/packages/payload/src/collections/operations/docAccess.ts
@@ -1,4 +1,4 @@
-import type { CollectionPermission, SanitizedCollectionPermission } from '../../auth/index.js'
+import type { SanitizedCollectionPermission } from '../../auth/index.js'
 import type { AllOperations, PayloadRequest } from '../../types/index.js'
 import type { Collection } from '../config/types.js'
 
@@ -45,13 +45,12 @@ export async function docAccessOperation(args: Arguments): Promise<SanitizedColl
     })
 
     const sanitizedPermissions = sanitizePermissions({
-      canAccessAdmin: true,
       collections: {
         [config.slug]: result,
       },
     })
 
-    return sanitizedPermissions.collections[config.slug]
+    return sanitizedPermissions?.collections?.[config.slug]
   } catch (e: unknown) {
     await killTransaction(req)
     throw e

--- a/packages/payload/src/globals/operations/docAccess.ts
+++ b/packages/payload/src/globals/operations/docAccess.ts
@@ -34,13 +34,12 @@ export const docAccessOperation = async (args: Arguments): Promise<SanitizedGlob
       await commitTransaction(req)
     }
     const sanitizedPermissions = sanitizePermissions({
-      canAccessAdmin: true,
       globals: {
         [globalConfig.slug]: result,
       },
     })
 
-    return sanitizedPermissions.globals[globalConfig.slug]
+    return sanitizedPermissions?.globals?.[globalConfig.slug]
   } catch (e: unknown) {
     await killTransaction(req)
     throw e

--- a/packages/payload/src/utilities/sanitizePermissions.ts
+++ b/packages/payload/src/utilities/sanitizePermissions.ts
@@ -1,3 +1,5 @@
+import type { MarkOptional } from 'ts-essentials'
+
 import type {
   CollectionPermission,
   FieldPermissions,
@@ -196,7 +198,9 @@ export function recursivelySanitizeGlobals(obj: Permissions['globals']): void {
 /**
  * Recursively remove empty objects and false values from an object.
  */
-export function sanitizePermissions(data: Permissions): SanitizedPermissions {
+export function sanitizePermissions(
+  data: MarkOptional<Permissions, 'canAccessAdmin'>,
+): SanitizedPermissions {
   if (data.canAccessAdmin === false) {
     delete data.canAccessAdmin
   }


### PR DESCRIPTION
We were getting the following error when opening the create first user page, as sanitizedPermissions is `{}` if the user has no permissions at all

![CleanShot 2024-11-20 at 18 48 46@2x](https://github.com/user-attachments/assets/90270a0b-10e5-4f22-a91e-174f82a559b2)
