### PR TITLE
docs: adds missing comma to example config in localization.mdx 

### DIFF
--- a/docs/configuration/localization.mdx
+++ b/docs/configuration/localization.mdx
@@ -35,7 +35,7 @@ import { buildConfig } from 'payload'
 export default buildConfig({
   // ...
   localization: {
-    locales: ['en', 'es', 'de'] // required
+    locales: ['en', 'es', 'de'], // required
     defaultLocale: 'en', // required
   },
 })


### PR DESCRIPTION
### What?

Just a missing comma on config

### Why?

I spend 5 seconds when I copied these lines to find out why I had an error :D

### How?

Typed a comma!!

Fixes #

https://payloadcms.com/docs/configuration/localization

