### PR TITLE
fix: remove duplicate afterRead collection hook call on loginOperation

### DIFF
--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -292,22 +292,6 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
         })) || user
     }, Promise.resolve())
 
-    // /////////////////////////////////////
-    // afterRead - Collection
-    // /////////////////////////////////////
-
-    await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      user =
-        (await hook({
-          collection: args.collection?.config,
-          context: req.context,
-          doc: user,
-          req,
-        })) || user
-    }, Promise.resolve())
-
     let result: { user: DataFromCollectionSlug<TSlug> } & Result = {
       exp,
       token,


### PR DESCRIPTION
Hi there,

i noticed that the `afterRead` hook is triggered twice on `loginOperation`. 

This just removes the duplicated code.

-Tobi

