### PR TITLE
ci: wait until version resolves in post-release-templates

### DIFF
--- a/.github/workflows/post-release-templates.yml
+++ b/.github/workflows/post-release-templates.yml
@@ -13,7 +13,33 @@ env:
   NEXT_TELEMETRY_DISABLED: 1 # Disable Next telemetry
 
 jobs:
+  wait_for_release:
+    runs-on: ubuntu-24.04
+    outputs:
+      release_tag: ${{ steps.determine_tag.outputs.release_tag }}
+    steps:
+      - name: Determine Release Tag
+        id: determine_tag
+        run: |
+          if [ "${{ github.event_name }}" == "release" ]; then
+            echo "Using tag from release event: ${{ github.event.release.tag_name }}"
+            echo "release_tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            # pull latest tag from github, must match any version except v2. Should match v3, v4, v99, etc.
+            echo "Fetching latest tag from github..."
+            LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude 'v2*')
+            echo "Latest tag: $LATEST_TAG"
+            echo "release_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait until latest versions resolve on npm registry
+        run: |
+          ./wait-until-package-version.sh payload ${{ steps.determine_tag.outputs.release_tag }}
+          ./wait-until-package-version.sh @payloadcms/translations ${{ steps.determine_tag.outputs.release_tag }}
+          ./wait-until-package-version.sh @payloadcms/next ${{ steps.determine_tag.outputs.release_tag }}
+
   update_templates:
+    needs: wait_for_release
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -60,20 +86,6 @@ jobs:
       - name: Update template lockfiles and migrations
         run: pnpm script:gen-templates
 
-      - name: Determine Release Tag
-        id: determine_tag
-        run: |
-          if [ "${{ github.event_name }}" == "release" ]; then
-            echo "Using tag from release event: ${{ github.event.release.tag_name }}"
-            echo "release_tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
-          else
-            # pull latest tag from github, must match any version except v2. Should match v3, v4, v99, etc.
-            echo "Fetching latest tag from github..."
-            LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude 'v2*')
-            echo "Latest tag: $LATEST_TAG"
-            echo "release_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Commit and push changes
         id: commit
         env:
@@ -85,7 +97,7 @@ jobs:
 
           git diff --name-only
 
-          export BRANCH_NAME=templates/bump-${{ steps.determine_tag.outputs.release_tag }}-$(date +%s)
+          export BRANCH_NAME=templates/bump-${{ needs.wait_for_release.outputs.release_tag }}-$(date +%s)
           echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Create pull request
@@ -94,12 +106,12 @@ jobs:
           token: ${{ secrets.GH_TOKEN_POST_RELEASE_TEMPLATES }}
           labels: 'area: templates'
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          commit-message: 'templates: bump templates for ${{ steps.determine_tag.outputs.release_tag }}'
+          commit-message: 'templates: bump templates for ${{ needs.wait_for_release.outputs.release_tag }}'
           branch: ${{ steps.commit.outputs.branch }}
           base: main
           assignees: ${{ github.actor }}
-          title: 'templates: bump for ${{ steps.determine_tag.outputs.release_tag }}'
+          title: 'templates: bump for ${{ needs.wait_for_release.outputs.release_tag }}'
           body: |
-            🤖 Automated bump of templates for ${{ steps.determine_tag.outputs.release_tag }}
+            🤖 Automated bump of templates for ${{ needs.wait_for_release.outputs.release_tag }}
 
             Triggered by user: @${{ github.actor }}

--- a/.github/workflows/post-release-templates.yml
+++ b/.github/workflows/post-release-templates.yml
@@ -18,6 +18,11 @@ jobs:
     outputs:
       release_tag: ${{ steps.determine_tag.outputs.release_tag }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
       - name: Determine Release Tag
         id: determine_tag
         run: |
@@ -51,8 +56,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Needed for tags
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/post-release-templates.yml
+++ b/.github/workflows/post-release-templates.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
+          sparse-checkout: .github/workflows
 
       - name: Determine Release Tag
         id: determine_tag

--- a/.github/workflows/post-release-templates.yml
+++ b/.github/workflows/post-release-templates.yml
@@ -40,9 +40,9 @@ jobs:
 
       - name: Wait until latest versions resolve on npm registry
         run: |
-          ./wait-until-package-version.sh payload ${{ steps.determine_tag.outputs.release_tag }}
-          ./wait-until-package-version.sh @payloadcms/translations ${{ steps.determine_tag.outputs.release_tag }}
-          ./wait-until-package-version.sh @payloadcms/next ${{ steps.determine_tag.outputs.release_tag }}
+          ./.github/workflows/wait-until-package-version.sh payload ${{ steps.determine_tag.outputs.release_tag }}
+          ./.github/workflows/wait-until-package-version.sh @payloadcms/translations ${{ steps.determine_tag.outputs.release_tag }}
+          ./.github/workflows/wait-until-package-version.sh @payloadcms/next ${{ steps.determine_tag.outputs.release_tag }}
 
   update_templates:
     needs: wait_for_release

--- a/.github/workflows/wait-until-package-version.sh
+++ b/.github/workflows/wait-until-package-version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [[ "$#" -ne 2 ]]; then
+  echo "Usage: $0 <package-name> <version>"
+  exit 1
+fi
+
+PACKAGE_NAME="$1"
+TARGET_VERSION="$2"
+TIMEOUT=300  # 5 minutes in seconds
+INTERVAL=10  # 10 seconds
+ELAPSED=0
+
+echo "Waiting for version ${TARGET_VERSION} of '${PACKAGE_NAME}' to resolve... (timeout: ${TIMEOUT} seconds)"
+
+while [[ ${ELAPSED} -lt ${TIMEOUT} ]]; do
+  latest_version=$(npm show "${PACKAGE_NAME}" version 2>/dev/null)
+
+  if [[ ${latest_version} == "${TARGET_VERSION}" ]]; then
+    echo "SUCCCESS: Version ${TARGET_VERSION} of ${PACKAGE_NAME} is available."
+    exit 0
+  else
+    echo "Version ${TARGET_VERSION} of ${PACKAGE_NAME} is not available yet. Retrying in ${INTERVAL} seconds... (elapsed: ${ELAPSED}s)"
+  fi
+
+  sleep "${INTERVAL}"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo "Timed out after ${TIMEOUT} seconds waiting for version ${TARGET_VERSION} of '${PACKAGE_NAME}' to resolve."
+exit 1

--- a/.github/workflows/wait-until-package-version.sh
+++ b/.github/workflows/wait-until-package-version.sh
@@ -6,7 +6,7 @@ if [[ "$#" -ne 2 ]]; then
 fi
 
 PACKAGE_NAME="$1"
-TARGET_VERSION="$2"
+TARGET_VERSION=${2#v} # Git tag has leading 'v', npm version does not
 TIMEOUT=300  # 5 minutes in seconds
 INTERVAL=10  # 10 seconds
 ELAPSED=0


### PR DESCRIPTION
The post-release-templates workflow gets triggered whenever we create a github release. It is fed the git tag. A script is then run to update the templates' migrations and lockfile (if applicable).

There was a scenario where despite the packages already being published to npm a few minutes prior, this process would error out saying that the latest version was not available.

This PR adds a script that polls for 5 minutes against npm to wait for the newly published version to resolve and match the git release tag.

Here is an example of the error that was happening:

```sh
> payload-monorepo@3.7.0 runts /home/runner/work/payload/payload
> cross-env NODE_OPTIONS=--no-deprecation node --no-deprecation --import @swc-node/register/esm-register "./scripts/generate-template-variations.ts"


Generating payload-vercel-postgres-template...

Copied to /home/runner/work/payload/payload/templates/with-vercel-postgres
Configuring payload.config.ts
Configuring .env.example
Writing to /home/runner/work/payload/payload/templates/with-vercel-postgres/.env.example
Generated README.md
Installing dependencies without generating lockfile
Executing: pnpm install --ignore-workspace
Progress: resolved 1, reused 0, downloaded 0, added 0
Progress: resolved 46, reused 26, downloaded 13, added 0
 ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @payloadcms/translations@3.7.0

This error happened while installing the dependencies of @payloadcms/next@3.7.0

The latest release of @payloadcms/translations is "3.6.0".

Other releases are:
  * beta: 3.0.0-beta.135
  * canary: 3.6.1-canary.ca44922

If you need the full list of all 387 published versions run "$ pnpm view @payloadcms/translations versions".
An unknown error occurred with no output.
Error: Command failed: pnpm install --ignore-workspace
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:890:11)
    at execSync (node:child_process:962:15)
    at execSyncSafe (file:///home/runner/work/payload/payload/scripts/generate-template-variations.ts:[24](https://github.com/payloadcms/payload/actions/runs/12320006970/job/34388340573#step:10:25)2:9)
    at main (file:///home/runner/work/payload/payload/scripts/generate-template-variations.ts:152:13) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: [31](https://github.com/payloadcms/payload/actions/runs/12320006970/job/34388340573#step:10:32)15,
  stdout: null,
  stderr: null
}
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
 ```