### PR TITLE
fix: job task output data was not fetched and restored, if task failed previously

### DIFF
--- a/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
@@ -70,7 +70,7 @@ export async function handleTaskFailed({
   taskStatus: null | SingleTaskStatus<string>
   updateJob: UpdateJobFunction
 }): Promise<never> {
-  req.payload.logger.error({ err: error, job, msg: 'Error running task', taskSlug })
+  req.payload.logger.error({ err: error, job, msg: `Error running task ${taskID}`, taskSlug })
 
   if (taskConfig?.onFail) {
     await taskConfig.onFail()

--- a/packages/payload/src/queues/utilities/getJobTaskStatus.ts
+++ b/packages/payload/src/queues/utilities/getJobTaskStatus.ts
@@ -29,6 +29,11 @@ export const getJobTaskStatus = ({ jobLog }: Args): JobTaskStatus => {
 
       if (loggedJob.state === 'succeeded') {
         newTaskStatus.complete = true
+        // As the task currently saved in taskStatus has likely failed and thus has no
+        // Output data, we need to update it with the new data from the successful task
+        newTaskStatus.output = loggedJob.output
+        newTaskStatus.input = loggedJob.input
+        newTaskStatus.taskSlug = loggedJob.taskSlug
       }
       taskStatus[loggedJob.taskSlug][loggedJob.taskID] = newTaskStatus
     }


### PR DESCRIPTION
Assume you had the following workflow:

```ts
 handler: async ({ job, inlineTask, req }) => {
          const { customerData } = await inlineTask('Fetch Customer Data', {
            task: ({ req }) => {
              if (Math.random() < 0.2) {
                throw new Error('Failed on purpose')
              }
              return {
                output: {
                  customerData: 'test',
                },
              }
            },
            retries: {
              attempts: 40,
            },
          })
          
          console.log('customer Data', customerData)

          await inlineTask('Analyze Segments', {
          // Rest of task...
```

It was possible for the following to happen:

Run attempt 1:

- Task "Fetch Customer Data" fails
- Task is added to job log without output data and state "failed"

Run attempt 2:

- Task "Fetch Customer Data" succeeds
- Task is added to job log with correct output data and state "succeeded"
- Task "Analyze Segments" fails
- Task is added to job log without output data and state "failed"

Run attempt 3:

- Task "Fetch Customer Data"  has already run successfully => restore from DB
- Task "Analyze Segments" fails because input data is undefined.

The restoration of the already-succeeded "Fetch Customer Data" task did not fetch and restore the correct output data, as it was taking the output data from the previously failed task that did not save any, even though it should have been taking and restoring the output data of the last-run, successful task run.

This PR fixed that