### PR TITLE
chore(eslint): disable no-direct-set-state-in-use-effect

### DIFF
--- a/packages/eslint-config/configs/jest/index.mjs
+++ b/packages/eslint-config/configs/jest/index.mjs
@@ -4,7 +4,7 @@ import jestDom from 'eslint-plugin-jest-dom'
 import jest from 'eslint-plugin-jest'
 import { deepMerge } from '../../deepMerge.js'
 
-/** @type {import('eslint').Linter.FlatConfig} */
+/** @type {import('eslint').Linter.Config} */
 export const index = deepMerge(
   {
     rules: jestRules,

--- a/packages/eslint-config/configs/jest/rules/jest-dom.mjs
+++ b/packages/eslint-config/configs/jest/rules/jest-dom.mjs
@@ -1,4 +1,4 @@
-/** @type {import('eslint').Linter.FlatConfig} */
+/** @type {import('eslint').Linter.Config} */
 export const index = {
   'jest-dom/prefer-checked': 'error',
   'jest-dom/prefer-enabled-disabled': 'error',

--- a/packages/eslint-config/configs/jest/rules/jest.mjs
+++ b/packages/eslint-config/configs/jest/rules/jest.mjs
@@ -1,4 +1,4 @@
-/** @type {import('eslint').Linter.FlatConfig} */
+/** @type {import('eslint').Linter.Config} */
 export const index = {
   'jest/consistent-test-it': ['error', { fn: 'it' }],
   'jest/expect-expect': 'error',

--- a/packages/eslint-config/configs/react/index.mjs
+++ b/packages/eslint-config/configs/react/index.mjs
@@ -6,11 +6,14 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import globals from 'globals'
 import { deepMerge } from '../../deepMerge.js'
 
-/** @type {import('eslint').Linter.FlatConfig} */
+/** @type {import('eslint').Linter.Config} */
 export const index = deepMerge(
   react.configs['recommended-type-checked'],
   {
-    rules: reactHooks.configs.recommended.rules,
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      '@eslint-react/hooks-extra/no-direct-set-state-in-use-effect': 'off',
+    },
   },
   {
     rules: reactRules,

--- a/packages/eslint-config/configs/react/rules/react-a11y.mjs
+++ b/packages/eslint-config/configs/react/rules/react-a11y.mjs
@@ -1,6 +1,6 @@
 // Sourced from https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react-a11y.js
 
-/** @type {import('eslint').Linter.FlatConfig} */
+/** @type {import('eslint').Linter.Config} */
 export const index = {
   // Enforce that anchors have content
   // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md

--- a/packages/eslint-config/configs/react/rules/react.mjs
+++ b/packages/eslint-config/configs/react/rules/react.mjs
@@ -1,4 +1,4 @@
-/** @type {import('eslint').Linter.FlatConfig} */
+/** @type {import('eslint').Linter.Config} */
 export const index = {
   '@eslint-react/dom/no-dangerously-set-innerhtml': 'off',
   '@eslint-react/dom/no-dangerously-set-innerhtml-with-children': 'off',

--- a/packages/ui/src/elements/SearchFilter/index.tsx
+++ b/packages/ui/src/elements/SearchFilter/index.tsx
@@ -44,7 +44,6 @@ export const SearchFilter: React.FC<SearchFilterProps> = (props) => {
   useEffect(() => {
     if (initialParams?.search !== previousSearch.current) {
       shouldUpdateState.current = false
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setSearch(initialParams?.search as string)
       previousSearch.current = initialParams?.search as string
     }

--- a/packages/ui/src/elements/Thumbnail/index.tsx
+++ b/packages/ui/src/elements/Thumbnail/index.tsx
@@ -29,7 +29,6 @@ export const Thumbnail: React.FC<ThumbnailProps> = (props) => {
 
   React.useEffect(() => {
     if (!fileSrc) {
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setFileExists(false)
       return
     }
@@ -74,7 +73,6 @@ export function ThumbnailComponent(props: ThumbnailComponentProps) {
 
   React.useEffect(() => {
     if (!fileSrc) {
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setFileExists(false)
       return
     }

--- a/packages/ui/src/elements/WhereBuilder/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/index.tsx
@@ -30,7 +30,6 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
   const [reducedFields, setReducedColumns] = useState(() => reduceClientFields({ fields, i18n }))
 
   useEffect(() => {
-    // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
     setReducedColumns(reduceClientFields({ fields, i18n }))
   }, [fields, i18n])
 

--- a/packages/ui/src/providers/ListQuery/index.tsx
+++ b/packages/ui/src/providers/ListQuery/index.tsx
@@ -184,7 +184,6 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
         shouldUpdateQueryString = true
       }
 
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setCurrentQuery(currentQuery)
 
       if (shouldUpdateQueryString) {

--- a/packages/ui/src/providers/Selection/index.tsx
+++ b/packages/ui/src/providers/Selection/index.tsx
@@ -166,13 +166,10 @@ export const SelectionProvider: React.FC<Props> = ({ children, docs = [], totalD
     }
 
     if (all && selected.size === docs.length) {
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setSelectAll(SelectAllStatus.AllInPage)
     } else if (some) {
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setSelectAll(SelectAllStatus.Some)
     } else {
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setSelectAll(SelectAllStatus.None)
     }
   }, [selectAll, selected, totalDocs, docs])
@@ -190,7 +187,6 @@ export const SelectionProvider: React.FC<Props> = ({ children, docs = [], totalD
       }
     }
 
-    // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
     setCount(newCount)
   }, [selectAll, selected, totalDocs])
 


### PR DESCRIPTION
Disables [`@eslint-react/hooks-extra/no-direct-set-state-in-use-effect`](https://eslint-react.xyz/docs/rules/hooks-extra-no-direct-set-state-in-use-effect)