### PR TITLE
fix(db-mongodb): `sanitizeRelationshipIDs` named tabs within tabs

### DIFF
--- a/packages/db-mongodb/src/predefinedMigrations/migrateRelationshipsV2_V3.ts
+++ b/packages/db-mongodb/src/predefinedMigrations/migrateRelationshipsV2_V3.ts
@@ -154,15 +154,18 @@ export async function migrateRelationshipsV2_V3({
       { lean: true, session },
     )
 
-    sanitizeRelationshipIDs({ config, data: doc, fields: global.fields })
+    // in case if the global doesn't exist in the database yet  (not saved)
+    if (doc) {
+      sanitizeRelationshipIDs({ config, data: doc, fields: global.fields })
 
-    await GlobalsModel.collection.updateOne(
-      {
-        globalType: global.slug,
-      },
-      { $set: doc },
-      { session },
-    )
+      await GlobalsModel.collection.updateOne(
+        {
+          globalType: global.slug,
+        },
+        { $set: doc },
+        { session },
+      )
+    }
 
     payload.logger.info(`Migrated global "${global.slug}"`)
 

--- a/packages/db-mongodb/src/utilities/sanitizeRelationshipIDs.spec.ts
+++ b/packages/db-mongodb/src/utilities/sanitizeRelationshipIDs.spec.ts
@@ -191,6 +191,20 @@ const config = {
               fields: relsFields,
               localized: true,
             },
+            {
+              label: 'another',
+              fields: [
+                {
+                  type: 'tabs',
+                  tabs: [
+                    {
+                      name: 'nestedTab',
+                      fields: relsFields,
+                    },
+                  ],
+                },
+              ],
+            },
           ],
         },
       ],
@@ -330,6 +344,7 @@ describe('sanitizeRelationshipIDs', () => {
         en: { ...relsData },
         es: { ...relsData },
       },
+      nestedTab: { ...relsData },
     }
     const flattenValuesBefore = Object.values(flattenRelationshipValues(data))
 

--- a/packages/db-mongodb/src/utilities/sanitizeRelationshipIDs.ts
+++ b/packages/db-mongodb/src/utilities/sanitizeRelationshipIDs.ts
@@ -30,18 +30,15 @@ const convertValue = ({
     (field) => fieldAffectsData(field) && field.name === 'id',
   )
 
-  if (!customIDField) {
-    try {
-      return new Types.ObjectId(value)
-    } catch (error) {
-      throw new APIError(
-        `Failed to create ObjectId from value: ${value}. Error: ${error.message}`,
-        400,
-      )
-    }
+  if (customIDField) {
+    return value
   }
 
-  return value
+  try {
+    return new Types.ObjectId(value)
+  } catch {
+    return value
+  }
 }
 
 const sanitizeRelationship = ({ config, field, locale, ref, value }) => {


### PR DESCRIPTION
Ensures `sanitizeRelationshipIDs` works properly in any case

Skips ObjectID creation errors to not fail with outdated data to the schema.