### PR TITLE
feat: add `draft` argument to count operation

### DIFF
--- a/packages/next/src/routes/rest/collections/count.ts
+++ b/packages/next/src/routes/rest/collections/count.ts
@@ -6,12 +6,16 @@ import { countOperation } from 'payload'
 import type { CollectionRouteHandler } from '../types.js'
 
 export const count: CollectionRouteHandler = async ({ collection, req }) => {
-  const { where } = req.query as {
+  const { draft, locale, where } = req.query as {
+    draft?: string
+    locale?: string
     where?: Where
   }
 
   const result = await countOperation({
     collection,
+    draft: draft === 'true',
+    locale,
     req,
     where,
   })

--- a/packages/payload/src/collections/operations/countVersions.ts
+++ b/packages/payload/src/collections/operations/countVersions.ts
@@ -1,17 +1,19 @@
 import type { AccessResult } from '../../config/types.js'
+import type { CollectionSlug, TypedLocale } from '../../index.js'
 import type { PayloadRequest, Where } from '../../types/index.js'
 import type { Collection } from '../config/types.js'
 
 import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
-import { buildVersionCollectionFields, type CollectionSlug } from '../../index.js'
+import { buildVersionCollectionFields } from '../../index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { buildAfterOperation } from './utils.js'
 
 export type Arguments = {
   collection: Collection
   disableErrors?: boolean
+  locale?: TypedLocale
   overrideAccess?: boolean
   req?: PayloadRequest
   where?: Where
@@ -43,6 +45,7 @@ export const countVersionsOperation = async <TSlug extends CollectionSlug>(
     const {
       collection: { config: collectionConfig },
       disableErrors,
+      locale,
       overrideAccess,
       req: { payload },
       req,
@@ -85,6 +88,7 @@ export const countVersionsOperation = async <TSlug extends CollectionSlug>(
 
     result = await payload.db.countVersions({
       collection: collectionConfig.slug,
+      locale,
       req,
       where: fullWhere,
     })

--- a/packages/payload/src/collections/operations/local/count.ts
+++ b/packages/payload/src/collections/operations/local/count.ts
@@ -13,6 +13,7 @@ export type Options<TSlug extends CollectionSlug> = {
   context?: RequestContext
   depth?: number
   disableErrors?: boolean
+  draft?: boolean
   locale?: TypedLocale
   overrideAccess?: boolean
   req?: PayloadRequest
@@ -25,7 +26,7 @@ export default async function countLocal<TSlug extends CollectionSlug>(
   payload: Payload,
   options: Options<TSlug>,
 ): Promise<{ totalDocs: number }> {
-  const { collection: collectionSlug, disableErrors, overrideAccess = true, where } = options
+  const { collection: collectionSlug, disableErrors, draft, overrideAccess = true, where } = options
 
   const collection = payload.collections[collectionSlug]
 
@@ -38,6 +39,7 @@ export default async function countLocal<TSlug extends CollectionSlug>(
   return countOperation<TSlug>({
     collection,
     disableErrors,
+    draft,
     overrideAccess,
     req: await createLocalReq(options, payload),
     where,

--- a/packages/payload/src/globals/operations/countGlobalVersions.ts
+++ b/packages/payload/src/globals/operations/countGlobalVersions.ts
@@ -4,11 +4,8 @@ import type { PayloadRequest, Where } from '../../types/index.js'
 import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
-import {
-  buildVersionGlobalFields,
-  type GlobalSlug,
-  type SanitizedGlobalConfig,
-} from '../../index.js'
+import { buildVersionGlobalFields } from '../../index.js'
+import { type GlobalSlug, type SanitizedGlobalConfig, type TypedLocale } from '../../index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 
 export type Arguments = {

--- a/packages/payload/src/globals/operations/countGlobalVersions.ts
+++ b/packages/payload/src/globals/operations/countGlobalVersions.ts
@@ -14,6 +14,7 @@ import { killTransaction } from '../../utilities/killTransaction.js'
 export type Arguments = {
   disableErrors?: boolean
   global: SanitizedGlobalConfig
+  locale?: TypedLocale
   overrideAccess?: boolean
   req?: PayloadRequest
   where?: Where
@@ -26,6 +27,7 @@ export const countGlobalVersionsOperation = async <TSlug extends GlobalSlug>(
     const {
       disableErrors,
       global,
+      locale,
       overrideAccess,
       req: { payload },
       req,
@@ -63,6 +65,7 @@ export const countGlobalVersionsOperation = async <TSlug extends GlobalSlug>(
 
     const result = await payload.db.countGlobalVersions({
       global: global.slug,
+      locale,
       req,
       where: fullWhere,
     })

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -40,9 +40,9 @@ export interface Config {
   user: User & {
     collection: 'users';
   };
-  jobs?: {
+  jobs: {
     tasks: unknown;
-    workflows?: unknown;
+    workflows: unknown;
   };
 }
 export interface UserAuthOperations {

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -228,6 +228,17 @@ export default buildConfigWithDefaults({
       ],
     },
     {
+      slug: 'drafts',
+      access: openAccess,
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+        },
+      ],
+      versions: { drafts: true },
+    },
+    {
       slug: errorOnHookSlug,
       access: openAccess,
       fields: [

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -75,6 +75,18 @@ describe('collections-rest', () => {
       expect(result).toEqual({ totalDocs: 2 })
     })
 
+    it('should count drafts', async () => {
+      await payload.create({ collection: 'drafts', data: { name: 'a' }, draft: true })
+      await payload.create({ collection: 'drafts', data: { name: 'b' }, draft: true })
+      const response = await restClient.GET(`/drafts/count`, {
+        query: { where: { name: { equals: 'b' } }, draft: true },
+      })
+      const result = await response.json()
+
+      expect(response.status).toEqual(200)
+      expect(result).toEqual({ totalDocs: 1 })
+    })
+
     it('should find where id', async () => {
       const post1 = await createPost()
       await createPost()

--- a/test/collections-rest/payload-types.ts
+++ b/test/collections-rest/payload-types.ts
@@ -17,6 +17,7 @@ export interface Config {
     dummy: Dummy;
     'custom-id': CustomId;
     'custom-id-number': CustomIdNumber;
+    drafts: Draft;
     'error-on-hooks': ErrorOnHook;
     endpoints: Endpoint;
     users: User;
@@ -32,6 +33,7 @@ export interface Config {
     dummy: DummySelect<false> | DummySelect<true>;
     'custom-id': CustomIdSelect<false> | CustomIdSelect<true>;
     'custom-id-number': CustomIdNumberSelect<false> | CustomIdNumberSelect<true>;
+    drafts: DraftsSelect<false> | DraftsSelect<true>;
     'error-on-hooks': ErrorOnHooksSelect<false> | ErrorOnHooksSelect<true>;
     endpoints: EndpointsSelect<false> | EndpointsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
@@ -48,9 +50,9 @@ export interface Config {
   user: User & {
     collection: 'users';
   };
-  jobs?: {
+  jobs: {
     tasks: unknown;
-    workflows?: unknown;
+    workflows: unknown;
   };
 }
 export interface UserAuthOperations {
@@ -172,6 +174,16 @@ export interface CustomIdNumber {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "drafts".
+ */
+export interface Draft {
+  id: string;
+  name?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "error-on-hooks".
  */
 export interface ErrorOnHook {
@@ -238,6 +250,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'custom-id-number';
         value: number | CustomIdNumber;
+      } | null)
+    | ({
+        relationTo: 'drafts';
+        value: string | Draft;
       } | null)
     | ({
         relationTo: 'error-on-hooks';
@@ -367,6 +383,15 @@ export interface CustomIdSelect<T extends boolean = true> {
  */
 export interface CustomIdNumberSelect<T extends boolean = true> {
   id?: T;
+  name?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "drafts_select".
+ */
+export interface DraftsSelect<T extends boolean = true> {
   name?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/test/helpers/NextRESTClient.ts
+++ b/test/helpers/NextRESTClient.ts
@@ -18,6 +18,7 @@ type RequestOptions = {
   auth?: boolean
   query?: {
     depth?: number
+    draft?: boolean
     fallbackLocale?: string
     joins?: JoinQuery
     limit?: number


### PR DESCRIPTION
Allows to count drafts in count operation (both Local and REST) via `draft: true`.
Additionally, passes the `locale` argument to `db.count` / `db.countVersions` / `db.countGlobalVersions` as the database adapter may use it for querying.
