### PR TITLE
fix: improper spread of list preferences

### DIFF
--- a/packages/ui/src/utilities/buildTableState.ts
+++ b/packages/ui/src/utilities/buildTableState.ts
@@ -10,7 +10,7 @@ import type {
   SanitizedConfig,
 } from 'payload'
 
-import { dequal } from 'dequal' // TODO: Can we change this to dequal/lite ? If not, please add comment explaining why
+import { dequal } from 'dequal/lite'
 import { createClientConfig, formatErrors } from 'payload'
 
 import type { Column } from '../elements/Table/index.js'
@@ -196,10 +196,6 @@ export const buildTableState = async (
   let newPrefs = preferencesResult.value
 
   if (!preferencesResult.id || !dequal(columns, preferencesResult?.columns)) {
-    const mergedPrefs = {
-      ...(preferencesResult || {}),
-      columns,
-    }
     const preferencesArgs = {
       collection: 'payload-preferences',
       data: {
@@ -208,7 +204,10 @@ export const buildTableState = async (
           collection: user.collection,
           value: user.id,
         },
-        value: mergedPrefs,
+        value: {
+          ...(preferencesResult?.value || {}),
+          columns,
+        },
       },
       depth: 0,
       req,


### PR DESCRIPTION
List preferences were improperly saving their own records onto themselves when building table state through the server function. This was happening because the entire preference document was being spread onto the new preferences, as opposed to just the value itself:

```diff
const mergedPrefs = {
-  ...(preferencesResult || {}),
+  ...(preferencesResult?.value || {}),
   columns,
}
```

This PR also swaps `dequal` out for `dequal/lite`. 