### PR TITLE
fix(ui): properly animates height for dynamically rendered children

### DIFF
--- a/packages/ui/src/elements/AnimateHeight/index.tsx
+++ b/packages/ui/src/elements/AnimateHeight/index.tsx
@@ -12,6 +12,7 @@ export const AnimateHeight: React.FC<{
   id?: string
 }> = ({ id, children, className, duration = 300, height }) => {
   const [open, setOpen] = React.useState(() => Boolean(height))
+
   const prevIsOpen = useRef(open)
 
   const [childrenDisplay, setChildrenDisplay] = React.useState<CSSStyleDeclaration['display']>(
@@ -23,6 +24,9 @@ export const AnimateHeight: React.FC<{
   )
 
   const [isAnimating, setIsAnimating] = React.useState(false)
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     let displayTimer: number
@@ -65,10 +69,9 @@ export const AnimateHeight: React.FC<{
     }
   }, [height, duration])
 
-  const containerRef = useRef<HTMLDivElement>(null)
-
   usePatchAnimateHeight({
     containerRef,
+    contentRef,
     duration,
     open,
   })
@@ -92,7 +95,9 @@ export const AnimateHeight: React.FC<{
         transition: `height ${duration}ms ease`,
       }}
     >
-      <div {...(childrenDisplay ? { style: { display: childrenDisplay } } : {})}>{children}</div>
+      <div ref={contentRef} {...(childrenDisplay ? { style: { display: childrenDisplay } } : {})}>
+        {children}
+      </div>
     </div>
   )
 }

--- a/packages/ui/src/elements/AnimateHeight/usePatchAnimateHeight.ts
+++ b/packages/ui/src/elements/AnimateHeight/usePatchAnimateHeight.ts
@@ -21,6 +21,7 @@ export const usePatchAnimateHeight = ({
     [],
   )
 
+  const hasInitialized = useRef(false)
   const previousOpenState = useRef(open)
   const [isAnimating, setIsAnimating] = useState(false)
   const resizeObserverRef = useRef<null | ResizeObserver>(null)
@@ -43,6 +44,15 @@ export const usePatchAnimateHeight = ({
 
     const animate = () => {
       setIsAnimating(true)
+
+      // Skip animation on the first render
+      if (!hasInitialized.current) {
+        container.style.transition = ''
+        container.style.height = open ? 'auto' : '0px'
+        hasInitialized.current = true
+        setIsAnimating(false)
+        return
+      }
 
       // Set initial state
       if (previousOpenState.current !== open) {

--- a/packages/ui/src/elements/AnimateHeight/usePatchAnimateHeight.ts
+++ b/packages/ui/src/elements/AnimateHeight/usePatchAnimateHeight.ts
@@ -46,13 +46,14 @@ export const usePatchAnimateHeight = ({
       setIsAnimating(true)
 
       // Skip animation on the first render
-      if (!hasInitialized.current) {
+      if (!hasInitialized.current && open) {
         container.style.transition = ''
         container.style.height = open ? 'auto' : '0px'
-        hasInitialized.current = true
         setIsAnimating(false)
         return
       }
+
+      hasInitialized.current = true
 
       // Set initial state
       if (previousOpenState.current !== open) {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/9567. When using the `AnimateHeight` component on a patched browser such as Webkit, components with dynamically rendered children are not properly animating in, such as blocks with rich text. This is because the height of that content is unable to be calculated before it's rendered, preventing the component from acquiring a target height to animate toward. This change was originally introduced in #9456 in effort to remove unnecessary dependencies.

The fix is to setup a ResizeObserver during animation to watch for changes to the content's height. This way, as components  dynamically render in based on the "open" state, the hook will simply increment the target height accordingly.