### PR TITLE
fix(next): upload handlers can stop the next ones

### DIFF
--- a/packages/next/src/routes/rest/files/getFile.ts
+++ b/packages/next/src/routes/rest/files/getFile.ts
@@ -47,10 +47,10 @@ export const getFile = async ({ collection, filename, req }: Args): Promise<Resp
             filename,
           },
         })
-      }
 
-      if (customResponse instanceof Response) {
-        return customResponse
+        if (customResponse instanceof Response) {
+          return customResponse
+        }
       }
     }
 

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -156,7 +156,7 @@ export type UploadConfig = {
       doc: TypeWithID
       params: { collection: string; filename: string }
     },
-  ) => Promise<Response> | Promise<void> | Response | void)[]
+  ) => Promise<Response | void | null> | Response | void | null)[]
   imageSizes?: ImageSize[]
   /**
    * Restrict mimeTypes in the file picker. Array of valid mime types or mimetype wildcards


### PR DESCRIPTION
### What ?
This PR fix the uploads handlers to work accordingly to the documentation.

See packages/payload/src/uploads/types.ts:144 :
```typescript  
 /**
   * Custom handlers to run when a file is fetched.
   *
   * - If a handler returns a Response, the response will be sent to the client and no further handlers will be run.
   * - If a handler returns null, the next handler will be run.
   * - If no handlers return a response the file will be returned by default.
   *
   * @default undefined
   */
  handlers?: ((
    req: PayloadRequest,
    args: {
      doc: TypeWithID
      params: { collection: string; filename: string }
    },
  ) => Promise<Response> | Promise<void> | Response | void)[]
```
https://github.com/payloadcms/payload/blob/76428373e4ad94ec29dd58ee293a68b0b67429dc/packages/payload/src/uploads/types.ts#L144C1-L159C62

### Why ?
Currently, the customResponse instanceof Response check is done only after the whole for loop, so there's no way to prevent the other handlers to run by returning a response.

### How ?
The proposed fix just make it works as the documentation says. It also allows for returning null in the handler.
By moving the conditional check inside the for loop we avoid running the whole loop if we have any significant result

### Example
In my implementation, I have a field on a collection called "location" with value "gcp" and "local". I created a handler that checks this field, and stream the file it it's local. Otherwise, the GCP storage plugin handles it.
But with the current code, the GCP handler is always running and returns a 404, as it's the last registered #handler.