### PR TITLE
fix(ui): truncates richtext fields when displaying within a joins field

### DIFF
--- a/packages/ui/src/elements/RelationshipTable/index.scss
+++ b/packages/ui/src/elements/RelationshipTable/index.scss
@@ -19,6 +19,22 @@
     }
 
     .table {
+      table {
+        width: 100%;
+        overflow: auto;
+
+        [class^='cell'] > p,
+        [class^='cell'] > span,
+        [class^='cell'] > a {
+          line-clamp: 4;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 4;
+          overflow: hidden;
+          display: -webkit-box;
+          max-width: 100vw;
+        }
+      }
+
       th,
       td:first-child {
         min-width: 0;


### PR DESCRIPTION
### What?

Previously, `richtext` fields were not properly truncated when displayed in a `joins` field.

`Before`:

![Screenshot 2024-12-11 at 3 42 13 PM](https://github.com/user-attachments/assets/a6f44248-8cb9-4a38-a74c-eaa88b739601)

### How?

Now - we've added proper css styling to truncate extended `richtext` elements inside a `joins` table.

`After`:

![Screenshot 2024-12-11 at 3 41 53 PM](https://github.com/user-attachments/assets/ae846c50-2e29-411f-b056-20e4caf3ef20)

