### PR TITLE
test: properly mock nodemailer verify in unit test

### DIFF
--- a/packages/payload-cloud/src/plugin.spec.ts
+++ b/packages/payload-cloud/src/plugin.spec.ts
@@ -94,6 +94,8 @@ describe('plugin', () => {
 
         const existingTransport = nodemailer.createTransport({
           name: 'existing-transport',
+          // eslint-disable-next-line @typescript-eslint/require-await
+          verify: async (): Promise<true> => true,
           // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-misused-promises
           send: async (mail) => {
             // eslint-disable-next-line no-console


### PR DESCRIPTION
If nodemailer was down, this unit test would fail. Verify function should now be properly mock and not make a network call.