### PR TITLE
fix(plugin-search): prevent error on undefined value in linkToDoc component

### DIFF
--- a/packages/plugin-search/src/Search/ui/LinkToDoc/index.client.tsx
+++ b/packages/plugin-search/src/Search/ui/LinkToDoc/index.client.tsx
@@ -18,14 +18,14 @@ export const LinkToDocClient: React.FC = () => {
 
   const { value } = useField<{ relationTo?: string; value?: string }>({ path: 'doc' })
 
+  if (!value?.relationTo || !value?.value) {
+    return null
+  }
+
   const href = `${serverURL}${formatAdminURL({
     adminRoute,
     path: `/collections/${value.relationTo || ''}/${value.value || ''}`,
   })}`
-
-  if (!value.relationTo || !value.value) {
-    return null
-  }
 
   return (
     <div style={{ marginBottom: 'var(--spacing-field, 1rem)' }}>


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes a runtime error encountered when navigating into a search doc that had its' related collection doc deleted, but it itself remained (if for example `deleteFromSearch` deletion failed for some reason).

### Why?
To prevent runtime errors for end-users using `plugin-search`.

### How?
By returning earlier if the field value is undefined or missing required values in `LinkToDoc`.

Related #9443 (see also: #9623)