### PR TITLE
chore(examples): multi-tenant compatible with postgres ID check

### DIFF
--- a/examples/multi-tenant/src/utilities/extractID.ts
+++ b/examples/multi-tenant/src/utilities/extractID.ts
@@ -1,0 +1,10 @@
+import { Config } from '@/payload-types'
+import type { CollectionSlug } from 'payload'
+
+export const extractID = <T extends Config['collections'][CollectionSlug]>(
+  objectOrID: T | T['id'],
+): T['id'] => {
+  if (objectOrID && typeof objectOrID === 'object') return objectOrID.id
+
+  return objectOrID
+}

--- a/examples/multi-tenant/src/utilities/getTenantAccessIDs.ts
+++ b/examples/multi-tenant/src/utilities/getTenantAccessIDs.ts
@@ -1,28 +1,29 @@
-import type { User } from '../payload-types'
+import type { Tenant, User } from '../payload-types'
+import { extractID } from './extractID'
 
-export const getTenantAccessIDs = (user: null | User): string[] => {
+export const getTenantAccessIDs = (user: null | User): Tenant['id'][] => {
   if (!user) {
     return []
   }
   return (
-    user?.tenants?.reduce((acc: string[], { tenant }) => {
+    user?.tenants?.reduce<Tenant['id'][]>((acc, { tenant }) => {
       if (tenant) {
-        acc.push(typeof tenant === 'string' ? tenant : tenant.id)
+        acc.push(extractID(tenant))
       }
       return acc
     }, []) || []
   )
 }
 
-export const getTenantAdminTenantAccessIDs = (user: null | User): string[] => {
+export const getTenantAdminTenantAccessIDs = (user: null | User): Tenant['id'][] => {
   if (!user) {
     return []
   }
 
   return (
-    user?.tenants?.reduce((acc: string[], { roles, tenant }) => {
+    user?.tenants?.reduce<Tenant['id'][]>((acc, { roles, tenant }) => {
       if (roles.includes('tenant-admin') && tenant) {
-        acc.push(typeof tenant === 'string' ? tenant : tenant.id)
+        acc.push(extractID(tenant))
       }
       return acc
     }, []) || []


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/9565 multi-tenant compatibility with Postgres (and custom IDs)

Adds a useful `extractID` utility:
```ts
import { Config } from '@/payload-types'
import type { CollectionSlug } from 'payload'

export const extractID = <T extends Config['collections'][CollectionSlug]>(
  objectOrID: T | T['id'],
): T['id'] => {
  if (objectOrID && typeof objectOrID === 'object') return objectOrID.id

  return objectOrID
}

```