### PR TITLE
fix: ensure job errors are saved in payload

### DIFF
--- a/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
@@ -79,9 +79,17 @@ export async function handleTaskFailed({
   if (!job.log) {
     job.log = []
   }
+  const errorJSON = error
+    ? {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      }
+    : runnerOutput.state
+
   job.log.push({
     completedAt: new Date().toISOString(),
-    error: error ?? runnerOutput.state,
+    error: errorJSON,
     executedAt: executedAt.toISOString(),
     input,
     output,

--- a/packages/payload/src/queues/operations/runJobs/runJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/index.ts
@@ -56,10 +56,17 @@ export const runJob = async ({
       workflowConfig,
     })
 
+    const errorJSON = hasFinalError
+      ? {
+          name: err.name,
+          message: err.message,
+          stack: err.stack,
+        }
+      : undefined
     // Tasks update the job if they error - but in case there is an unhandled error (e.g. in the workflow itself, not in a task)
     // we need to ensure the job is updated to reflect the error
     await updateJob({
-      error: hasFinalError ? err : undefined,
+      error: errorJSON,
       hasError: hasFinalError, // If reached max retries => final error. If hasError is true this job will not be retried
       processing: false,
       totalTried: (job.totalTried ?? 0) + 1,


### PR DESCRIPTION
Previously, job errors were not saved in payload