### PR TITLE
fix(ui): error after view is left idle on edit views

### DIFF
--- a/packages/next/src/views/LivePreview/index.client.tsx
+++ b/packages/next/src/views/LivePreview/index.client.tsx
@@ -256,7 +256,7 @@ const PreviewView: React.FC<Props> = ({
       operation,
       schemaPath,
       setDocumentIsLocked,
-      user.id,
+      user?.id,
       setCurrentEditor,
     ],
   )

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -233,7 +233,7 @@ export const DefaultEditView: React.FC<ClientSideEditViewProps> = ({
         }
       }
     },
-    [setCurrentEditor, setDocumentIsLocked, user.id],
+    [setCurrentEditor, setDocumentIsLocked, user?.id],
   )
 
   const onSave = useCallback(


### PR DESCRIPTION
### What?
![CleanShot 2024-12-03 at 15 00 13](https://github.com/user-attachments/assets/63afb1cf-59ae-4ae7-8741-c98cca0134df)

### Why?
`user.id` was being used as a dependency is callbacks and when the user was logged out due to inactivity the above error would throw.

### How?
Added optional chaining to the dependency.
