### PR TITLE
templates(website): do not change slug field value if locked

### DIFF
--- a/templates/website/src/fields/slug/SlugComponent.tsx
+++ b/templates/website/src/fields/slug/SlugComponent.tsx
@@ -41,7 +41,7 @@ export const SlugComponent: React.FC<SlugComponentProps> = ({
   })
 
   useEffect(() => {
-    if (checkboxValue) {
+    if (!checkboxValue) {
       if (targetFieldValue) {
         const formattedSlug = formatSlug(targetFieldValue)
 


### PR DESCRIPTION
Fixes website template slug component. Slug field value is incorrectly changed based on title field change even though this field is locked (slug lock field checked).