### PR TITLE
fix: incorrect locale registration in datepicker

### DIFF
--- a/packages/ui/src/elements/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/elements/DatePicker/DatePicker.tsx
@@ -35,16 +35,10 @@ const DatePicker: React.FC<Props> = (props) => {
     value,
   } = props
 
+  const [datepickerLocale, setDatepickerLocale] = React.useState<string>(undefined)
+
   // Use the user's AdminUI language preference for the locale
   const { i18n } = useTranslation()
-
-  const datepickerLocale = getFormattedLocale(i18n.language)
-
-  try {
-    registerLocale(datepickerLocale, i18n.dateFNS)
-  } catch (e) {
-    console.warn(`Could not find DatePicker locale for ${i18n.language}`)
-  }
 
   let dateFormat = customDisplayFormat
 
@@ -98,6 +92,19 @@ const DatePicker: React.FC<Props> = (props) => {
   const classes = [baseClass, `${baseClass}__appearance--${pickerAppearance}`]
     .filter(Boolean)
     .join(' ')
+
+  React.useEffect(() => {
+    // register the locale for the datepicker
+    const localeToRegister = getFormattedLocale(i18n.language)
+    if (localeToRegister !== datepickerLocale) {
+      try {
+        registerLocale(localeToRegister, i18n.dateFNS)
+        setDatepickerLocale(localeToRegister)
+      } catch (e) {
+        console.warn(`Could not find DatePicker locale for ${i18n.language}`)
+      }
+    }
+  }, [datepickerLocale, i18n.dateFNS, i18n.language])
 
   return (
     <div className={classes}>

--- a/packages/ui/src/elements/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/elements/DatePicker/DatePicker.tsx
@@ -93,9 +93,13 @@ const DatePicker: React.FC<Props> = (props) => {
 
   React.useEffect(() => {
     if (i18n.dateFNS) {
-      const datepickerLocale = getFormattedLocale(i18n.language)
-      registerLocale(datepickerLocale, i18n.dateFNS)
-      setDefaultLocale(datepickerLocale)
+      try {
+        const datepickerLocale = getFormattedLocale(i18n.language)
+        registerLocale(datepickerLocale, i18n.dateFNS)
+        setDefaultLocale(datepickerLocale)
+      } catch (e) {
+        console.warn(`Could not find DatePicker locale for ${i18n.language}`)
+      }
     }
   }, [i18n.language, i18n.dateFNS])
 

--- a/packages/ui/src/elements/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/elements/DatePicker/DatePicker.tsx
@@ -2,7 +2,7 @@
 import type { ReactDatePickerProps } from 'react-datepicker'
 
 import React from 'react'
-import ReactDatePickerDefaultImport, { registerLocale } from 'react-datepicker'
+import ReactDatePickerDefaultImport, { registerLocale, setDefaultLocale } from 'react-datepicker'
 const ReactDatePicker = (ReactDatePickerDefaultImport.default ||
   ReactDatePickerDefaultImport) as unknown as typeof ReactDatePickerDefaultImport.default
 
@@ -34,8 +34,6 @@ const DatePicker: React.FC<Props> = (props) => {
     timeIntervals = 30,
     value,
   } = props
-
-  const [datepickerLocale, setDatepickerLocale] = React.useState<string>(undefined)
 
   // Use the user's AdminUI language preference for the locale
   const { i18n } = useTranslation()
@@ -94,17 +92,12 @@ const DatePicker: React.FC<Props> = (props) => {
     .join(' ')
 
   React.useEffect(() => {
-    // register the locale for the datepicker
-    const localeToRegister = getFormattedLocale(i18n.language)
-    if (localeToRegister !== datepickerLocale) {
-      try {
-        registerLocale(localeToRegister, i18n.dateFNS)
-        setDatepickerLocale(localeToRegister)
-      } catch (e) {
-        console.warn(`Could not find DatePicker locale for ${i18n.language}`)
-      }
+    if (i18n.dateFNS) {
+      const datepickerLocale = getFormattedLocale(i18n.language)
+      registerLocale(datepickerLocale, i18n.dateFNS)
+      setDefaultLocale(datepickerLocale)
     }
-  }, [datepickerLocale, i18n.dateFNS, i18n.language])
+  }, [i18n.language, i18n.dateFNS])
 
   return (
     <div className={classes}>
@@ -124,7 +117,6 @@ const DatePicker: React.FC<Props> = (props) => {
         <ReactDatePicker
           {...dateTimePickerProps}
           dropdownMode="select"
-          locale={datepickerLocale}
           showMonthDropdown
           showYearDropdown
         />

--- a/packages/ui/src/elements/DatePicker/index.scss
+++ b/packages/ui/src/elements/DatePicker/index.scss
@@ -39,7 +39,7 @@ $cal-icon-width: 18px;
     }
 
     .icon--calendar {
-      top: base(0.625);
+      top: base(0.5);
       right: base(0.75);
       width: $cal-icon-width;
       pointer-events: none;


### PR DESCRIPTION
### What?
This log was appearing when the DatePicker loaded without a registered locale:
```
A locale object was not found for the provided string ["enUS"].
```
Also fixes css misalignment of icons inside date picker field

### Why?
If i`18n.dateFNS` had not loaded, we were registering the locale with an undefined value.

### How?
Only register the locale for react-datepicker if i18n.dateFNS is present.