### PR TITLE
chore: adds jsdocs for `auth.forgotPassword.expiration` prop

### DIFF
--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -221,6 +221,10 @@ export interface IncomingAuthType {
    * @link https://payloadcms.com/docs/authentication/email#forgot-password
    */
   forgotPassword?: {
+    /**
+     * The number of milliseconds that the forgot password token should be valid for.
+     * @default 3600000 // 1 hour
+     */
     expiration?: number
     generateEmailHTML?: GenerateForgotPasswordEmailHTML
     generateEmailSubject?: GenerateForgotPasswordEmailSubject


### PR DESCRIPTION
### What

Updates auth.forgotPassword.expiration prop type to include JSDocs

I.e

```
/**
  * The number of milliseconds that the forgot password token should be valid for.
  * @default 3600000 // 1 hour
  */
```
