### PR TITLE
feat(ui): allow customizing min height of code editor

### DIFF
--- a/packages/ui/src/elements/CodeEditor/CodeEditor.tsx
+++ b/packages/ui/src/elements/CodeEditor/CodeEditor.tsx
@@ -13,11 +13,11 @@ const Editor = (EditorImport.default || EditorImport) as unknown as typeof Edito
 const baseClass = 'code-editor'
 
 const CodeEditor: React.FC<Props> = (props) => {
-  const { className, maxHeight, options, readOnly, ...rest } = props
-  const [dynamicHeight, setDynamicHeight] = useState(20)
-  const { theme } = useTheme()
+  const { className, maxHeight, minHeight, options, readOnly, ...rest } = props
+  const MIN_HEIGHT = minHeight ?? 56 // equivalent to 3 lines
 
-  const MIN_HEIGHT = 56 // equivalent to 3 lines
+  const [dynamicHeight, setDynamicHeight] = useState(MIN_HEIGHT)
+  const { theme } = useTheme()
 
   const classes = [
     baseClass,

--- a/packages/ui/src/elements/CodeEditor/types.ts
+++ b/packages/ui/src/elements/CodeEditor/types.ts
@@ -2,5 +2,9 @@ import type { EditorProps } from '@monaco-editor/react'
 
 export type Props = {
   maxHeight?: number
+  /**
+   * @default 56 (3 lines)
+   */
+  minHeight?: number
   readOnly?: boolean
 } & EditorProps


### PR DESCRIPTION
Requirement for https://github.com/payloadcms/payload/pull/9645.

Dynamic code field resizing currently is broken for line-breaks - need to address that in a future PR.