### PR TITLE
fix(storage-s3): Do not generate file url when filename does not exist

### DIFF
--- a/packages/plugin-cloud-storage/src/adapters/s3/generateURL.ts
+++ b/packages/plugin-cloud-storage/src/adapters/s3/generateURL.ts
@@ -12,5 +12,8 @@ interface Args {
 export const getGenerateURL =
   ({ bucket, config: { endpoint } }: Args): GenerateURL =>
   ({ filename, prefix = '' }) => {
+    if (filename == null) {
+      return null
+    }
     return `${endpoint}/${bucket}/${path.posix.join(prefix, filename)}`
   }

--- a/packages/plugin-cloud-storage/src/types.ts
+++ b/packages/plugin-cloud-storage/src/types.ts
@@ -37,9 +37,9 @@ export type HandleDelete = (args: {
 export type GenerateURL = (args: {
   collection: CollectionConfig
   data: any
-  filename: string
+  filename?: string
   prefix?: string
-}) => Promise<string> | string
+}) => null | Promise<string> | string
 
 export type StaticHandler = (
   req: PayloadRequest,
@@ -66,10 +66,10 @@ export type Adapter = (args: { collection: CollectionConfig; prefix?: string }) 
 
 export type GenerateFileURL = (args: {
   collection: CollectionConfig
-  filename: string
+  filename?: string
   prefix?: string
   size?: ImageSize
-}) => Promise<string> | string
+}) => null | Promise<string> | string
 
 export interface CollectionOptions {
   adapter: Adapter | null

--- a/packages/storage-s3/src/generateURL.ts
+++ b/packages/storage-s3/src/generateURL.ts
@@ -11,6 +11,9 @@ interface Args {
 export const getGenerateURL =
   ({ bucket, config: { endpoint } }: Args): GenerateURL =>
   ({ filename, prefix = '' }) => {
+    if (filename == null) {
+      return null
+    }
     const stringifiedEndpoint = typeof endpoint === 'string' ? endpoint : endpoint?.toString()
     return `${stringifiedEndpoint}/${bucket}/${path.posix.join(prefix, filename)}`
   }

--- a/test/storage-s3/config.ts
+++ b/test/storage-s3/config.ts
@@ -40,6 +40,12 @@ export default buildConfigWithDefaults({
       collections: {
         [mediaSlug]: true,
         [mediaWithPrefixSlug]: {
+          generateFileURL: ({ filename }) => {
+            if (filename === null) {
+              return null
+            }
+            return `https://example.com/${prefix}/${filename}`
+          },
           prefix,
         },
       },

--- a/test/storage-s3/tsconfig.json
+++ b/test/storage-s3/tsconfig.json
@@ -1,3 +1,6 @@
 {
   "extends": "../tsconfig.json"
+  // "compilerOptions": {
+  //   "strictNullChecks": true
+  // }
 }


### PR DESCRIPTION
### What?
generateFileURL() can return null if the filename does not exist.

### Why?
By default, the image size will return NULL when the uploaded image is smaller than the defined image size. Use the withoutEnlargement prop to change this.
[Docs: image sizes defaults](https://payloadcms.com/docs/upload/overview#handling-image-enlargement)

The result is an image size object like this:
```ts
portrait: {
  width: null,
  height: null,
  mimeType: null,
  filesize: null,
  filename: null,
  url: 'https://bucket.example.com/media/null' 
},
```

### How?
Since the plugin-cloud-storage are closely related, I updated both generateURL() to return null if `filename === null`. Notice the type error is not easily seen without the tsconfig setting:
```ts
"compilerOptions": {
  "strictNullChecks": true
}
  ```
Fixes  [#9095](https://github.com/payloadcms/payload/issues/9095)