### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report_v3.yml
@@ -14,7 +14,7 @@ body:
       label: Link to the code that reproduces this issue
       description: >-
         _REQUIRED_: Please provide a link to your reproduction. Note, if the URL is invalid (404 or a private repository), we may close the issue.
-        Either use `npx create-payload-app@beta -t blank` then push to a repo or follow the [reproduction-guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md) for more information.
+        Either use `pnpx create-payload-app@latest -t blank` then push to a repo or follow the [reproduction-guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md) for more information.
     validations:
       required: true
 
@@ -57,7 +57,7 @@ body:
   - type: textarea
     attributes:
       label: Environment Info
-      description: Paste output from `pnpm payload info` (>= beta.92) _or_ Payload, Node.js, and Next.js versions.
+      description: Paste output from `pnpm payload info` _or_ Payload, Node.js, and Next.js versions.
       render: text
       placeholder: |
         Payload:

--- a/.github/ISSUE_TEMPLATE/2.design_issue.yml
+++ b/.github/ISSUE_TEMPLATE/2.design_issue.yml
@@ -20,7 +20,7 @@ body:
   - type: textarea
     attributes:
       label: Environment Info
-      description: Paste output from `pnpm payload info` (>= beta.92) _or_ Payload, Node.js, and Next.js versions.
+      description: Paste output from `pnpm payload info` _or_ Payload, Node.js, and Next.js versions.
       render: text
       placeholder: |
         Payload:


### PR DESCRIPTION
Removes mentions of `beta` in issue templates now that 3.0 has been released.
