### PR TITLE
fix(ui): data disappearing when form state updates in globals

### DIFF
--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -286,7 +286,7 @@ export const DefaultEditView: React.FC<ClientSideEditViewProps> = ({
         const { state } = await getFormState({
           id,
           collectionSlug,
-          data: json?.doc,
+          data: json?.doc || json?.result,
           docPermissions,
           docPreferences,
           globalSlug,


### PR DESCRIPTION
Fixes a bug where data would visually disappear from the form when merging new form stats when saving globals.