### PR TITLE
fix: prevent workflow destructuring errors for failing tasks

### DIFF
--- a/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
@@ -231,7 +231,7 @@ export const getRunTaskFunction = <TIsInline extends boolean>(
         return
       }
 
-      let output: object
+      let output: object = {}
 
       try {
         const runnerOutput = await runner({


### PR DESCRIPTION
When destructuring the output of task in a job workflow handler, there is a chance of a destructuring error being thrown if the task fails