### PR TITLE
fix: do not send admin dependencies to client

### DIFF
--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -39,7 +39,6 @@ export type ServerOnlyRootAdminProperties = keyof Pick<SanitizedConfig['admin'],
 
 export type ClientConfig = {
   admin: {
-    dependencies?: Record<string, React.ReactNode>
     livePreview?: Omit<LivePreviewConfig, ServerOnlyLivePreviewProperties>
   } & Omit<SanitizedConfig['admin'], 'components' | 'dependencies' | 'livePreview'>
   collections: ClientCollectionConfig[]
@@ -93,7 +92,6 @@ export const createClientConfig = ({
           avatar: config.admin.avatar,
           custom: config.admin.custom,
           dateFormat: config.admin.dateFormat,
-          dependencies: config.admin.dependencies,
           disable: config.admin.disable,
           importMap: config.admin.importMap,
           meta: config.admin.meta,


### PR DESCRIPTION
We were sending unrendered `PayloadComponent`s to the client, which is a remnant of old betas where those were actually rendered.

There is no point sending them to the client as they are useless there and cannot be rendered without the server-only importMap. Additionally, this could have potentially caused server-only modules to be sent to the client (e.g. if serverProps was used), which would have lead to a webpack error.

The types were also incorrect, as admin.dependencies on the ClientConfig did not contain the React nodes.