### PR TITLE
fix(next): thread default ServerProps to view actions and other components that were missing

### DIFF
--- a/packages/next/src/templates/Default/index.tsx
+++ b/packages/next/src/templates/Default/index.tsx
@@ -57,8 +57,9 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
       permissions,
       searchParams,
       user,
+      visibleEntities,
     }),
-    [i18n, locale, params, payload, permissions, searchParams, user],
+    [i18n, locale, params, payload, permissions, searchParams, user, visibleEntities],
   )
 
   const { Actions } = React.useMemo<{
@@ -94,10 +95,7 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
     Component: CustomNav,
     Fallback: DefaultNav,
     importMap: payload.importMap,
-    serverProps: {
-      ...serverProps,
-      visibleEntities,
-    },
+    serverProps,
   })
 
   return (
@@ -108,10 +106,7 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
             clientProps: { clientProps: { visibleEntities } },
             Component: CustomHeader,
             importMap: payload.importMap,
-            serverProps: {
-              ...serverProps,
-              visibleEntities,
-            },
+            serverProps,
           })}
           <div style={{ position: 'relative' }}>
             <div className={`${baseClass}__nav-toggler-wrapper`} id="nav-toggler">
@@ -130,6 +125,7 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
                       ? RenderServerComponent({
                           Component: avatar.Component,
                           importMap: payload.importMap,
+                          serverProps,
                         })
                       : undefined
                   }
@@ -138,6 +134,7 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
                       ? RenderServerComponent({
                           Component: components.graphics.Icon,
                           importMap: payload.importMap,
+                          serverProps,
                         })
                       : undefined
                   }

--- a/packages/next/src/templates/Default/index.tsx
+++ b/packages/next/src/templates/Default/index.tsx
@@ -51,6 +51,15 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
   const { Actions } = React.useMemo<{
     Actions: Record<string, React.ReactNode>
   }>(() => {
+    const viewActionServerProps = {
+      i18n,
+      locale,
+      params,
+      payload,
+      permissions,
+      searchParams,
+      user,
+    }
     return {
       Actions: viewActions
         ? viewActions.reduce((acc, action) => {
@@ -59,11 +68,13 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
                 acc[action.path] = RenderServerComponent({
                   Component: action,
                   importMap: payload.importMap,
+                  serverProps: viewActionServerProps,
                 })
               } else {
                 acc[action] = RenderServerComponent({
                   Component: action,
                   importMap: payload.importMap,
+                  serverProps: viewActionServerProps,
                 })
               }
             }
@@ -72,7 +83,7 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
           }, {})
         : undefined,
     }
-  }, [viewActions, payload])
+  }, [i18n, locale, params, payload, permissions, searchParams, user, viewActions])
 
   const NavComponent = RenderServerComponent({
     clientProps: { clientProps: { visibleEntities } },

--- a/packages/next/src/templates/Default/index.tsx
+++ b/packages/next/src/templates/Default/index.tsx
@@ -48,10 +48,8 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
     } = {},
   } = payload.config || {}
 
-  const { Actions } = React.useMemo<{
-    Actions: Record<string, React.ReactNode>
-  }>(() => {
-    const viewActionServerProps = {
+  const serverProps = React.useMemo<ServerProps>(
+    () => ({
       i18n,
       locale,
       params,
@@ -59,7 +57,13 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
       permissions,
       searchParams,
       user,
-    }
+    }),
+    [i18n, locale, params, payload, permissions, searchParams, user],
+  )
+
+  const { Actions } = React.useMemo<{
+    Actions: Record<string, React.ReactNode>
+  }>(() => {
     return {
       Actions: viewActions
         ? viewActions.reduce((acc, action) => {
@@ -68,13 +72,13 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
                 acc[action.path] = RenderServerComponent({
                   Component: action,
                   importMap: payload.importMap,
-                  serverProps: viewActionServerProps,
+                  serverProps,
                 })
               } else {
                 acc[action] = RenderServerComponent({
                   Component: action,
                   importMap: payload.importMap,
-                  serverProps: viewActionServerProps,
+                  serverProps,
                 })
               }
             }
@@ -83,7 +87,7 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
           }, {})
         : undefined,
     }
-  }, [i18n, locale, params, payload, permissions, searchParams, user, viewActions])
+  }, [payload, serverProps, viewActions])
 
   const NavComponent = RenderServerComponent({
     clientProps: { clientProps: { visibleEntities } },
@@ -91,13 +95,7 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
     Fallback: DefaultNav,
     importMap: payload.importMap,
     serverProps: {
-      i18n,
-      locale,
-      params,
-      payload,
-      permissions,
-      searchParams,
-      user,
+      ...serverProps,
       visibleEntities,
     },
   })
@@ -111,13 +109,7 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
             Component: CustomHeader,
             importMap: payload.importMap,
             serverProps: {
-              i18n,
-              locale,
-              params,
-              payload,
-              permissions,
-              searchParams,
-              user,
+              ...serverProps,
               visibleEntities,
             },
           })}

--- a/packages/next/src/views/Document/renderDocumentSlots.tsx
+++ b/packages/next/src/views/Document/renderDocumentSlots.tsx
@@ -5,12 +5,12 @@ import type {
   SanitizedCollectionConfig,
   SanitizedDocumentPermissions,
   SanitizedGlobalConfig,
+  ServerProps,
   StaticDescription,
 } from 'payload'
 
 import { ViewDescription } from '@payloadcms/ui'
 import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
-import React from 'react'
 
 import { getDocumentPermissions } from './getDocumentPermissions.js'
 
@@ -29,6 +29,13 @@ export const renderDocumentSlots: (args: {
 
   const isPreviewEnabled = collectionConfig?.admin?.preview || globalConfig?.admin?.preview
 
+  const serverProps: ServerProps = {
+    i18n: req.i18n,
+    payload: req.payload,
+    user: req.user,
+    // TODO: Add remaining serverProps
+  }
+
   const CustomPreviewButton =
     collectionConfig?.admin?.components?.edit?.PreviewButton ||
     globalConfig?.admin?.components?.elements?.PreviewButton
@@ -37,6 +44,7 @@ export const renderDocumentSlots: (args: {
     components.PreviewButton = RenderServerComponent({
       Component: CustomPreviewButton,
       importMap: req.payload.importMap,
+      serverProps,
     })
   }
 
@@ -60,6 +68,7 @@ export const renderDocumentSlots: (args: {
       Component: CustomDescription,
       Fallback: ViewDescription,
       importMap: req.payload.importMap,
+      serverProps,
     })
   }
 
@@ -73,6 +82,7 @@ export const renderDocumentSlots: (args: {
         components.PublishButton = RenderServerComponent({
           Component: CustomPublishButton,
           importMap: req.payload.importMap,
+          serverProps,
         })
       }
       const CustomSaveDraftButton =
@@ -87,6 +97,7 @@ export const renderDocumentSlots: (args: {
         components.SaveDraftButton = RenderServerComponent({
           Component: CustomSaveDraftButton,
           importMap: req.payload.importMap,
+          serverProps,
         })
       }
     } else {
@@ -98,6 +109,7 @@ export const renderDocumentSlots: (args: {
         components.SaveButton = RenderServerComponent({
           Component: CustomSaveButton,
           importMap: req.payload.importMap,
+          serverProps,
         })
       }
     }

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -704,7 +704,7 @@ export type Config = {
       | 'default'
       | 'gravatar'
       | {
-          Component: PayloadComponent<never>
+          Component: PayloadComponent
         }
     /**
      * Add extra and/or replace built-in components with custom components


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR threads default `serverProps` to Edit & List view action slots.

### Why?
To be more in-line with how the docs specify custom components should work. Custom components should recieve, at minimum, the `BasePayload` instance and `i18n` object.

### How?
By including props into `RenderServerComponent` call in the `DefaultTemplate`

Notes:
- There is an opportunity for a refactor here to reuse these props throughout multiple places in `DefaultTemplate`. Slightly awkward due to having the actions being memoized but doable. Happy to make the necessary changes for this.