### PR TITLE
docs: fix names in examples for formBuilder and nestedDocs plugins

### DIFF
--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -72,7 +72,7 @@ The `fields` property is an object of field types to allow your admin editors to
 
 ```ts
 // payload.config.ts
-formBuilder({
+formBuilderPlugin({
   // ...
   fields: {
     text: true,
@@ -95,7 +95,7 @@ The `redirectRelationships` property is an array of collection slugs that, when 
 
 ```ts
 // payload.config.ts
-formBuilder({
+formBuilderPlugin({
   // ...
   redirectRelationships: ['pages'],
 })
@@ -107,7 +107,7 @@ The `beforeEmail` property is a [beforeChange](https://payloadcms.com/docs/hooks
 
 ```ts
 // payload.config.ts
-formBuilder({
+formBuilderPlugin({
   // ...
   beforeEmail: (emailsToSend, beforeChangeParams) => {
     // modify the emails in any way before they are sent
@@ -142,7 +142,7 @@ Provide a fallback for the email address to send form submissions to. If the ema
 
 ```ts
 // payload.config.ts
-formBuilder({
+formBuilderPlugin({
   // ...
   defaultToEmail: 'test@example.com',
 })
@@ -160,7 +160,7 @@ Good to know: The form collection is publicly available to read by default. The 
 
 ```ts
 // payload.config.ts
-formBuilder({
+formBuilderPlugin({
   // ...
   formOverrides: {
     slug: 'contact-forms',
@@ -196,7 +196,7 @@ Override anything on the `form-submissions` collection by sending a [Payload Col
 
 ```ts
 // payload.config.ts
-formBuilder({
+formBuilderPlugin({
   // ...
   formSubmissionOverrides: {
     slug: 'leads',
@@ -228,7 +228,7 @@ Then in your plugin's config:
 
 ```ts
 // payload.config.ts
-formBuilder({
+formBuilderPlugin({
   // ...
   handlePayment: async ({ form, submissionData }) => {
     // first calculate the price
@@ -396,7 +396,7 @@ Then merging it into your own custom field:
 
 ```ts
 // payload.config.ts
-formBuilder({
+formBuilderPlugin({
   // ...
   fields: {
     text: {

--- a/docs/plugins/nested-docs.mdx
+++ b/docs/plugins/nested-docs.mdx
@@ -120,7 +120,7 @@ You can also pass a function to dynamically set the `label` of your breadcrumb.
 
 ```ts
 // payload.config.ts
-nestedDocs({
+nestedDocsPlugin({
   //...
   generateLabel: (_, doc) => doc.title, // NOTE: 'title' is a hypothetical field
 })
@@ -141,7 +141,7 @@ that point, like `/about-us/company/our-team`.
 
 ```ts
 // payload.config.ts
-nestedDocs({
+nestedDocsPlugin({
   //...
   generateURL: (docs) => docs.reduce((url, doc) => `${url}/${doc.slug}`, ''), // NOTE: 'slug' is a hypothetical field
 })


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
The examples in nestedDocs and formBuilder plugins were referencing the plugins incorrectly.

### Why?
To prevent confusion for readers.

### How?
Changes to `docs/plugins/form-builder.mdx` and `docs/plugins/nested-docs.mdx`.