### PR TITLE
docs: spelling error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ We're constantly adding more templates to our [Templates Directory](https://gith
 - [Auth out of the box](https://payloadcms.com/docs/authentication/overview)
 - [Versions and drafts](https://payloadcms.com/docs/versions/overview)
 - [Localization](https://payloadcms.com/docs/configuration/localization)
-- [Block-based kayout builder](https://payloadcms.com/docs/fields/blocks)
+- [Block-based layout builder](https://payloadcms.com/docs/fields/blocks)
 - [Customizable React admin](https://payloadcms.com/docs/admin/overview)
 - [Lexical rich text editor](https://payloadcms.com/docs/fields/rich-text)
 - [Conditional field logic](https://payloadcms.com/docs/fields/overview#conditional-logic)

--- a/packages/payload/README.md
+++ b/packages/payload/README.md
@@ -69,7 +69,7 @@ We're constantly adding more templates to our [Templates Directory](https://gith
 - [Auth out of the box](https://payloadcms.com/docs/authentication/overview)
 - [Versions and drafts](https://payloadcms.com/docs/versions/overview)
 - [Localization](https://payloadcms.com/docs/configuration/localization)
-- [Block-based kayout builder](https://payloadcms.com/docs/fields/blocks)
+- [Block-based layout builder](https://payloadcms.com/docs/fields/blocks)
 - [Customizable React admin](https://payloadcms.com/docs/admin/overview)
 - [Lexical rich text editor](https://payloadcms.com/docs/fields/rich-text)
 - [Conditional field logic](https://payloadcms.com/docs/fields/overview#conditional-logic)


### PR DESCRIPTION
## Title

fix(docs): correct "kayout" typo to "layout" in README.md

### What?
- Corrected a typo in the `README.md` file where "kayout" was incorrectly written instead of "layout".

### Why?
- To improve the documentation's readability and professionalism.

### How?
- Located the typo in `README.md` and replaced "kayout" with "layout".

Fixes #9472

----


### Before
<img width="1148" alt="before" src="https://github.com/user-attachments/assets/232d0e01-ea06-4568-b283-afad09719f0c">

### After
<img width="1208" alt="after" src="https://github.com/user-attachments/assets/f96f3b6c-6ccc-4d2e-8de3-88b9057a6cab">



