### PR TITLE
feat: allow augmentation of payload object with generated types

### DIFF
--- a/packages/payload/src/bin/generateTypes.ts
+++ b/packages/payload/src/bin/generateTypes.ts
@@ -44,6 +44,10 @@ export async function generateTypes(
         },
         unreachableDefinitions: true,
       }))
+
+    payloadModuleAugmentation = addSelectGenericsToGeneratedTypes({
+      compiledGeneratedTypes: payloadModuleAugmentation,
+    })
   }
 
   const declare = `declare module 'payload' {\n  export interface GeneratedTypes extends Config {}\n${payloadModuleAugmentation}}`

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1089,6 +1089,10 @@ export type Config = {
     outputFile?: string
 
     /**
+     * Allows you to specify schemas that will be used to generate the TypeScript interfaces to extend the `Payload` class
+     */
+    payloadSchema?: Array<(args: { jsonSchema: JSONSchema4 }) => JSONSchema4>
+    /**
      * Allows you to modify the base JSON schema that is generated during generate:types. This JSON schema will be used
      * to generate the TypeScript interfaces.
      */


### PR DESCRIPTION
This PR allows you to type additional properties that you may want to add to `payload`.

## Example usage:

payload.config.ts:
```ts
  typescript: {
    outputFile: path.resolve(dirname, 'payload-types.ts'),
    payloadSchema: [
      ({ jsonSchema }) => {
        return {
          ...jsonSchema,
          additionalProperties: false,
          properties: {
            hello: {
              type: 'object',
              additionalProperties: false,
              properties: {
                someFn: {
                  description: 'Hello there',
                  tsType: '(a: number, b: number) => number',
                },
              },
            },
          },
        }
      },
    ],
  },
```

This generates:

```ts
declare module 'payload' {
  // @ts-ignore 
  export interface GeneratedTypes extends Config {}


export interface BasePayload {
  hello?: {
    /**
     * Hello there
     */
    someFn?: (a: number, b: number) => number;
  };
}
}
```

And now this is fully-typed:

![CleanShot 2024-12-09 at 10 47 49@2x](https://github.com/user-attachments/assets/1ab90532-b8d0-4180-a5f7-cf33c2c25ed0)
