### PR TITLE
fix(ui): disable doc submenu when parent button is disabled

### DIFF
--- a/packages/ui/src/elements/Button/index.tsx
+++ b/packages/ui/src/elements/Button/index.tsx
@@ -183,6 +183,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, Props>((
           button={<ChevronIcon />}
           buttonSize={size}
           className={disabled ? `${baseClass}--popup-disabled` : ''}
+          disabled={disabled}
           horizontalAlign="right"
           noBackground
           render={({ close }) => SubMenuPopupContent({ close: () => close() })}

--- a/packages/ui/src/elements/Popup/PopupTrigger/index.scss
+++ b/packages/ui/src/elements/Popup/PopupTrigger/index.scss
@@ -27,5 +27,9 @@
     &--size-large {
       padding: base(0.8);
     }
+
+    &--disabled {
+      cursor: not-allowed;
+    }
   }
 }

--- a/packages/ui/src/elements/Popup/PopupTrigger/index.tsx
+++ b/packages/ui/src/elements/Popup/PopupTrigger/index.tsx
@@ -25,6 +25,7 @@ export const PopupTrigger: React.FC<PopupTriggerProps> = (props) => {
     `${baseClass}--${buttonType}`,
     !noBackground && `${baseClass}--background`,
     size && `${baseClass}--size-${size}`,
+    disabled && `${baseClass}--disabled`,
   ]
     .filter(Boolean)
     .join(' ')


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes an issue where a disabled button that had a submenu still allowed the submenu to be reachable. In turn, this allows docs in the edit view that have had no changes to be publishable

### Why?
To prevent docs with no changes from being published, and fix a ui issue where parent disabled buttons still allowed their submenus to be reachable.

### How?
Threading `disabled` down to the submenu, and creating a style rule targetting disabled popups to show a disallowed cursor.

Before:
[Dashboard-disabled-before-Payload.webm](https://github.com/user-attachments/assets/536ef89c-9ef9-43d1-8ac7-df36dabad042)

After:
[Dashboard-disabled-after-Payload.webm](https://github.com/user-attachments/assets/fb84cc78-f89e-4ca6-9d5a-77066cd6b3eb)

Fixes #9749