### PR TITLE
fix(richtext-lexical): prevent use of text formats whose features were not enabled

### DIFF
--- a/packages/richtext-lexical/src/features/format/bold/feature.client.tsx
+++ b/packages/richtext-lexical/src/features/format/bold/feature.client.tsx
@@ -40,6 +40,7 @@ export const BoldFeatureClient = createClientFeature(({ featureProviderMap }) =>
   }
 
   return {
+    enableFormats: ['bold'],
     markdownTransformers,
     toolbarFixed: {
       groups: toolbarGroups,

--- a/packages/richtext-lexical/src/features/format/inlineCode/feature.client.tsx
+++ b/packages/richtext-lexical/src/features/format/inlineCode/feature.client.tsx
@@ -30,6 +30,7 @@ const toolbarGroups: ToolbarGroup[] = [
 ]
 
 export const InlineCodeFeatureClient = createClientFeature({
+  enableFormats: ['code'],
   markdownTransformers: [INLINE_CODE],
   toolbarFixed: {
     groups: toolbarGroups,

--- a/packages/richtext-lexical/src/features/format/italic/feature.client.tsx
+++ b/packages/richtext-lexical/src/features/format/italic/feature.client.tsx
@@ -30,6 +30,7 @@ const toolbarGroups: ToolbarGroup[] = [
 ]
 
 export const ItalicFeatureClient = createClientFeature({
+  enableFormats: ['italic'],
   markdownTransformers: [ITALIC_STAR, ITALIC_UNDERSCORE],
   toolbarFixed: {
     groups: toolbarGroups,

--- a/packages/richtext-lexical/src/features/format/strikethrough/feature.client.tsx
+++ b/packages/richtext-lexical/src/features/format/strikethrough/feature.client.tsx
@@ -28,6 +28,7 @@ const toolbarGroups = [
 ]
 
 export const StrikethroughFeatureClient = createClientFeature({
+  enableFormats: ['strikethrough'],
   markdownTransformers: [STRIKETHROUGH],
   toolbarFixed: {
     groups: toolbarGroups,

--- a/packages/richtext-lexical/src/features/format/subscript/feature.client.tsx
+++ b/packages/richtext-lexical/src/features/format/subscript/feature.client.tsx
@@ -29,6 +29,7 @@ const toolbarGroups: ToolbarGroup[] = [
 ]
 
 export const SubscriptFeatureClient = createClientFeature({
+  enableFormats: ['subscript'],
   toolbarFixed: {
     groups: toolbarGroups,
   },

--- a/packages/richtext-lexical/src/features/format/superscript/feature.client.tsx
+++ b/packages/richtext-lexical/src/features/format/superscript/feature.client.tsx
@@ -29,6 +29,7 @@ const toolbarGroups: ToolbarGroup[] = [
 ]
 
 export const SuperscriptFeatureClient = createClientFeature({
+  enableFormats: ['superscript'],
   toolbarFixed: {
     groups: toolbarGroups,
   },

--- a/packages/richtext-lexical/src/features/format/underline/feature.client.tsx
+++ b/packages/richtext-lexical/src/features/format/underline/feature.client.tsx
@@ -29,6 +29,7 @@ const toolbarGroups: ToolbarGroup[] = [
 ]
 
 export const UnderlineFeatureClient = createClientFeature({
+  enableFormats: ['underline'],
   toolbarFixed: {
     groups: toolbarGroups,
   },

--- a/packages/richtext-lexical/src/features/typesClient.ts
+++ b/packages/richtext-lexical/src/features/typesClient.ts
@@ -1,4 +1,10 @@
-import type { Klass, LexicalEditor, LexicalNode, LexicalNodeReplacement } from 'lexical'
+import type {
+  Klass,
+  LexicalEditor,
+  LexicalNode,
+  LexicalNodeReplacement,
+  TextFormatType,
+} from 'lexical'
 import type { RichTextFieldClient } from 'payload'
 import type React from 'react'
 import type { JSX } from 'react'
@@ -95,6 +101,10 @@ export type SanitizedPlugin =
     }
 
 export type ClientFeature<ClientFeatureProps> = {
+  /**
+   * The text formats which are enabled by this feature.
+   */
+  enableFormats?: Array<Omit<TextFormatType, 'highlight'>>
   markdownTransformers?: (
     | ((props: {
         allNodes: Array<Klass<LexicalNode> | LexicalNodeReplacement>
@@ -204,7 +214,7 @@ export type ClientFeatureProviderMap = Map<string, FeatureProviderClient<any, an
 export type SanitizedClientFeatures = {
   /** The keys of all enabled features */
   enabledFeatures: string[]
-  enabledFormats: Array<'bold' | 'italic' | 'strikethrough' | 'underline'>
+  enabledFormats: Array<Omit<TextFormatType, 'highlight'>>
   markdownTransformers: Transformer[]
 
   /**

--- a/packages/richtext-lexical/src/features/typesClient.ts
+++ b/packages/richtext-lexical/src/features/typesClient.ts
@@ -204,6 +204,7 @@ export type ClientFeatureProviderMap = Map<string, FeatureProviderClient<any, an
 export type SanitizedClientFeatures = {
   /** The keys of all enabled features */
   enabledFeatures: string[]
+  enabledFormats: Array<'bold' | 'italic' | 'strikethrough' | 'underline'>
   markdownTransformers: Transformer[]
 
   /**

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -39,6 +39,7 @@ let checkedDependencies = false
 
 export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapterProvider {
   return async ({ config, isRoot, parentIsLocalized }) => {
+    // is this dependency check still necessary?
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.PAYLOAD_DISABLE_DEPENDENCY_CHECKER !== 'true' &&

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -39,7 +39,6 @@ let checkedDependencies = false
 
 export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapterProvider {
   return async ({ config, isRoot, parentIsLocalized }) => {
-    // is this dependency check still necessary?
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.PAYLOAD_DISABLE_DEPENDENCY_CHECKER !== 'true' &&

--- a/packages/richtext-lexical/src/lexical/LexicalEditor.tsx
+++ b/packages/richtext-lexical/src/lexical/LexicalEditor.tsx
@@ -18,6 +18,7 @@ import { AddBlockHandlePlugin } from './plugins/handles/AddBlockHandlePlugin/ind
 import { DraggableBlockPlugin } from './plugins/handles/DraggableBlockPlugin/index.js'
 import { MarkdownShortcutPlugin } from './plugins/MarkdownShortcut/index.js'
 import { SlashMenuPlugin } from './plugins/SlashMenu/index.js'
+import { TextPlugin } from './plugins/TextPlugin/index.js'
 import { LexicalContentEditable } from './ui/ContentEditable.js'
 
 export const LexicalEditor: React.FC<
@@ -121,6 +122,7 @@ export const LexicalEditor: React.FC<
           }
           ErrorBoundary={LexicalErrorBoundary}
         />
+        <TextPlugin features={editorConfig.features} />
         <OnChangePlugin
           // Selection changes can be ignored here, reducing the
           // frequency that the FieldComponent and Payload receive updates.

--- a/packages/richtext-lexical/src/lexical/config/client/sanitize.ts
+++ b/packages/richtext-lexical/src/lexical/config/client/sanitize.ts
@@ -40,6 +40,10 @@ export const sanitizeClientFeatures = (
       sanitized.providers = sanitized.providers.concat(feature.providers)
     }
 
+    if (feature.enableFormats?.length) {
+      sanitized.enabledFormats.push(...feature.enableFormats)
+    }
+
     if (feature.nodes?.length) {
       // Important: do not use concat
       for (const node of feature.nodes) {

--- a/packages/richtext-lexical/src/lexical/config/client/sanitize.ts
+++ b/packages/richtext-lexical/src/lexical/config/client/sanitize.ts
@@ -14,6 +14,7 @@ export const sanitizeClientFeatures = (
 ): SanitizedClientFeatures => {
   const sanitized: SanitizedClientFeatures = {
     enabledFeatures: [],
+    enabledFormats: [],
     markdownTransformers: [],
     nodes: [],
     plugins: [],

--- a/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
@@ -10,6 +10,9 @@ export function TextPlugin({ features }: { features: SanitizedClientFeatures }) 
 
   useEffect(() => {
     const disabledFormats = getDisabledFormats(features.enabledFormats as TextFormatType[])
+    if (disabledFormats.length === 0) {
+      return
+    }
     return editor.registerNodeTransform(TextNode, (textNode) => {
       disabledFormats.forEach((disabledFormat) => {
         if (textNode.hasFormat(disabledFormat)) {

--- a/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable no-console */
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { TextNode } from 'lexical'
+import { type SanitizedClientFeatures } from 'packages/richtext-lexical/src/features/typesClient.js'
+import { useEffect } from 'react'
+
+export function TextPlugin({ features }: { features: SanitizedClientFeatures }) {
+  const [editor] = useLexicalComposerContext()
+
+  useEffect(() => {
+    console.log('features', features)
+    return editor.registerNodeTransform(TextNode, (textNode) => {
+      console.log('textNode', textNode)
+    })
+  }, [editor, features])
+
+  return null
+}

--- a/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
@@ -1,6 +1,7 @@
-/* eslint-disable no-console */
+import type { TextFormatType } from 'lexical'
+
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
-import { TextNode } from 'lexical'
+import { TEXT_TYPE_TO_FORMAT, TextNode } from 'lexical'
 import { type SanitizedClientFeatures } from 'packages/richtext-lexical/src/features/typesClient.js'
 import { useEffect } from 'react'
 
@@ -8,11 +9,26 @@ export function TextPlugin({ features }: { features: SanitizedClientFeatures }) 
   const [editor] = useLexicalComposerContext()
 
   useEffect(() => {
-    console.log('features', features)
+    const disabledFormats = getDisabledFormats(features.enabledFormats as TextFormatType[])
     return editor.registerNodeTransform(TextNode, (textNode) => {
-      console.log('textNode', textNode)
+      disabledFormats.forEach((disabledFormat) => {
+        if (textNode.hasFormat(disabledFormat)) {
+          textNode.toggleFormat(disabledFormat)
+        }
+      })
     })
   }, [editor, features])
 
   return null
+}
+
+function getDisabledFormats(enabledFormats: TextFormatType[]): TextFormatType[] {
+  // not sure why Lexical added highlight as TextNode format.
+  // see https://github.com/facebook/lexical/pull/3583
+  // We are going to implement it in other way to support multiple colors
+  delete TEXT_TYPE_TO_FORMAT.highlight
+  const allFormats = Object.keys(TEXT_TYPE_TO_FORMAT) as TextFormatType[]
+  const enabledSet = new Set(enabledFormats)
+
+  return allFormats.filter((format) => !enabledSet.has(format))
 }

--- a/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import type { TextFormatType } from 'lexical'
 
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'

--- a/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
@@ -13,6 +13,11 @@ export function TextPlugin({ features }: { features: SanitizedClientFeatures }) 
     if (disabledFormats.length === 0) {
       return
     }
+    // Ideally override the TextNode with our own TextNode (changing its setFormat or toggleFormat methods),
+    // would be more performant. If we find a noticeable perf regression we can switch to that option.
+    // Overriding the FORMAT_TEXT_COMMAND and PASTE_COMMAND commands is not an option I considered because
+    // there might be other forms of mutation that we might not be considering. For example:
+    // browser extensions or Payload/Lexical plugins that have their own commands.
     return editor.registerNodeTransform(TextNode, (textNode) => {
       disabledFormats.forEach((disabledFormat) => {
         if (textNode.hasFormat(disabledFormat)) {


### PR DESCRIPTION
Fixes #8811

Before this PR, even if you did not include text formatting features (such as BoldFeature, ItalicFeature, etc), it was possible to apply that formatting by (a) pasting content from the clipboard and (b) using keyboard shortcuts.

This PR fixes that by requiring the formatting features to be registered so that they can be inserted in the editor.


