### PR TITLE
fix(richtext-lexical): add form id to drawSlug

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/componentInline/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/componentInline/index.tsx
@@ -97,7 +97,7 @@ export const InlineBlockComponent: React.FC<Props> = (props) => {
   )
 
   const drawerSlug = formatDrawerSlug({
-    slug: `lexical-inlineBlocks-create-` + uuidFromContext,
+    slug: `lexical-inlineBlocks-create-${uuidFromContext}-${formData.id}`,
     depth: editDepth,
   })
   const { toggleDrawer } = useLexicalDrawer(drawerSlug, true)


### PR DESCRIPTION
Fixes #9532 

The error occurs because the drawerSlug declaration in `blocks/client/component` contains `formData.id`, while `blocks/client/componentInline` does not. So I add `formData.id`.

### Before


https://github.com/user-attachments/assets/14247634-ab60-437f-8986-c76cafec5c09


### After

https://github.com/user-attachments/assets/b26bc1ca-b071-4bf5-a9f0-fda4e9282538


