### PR TITLE
feat(ui): adds before & after inputs to join field

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1358,8 +1358,8 @@ export type JoinField = {
   admin?: {
     allowCreate?: boolean
     components?: {
-      AfterInput?: CustomComponent[]
-      BeforeInput?: CustomComponent[]
+      afterInput?: CustomComponent[]
+      beforeInput?: CustomComponent[]
       Error?: CustomComponent<JoinFieldErrorClientComponent | JoinFieldErrorServerComponent>
       Label?: CustomComponent<JoinFieldLabelClientComponent | JoinFieldLabelServerComponent>
     } & Admin['components']

--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -35,7 +35,9 @@ import { RelationshipTablePagination } from './Pagination.js'
 const baseClass = 'relationship-table'
 
 type RelationshipTableComponentProps = {
+  readonly AfterInput?: React.ReactNode
   readonly allowCreate?: boolean
+  readonly BeforeInput?: React.ReactNode
   readonly disableTable?: boolean
   readonly field: JoinFieldClient
   readonly filterOptions?: Where
@@ -47,7 +49,9 @@ type RelationshipTableComponentProps = {
 
 export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (props) => {
   const {
+    AfterInput,
     allowCreate = true,
+    BeforeInput,
     disableTable = false,
     filterOptions,
     initialData: initialDataFromProps,
@@ -197,6 +201,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
           </Pill>
         </div>
       </div>
+      {BeforeInput}
       {isLoadingTable ? (
         <p>{t('general:loading')}</p>
       ) : (
@@ -257,6 +262,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
           )}
         </Fragment>
       )}
+      {AfterInput}
       <DocumentDrawer initialData={initialDrawerData} onSave={onDrawerCreate} />
     </div>
   )

--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -59,9 +59,10 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
       className={[fieldBaseClass, 'join'].filter(Boolean).join(' ')}
       id={`field-${path?.replace(/\./g, '__')}`}
     >
-      {BeforeInput}
       <RelationshipTable
+        AfterInput={AfterInput}
         allowCreate={typeof docID !== 'undefined' && allowCreate}
+        BeforeInput={BeforeInput}
         disableTable={filterOptions === null}
         field={field as JoinFieldClient}
         filterOptions={filterOptions}
@@ -78,7 +79,6 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
         }
         relationTo={collection}
       />
-      {AfterInput}
       <RenderCustomComponent
         CustomComponent={Description}
         Fallback={<FieldDescription description={description} path={path} />}

--- a/test/joins/collections/Categories.ts
+++ b/test/joins/collections/Categories.ts
@@ -49,6 +49,8 @@ export const Categories: CollectionConfig = {
       type: 'join',
       admin: {
         components: {
+          afterInput: ['/components/AfterInput.js#AfterInput'],
+          beforeInput: ['/components/BeforeInput.js#BeforeInput'],
           Description: '/components/CustomDescription/index.js#FieldDescriptionComponent',
         },
       },

--- a/test/joins/components/AfterInput.tsx
+++ b/test/joins/components/AfterInput.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import React from 'react'
+
+export const AfterInput: React.FC = () => {
+  return <div className="after-input">#after-input</div>
+}

--- a/test/joins/components/BeforeInput.tsx
+++ b/test/joins/components/BeforeInput.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import React from 'react'
+
+export const BeforeInput: React.FC = () => {
+  return <div className="before-input">#before-input</div>
+}


### PR DESCRIPTION
Adds `beforeInput` & `afterInput` props to the `join` field.

`Example`:
![Screenshot 2024-12-03 at 2 10 11 PM](https://github.com/user-attachments/assets/8c1b3d71-053d-4ffb-8d6f-1581414c20a1)
