### PR TITLE
ci: add missing tests to all-green dependency array

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -492,9 +492,12 @@ jobs:
     needs:
       - lint
       - build
+      - build-templates
       - tests-unit
       - tests-int
       - tests-e2e
+      - tests-types
+      - tests-type-generation
 
     steps:
       - if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}


### PR DESCRIPTION
Adds the missing tests to the `needs:` dependency array for `all-green` step in CI so that all-green doesn't pass if these tests fail or are in progress

```
- build-templates
- tests-types
- tests-type-generation
```