### PR TITLE
fix: run queues via the `/payload-jobs/run` endpoint without workflows

### DIFF
--- a/packages/payload/src/queues/restEndpointRun.ts
+++ b/packages/payload/src/queues/restEndpointRun.ts
@@ -1,13 +1,25 @@
-import type { Endpoint } from '../config/types.js'
+import type { Endpoint, SanitizedConfig } from '../config/types.js'
 
 import { runJobs, type RunJobsArgs } from './operations/runJobs/index.js'
 
+const configHasJobs = (config: SanitizedConfig): boolean => {
+  if (!config.jobs) {
+    return false
+  }
+
+  if (config.jobs.tasks.length > 0) {
+    return true
+  }
+  if (Array.isArray(config.jobs.workflows) && config.jobs.workflows.length > 0) {
+    return true
+  }
+
+  return false
+}
+
 export const runJobsEndpoint: Endpoint = {
   handler: async (req) => {
-    if (
-      !Array.isArray(req.payload.config.jobs.workflows) ||
-      !(req.payload.config.jobs?.workflows?.length > 0)
-    ) {
+    if (!configHasJobs(req.payload.config)) {
       return Response.json(
         {
           message: 'No jobs to run.',

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -378,6 +378,32 @@ describe('Queues', () => {
     expect(allSimples.docs[0].title).toBe('from single task')
   })
 
+  it('can queue and run via the endpoint single tasks without workflows', async () => {
+    const workflowsRef = payload.config.jobs.workflows
+    delete payload.config.jobs.workflows
+    await payload.jobs.queue({
+      task: 'CreateSimple',
+      input: {
+        message: 'from single task',
+      },
+    })
+
+    await restClient.GET('/payload-jobs/run', {
+      headers: {
+        Authorization: `JWT ${token}`,
+      },
+    })
+
+    const allSimples = await payload.find({
+      collection: 'simple',
+      limit: 100,
+    })
+
+    expect(allSimples.totalDocs).toBe(1)
+    expect(allSimples.docs[0].title).toBe('from single task')
+    payload.config.jobs.workflows = workflowsRef
+  })
+
   /*
   // Task rollbacks are not supported in the current version of Payload. This test will be re-enabled when task rollbacks are supported once we figure out the transaction issues
   it('transaction test against payload-jobs collection', async () => {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/discussions/9418 (the `/api/payload-jobs/run` endpoint) when the config doesn't have any `workflows` but only `tasks`