### PR TITLE
refactor(ui): export TableColumnsProvider, documentDrawerBaseClass and SelectMany

### DIFF
--- a/packages/ui/src/elements/DocumentDrawer/DrawerHeader/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/DrawerHeader/index.tsx
@@ -7,7 +7,7 @@ import { XIcon } from '../../../icons/X/index.js'
 import { useDocumentInfo } from '../../../providers/DocumentInfo/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
 import { IDLabel } from '../../IDLabel/index.js'
-import { baseClass as docDrawerBaseClass } from '../index.js'
+import { documentDrawerBaseClass } from '../index.js'
 import './index.scss'
 
 export const DocumentDrawerHeader: React.FC<{
@@ -17,12 +17,14 @@ export const DocumentDrawerHeader: React.FC<{
   const { t } = useTranslation()
 
   return (
-    <Gutter className={`${docDrawerBaseClass}__header`}>
-      <div className={`${docDrawerBaseClass}__header-content`}>
-        <h2 className={`${docDrawerBaseClass}__header-text`}>{<RenderTitle element="span" />}</h2>
+    <Gutter className={`${documentDrawerBaseClass}__header`}>
+      <div className={`${documentDrawerBaseClass}__header-content`}>
+        <h2 className={`${documentDrawerBaseClass}__header-text`}>
+          {<RenderTitle element="span" />}
+        </h2>
         <button
           aria-label={t('general:close')}
-          className={`${docDrawerBaseClass}__header-close`}
+          className={`${documentDrawerBaseClass}__header-close`}
           onClick={() => closeModal(drawerSlug)}
           type="button"
         >

--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -11,7 +11,7 @@ import { Drawer, DrawerToggler } from '../Drawer/index.js'
 import { DocumentDrawerContent } from './DrawerContent.js'
 import './index.scss'
 
-export const baseClass = 'doc-drawer'
+export const documentDrawerBaseClass = 'doc-drawer'
 
 const formatDocumentDrawerSlug = ({
   id,
@@ -43,7 +43,7 @@ export const DocumentDrawerToggler: React.FC<DocumentTogglerProps> = ({
       aria-label={t(!id ? 'fields:addNewLabel' : 'general:editLabel', {
         label: collectionConfig?.labels.singular,
       })}
-      className={[className, `${baseClass}__toggler`].filter(Boolean).join(' ')}
+      className={[className, `${documentDrawerBaseClass}__toggler`].filter(Boolean).join(' ')}
       disabled={disabled}
       onClick={onClick}
       slug={drawerSlug}
@@ -58,7 +58,7 @@ export const DocumentDrawer: React.FC<DocumentDrawerProps> = (props) => {
   const { drawerSlug } = props
 
   return (
-    <Drawer className={baseClass} gutter={false} Header={null} slug={drawerSlug}>
+    <Drawer className={documentDrawerBaseClass} gutter={false} Header={null} slug={drawerSlug}>
       <DocumentDrawerContent {...props} />
     </Drawer>
   )

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -24,7 +24,7 @@ export { useUseTitleField } from '../../hooks/useUseAsTitle.js'
 export { LeaveWithoutSaving } from '../../elements/LeaveWithoutSaving/index.js'
 export { DocumentTakeOver } from '../../elements/DocumentTakeOver/index.js'
 export { DocumentLocked } from '../../elements/DocumentLocked/index.js'
-export { useTableColumns } from '../../elements/TableColumns/index.js'
+export { TableColumnsProvider, useTableColumns } from '../../elements/TableColumns/index.js'
 export {
   RenderDefaultCell,
   useCellProps,
@@ -51,7 +51,7 @@ export { CopyToClipboard } from '../../elements/CopyToClipboard/index.js'
 export { DeleteMany } from '../../elements/DeleteMany/index.js'
 export { DocumentControls } from '../../elements/DocumentControls/index.js'
 export { Dropzone } from '../../elements/Dropzone/index.js'
-export { useDocumentDrawer } from '../../elements/DocumentDrawer/index.js'
+export { documentDrawerBaseClass, useDocumentDrawer } from '../../elements/DocumentDrawer/index.js'
 export type {
   DocumentDrawerProps,
   DocumentTogglerProps,
@@ -269,6 +269,7 @@ export { DateField as DateCondition } from '../../elements/WhereBuilder/Conditio
 export { EmailAndUsernameFields } from '../../elements/EmailAndUsername/index.js'
 export { SelectAll } from '../../elements/SelectAll/index.js'
 export { SelectRow } from '../../elements/SelectRow/index.js'
+export { SelectMany } from '../../elements/SelectMany/index.js'
 
 export {
   DefaultListView,


### PR DESCRIPTION
Will be able to import it like this: `'import { TableColumnsProvider, documentDrawerBaseClass, SelectMany } from '@payloadcms/ui'`