### PR TITLE
chore(next): remove deep copying of `docPermissions` in the Version View

### DIFF
--- a/packages/next/src/views/Version/index.tsx
+++ b/packages/next/src/views/Version/index.tsx
@@ -8,7 +8,6 @@ import type {
 } from 'payload'
 
 import { notFound } from 'next/navigation.js'
-import { deepCopyObjectSimple } from 'payload'
 import React from 'react'
 
 import { getLatestVersion } from '../Versions/getLatestVersion.js'
@@ -140,14 +139,7 @@ export const VersionView: PayloadServerReactComponent<EditViewComponent> = async
   return (
     <DefaultVersionView
       doc={doc}
-      /**
-       * After bumping the Next.js canary to 104, and React to 19.0.0-rc-06d0b89e-20240801" we have to deepCopy the permissions object (https://github.com/payloadcms/payload/pull/7541).
-       * If both HydrateClientUser and RenderCustomComponent receive the same permissions object (same object reference), we get a
-       * "TypeError: Cannot read properties of undefined (reading '$$typeof')" error
-       *
-       * // TODO: Revisit this in the future and figure out why this is happening. Might be a React/Next.js bug. We don't know why it happens, and a future React/Next version might unbreak this (keep an eye on this and remove deepCopyObjectSimple if that's the case)
-       */
-      docPermissions={deepCopyObjectSimple(docPermissions)}
+      docPermissions={docPermissions}
       initialComparisonDoc={latestVersion}
       latestDraftVersion={latestDraftVersion?.id}
       latestPublishedVersion={latestPublishedVersion?.id}

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -60,9 +60,9 @@ export interface Config {
   user: User & {
     collection: 'users';
   };
-  jobs?: {
+  jobs: {
     tasks: unknown;
-    workflows?: unknown;
+    workflows: unknown;
   };
 }
 export interface UserAuthOperations {


### PR DESCRIPTION
Removes unnecessary `deepCopyObject(docPermissions)` in the Version View which slows down loading speed. 
The comment seems to be resolved, I'm not getting this error and here for example in the same case https://github.com/payloadcms/payload/blob/3c0e832a9af2e16179891a87706c65cc3f3cd42d/packages/next/src/views/Document/index.tsx#L327 we don't do deep copying.