### PR TITLE
docs: update the "More details" URLs in email.mdx

### DIFF
--- a/docs/authentication/email.mdx
+++ b/docs/authentication/email.mdx
@@ -34,8 +34,8 @@ The following options are available:
 
 | Option               | Description                                                                                                                                                                                                                         |
 |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **`generateEmailHTML`** | Allows for overriding the HTML within emails that are sent to users indicating how to validate their account. [More details](#generateEmailHTML). |
-| **`generateEmailSubject`** | Allows for overriding the subject of the email that is sent to users indicating how to validate their account. [More details](#generateEmailSubject). |
+| **`generateEmailHTML`** | Allows for overriding the HTML within emails that are sent to users indicating how to validate their account. [More details](#generateemailhtml). |
+| **`generateEmailSubject`** | Allows for overriding the subject of the email that is sent to users indicating how to validate their account. [More details](#generateemailsubject). |
 
 #### generateEmailHTML
 


### PR DESCRIPTION
Updates the "More details" link URLs in the generateEmailHTML and generateEmailSubject rows to link to the correct element.

The links current use camelcase but the corresponding element IDs are lowercase.

See this page: https://payloadcms.com/docs/authentication/email