### PR TITLE
feat(templates): website template add performance optimizations with `select`, `pagination: false` and `count`

### DIFF
--- a/templates/website/src/app/(frontend)/[slug]/page.tsx
+++ b/templates/website/src/app/(frontend)/[slug]/page.tsx
@@ -94,6 +94,7 @@ const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
     collection: 'pages',
     draft,
     limit: 1,
+    pagination: false,
     overrideAccess: draft,
     where: {
       slug: {

--- a/templates/website/src/app/(frontend)/next/preview/route.ts
+++ b/templates/website/src/app/(frontend)/next/preview/route.ts
@@ -67,8 +67,13 @@ export async function GET(
     // Verify the given slug exists
     try {
       const docs = await payload.find({
-        collection: collection,
+        collection,
         draft: true,
+        limit: 1,
+        // pagination: false reduces overhead if you don't need totalDocs
+        pagination: false,
+        depth: 0,
+        select: {},
         where: {
           slug: {
             equals: slug,

--- a/templates/website/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/templates/website/src/app/(frontend)/posts/[slug]/page.tsx
@@ -1,23 +1,23 @@
 import type { Metadata } from 'next'
 
+import { RelatedPosts } from '@/blocks/RelatedPosts/Component'
 import { PayloadRedirects } from '@/components/PayloadRedirects'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 import { draftMode } from 'next/headers'
 import React, { cache } from 'react'
-import { homeStatic } from '@/endpoints/seed/home-static'
+import RichText from '@/components/RichText'
 
-import type { Page as PageType } from '@/payload-types'
+import type { Post } from '@/payload-types'
 
-import { RenderBlocks } from '@/blocks/RenderBlocks'
-import { RenderHero } from '@/heros/RenderHero'
+import { PostHero } from '@/heros/PostHero'
 import { generateMeta } from '@/utilities/generateMeta'
 import PageClient from './page.client'
 
 export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
-  const pages = await payload.find({
-    collection: 'pages',
+  const posts = await payload.find({
+    collection: 'posts',
     draft: false,
     limit: 1000,
     overrideAccess: false,
@@ -26,13 +26,9 @@ export async function generateStaticParams() {
     },
   })
 
-  const params = pages.docs
-    ?.filter((doc) => {
-      return doc.slug !== 'home'
-    })
-    .map(({ slug }) => {
-      return { slug }
-    })
+  const params = posts.docs.map(({ slug }) => {
+    return { slug }
+  })
 
   return params
 }
@@ -43,64 +39,55 @@ type Args = {
   }>
 }
 
-export default async function Page({ params: paramsPromise }: Args) {
-  const { slug = 'home' } = await paramsPromise
-  const url = '/' + slug
+export default async function Post({ params: paramsPromise }: Args) {
+  const { slug = '' } = await paramsPromise
+  const url = '/posts/' + slug
+  const post = await queryPostBySlug({ slug })
 
-  let page: Pick<PageType, 'slug' | 'layout' | 'hero'> | null
-
-  page = await queryPageBySlug({
-    slug,
-  })
-
-  // Remove this code once your website is seeded
-  if (!page && slug === 'home') {
-    page = homeStatic
-  }
-
-  if (!page) {
-    return <PayloadRedirects url={url} />
-  }
-
-  const { hero, layout } = page
+  if (!post) return <PayloadRedirects url={url} />
 
   return (
-    <article className="pt-16 pb-24">
+    <article className="pt-16 pb-16">
       <PageClient />
+
       {/* Allows redirects for valid pages too */}
       <PayloadRedirects disableNotFound url={url} />
 
-      <RenderHero {...hero} />
-      <RenderBlocks blocks={layout} />
+      <PostHero post={post} />
+
+      <div className="flex flex-col items-center gap-4 pt-8">
+        <div className="container">
+          <RichText className="max-w-[48rem] mx-auto" content={post.content} enableGutter={false} />
+          {post.relatedPosts && post.relatedPosts.length > 0 && (
+            <RelatedPosts
+              className="mt-12 max-w-[52rem] lg:grid lg:grid-cols-subgrid col-start-1 col-span-3 grid-rows-[2fr]"
+              docs={post.relatedPosts.filter((post) => typeof post === 'object')}
+            />
+          )}
+        </div>
+      </div>
     </article>
   )
 }
 
-export async function generateMetadata({ params: paramsPromise }): Promise<Metadata> {
-  const { slug = 'home' } = await paramsPromise
-  const page = await queryPageBySlug({
-    slug,
-  })
+export async function generateMetadata({ params: paramsPromise }: Args): Promise<Metadata> {
+  const { slug = '' } = await paramsPromise
+  const post = await queryPostBySlug({ slug })
 
-  return generateMeta({ doc: page })
+  return generateMeta({ doc: post })
 }
 
-const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
+const queryPostBySlug = cache(async ({ slug }: { slug: string }) => {
   const { isEnabled: draft } = await draftMode()
 
   const payload = await getPayload({ config: configPromise })
 
   const result = await payload.find({
-    collection: 'pages',
+    collection: 'posts',
     draft,
     limit: 1,
-    pagination: false,
     overrideAccess: draft,
-    select: {
-      slug: true,
-      hero: true,
-      layout: true,
-    },
+    pagination: false,
     where: {
       slug: {
         equals: slug,

--- a/templates/website/src/app/(frontend)/posts/page.tsx
+++ b/templates/website/src/app/(frontend)/posts/page.tsx
@@ -19,6 +19,12 @@ export default async function Page() {
     depth: 1,
     limit: 12,
     overrideAccess: false,
+    select: {
+      title: true,
+      slug: true,
+      categories: true,
+      meta: true,
+    },
   })
 
   return (

--- a/templates/website/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
+++ b/templates/website/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
@@ -71,20 +71,17 @@ export async function generateMetadata({ params: paramsPromise }: Args): Promise
 
 export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
-  const posts = await payload.find({
+  const { totalDocs } = await payload.count({
     collection: 'posts',
-    depth: 0,
-    limit: 10,
-    draft: false,
     overrideAccess: false,
   })
 
+  const totalPages = Math.ceil(totalDocs / 10)
+
   const pages: { pageNumber: string }[] = []
 
-  if (posts.totalPages) {
-    for (let i = 1; i <= posts.totalPages; i++) {
-      pages.push({ pageNumber: String(i) })
-    }
+  for (let i = 1; i <= totalPages; i++) {
+    pages.push({ pageNumber: String(i) })
   }
 
   return pages

--- a/templates/website/src/app/(frontend)/search/page.tsx
+++ b/templates/website/src/app/(frontend)/search/page.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import { Post } from '@/payload-types'
 import { Search } from '@/search/Component'
 import PageClient from './page.client'
+import { CardPostData } from '@/components/Card'
 
 type Args = {
   searchParams: Promise<{
@@ -21,6 +22,14 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
     collection: 'search',
     depth: 1,
     limit: 12,
+    select: {
+      title: true,
+      slug: true,
+      categories: true,
+      meta: true,
+    },
+    // pagination: false reduces overhead if you don't need totalDocs
+    pagination: false,
     ...(query
       ? {
           where: {
@@ -62,7 +71,7 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
       </div>
 
       {posts.totalDocs > 0 ? (
-        <CollectionArchive posts={posts.docs as unknown as Post[]} />
+        <CollectionArchive posts={posts.docs as CardPostData[]} />
       ) : (
         <div className="container">No results found.</div>
       )}

--- a/templates/website/src/collections/Pages/index.ts
+++ b/templates/website/src/collections/Pages/index.ts
@@ -22,7 +22,7 @@ import {
 } from '@payloadcms/plugin-seo/fields'
 import { getServerSideURL } from '@/utilities/getURL'
 
-export const Pages: CollectionConfig = {
+export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
   access: {
     create: authenticated,
@@ -32,6 +32,7 @@ export const Pages: CollectionConfig = {
   },
   // This config controls what's populated by default when a page is referenced
   // https://payloadcms.com/docs/queries/select#defaultpopulate-collection-config-property
+  // Type safe if the collection slug generic is passed to `CollectionConfig` - `CollectionConfig<'pagess'>
   defaultPopulate: {
     title: true,
     slug: true,

--- a/templates/website/src/collections/Posts/index.ts
+++ b/templates/website/src/collections/Posts/index.ts
@@ -28,7 +28,7 @@ import {
 import { slugField } from '@/fields/slug'
 import { getServerSideURL } from '@/utilities/getURL'
 
-export const Posts: CollectionConfig = {
+export const Posts: CollectionConfig<'posts'> = {
   slug: 'posts',
   access: {
     create: authenticated,
@@ -38,6 +38,7 @@ export const Posts: CollectionConfig = {
   },
   // This config controls what's populated by default when a post is referenced
   // https://payloadcms.com/docs/queries/select#defaultpopulate-collection-config-property
+  // Type safe if the collection slug generic is passed to `CollectionConfig` - `CollectionConfig<'posts'>
   defaultPopulate: {
     title: true,
     slug: true,

--- a/templates/website/src/components/Card/index.tsx
+++ b/templates/website/src/components/Card/index.tsx
@@ -8,10 +8,12 @@ import type { Post } from '@/payload-types'
 
 import { Media } from '@/components/Media'
 
+export type CardPostData = Pick<Post, 'slug' | 'categories' | 'meta' | 'title'>
+
 export const Card: React.FC<{
   alignItems?: 'center'
   className?: string
-  doc?: Post
+  doc?: CardPostData
   relationTo?: 'posts'
   showCategories?: boolean
   title?: string

--- a/templates/website/src/components/CollectionArchive/index.tsx
+++ b/templates/website/src/components/CollectionArchive/index.tsx
@@ -3,10 +3,10 @@ import React from 'react'
 
 import type { Post } from '@/payload-types'
 
-import { Card } from '@/components/Card'
+import { Card, CardPostData } from '@/components/Card'
 
 export type Props = {
-  posts: Post[]
+  posts: CardPostData[]
 }
 
 export const CollectionArchive: React.FC<Props> = (props) => {

--- a/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
@@ -21,6 +21,7 @@ export async function generateStaticParams() {
     draft: false,
     limit: 1000,
     overrideAccess: false,
+    pagination: false,
     select: {
       slug: true,
     },

--- a/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
@@ -47,7 +47,7 @@ export default async function Page({ params: paramsPromise }: Args) {
   const { slug = 'home' } = await paramsPromise
   const url = '/' + slug
 
-  let page: PageType | null
+  let page: Pick<PageType, 'slug' | 'layout' | 'hero'> | null
 
   page = await queryPageBySlug({
     slug,
@@ -94,7 +94,13 @@ const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
     collection: 'pages',
     draft,
     limit: 1,
+    pagination: false,
     overrideAccess: draft,
+    select: {
+      slug: true,
+      hero: true,
+      layout: true,
+    },
     where: {
       slug: {
         equals: slug,

--- a/templates/with-vercel-website/src/app/(frontend)/next/preview/route.ts
+++ b/templates/with-vercel-website/src/app/(frontend)/next/preview/route.ts
@@ -67,8 +67,12 @@ export async function GET(
     // Verify the given slug exists
     try {
       const docs = await payload.find({
-        collection: collection,
+        collection,
         draft: true,
+        limit: 1,
+        pagination: false,
+        depth: 0,
+        select: {},
         where: {
           slug: {
             equals: slug,

--- a/templates/with-vercel-website/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/posts/[slug]/page.tsx
@@ -20,6 +20,7 @@ export async function generateStaticParams() {
     collection: 'posts',
     draft: false,
     limit: 1000,
+    pagination: false,
     overrideAccess: false,
     select: {
       slug: true,
@@ -87,6 +88,7 @@ const queryPostBySlug = cache(async ({ slug }: { slug: string }) => {
     draft,
     limit: 1,
     overrideAccess: draft,
+    pagination: false,
     where: {
       slug: {
         equals: slug,

--- a/templates/with-vercel-website/src/app/(frontend)/posts/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/posts/page.tsx
@@ -19,6 +19,12 @@ export default async function Page() {
     depth: 1,
     limit: 12,
     overrideAccess: false,
+    select: {
+      title: true,
+      slug: true,
+      categories: true,
+      meta: true,
+    },
   })
 
   return (

--- a/templates/with-vercel-website/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
@@ -7,30 +7,24 @@ import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 import React from 'react'
 import PageClient from './page.client'
-import { notFound } from 'next/navigation'
 
+export const dynamic = 'force-static'
 export const revalidate = 600
 
-type Args = {
-  params: Promise<{
-    pageNumber: string
-  }>
-}
-
-export default async function Page({ params: paramsPromise }: Args) {
-  const { pageNumber } = await paramsPromise
+export default async function Page() {
   const payload = await getPayload({ config: configPromise })
-
-  const sanitizedPageNumber = Number(pageNumber)
-
-  if (!Number.isInteger(sanitizedPageNumber)) notFound()
 
   const posts = await payload.find({
     collection: 'posts',
     depth: 1,
     limit: 12,
-    page: sanitizedPageNumber,
     overrideAccess: false,
+    select: {
+      title: true,
+      slug: true,
+      categories: true,
+      meta: true,
+    },
   })
 
   return (
@@ -54,7 +48,7 @@ export default async function Page({ params: paramsPromise }: Args) {
       <CollectionArchive posts={posts.docs} />
 
       <div className="container">
-        {posts?.page && posts?.totalPages > 1 && (
+        {posts.totalPages > 1 && posts.page && (
           <Pagination page={posts.page} totalPages={posts.totalPages} />
         )}
       </div>
@@ -62,30 +56,8 @@ export default async function Page({ params: paramsPromise }: Args) {
   )
 }
 
-export async function generateMetadata({ params: paramsPromise }: Args): Promise<Metadata> {
-  const { pageNumber } = await paramsPromise
+export function generateMetadata(): Metadata {
   return {
-    title: `Payload Website Template Posts Page ${pageNumber || ''}`,
+    title: `Payload Website Template Posts`,
   }
-}
-
-export async function generateStaticParams() {
-  const payload = await getPayload({ config: configPromise })
-  const posts = await payload.find({
-    collection: 'posts',
-    depth: 0,
-    limit: 10,
-    draft: false,
-    overrideAccess: false,
-  })
-
-  const pages: { pageNumber: string }[] = []
-
-  if (posts.totalPages) {
-    for (let i = 1; i <= posts.totalPages; i++) {
-      pages.push({ pageNumber: String(i) })
-    }
-  }
-
-  return pages
 }

--- a/templates/with-vercel-website/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
@@ -7,24 +7,30 @@ import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 import React from 'react'
 import PageClient from './page.client'
+import { notFound } from 'next/navigation'
 
-export const dynamic = 'force-static'
 export const revalidate = 600
 
-export default async function Page() {
+type Args = {
+  params: Promise<{
+    pageNumber: string
+  }>
+}
+
+export default async function Page({ params: paramsPromise }: Args) {
+  const { pageNumber } = await paramsPromise
   const payload = await getPayload({ config: configPromise })
+
+  const sanitizedPageNumber = Number(pageNumber)
+
+  if (!Number.isInteger(sanitizedPageNumber)) notFound()
 
   const posts = await payload.find({
     collection: 'posts',
     depth: 1,
     limit: 12,
+    page: sanitizedPageNumber,
     overrideAccess: false,
-    select: {
-      title: true,
-      slug: true,
-      categories: true,
-      meta: true,
-    },
   })
 
   return (
@@ -48,7 +54,7 @@ export default async function Page() {
       <CollectionArchive posts={posts.docs} />
 
       <div className="container">
-        {posts.totalPages > 1 && posts.page && (
+        {posts?.page && posts?.totalPages > 1 && (
           <Pagination page={posts.page} totalPages={posts.totalPages} />
         )}
       </div>
@@ -56,8 +62,27 @@ export default async function Page() {
   )
 }
 
-export function generateMetadata(): Metadata {
+export async function generateMetadata({ params: paramsPromise }: Args): Promise<Metadata> {
+  const { pageNumber } = await paramsPromise
   return {
-    title: `Payload Website Template Posts`,
+    title: `Payload Website Template Posts Page ${pageNumber || ''}`,
   }
+}
+
+export async function generateStaticParams() {
+  const payload = await getPayload({ config: configPromise })
+  const { totalDocs } = await payload.count({
+    collection: 'posts',
+    overrideAccess: false,
+  })
+
+  const totalPages = Math.ceil(totalDocs / 10)
+
+  const pages: { pageNumber: string }[] = []
+
+  for (let i = 1; i <= totalPages; i++) {
+    pages.push({ pageNumber: String(i) })
+  }
+
+  return pages
 }

--- a/templates/with-vercel-website/src/app/(frontend)/search/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/search/page.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import { Post } from '@/payload-types'
 import { Search } from '@/search/Component'
 import PageClient from './page.client'
+import { CardPostData } from '@/components/Card'
 
 type Args = {
   searchParams: Promise<{
@@ -21,6 +22,14 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
     collection: 'search',
     depth: 1,
     limit: 12,
+    select: {
+      title: true,
+      slug: true,
+      categories: true,
+      meta: true,
+    },
+    // pagination: false reduces overhead if you don't need totalDocs
+    pagination: false,
     ...(query
       ? {
           where: {
@@ -62,7 +71,7 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
       </div>
 
       {posts.totalDocs > 0 ? (
-        <CollectionArchive posts={posts.docs as unknown as Post[]} />
+        <CollectionArchive posts={posts.docs as CardPostData[]} />
       ) : (
         <div className="container">No results found.</div>
       )}

--- a/templates/with-vercel-website/src/collections/Pages/index.ts
+++ b/templates/with-vercel-website/src/collections/Pages/index.ts
@@ -22,7 +22,7 @@ import {
 } from '@payloadcms/plugin-seo/fields'
 import { getServerSideURL } from '@/utilities/getURL'
 
-export const Pages: CollectionConfig = {
+export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
   access: {
     create: authenticated,
@@ -32,6 +32,7 @@ export const Pages: CollectionConfig = {
   },
   // This config controls what's populated by default when a page is referenced
   // https://payloadcms.com/docs/queries/select#defaultpopulate-collection-config-property
+  // Type safe if the collection slug generic is passed to `CollectionConfig` - `CollectionConfig<'pages'>
   defaultPopulate: {
     title: true,
     slug: true,

--- a/templates/with-vercel-website/src/collections/Posts/index.ts
+++ b/templates/with-vercel-website/src/collections/Posts/index.ts
@@ -28,7 +28,7 @@ import {
 import { slugField } from '@/fields/slug'
 import { getServerSideURL } from '@/utilities/getURL'
 
-export const Posts: CollectionConfig = {
+export const Posts: CollectionConfig<'posts'> = {
   slug: 'posts',
   access: {
     create: authenticated,
@@ -38,6 +38,7 @@ export const Posts: CollectionConfig = {
   },
   // This config controls what's populated by default when a post is referenced
   // https://payloadcms.com/docs/queries/select#defaultpopulate-collection-config-property
+  // Type safe if the collection slug generic is passed to `CollectionConfig` - `CollectionConfig<'posts'>
   defaultPopulate: {
     title: true,
     slug: true,

--- a/templates/with-vercel-website/src/components/Card/index.tsx
+++ b/templates/with-vercel-website/src/components/Card/index.tsx
@@ -8,10 +8,12 @@ import type { Post } from '@/payload-types'
 
 import { Media } from '@/components/Media'
 
+export type CardPostData = Pick<Post, 'slug' | 'categories' | 'meta' | 'title'>
+
 export const Card: React.FC<{
   alignItems?: 'center'
   className?: string
-  doc?: Post
+  doc?: CardPostData
   relationTo?: 'posts'
   showCategories?: boolean
   title?: string

--- a/templates/with-vercel-website/src/components/CollectionArchive/index.tsx
+++ b/templates/with-vercel-website/src/components/CollectionArchive/index.tsx
@@ -3,10 +3,10 @@ import React from 'react'
 
 import type { Post } from '@/payload-types'
 
-import { Card } from '@/components/Card'
+import { Card, CardPostData } from '@/components/Card'
 
 export type Props = {
-  posts: Post[]
+  posts: CardPostData[]
 }
 
 export const CollectionArchive: React.FC<Props> = (props) => {


### PR DESCRIPTION
- Uses `pagination: false` where we don't need `totalDocs`.
- in `preview/route.ts` uses `depth: 0`, select of only ID to improve performance
- in `search` uses `select` to select only needed properties
- adds type safety best practices to collection configs with `defaultPopulate`
- uses `payload.count` to resolve SSG `pageNumber`s