### PR TITLE
fix(plugin-search): delete proper search document when `doc` has the same `value` but different `relationTo`

### DIFF
--- a/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
@@ -1,6 +1,7 @@
 import type { DeleteFromSearch } from '../../types.js'
 
 export const deleteFromSearch: DeleteFromSearch = async ({
+  collection,
   doc,
   pluginConfig,
   req: { payload },
@@ -13,8 +14,11 @@ export const deleteFromSearch: DeleteFromSearch = async ({
       depth: 0,
       req,
       where: {
-        'doc.value': {
-          equals: doc.id,
+        doc: {
+          equals: {
+            relationTo: collection.slug,
+            value: doc.id,
+          },
         },
       },
     })

--- a/packages/plugin-search/src/types.ts
+++ b/packages/plugin-search/src/types.ts
@@ -72,5 +72,5 @@ export type SyncWithSearch = (Args: SyncWithSearchArgs) => ReturnType<Collection
 export type DeleteFromSearch = (
   Args: {
     pluginConfig: SearchPluginConfig
-  } & Omit<Parameters<CollectionAfterDeleteHook>[0], 'collection'>,
+  } & Parameters<CollectionAfterDeleteHook>[0],
 ) => ReturnType<CollectionAfterDeleteHook>

--- a/test/plugin-search/config.ts
+++ b/test/plugin-search/config.ts
@@ -13,7 +13,19 @@ import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
 
 export default buildConfigWithDefaults({
-  collections: [Users, Pages, Posts],
+  collections: [
+    Users,
+    Pages,
+    Posts,
+    {
+      slug: 'custom-ids-1',
+      fields: [{ type: 'text', name: 'id' }],
+    },
+    {
+      slug: 'custom-ids-2',
+      fields: [{ type: 'text', name: 'id' }],
+    },
+  ],
   localization: {
     defaultLocale: 'en',
     fallback: true,
@@ -44,7 +56,7 @@ export default buildConfigWithDefaults({
           slug: originalDoc.slug,
         }
       },
-      collections: ['pages', 'posts'],
+      collections: ['pages', 'posts', 'custom-ids-1', 'custom-ids-2'],
       defaultPriorities: {
         pages: 10,
         posts: ({ title }) => (title === 'Hello, world!' ? 30 : 20),

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -237,6 +237,46 @@ describe('@payloadcms/plugin-search', () => {
     expect(deletedResults).toHaveLength(0)
   })
 
+  it('should clear the proper search document when having the same doc.value but different doc.relationTo', async () => {
+    const custom_id_1 = await payload.create({
+      collection: 'custom-ids-1',
+      data: { id: 'custom_id' },
+    })
+
+    await payload.create({
+      collection: 'custom-ids-2',
+      data: { id: 'custom_id' },
+    })
+
+    await wait(200)
+
+    const {
+      docs: [docBefore],
+    } = await payload.find({
+      collection: 'search',
+      where: { 'doc.value': { equals: 'custom_id' } },
+      limit: 1,
+      sort: 'createdAt',
+    })
+
+    expect(docBefore.doc.relationTo).toBe('custom-ids-1')
+
+    await payload.delete({ collection: 'custom-ids-1', id: custom_id_1.id })
+
+    await wait(200)
+
+    const {
+      docs: [docAfter],
+    } = await payload.find({
+      collection: 'search',
+      where: { 'doc.value': { equals: 'custom_id' } },
+      limit: 1,
+      sort: 'createdAt',
+    })
+
+    expect(docAfter.doc.relationTo).toBe('custom-ids-2')
+  })
+
   it('should sync localized data', async () => {
     const createdDoc = await payload.create({
       collection: 'posts',

--- a/test/plugin-search/payload-types.ts
+++ b/test/plugin-search/payload-types.ts
@@ -14,6 +14,8 @@ export interface Config {
     users: User;
     pages: Page;
     posts: Post;
+    'custom-ids-1': CustomIds1;
+    'custom-ids-2': CustomIds2;
     search: Search;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -24,6 +26,8 @@ export interface Config {
     users: UsersSelect<false> | UsersSelect<true>;
     pages: PagesSelect<false> | PagesSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
+    'custom-ids-1': CustomIds1Select<false> | CustomIds1Select<true>;
+    'custom-ids-2': CustomIds2Select<false> | CustomIds2Select<true>;
     search: SearchSelect<false> | SearchSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -105,6 +109,24 @@ export interface Post {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "custom-ids-1".
+ */
+export interface CustomIds1 {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "custom-ids-2".
+ */
+export interface CustomIds2 {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "search".
  */
 export interface Search {
@@ -118,6 +140,14 @@ export interface Search {
     | {
         relationTo: 'posts';
         value: string | Post;
+      }
+    | {
+        relationTo: 'custom-ids-1';
+        value: string | CustomIds1;
+      }
+    | {
+        relationTo: 'custom-ids-2';
+        value: string | CustomIds2;
       };
   id: string;
   excerpt?: string | null;
@@ -143,6 +173,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'posts';
         value: string | Post;
+      } | null)
+    | ({
+        relationTo: 'custom-ids-1';
+        value: string | CustomIds1;
+      } | null)
+    | ({
+        relationTo: 'custom-ids-2';
+        value: string | CustomIds2;
       } | null)
     | ({
         relationTo: 'search';
@@ -227,6 +265,24 @@ export interface PostsSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "custom-ids-1_select".
+ */
+export interface CustomIds1Select<T extends boolean = true> {
+  id?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "custom-ids-2_select".
+ */
+export interface CustomIds2Select<T extends boolean = true> {
+  id?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/9612

Previously, the plugin search with  different collections but the same IDs could delete a wrong search document on synchronization, because we queried the search document only by `doc.value`. Instead, we should also query by `doc.relationTo`.