### PR TITLE
fix: improve error handling for missing @payload-config path alias

### DIFF
--- a/packages/payload/src/config/find.ts
+++ b/packages/payload/src/config/find.ts
@@ -28,11 +28,11 @@ const getTSConfigPaths = (): {
     const rootConfigDir = path.resolve(tsConfigDir, tsConfig.compilerOptions.baseUrl || '')
     const srcPath = tsConfig.compilerOptions?.rootDir || path.resolve(process.cwd(), 'src')
     const outPath = tsConfig.compilerOptions?.outDir || path.resolve(process.cwd(), 'dist')
-    let configPath = tsConfig.compilerOptions?.paths?.['@payload-config']?.[0]
+    let configPath =
+      tsConfig.compilerOptions?.paths?.['@payload-config']?.[0] ??
+      (process.env.PAYLOAD_CONFIG_PATH || './src/payload.config.ts')
 
-    if (configPath) {
-      configPath = path.resolve(rootConfigDir, configPath)
-    }
+    configPath = path.resolve(rootConfigDir, configPath)
     return {
       configPath,
       outPath,
@@ -65,6 +65,14 @@ export const findConfig = (): string => {
   }
 
   const { configPath, outPath, rootPath, srcPath } = getTSConfigPaths()
+  if (!configPath) {
+    throw new Error(
+      'Could not locate payload.config.ts file. To resolve this:\n' +
+        '1. Add @payload-config path alias to your tsconfig.json\n' +
+        '2. Ensure payload.config.ts exists in your src directory\n' +
+        '3. Or set PAYLOAD_CONFIG_PATH environment variable',
+    )
+  }
 
   // if configPath is absolute file, not folder, return it
   if (path.extname(configPath) === '.js' || path.extname(configPath) === '.ts') {


### PR DESCRIPTION
## Description
Currently, when the `@payload-config` path alias is missing from tsconfig.json, the package fails with a cryptic error when running commands such as generate:types or generate:importmap:
```typescript
node:path:1464
    validateString(path, 'path');
    ^
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
```

This happens because configPath becomes undefined when the path alias is missing, which later causes a path resolution error. This PR improves error handling to provide clearer feedback.

## Changes

Added explicit error handling when @payload-config path alias is missing
Added descriptive error message to guide users on how to fix the issue
Added fallback to default configuration path (./src/payload.config.ts)

## Related Issue
Closes #9796