### PR TITLE
feat(richtext-lexical): more powerful custom Block RSCs, improved selection handling

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
@@ -67,7 +67,7 @@ export const BlockComponent: React.FC<Props> = (props) => {
     slug: `lexical-blocks-create-${uuidFromContext}-${formData.id}`,
     depth: editDepth,
   })
-  const { toggleDrawer } = useLexicalDrawer(drawerSlug, true)
+  const { toggleDrawer } = useLexicalDrawer(drawerSlug)
 
   // Used for saving collapsed to preferences (and gettin' it from there again)
   // Remember, these preferences are scoped to the whole document, not just this form. This
@@ -291,10 +291,18 @@ export const BlockComponent: React.FC<Props> = (props) => {
         buttonStyle="icon-label"
         className={`${baseClass}__editButton`}
         disabled={readOnly}
-        el="div"
+        el="button"
         icon="edit"
-        onClick={() => {
+        onClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
           toggleDrawer()
+          return false
+        }}
+        onMouseDown={(e) => {
+          // Needed to preserve lexical selection for toggleDrawer lexical selection restore.
+          // I believe this is needed due to this button (usually) being inside of a collapsible.
+          e.preventDefault()
         }}
         round
         size="small"

--- a/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
@@ -92,6 +92,16 @@ export const BlockComponent: React.FC<Props> = (props) => {
       : false,
   )
 
+  const [CustomLabel, setCustomLabel] = React.useState<React.ReactNode | undefined>(
+    // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
+    initialState?.['_components']?.customComponents?.BlockLabel,
+  )
+
+  const [CustomBlock, setCustomBlock] = React.useState<React.ReactNode | undefined>(
+    // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
+    initialState?.['_components']?.customComponents?.Block,
+  )
+
   // Initial state for newly created blocks
   useEffect(() => {
     const abortController = new AbortController()
@@ -124,6 +134,8 @@ export const BlockComponent: React.FC<Props> = (props) => {
         }
 
         setInitialState(state)
+        setCustomLabel(state._components?.customComponents?.BlockLabel)
+        setCustomBlock(state._components?.customComponents?.Block)
       }
     }
 
@@ -178,6 +190,7 @@ export const BlockComponent: React.FC<Props> = (props) => {
         formState: prevFormState,
         globalSlug,
         operation: 'update',
+        renderAllFields: submit ? true : false,
         schemaPath: schemaFieldsPath,
         signal: controller.signal,
       })
@@ -209,6 +222,9 @@ export const BlockComponent: React.FC<Props> = (props) => {
       }, 0)
 
       if (submit) {
+        setCustomLabel(newFormState._components?.customComponents?.BlockLabel)
+        setCustomBlock(newFormState._components?.customComponents?.Block)
+
         let rowErrorCount = 0
         for (const formField of Object.values(newFormState)) {
           if (formField?.valid === false) {
@@ -245,11 +261,6 @@ export const BlockComponent: React.FC<Props> = (props) => {
       $getNodeByKey(nodeKey)?.remove()
     })
   }, [editor, nodeKey])
-
-  // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
-  const CustomLabel = initialState?.['_components']?.customComponents?.BlockLabel
-  // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
-  const CustomBlock = initialState?.['_components']?.customComponents?.Block
 
   const blockDisplayName = clientBlock?.labels?.singular
     ? getTranslation(clientBlock.labels.singular, i18n)
@@ -461,6 +472,7 @@ export const BlockComponent: React.FC<Props> = (props) => {
       <Form
         beforeSubmit={[
           async ({ formState }) => {
+            // This is only called when form is submitted from drawer - usually only the case if the block has a custom Block component
             return await onChange({ formState, submit: true })
           },
         ]}
@@ -468,7 +480,7 @@ export const BlockComponent: React.FC<Props> = (props) => {
         initialState={initialState}
         onChange={[onChange]}
         onSubmit={(formState) => {
-          // THis is only called when form is submitted from drawer - usually only the case if the block has a custom Block component
+          // This is only called when form is submitted from drawer - usually only the case if the block has a custom Block component
           const newData: any = reduceFieldsToValues(formState)
           newData.blockType = formData.blockType
           editor.update(() => {

--- a/packages/richtext-lexical/src/features/blocks/client/componentInline/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/componentInline/index.tsx
@@ -300,7 +300,7 @@ export const InlineBlockComponent: React.FC<Props> = (props) => {
         buttonStyle="icon-label"
         className={`${baseClass}__editButton`}
         disabled={readOnly}
-        el="div"
+        el="button"
         icon="edit"
         onClick={() => {
           toggleDrawer()

--- a/test/fields/collections/Lexical/blockComponents/BlockComponentRSC.tsx
+++ b/test/fields/collections/Lexical/blockComponents/BlockComponentRSC.tsx
@@ -1,0 +1,10 @@
+import type { BlocksFieldServerComponent } from 'payload'
+
+import { BlockCollapsible } from '@payloadcms/richtext-lexical/client'
+import React from 'react'
+
+export const BlockComponentRSC: BlocksFieldServerComponent = (props) => {
+  const { data } = props
+
+  return <BlockCollapsible>Data: {data?.key ?? ''}</BlockCollapsible>
+}

--- a/test/fields/collections/Lexical/e2e/blocks/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e/blocks/e2e.spec.ts
@@ -136,11 +136,9 @@ describe('lexicalBlocks', () => {
     await newRSCBlock.scrollIntoViewIfNeeded()
     await expect(newRSCBlock.locator('.collapsible__content')).toHaveText('Data:')
 
-    // Select paragraph with text "testtext"
-    await richTextField.locator('p').getByText('123').first().click()
-    await page.keyboard.press('Shift+ArrowLeft')
-    await page.keyboard.press('Shift+ArrowLeft')
-    await page.keyboard.press('Shift+ArrowLeft')
+    // Select paragraph with text "123"
+    // Now double-click to select entire line
+    await richTextField.locator('p').getByText('123').first().click({ clickCount: 2 })
 
     const editButton = newRSCBlock.locator('.lexical-block__editButton').first()
     await editButton.click()
@@ -199,10 +197,8 @@ describe('lexicalBlocks', () => {
 
       expect(rscBlock.fields.blockType).toBe('BlockRSC')
       expect(rscBlock.fields.key).toBe('value2')
-      expect((paragraphBlock.children[0] as SerializedTextNode).text).toBe('12')
+      expect((paragraphBlock.children[0] as SerializedTextNode).text).toBe('123')
       expect((paragraphBlock.children[0] as SerializedTextNode).format).toBe(1)
-      expect((paragraphBlock.children[1] as SerializedTextNode).text).toBe('3')
-      expect((paragraphBlock.children[1] as SerializedTextNode).format).toBe(0)
     }).toPass({
       timeout: POLL_TOPASS_TIMEOUT,
     })

--- a/test/fields/collections/Lexical/index.ts
+++ b/test/fields/collections/Lexical/index.ts
@@ -135,6 +135,25 @@ const editorConfig: ServerEditorConfig = {
           ],
         },
         {
+          slug: 'BlockRSC',
+
+          admin: {
+            components: {
+              Block: '/collections/Lexical/blockComponents/BlockComponentRSC.js#BlockComponentRSC',
+            },
+          },
+          fields: [
+            {
+              name: 'key',
+              label: () => {
+                return 'Key'
+              },
+              type: 'select',
+              options: ['value1', 'value2', 'value3'],
+            },
+          ],
+        },
+        {
           slug: 'myBlockWithBlockAndLabel',
           admin: {
             components: {


### PR DESCRIPTION
Now, custom Lexical block & inline block components are re-rendered if the fields drawer is saved. This ensures that RSCs receive the updated values, without having to resort to a client component that utilizes the `useForm` hook.

Additionally, this PRs fixes the lexical selection jumping around after opening a Block or InlineBlock drawer and clicking inside of it.