### PR TITLE
chore(templates): fixed hero on vercel template

### DIFF
--- a/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
@@ -21,7 +21,6 @@ export async function generateStaticParams() {
     draft: false,
     limit: 1000,
     overrideAccess: false,
-    pagination: false,
     select: {
       slug: true,
     },
@@ -48,7 +47,7 @@ export default async function Page({ params: paramsPromise }: Args) {
   const { slug = 'home' } = await paramsPromise
   const url = '/' + slug
 
-  let page: Pick<PageType, 'slug' | 'layout' | 'hero'> | null
+  let page: PageType | null
 
   page = await queryPageBySlug({
     slug,
@@ -97,11 +96,6 @@ const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
     limit: 1,
     pagination: false,
     overrideAccess: draft,
-    select: {
-      slug: true,
-      hero: true,
-      layout: true,
-    },
     where: {
       slug: {
         equals: slug,


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
The homepage did not take any hero changes into account because it was stuck in homeStatic.

### Why?
It has something to do with how the querying of the pages is handled.

### How?
The homepage hero section stayed on lowImpact mode even though it had been changed in the admin UI. I think this originated from the homeStatic page type that is used before the seeding of the db.

Fixes #
Removed the select param from the query and initialised the page variable as PageType without the Pick<>.

-->
