### PR TITLE
fix: close db connections after running jobs from command line.

### DIFF
--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -102,10 +102,14 @@ export const bin = async () => {
 
       return
     } else {
-      return await payload.jobs.run({
+      await payload.jobs.run({
         limit,
         queue,
       })
+
+      await payload.db.destroy() // close database connections after running jobs so process can exit cleanly
+
+      return
     }
   }
 


### PR DESCRIPTION
### What?

Exit process after `payload jobs:run` without cron is executed

### Why?

I would expect the `payload jobs:run` command to exit normally after execution. With mongodb this is not the case as database connections are open so the node process itself will not exit.

### How?

Execute `payload.db.destroy` to close all db connections after queue is execution is done.

Fixes: #9851
