### PR TITLE
fix: revert the removal of the default importMap location

### DIFF
--- a/packages/payload/src/bin/generateImportMap/index.ts
+++ b/packages/payload/src/bin/generateImportMap/index.ts
@@ -214,9 +214,13 @@ export async function writeImportMap({
     importMapFolderPath = path.resolve(rootDir, `app/(payload)${config.routes.admin}/`)
   } else if (fs.existsSync(path.resolve(rootDir, `src/app/(payload)${config.routes.admin}/`))) {
     importMapFolderPath = path.resolve(rootDir, `src/app/(payload)${config.routes.admin}/`)
+  } else if (fs.existsSync(path.resolve(rootDir, 'app/(payload)/admin/'))) {
+    importMapFolderPath = path.resolve(rootDir, 'app/(payload)/admin/')
+  } else if (fs.existsSync(path.resolve(rootDir, 'src/app/(payload)/admin/'))) {
+    importMapFolderPath = path.resolve(rootDir, 'src/app/(payload)/admin/')
   } else {
     throw new Error(
-      `Could not find the payload admin directory. Looked in ${path.resolve(rootDir, `app/(payload)${config.routes.admin}/`)} and ${path.resolve(rootDir, `src/app/(payload)${config.routes.admin}/`)}`,
+      `Could not find the payload admin directory. Looked in ${path.resolve(rootDir, `app/(payload)${config.routes.admin}/`)}, ${path.resolve(rootDir, `src/app/(payload)${config.routes.admin}/`)}, ${path.resolve(rootDir, 'app/(payload)/admin/')} and ${path.resolve(rootDir, 'src/app/(payload)/admin/')}`,
     )
   }
 


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

 ## Description
 Fixes: [#7803](https://github.com/payloadcms/payload/issues/7803)
 
 * [x]  I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.
 
 ## Type of change
 * [ ]  Chore (non-breaking change which does not add functionality)
 * [x]  Bug fix (non-breaking change which fixes an issue)
 * [ ]  New feature (non-breaking change which adds functionality)
 * [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 * [ ]  Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)
 * [ ]  Change to the [examples](https://github.com/payloadcms/payload/tree/main/examples) directory (does not affect core functionality)
 * [ ]  This change requires a documentation update
 
 ## Checklist:
 * [ ]  I have added tests that prove my fix is effective or that my feature works
 * [ ]  Existing test suite passes locally with my changes
 * [ ]  I have made corresponding changes to the documentation
 
 
### What?

This is a revert of the removal of the default importMap location here: [8085](https://github.com/payloadcms/payload/pull/8085)

### Why?

When configuring a custom admin route, such as:

      routes: {
        admin: '/admin/490d6a65bf0f8309e5915779',
      },

you are not able to use dynamic routes like `app/(payload)/admin/[slug]/` and without a default path location
you are forced to hard code the route for the `generate:importmap` command to work. 
I believe leaving the default path, gives people more freedom of customizing the admin routes.

![image](https://github.com/user-attachments/assets/f0bf3601-a754-437b-86bc-601c77d2c903)


