### PR TITLE
fix: edit join field not rendering

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,6 +283,7 @@ jobs:
           - admin-root
           - auth
           - auth-basic
+          - joins
           - field-error-states
           - fields-relationship
           - fields__collections__Array

--- a/packages/ui/src/utilities/buildTableState.ts
+++ b/packages/ui/src/utilities/buildTableState.ts
@@ -211,6 +211,7 @@ export const buildTableState = async (
       overrideAccess: false,
       page: query?.page ? parseInt(query.page, 10) : undefined,
       sort: query?.sort,
+      user: req.user,
       where: query?.where,
     })
 

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -307,7 +307,7 @@ export interface CollectionRestricted {
   id: string;
   title?: string | null;
   canRead?: boolean | null;
-  category?: (string | null) | RestrictedCategory;
+  category?: (string | null) | CategoriesJoinRestricted;
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
In PR #9930 we added `overrideAccess: false` to the find operation and failed to pass the user. This caused https://github.com/payloadcms/payload/issues/9974, #9975 where any access control causes the edit view to error.

The fix was to pass the user through.

This change also adds Join Field e2e tests to the CI pipeline which was previously missing and would have caught the error.