### PR TITLE
fix(db-postgres): allow to clear select fields with `hasMany: true`

### DIFF
--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -114,13 +114,13 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
     // store by table name and rows
     if (Object.keys(rowToInsert.selects).length > 0) {
       Object.entries(rowToInsert.selects).forEach(([selectTableName, selectRows]) => {
+        selectsToInsert[selectTableName] = []
+
         selectRows.forEach((row) => {
           if (typeof row.parent === 'undefined') {
             row.parent = insertedRow.id
           }
-          if (!selectsToInsert[selectTableName]) {
-            selectsToInsert[selectTableName] = []
-          }
+
           selectsToInsert[selectTableName].push(row)
         })
       })
@@ -343,11 +343,14 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
           where: eq(selectTable.parent, insertedRow.id),
         })
       }
-      await adapter.insert({
-        db,
-        tableName: selectTableName,
-        values: tableRows,
-      })
+
+      if (tableRows.length) {
+        await adapter.insert({
+          db,
+          tableName: selectTableName,
+          values: tableRows,
+        })
+      }
     }
 
     // //////////////////////////////////

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -521,6 +521,25 @@ describe('Fields', () => {
       expect(updatedDoc.selectHasMany).toEqual(['one', 'two'])
     })
 
+    it('should clear select hasMany field', async () => {
+      const { id } = await payload.create({
+        collection: 'select-fields',
+        data: {
+          selectHasMany: ['one', 'two'],
+        },
+      })
+
+      const updatedDoc = await payload.update({
+        id,
+        collection: 'select-fields',
+        data: {
+          selectHasMany: [],
+        },
+      })
+
+      expect(updatedDoc.selectHasMany).toHaveLength(0)
+    })
+
     it('should query hasMany in', async () => {
       const hit = await payload.create({
         collection: 'select-fields',


### PR DESCRIPTION
### What?
Previously, using Postgres, select fields with `hasMany: true` weren't clearable.
Meaning, you couldn't pass an empty array:
```ts
const updatedDoc = await payload.update({
  id,
  collection: 'select-fields',
  data: {
    selectHasMany: [],
  },
})
```

### Why?
To achieve the same behavior with MongoDB.

### How?
Modifies logic in `packages/drizzle/src/upsertRow/index.ts` to include empty arrays.
