### PR TITLE
feat: make `req` partial and optional in DB / Local API operations

### DIFF
--- a/packages/db-mongodb/src/count.ts
+++ b/packages/db-mongodb/src/count.ts
@@ -1,18 +1,20 @@
 import type { CountOptions } from 'mongodb'
-import type { Count, PayloadRequest } from 'payload'
+import type { Count } from 'payload'
 
 import { flattenWhereToOperators } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
-import { withSession } from './withSession.js'
+import { getSession } from './utilities/getSession.js'
 
 export const count: Count = async function count(
   this: MongooseAdapter,
-  { collection, locale, req = {} as PayloadRequest, where },
+  { collection, locale, req, where },
 ) {
   const Model = this.collections[collection]
-  const options: CountOptions = await withSession(this, req)
+  const options: CountOptions = {
+    session: await getSession(this, req),
+  }
 
   let hasNearConstraint = false
 

--- a/packages/db-mongodb/src/countGlobalVersions.ts
+++ b/packages/db-mongodb/src/countGlobalVersions.ts
@@ -1,18 +1,20 @@
 import type { CountOptions } from 'mongodb'
-import type { CountGlobalVersions, PayloadRequest } from 'payload'
+import type { CountGlobalVersions } from 'payload'
 
 import { flattenWhereToOperators } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
-import { withSession } from './withSession.js'
+import { getSession } from './utilities/getSession.js'
 
 export const countGlobalVersions: CountGlobalVersions = async function countGlobalVersions(
   this: MongooseAdapter,
-  { global, locale, req = {} as PayloadRequest, where },
+  { global, locale, req, where },
 ) {
   const Model = this.versions[global]
-  const options: CountOptions = await withSession(this, req)
+  const options: CountOptions = {
+    session: await getSession(this, req),
+  }
 
   let hasNearConstraint = false
 

--- a/packages/db-mongodb/src/countVersions.ts
+++ b/packages/db-mongodb/src/countVersions.ts
@@ -1,18 +1,20 @@
 import type { CountOptions } from 'mongodb'
-import type { CountVersions, PayloadRequest } from 'payload'
+import type { CountVersions } from 'payload'
 
 import { flattenWhereToOperators } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
-import { withSession } from './withSession.js'
+import { getSession } from './utilities/getSession.js'
 
 export const countVersions: CountVersions = async function countVersions(
   this: MongooseAdapter,
-  { collection, locale, req = {} as PayloadRequest, where },
+  { collection, locale, req, where },
 ) {
   const Model = this.versions[collection]
-  const options: CountOptions = await withSession(this, req)
+  const options: CountOptions = {
+    session: await getSession(this, req),
+  }
 
   let hasNearConstraint = false
 

--- a/packages/db-mongodb/src/create.ts
+++ b/packages/db-mongodb/src/create.ts
@@ -1,17 +1,21 @@
-import type { Create, Document, PayloadRequest } from 'payload'
+import type { CreateOptions } from 'mongoose'
+import type { Create, Document } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
+import { getSession } from './utilities/getSession.js'
 import { handleError } from './utilities/handleError.js'
 import { sanitizeRelationshipIDs } from './utilities/sanitizeRelationshipIDs.js'
-import { withSession } from './withSession.js'
 
 export const create: Create = async function create(
   this: MongooseAdapter,
-  { collection, data, req = {} as PayloadRequest },
+  { collection, data, req },
 ) {
   const Model = this.collections[collection]
-  const options = await withSession(this, req)
+  const options: CreateOptions = {
+    session: await getSession(this, req),
+  }
+
   let doc
 
   const sanitizedData = sanitizeRelationshipIDs({

--- a/packages/db-mongodb/src/createGlobal.ts
+++ b/packages/db-mongodb/src/createGlobal.ts
@@ -1,14 +1,15 @@
-import type { CreateGlobal, PayloadRequest } from 'payload'
+import type { CreateOptions } from 'mongoose'
+import type { CreateGlobal } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
+import { getSession } from './utilities/getSession.js'
 import { sanitizeInternalFields } from './utilities/sanitizeInternalFields.js'
 import { sanitizeRelationshipIDs } from './utilities/sanitizeRelationshipIDs.js'
-import { withSession } from './withSession.js'
 
 export const createGlobal: CreateGlobal = async function createGlobal(
   this: MongooseAdapter,
-  { slug, data, req = {} as PayloadRequest },
+  { slug, data, req },
 ) {
   const Model = this.globals
 
@@ -21,7 +22,9 @@ export const createGlobal: CreateGlobal = async function createGlobal(
     fields: this.payload.config.globals.find((globalConfig) => globalConfig.slug === slug).fields,
   })
 
-  const options = await withSession(this, req)
+  const options: CreateOptions = {
+    session: await getSession(this, req),
+  }
 
   let [result] = (await Model.create([global], options)) as any
 

--- a/packages/db-mongodb/src/createGlobalVersion.ts
+++ b/packages/db-mongodb/src/createGlobalVersion.ts
@@ -1,14 +1,11 @@
-import {
-  buildVersionGlobalFields,
-  type CreateGlobalVersion,
-  type Document,
-  type PayloadRequest,
-} from 'payload'
+import type { CreateOptions } from 'mongoose'
+
+import { buildVersionGlobalFields, type CreateGlobalVersion, type Document } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
+import { getSession } from './utilities/getSession.js'
 import { sanitizeRelationshipIDs } from './utilities/sanitizeRelationshipIDs.js'
-import { withSession } from './withSession.js'
 
 export const createGlobalVersion: CreateGlobalVersion = async function createGlobalVersion(
   this: MongooseAdapter,
@@ -18,14 +15,16 @@ export const createGlobalVersion: CreateGlobalVersion = async function createGlo
     globalSlug,
     parent,
     publishedLocale,
-    req = {} as PayloadRequest,
+    req,
     snapshot,
     updatedAt,
     versionData,
   },
 ) {
   const VersionModel = this.versions[globalSlug]
-  const options = await withSession(this, req)
+  const options: CreateOptions = {
+    session: await getSession(this, req),
+  }
 
   const data = sanitizeRelationshipIDs({
     config: this.payload.config,

--- a/packages/db-mongodb/src/createVersion.ts
+++ b/packages/db-mongodb/src/createVersion.ts
@@ -1,15 +1,12 @@
+import type { CreateOptions } from 'mongoose'
+
 import { Types } from 'mongoose'
-import {
-  buildVersionCollectionFields,
-  type CreateVersion,
-  type Document,
-  type PayloadRequest,
-} from 'payload'
+import { buildVersionCollectionFields, type CreateVersion, type Document } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
+import { getSession } from './utilities/getSession.js'
 import { sanitizeRelationshipIDs } from './utilities/sanitizeRelationshipIDs.js'
-import { withSession } from './withSession.js'
 
 export const createVersion: CreateVersion = async function createVersion(
   this: MongooseAdapter,
@@ -19,14 +16,16 @@ export const createVersion: CreateVersion = async function createVersion(
     createdAt,
     parent,
     publishedLocale,
-    req = {} as PayloadRequest,
+    req,
     snapshot,
     updatedAt,
     versionData,
   },
 ) {
   const VersionModel = this.versions[collectionSlug]
-  const options = await withSession(this, req)
+  const options: CreateOptions = {
+    session: await getSession(this, req),
+  }
 
   const data = sanitizeRelationshipIDs({
     config: this.payload.config,

--- a/packages/db-mongodb/src/deleteMany.ts
+++ b/packages/db-mongodb/src/deleteMany.ts
@@ -1,17 +1,17 @@
-import type { DeleteMany, PayloadRequest } from 'payload'
+import type { DeleteOptions } from 'mongodb'
+import type { DeleteMany } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
-import { withSession } from './withSession.js'
+import { getSession } from './utilities/getSession.js'
 
 export const deleteMany: DeleteMany = async function deleteMany(
   this: MongooseAdapter,
-  { collection, req = {} as PayloadRequest, where },
+  { collection, req, where },
 ) {
   const Model = this.collections[collection]
-  const options = {
-    ...(await withSession(this, req)),
-    lean: true,
+  const options: DeleteOptions = {
+    session: await getSession(this, req),
   }
 
   const query = await Model.buildQuery({

--- a/packages/db-mongodb/src/deleteVersions.ts
+++ b/packages/db-mongodb/src/deleteVersions.ts
@@ -1,18 +1,16 @@
-import type { DeleteVersions, PayloadRequest } from 'payload'
+import type { DeleteVersions } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
-import { withSession } from './withSession.js'
+import { getSession } from './utilities/getSession.js'
 
 export const deleteVersions: DeleteVersions = async function deleteVersions(
   this: MongooseAdapter,
-  { collection, locale, req = {} as PayloadRequest, where },
+  { collection, locale, req, where },
 ) {
   const VersionsModel = this.versions[collection]
-  const options = {
-    ...(await withSession(this, req)),
-    lean: true,
-  }
+
+  const session = await getSession(this, req)
 
   const query = await VersionsModel.buildQuery({
     locale,
@@ -20,5 +18,5 @@ export const deleteVersions: DeleteVersions = async function deleteVersions(
     where,
   })
 
-  await VersionsModel.deleteMany(query, options)
+  await VersionsModel.deleteMany(query, { session })
 }

--- a/packages/db-mongodb/src/findGlobal.ts
+++ b/packages/db-mongodb/src/findGlobal.ts
@@ -1,26 +1,27 @@
-import type { FindGlobal, PayloadRequest } from 'payload'
+import type { QueryOptions } from 'mongoose'
+import type { FindGlobal } from 'payload'
 
 import { combineQueries } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
+import { getSession } from './utilities/getSession.js'
 import { sanitizeInternalFields } from './utilities/sanitizeInternalFields.js'
-import { withSession } from './withSession.js'
 
 export const findGlobal: FindGlobal = async function findGlobal(
   this: MongooseAdapter,
-  { slug, locale, req = {} as PayloadRequest, select, where },
+  { slug, locale, req, select, where },
 ) {
   const Model = this.globals
-  const options = {
-    ...(await withSession(this, req)),
+  const options: QueryOptions = {
     lean: true,
     select: buildProjectionFromSelect({
       adapter: this,
       fields: this.payload.globals.config.find((each) => each.slug === slug).flattenedFields,
       select,
     }),
+    session: await getSession(this, req),
   }
 
   const query = await Model.buildQuery({

--- a/packages/db-mongodb/src/findOne.ts
+++ b/packages/db-mongodb/src/findOne.ts
@@ -1,22 +1,23 @@
-import type { MongooseQueryOptions, QueryOptions } from 'mongoose'
-import type { Document, FindOne, PayloadRequest } from 'payload'
+import type { AggregateOptions, QueryOptions } from 'mongoose'
+import type { Document, FindOne } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
 import { buildJoinAggregation } from './utilities/buildJoinAggregation.js'
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
+import { getSession } from './utilities/getSession.js'
 import { sanitizeInternalFields } from './utilities/sanitizeInternalFields.js'
-import { withSession } from './withSession.js'
 
 export const findOne: FindOne = async function findOne(
   this: MongooseAdapter,
-  { collection, joins, locale, req = {} as PayloadRequest, select, where },
+  { collection, joins, locale, req, select, where },
 ) {
   const Model = this.collections[collection]
   const collectionConfig = this.payload.collections[collection].config
-  const options: MongooseQueryOptions = {
-    ...(await withSession(this, req)),
+  const session = await getSession(this, req)
+  const options: AggregateOptions & QueryOptions = {
     lean: true,
+    session,
   }
 
   const query = await Model.buildQuery({
@@ -44,7 +45,7 @@ export const findOne: FindOne = async function findOne(
 
   let doc
   if (aggregate) {
-    ;[doc] = await Model.aggregate(aggregate, options)
+    ;[doc] = await Model.aggregate(aggregate, { session })
   } else {
     ;(options as Record<string, unknown>).projection = projection
     doc = await Model.findOne(query, {}, options)

--- a/packages/db-mongodb/src/findVersions.ts
+++ b/packages/db-mongodb/src/findVersions.ts
@@ -1,5 +1,5 @@
-import type { PaginateOptions } from 'mongoose'
-import type { FindVersions, PayloadRequest } from 'payload'
+import type { PaginateOptions, QueryOptions } from 'mongoose'
+import type { FindVersions } from 'payload'
 
 import { buildVersionCollectionFields, flattenWhereToOperators } from 'payload'
 
@@ -7,29 +7,19 @@ import type { MongooseAdapter } from './index.js'
 
 import { buildSortParam } from './queries/buildSortParam.js'
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
+import { getSession } from './utilities/getSession.js'
 import { sanitizeInternalFields } from './utilities/sanitizeInternalFields.js'
-import { withSession } from './withSession.js'
 
 export const findVersions: FindVersions = async function findVersions(
   this: MongooseAdapter,
-  {
-    collection,
-    limit,
-    locale,
-    page,
-    pagination,
-    req = {} as PayloadRequest,
-    select,
-    skip,
-    sort: sortArg,
-    where,
-  },
+  { collection, limit, locale, page, pagination, req = {}, select, skip, sort: sortArg, where },
 ) {
   const Model = this.versions[collection]
   const collectionConfig = this.payload.collections[collection].config
-  const options = {
-    ...(await withSession(this, req)),
+  const session = await getSession(this, req)
+  const options: QueryOptions = {
     limit,
+    session,
     skip,
   }
 
@@ -91,8 +81,8 @@ export const findVersions: FindVersions = async function findVersions(
     paginationOptions.useCustomCountFn = () => {
       return Promise.resolve(
         Model.countDocuments(query, {
-          ...options,
           hint: { _id: 1 },
+          session,
         }),
       )
     }

--- a/packages/db-mongodb/src/migrateFresh.ts
+++ b/packages/db-mongodb/src/migrateFresh.ts
@@ -45,7 +45,7 @@ export async function migrateFresh(
     msg: `Found ${migrationFiles.length} migration files.`,
   })
 
-  const req = { payload } as PayloadRequest
+  const req = { payload }
 
   // Run all migrate up
   for (const migration of migrationFiles) {

--- a/packages/db-mongodb/src/predefinedMigrations/migrateRelationshipsV2_V3.ts
+++ b/packages/db-mongodb/src/predefinedMigrations/migrateRelationshipsV2_V3.ts
@@ -5,8 +5,8 @@ import { buildVersionCollectionFields, buildVersionGlobalFields } from 'payload'
 
 import type { MongooseAdapter } from '../index.js'
 
+import { getSession } from '../utilities/getSession.js'
 import { sanitizeRelationshipIDs } from '../utilities/sanitizeRelationshipIDs.js'
-import { withSession } from '../withSession.js'
 
 const migrateModelWithBatching = async ({
   batchSize,
@@ -109,7 +109,7 @@ export async function migrateRelationshipsV2_V3({
   const db = payload.db as MongooseAdapter
   const config = payload.config
 
-  const { session } = await withSession(db, req)
+  const session = await getSession(db, req)
 
   for (const collection of payload.config.collections.filter(hasRelationshipOrUploadField)) {
     payload.logger.info(`Migrating collection "${collection.slug}"`)

--- a/packages/db-mongodb/src/predefinedMigrations/migrateVersionsV1_V2.ts
+++ b/packages/db-mongodb/src/predefinedMigrations/migrateVersionsV1_V2.ts
@@ -3,12 +3,12 @@ import type { Payload, PayloadRequest } from 'payload'
 
 import type { MongooseAdapter } from '../index.js'
 
-import { withSession } from '../withSession.js'
+import { getSession } from '../utilities/getSession.js'
 
 export async function migrateVersionsV1_V2({ req }: { req: PayloadRequest }) {
   const { payload } = req
 
-  const { session } = await withSession(payload.db as MongooseAdapter, req)
+  const session = await getSession(payload.db as MongooseAdapter, req)
 
   // For each collection
 

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -1,5 +1,5 @@
-import type { PaginateOptions } from 'mongoose'
-import type { PayloadRequest, QueryDrafts } from 'payload'
+import type { PaginateOptions, QueryOptions } from 'mongoose'
+import type { QueryDrafts } from 'payload'
 
 import { buildVersionCollectionFields, combineQueries, flattenWhereToOperators } from 'payload'
 
@@ -8,27 +8,18 @@ import type { MongooseAdapter } from './index.js'
 import { buildSortParam } from './queries/buildSortParam.js'
 import { buildJoinAggregation } from './utilities/buildJoinAggregation.js'
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
+import { getSession } from './utilities/getSession.js'
 import { sanitizeInternalFields } from './utilities/sanitizeInternalFields.js'
-import { withSession } from './withSession.js'
 
 export const queryDrafts: QueryDrafts = async function queryDrafts(
   this: MongooseAdapter,
-  {
-    collection,
-    joins,
-    limit,
-    locale,
-    page,
-    pagination,
-    req = {} as PayloadRequest,
-    select,
-    sort: sortArg,
-    where,
-  },
+  { collection, joins, limit, locale, page, pagination, req, select, sort: sortArg, where },
 ) {
   const VersionModel = this.versions[collection]
   const collectionConfig = this.payload.collections[collection].config
-  const options = await withSession(this, req)
+  const options: QueryOptions = {
+    session: await getSession(this, req),
+  }
 
   let hasNearConstraint
   let sort

--- a/packages/db-mongodb/src/updateGlobal.ts
+++ b/packages/db-mongodb/src/updateGlobal.ts
@@ -1,23 +1,22 @@
 import type { QueryOptions } from 'mongoose'
-import type { PayloadRequest, UpdateGlobal } from 'payload'
+import type { UpdateGlobal } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
+import { getSession } from './utilities/getSession.js'
 import { sanitizeInternalFields } from './utilities/sanitizeInternalFields.js'
 import { sanitizeRelationshipIDs } from './utilities/sanitizeRelationshipIDs.js'
-import { withSession } from './withSession.js'
 
 export const updateGlobal: UpdateGlobal = async function updateGlobal(
   this: MongooseAdapter,
-  { slug, data, options: optionsArgs = {}, req = {} as PayloadRequest, select },
+  { slug, data, options: optionsArgs = {}, req, select },
 ) {
   const Model = this.globals
   const fields = this.payload.config.globals.find((global) => global.slug === slug).fields
 
   const options: QueryOptions = {
     ...optionsArgs,
-    ...(await withSession(this, req)),
     lean: true,
     new: true,
     projection: buildProjectionFromSelect({
@@ -25,6 +24,7 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
       fields: this.payload.config.globals.find((global) => global.slug === slug).flattenedFields,
       select,
     }),
+    session: await getSession(this, req),
   }
 
   let result

--- a/packages/db-mongodb/src/updateGlobalVersion.ts
+++ b/packages/db-mongodb/src/updateGlobalVersion.ts
@@ -1,17 +1,12 @@
 import type { QueryOptions } from 'mongoose'
 
-import {
-  buildVersionGlobalFields,
-  type PayloadRequest,
-  type TypeWithID,
-  type UpdateGlobalVersionArgs,
-} from 'payload'
+import { buildVersionGlobalFields, type TypeWithID, type UpdateGlobalVersionArgs } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
+import { getSession } from './utilities/getSession.js'
 import { sanitizeRelationshipIDs } from './utilities/sanitizeRelationshipIDs.js'
-import { withSession } from './withSession.js'
 
 export async function updateGlobalVersion<T extends TypeWithID>(
   this: MongooseAdapter,
@@ -20,7 +15,7 @@ export async function updateGlobalVersion<T extends TypeWithID>(
     global: globalSlug,
     locale,
     options: optionsArgs = {},
-    req = {} as PayloadRequest,
+    req,
     select,
     versionData,
     where,
@@ -34,7 +29,6 @@ export async function updateGlobalVersion<T extends TypeWithID>(
 
   const options: QueryOptions = {
     ...optionsArgs,
-    ...(await withSession(this, req)),
     lean: true,
     new: true,
     projection: buildProjectionFromSelect({
@@ -42,6 +36,7 @@ export async function updateGlobalVersion<T extends TypeWithID>(
       fields: buildVersionGlobalFields(this.payload.config, currentGlobal, true),
       select,
     }),
+    session: await getSession(this, req),
   }
 
   const query = await VersionModel.buildQuery({

--- a/packages/db-mongodb/src/upsert.ts
+++ b/packages/db-mongodb/src/upsert.ts
@@ -1,10 +1,10 @@
-import type { PayloadRequest, Upsert } from 'payload'
+import type { Upsert } from 'payload'
 
 import type { MongooseAdapter } from './index.js'
 
 export const upsert: Upsert = async function upsert(
   this: MongooseAdapter,
-  { collection, data, locale, req = {} as PayloadRequest, select, where },
+  { collection, data, locale, req, select, where },
 ) {
   return this.updateOne({ collection, data, locale, options: { upsert: true }, req, select, where })
 }

--- a/packages/db-mongodb/src/utilities/getSession.ts
+++ b/packages/db-mongodb/src/utilities/getSession.ts
@@ -1,23 +1,27 @@
 import type { ClientSession } from 'mongoose'
 import type { PayloadRequest } from 'payload'
 
-import type { MongooseAdapter } from './index.js'
+import type { MongooseAdapter } from '../index.js'
 
 /**
  * returns the session belonging to the transaction of the req.session if exists
  * @returns ClientSession
  */
-export async function withSession(
+export async function getSession(
   db: MongooseAdapter,
-  req: PayloadRequest,
-): Promise<{ session: ClientSession } | Record<string, never>> {
+  req?: Partial<PayloadRequest>,
+): Promise<ClientSession | undefined> {
+  if (!req) {
+    return
+  }
+
   let transactionID = req.transactionID
 
   if (transactionID instanceof Promise) {
     transactionID = await req.transactionID
   }
 
-  if (req) {
-    return db.sessions[transactionID] ? { session: db.sessions[transactionID] } : {}
+  if (transactionID) {
+    return db.sessions[transactionID]
   }
 }

--- a/packages/drizzle/src/count.ts
+++ b/packages/drizzle/src/count.ts
@@ -5,6 +5,7 @@ import toSnakeCase from 'to-snake-case'
 import type { DrizzleAdapter } from './types.js'
 
 import buildQuery from './queries/buildQuery.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export const count: Count = async function count(
   this: DrizzleAdapter,
@@ -14,7 +15,7 @@ export const count: Count = async function count(
 
   const tableName = this.tableNameMap.get(toSnakeCase(collectionConfig.slug))
 
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
 
   const { joins, where } = buildQuery({
     adapter: this,

--- a/packages/drizzle/src/countGlobalVersions.ts
+++ b/packages/drizzle/src/countGlobalVersions.ts
@@ -6,6 +6,7 @@ import toSnakeCase from 'to-snake-case'
 import type { DrizzleAdapter } from './types.js'
 
 import buildQuery from './queries/buildQuery.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export const countGlobalVersions: CountGlobalVersions = async function countGlobalVersions(
   this: DrizzleAdapter,
@@ -19,7 +20,7 @@ export const countGlobalVersions: CountGlobalVersions = async function countGlob
     `_${toSnakeCase(globalConfig.slug)}${this.versionsSuffix}`,
   )
 
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
 
   const fields = buildVersionGlobalFields(this.payload.config, globalConfig, true)
 

--- a/packages/drizzle/src/countVersions.ts
+++ b/packages/drizzle/src/countVersions.ts
@@ -6,6 +6,7 @@ import toSnakeCase from 'to-snake-case'
 import type { DrizzleAdapter } from './types.js'
 
 import buildQuery from './queries/buildQuery.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export const countVersions: CountVersions = async function countVersions(
   this: DrizzleAdapter,
@@ -17,7 +18,7 @@ export const countVersions: CountVersions = async function countVersions(
     `_${toSnakeCase(collectionConfig.slug)}${this.versionsSuffix}`,
   )
 
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
 
   const fields = buildVersionCollectionFields(this.payload.config, collectionConfig, true)
 

--- a/packages/drizzle/src/create.ts
+++ b/packages/drizzle/src/create.ts
@@ -5,12 +5,13 @@ import toSnakeCase from 'to-snake-case'
 import type { DrizzleAdapter } from './types.js'
 
 import { upsertRow } from './upsertRow/index.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export const create: Create = async function create(
   this: DrizzleAdapter,
   { collection: collectionSlug, data, req, select },
 ) {
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
   const collection = this.payload.collections[collectionSlug].config
 
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))

--- a/packages/drizzle/src/createGlobal.ts
+++ b/packages/drizzle/src/createGlobal.ts
@@ -1,16 +1,17 @@
-import type { CreateGlobalArgs, PayloadRequest } from 'payload'
+import type { CreateGlobalArgs } from 'payload'
 
 import toSnakeCase from 'to-snake-case'
 
 import type { DrizzleAdapter } from './types.js'
 
 import { upsertRow } from './upsertRow/index.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export async function createGlobal<T extends Record<string, unknown>>(
   this: DrizzleAdapter,
-  { slug, data, req = {} as PayloadRequest }: CreateGlobalArgs,
+  { slug, data, req }: CreateGlobalArgs,
 ): Promise<T> {
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
   const globalConfig = this.payload.globals.config.find((config) => config.slug === slug)
 
   const tableName = this.tableNameMap.get(toSnakeCase(globalConfig.slug))

--- a/packages/drizzle/src/createVersion.ts
+++ b/packages/drizzle/src/createVersion.ts
@@ -1,4 +1,4 @@
-import type { CreateVersionArgs, PayloadRequest, TypeWithID, TypeWithVersion } from 'payload'
+import type { CreateVersionArgs, TypeWithID, TypeWithVersion } from 'payload'
 
 import { sql } from 'drizzle-orm'
 import { buildVersionCollectionFields } from 'payload'
@@ -7,6 +7,7 @@ import toSnakeCase from 'to-snake-case'
 import type { DrizzleAdapter } from './types.js'
 
 import { upsertRow } from './upsertRow/index.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export async function createVersion<T extends TypeWithID>(
   this: DrizzleAdapter,
@@ -16,14 +17,14 @@ export async function createVersion<T extends TypeWithID>(
     createdAt,
     parent,
     publishedLocale,
-    req = {} as PayloadRequest,
+    req,
     select,
     snapshot,
     updatedAt,
     versionData,
   }: CreateVersionArgs<T>,
 ) {
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
   const collection = this.payload.collections[collectionSlug].config
   const defaultTableName = toSnakeCase(collection.slug)
 

--- a/packages/drizzle/src/deleteMany.ts
+++ b/packages/drizzle/src/deleteMany.ts
@@ -1,4 +1,4 @@
-import type { DeleteMany, PayloadRequest } from 'payload'
+import type { DeleteMany } from 'payload'
 
 import { inArray } from 'drizzle-orm'
 import toSnakeCase from 'to-snake-case'
@@ -6,12 +6,13 @@ import toSnakeCase from 'to-snake-case'
 import type { DrizzleAdapter } from './types.js'
 
 import { findMany } from './find/findMany.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export const deleteMany: DeleteMany = async function deleteMany(
   this: DrizzleAdapter,
-  { collection, req = {} as PayloadRequest, where },
+  { collection, req, where },
 ) {
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
   const collectionConfig = this.payload.collections[collection].config
 
   const tableName = this.tableNameMap.get(toSnakeCase(collectionConfig.slug))
@@ -21,7 +22,7 @@ export const deleteMany: DeleteMany = async function deleteMany(
     fields: collectionConfig.flattenedFields,
     joins: false,
     limit: 0,
-    locale: req.locale,
+    locale: req?.locale,
     page: 1,
     pagination: false,
     req,

--- a/packages/drizzle/src/deleteVersions.ts
+++ b/packages/drizzle/src/deleteVersions.ts
@@ -1,4 +1,4 @@
-import type { DeleteVersions, PayloadRequest, SanitizedCollectionConfig } from 'payload'
+import type { DeleteVersions, SanitizedCollectionConfig } from 'payload'
 
 import { inArray } from 'drizzle-orm'
 import { buildVersionCollectionFields } from 'payload'
@@ -7,12 +7,13 @@ import toSnakeCase from 'to-snake-case'
 import type { DrizzleAdapter } from './types.js'
 
 import { findMany } from './find/findMany.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export const deleteVersions: DeleteVersions = async function deleteVersion(
   this: DrizzleAdapter,
-  { collection, locale, req = {} as PayloadRequest, where: where },
+  { collection, locale, req, where: where },
 ) {
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
 
   const tableName = this.tableNameMap.get(

--- a/packages/drizzle/src/find.ts
+++ b/packages/drizzle/src/find.ts
@@ -1,4 +1,4 @@
-import type { Find, PayloadRequest, SanitizedCollectionConfig } from 'payload'
+import type { Find, SanitizedCollectionConfig } from 'payload'
 
 import toSnakeCase from 'to-snake-case'
 
@@ -8,18 +8,7 @@ import { findMany } from './find/findMany.js'
 
 export const find: Find = async function find(
   this: DrizzleAdapter,
-  {
-    collection,
-    joins,
-    limit,
-    locale,
-    page = 1,
-    pagination,
-    req = {} as PayloadRequest,
-    select,
-    sort: sortArg,
-    where,
-  },
+  { collection, joins, limit, locale, page = 1, pagination, req, select, sort: sortArg, where },
 ) {
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
   const sort = sortArg !== undefined && sortArg !== null ? sortArg : collectionConfig.defaultSort

--- a/packages/drizzle/src/find/findMany.ts
+++ b/packages/drizzle/src/find/findMany.ts
@@ -1,4 +1,4 @@
-import type { FindArgs, FlattenedField, PayloadRequest, TypeWithID } from 'payload'
+import type { FindArgs, FlattenedField, TypeWithID } from 'payload'
 
 import { inArray } from 'drizzle-orm'
 
@@ -8,6 +8,7 @@ import type { ChainedMethods } from './chainMethods.js'
 import buildQuery from '../queries/buildQuery.js'
 import { selectDistinct } from '../queries/selectDistinct.js'
 import { transform } from '../transform/read/index.js'
+import { getTransaction } from '../utilities/getTransaction.js'
 import { buildFindManyArgs } from './buildFindManyArgs.js'
 
 type Args = {
@@ -25,7 +26,7 @@ export const findMany = async function find({
   locale,
   page = 1,
   pagination,
-  req = {} as PayloadRequest,
+  req,
   select,
   skip,
   sort,
@@ -33,7 +34,7 @@ export const findMany = async function find({
   versions,
   where: whereArg,
 }: Args) {
-  const db = adapter.sessions[await req.transactionID]?.db || adapter.drizzle
+  const db = await getTransaction(adapter, req)
   let limit = limitArg
   let totalDocs: number
   let totalPages: number

--- a/packages/drizzle/src/findGlobalVersions.ts
+++ b/packages/drizzle/src/findGlobalVersions.ts
@@ -1,4 +1,4 @@
-import type { FindGlobalVersions, PayloadRequest, SanitizedGlobalConfig } from 'payload'
+import type { FindGlobalVersions, SanitizedGlobalConfig } from 'payload'
 
 import { buildVersionGlobalFields } from 'payload'
 import toSnakeCase from 'to-snake-case'
@@ -9,18 +9,7 @@ import { findMany } from './find/findMany.js'
 
 export const findGlobalVersions: FindGlobalVersions = async function findGlobalVersions(
   this: DrizzleAdapter,
-  {
-    global,
-    limit,
-    locale,
-    page,
-    pagination,
-    req = {} as PayloadRequest,
-    select,
-    skip,
-    sort: sortArg,
-    where,
-  },
+  { global, limit, locale, page, pagination, req, select, skip, sort: sortArg, where },
 ) {
   const globalConfig: SanitizedGlobalConfig = this.payload.globals.config.find(
     ({ slug }) => slug === global,

--- a/packages/drizzle/src/findOne.ts
+++ b/packages/drizzle/src/findOne.ts
@@ -1,4 +1,4 @@
-import type { FindOneArgs, PayloadRequest, SanitizedCollectionConfig, TypeWithID } from 'payload'
+import type { FindOneArgs, SanitizedCollectionConfig, TypeWithID } from 'payload'
 
 import toSnakeCase from 'to-snake-case'
 
@@ -8,7 +8,7 @@ import { findMany } from './find/findMany.js'
 
 export async function findOne<T extends TypeWithID>(
   this: DrizzleAdapter,
-  { collection, joins, locale, req = {} as PayloadRequest, select, where }: FindOneArgs,
+  { collection, joins, locale, req, select, where }: FindOneArgs,
 ): Promise<T> {
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
 

--- a/packages/drizzle/src/findVersions.ts
+++ b/packages/drizzle/src/findVersions.ts
@@ -1,4 +1,4 @@
-import type { FindVersions, PayloadRequest, SanitizedCollectionConfig } from 'payload'
+import type { FindVersions, SanitizedCollectionConfig } from 'payload'
 
 import { buildVersionCollectionFields } from 'payload'
 import toSnakeCase from 'to-snake-case'
@@ -9,18 +9,7 @@ import { findMany } from './find/findMany.js'
 
 export const findVersions: FindVersions = async function findVersions(
   this: DrizzleAdapter,
-  {
-    collection,
-    limit,
-    locale,
-    page,
-    pagination,
-    req = {} as PayloadRequest,
-    select,
-    skip,
-    sort: sortArg,
-    where,
-  },
+  { collection, limit, locale, page, pagination, req, select, skip, sort: sortArg, where },
 ) {
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
   const sort = sortArg !== undefined && sortArg !== null ? sortArg : collectionConfig.defaultSort

--- a/packages/drizzle/src/migrate.ts
+++ b/packages/drizzle/src/migrate.ts
@@ -1,10 +1,17 @@
-import type { Payload, PayloadRequest } from 'payload'
+import type { Payload } from 'payload'
 
-import { commitTransaction, initTransaction, killTransaction, readMigrationFiles } from 'payload'
+import {
+  commitTransaction,
+  createLocalReq,
+  initTransaction,
+  killTransaction,
+  readMigrationFiles,
+} from 'payload'
 import prompts from 'prompts'
 
 import type { DrizzleAdapter, Migration } from './types.js'
 
+import { getTransaction } from './utilities/getTransaction.js'
 import { migrationTableExists } from './utilities/migrationTableExists.js'
 import { parseError } from './utilities/parseError.js'
 
@@ -79,14 +86,13 @@ export const migrate: DrizzleAdapter['migrate'] = async function migrate(
 
 async function runMigrationFile(payload: Payload, migration: Migration, batch: number) {
   const start = Date.now()
-  const req = { payload } as PayloadRequest
-  const adapter = payload.db as DrizzleAdapter
+  const req = await createLocalReq({}, payload)
 
   payload.logger.info({ msg: `Migrating: ${migration.name}` })
 
   try {
     await initTransaction(req)
-    const db = adapter?.sessions[await req.transactionID]?.db || adapter.drizzle
+    const db = await getTransaction(payload.db as DrizzleAdapter, req)
     await migration.up({ db, payload, req })
     payload.logger.info({ msg: `Migrated:  ${migration.name} (${Date.now() - start}ms)` })
     await payload.create({

--- a/packages/drizzle/src/migrateDown.ts
+++ b/packages/drizzle/src/migrateDown.ts
@@ -1,7 +1,6 @@
-import type { PayloadRequest } from 'payload'
-
 import {
   commitTransaction,
+  createLocalReq,
   getMigrations,
   initTransaction,
   killTransaction,
@@ -10,6 +9,7 @@ import {
 
 import type { DrizzleAdapter } from './types.js'
 
+import { getTransaction } from './utilities/getTransaction.js'
 import { migrationTableExists } from './utilities/migrationTableExists.js'
 import { parseError } from './utilities/parseError.js'
 
@@ -39,12 +39,12 @@ export async function migrateDown(this: DrizzleAdapter): Promise<void> {
     }
 
     const start = Date.now()
-    const req = { payload } as PayloadRequest
+    const req = await createLocalReq({}, payload)
 
     try {
       payload.logger.info({ msg: `Migrating down: ${migrationFile.name}` })
       await initTransaction(req)
-      const db = this.sessions[await req.transactionID]?.db || this.drizzle
+      const db = await getTransaction(this, req)
       await migrationFile.down({ db, payload, req })
       payload.logger.info({
         msg: `Migrated down:  ${migrationFile.name} (${Date.now() - start}ms)`,

--- a/packages/drizzle/src/migrateFresh.ts
+++ b/packages/drizzle/src/migrateFresh.ts
@@ -1,10 +1,15 @@
-import type { PayloadRequest } from 'payload'
-
-import { commitTransaction, initTransaction, killTransaction, readMigrationFiles } from 'payload'
+import {
+  commitTransaction,
+  createLocalReq,
+  initTransaction,
+  killTransaction,
+  readMigrationFiles,
+} from 'payload'
 import prompts from 'prompts'
 
 import type { DrizzleAdapter } from './types.js'
 
+import { getTransaction } from './utilities/getTransaction.js'
 import { parseError } from './utilities/parseError.js'
 
 /**
@@ -47,7 +52,7 @@ export async function migrateFresh(
     msg: `Found ${migrationFiles.length} migration files.`,
   })
 
-  const req = { payload } as PayloadRequest
+  const req = await createLocalReq({}, payload)
 
   if ('createExtensions' in this && typeof this.createExtensions === 'function') {
     await this.createExtensions()
@@ -59,7 +64,7 @@ export async function migrateFresh(
     try {
       const start = Date.now()
       await initTransaction(req)
-      const db = this.sessions[await req.transactionID]?.db || this.drizzle
+      const db = await getTransaction(this, req)
       await migration.up({ db, payload, req })
       await payload.create({
         collection: 'payload-migrations',

--- a/packages/drizzle/src/migrateReset.ts
+++ b/packages/drizzle/src/migrateReset.ts
@@ -1,7 +1,6 @@
-import type { PayloadRequest } from 'payload'
-
 import {
   commitTransaction,
+  createLocalReq,
   getMigrations,
   initTransaction,
   killTransaction,
@@ -10,6 +9,7 @@ import {
 
 import type { DrizzleAdapter } from './types.js'
 
+import { getTransaction } from './utilities/getTransaction.js'
 import { migrationTableExists } from './utilities/migrationTableExists.js'
 
 /**
@@ -26,7 +26,7 @@ export async function migrateReset(this: DrizzleAdapter): Promise<void> {
     return
   }
 
-  const req = { payload } as PayloadRequest
+  const req = await createLocalReq({}, payload)
 
   // Rollback all migrations in order
   for (const migration of existingMigrations) {
@@ -39,7 +39,7 @@ export async function migrateReset(this: DrizzleAdapter): Promise<void> {
       const start = Date.now()
       payload.logger.info({ msg: `Migrating down: ${migrationFile.name}` })
       await initTransaction(req)
-      const db = this.sessions[await req.transactionID]?.db || this.drizzle
+      const db = await getTransaction(this, req)
       await migrationFile.down({ db, payload, req })
       payload.logger.info({
         msg: `Migrated down:  ${migrationFile.name} (${Date.now() - start}ms)`,

--- a/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/fetchAndResave/index.ts
+++ b/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/fetchAndResave/index.ts
@@ -1,7 +1,6 @@
 import type { FlattenedField, Payload, PayloadRequest } from 'payload'
 
-import type { TransactionPg } from '../../../../types.js'
-import type { BasePostgresAdapter } from '../../../types.js'
+import type { BasePostgresAdapter, PostgresDB } from '../../../types.js'
 import type { DocsToResave } from '../types.js'
 
 import { upsertRow } from '../../../../upsertRow/index.js'
@@ -10,14 +9,14 @@ import { traverseFields } from './traverseFields.js'
 type Args = {
   adapter: BasePostgresAdapter
   collectionSlug?: string
-  db: TransactionPg
+  db: PostgresDB
   debug: boolean
   docsToResave: DocsToResave
   fields: FlattenedField[]
   globalSlug?: string
   isVersions: boolean
   payload: Payload
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   tableName: string
 }
 

--- a/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/index.ts
+++ b/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/index.ts
@@ -6,10 +6,10 @@ import fs from 'fs'
 import { buildVersionCollectionFields, buildVersionGlobalFields } from 'payload'
 import toSnakeCase from 'to-snake-case'
 
-import type { TransactionPg } from '../../../types.js'
 import type { BasePostgresAdapter } from '../../types.js'
 import type { PathsToQuery } from './types.js'
 
+import { getTransaction } from '../../../utilities/getTransaction.js'
 import { groupUpSQLStatements } from './groupUpSQLStatements.js'
 import { migrateRelationships } from './migrateRelationships.js'
 import { traverseFields } from './traverseFields.js'
@@ -36,7 +36,7 @@ type Args = {
  */
 export const migratePostgresV2toV3 = async ({ debug, payload, req }: Args) => {
   const adapter = payload.db as unknown as BasePostgresAdapter
-  const db = adapter.sessions[await req.transactionID].db as TransactionPg
+  const db = await getTransaction(adapter, req)
   const dir = payload.db.migrationDir
 
   // get the drizzle migrateUpSQL from drizzle using the last schema

--- a/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/migrateRelationships.ts
+++ b/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/migrateRelationships.ts
@@ -2,8 +2,7 @@ import type { FlattenedField, Payload, PayloadRequest } from 'payload'
 
 import { sql } from 'drizzle-orm'
 
-import type { TransactionPg } from '../../../types.js'
-import type { BasePostgresAdapter } from '../../types.js'
+import type { BasePostgresAdapter, PostgresDB } from '../../types.js'
 import type { DocsToResave, PathsToQuery } from './types.js'
 
 import { fetchAndResave } from './fetchAndResave/index.js'
@@ -11,7 +10,7 @@ import { fetchAndResave } from './fetchAndResave/index.js'
 type Args = {
   adapter: BasePostgresAdapter
   collectionSlug?: string
-  db: TransactionPg
+  db: PostgresDB
   debug: boolean
   fields: FlattenedField[]
   globalSlug?: string
@@ -95,7 +94,7 @@ export const migrateRelationships = async ({
       globalSlug,
       isVersions,
       payload,
-      req: req as unknown as PayloadRequest,
+      req,
       tableName,
     })
   }

--- a/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/traverseFields.ts
+++ b/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/traverseFields.ts
@@ -2,15 +2,14 @@ import type { FlattenedField, Payload } from 'payload'
 
 import toSnakeCase from 'to-snake-case'
 
-import type { TransactionPg } from '../../../types.js'
-import type { BasePostgresAdapter } from '../../types.js'
+import type { BasePostgresAdapter, PostgresDB } from '../../types.js'
 import type { PathsToQuery } from './types.js'
 
 type Args = {
   adapter: BasePostgresAdapter
   collectionSlug?: string
   columnPrefix: string
-  db: TransactionPg
+  db: PostgresDB
   disableNotNull: boolean
   fields: FlattenedField[]
   globalSlug?: string

--- a/packages/drizzle/src/queryDrafts.ts
+++ b/packages/drizzle/src/queryDrafts.ts
@@ -1,4 +1,4 @@
-import type { PayloadRequest, QueryDrafts, SanitizedCollectionConfig } from 'payload'
+import type { QueryDrafts, SanitizedCollectionConfig } from 'payload'
 
 import { buildVersionCollectionFields, combineQueries } from 'payload'
 import toSnakeCase from 'to-snake-case'
@@ -9,18 +9,7 @@ import { findMany } from './find/findMany.js'
 
 export const queryDrafts: QueryDrafts = async function queryDrafts(
   this: DrizzleAdapter,
-  {
-    collection,
-    joins,
-    limit,
-    locale,
-    page = 1,
-    pagination,
-    req = {} as PayloadRequest,
-    select,
-    sort,
-    where,
-  },
+  { collection, joins, limit, locale, page = 1, pagination, req, select, sort, where },
 ) {
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
   const tableName = this.tableNameMap.get(

--- a/packages/drizzle/src/update.ts
+++ b/packages/drizzle/src/update.ts
@@ -8,12 +8,13 @@ import { buildFindManyArgs } from './find/buildFindManyArgs.js'
 import buildQuery from './queries/buildQuery.js'
 import { selectDistinct } from './queries/selectDistinct.js'
 import { upsertRow } from './upsertRow/index.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export const updateOne: UpdateOne = async function updateOne(
   this: DrizzleAdapter,
   { id, collection: collectionSlug, data, joins: joinQuery, locale, req, select, where: whereArg },
 ) {
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
   const collection = this.payload.collections[collectionSlug].config
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))
   const whereToUse = whereArg || { id: { equals: id } }

--- a/packages/drizzle/src/updateGlobal.ts
+++ b/packages/drizzle/src/updateGlobal.ts
@@ -1,16 +1,17 @@
-import type { PayloadRequest, UpdateGlobalArgs } from 'payload'
+import type { UpdateGlobalArgs } from 'payload'
 
 import toSnakeCase from 'to-snake-case'
 
 import type { DrizzleAdapter } from './types.js'
 
 import { upsertRow } from './upsertRow/index.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export async function updateGlobal<T extends Record<string, unknown>>(
   this: DrizzleAdapter,
-  { slug, data, req = {} as PayloadRequest, select }: UpdateGlobalArgs,
+  { slug, data, req, select }: UpdateGlobalArgs,
 ): Promise<T> {
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
   const globalConfig = this.payload.globals.config.find((config) => config.slug === slug)
   const tableName = this.tableNameMap.get(toSnakeCase(globalConfig.slug))
 

--- a/packages/drizzle/src/updateGlobalVersion.ts
+++ b/packages/drizzle/src/updateGlobalVersion.ts
@@ -1,5 +1,4 @@
 import type {
-  PayloadRequest,
   SanitizedGlobalConfig,
   TypeWithID,
   TypeWithVersion,
@@ -13,20 +12,13 @@ import type { DrizzleAdapter } from './types.js'
 
 import buildQuery from './queries/buildQuery.js'
 import { upsertRow } from './upsertRow/index.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export async function updateGlobalVersion<T extends TypeWithID>(
   this: DrizzleAdapter,
-  {
-    id,
-    global,
-    locale,
-    req = {} as PayloadRequest,
-    select,
-    versionData,
-    where: whereArg,
-  }: UpdateGlobalVersionArgs<T>,
+  { id, global, locale, req, select, versionData, where: whereArg }: UpdateGlobalVersionArgs<T>,
 ) {
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
   const globalConfig: SanitizedGlobalConfig = this.payload.globals.config.find(
     ({ slug }) => slug === global,
   )

--- a/packages/drizzle/src/updateVersion.ts
+++ b/packages/drizzle/src/updateVersion.ts
@@ -1,5 +1,4 @@
 import type {
-  PayloadRequest,
   SanitizedCollectionConfig,
   TypeWithID,
   TypeWithVersion,
@@ -13,20 +12,13 @@ import type { DrizzleAdapter } from './types.js'
 
 import buildQuery from './queries/buildQuery.js'
 import { upsertRow } from './upsertRow/index.js'
+import { getTransaction } from './utilities/getTransaction.js'
 
 export async function updateVersion<T extends TypeWithID>(
   this: DrizzleAdapter,
-  {
-    id,
-    collection,
-    locale,
-    req = {} as PayloadRequest,
-    select,
-    versionData,
-    where: whereArg,
-  }: UpdateVersionArgs<T>,
+  { id, collection, locale, req, select, versionData, where: whereArg }: UpdateVersionArgs<T>,
 ) {
-  const db = this.sessions[await req?.transactionID]?.db || this.drizzle
+  const db = await getTransaction(this, req)
   const collectionConfig: SanitizedCollectionConfig = this.payload.collections[collection].config
   const whereToUse = whereArg || { id: { equals: id } }
   const tableName = this.tableNameMap.get(

--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -394,12 +394,12 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
           id,
           errors: [
             {
-              message: req.t('error:valueMustBeUnique'),
+              message: req?.t ? 'error:valueMustBeUnique' : 'Value must be unique',
               path: fieldName,
             },
           ],
         },
-        req.t,
+        req?.t,
       )
     } else {
       throw error

--- a/packages/drizzle/src/upsertRow/types.ts
+++ b/packages/drizzle/src/upsertRow/types.ts
@@ -15,7 +15,7 @@ type BaseArgs = {
   ignoreResult?: boolean
   joinQuery?: JoinQuery
   path?: string
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   tableName: string
 }
 

--- a/packages/drizzle/src/utilities/getTransaction.ts
+++ b/packages/drizzle/src/utilities/getTransaction.ts
@@ -1,0 +1,17 @@
+import type { PayloadRequest } from 'payload'
+
+import type { DrizzleAdapter } from '../types.js'
+
+/**
+ * Returns current db transaction instance from req or adapter.drizzle itself
+ */
+export const getTransaction = async <T extends DrizzleAdapter = DrizzleAdapter>(
+  adapter: T,
+  req?: Partial<PayloadRequest>,
+): Promise<T['drizzle']> => {
+  if (!req?.transactionID) {
+    return adapter.drizzle
+  }
+
+  return (adapter.sessions[await req.transactionID]?.db as T['drizzle']) || adapter.drizzle
+}

--- a/packages/payload/src/auth/operations/local/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/local/forgotPassword.ts
@@ -14,7 +14,7 @@ export type Options<T extends CollectionSlug> = {
   }
   disableEmail?: boolean
   expiration?: number
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
 }
 
 async function localForgotPassword<T extends CollectionSlug>(

--- a/packages/payload/src/auth/operations/local/login.ts
+++ b/packages/payload/src/auth/operations/local/login.ts
@@ -20,7 +20,7 @@ export type Options<TSlug extends CollectionSlug> = {
   fallbackLocale?: string
   locale?: string
   overrideAccess?: boolean
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   showHiddenFields?: boolean
 }
 

--- a/packages/payload/src/auth/operations/local/resetPassword.ts
+++ b/packages/payload/src/auth/operations/local/resetPassword.ts
@@ -14,7 +14,7 @@ export type Options<T extends CollectionSlug> = {
     token: string
   }
   overrideAccess: boolean
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
 }
 
 async function localResetPassword<T extends CollectionSlug>(

--- a/packages/payload/src/auth/operations/local/unlock.ts
+++ b/packages/payload/src/auth/operations/local/unlock.ts
@@ -15,7 +15,7 @@ export type Options<TSlug extends CollectionSlug> = {
   context?: RequestContext
   data: AuthOperationsFromCollectionSlug<TSlug>['unlock']
   overrideAccess: boolean
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
 }
 
 async function localUnlock<TSlug extends CollectionSlug>(

--- a/packages/payload/src/auth/operations/local/verifyEmail.ts
+++ b/packages/payload/src/auth/operations/local/verifyEmail.ts
@@ -8,7 +8,7 @@ import { verifyEmailOperation } from '../verifyEmail.js'
 export type Options<T extends CollectionSlug> = {
   collection: T
   context?: RequestContext
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   token: string
 }
 

--- a/packages/payload/src/collections/operations/local/count.ts
+++ b/packages/payload/src/collections/operations/local/count.ts
@@ -15,7 +15,7 @@ export type Options<TSlug extends CollectionSlug> = {
   disableErrors?: boolean
   locale?: TypedLocale
   overrideAccess?: boolean
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   user?: Document
   where?: Where
 }

--- a/packages/payload/src/collections/operations/local/countVersions.ts
+++ b/packages/payload/src/collections/operations/local/countVersions.ts
@@ -15,7 +15,7 @@ export type Options<TSlug extends CollectionSlug> = {
   disableErrors?: boolean
   locale?: TypedLocale
   overrideAccess?: boolean
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   user?: Document
   where?: Where
 }

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -37,7 +37,7 @@ export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = 
   overrideAccess?: boolean
   overwriteExistingFiles?: boolean
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: TSelect
   showHiddenFields?: boolean
   user?: Document

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -27,7 +27,7 @@ export type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType
   overrideAccess?: boolean
   overrideLock?: boolean
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: TSelect
   showHiddenFields?: boolean
   user?: Document

--- a/packages/payload/src/collections/operations/local/duplicate.ts
+++ b/packages/payload/src/collections/operations/local/duplicate.ts
@@ -33,7 +33,7 @@ export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = 
   locale?: TypedLocale
   overrideAccess?: boolean
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: TSelect
   showHiddenFields?: boolean
   user?: Document

--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -40,7 +40,7 @@ export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = 
   page?: number
   pagination?: boolean
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: TSelect
   showHiddenFields?: boolean
   sort?: Sort

--- a/packages/payload/src/collections/operations/local/findByID.ts
+++ b/packages/payload/src/collections/operations/local/findByID.ts
@@ -41,7 +41,7 @@ export type Options<
   locale?: 'all' | TypedLocale
   overrideAccess?: boolean
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: TSelect
   showHiddenFields?: boolean
   user?: Document

--- a/packages/payload/src/collections/operations/local/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/local/findVersionByID.ts
@@ -21,7 +21,7 @@ export type Options<TSlug extends CollectionSlug> = {
   locale?: 'all' | TypedLocale
   overrideAccess?: boolean
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   showHiddenFields?: boolean
   user?: Document

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -29,7 +29,7 @@ export type Options<TSlug extends CollectionSlug> = {
   overrideAccess?: boolean
   page?: number
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   showHiddenFields?: boolean
   sort?: Sort

--- a/packages/payload/src/collections/operations/local/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/local/restoreVersion.ts
@@ -19,7 +19,7 @@ export type Options<TSlug extends CollectionSlug> = {
   locale?: TypedLocale
   overrideAccess?: boolean
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   showHiddenFields?: boolean
   user?: Document

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -42,7 +42,7 @@ export type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType
   overwriteExistingFiles?: boolean
   populate?: PopulateType
   publishSpecificLocale?: string
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: TSelect
   showHiddenFields?: boolean
   user?: Document

--- a/packages/payload/src/database/migrations/migrate.ts
+++ b/packages/payload/src/database/migrations/migrate.ts
@@ -1,7 +1,7 @@
-import type { PayloadRequest } from '../../types/index.js'
 import type { BaseDatabaseAdapter } from '../types.js'
 
 import { commitTransaction } from '../../utilities/commitTransaction.js'
+import { createLocalReq } from '../../utilities/createLocalReq.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { getMigrations } from './getMigrations.js'
@@ -29,7 +29,7 @@ export const migrate: BaseDatabaseAdapter['migrate'] = async function migrate(
     }
 
     const start = Date.now()
-    const req = { payload } as PayloadRequest
+    const req = await createLocalReq({}, payload)
 
     payload.logger.info({ msg: `Migrating: ${migration.name}` })
 

--- a/packages/payload/src/database/migrations/migrateDown.ts
+++ b/packages/payload/src/database/migrations/migrateDown.ts
@@ -1,7 +1,7 @@
-import type { PayloadRequest } from '../../types/index.js'
 import type { BaseDatabaseAdapter } from '../types.js'
 
 import { commitTransaction } from '../../utilities/commitTransaction.js'
+import { createLocalReq } from '../../utilities/createLocalReq.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { getMigrations } from './getMigrations.js'
@@ -33,7 +33,7 @@ export async function migrateDown(this: BaseDatabaseAdapter): Promise<void> {
     }
 
     const start = Date.now()
-    const req = { payload } as PayloadRequest
+    const req = await createLocalReq({}, payload)
 
     try {
       payload.logger.info({ msg: `Migrating down: ${migrationFile.name}` })

--- a/packages/payload/src/database/migrations/migrateRefresh.ts
+++ b/packages/payload/src/database/migrations/migrateRefresh.ts
@@ -1,7 +1,7 @@
-import type { PayloadRequest } from '../../types/index.js'
 import type { BaseDatabaseAdapter } from '../types.js'
 
 import { commitTransaction } from '../../utilities/commitTransaction.js'
+import { createLocalReq } from '../../utilities/createLocalReq.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { getMigrations } from './getMigrations.js'
@@ -18,7 +18,7 @@ export async function migrateRefresh(this: BaseDatabaseAdapter) {
     payload,
   })
 
-  const req = { payload } as PayloadRequest
+  const req = await createLocalReq({}, payload)
 
   if (existingMigrations?.length) {
     payload.logger.info({

--- a/packages/payload/src/database/migrations/migrateReset.ts
+++ b/packages/payload/src/database/migrations/migrateReset.ts
@@ -1,7 +1,7 @@
-import type { PayloadRequest } from '../../types/index.js'
 import type { BaseDatabaseAdapter } from '../types.js'
 
 import { commitTransaction } from '../../utilities/commitTransaction.js'
+import { createLocalReq } from '../../utilities/createLocalReq.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { getMigrations } from './getMigrations.js'
@@ -18,7 +18,7 @@ export async function migrateReset(this: BaseDatabaseAdapter): Promise<void> {
     return
   }
 
-  const req = { payload } as PayloadRequest
+  const req = await createLocalReq({}, payload)
 
   // Rollback all migrations in order
   for (const migration of migrationFiles) {

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -191,7 +191,7 @@ export type QueryDraftsArgs = {
   locale?: string
   page?: number
   pagination?: boolean
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   sort?: Sort
   where?: Where
@@ -203,7 +203,7 @@ export type FindOneArgs = {
   collection: CollectionSlug
   joins?: JoinQuery
   locale?: string
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   where?: Where
 }
@@ -219,7 +219,7 @@ export type FindArgs = {
   page?: number
   pagination?: boolean
   projection?: Record<string, unknown>
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   skip?: number
   sort?: Sort
@@ -232,7 +232,7 @@ export type Find = <T = TypeWithID>(args: FindArgs) => Promise<PaginatedDocs<T>>
 export type CountArgs = {
   collection: CollectionSlug
   locale?: string
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   where?: Where
 }
 
@@ -243,7 +243,7 @@ export type CountVersions = (args: CountArgs) => Promise<{ totalDocs: number }>
 export type CountGlobalVersionArgs = {
   global: string
   locale?: string
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   where?: Where
 }
 
@@ -254,7 +254,7 @@ type BaseVersionArgs = {
   locale?: string
   page?: number
   pagination?: boolean
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   skip?: number
   sort?: Sort
@@ -276,7 +276,7 @@ export type FindGlobalVersionsArgs = {
 
 export type FindGlobalArgs = {
   locale?: string
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   slug: string
   where?: Where
@@ -289,7 +289,7 @@ export type UpdateGlobalVersionArgs<T = TypeWithID> = {
    * Additional database adapter specific options to pass to the query
    */
   options?: Record<string, unknown>
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   versionData: T
 } & (
@@ -313,7 +313,7 @@ export type FindGlobal = <T extends Record<string, unknown> = any>(
 
 export type CreateGlobalArgs<T extends Record<string, unknown> = any> = {
   data: T
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   slug: string
 }
 export type CreateGlobal = <T extends Record<string, unknown> = any>(
@@ -326,7 +326,7 @@ export type UpdateGlobalArgs<T extends Record<string, unknown> = any> = {
    * Additional database adapter specific options to pass to the query
    */
   options?: Record<string, unknown>
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   slug: string
 }
@@ -342,7 +342,7 @@ export type FindGlobalVersions = <T = TypeWithID>(
 export type DeleteVersionsArgs = {
   collection: CollectionSlug
   locale?: string
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   sort?: {
     [key: string]: string
   }
@@ -356,7 +356,7 @@ export type CreateVersionArgs<T = TypeWithID> = {
   /** ID of the parent document for which the version should be created for */
   parent: number | string
   publishedLocale?: string
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   snapshot?: true
   updatedAt: string
@@ -374,7 +374,7 @@ export type CreateGlobalVersionArgs<T = TypeWithID> = {
   /** ID of the parent document for which the version should be created for */
   parent: number | string
   publishedLocale?: string
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   snapshot?: true
   updatedAt: string
@@ -394,7 +394,7 @@ export type UpdateVersionArgs<T = TypeWithID> = {
    * Additional database adapter specific options to pass to the query
    */
   options?: Record<string, unknown>
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   versionData: T
 } & (
@@ -417,7 +417,7 @@ export type CreateArgs = {
   data: Record<string, unknown>
   draft?: boolean
   locale?: string
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
 }
 
@@ -433,7 +433,7 @@ export type UpdateOneArgs = {
    * Additional database adapter specific options to pass to the query
    */
   options?: Record<string, unknown>
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
 } & (
   | {
@@ -453,7 +453,7 @@ export type UpsertArgs = {
   data: Record<string, unknown>
   joins?: JoinQuery
   locale?: string
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   where: Where
 }
@@ -463,7 +463,7 @@ export type Upsert = (args: UpsertArgs) => Promise<Document>
 export type DeleteOneArgs = {
   collection: CollectionSlug
   joins?: JoinQuery
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   where: Where
 }
@@ -473,7 +473,7 @@ export type DeleteOne = (args: DeleteOneArgs) => Promise<Document>
 export type DeleteManyArgs = {
   collection: CollectionSlug
   joins?: JoinQuery
-  req: PayloadRequest
+  req?: Partial<PayloadRequest>
   where: Where
 }
 

--- a/packages/payload/src/globals/operations/local/countGlobalVersions.ts
+++ b/packages/payload/src/globals/operations/local/countGlobalVersions.ts
@@ -15,7 +15,7 @@ export type CountGlobalVersionsOptions<TSlug extends GlobalSlug> = {
   global: TSlug
   locale?: TypedLocale
   overrideAccess?: boolean
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   user?: Document
   where?: Where
 }

--- a/packages/payload/src/globals/operations/local/findOne.ts
+++ b/packages/payload/src/globals/operations/local/findOne.ts
@@ -21,7 +21,7 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
   locale?: 'all' | TypedLocale
   overrideAccess?: boolean
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: TSelect
   showHiddenFields?: boolean
   slug: TSlug

--- a/packages/payload/src/globals/operations/local/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/local/findVersionByID.ts
@@ -16,7 +16,7 @@ export type Options<TSlug extends GlobalSlug> = {
   locale?: 'all' | TypedLocale
   overrideAccess?: boolean
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   showHiddenFields?: boolean
   slug: TSlug

--- a/packages/payload/src/globals/operations/local/findVersions.ts
+++ b/packages/payload/src/globals/operations/local/findVersions.ts
@@ -25,7 +25,7 @@ export type Options<TSlug extends GlobalSlug> = {
   overrideAccess?: boolean
   page?: number
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: SelectType
   showHiddenFields?: boolean
   slug: TSlug

--- a/packages/payload/src/globals/operations/local/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/local/restoreVersion.ts
@@ -15,7 +15,7 @@ export type Options<TSlug extends GlobalSlug> = {
   locale?: TypedLocale
   overrideAccess?: boolean
   populate?: PopulateType
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   showHiddenFields?: boolean
   slug: TSlug
   user?: Document

--- a/packages/payload/src/globals/operations/local/update.ts
+++ b/packages/payload/src/globals/operations/local/update.ts
@@ -25,7 +25,7 @@ export type Options<TSlug extends GlobalSlug, TSelect extends SelectType> = {
   overrideLock?: boolean
   populate?: PopulateType
   publishSpecificLocale?: TypedLocale
-  req?: PayloadRequest
+  req?: Partial<PayloadRequest>
   select?: TSelect
   showHiddenFields?: boolean
   slug: TSlug

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -62,6 +62,7 @@ export type CustomPayloadRequestProperties = {
   transactionID?: number | Promise<number | string> | string
   /**
    * Used to ensure consistency when multiple operations try to create a transaction concurrently on the same request
+   * @deprecated This is not used anywhere, instead `transactionID` is used for the above. Will be removed in next major version.
    */
   transactionIDPromise?: Promise<void>
   /** The signed-in user */

--- a/packages/payload/src/utilities/commitTransaction.ts
+++ b/packages/payload/src/utilities/commitTransaction.ts
@@ -1,9 +1,13 @@
+import type { MarkRequired } from 'ts-essentials'
+
 import type { PayloadRequest } from '../types/index.js'
 
 /**
  * complete a transaction calling adapter db.commitTransaction and delete the transactionID from req
  */
-export async function commitTransaction(req: PayloadRequest): Promise<void> {
+export async function commitTransaction(
+  req: MarkRequired<Partial<PayloadRequest>, 'payload'>,
+): Promise<void> {
   const { payload, transactionID } = req
 
   await payload.db.commitTransaction(transactionID)

--- a/packages/payload/src/utilities/initTransaction.ts
+++ b/packages/payload/src/utilities/initTransaction.ts
@@ -1,10 +1,14 @@
+import type { MarkRequired } from 'ts-essentials'
+
 import type { PayloadRequest } from '../types/index.js'
 
 /**
  * Starts a new transaction using the db adapter with a random id and then assigns it to the req.transaction
  * @returns true if beginning a transaction and false when req already has a transaction to use
  */
-export async function initTransaction(req: PayloadRequest): Promise<boolean> {
+export async function initTransaction(
+  req: MarkRequired<Partial<PayloadRequest>, 'payload'>,
+): Promise<boolean> {
   const { payload, transactionID } = req
   if (transactionID instanceof Promise) {
     // wait for whoever else is already creating the transaction

--- a/packages/payload/src/utilities/killTransaction.ts
+++ b/packages/payload/src/utilities/killTransaction.ts
@@ -1,9 +1,13 @@
+import type { MarkRequired } from 'ts-essentials'
+
 import type { PayloadRequest } from '../types/index.js'
 
 /**
  * Rollback the transaction from the req using the db adapter and removes it from the req
  */
-export async function killTransaction(req: PayloadRequest): Promise<void> {
+export async function killTransaction(
+  req: MarkRequired<Partial<PayloadRequest>, 'payload'>,
+): Promise<void> {
   const { payload, transactionID } = req
   if (transactionID && !(transactionID instanceof Promise)) {
     try {


### PR DESCRIPTION
### What?
Previously, the `req` argument:
In database operations (e.g `payload.db`) was required and you needed to pass the whole `req` with all the properties. This is confusing because in database operations we never use its properties outside of `req.transactionID` and `req.t`, both of which should be optional as well.

Now, you don't have to do that cast:
```ts
payload.db.findOne({
  collection: 'posts',
  req: {} as PayloadRequest,
  where: {
    id: {
      equals: 1,
    },
  },
})
```
Becomes:
```ts
payload.db.findOne({
  collection: 'posts',
  where: {
    id: {
      equals: 1,
    },
  },
})
```

If you need to use transactions, you're not required to do the `as` cast as well now, as the `req` not only optional but also partial - `Partial<PayloadRequest>`.
`initTransaction`, `commitTransaction`, `killTransaction` utilities are typed better now as well. They do not require to you pass all the properties of `req`, but only `payload` - `MarkRequired<Partial<PayloadRequest>, 'payload'>`
```ts
const req = { payload }
await initTransaction(req)
await payload.db.create({
  collection: "posts",
  data: {},
  req
})
await commitTransaction(req)
```

The same for the Local API. Internal operations (for example `packages/payload/src/collections/operations/find.ts`) still accept the whole `req`, but local ones (`packages/payload/src/collections/operations/local/find.ts`) which are used through `payload.` now accept `Partial<PayloadRequest>`, as they pass it through to internal operations with `createLocalReq`.

So now, this is also valid, while previously you had to do `as` cast for `req`.
```ts
const req = { payload }
await initTransaction(req)
await payload.create({
  collection: "posts",
  data: {},
  req
})
await commitTransaction(req)
```


Marked as deprecated `PayloadRequest['transactionIDPromise']` to remove in the next major version. It was never used anywhere.
Refactored `withSession` that returns an object to `getSession` that returns just `ClientSession`. Better type safety for arguments
Deduplicated in all drizzle operations to `getTransaction(this, req)` utility:
```ts
const db = this.sessions[await req?.transactionID]?.db || this.drizzle
```
Added fallback for throwing unique validation errors in database operations when `req.t` is not available.

In migration `up` and `down` functions our `req` is not partial, while we used to passed `req` with only 2 properties - `payload` and `transactionID`. This is misleading and you can't access for example `req.t`.
 Now, to achieve "real" full `req` - we generate it with `createLocalReq` in all migration functions.

This all is backwards compatible. In all public API places where you expect the full `req` (like hooks) you still have it.

### Why?
Better DX, more expected types, less errors because of types casting.
