### PR TITLE
perf: reduce generated types for select by respecting `interfaceName`

### DIFF
--- a/packages/payload/src/utilities/addSelectGenericsToGeneratedTypes.spec.ts
+++ b/packages/payload/src/utilities/addSelectGenericsToGeneratedTypes.spec.ts
@@ -178,6 +178,7 @@ export interface PayloadMigration {
 export interface PostsSelect {
   text?: boolean;
   number?: boolean;
+  sharedGroup?: boolean | SharedGroup;
   group?:
     | boolean
     | {
@@ -451,6 +452,7 @@ export interface PayloadMigration {
 export interface PostsSelect<T extends boolean = true> {
   text?: T;
   number?: T;
+  sharedGroup?: T | SharedGroup<T>;
   group?:
     | T
     | {

--- a/packages/payload/src/utilities/addSelectGenericsToGeneretedTypes.ts
+++ b/packages/payload/src/utilities/addSelectGenericsToGeneretedTypes.ts
@@ -35,8 +35,14 @@ export const addSelectGenericsToGeneratedTypes = ({
         // add generic to the interface
         newLine = line.replace(/(export interface\s+\w+)(\s*\{)/g, '$1<T extends boolean = true>$2')
       } else {
-        // replace booleans with T on the line
-        newLine = line.replace(/(?<!\?)\bboolean\b/g, 'T')
+        newLine = line
+          // replace booleans with T on the line
+          .replace(/(?<!\?)\bboolean\b/g, 'T')
+          // replace interface names like CtaBlock to CtaBlock<T>
+          .replace(
+            /\b(\w+)\s*\|\s*(\w+)\b/g,
+            (_match, left, right) => `${left} | ${right}<${left}>`,
+          )
 
         if (line === '}') {
           isSelectTypeToken = false

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -643,7 +643,13 @@ export function entityToJSONSchema(
   }
 }
 
-export function fieldsToSelectJSONSchema({ fields }: { fields: FlattenedField[] }): JSONSchema4 {
+export function fieldsToSelectJSONSchema({
+  fields,
+  interfaceNameDefinitions,
+}: {
+  fields: FlattenedField[]
+  interfaceNameDefinitions: Map<string, JSONSchema4>
+}): JSONSchema4 {
   const schema: JSONSchema4 = {
     type: 'object',
     additionalProperties: false,
@@ -654,16 +660,32 @@ export function fieldsToSelectJSONSchema({ fields }: { fields: FlattenedField[] 
     switch (field.type) {
       case 'array':
       case 'group':
-      case 'tab':
+      case 'tab': {
+        let fieldSchema: JSONSchema4 = fieldsToSelectJSONSchema({
+          fields: field.flattenedFields,
+          interfaceNameDefinitions,
+        })
+
+        if (field.interfaceName) {
+          const definition = `${field.interfaceName}_select`
+          interfaceNameDefinitions.set(definition, fieldSchema)
+
+          fieldSchema = {
+            $ref: `#/definitions/${definition}`,
+          }
+        }
+
         schema.properties[field.name] = {
           oneOf: [
             {
               type: 'boolean',
             },
-            fieldsToSelectJSONSchema({ fields: field.flattenedFields }),
+            fieldSchema,
           ],
         }
+
         break
+      }
 
       case 'blocks': {
         const blocksSchema: JSONSchema4 = {
@@ -673,12 +695,25 @@ export function fieldsToSelectJSONSchema({ fields }: { fields: FlattenedField[] 
         }
 
         for (const block of field.blocks) {
+          let blockSchema = fieldsToSelectJSONSchema({
+            fields: block.flattenedFields,
+            interfaceNameDefinitions,
+          })
+
+          if (block.interfaceName) {
+            const definition = `${block.interfaceName}_select`
+            interfaceNameDefinitions.set(definition, blockSchema)
+            blockSchema = {
+              $ref: `#/definitions/${definition}`,
+            }
+          }
+
           blocksSchema.properties[block.slug] = {
             oneOf: [
               {
                 type: 'boolean',
               },
-              fieldsToSelectJSONSchema({ fields: block.flattenedFields }),
+              blockSchema,
             ],
           }
         }
@@ -900,7 +935,10 @@ export function configToJSONSchema(
         defaultIDType,
         collectionIDFieldTypes,
       )
-      const select = fieldsToSelectJSONSchema({ fields: entity.flattenedFields })
+      const select = fieldsToSelectJSONSchema({
+        fields: entity.flattenedFields,
+        interfaceNameDefinitions,
+      })
 
       if (type === 'global') {
         select.properties.globalType = {

--- a/test/auth/payload-types.ts
+++ b/test/auth/payload-types.ts
@@ -35,7 +35,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {};
   globalsSelect: {};
@@ -135,7 +135,7 @@ export interface PublicUserAuthOperations {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   adminOnlyField?: string | null;
   roles: ('admin' | 'editor' | 'moderator' | 'user' | 'viewer')[];
   namedSaveToJWT?: string | null;
@@ -175,7 +175,7 @@ export interface User {
  * via the `definition` "partial-disable-locale-strategies".
  */
 export interface PartialDisableLocaleStrategy {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -192,7 +192,7 @@ export interface PartialDisableLocaleStrategy {
  * via the `definition` "api-keys".
  */
 export interface ApiKey {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   enableAPIKey?: boolean | null;
@@ -204,7 +204,7 @@ export interface ApiKey {
  * via the `definition` "public-users".
  */
 export interface PublicUser {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -223,8 +223,8 @@ export interface PublicUser {
  * via the `definition` "relationsCollection".
  */
 export interface RelationsCollection {
-  id: number;
-  rel?: (number | null) | User;
+  id: string;
+  rel?: (string | null) | User;
   text?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -234,45 +234,45 @@ export interface RelationsCollection {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null)
     | ({
         relationTo: 'partial-disable-locale-strategies';
-        value: number | PartialDisableLocaleStrategy;
+        value: string | PartialDisableLocaleStrategy;
       } | null)
     | ({
         relationTo: 'api-keys';
-        value: number | ApiKey;
+        value: string | ApiKey;
       } | null)
     | ({
         relationTo: 'public-users';
-        value: number | PublicUser;
+        value: string | PublicUser;
       } | null)
     | ({
         relationTo: 'relationsCollection';
-        value: number | RelationsCollection;
+        value: string | RelationsCollection;
       } | null);
   globalSlug?: string | null;
   user:
     | {
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       }
     | {
         relationTo: 'partial-disable-locale-strategies';
-        value: number | PartialDisableLocaleStrategy;
+        value: string | PartialDisableLocaleStrategy;
       }
     | {
         relationTo: 'api-keys';
-        value: number | ApiKey;
+        value: string | ApiKey;
       }
     | {
         relationTo: 'public-users';
-        value: number | PublicUser;
+        value: string | PublicUser;
       };
   updatedAt: string;
   createdAt: string;
@@ -282,23 +282,23 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user:
     | {
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       }
     | {
         relationTo: 'partial-disable-locale-strategies';
-        value: number | PartialDisableLocaleStrategy;
+        value: string | PartialDisableLocaleStrategy;
       }
     | {
         relationTo: 'api-keys';
-        value: number | ApiKey;
+        value: string | ApiKey;
       }
     | {
         relationTo: 'public-users';
-        value: number | PublicUser;
+        value: string | PublicUser;
       };
   key?: string | null;
   value?:
@@ -318,7 +318,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -11,6 +11,8 @@ export const getBlocksField = (prefix?: string): BlocksField => ({
   blocks: [
     {
       slug: prefix ? `${prefix}Content` : 'content',
+      // non in pascal case should be still handled
+      interfaceName: 'contentBlock',
       fields: [
         {
           name: 'text',
@@ -26,6 +28,7 @@ export const getBlocksField = (prefix?: string): BlocksField => ({
     },
     {
       slug: prefix ? `${prefix}Number` : 'number',
+      interfaceName: 'NumberBlock',
       fields: [
         {
           name: 'number',
@@ -36,6 +39,7 @@ export const getBlocksField = (prefix?: string): BlocksField => ({
     },
     {
       slug: prefix ? `${prefix}SubBlocks` : 'subBlocks',
+      interfaceName: 'SubBlocksBlock',
       fields: [
         {
           type: 'collapsible',
@@ -73,6 +77,7 @@ export const getBlocksField = (prefix?: string): BlocksField => ({
     },
     {
       slug: prefix ? `${prefix}Tabs` : 'tabs',
+      interfaceName: 'TabsBlock',
       fields: [
         {
           type: 'tabs',

--- a/test/fields/collections/Blocks/index.ts
+++ b/test/fields/collections/Blocks/index.ts
@@ -11,8 +11,7 @@ export const getBlocksField = (prefix?: string): BlocksField => ({
   blocks: [
     {
       slug: prefix ? `${prefix}Content` : 'content',
-      // non in pascal case should be still handled
-      interfaceName: 'contentBlock',
+      interfaceName: prefix ? `${prefix}ContentBlock` : 'ContentBlock',
       fields: [
         {
           name: 'text',
@@ -28,7 +27,7 @@ export const getBlocksField = (prefix?: string): BlocksField => ({
     },
     {
       slug: prefix ? `${prefix}Number` : 'number',
-      interfaceName: 'NumberBlock',
+      interfaceName: prefix ? `${prefix}NumberBlock` : 'NumberBlock',
       fields: [
         {
           name: 'number',
@@ -39,7 +38,7 @@ export const getBlocksField = (prefix?: string): BlocksField => ({
     },
     {
       slug: prefix ? `${prefix}SubBlocks` : 'subBlocks',
-      interfaceName: 'SubBlocksBlock',
+      interfaceName: prefix ? `${prefix}SubBlocksBlock` : 'SubBlocksBlock',
       fields: [
         {
           type: 'collapsible',
@@ -77,7 +76,7 @@ export const getBlocksField = (prefix?: string): BlocksField => ({
     },
     {
       slug: prefix ? `${prefix}Tabs` : 'tabs',
-      interfaceName: 'TabsBlock',
+      interfaceName: prefix ? `${prefix}TabsBlock` : 'TabsBlock',
       fields: [
         {
           type: 'tabs',

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -516,9 +516,14 @@ export interface BlockField {
   id: string;
   blocks: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
   duplicate: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
-  collapsedByDefaultBlocks: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
-  disableSort: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
-  localizedBlocks: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
+  collapsedByDefaultBlocks: (
+    | LocalizedContentBlock
+    | LocalizedNumberBlock
+    | LocalizedSubBlocksBlock
+    | LocalizedTabsBlock
+  )[];
+  disableSort: (LocalizedContentBlock | LocalizedNumberBlock | LocalizedSubBlocksBlock | LocalizedTabsBlock)[];
+  localizedBlocks: (LocalizedContentBlock | LocalizedNumberBlock | LocalizedSubBlocksBlock | LocalizedTabsBlock)[];
   i18nBlocks?:
     | {
         text?: string | null;
@@ -634,7 +639,7 @@ export interface BlockField {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "contentBlock".
+ * via the `definition` "ContentBlock".
  */
 export interface ContentBlock {
   text: string;
@@ -692,6 +697,67 @@ export interface TabsBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'tabs';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedContentBlock".
+ */
+export interface LocalizedContentBlock {
+  text: string;
+  richText?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'localizedContent';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedNumberBlock".
+ */
+export interface LocalizedNumberBlock {
+  number: number;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'localizedNumber';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedSubBlocksBlock".
+ */
+export interface LocalizedSubBlocksBlock {
+  subBlocks?:
+    | (
+        | {
+            text: string;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'text';
+          }
+        | {
+            number: number;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'number';
+          }
+      )[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'localizedSubBlocks';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedTabsBlock".
+ */
+export interface LocalizedTabsBlock {
+  textInCollapsible?: string | null;
+  textInRow?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'localizedTabs';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1984,26 +2050,26 @@ export interface BlockFieldsSelect<T extends boolean = true> {
   collapsedByDefaultBlocks?:
     | T
     | {
-        localizedContent?: T | ContentBlockSelect<T>;
-        localizedNumber?: T | NumberBlockSelect<T>;
-        localizedSubBlocks?: T | SubBlocksBlockSelect<T>;
-        localizedTabs?: T | TabsBlockSelect<T>;
+        localizedContent?: T | LocalizedContentBlockSelect<T>;
+        localizedNumber?: T | LocalizedNumberBlockSelect<T>;
+        localizedSubBlocks?: T | LocalizedSubBlocksBlockSelect<T>;
+        localizedTabs?: T | LocalizedTabsBlockSelect<T>;
       };
   disableSort?:
     | T
     | {
-        localizedContent?: T | ContentBlockSelect<T>;
-        localizedNumber?: T | NumberBlockSelect<T>;
-        localizedSubBlocks?: T | SubBlocksBlockSelect<T>;
-        localizedTabs?: T | TabsBlockSelect<T>;
+        localizedContent?: T | LocalizedContentBlockSelect<T>;
+        localizedNumber?: T | LocalizedNumberBlockSelect<T>;
+        localizedSubBlocks?: T | LocalizedSubBlocksBlockSelect<T>;
+        localizedTabs?: T | LocalizedTabsBlockSelect<T>;
       };
   localizedBlocks?:
     | T
     | {
-        localizedContent?: T | ContentBlockSelect<T>;
-        localizedNumber?: T | NumberBlockSelect<T>;
-        localizedSubBlocks?: T | SubBlocksBlockSelect<T>;
-        localizedTabs?: T | TabsBlockSelect<T>;
+        localizedContent?: T | LocalizedContentBlockSelect<T>;
+        localizedNumber?: T | LocalizedNumberBlockSelect<T>;
+        localizedSubBlocks?: T | LocalizedSubBlocksBlockSelect<T>;
+        localizedTabs?: T | LocalizedTabsBlockSelect<T>;
       };
   i18nBlocks?:
     | T
@@ -2143,7 +2209,7 @@ export interface BlockFieldsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "contentBlock_select".
+ * via the `definition` "ContentBlock_select".
  */
 export interface ContentBlockSelect<T extends boolean = true> {
   text?: T;
@@ -2191,6 +2257,61 @@ export interface SubBlocksBlockSelect<T extends boolean = true> {
  * via the `definition` "TabsBlock_select".
  */
 export interface TabsBlockSelect<T extends boolean = true> {
+  textInCollapsible?: T;
+  textInRow?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedContentBlock_select".
+ */
+export interface LocalizedContentBlockSelect<T extends boolean = true> {
+  text?: T;
+  richText?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedNumberBlock_select".
+ */
+export interface LocalizedNumberBlockSelect<T extends boolean = true> {
+  number?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedSubBlocksBlock_select".
+ */
+export interface LocalizedSubBlocksBlockSelect<T extends boolean = true> {
+  subBlocks?:
+    | T
+    | {
+        text?:
+          | T
+          | {
+              text?: T;
+              id?: T;
+              blockName?: T;
+            };
+        number?:
+          | T
+          | {
+              number?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localizedTabsBlock_select".
+ */
+export interface LocalizedTabsBlockSelect<T extends boolean = true> {
   textInCollapsible?: T;
   textInRow?: T;
   id?: T;

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -514,241 +514,11 @@ export interface ArrayField {
  */
 export interface BlockField {
   id: string;
-  blocks: (
-    | {
-        text: string;
-        richText?:
-          | {
-              [k: string]: unknown;
-            }[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'content';
-      }
-    | {
-        number: number;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'number';
-      }
-    | {
-        subBlocks?:
-          | (
-              | {
-                  text: string;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'text';
-                }
-              | {
-                  number: number;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'number';
-                }
-            )[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'subBlocks';
-      }
-    | {
-        textInCollapsible?: string | null;
-        textInRow?: string | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'tabs';
-      }
-  )[];
-  duplicate: (
-    | {
-        text: string;
-        richText?:
-          | {
-              [k: string]: unknown;
-            }[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'content';
-      }
-    | {
-        number: number;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'number';
-      }
-    | {
-        subBlocks?:
-          | (
-              | {
-                  text: string;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'text';
-                }
-              | {
-                  number: number;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'number';
-                }
-            )[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'subBlocks';
-      }
-    | {
-        textInCollapsible?: string | null;
-        textInRow?: string | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'tabs';
-      }
-  )[];
-  collapsedByDefaultBlocks: (
-    | {
-        text: string;
-        richText?:
-          | {
-              [k: string]: unknown;
-            }[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedContent';
-      }
-    | {
-        number: number;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedNumber';
-      }
-    | {
-        subBlocks?:
-          | (
-              | {
-                  text: string;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'text';
-                }
-              | {
-                  number: number;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'number';
-                }
-            )[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedSubBlocks';
-      }
-    | {
-        textInCollapsible?: string | null;
-        textInRow?: string | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedTabs';
-      }
-  )[];
-  disableSort: (
-    | {
-        text: string;
-        richText?:
-          | {
-              [k: string]: unknown;
-            }[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedContent';
-      }
-    | {
-        number: number;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedNumber';
-      }
-    | {
-        subBlocks?:
-          | (
-              | {
-                  text: string;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'text';
-                }
-              | {
-                  number: number;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'number';
-                }
-            )[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedSubBlocks';
-      }
-    | {
-        textInCollapsible?: string | null;
-        textInRow?: string | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedTabs';
-      }
-  )[];
-  localizedBlocks: (
-    | {
-        text: string;
-        richText?:
-          | {
-              [k: string]: unknown;
-            }[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedContent';
-      }
-    | {
-        number: number;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedNumber';
-      }
-    | {
-        subBlocks?:
-          | (
-              | {
-                  text: string;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'text';
-                }
-              | {
-                  number: number;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'number';
-                }
-            )[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedSubBlocks';
-      }
-    | {
-        textInCollapsible?: string | null;
-        textInRow?: string | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'localizedTabs';
-      }
-  )[];
+  blocks: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
+  duplicate: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
+  collapsedByDefaultBlocks: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
+  disableSort: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
+  localizedBlocks: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
   i18nBlocks?:
     | {
         text?: string | null;
@@ -861,6 +631,67 @@ export interface BlockField {
     | null;
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "contentBlock".
+ */
+export interface ContentBlock {
+  text: string;
+  richText?:
+    | {
+        [k: string]: unknown;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'content';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "NumberBlock".
+ */
+export interface NumberBlock {
+  number: number;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'number';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SubBlocksBlock".
+ */
+export interface SubBlocksBlock {
+  subBlocks?:
+    | (
+        | {
+            text: string;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'text';
+          }
+        | {
+            number: number;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'number';
+          }
+      )[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'subBlocks';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TabsBlock".
+ */
+export interface TabsBlock {
+  textInCollapsible?: string | null;
+  textInRow?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'tabs';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1546,53 +1377,7 @@ export interface TabsField {
     text: string;
     id?: string | null;
   }[];
-  blocks: (
-    | {
-        text: string;
-        richText?:
-          | {
-              [k: string]: unknown;
-            }[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'content';
-      }
-    | {
-        number: number;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'number';
-      }
-    | {
-        subBlocks?:
-          | (
-              | {
-                  text: string;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'text';
-                }
-              | {
-                  number: number;
-                  id?: string | null;
-                  blockName?: string | null;
-                  blockType: 'number';
-                }
-            )[]
-          | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'subBlocks';
-      }
-    | {
-        textInCollapsible?: string | null;
-        textInRow?: string | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'tabs';
-      }
-  )[];
+  blocks: (ContentBlock | NumberBlock | SubBlocksBlock | TabsBlock)[];
   group: {
     number: number;
   };
@@ -2183,257 +1968,42 @@ export interface BlockFieldsSelect<T extends boolean = true> {
   blocks?:
     | T
     | {
-        content?:
-          | T
-          | {
-              text?: T;
-              richText?: T;
-              id?: T;
-              blockName?: T;
-            };
-        number?:
-          | T
-          | {
-              number?: T;
-              id?: T;
-              blockName?: T;
-            };
-        subBlocks?:
-          | T
-          | {
-              subBlocks?:
-                | T
-                | {
-                    text?:
-                      | T
-                      | {
-                          text?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                    number?:
-                      | T
-                      | {
-                          number?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                  };
-              id?: T;
-              blockName?: T;
-            };
-        tabs?:
-          | T
-          | {
-              textInCollapsible?: T;
-              textInRow?: T;
-              id?: T;
-              blockName?: T;
-            };
+        content?: T | ContentBlockSelect<T>;
+        number?: T | NumberBlockSelect<T>;
+        subBlocks?: T | SubBlocksBlockSelect<T>;
+        tabs?: T | TabsBlockSelect<T>;
       };
   duplicate?:
     | T
     | {
-        content?:
-          | T
-          | {
-              text?: T;
-              richText?: T;
-              id?: T;
-              blockName?: T;
-            };
-        number?:
-          | T
-          | {
-              number?: T;
-              id?: T;
-              blockName?: T;
-            };
-        subBlocks?:
-          | T
-          | {
-              subBlocks?:
-                | T
-                | {
-                    text?:
-                      | T
-                      | {
-                          text?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                    number?:
-                      | T
-                      | {
-                          number?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                  };
-              id?: T;
-              blockName?: T;
-            };
-        tabs?:
-          | T
-          | {
-              textInCollapsible?: T;
-              textInRow?: T;
-              id?: T;
-              blockName?: T;
-            };
+        content?: T | ContentBlockSelect<T>;
+        number?: T | NumberBlockSelect<T>;
+        subBlocks?: T | SubBlocksBlockSelect<T>;
+        tabs?: T | TabsBlockSelect<T>;
       };
   collapsedByDefaultBlocks?:
     | T
     | {
-        localizedContent?:
-          | T
-          | {
-              text?: T;
-              richText?: T;
-              id?: T;
-              blockName?: T;
-            };
-        localizedNumber?:
-          | T
-          | {
-              number?: T;
-              id?: T;
-              blockName?: T;
-            };
-        localizedSubBlocks?:
-          | T
-          | {
-              subBlocks?:
-                | T
-                | {
-                    text?:
-                      | T
-                      | {
-                          text?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                    number?:
-                      | T
-                      | {
-                          number?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                  };
-              id?: T;
-              blockName?: T;
-            };
-        localizedTabs?:
-          | T
-          | {
-              textInCollapsible?: T;
-              textInRow?: T;
-              id?: T;
-              blockName?: T;
-            };
+        localizedContent?: T | ContentBlockSelect<T>;
+        localizedNumber?: T | NumberBlockSelect<T>;
+        localizedSubBlocks?: T | SubBlocksBlockSelect<T>;
+        localizedTabs?: T | TabsBlockSelect<T>;
       };
   disableSort?:
     | T
     | {
-        localizedContent?:
-          | T
-          | {
-              text?: T;
-              richText?: T;
-              id?: T;
-              blockName?: T;
-            };
-        localizedNumber?:
-          | T
-          | {
-              number?: T;
-              id?: T;
-              blockName?: T;
-            };
-        localizedSubBlocks?:
-          | T
-          | {
-              subBlocks?:
-                | T
-                | {
-                    text?:
-                      | T
-                      | {
-                          text?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                    number?:
-                      | T
-                      | {
-                          number?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                  };
-              id?: T;
-              blockName?: T;
-            };
-        localizedTabs?:
-          | T
-          | {
-              textInCollapsible?: T;
-              textInRow?: T;
-              id?: T;
-              blockName?: T;
-            };
+        localizedContent?: T | ContentBlockSelect<T>;
+        localizedNumber?: T | NumberBlockSelect<T>;
+        localizedSubBlocks?: T | SubBlocksBlockSelect<T>;
+        localizedTabs?: T | TabsBlockSelect<T>;
       };
   localizedBlocks?:
     | T
     | {
-        localizedContent?:
-          | T
-          | {
-              text?: T;
-              richText?: T;
-              id?: T;
-              blockName?: T;
-            };
-        localizedNumber?:
-          | T
-          | {
-              number?: T;
-              id?: T;
-              blockName?: T;
-            };
-        localizedSubBlocks?:
-          | T
-          | {
-              subBlocks?:
-                | T
-                | {
-                    text?:
-                      | T
-                      | {
-                          text?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                    number?:
-                      | T
-                      | {
-                          number?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                  };
-              id?: T;
-              blockName?: T;
-            };
-        localizedTabs?:
-          | T
-          | {
-              textInCollapsible?: T;
-              textInRow?: T;
-              id?: T;
-              blockName?: T;
-            };
+        localizedContent?: T | ContentBlockSelect<T>;
+        localizedNumber?: T | NumberBlockSelect<T>;
+        localizedSubBlocks?: T | SubBlocksBlockSelect<T>;
+        localizedTabs?: T | TabsBlockSelect<T>;
       };
   i18nBlocks?:
     | T
@@ -2570,6 +2140,61 @@ export interface BlockFieldsSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "contentBlock_select".
+ */
+export interface ContentBlockSelect<T extends boolean = true> {
+  text?: T;
+  richText?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "NumberBlock_select".
+ */
+export interface NumberBlockSelect<T extends boolean = true> {
+  number?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SubBlocksBlock_select".
+ */
+export interface SubBlocksBlockSelect<T extends boolean = true> {
+  subBlocks?:
+    | T
+    | {
+        text?:
+          | T
+          | {
+              text?: T;
+              id?: T;
+              blockName?: T;
+            };
+        number?:
+          | T
+          | {
+              number?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TabsBlock_select".
+ */
+export interface TabsBlockSelect<T extends boolean = true> {
+  textInCollapsible?: T;
+  textInRow?: T;
+  id?: T;
+  blockName?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -3108,53 +2733,10 @@ export interface TabsFieldsSelect<T extends boolean = true> {
   blocks?:
     | T
     | {
-        content?:
-          | T
-          | {
-              text?: T;
-              richText?: T;
-              id?: T;
-              blockName?: T;
-            };
-        number?:
-          | T
-          | {
-              number?: T;
-              id?: T;
-              blockName?: T;
-            };
-        subBlocks?:
-          | T
-          | {
-              subBlocks?:
-                | T
-                | {
-                    text?:
-                      | T
-                      | {
-                          text?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                    number?:
-                      | T
-                      | {
-                          number?: T;
-                          id?: T;
-                          blockName?: T;
-                        };
-                  };
-              id?: T;
-              blockName?: T;
-            };
-        tabs?:
-          | T
-          | {
-              textInCollapsible?: T;
-              textInRow?: T;
-              id?: T;
-              blockName?: T;
-            };
+        content?: T | ContentBlockSelect<T>;
+        number?: T | NumberBlockSelect<T>;
+        subBlocks?: T | SubBlocksBlockSelect<T>;
+        tabs?: T | TabsBlockSelect<T>;
       };
   group?:
     | T
@@ -3164,24 +2746,7 @@ export interface TabsFieldsSelect<T extends boolean = true> {
   textInRow?: T;
   numberInRow?: T;
   json?: T;
-  tab?:
-    | T
-    | {
-        array?:
-          | T
-          | {
-              text?: T;
-              id?: T;
-            };
-        text?: T;
-        defaultValue?: T;
-        arrayInRow?:
-          | T
-          | {
-              textInArrayInRow?: T;
-              id?: T;
-            };
-      };
+  tab?: T | TabWithNameSelect<T>;
   namedTabWithDefaultValue?:
     | T
     | {
@@ -3230,6 +2795,26 @@ export interface TabsFieldsSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TabWithName_select".
+ */
+export interface TabWithNameSelect<T extends boolean = true> {
+  array?:
+    | T
+    | {
+        text?: T;
+        id?: T;
+      };
+  text?: T;
+  defaultValue?: T;
+  arrayInRow?:
+    | T
+    | {
+        textInArrayInRow?: T;
+        id?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/graphql-schema-gen/payload-types.ts
+++ b/test/graphql-schema-gen/payload-types.ts
@@ -229,66 +229,67 @@ export interface PayloadMigration {
 export interface Collection1Select<T extends boolean = true> {
   testing?: T;
   title?: T;
-  meta?:
-    | T
-    | {
-        title?: T;
-        description?: T;
-        id?: T;
-      };
+  meta?: T | SharedMetaArraySelect<T>;
   blocks?:
     | T
     | {
-        block1?:
-          | T
-          | {
-              b1title?: T;
-              b1description?: T;
-              id?: T;
-              blockName?: T;
-            };
-        block2?:
-          | T
-          | {
-              b2title?: T;
-              b2description?: T;
-              id?: T;
-              blockName?: T;
-            };
+        block1?: T | SharedMetaBlockSelect<T>;
+        block2?: T | AnotherSharedBlockSelect<T>;
       };
   updatedAt?: T;
   createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SharedMetaArray_select".
+ */
+export interface SharedMetaArraySelect<T extends boolean = true> {
+  title?: T;
+  description?: T;
+  id?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SharedMetaBlock_select".
+ */
+export interface SharedMetaBlockSelect<T extends boolean = true> {
+  b1title?: T;
+  b1description?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "AnotherSharedBlock_select".
+ */
+export interface AnotherSharedBlockSelect<T extends boolean = true> {
+  b2title?: T;
+  b2description?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "collection2_select".
  */
 export interface Collection2Select<T extends boolean = true> {
-  metaArray?:
-    | T
-    | {
-        title?: T;
-        description?: T;
-        id?: T;
-      };
-  metaGroup?:
-    | T
-    | {
-        title?: T;
-        description?: T;
-      };
+  metaArray?: T | SharedMetaArraySelect<T>;
+  metaGroup?: T | SharedMetaSelect<T>;
   nestedGroup?:
     | T
     | {
-        meta?:
-          | T
-          | {
-              title?: T;
-              description?: T;
-            };
+        meta?: T | SharedMetaSelect<T>;
       };
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SharedMeta_select".
+ */
+export interface SharedMetaSelect<T extends boolean = true> {
+  title?: T;
+  description?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
This PR can significantly reduce your `payload-types.ts` file if you have sharable fields / blocks that use the `interfaceName` property.
Previously we didn't respect it for select types.

Before:
```ts
export interface Collection1Select<T extends boolean = true> {
  testing?: T;
  title?: T;
  meta?:
    | T
    | {
        title?: T;
        description?: T;
        id?: T;
      };
  blocks?:
    | T
    | {
        block1?:
          | T
          | {
              b1title?: T;
              b1description?: T;
              id?: T;
              blockName?: T;
            };
        block2?:
          | T
          | {
              b2title?: T;
              b2description?: T;
              id?: T;
              blockName?: T;
            };
      };
  updatedAt?: T;
  createdAt?: T;
}
```
After:
```ts
export interface Collection1Select<T extends boolean = true> {
  testing?: T;
  title?: T;
  meta?: T | SharedMetaArraySelect<T>;
  blocks?:
    | T
    | {
        block1?: T | SharedMetaBlockSelect<T>;
        block2?: T | AnotherSharedBlockSelect<T>;
      };
  updatedAt?: T;
  createdAt?: T;
}

/**
 * This interface was referenced by `Config`'s JSON-Schema
 * via the `definition` "SharedMetaArray_select".
 */
export interface SharedMetaArraySelect<T extends boolean = true> {
  title?: T;
  description?: T;
  id?: T;
}
/**
 * This interface was referenced by `Config`'s JSON-Schema
 * via the `definition` "SharedMetaBlock_select".
 */
export interface SharedMetaBlockSelect<T extends boolean = true> {
  b1title?: T;
  b1description?: T;
  id?: T;
  blockName?: T;
}
/**
 * This interface was referenced by `Config`'s JSON-Schema
 * via the `definition` "AnotherSharedBlock_select".
 */
export interface AnotherSharedBlockSelect<T extends boolean = true> {
  b2title?: T;
  b2description?: T;
  id?: T;
  blockName?: T;
}
```

Regenerated all the types in `/test`. The diff is noticeable for `fields` - https://github.com/payloadcms/payload/pull/9870/files#diff-95beaac24c72c7bd60933e325cdcd94a4c3630a1ce22fabad624ec80cc74fc8c
