### PR TITLE
fix(ui): remove overflow hidden from app-header wrappers since it breaks any popout elements

### DIFF
--- a/packages/ui/src/elements/AppHeader/index.scss
+++ b/packages/ui/src/elements/AppHeader/index.scss
@@ -90,7 +90,6 @@
       display: flex;
       align-items: center;
       flex-grow: 1;
-      overflow: hidden;
       width: 100%;
     }
 
@@ -128,7 +127,6 @@
       gap: calc(var(--base) / 2);
       flex-shrink: 0;
       max-width: 600px;
-      overflow: auto;
       white-space: nowrap;
 
       &::-webkit-scrollbar {


### PR DESCRIPTION
Unblocks https://github.com/payloadcms/payload/pull/9391

It was previously impossible to create popout, dropdown or other menus from buttons added to the app-header component