### PR TITLE
ci: add back CI-level automatic retrying for failing int and e2e tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,11 +274,16 @@ jobs:
         if: matrix.database == 'supabase'
 
       - name: Integration Tests
-        run: pnpm test:int
+        uses: nick-fields/retry@v3
         env:
           NODE_OPTIONS: --max-old-space-size=8096
           PAYLOAD_DATABASE: ${{ matrix.database }}
           POSTGRES_URL: ${{ env.POSTGRES_URL }}
+        with:
+          retry_on: error
+          max_attempts: 5
+          timeout_minutes: 15
+          command: pnpm test:int
 
   tests-e2e:
     runs-on: ubuntu-latest
@@ -374,7 +379,12 @@ jobs:
         run: pnpm exec playwright install-deps chromium
 
       - name: E2E Tests
-        run: PLAYWRIGHT_JSON_OUTPUT_NAME=results_${{ matrix.suite }}.json pnpm test:e2e:prod:ci ${{ matrix.suite }}
+        uses: nick-fields/retry@v3
+        with:
+          retry_on: error
+          max_attempts: 5
+          timeout_minutes: 20
+          command: PLAYWRIGHT_JSON_OUTPUT_NAME=results_${{ matrix.suite }}.json pnpm test:e2e:prod:ci ${{ matrix.suite }}
         env:
           PLAYWRIGHT_JSON_OUTPUT_NAME: results_${{ matrix.suite }}.json
           NEXT_TELEMETRY_DISABLED: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -280,7 +280,7 @@ jobs:
           PAYLOAD_DATABASE: ${{ matrix.database }}
           POSTGRES_URL: ${{ env.POSTGRES_URL }}
         with:
-          retry_on: error
+          retry_on: any
           max_attempts: 5
           timeout_minutes: 15
           command: pnpm test:int
@@ -381,7 +381,7 @@ jobs:
       - name: E2E Tests
         uses: nick-fields/retry@v3
         with:
-          retry_on: error
+          retry_on: any
           max_attempts: 5
           timeout_minutes: 20
           command: PLAYWRIGHT_JSON_OUTPUT_NAME=results_${{ matrix.suite }}.json pnpm test:e2e:prod:ci ${{ matrix.suite }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -284,6 +284,7 @@ jobs:
           max_attempts: 5
           timeout_minutes: 15
           command: pnpm test:int
+          on_retry_command: pnpm clean:all && pnpm install
 
   tests-e2e:
     runs-on: ubuntu-latest
@@ -385,6 +386,7 @@ jobs:
           max_attempts: 5
           timeout_minutes: 20
           command: PLAYWRIGHT_JSON_OUTPUT_NAME=results_${{ matrix.suite }}.json pnpm test:e2e:prod:ci ${{ matrix.suite }}
+          on_retry_command: pnpm clean:all && pnpm install && pnpm build:all
         env:
           PLAYWRIGHT_JSON_OUTPUT_NAME: results_${{ matrix.suite }}.json
           NEXT_TELEMETRY_DISABLED: 1


### PR DESCRIPTION
We should fix all the flaky tests in the future - in the meantime this PR will reduce collectively wasted engineer hours, as we now don't have to manually open the awkward GH actions UI and press the retry button - often multiple times for each PR.

It may not be enough to simply retry the test:int / test:e2e commands to get the tests not to flake for the next run, but let's see how this goes