### PR TITLE
chore: deflake postgres and sqlite integration joins test

### DIFF
--- a/test/joins/config.ts
+++ b/test/joins/config.ts
@@ -162,7 +162,7 @@ export default buildConfigWithDefaults({
         {
           name: 'category',
           type: 'relationship',
-          relationTo: restrictedCategoriesSlug,
+          relationTo: categoriesJoinRestrictedSlug,
         },
       ],
     },


### PR DESCRIPTION
`relationTo` was specified incorrectly which led to 
```
  ● Joins Field › rEST API should not populate individual join by providing schemaPath=false

    error: insert or update on table "collection_restricted" violates foreign key constraint "collection_restricted_category_id_restricted_categories_id_fk"

      18 |       .returning()
      19 |   } else {
    > 20 |     result = await (db as TransactionPg).insert(table).values(values).returning()
```