### PR TITLE
chore: better default for useAsTitle with custom auth collections

### DIFF
--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -195,6 +195,10 @@ export const sanitizeCollection = async (
       sanitized.auth.loginWithUsername = false
     }
 
+    if (!collection?.admin?.useAsTitle) {
+      sanitized.admin.useAsTitle = sanitized.auth.loginWithUsername ? 'username' : 'email'
+    }
+
     sanitized.fields = mergeBaseFields(sanitized.fields, getBaseAuthFields(sanitized.auth))
   }
 

--- a/test/login-with-username/config.ts
+++ b/test/login-with-username/config.ts
@@ -32,6 +32,19 @@ export const LoginWithUsernameConfig = buildConfigWithDefaults({
       },
       fields: [],
     },
+    {
+      slug: 'require-email',
+      auth: {
+        loginWithUsername: {
+          requireEmail: true,
+          allowEmailLogin: false,
+        },
+      },
+      fields: [],
+      admin: {
+        useAsTitle: 'email',
+      },
+    },
   ],
 })
 

--- a/test/login-with-username/payload-types.ts
+++ b/test/login-with-username/payload-types.ts
@@ -10,10 +10,12 @@ export interface Config {
   auth: {
     users: UserAuthOperations;
     'login-with-either': LoginWithEitherAuthOperations;
+    'require-email': RequireEmailAuthOperations;
   };
   collections: {
     users: User;
     'login-with-either': LoginWithEither;
+    'require-email': RequireEmail;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -22,6 +24,7 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     'login-with-either': LoginWithEitherSelect<false> | LoginWithEitherSelect<true>;
+    'require-email': RequireEmailSelect<false> | RequireEmailSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -38,6 +41,9 @@ export interface Config {
       })
     | (LoginWithEither & {
         collection: 'login-with-either';
+      })
+    | (RequireEmail & {
+        collection: 'require-email';
       });
   jobs: {
     tasks: unknown;
@@ -90,6 +96,23 @@ export interface LoginWithEitherAuthOperations {
         username: string;
       };
 }
+export interface RequireEmailAuthOperations {
+  forgotPassword: {
+    username: string;
+  };
+  login: {
+    password: string;
+    username: string;
+  };
+  registerFirstUser: {
+    password: string;
+    username: string;
+    email: string;
+  };
+  unlock: {
+    username: string;
+  };
+}
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
@@ -128,6 +151,24 @@ export interface LoginWithEither {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "require-email".
+ */
+export interface RequireEmail {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  email: string;
+  username: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
+  password?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -140,6 +181,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'login-with-either';
         value: string | LoginWithEither;
+      } | null)
+    | ({
+        relationTo: 'require-email';
+        value: string | RequireEmail;
       } | null);
   globalSlug?: string | null;
   user:
@@ -150,6 +195,10 @@ export interface PayloadLockedDocument {
     | {
         relationTo: 'login-with-either';
         value: string | LoginWithEither;
+      }
+    | {
+        relationTo: 'require-email';
+        value: string | RequireEmail;
       };
   updatedAt: string;
   createdAt: string;
@@ -168,6 +217,10 @@ export interface PayloadPreference {
     | {
         relationTo: 'login-with-either';
         value: string | LoginWithEither;
+      }
+    | {
+        relationTo: 'require-email';
+        value: string | RequireEmail;
       };
   key?: string | null;
   value?:
@@ -214,6 +267,22 @@ export interface UsersSelect<T extends boolean = true> {
  * via the `definition` "login-with-either_select".
  */
 export interface LoginWithEitherSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+  email?: T;
+  username?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "require-email_select".
+ */
+export interface RequireEmailSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   email?: T;


### PR DESCRIPTION
### What?
Custom auth collections default `useAsTitle` to `id`.

### Why?
It is more expected for auth collections to search on email or username. 

### How?
Defaults useAsTitle to `username` if loginWithUsername is used, else `email`. Can still be overridden by setting a custom `admin.useAsTitle` property.