### PR TITLE
ci: explicitly use ubuntu-24.04 instead of latest to ensure compat

### DIFF
--- a/.github/workflows/label-on-change.yml
+++ b/.github/workflows/label-on-change.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   on-labeled-ensure-one-status:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     # Only run on issue labeled and if label starts with 'status:'
@@ -49,7 +49,7 @@ jobs:
             }
 
   on-issue-close:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     if: github.event.action == 'closed'
@@ -82,7 +82,7 @@ jobs:
             }
 
   on-issue-reopen:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     if: github.event.action == 'reopened'
@@ -93,7 +93,7 @@ jobs:
           labels: 'status: needs-triage'
 
   on-issue-assigned:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     if: >
@@ -106,11 +106,11 @@ jobs:
           labels: 'status: needs-triage'
 
   # on-pr-merge:
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-24.04
   #   if: github.event.pull_request.merged == true
   #   steps:
 
   # on-pr-close:
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-24.04
   #   if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == false
   #   steps:

--- a/.github/workflows/lock-issues.yml
+++ b/.github/workflows/lock-issues.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lock_issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Lock issues
         uses: dessant/lock-threads@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
     outputs:
@@ -64,7 +64,7 @@ jobs:
   lint:
     if: >
       github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'no-lint') && !contains(github.event.pull_request.title, 'skip-lint')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -83,7 +83,7 @@ jobs:
   build:
     needs: changes
     if: ${{ needs.changes.outputs.needs_build == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
           key: ${{ github.sha }}-${{ github.run_number }}
 
   tests-unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [changes, build]
     if: ${{ needs.changes.outputs.needs_tests == 'true' }}
     steps:
@@ -133,7 +133,7 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8096
 
   tests-int:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [changes, build]
     if: ${{ needs.changes.outputs.needs_tests == 'true' }}
     name: int-${{ matrix.database }}
@@ -233,7 +233,7 @@ jobs:
           on_retry_command: pnpm clean:build && pnpm install --no-frozen-lockfile
 
   tests-e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [changes, build]
     if: ${{ needs.changes.outputs.needs_tests == 'true' }}
     name: e2e-${{ matrix.suite }}
@@ -350,7 +350,7 @@ jobs:
 
   # Build listed templates with packed local packages
   build-templates:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     strategy:
       matrix:
@@ -429,7 +429,7 @@ jobs:
           pnpm runts scripts/build-template-with-local-pkgs.ts ${{ matrix.template }} $POSTGRES_URL
 
   tests-type-generation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [changes, build]
     if: ${{ needs.changes.outputs.needs_tests == 'true' }}
     steps:
@@ -459,7 +459,7 @@ jobs:
   all-green:
     name: All Green
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - lint
       - build
@@ -473,7 +473,7 @@ jobs:
 
   publish-canary:
     name: Publish Canary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ needs.all-green.result == 'success' && github.ref_name == 'main' }}
     needs:
       - all-green

--- a/.github/workflows/post-release-templates.yml
+++ b/.github/workflows/post-release-templates.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   update_templates:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   post_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
             🚀 This is included in version {release_link}
 
   github-releases-to-discord:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'workflow_dispatch' }}
     steps:
       - name: Checkout

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   main:
     name: lint-pr-title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title
@@ -107,7 +107,7 @@ jobs:
 
   label-pr-on-open:
     name: label-pr-on-open
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.action == 'opened'
     steps:
       - name: Tag with 2.x branch with v2

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -14,7 +14,7 @@ jobs:
     name: release-canary-${{ github.ref_name }}-${{ github.sha }}
     permissions:
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   debug-context:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: View context attributes
         uses: actions/github-script@v7
@@ -27,7 +27,7 @@ jobs:
 
   label-created-by:
     name: label-on-open
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Tag with 'created-by'
         uses: actions/github-script@v7
@@ -88,7 +88,7 @@ jobs:
   triage:
     name: initial-triage
     if: github.event_name == 'issues'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The runner image `ubuntu-latest` image will be switching from Ubuntu 22.04 to Ubuntu 24.04 as specified in https://github.com/actions/runner-images/issues/10636.

> Rollout will begin on December 5th and will complete on January 17th, 2025.
Breaking changes 
Ubuntu 24.04 is ready to be the default version for the "ubuntu-latest" label in GitHub Actions and Azure DevOps.

This PR moves us to explicitly use `ubuntu-24.04` to ensure compatibility and to allow explicit upgrades in the future.

