### PR TITLE
fix(next): remove keyboard focus for closed nav items

### DIFF
--- a/packages/next/src/elements/Nav/NavWrapper/index.tsx
+++ b/packages/next/src/elements/Nav/NavWrapper/index.tsx
@@ -22,6 +22,7 @@ export const NavWrapper: React.FC<{
       ]
         .filter(Boolean)
         .join(' ')}
+      inert={!navOpen ? true : undefined}
     >
       <div className={`${baseClass}__scroll`} ref={navRef}>
         {children}

--- a/packages/next/src/elements/Nav/index.client.tsx
+++ b/packages/next/src/elements/Nav/index.client.tsx
@@ -4,7 +4,7 @@ import type { groupNavItems } from '@payloadcms/ui/shared'
 import type { NavPreferences } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
-import { NavGroup, useConfig, useNav, useTranslation } from '@payloadcms/ui'
+import { NavGroup, useConfig, useTranslation } from '@payloadcms/ui'
 import { EntityType, formatAdminURL } from '@payloadcms/ui/shared'
 import LinkWithDefault from 'next/link.js'
 import { usePathname } from 'next/navigation.js'
@@ -25,7 +25,6 @@ export const DefaultNavClient: React.FC<{
   } = useConfig()
 
   const { i18n } = useTranslation()
-  const { navOpen } = useNav()
 
   return (
     <Fragment>
@@ -62,7 +61,6 @@ export const DefaultNavClient: React.FC<{
                   id={id}
                   key={i}
                   prefetch={Link ? false : undefined}
-                  tabIndex={!navOpen ? -1 : undefined}
                 >
                   {activeCollection && <div className={`${baseClass}__link-indicator`} />}
                   <span className={`${baseClass}__link-label`}>{getTranslation(label, i18n)}</span>


### PR DESCRIPTION
Fixes: #9610.

### What?

Currently some links inside the main nav are still focusable with a keyboard when the main nav is closed.

### Why?

This leads to the active keyboard focus getting lost until it eventually finds its way to the hamburger menu button. It can also lead to links that are not currently visible being selected accidentally.

### How?

When the [inert attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) is set to `true`, we can prevent focus on any child elements automatically. We simply toggle the attribute on or off based on whether the nav is open or closed.

The inert attribute has [great compatibility](https://caniuse.com/mdn-html_global_attributes_inert) with modern browsers these days, making it a solid choice to resolve this issue.

### Recordings

#### Before

You can see down the bottom left of the screen that links available in the main nav are still focusable even when the main nav is closed.

https://github.com/user-attachments/assets/e16d5336-7d2b-42f1-886b-cfa3ed82dbb1

#### After

You can see that focus is immediately moved to the hamburger menu when the main nav is closed.

https://github.com/user-attachments/assets/8c81197a-53aa-4af1-8e5c-f6835ba955a5