### PR TITLE
ci: allow more commit types in release notes

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,14 +24,15 @@ jobs:
             chore
             ci
             docs
+            examples
             feat
             fix
             perf
             refactor
             revert
             style
+            templates
             test
-            types
           scopes: |
             cpa
             db-\*


### PR DESCRIPTION
More commit types will now show in the release notes. The full list of allowable types are the following and will show in order:

```ts
const commitTypesForChangelog = [
  'feat',
  'fix',
  'perf',
  'refactor',
  'docs',
  'style',
  'test',
  'templates',
  'examples',
  'build',
  'ci',
  'chore',
]
  ```