### PR TITLE
fix(ui): properly passes `readOnly` prop to email & username auth fields

### DIFF
--- a/packages/ui/src/elements/EmailAndUsername/index.tsx
+++ b/packages/ui/src/elements/EmailAndUsername/index.tsx
@@ -23,7 +23,7 @@ type RenderEmailAndUsernameFieldsProps = {
 }
 
 export function EmailAndUsernameFields(props: RenderEmailAndUsernameFieldsProps) {
-  const { className, loginWithUsername, t } = props
+  const { className, loginWithUsername, readOnly, t } = props
 
   const showEmailField =
     !loginWithUsername || loginWithUsername?.requireEmail || loginWithUsername?.allowEmailLogin
@@ -43,6 +43,7 @@ export function EmailAndUsernameFields(props: RenderEmailAndUsernameFieldsProps)
             required: !loginWithUsername || (loginWithUsername && loginWithUsername.requireEmail),
           }}
           path="email"
+          readOnly={readOnly}
           schemaPath="email"
           validate={email}
         />
@@ -55,6 +56,7 @@ export function EmailAndUsernameFields(props: RenderEmailAndUsernameFieldsProps)
             required: loginWithUsername && loginWithUsername.requireUsername,
           }}
           path="username"
+          readOnly={readOnly}
           schemaPath="username"
           validate={username}
         />


### PR DESCRIPTION
### What?

The `readOnly` prop was not being passed down to the `email` & `username` auth fields. 

Resulting in these fields not being disabled properly if `update` access was restricted. 

### How?

Passes the `readOnly` prop through to the fields and now properly disables these fields if `update` access is restricted.
