### PR TITLE
chore: fix path and samples for lexical-mdx tests

### DIFF
--- a/test/lexical-mdx/collections/Posts/shared.ts
+++ b/test/lexical-mdx/collections/Posts/shared.ts
@@ -1,4 +1,10 @@
-export const docsBasePath = '/Users/alessio/Documents/payloadcms-mdx-mock/docs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+export const docsBasePath =
+  typeof window === 'undefined'
+    ? path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../sampleDocs')
+    : null // O maneja de otra forma para el cliente
 
 export const languages = {
   ts: 'TypeScript',

--- a/test/lexical-mdx/collections/Posts/shared.ts
+++ b/test/lexical-mdx/collections/Posts/shared.ts
@@ -4,8 +4,7 @@ import { fileURLToPath } from 'url'
 export const docsBasePath =
   typeof window === 'undefined'
     ? path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../sampleDocs')
-    : null // O maneja de otra forma para el cliente
-
+    : null
 export const languages = {
   ts: 'TypeScript',
   plaintext: 'Plain Text',

--- a/test/lexical-mdx/sampleDocs/test.mdx
+++ b/test/lexical-mdx/sampleDocs/test.mdx
@@ -1,0 +1,3 @@
+# You can write MDX here
+
+Write whatever content you want for testing purposes


### PR DESCRIPTION
Later we could add better examples that test complex use cases, but at least this allows the code to compile.