### PR TITLE
fix(translations): changes rs and rs-Latin dateFNSkey to proper locale instead of en-US

### DIFF
--- a/packages/translations/src/importDateFNSLocale.ts
+++ b/packages/translations/src/importDateFNSLocale.ts
@@ -88,6 +88,14 @@ export const importDateFNSLocale = async (locale: string): Promise<Locale> => {
       result = (await import('date-fns/locale/ro')).ro
 
       break
+    case 'rs':
+      result = (await import('date-fns/locale/sr')).sr
+
+      break
+    case 'rs-Latin':
+      result = (await import('date-fns/locale/sr-Latn')).srLatn
+
+      break
     case 'ru':
       result = (await import('date-fns/locale/ru')).ru
 

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -478,6 +478,6 @@ export const rsTranslations: DefaultTranslationsObject = {
 }
 
 export const rs: Language = {
-  dateFNSKey: 'en-US',
+  dateFNSKey: 'rs',
   translations: rsTranslations,
 }

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -479,6 +479,6 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
 }
 
 export const rsLatin: Language = {
-  dateFNSKey: 'en-US',
+  dateFNSKey: 'rs-Latin',
   translations: rsLatinTranslations,
 }

--- a/packages/translations/src/types.ts
+++ b/packages/translations/src/types.ts
@@ -26,6 +26,8 @@ type DateFNSKeys =
   | 'pl'
   | 'pt'
   | 'ro'
+  | 'rs'
+  | 'rs-Latin'
   | 'ru'
   | 'sk'
   | 'sl-SI'


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
Adds Serbian `rs` and `rs-Latin` to `importDateFNSLocale` as well as changes their `dateFNSKey` in the language definition to the appropriate key instead of `en-US`

### Why?
To support Serbian language with appropriately localized dates.

### How?
Minor changes in translations package.