### PR TITLE
feat: allow to define global label as function 

### DIFF
--- a/packages/payload/src/globals/config/client.ts
+++ b/packages/payload/src/globals/config/client.ts
@@ -102,6 +102,10 @@ export const createClientGlobalConfig = ({
           importMap,
         })
         break
+      case 'label':
+        clientGlobal.label =
+          typeof global.label === 'function' ? global.label({ t: i18n.t }) : global.label
+        break
       default: {
         clientGlobal[key] = global[key]
         break

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -14,8 +14,10 @@ import type {
   EntityDescription,
   EntityDescriptionComponent,
   GeneratePreviewURL,
+  LabelFunction,
   LivePreviewConfig,
   MetaConfig,
+  StaticLabel,
 } from '../../config/types.js'
 import type { DBIdentifierName } from '../../database/types.js'
 import type { Field, FlattenedField } from '../../fields/config/types.js'
@@ -165,7 +167,7 @@ export type GlobalConfig = {
     beforeRead?: BeforeReadHook[]
     beforeValidate?: BeforeValidateHook[]
   }
-  label?: Record<string, string> | string
+  label?: LabelFunction | StaticLabel
   /**
    * Enables / Disables the ability to lock documents while editing
    * @default true

--- a/packages/ui/src/utilities/groupNavItems.ts
+++ b/packages/ui/src/utilities/groupNavItems.ts
@@ -42,6 +42,14 @@ export function groupNavItems(
       if (permissions?.[entityToGroup.type.toLowerCase()]?.[entityToGroup.entity.slug]?.read) {
         const translatedGroup = getTranslation(entityToGroup.entity.admin.group, i18n)
 
+        const labelOrFunction =
+          'labels' in entityToGroup.entity
+            ? entityToGroup.entity.labels.plural
+            : entityToGroup.entity.label
+
+        const label =
+          typeof labelOrFunction === 'function' ? labelOrFunction({ t: i18n.t }) : labelOrFunction
+
         if (entityToGroup.entity.admin.group) {
           const existingGroup = groups.find(
             (group) => getTranslation(group.label, i18n) === translatedGroup,
@@ -57,12 +65,7 @@ export function groupNavItems(
           matchedGroup.entities.push({
             slug: entityToGroup.entity.slug,
             type: entityToGroup.type,
-            label:
-              'labels' in entityToGroup.entity
-                ? typeof entityToGroup.entity.labels.plural === 'function'
-                  ? entityToGroup.entity.labels.plural({ t: i18n.t })
-                  : entityToGroup.entity.labels.plural
-                : entityToGroup.entity.label,
+            label,
           })
         } else {
           const defaultGroup = groups.find((group) => {
@@ -71,12 +74,7 @@ export function groupNavItems(
           defaultGroup.entities.push({
             slug: entityToGroup.entity.slug,
             type: entityToGroup.type,
-            label:
-              'labels' in entityToGroup.entity
-                ? typeof entityToGroup.entity.labels.plural === 'function'
-                  ? entityToGroup.entity.labels.plural({ t: i18n.t })
-                  : entityToGroup.entity.labels.plural
-                : entityToGroup.entity.label,
+            label,
           })
         }
       }


### PR DESCRIPTION
This PR improves consistency between globals `label` and collections `labels`
`collection.labels.plural`, `collection.labels.singular` and `global.label` are typed in the same way now:
```ts
{ label?: LabelFunction | StaticLabel }
```

Previously you couldn't pass a function to `global.label`