### PR TITLE
docs: fix links in rich-text referencing old lexical sections

### DIFF
--- a/docs/rich-text/building-custom-features.mdx
+++ b/docs/rich-text/building-custom-features.mdx
@@ -79,7 +79,7 @@ This allows you to add i18n translations scoped to your feature. This specific e
 
 ### Markdown Transformers#server-feature-markdown-transformers
 
-The Server Feature, just like the Client Feature, allows you to add markdown transformers. Markdown transformers on the server are used when [converting the editor from or to markdown](/docs/lexical/converters#markdown-lexical).
+The Server Feature, just like the Client Feature, allows you to add markdown transformers. Markdown transformers on the server are used when [converting the editor from or to markdown](/docs/rich-text/converters#markdown-lexical).
 
 ```ts
 import { createServerFeature } from '@payloadcms/richtext-lexical';

--- a/docs/rich-text/overview.mdx
+++ b/docs/rich-text/overview.mdx
@@ -180,7 +180,7 @@ Notice how even the toolbars are features? That's how extensible our lexical edi
 
 ## Creating your own, custom Feature
 
-You can find more information about creating your own feature in our [building custom feature docs](/docs/lexical/building-custom-features).
+You can find more information about creating your own feature in our [building custom feature docs](/docs/rich-text/building-custom-features).
 
 ## TypeScript
 


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes an issue in the docs where some links referenced the old `/docs/lexical` path instead of the newer `/docs/rich-text` path resulting in 500 errors for users.

### Why?
To navigate users to the correct spot in the docs.

### How?
Changes to `/docs/rich-text/building-custom-features.mdx` and `/docs/rich-text/overview.mdx`