### PR TITLE
feat: add better invalid collection warning to lockedDocumentsCollection.ts

### DIFF
--- a/packages/payload/src/lockedDocuments/lockedDocumentsCollection.ts
+++ b/packages/payload/src/lockedDocuments/lockedDocumentsCollection.ts
@@ -12,7 +12,14 @@ export const getLockedDocumentsCollection = (config: Config): CollectionConfig =
       type: 'relationship',
       index: true,
       maxDepth: 0,
-      relationTo: [...config.collections.map((collectionConfig) => collectionConfig.slug)],
+      relationTo: [
+        ...config.collections.map((collectionConfig, index) => {
+          if (!collectionConfig?.slug) {
+            throw new Error(`Invalid collection config. Each collection must have a valid slug. Please check your Payload Config collections array.`);
+          }
+          return collectionConfig.slug;
+        })
+      ]
     },
     {
       name: 'globalSlug',
@@ -23,9 +30,12 @@ export const getLockedDocumentsCollection = (config: Config): CollectionConfig =
       name: 'user',
       type: 'relationship',
       maxDepth: 1,
-      relationTo: config.collections
-        .filter((collectionConfig) => collectionConfig.auth)
-        .map((collectionConfig) => collectionConfig.slug),
+      relationTo: config.collections.map((collectionConfig, index) => {
+        if (!collectionConfig?.slug) {
+            throw new Error(`Invalid collection config. Each collection must have a valid slug. Please check your Payload Config collections array.`);
+        }
+        return collectionConfig.auth ? collectionConfig.slug : null;
+      }).filter(Boolean),
       required: true,
     },
   ],


### PR DESCRIPTION
Adds protection against misconfigured collections being passed into the payload-config.js collections array

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

This is a DevX convenience feature intended to help debug potential Payload Config issues. Specifically if an invalid collection has been passed into the config.collections field.

### Why?

If you have a large number of collections, it may become pertinent to split these into separate arrays and concat them:

```ts

const systemCollections = [Users, Media, Permissions];
const ecommerceCollections = [Products, Prices, Discounts, Categories]

export default buildConfig({
collections: [...systemCollections, ...ecommerceCollections] 
...
});
```

In my particular case, I had accidently left a hanging `,` which caused my Payload Config to error without a clear reason as to why:

```
// offending array
const systemCollections = [Users, Media, , Permissions, ];

TypeError: Cannot read properties of undefined (reading 'slug')
app:dev:     at Array.map (<anonymous>)
app:dev: digest: "764122206"
app:dev:   11 |                 maxDepth: 0,
app:dev:   12 |                 relationTo: [
app:dev: > 13 |                     ...config.collections.map((collectionConfig)=>collectionConfig.slug)
app:dev:      | ^
app:dev:   14 |                 ]
app:dev:   15 |             },
```

### How?

This PR adds a check for an invalid config in the locked documents collection, before the app can instantiate, and before the rest of the config can be fully analyzed - allowing users to view the error sooner. The additional error context should help developers diagnose the issue