### PR TITLE
fix(ui): incorrect label size for group field

### DIFF
--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -79,6 +79,7 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
                   Fallback={
                     <h3 className={`${baseClass}__title`}>
                       <FieldLabel
+                        as="span"
                         label={getTranslation(label, i18n)}
                         localized={false}
                         path={path}


### PR DESCRIPTION
### What?
The group label was incorrectly sized.

![CleanShot 2024-12-04 at 10 33 13](https://github.com/user-attachments/assets/c94cb8b9-4453-4d57-a483-ea35a63f04a9)

### Why?
It should be rendered as a span not a label.

### How?
Added `as="span"` to the FieldLabel for the group field like we do for the array field.

![CleanShot 2024-12-04 at 10 35 13](https://github.com/user-attachments/assets/99bdec33-39ee-4bd0-a4d1-ed3635e2bea7)

