### PR TITLE
docs: removes public demo references

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -52,7 +52,7 @@ export const Posts: CollectionConfig = {
 
 <Banner type="success">
   <strong>Reminder:</strong>
-  For a more complex example, see the [Public Demo](https://github.com/payloadcms/public-demo) source code on GitHub, or the [Templates](https://github.com/payloadcms/payload/tree/main/templates) and [Examples](https://github.com/payloadcms/payload/tree/main/examples) directories in the Payload repository.
+  For more complex examples, see the [Templates](https://github.com/payloadcms/payload/tree/main/templates) and [Examples](https://github.com/payloadcms/payload/tree/main/examples) directories in the Payload repository.
 </Banner>
 
 The following options are available:

--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -60,7 +60,7 @@ export const Nav: GlobalConfig = {
 
 <Banner type="success">
   <strong>Reminder:</strong>
-  For a more complex example, see the [Public Demo](https://github.com/payloadcms/public-demo) source code on GitHub, or the [Templates](https://github.com/payloadcms/payload/tree/main/templates) and [Examples](https://github.com/payloadcms/payload/tree/main/examples) directories in the Payload repository.
+  For more complex examples, see the [Templates](https://github.com/payloadcms/payload/tree/main/templates) and [Examples](https://github.com/payloadcms/payload/tree/main/examples) directories in the Payload repository.
 </Banner>
 
 The following options are available:

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -58,7 +58,7 @@ export default buildConfig({
 
 <Banner type="success">
   <strong>Note:</strong>
-  For a more complex example, see the [Public Demo](https://github.com/payloadcms/public-demo) source code on GitHub, or the [Templates](https://github.com/payloadcms/payload/tree/main/templates) and [Examples](https://github.com/payloadcms/payload/tree/main/examples) directories in the Payload repository.
+  For more complex examples, see the [Templates](https://github.com/payloadcms/payload/tree/main/templates) and [Examples](https://github.com/payloadcms/payload/tree/main/examples) directories in the Payload repository.
 </Banner>
 
 The following options are available:


### PR DESCRIPTION
### What?

Removes all references to the `public-demo` from the docs
