### PR TITLE
feat(richtext-lexical): export hasText helper

### DIFF
--- a/packages/richtext-lexical/src/exports/shared.ts
+++ b/packages/richtext-lexical/src/exports/shared.ts
@@ -7,3 +7,4 @@ export {
   objectToFrontmatter,
   propsToJSXString,
 } from '../utilities/jsx/jsx.js'
+export { hasText } from '../validate/hasText.js'

--- a/packages/richtext-lexical/src/validate/hasText.ts
+++ b/packages/richtext-lexical/src/validate/hasText.ts
@@ -1,0 +1,36 @@
+import type {
+  SerializedEditorState,
+  SerializedLexicalNode,
+  SerializedParagraphNode,
+  SerializedTextNode,
+} from 'lexical'
+
+export function hasText(
+  value: null | SerializedEditorState<SerializedLexicalNode> | undefined,
+): boolean {
+  const hasChildren = !!value?.root?.children?.length
+
+  let hasOnlyEmptyParagraph = false
+  if (value?.root?.children?.length === 1) {
+    if (value?.root?.children[0]?.type === 'paragraph') {
+      const paragraphNode = value?.root?.children[0] as SerializedParagraphNode
+
+      if (!paragraphNode?.children || paragraphNode?.children?.length === 0) {
+        hasOnlyEmptyParagraph = true
+      } else if (paragraphNode?.children?.length === 1) {
+        const paragraphNodeChild = paragraphNode?.children[0]
+        if (paragraphNodeChild.type === 'text') {
+          if (!(paragraphNodeChild as SerializedTextNode | undefined)?.['text']?.length) {
+            hasOnlyEmptyParagraph = true
+          }
+        }
+      }
+    }
+  }
+
+  if (!hasChildren || hasOnlyEmptyParagraph) {
+    return false
+  } else {
+    return true
+  }
+}

--- a/packages/richtext-lexical/src/validate/index.ts
+++ b/packages/richtext-lexical/src/validate/index.ts
@@ -1,44 +1,10 @@
-import type {
-  SerializedEditorState,
-  SerializedLexicalNode,
-  SerializedParagraphNode,
-  SerializedTextNode,
-} from 'lexical'
+import type { SerializedEditorState } from 'lexical'
 import type { RichTextField, Validate } from 'payload'
 
 import type { SanitizedServerEditorConfig } from '../lexical/config/types.js'
 
+import { hasText } from './hasText.js'
 import { validateNodes } from './validateNodes.js'
-
-export function hasText(
-  value: null | SerializedEditorState<SerializedLexicalNode> | undefined,
-): boolean {
-  const hasChildren = !!value?.root?.children?.length
-
-  let hasOnlyEmptyParagraph = false
-  if (value?.root?.children?.length === 1) {
-    if (value?.root?.children[0]?.type === 'paragraph') {
-      const paragraphNode = value?.root?.children[0] as SerializedParagraphNode
-
-      if (!paragraphNode?.children || paragraphNode?.children?.length === 0) {
-        hasOnlyEmptyParagraph = true
-      } else if (paragraphNode?.children?.length === 1) {
-        const paragraphNodeChild = paragraphNode?.children[0]
-        if (paragraphNodeChild.type === 'text') {
-          if (!(paragraphNodeChild as SerializedTextNode | undefined)?.['text']?.length) {
-            hasOnlyEmptyParagraph = true
-          }
-        }
-      }
-    }
-  }
-
-  if (!hasChildren || hasOnlyEmptyParagraph) {
-    return false
-  } else {
-    return true
-  }
-}
 
 export const richTextValidateHOC = ({
   editorConfig,

--- a/packages/richtext-lexical/src/validate/index.ts
+++ b/packages/richtext-lexical/src/validate/index.ts
@@ -34,9 +34,9 @@ export function hasText(
   }
 
   if (!hasChildren || hasOnlyEmptyParagraph) {
-    return true
-  } else {
     return false
+  } else {
+    return true
   }
 }
 


### PR DESCRIPTION
@AlessioGr 

### What?

Extracted `hasText` helper method in `richTextValidateHOC`

### Why?

The new exported `hasText` helper method can now also be used during front-end serialization - for example, to check whether a caption element should be rendered  when text is optional and therefore possibly empty (which would allow us to prevent rendering an empty caption element).
