### PR TITLE
perf: optimizes hidden and disabled fields within the client config

### DIFF
--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -106,12 +106,15 @@ export const createClientCollectionConfig = ({
     if (serverOnlyCollectionProperties.includes(key as any)) {
       continue
     }
+
     switch (key) {
       case 'admin':
         if (!collection.admin) {
           break
         }
+
         clientCollection.admin = {} as ClientCollectionConfig['admin']
+
         for (const adminKey in collection.admin) {
           if (serverOnlyCollectionAdminProperties.includes(adminKey as any)) {
             continue

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -18,7 +18,7 @@ import type { Payload } from '../../types/index.js'
 
 import { getFromImportMap } from '../../bin/generateImportMap/getFromImportMap.js'
 import { MissingEditorProp } from '../../errors/MissingEditorProp.js'
-import { fieldAffectsData } from '../../fields/config/types.js'
+import { fieldAffectsData, fieldIsHiddenOrDisabled } from '../../fields/config/types.js'
 import { flattenTopLevelFields, type ImportMap } from '../../index.js'
 import { removeUndefined } from '../../utilities/removeUndefined.js'
 
@@ -74,6 +74,24 @@ export const createClientField = ({
   importMap: ImportMap
 }): ClientField => {
   const clientField: ClientField = {} as ClientField
+
+  if (fieldAffectsData(incomingField) && fieldIsHiddenOrDisabled(incomingField)) {
+    clientField.type = incomingField.type
+
+    if (incomingField.hidden) {
+      clientField.hidden = true
+    }
+
+    if (incomingField.admin?.disabled) {
+      if (!clientField.admin) {
+        clientField.admin = {} as AdminClient
+      }
+
+      clientField.admin.disabled = true
+    }
+
+    return clientField
+  }
 
   for (const key in incomingField) {
     if (serverOnlyFieldProperties.includes(key as any)) {


### PR DESCRIPTION
Continuation of #9680. Hidden and disabled fields used to be sanitized from the client config, causing fields to be iterated out of their original order. Now, they're included in the client config–but in their entirety. This means the client config includes properties of these fields that are never used, increasing its overall size if you have many hidden or disabled fields. Instead, we can simply omit all of its properties, keeping only `type`, `hidden`, and `admin.disabled`. This will slim down the client config and also prevent these fields from continuing to be processed, which will ultimately make it faster to generate.