### PR TITLE
fix(ui): show outline on focus for sort column buttons

### DIFF
--- a/packages/ui/src/elements/SortColumn/index.scss
+++ b/packages/ui/src/elements/SortColumn/index.scss
@@ -37,7 +37,6 @@
       justify-content: center;
       background: transparent;
       border: none;
-      outline: none;
       cursor: pointer;
 
       &.sort-column--active {


### PR DESCRIPTION
Fixes #9611.

When using the keyboard, focus is invisible when the active element is a sort column button. This change ensures that focus remains visible when the active element is a sort column button.

![sort-column-buttons-1](https://github.com/user-attachments/assets/6a2fd6e1-23c0-4a18-beae-c206de56f22e)

![sort-column-buttons-2](https://github.com/user-attachments/assets/e9335d9f-6cdb-4b43-9cdc-bb3bea763b0f)
