### PR TITLE
chore: fix test/lexical-mdx imports

### DIFF
--- a/test/lexical-mdx/mdx/hooks.ts
+++ b/test/lexical-mdx/mdx/hooks.ts
@@ -1,8 +1,6 @@
-import type { SerializedEditorState } from 'lexical'
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
 import type { CollectionAfterReadHook, CollectionBeforeChangeHook, RichTextField } from 'payload'
 
-import { createHeadlessEditor } from '@lexical/headless'
-import { $convertToMarkdownString } from '@lexical/markdown'
 import {
   $convertFromMarkdownString,
   extractFrontmatter,
@@ -12,6 +10,8 @@ import {
   objectToFrontmatter,
   type SanitizedServerEditorConfig,
 } from '@payloadcms/richtext-lexical'
+import { createHeadlessEditor } from '@payloadcms/richtext-lexical/lexical/headless'
+import { $convertToMarkdownString } from '@payloadcms/richtext-lexical/lexical/markdown'
 import fs from 'node:fs'
 import path from 'path'
 import { deepCopyObjectSimple } from 'payload'


### PR DESCRIPTION
missing from #9229