### PR TITLE
docs: fix links to `/access-control/overview`

### DIFF
--- a/docs/access-control/collections.mdx
+++ b/docs/access-control/collections.mdx
@@ -6,7 +6,7 @@ desc: With Collection-level Access Control you can define which users can create
 keywords: collections, access control, permissions, documentation, Content Management System, cms, headless, javascript, node, react, nextjs
 ---
 
-Collection Access Control is [Access Control](../access-control) used to restrict access to Documents within a [Collection](../collections/overview), as well as what they can and cannot see within the [Admin Panel](../admin/overview) as it relates to that Collection.
+Collection Access Control is [Access Control](../overview) used to restrict access to Documents within a [Collection](../collections/overview), as well as what they can and cannot see within the [Admin Panel](../admin/overview) as it relates to that Collection.
 
 To add Access Control to a Collection, use the `access` property in your [Collection Config](../configuration/collections):
 

--- a/docs/access-control/fields.mdx
+++ b/docs/access-control/fields.mdx
@@ -6,7 +6,7 @@ desc: Field-level Access Control is specified within a field's config, and allow
 keywords: fields, access control, permissions, documentation, Content Management System, cms, headless, javascript, node, react, nextjs
 ---
 
-Field Access Control is [Access Control](../access-control) used to restrict access to specific [Fields](../fields/overview) within a Document.
+Field Access Control is [Access Control](../overview) used to restrict access to specific [Fields](../fields/overview) within a Document.
 
 To add Access Control to a Field, use the `access` property in your [Field Config](../fields/overview):
 

--- a/docs/access-control/globals.mdx
+++ b/docs/access-control/globals.mdx
@@ -6,7 +6,7 @@ desc: Global-level Access Control is specified within each Global's `access` pro
 keywords: globals, access control, permissions, documentation, Content Management System, cms, headless, javascript, node, react, nextjs
 ---
 
-Global Access Control is [Access Control](../access-control) used to restrict access to [Global](../globals/overview) Documents, as well as what they can and cannot see within the [Admin Panel](../admin/overview) as it relates to that Global.
+Global Access Control is [Access Control](../overview) used to restrict access to [Global](../globals/overview) Documents, as well as what they can and cannot see within the [Admin Panel](../admin/overview) as it relates to that Global.
 
 To add Access Control to a Global, use the `access` property in your [Global Config](../configuration/globals):
 


### PR DESCRIPTION
Fixes links to **Access Control**  like here https://payloadcms.com/docs/access-control/fields