### PR TITLE
fix(next): next.js 15.1.0 compatibility by not importing isRedirectError from next/dist

### DIFF
--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -4,7 +4,6 @@ import { DocumentInfoProvider, EditDepthProvider, HydrateAuthProvider } from '@p
 import { RenderServerComponent } from '@payloadcms/ui/elements/RenderServerComponent'
 import { formatAdminURL, isEditing as getIsEditing } from '@payloadcms/ui/shared'
 import { buildFormState } from '@payloadcms/ui/utilities/buildFormState'
-import { isRedirectError } from 'next/dist/client/components/redirect.js'
 import { notFound, redirect } from 'next/navigation.js'
 import React from 'react'
 
@@ -382,7 +381,7 @@ export const Document: React.FC<AdminViewProps> = async (args) => {
     const { Document: RenderedDocument } = await renderDocument(args)
     return RenderedDocument
   } catch (error) {
-    if (isRedirectError(error)) {
+    if (error?.message === 'NEXT_REDIRECT') {
       throw error
     }
     args.initPageResult.req.payload.logger.error(error)


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/9876

The import path has changed in Next.js 15.1.0