### PR TITLE
docs: add payload.auth to local api

### DIFF
--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -304,6 +304,27 @@ const result = await payload.delete({
 If a collection has [`Authentication`](/docs/authentication/overview) enabled, additional Local API operations will be
 available:
 
+### Auth
+
+```js
+// If you're using nextjs, you'll have to import headers from next/headers, like so:
+// import { headers as nextHeaders } from 'next/headers'
+
+// you'll also have to await headers inside your function, or component, like so:
+// const headers = await nextHeaders()
+
+// If you're using payload outside of NextJS, you'll have to provide headers accordingly.
+
+// result will be formatted as follows:
+// {
+//    permissions: {...}, // object containing current user's permissions
+//    user: {...}, // currently logged in user's document
+//    responseHeaders: {} // returned headers from the response
+// }
+
+const result = await payload.auth({headers})
+```
+
 ### Login
 
 ```js

--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -317,9 +317,9 @@ available:
 
 // result will be formatted as follows:
 // {
-//    permissions: {...}, // object containing current user's permissions
-//    user: {...}, // currently logged in user's document
-//    responseHeaders: {} // returned headers from the response
+//    permissions: { ... }, // object containing current user's permissions
+//    user: { ... }, // currently logged in user's document
+//    responseHeaders: { ... } // returned headers from the response
 // }
 
 const result = await payload.auth({headers})


### PR DESCRIPTION
### What?
https://payloadcms.com/docs does not document the `payload.auth` feature.

### Why?
With custom components, there is no explanation as to how you can get the current user on the server side. It is also something useful to know  for many other scenarios. A Discord user even mentioned today, that they spent quite some time, trying to figure out how to get the current user, while on the server.

While I don't think it's the cleanest "place" to document it, I think its what makes the most sense, given the current state of the documentation. I tried to follow the existing format as close as possible. The comments are longer, but I feel the information is absolutely necessary to provide.

Confirmed that formatting works as expected and there are no errors parsing the addition:
![image](https://github.com/user-attachments/assets/c8e203cd-3c9c-482c-850b-2a16f3958344)


Fixes #9631 
