### PR TITLE
docs: fix typo

### DIFF
--- a/docs/admin/metadata.mdx
+++ b/docs/admin/metadata.mdx
@@ -184,7 +184,7 @@ export const MyGlobal: GlobalConfig = {
     meta: {
     // highlight-end
       title: 'My Global',
-      description: 'The best
+      description: 'The best admin panel in the world',
     },
   },
 }


### PR DESCRIPTION
Unfinished value string in documentation example