### PR TITLE
docs: fix erroneous occurence of "RefreshRouteOnChange"

### DIFF
--- a/docs/live-preview/server.mdx
+++ b/docs/live-preview/server.mdx
@@ -16,7 +16,7 @@ Server-side Live Preview works by making a roundtrip to the server every time yo
   It is recommended that you enable [Autosave](../versions/autosave) alongside Live Preview to make the experience feel more responsive.
 </Banner>
 
-If your front-end application is built with [React](#react), you can use the `RefreshRouteOnChange` function that Payload provides. In the future, all other major frameworks like Vue and Svelte will be officially supported. If you are using any of these frameworks today, you can still integrate with Live Preview yourself using the underlying tooling that Payload provides. See [building your own router refresh component](#building-your-own-router-refresh-component) for more information.
+If your front-end application is built with [React](#react), you can use the `RefreshRouteOnSave` function that Payload provides. In the future, all other major frameworks like Vue and Svelte will be officially supported. If you are using any of these frameworks today, you can still integrate with Live Preview yourself using the underlying tooling that Payload provides. See [building your own router refresh component](#building-your-own-router-refresh-component) for more information.
 
 ## React
 


### PR DESCRIPTION
### What?

I assume the docs mean to say `RefreshRouteOnSave` (since that is actual functionality from Payload) instead of `RefreshRouteOnChange` since the latter is doesn't really exists anywhere in Payload or the world wide web (according to Google search).

### How?
Renamed `RefreshRouteOnChange` to `RefreshRouteOnSave`
