### PR TITLE
fix(ui): upgrade react-select, fixes type issues with select input

### DIFF
--- a/examples/form-builder/next-app/package.json
+++ b/examples/form-builder/next-app/package.json
@@ -20,7 +20,7 @@
     "react": "18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.41.0",
-    "react-select": "^5.7.0",
+    "react-select": "5.8.3",
     "sass": "^1.55.0",
     "slate": "^0.84.0"
   },

--- a/examples/form-builder/next-pages/package.json
+++ b/examples/form-builder/next-pages/package.json
@@ -20,7 +20,7 @@
     "react": "18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.41.0",
-    "react-select": "^5.7.0",
+    "react-select": "5.8.3",
     "sass": "^1.55.0",
     "slate": "^0.84.0"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -117,7 +117,7 @@
     "qs-esm": "7.0.2",
     "react-datepicker": "6.9.0",
     "react-image-crop": "10.1.8",
-    "react-select": "5.8.0",
+    "react-select": "5.8.3",
     "scheduler": "0.0.0-experimental-3edc000d-20240926",
     "sonner": "^1.5.0",
     "ts-essentials": "10.0.3",

--- a/packages/ui/src/elements/ReactSelect/Input/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/Input/index.tsx
@@ -1,15 +1,14 @@
 'use client'
-import type { ControlProps } from 'react-select'
+import type { InputProps } from 'react-select'
 
 import React from 'react'
 import { components as SelectComponents } from 'react-select'
 
 import type { Option } from '../types.js'
 
-export const Input: React.FC<ControlProps<Option, any>> = (props) => {
+export const Input: React.FC<InputProps<Option, any>> = (props) => {
   return (
     <React.Fragment>
-      {/* @ts-expect-error // TODO Fix this - Broke with React 19 types */}
       <SelectComponents.Input
         {...props}
         /**

--- a/packages/ui/src/elements/ReactSelect/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/index.tsx
@@ -1,10 +1,10 @@
 'use client'
-import type { CSSProperties, KeyboardEventHandler } from 'react'
+import type { KeyboardEventHandler } from 'react'
 
 import { arrayMove } from '@dnd-kit/sortable'
 import { getTranslation } from '@payloadcms/translations'
 import React, { useEffect, useId } from 'react'
-import Select from 'react-select'
+import Select, { type StylesConfig } from 'react-select'
 import CreatableSelect from 'react-select/creatable'
 
 import type { Option, ReactSelectAdapterProps } from './types.js'
@@ -67,11 +67,11 @@ const SelectAdapter: React.FC<ReactSelectAdapterProps> = (props) => {
     .filter(Boolean)
     .join(' ')
 
-  const styles = {
+  const styles: StylesConfig<Option> = {
     // Remove the default react-select z-index from the menu so that our custom
     // z-index in the "payload-default" css layer can take effect, in such a way
     // that end users can easily override it as with other styles.
-    menu: (rsStyles: CSSProperties): CSSProperties => ({ ...rsStyles, zIndex: undefined }),
+    menu: (rsStyles) => ({ ...rsStyles, zIndex: undefined }),
   }
 
   if (!hasMounted) {

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -625,7 +625,7 @@ const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => 
                 }
                 return hasMany && Array.isArray(relationTo)
                   ? `${option.relationTo}_${option.value}`
-                  : option.value
+                  : (option.value as string)
               }}
               isLoading={isLoading}
               isMulti={hasMany}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1537,8 +1537,8 @@ importers:
         specifier: 10.1.8
         version: 10.1.8(react@19.0.0-rc-65a56d0e-20241020)
       react-select:
-        specifier: 5.8.0
-        version: 5.8.0(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)(types-react@19.0.0-rc.1)
+        specifier: 5.8.3
+        version: 5.8.3(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)(types-react@19.0.0-rc.1)
       scheduler:
         specifier: 0.0.0-experimental-3edc000d-20240926
         version: 0.0.0-experimental-3edc000d-20240926
@@ -8645,8 +8645,8 @@ packages:
       react: 19.0.0-rc-65a56d0e-20241020
       react-dom: 19.0.0-rc-65a56d0e-20241020
 
-  react-select@5.8.0:
-    resolution: {integrity: sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==}
+  react-select@5.8.3:
+    resolution: {integrity: sha512-lVswnIq8/iTj1db7XCG74M/3fbGB6ZaluCzvwPGT5ZOjCdL/k0CLWhEK0vCBLuU5bHTEf6Gj8jtSvi+3v+tO1w==}
     peerDependencies:
       react: 19.0.0-rc-65a56d0e-20241020
       react-dom: 19.0.0-rc-65a56d0e-20241020
@@ -18691,7 +18691,7 @@ snapshots:
       react: 19.0.0-rc-65a56d0e-20241020
       react-dom: 19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020)
 
-  react-select@5.8.0(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)(types-react@19.0.0-rc.1):
+  react-select@5.8.3(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)(types-react@19.0.0-rc.1):
     dependencies:
       '@babel/runtime': 7.26.0
       '@emotion/cache': 11.13.1


### PR DESCRIPTION
React-select fixed React 19 type compatibility here: https://github.com/JedWatson/react-select/pull/5974