### PR TITLE
fix(plugin-nested-docs): publishing parent doc should not publish child doc

### DIFF
--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -23,11 +23,10 @@ type ResaveArgs = {
 const resave = async ({ collection, doc, draft, pluginConfig, req }: ResaveArgs) => {
   const parentSlug = pluginConfig?.parentFieldSlug || 'parent'
   const parentDocIsPublished = doc._status === 'published'
-
   const children = await req.payload.find({
     collection: collection.slug,
     depth: 0,
-    draft,
+    draft: true,
     locale: req.locale,
     req,
     where: {

--- a/test/plugin-nested-docs/e2e.spec.ts
+++ b/test/plugin-nested-docs/e2e.spec.ts
@@ -136,5 +136,18 @@ describe('Nested Docs Plugin', () => {
       // TODO: add back when error states are fixed
       // await expect(parentSlugInChild).toHaveValue('/parent-slug-draft')
     })
+
+    test('Publishing parent doc should not publish child', async () => {
+      await page.goto(url.edit(childId))
+      await page.locator(slugClass).nth(0).fill('child-updated-draft')
+      await page.locator(draftButtonClass).nth(0).click()
+
+      await page.goto(url.edit(parentId))
+      await page.locator(slugClass).nth(0).fill('parent-updated-published')
+      await page.locator(publishButtonClass).nth(0).click()
+
+      await page.goto(url.edit(childId))
+      await expect(page.locator(slugClass).nth(0)).toHaveValue('child-updated-draft')
+    })
   })
 })


### PR DESCRIPTION
## Bug Fix

### Issue
Draft children documents get overwritten when the parent document is published.

### Fix
Correctly retrieve all documents, including drafts, during the resave process. Add test to ensure parent documents can be published without impacting the state of any children docs.