### PR TITLE
fix(db-sqlite): working point field CRUD and default value

### DIFF
--- a/packages/db-sqlite/src/schema/traverseFields.ts
+++ b/packages/db-sqlite/src/schema/traverseFields.ts
@@ -572,6 +572,7 @@ export const traverseFields = ({
       }
 
       case 'point': {
+        targetTable[fieldName] = withDefault(text(columnName, { mode: 'json' }), field)
         break
       }
 

--- a/packages/db-sqlite/src/schema/withDefault.ts
+++ b/packages/db-sqlite/src/schema/withDefault.ts
@@ -9,6 +9,15 @@ export const withDefault = (
     return column
   }
 
+  if (field.type === 'point' && Array.isArray(field.defaultValue)) {
+    return column.default(
+      JSON.stringify({
+        type: 'Point',
+        coordinates: [field.defaultValue[0], field.defaultValue[1]],
+      }),
+    )
+  }
+
   if (typeof field.defaultValue === 'string' && field.defaultValue.includes("'")) {
     const escapedString = field.defaultValue.replaceAll("'", "''")
     return column.default(escapedString)

--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -599,6 +599,14 @@ export const traverseFields = <T extends Record<string, unknown>>({
           break
         }
 
+        case 'point': {
+          if (typeof fieldData === 'string') {
+            val = JSON.parse(fieldData)
+          }
+
+          break
+        }
+
         case 'relationship':
         case 'upload': {
           if (

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -754,6 +754,17 @@ describe('database', () => {
       expect(helloDocs).toHaveLength(5)
       expect(worldDocs).toHaveLength(5)
     })
+
+    it('should CRUD point field', async () => {
+      const result = await payload.create({
+        collection: 'default-values',
+        data: {
+          point: [5, 10],
+        },
+      })
+
+      expect(result.point).toEqual([5, 10])
+    })
   })
 
   describe('defaultValue', () => {
@@ -773,12 +784,10 @@ describe('database', () => {
       expect(result.array[0].defaultValue).toStrictEqual('default value from database')
       expect(result.group.defaultValue).toStrictEqual('default value from database')
       expect(result.select).toStrictEqual('default')
-      // eslint-disable-next-line jest/no-conditional-in-test
-      if (payload.db.name !== 'sqlite') {
-        expect(result.point).toStrictEqual({ coordinates: [10, 20], type: 'Point' })
-      }
+      expect(result.point).toStrictEqual({ coordinates: [10, 20], type: 'Point' })
     })
   })
+
   describe('drizzle: schema hooks', () => {
     it('should add tables with hooks', async () => {
       // eslint-disable-next-line jest/no-conditional-in-test


### PR DESCRIPTION
Previously, the point field with SQLite was incorrectly built to the schema and not parsed to the result. 
Now, it works with SQLite, just doesn't support queries (`near` etc.). Fixes https://github.com/payloadcms/payload/pull/9987#discussion_r1885674299