### PR TITLE
fix(ui): recalculate total height when children render in usePatchAnimateHeight

### DIFF
--- a/packages/ui/src/elements/AnimateHeight/index.tsx
+++ b/packages/ui/src/elements/AnimateHeight/index.tsx
@@ -68,6 +68,7 @@ export const AnimateHeight: React.FC<{
   const containerRef = useRef<HTMLDivElement>(null)
 
   usePatchAnimateHeight({
+    children,
     containerRef,
     duration,
     open,

--- a/packages/ui/src/elements/AnimateHeight/usePatchAnimateHeight.ts
+++ b/packages/ui/src/elements/AnimateHeight/usePatchAnimateHeight.ts
@@ -2,10 +2,12 @@
 import { useEffect, useMemo, useRef } from 'react'
 
 export const usePatchAnimateHeight = ({
+  children,
   containerRef,
   duration,
   open,
 }: {
+  children: React.ReactNode
   containerRef: React.RefObject<HTMLDivElement>
   duration: number
   open: boolean
@@ -64,7 +66,7 @@ export const usePatchAnimateHeight = ({
         container.style.height = ''
       }
     }
-  }, [open, duration, containerRef, browserSupportsKeywordAnimation])
+  }, [open, duration, containerRef, children, browserSupportsKeywordAnimation])
 
   return { browserSupportsKeywordAnimation }
 }


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes an issue where `AnimateHeight` components were not being rendered at the correct height due to calculating a total height before children were being rendered in some cases. By calculating the height in advance before children were rendered, the elements height was limited and caused overflow which meant that subsequent elements would stack underneath.

### Why?
To prevent UI issues on initial renders while using a component that relies on `AnimateHeight` in browser that do not support `interpolate-size`.

### How?
By including children in the `useEffect` in `usePatchAnimateHeight` to cause a recalculation of the total height.

Fixes #9567

Notes:
- In FF, the `up` animation causes a visible flicker to 0px before the animation begins. Happens frequently but not consistently from my testing. No clue why that happens. This is clearly visible in the linked `After` video at around 13s.
- The grid approach for auto animating height should be explored in this component as an alternative to calculating heights in advance as the browser will do the heavy lifting here and it does not require expirmental CSS features.
- An improvement here may be to use skeletons to prevent the large layout shift that occurs before the children get properly rendered.

Before:
https://github.com/user-attachments/assets/2d110974-2384-4176-898c-5895c195e5c8

After:
https://github.com/user-attachments/assets/06a690c1-bc73-4d06-a7c0-48e30aba89af

