### PR TITLE
fix: invalid `payload.collections` type

### DIFF
--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -100,12 +100,8 @@ export type SanitizedDocumentPermissions = SanitizedCollectionPermission | Sanit
 
 export type Permissions = {
   canAccessAdmin: boolean
-  collections?: {
-    [collectionSlug: CollectionSlug]: CollectionPermission
-  }
-  globals?: {
-    [globalSlug: GlobalSlug]: GlobalPermission
-  }
+  collections?: Record<CollectionSlug, CollectionPermission>
+  globals?: Record<GlobalSlug, GlobalPermission>
 }
 
 export type SanitizedPermissions = {

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -863,7 +863,7 @@ type UploadAdminClient = AdminClient & Pick<UploadAdmin, 'allowCreate' | 'isSort
 
 export type PolymorphicUploadField = {
   admin?: {
-    sortOptions?: { [collectionSlug: CollectionSlug]: string }
+    sortOptions?: Partial<Record<CollectionSlug, string>>
   } & UploadAdmin
   relationTo: CollectionSlug[]
 } & SharedUploadProperties
@@ -1044,7 +1044,7 @@ type RelationshipAdminClient = AdminClient &
 
 export type PolymorphicRelationshipField = {
   admin?: {
-    sortOptions?: { [collectionSlug: CollectionSlug]: string }
+    sortOptions?: Partial<Record<CollectionSlug, string>>
   } & RelationshipAdmin
   relationTo: CollectionSlug[]
 } & SharedRelationshipProperties

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -242,9 +242,7 @@ export class BasePayload {
 
   authStrategies: AuthStrategy[]
 
-  collections: {
-    [slug: CollectionSlug]: Collection
-  } = {}
+  collections: Record<CollectionSlug, Collection> = {}
 
   config: SanitizedConfig
   /**


### PR DESCRIPTION
### What?
`payload.collections` was improperly typed.
This doesn't seem to work: (the type is `{}`)
```
collections: {
  [slug: CollectionSlug]: Collection
} = {}
```
<img width="794" alt="image" src="https://github.com/user-attachments/assets/7daceab9-8f43-433b-9201-1bf8c48fb8ca">

However, this does:
```ts
collections: Record<CollectionSlug, Collection> = {}
```
<img width="540" alt="image" src="https://github.com/user-attachments/assets/e37d595d-f5b4-4b02-b190-bb5d4063787d">


Additionally, the same fix applied to `Permissions`, `PolymorphicUploadField['admin']['sortOptions']`, `PolymorphicRelationshipField['admin']['sortOptions']`
