### PR TITLE
fix(templates): website template copy code button darkmode behavior

### DIFF
--- a/templates/website/src/blocks/Code/CopyButton.tsx
+++ b/templates/website/src/blocks/Code/CopyButton.tsx
@@ -26,10 +26,7 @@ export function CopyButton({ code }: { code: string }) {
         }}
       >
         <p>{text}</p>
-
-        <div className="w-6 h-6 dark:invert">
-          <CopyIcon />
-        </div>
+        <CopyIcon />
       </Button>
     </div>
   )

--- a/templates/with-vercel-website/src/blocks/Code/CopyButton.tsx
+++ b/templates/with-vercel-website/src/blocks/Code/CopyButton.tsx
@@ -26,10 +26,7 @@ export function CopyButton({ code }: { code: string }) {
         }}
       >
         <p>{text}</p>
-
-        <div className="w-6 h-6 dark:invert">
-          <CopyIcon />
-        </div>
+        <CopyIcon />
       </Button>
     </div>
   )


### PR DESCRIPTION
### What?
Makes copybutton's CopyIcon behave as expected in darkmode.

### Why?
CopyIcon inverts on its own now and has a preset size.
Therefore this wrapper div creates unwanted behavior and is not needed anymore.
```tsx
<div className="w-6 h-6 dark:invert">
    <CopyIcon />
</div>
 ```
With div
![image](https://github.com/user-attachments/assets/9ff84539-022a-4b2a-93b8-3b0733b7a915)
Without div
![image](https://github.com/user-attachments/assets/b3a2c1e2-5690-4824-9394-fee704170f5c)
Light mode is unaffected.

### How?
Remove the wrapper div above, leaving only the CopyIcon.