### PR TITLE
fix(ui): add disabled attribute to blocks drawer toggler

### DIFF
--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -325,7 +325,11 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
       )}
       {!hasMaxRows && (
         <Fragment>
-          <DrawerToggler className={`${baseClass}__drawer-toggler`} slug={drawerSlug}>
+          <DrawerToggler
+            className={`${baseClass}__drawer-toggler`}
+            disabled={readOnly}
+            slug={drawerSlug}
+          >
             <Button
               buttonStyle="icon-label"
               disabled={readOnly}


### PR DESCRIPTION
### What?

When `update` access control is set to `false`, the blocks drawer can still be accessed. Blocks still cannot be saved to the document, making this more of a QoL improvement.

### Why?

The blocks `DrawerToggler` is missing the `disabled` attribute.

### How?

Adding the `disabled` attribute to the blocks `DrawerToggler`.

### Reproduction steps

https://github.com/rilrom/payload/tree/issue/disabled-add-block-button

1. Navigate to the posts collection.
2. Click the 'Add blocks' button.
3. Blocks can be selected (however they are still readonly in the document and cannot be saved).

### Recordings

Before

https://github.com/user-attachments/assets/da12829d-5b27-4da9-bbd1-067d679a89ba

After

https://github.com/user-attachments/assets/67166477-b83a-4495-98ae-2d272542103b