### PR TITLE
fix(templates): website remove maxDepth from references in link field

### DIFF
--- a/templates/website/src/Header/Component.client.tsx
+++ b/templates/website/src/Header/Component.client.tsx
@@ -31,7 +31,7 @@ export const HeaderClient: React.FC<HeaderClientProps> = ({ header }) => {
 
   return (
     <header className="container relative z-20   " {...(theme ? { 'data-theme': theme } : {})}>
-      <div className="py-8 border-b border-border flex justify-between">
+      <div className="py-8 flex justify-between">
         <Link href="/">
           <Logo loading="eager" priority="high" className="invert dark:invert-0" />
         </Link>

--- a/templates/website/src/fields/link.ts
+++ b/templates/website/src/fields/link.ts
@@ -75,7 +75,6 @@ export const link: LinkType = ({ appearances, disableLabel = false, overrides = 
         condition: (_, siblingData) => siblingData?.type === 'reference',
       },
       label: 'Document to link to',
-      maxDepth: 1,
       relationTo: ['pages'],
       required: true,
     },


### PR DESCRIPTION
Removes maxDepth from link fields which can cause issues sometimes depending on how deep the reference is

Also removes bottom border on website header.