### PR TITLE
chore: add better typeization for localized labels

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -2,6 +2,7 @@ import type {
   DefaultTranslationsObject,
   I18nClient,
   I18nOptions,
+  SupportedLanguages,
   TFunction,
 } from '@payloadcms/translations'
 import type { BusboyConfig } from 'busboy'
@@ -495,7 +496,7 @@ export type LocalizationConfig = Prettify<
 
 export type LabelFunction = ({ t }: { t: TFunction }) => string
 
-export type StaticLabel = Record<string, string> | string
+export type StaticLabel = Partial<Record<keyof SupportedLanguages, string>> | string
 
 export type SharpDependency = (
   input?:

--- a/packages/ui/src/elements/DeleteDocument/index.tsx
+++ b/packages/ui/src/elements/DeleteDocument/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientCollectionConfig, SanitizedCollectionConfig } from 'payload'
+import type { ClientCollectionConfig, CollectionConfig, SanitizedCollectionConfig } from 'payload'
 
 import { Modal, useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
@@ -30,7 +30,7 @@ export type Props = {
   readonly id?: string
   readonly onDelete?: DocumentDrawerContextType['onDelete']
   readonly redirectAfterDelete?: boolean
-  readonly singularLabel: SanitizedCollectionConfig['labels']['singular']
+  readonly singularLabel: CollectionConfig['labels']['singular']
   readonly title?: string
   readonly useAsTitle: SanitizedCollectionConfig['admin']['useAsTitle']
 }

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ClientCollectionConfig, SanitizedCollectionConfig } from 'payload'
+import type { ClientCollectionConfig, CollectionConfig } from 'payload'
 
 import { Modal, useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
@@ -28,7 +28,7 @@ export type Props = {
   readonly id: string
   readonly onDuplicate?: DocumentDrawerContextType['onDuplicate']
   readonly redirectAfterDuplicate?: boolean
-  readonly singularLabel: SanitizedCollectionConfig['labels']['singular']
+  readonly singularLabel: CollectionConfig['labels']['singular']
   readonly slug: string
 }
 

--- a/packages/ui/src/elements/WhereBuilder/types.ts
+++ b/packages/ui/src/elements/WhereBuilder/types.ts
@@ -1,7 +1,13 @@
-import type { ClientField, Operator, SanitizedCollectionConfig, Where } from 'payload'
+import type {
+  ClientField,
+  CollectionConfig,
+  Operator,
+  SanitizedCollectionConfig,
+  Where,
+} from 'payload'
 
 export type WhereBuilderProps = {
-  readonly collectionPluralLabel: SanitizedCollectionConfig['labels']['plural']
+  readonly collectionPluralLabel: CollectionConfig['labels']['plural']
   readonly collectionSlug: SanitizedCollectionConfig['slug']
   readonly fields?: ClientField[]
   readonly renderedFilters?: Map<string, React.ReactNode>

--- a/packages/ui/src/views/Edit/SetDocumentStepNav/index.tsx
+++ b/packages/ui/src/views/Edit/SetDocumentStepNav/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { SanitizedCollectionConfig, SanitizedGlobalConfig } from 'payload'
+import type { CollectionConfig, SanitizedCollectionConfig, SanitizedGlobalConfig } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
 import { useEffect } from 'react'
@@ -19,7 +19,7 @@ export const SetDocumentStepNav: React.FC<{
   globalLabel?: SanitizedGlobalConfig['label']
   globalSlug?: SanitizedGlobalConfig['slug']
   id?: number | string
-  pluralLabel?: SanitizedCollectionConfig['labels']['plural']
+  pluralLabel?: CollectionConfig['labels']['plural']
   useAsTitle?: SanitizedCollectionConfig['admin']['useAsTitle']
   view?: string
 }> = (props) => {


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

### What?

When adding localized variations for labels in payload, there is no type restrictions preventing you from misspelling a language code. 

Before:

![Screenshot_20241125_151000](https://github.com/user-attachments/assets/32924787-9cd9-4388-ba83-d8d61a7f5e61)


After:

![Screenshot_20241125_151159](https://github.com/user-attachments/assets/e2290397-9472-4aa3-a813-6b65064db169)
![Screenshot_20241125_151129](https://github.com/user-attachments/assets/8b925d4b-bcd1-4fec-86e0-fb3176a50706)

### How?

Used the `SupportedLanguages` type which is used  for i18n to infer all supported locale codes



