### PR TITLE
fix(ui): css is not defined error in production build

### DIFF
--- a/packages/ui/src/elements/AnimateHeight/index.tsx
+++ b/packages/ui/src/elements/AnimateHeight/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, { useEffect, useRef } from 'react'
 
 import { usePatchAnimateHeight } from './usePatchAnimateHeight.js'

--- a/packages/ui/src/elements/AnimateHeight/usePatchAnimateHeight.ts
+++ b/packages/ui/src/elements/AnimateHeight/usePatchAnimateHeight.ts
@@ -1,3 +1,4 @@
+'use client'
 import { useEffect, useMemo, useRef } from 'react'
 
 export const usePatchAnimateHeight = ({
@@ -10,7 +11,10 @@ export const usePatchAnimateHeight = ({
   open: boolean
 }): { browserSupportsKeywordAnimation: boolean } => {
   const browserSupportsKeywordAnimation = useMemo(
-    () => (CSS.supports ? Boolean(CSS.supports('interpolate-size', 'allow-keywords')) : false),
+    () =>
+      typeof CSS !== 'undefined' && CSS && CSS.supports
+        ? Boolean(CSS.supports('interpolate-size', 'allow-keywords'))
+        : false,
     [],
   )
 


### PR DESCRIPTION
Related: https://github.com/payloadcms/payload/pull/9456
Fixes https://github.com/payloadcms/payload/issues/9598

This ensures that the `CSS` property is accessed safely, preventing the "CSS is not defined" error