### PR TITLE
chore: use non-permanent / => /admin redirect so that the browser doesn't cache it for projects that don't redirect

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,7 +32,7 @@ const config = withBundleAnalyzer(
       return [
         {
           destination: '/admin',
-          permanent: true,
+          permanent: false,
           source: '/',
         },
       ]


### PR DESCRIPTION
When opening payload in our monorepo and then working on a different project that comes with a frontend, it will automatically redirect me from localhost:3000 => localhost:3000/admin, not letting me view the landing page until I clear my browser cache.

I'm hoping this will fix it