### PR TITLE
feat: disableLocalStrategy with auth fields still enabled

### DIFF
--- a/packages/graphql/src/schema/initCollections.ts
+++ b/packages/graphql/src/schema/initCollections.ts
@@ -126,12 +126,20 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
 
     const mutationInputFields = [...fields]
 
-    if (collectionConfig.auth && !collectionConfig.auth.disableLocalStrategy) {
+    if (
+      collectionConfig.auth &&
+      (!collectionConfig.auth.disableLocalStrategy ||
+        (typeof collectionConfig.auth.disableLocalStrategy === 'object' &&
+          collectionConfig.auth.disableLocalStrategy.optionalPassword))
+    ) {
       mutationInputFields.push({
         name: 'password',
         type: 'text',
         label: 'Password',
-        required: true,
+        required: !(
+          typeof collectionConfig.auth.disableLocalStrategy === 'object' &&
+          collectionConfig.auth.disableLocalStrategy.optionalPassword
+        ),
       })
     }
 

--- a/packages/payload/src/auth/getAuthFields.ts
+++ b/packages/payload/src/auth/getAuthFields.ts
@@ -15,7 +15,11 @@ export const getBaseAuthFields = (authConfig: IncomingAuthType): Field[] => {
     authFields.push(...apiKeyFields)
   }
 
-  if (!authConfig.disableLocalStrategy) {
+  if (
+    !authConfig.disableLocalStrategy ||
+    (typeof authConfig.disableLocalStrategy === 'object' &&
+      authConfig.disableLocalStrategy.enableFields)
+  ) {
     const emailField = { ...emailFieldConfig }
     let usernameField: TextField | undefined
 

--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -11,6 +11,7 @@ import type { PayloadRequest, Where } from '../../types/index.js'
 
 import { buildAfterOperation } from '../../collections/operations/utils.js'
 import { APIError } from '../../errors/index.js'
+import { Forbidden } from '../../index.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
@@ -43,14 +44,17 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
       ? data.username.toLowerCase().trim()
       : null
 
+  let args = incomingArgs
+
+  if (incomingArgs.collection.config.auth.disableLocalStrategy) {
+    throw new Forbidden(incomingArgs.req.t)
+  }
   if (!sanitizedEmail && !sanitizedUsername) {
     throw new APIError(
       `Missing ${loginWithUsername ? 'username' : 'email'}.`,
       httpStatus.BAD_REQUEST,
     )
   }
-
-  let args = incomingArgs
 
   try {
     const shouldCommit = await initTransaction(args.req)
@@ -74,7 +78,6 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
 
     const {
       collection: { config: collectionConfig },
-      data,
       disableEmail,
       expiration,
       req: {

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -10,6 +10,7 @@ import type { User } from '../types.js'
 import { buildAfterOperation } from '../../collections/operations/utils.js'
 import { AuthenticationError, LockedAuth, ValidationError } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
+import { Forbidden } from '../../index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields.js'
 import { getFieldsToSign } from '../getFieldsToSign.js'
@@ -39,6 +40,10 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
   incomingArgs: Arguments<TSlug>,
 ): Promise<{ user: DataFromCollectionSlug<TSlug> } & Result> => {
   let args = incomingArgs
+
+  if (args.collection.config.auth.disableLocalStrategy) {
+    throw new Forbidden(args.req.t)
+  }
 
   try {
     // /////////////////////////////////////

--- a/packages/payload/src/auth/operations/registerFirstUser.ts
+++ b/packages/payload/src/auth/operations/registerFirstUser.ts
@@ -42,6 +42,10 @@ export const registerFirstUserOperation = async <TSlug extends CollectionSlug>(
     req: { payload },
   } = args
 
+  if (config.auth.disableLocalStrategy) {
+    throw new Forbidden(req.t)
+  }
+
   try {
     const shouldCommit = await initTransaction(req)
 

--- a/packages/payload/src/auth/operations/resetPassword.ts
+++ b/packages/payload/src/auth/operations/resetPassword.ts
@@ -3,7 +3,7 @@ import httpStatus from 'http-status'
 import type { Collection } from '../../collections/config/types.js'
 import type { PayloadRequest } from '../../types/index.js'
 
-import { APIError } from '../../errors/index.js'
+import { APIError, Forbidden } from '../../errors/index.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
@@ -29,13 +29,6 @@ export type Arguments = {
 }
 
 export const resetPasswordOperation = async (args: Arguments): Promise<Result> => {
-  if (
-    !Object.prototype.hasOwnProperty.call(args.data, 'token') ||
-    !Object.prototype.hasOwnProperty.call(args.data, 'password')
-  ) {
-    throw new APIError('Missing required data.', httpStatus.BAD_REQUEST)
-  }
-
   const {
     collection: { config: collectionConfig },
     data,
@@ -47,6 +40,17 @@ export const resetPasswordOperation = async (args: Arguments): Promise<Result> =
     },
     req,
   } = args
+
+  if (
+    !Object.prototype.hasOwnProperty.call(data, 'token') ||
+    !Object.prototype.hasOwnProperty.call(data, 'password')
+  ) {
+    throw new APIError('Missing required data.', httpStatus.BAD_REQUEST)
+  }
+
+  if (collectionConfig.auth.disableLocalStrategy) {
+    throw new Forbidden(req.t)
+  }
 
   try {
     const shouldCommit = await initTransaction(req)

--- a/packages/payload/src/auth/operations/unlock.ts
+++ b/packages/payload/src/auth/operations/unlock.ts
@@ -8,6 +8,7 @@ import type { CollectionSlug } from '../../index.js'
 import type { PayloadRequest, Where } from '../../types/index.js'
 
 import { APIError } from '../../errors/index.js'
+import { Forbidden } from '../../index.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
@@ -44,6 +45,9 @@ export const unlockOperation = async <TSlug extends CollectionSlug>(
       args.data.username.toLowerCase().trim()) ||
     null
 
+  if (collectionConfig.auth.disableLocalStrategy) {
+    throw new Forbidden(req.t)
+  }
   if (!sanitizedEmail && !sanitizedUsername) {
     throw new APIError(
       `Missing ${collectionConfig.auth.loginWithUsername ? 'username' : 'email'}.`,

--- a/packages/payload/src/auth/operations/verifyEmail.ts
+++ b/packages/payload/src/auth/operations/verifyEmail.ts
@@ -3,7 +3,7 @@ import httpStatus from 'http-status'
 import type { Collection } from '../../collections/config/types.js'
 import type { PayloadRequest } from '../../types/index.js'
 
-import { APIError } from '../../errors/index.js'
+import { APIError, Forbidden } from '../../errors/index.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
@@ -16,6 +16,10 @@ export type Args = {
 
 export const verifyEmailOperation = async (args: Args): Promise<boolean> => {
   const { collection, req, token } = args
+
+  if (collection.config.auth.disableLocalStrategy) {
+    throw new Forbidden(req.t)
+  }
   if (!Object.prototype.hasOwnProperty.call(args, 'token')) {
     throw new APIError('Missing required data.', httpStatus.BAD_REQUEST)
   }

--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -206,7 +206,16 @@ export interface IncomingAuthType {
   /**
    * Advanced - disable Payload's built-in local auth strategy. Only use this property if you have replaced Payload's auth mechanisms with your own.
    */
-  disableLocalStrategy?: true
+  disableLocalStrategy?:
+    | {
+        /**
+         * Include auth fields on the collection even though the local strategy is disabled.
+         * Useful when you do not want the database or types to vary depending on the auth configuration.
+         */
+        enableFields?: true
+        optionalPassword?: true
+      }
+    | true
   /**
    * Customize the way that the forgotPassword operation functions.
    * @link https://payloadcms.com/docs/authentication/email#forgot-password

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -617,7 +617,13 @@ export function entityToJSONSchema(
     })
   }
 
-  if ('auth' in entity && entity.auth && !entity.auth?.disableLocalStrategy) {
+  if (
+    'auth' in entity &&
+    entity.auth &&
+    (!entity.auth?.disableLocalStrategy ||
+      (typeof entity.auth?.disableLocalStrategy === 'object' &&
+        entity.auth.disableLocalStrategy.enableFields))
+  ) {
     entity.flattenedFields.push({
       name: 'password',
       type: 'text',

--- a/packages/ui/src/views/Edit/Auth/types.ts
+++ b/packages/ui/src/views/Edit/Auth/types.ts
@@ -3,7 +3,7 @@ import type { SanitizedCollectionConfig } from 'payload'
 export type Props = {
   className?: string
   collectionSlug: SanitizedCollectionConfig['slug']
-  disableLocalStrategy?: boolean
+  disableLocalStrategy?: SanitizedCollectionConfig['auth']['disableLocalStrategy']
   email: string
   loginWithUsername: SanitizedCollectionConfig['auth']['loginWithUsername']
   operation: 'create' | 'update'

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -6,7 +6,13 @@ import { v4 as uuid } from 'uuid'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
-import { apiKeysSlug, namedSaveToJWTValue, saveToJWTKey, slug } from './shared.js'
+import {
+  apiKeysSlug,
+  namedSaveToJWTValue,
+  partialDisableLocaleStrategiesSlug,
+  saveToJWTKey,
+  slug,
+} from './shared.js'
 
 export default buildConfigWithDefaults({
   admin: {
@@ -172,6 +178,25 @@ export default buildConfigWithDefaults({
           },
           label: 'Auth Debug',
         },
+      ],
+    },
+    {
+      slug: partialDisableLocaleStrategiesSlug,
+      auth: {
+        disableLocalStrategy: {
+          // optionalPassword: true,
+          enableFields: true,
+        },
+      },
+      fields: [
+        // with `enableFields: true`, the following DB columns will be created:
+        // email
+        // reset_password_token
+        // reset_password_expiration
+        // salt
+        // hash
+        // login_attempts
+        // lock_until
       ],
     },
     {

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -4,7 +4,6 @@ import type { SanitizedConfig } from 'payload'
 import { expect, test } from '@playwright/test'
 import { devUser } from 'credentials.js'
 import path from 'path'
-import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
 import { v4 as uuid } from 'uuid'
 

--- a/test/auth/payload-types.ts
+++ b/test/auth/payload-types.ts
@@ -9,11 +9,13 @@
 export interface Config {
   auth: {
     users: UserAuthOperations;
+    'partial-disable-locale-strategies': PartialDisableLocaleStrategyAuthOperations;
     'api-keys': ApiKeyAuthOperations;
     'public-users': PublicUserAuthOperations;
   };
   collections: {
     users: User;
+    'partial-disable-locale-strategies': PartialDisableLocaleStrategy;
     'api-keys': ApiKey;
     'public-users': PublicUser;
     relationsCollection: RelationsCollection;
@@ -24,6 +26,7 @@ export interface Config {
   collectionsJoins: {};
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
+    'partial-disable-locale-strategies': PartialDisableLocaleStrategiesSelect<false> | PartialDisableLocaleStrategiesSelect<true>;
     'api-keys': ApiKeysSelect<false> | ApiKeysSelect<true>;
     'public-users': PublicUsersSelect<false> | PublicUsersSelect<true>;
     relationsCollection: RelationsCollectionSelect<false> | RelationsCollectionSelect<true>;
@@ -32,7 +35,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   globals: {};
   globalsSelect: {};
@@ -40,6 +43,9 @@ export interface Config {
   user:
     | (User & {
         collection: 'users';
+      })
+    | (PartialDisableLocaleStrategy & {
+        collection: 'partial-disable-locale-strategies';
       })
     | (ApiKey & {
         collection: 'api-keys';
@@ -53,6 +59,24 @@ export interface Config {
   };
 }
 export interface UserAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
+export interface PartialDisableLocaleStrategyAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -111,7 +135,7 @@ export interface PublicUserAuthOperations {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   adminOnlyField?: string | null;
   roles: ('admin' | 'editor' | 'moderator' | 'user' | 'viewer')[];
   namedSaveToJWT?: string | null;
@@ -148,10 +172,27 @@ export interface User {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "partial-disable-locale-strategies".
+ */
+export interface PartialDisableLocaleStrategy {
+  id: number;
+  updatedAt: string;
+  createdAt: string;
+  email: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
+  password?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "api-keys".
  */
 export interface ApiKey {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   enableAPIKey?: boolean | null;
@@ -163,7 +204,7 @@ export interface ApiKey {
  * via the `definition` "public-users".
  */
 export interface PublicUser {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -182,8 +223,8 @@ export interface PublicUser {
  * via the `definition` "relationsCollection".
  */
 export interface RelationsCollection {
-  id: string;
-  rel?: (string | null) | User;
+  id: number;
+  rel?: (number | null) | User;
   text?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -193,37 +234,45 @@ export interface RelationsCollection {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
+      } | null)
+    | ({
+        relationTo: 'partial-disable-locale-strategies';
+        value: number | PartialDisableLocaleStrategy;
       } | null)
     | ({
         relationTo: 'api-keys';
-        value: string | ApiKey;
+        value: number | ApiKey;
       } | null)
     | ({
         relationTo: 'public-users';
-        value: string | PublicUser;
+        value: number | PublicUser;
       } | null)
     | ({
         relationTo: 'relationsCollection';
-        value: string | RelationsCollection;
+        value: number | RelationsCollection;
       } | null);
   globalSlug?: string | null;
   user:
     | {
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
+      }
+    | {
+        relationTo: 'partial-disable-locale-strategies';
+        value: number | PartialDisableLocaleStrategy;
       }
     | {
         relationTo: 'api-keys';
-        value: string | ApiKey;
+        value: number | ApiKey;
       }
     | {
         relationTo: 'public-users';
-        value: string | PublicUser;
+        value: number | PublicUser;
       };
   updatedAt: string;
   createdAt: string;
@@ -233,19 +282,23 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user:
     | {
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
+      }
+    | {
+        relationTo: 'partial-disable-locale-strategies';
+        value: number | PartialDisableLocaleStrategy;
       }
     | {
         relationTo: 'api-keys';
-        value: string | ApiKey;
+        value: number | ApiKey;
       }
     | {
         relationTo: 'public-users';
-        value: string | PublicUser;
+        value: number | PublicUser;
       };
   key?: string | null;
   value?:
@@ -265,7 +318,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -309,6 +362,21 @@ export interface UsersSelect<T extends boolean = true> {
   enableAPIKey?: T;
   apiKey?: T;
   apiKeyIndex?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "partial-disable-locale-strategies_select".
+ */
+export interface PartialDisableLocaleStrategiesSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
   email?: T;
   resetPasswordToken?: T;
   resetPasswordExpiration?: T;

--- a/test/auth/shared.ts
+++ b/test/auth/shared.ts
@@ -1,6 +1,8 @@
 export const slug = 'users'
 export const apiKeysSlug = 'api-keys'
 
+export const partialDisableLocaleStrategiesSlug = 'partial-disable-locale-strategies'
+
 export const namedSaveToJWTValue = 'namedSaveToJWT value'
 
 export const saveToJWTKey = 'x-custom-jwt-property-name'


### PR DESCRIPTION
Adds configuration options to `auth.disableLocalStrategy` to allow customization of how payload treats an auth enabled collection.

Two new properties have been added to `disableLocalStrategy`:

- `enableFields` Include auth fields on the collection even though the local strategy is disabled. Useful when you do not want the database or types to vary depending on the auth configuration used.
- `optionalPassword`: makes the password field not required