### PR TITLE
examples(multi-tenant): update README.md to copy env variables

### DIFF
--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -7,10 +7,11 @@ This example demonstrates how to achieve a multi-tenancy in [Payload](https://gi
 To spin up this example locally, follow these steps:
 
 1. Clone this repo
-1. `cd` into this directory and run `pnpm i --ignore-workspace`\*, `yarn`, or `npm install`
+1. `cd` into this directory and run `pnpm i --ignore-workspace`, `yarn`, or `npm install`
 
    > \*If you are running using pnpm within the Payload Monorepo, the `--ignore-workspace` flag is needed so that pnpm generates a lockfile in this example's directory despite the fact that one exists in root.
 
+1. `cp .env.example .env` to add the [environment variables file](https://payloadcms.com/docs/configuration/environment-vars)
 1. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
    - Press `y` when prompted to seed the database
 1. `open http://localhost:3000` to access the home page


### PR DESCRIPTION
Running `dev` without an [environment variables file](https://payloadcms.com/docs/configuration/environment-vars) supplying `DATABASE_URI`, `PAYLOAD_SECRET` and `PAYLOAD_PUBLIC_SERVER_URL` will fail. 

The example in the repo already comes with  an `.env.example` which simply needs to be copied and renamed to `.env`.