### PR TITLE
feat(db-postgres): join field support relationships inside arrays

### DIFF
--- a/packages/drizzle/src/find/chainMethods.ts
+++ b/packages/drizzle/src/find/chainMethods.ts
@@ -1,5 +1,3 @@
-import type { QueryPromise } from 'drizzle-orm'
-
 export type ChainedMethods = {
   args: unknown[]
   method: string
@@ -10,7 +8,7 @@ export type ChainedMethods = {
  * @param methods
  * @param query
  */
-const chainMethods = <T>({ methods, query }): QueryPromise<T> => {
+const chainMethods = <T>({ methods, query }: { methods: ChainedMethods; query: T }): T => {
   return methods.reduce((query, { args, method }) => {
     return query[method](...args)
   }, query)

--- a/packages/drizzle/src/find/findMany.ts
+++ b/packages/drizzle/src/find/findMany.ts
@@ -73,6 +73,7 @@ export const findMany = async function find({
     fields,
     joinQuery,
     joins,
+    locale,
     select,
     tableName,
     versions,

--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -373,11 +373,7 @@ export const traverseFields = ({
           adapter,
           fields,
           joins,
-          locale:
-            locale ||
-            (adapter.payload.config.localization &&
-              adapter.payload.config.localization.defaultLocale) ||
-            undefined,
+          locale,
           selectLocale: true,
           sort,
           tableName: joinCollectionTableName,

--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -369,7 +369,11 @@ export const traverseFields = ({
           }
         }
 
-        const buildQueryResult = buildQuery({
+        const {
+          orderBy,
+          selectFields,
+          where: subQueryWhere,
+        } = buildQuery({
           adapter,
           fields,
           joins,
@@ -379,9 +383,6 @@ export const traverseFields = ({
           tableName: joinCollectionTableName,
           where: joinQueryWhere,
         })
-
-        const subQueryWhere = buildQueryResult.where
-        const orderBy = buildQueryResult.orderBy
 
         const chainedMethods: ChainedMethods = []
 
@@ -408,7 +409,7 @@ export const traverseFields = ({
         const subQuery = chainMethods({
           methods: chainedMethods,
           query: db
-            .select(buildQueryResult.selectFields as any)
+            .select(selectFields as any)
             .from(adapter.tables[joinCollectionTableName])
             .where(subQueryWhere)
             .orderBy(() => orderBy.map(({ column, order }) => order(column))),
@@ -420,8 +421,8 @@ export const traverseFields = ({
               adapter,
               jsonBuildObject(adapter, {
                 id: sql.raw(`"${subQueryAlias}".id`),
-                ...(buildQueryResult.selectFields._locale && {
-                  locale: sql.raw(buildQueryResult.selectFields._locale.name),
+                ...(selectFields._locale && {
+                  locale: sql.raw(`"${subQueryAlias}".${selectFields._locale.name}`),
                 }),
               }),
             ),

--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -9,7 +9,7 @@ import type { BuildQueryJoinAliases, ChainedMethods, DrizzleAdapter } from '../t
 import type { Result } from './buildFindManyArgs.js'
 
 import buildQuery from '../queries/buildQuery.js'
-import { jsonAgg, jsonBuildObject } from '../utilities/json.js'
+import { jsonAggBuildObject } from '../utilities/json.js'
 import { rawConstraint } from '../utilities/rawConstraint.js'
 import { chainMethods } from './chainMethods.js'
 
@@ -417,15 +417,12 @@ export const traverseFields = ({
 
         currentArgs.extras[columnName] = sql`${db
           .select({
-            result: jsonAgg(
-              adapter,
-              jsonBuildObject(adapter, {
-                id: sql.raw(`"${subQueryAlias}".id`),
-                ...(selectFields._locale && {
-                  locale: sql.raw(`"${subQueryAlias}".${selectFields._locale.name}`),
-                }),
+            result: jsonAggBuildObject(adapter, {
+              id: sql.raw(`"${subQueryAlias}".id`),
+              ...(selectFields._locale && {
+                locale: sql.raw(`"${subQueryAlias}".${selectFields._locale.name}`),
               }),
-            ),
+            }),
           })
           .from(sql`${subQuery}`)}`.as(columnName)
 

--- a/packages/drizzle/src/queries/buildAndOrConditions.ts
+++ b/packages/drizzle/src/queries/buildAndOrConditions.ts
@@ -12,6 +12,7 @@ export function buildAndOrConditions({
   joins,
   locale,
   selectFields,
+  selectLocale,
   tableName,
   where,
 }: {
@@ -22,6 +23,7 @@ export function buildAndOrConditions({
   joins: BuildQueryJoinAliases
   locale?: string
   selectFields: Record<string, GenericColumn>
+  selectLocale?: boolean
   tableName: string
   where: Where[]
 }): SQL[] {
@@ -38,6 +40,7 @@ export function buildAndOrConditions({
         joins,
         locale,
         selectFields,
+        selectLocale,
         tableName,
         where: condition,
       })

--- a/packages/drizzle/src/queries/buildQuery.ts
+++ b/packages/drizzle/src/queries/buildQuery.ts
@@ -18,6 +18,7 @@ type BuildQueryArgs = {
   fields: FlattenedField[]
   joins?: BuildQueryJoinAliases
   locale?: string
+  selectLocale?: boolean
   sort?: Sort
   tableName: string
   where: Where
@@ -37,6 +38,7 @@ const buildQuery = function buildQuery({
   fields,
   joins = [],
   locale,
+  selectLocale,
   sort,
   tableName,
   where: incomingWhere,
@@ -64,6 +66,7 @@ const buildQuery = function buildQuery({
       joins,
       locale,
       selectFields,
+      selectLocale,
       tableName,
       where: incomingWhere,
     })

--- a/packages/drizzle/src/queries/getTableColumnFromPath.ts
+++ b/packages/drizzle/src/queries/getTableColumnFromPath.ts
@@ -49,6 +49,7 @@ type Args = {
   pathSegments: string[]
   rootTableName?: string
   selectFields: Record<string, GenericColumn>
+  selectLocale?: boolean
   tableName: string
   /**
    * If creating a new table name for arrays and blocks, this suffix should be appended to the table name
@@ -77,6 +78,7 @@ export const getTableColumnFromPath = ({
   pathSegments: incomingSegments,
   rootTableName: incomingRootTableName,
   selectFields,
+  selectLocale,
   tableName,
   tableNameSuffix = '',
   value,
@@ -130,6 +132,10 @@ export const getTableColumnFromPath = ({
         if (locale && field.localized && adapter.payload.config.localization) {
           const conditions = [eq(arrayParentTable.id, adapter.tables[newTableName]._parentID)]
 
+          if (selectLocale) {
+            selectFields._locale = adapter.tables[newTableName]._locale
+          }
+
           if (locale !== 'all') {
             conditions.push(eq(adapter.tables[newTableName]._locale, locale))
           }
@@ -156,6 +162,7 @@ export const getTableColumnFromPath = ({
           pathSegments: pathSegments.slice(1),
           rootTableName,
           selectFields,
+          selectLocale,
           tableName: newTableName,
           value,
         })
@@ -213,6 +220,7 @@ export const getTableColumnFromPath = ({
               pathSegments: pathSegments.slice(1),
               rootTableName,
               selectFields: blockSelectFields,
+              selectLocale,
               tableName: newTableName,
               value,
             })
@@ -294,6 +302,7 @@ export const getTableColumnFromPath = ({
           pathSegments: pathSegments.slice(1),
           rootTableName,
           selectFields,
+          selectLocale,
           tableName: newTableName,
           tableNameSuffix: `${tableNameSuffix}${toSnakeCase(field.name)}_`,
           value,
@@ -347,6 +356,7 @@ export const getTableColumnFromPath = ({
       case 'relationship':
       case 'upload': {
         const newCollectionPath = pathSegments.slice(1).join('.')
+
         if (Array.isArray(field.relationTo) || field.hasMany) {
           let relationshipFields
           const relationTableName = `${rootTableName}${adapter.relationshipsSuffix}`
@@ -354,6 +364,10 @@ export const getTableColumnFromPath = ({
             newAliasTable: aliasRelationshipTable,
             newAliasTableName: aliasRelationshipTableName,
           } = getTableAlias({ adapter, tableName: relationTableName })
+
+          if (selectLocale && field.localized && adapter.payload.config.localization) {
+            selectFields._locale = aliasRelationshipTable.locale
+          }
 
           // Join in the relationships table
           if (locale && field.localized && adapter.payload.config.localization) {
@@ -365,6 +379,7 @@ export const getTableColumnFromPath = ({
             if (locale !== 'all') {
               conditions.push(eq(aliasRelationshipTable.locale, locale))
             }
+
             joins.push({
               condition: and(...conditions),
               table: aliasRelationshipTable,
@@ -523,6 +538,7 @@ export const getTableColumnFromPath = ({
             pathSegments: pathSegments.slice(1),
             rootTableName: newTableName,
             selectFields,
+            selectLocale,
             tableName: newTableName,
             value,
           })
@@ -544,6 +560,10 @@ export const getTableColumnFromPath = ({
             })
 
             const condtions = [eq(aliasLocaleTable._parentID, adapter.tables[rootTableName].id)]
+
+            if (selectLocale) {
+              selectFields._locale = aliasLocaleTable._locale
+            }
 
             if (locale !== 'all') {
               condtions.push(eq(aliasLocaleTable._locale, locale))
@@ -643,6 +663,7 @@ export const getTableColumnFromPath = ({
             pathSegments: pathSegments.slice(1),
             rootTableName,
             selectFields,
+            selectLocale,
             tableName: newTableName,
             tableNameSuffix: `${tableNameSuffix}${toSnakeCase(field.name)}_`,
             value,
@@ -661,6 +682,7 @@ export const getTableColumnFromPath = ({
           pathSegments: pathSegments.slice(1),
           rootTableName,
           selectFields,
+          selectLocale,
           tableName: newTableName,
           tableNameSuffix,
           value,
@@ -687,6 +709,10 @@ export const getTableColumnFromPath = ({
 
       if (locale !== 'all') {
         condition = and(condition, eq(newTable._locale, locale))
+      }
+
+      if (selectLocale) {
+        selectFields._locale = newTable._locale
       }
 
       addJoinTable({

--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -19,6 +19,7 @@ type Args = {
   joins: BuildQueryJoinAliases
   locale: string
   selectFields: Record<string, GenericColumn>
+  selectLocale?: boolean
   tableName: string
   where: Where
 }
@@ -29,6 +30,7 @@ export function parseParams({
   joins,
   locale,
   selectFields,
+  selectLocale,
   tableName,
   where,
 }: Args): SQL {
@@ -53,6 +55,7 @@ export function parseParams({
             joins,
             locale,
             selectFields,
+            selectLocale,
             tableName,
             where: condition,
           })
@@ -86,6 +89,7 @@ export function parseParams({
                   locale,
                   pathSegments: relationOrPath.replace(/__/g, '.').split('.'),
                   selectFields,
+                  selectLocale,
                   tableName,
                   value: val,
                 })

--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -8,6 +8,7 @@ import type { DrizzleAdapter } from '../types.js'
 
 import { getCollectionIdType } from '../utilities/getCollectionIdType.js'
 import { isPolymorphicRelationship } from '../utilities/isPolymorphicRelationship.js'
+import { isRawConstraint } from '../utilities/rawConstraint.js'
 
 type SanitizeQueryValueArgs = {
   adapter: DrizzleAdapter
@@ -48,6 +49,9 @@ export const sanitizeQueryValue = ({
     return { operator, value: formattedValue }
   }
 
+  if (isRawConstraint(val)) {
+    return { operator, value: val.value }
+  }
   if (
     (field.type === 'relationship' || field.type === 'upload') &&
     !relationOrPath.endsWith('relationTo') &&

--- a/packages/drizzle/src/utilities/json.ts
+++ b/packages/drizzle/src/utilities/json.ts
@@ -1,0 +1,37 @@
+import type { Column, SQL } from 'drizzle-orm'
+
+import { sql } from 'drizzle-orm'
+
+import type { DrizzleAdapter } from '../types.js'
+
+export function jsonAgg(adapter: DrizzleAdapter, expression: SQL) {
+  if (adapter.name === 'sqlite') {
+    return sql`coalesce(json_group_array(${expression}), '[]')`
+  }
+
+  return sql`coalesce(json_agg(${expression}), '[]'::json)`
+}
+
+/**
+ * @param shape Potential for SQL injections, so you shouldn't allow user-specified key names
+ */
+export function jsonBuildObject<T extends Record<string, Column | SQL>>(
+  adapter: DrizzleAdapter,
+  shape: T,
+) {
+  const chunks: SQL[] = []
+
+  Object.entries(shape).forEach(([key, value]) => {
+    if (chunks.length > 0) {
+      chunks.push(sql.raw(','))
+    }
+    chunks.push(sql.raw(`'${key}',`))
+    chunks.push(sql`${value}`)
+  })
+
+  if (adapter.name === 'sqlite') {
+    return sql`json_object(${sql.join(chunks)})`
+  }
+
+  return sql`json_build_object(${sql.join(chunks)})`
+}

--- a/packages/drizzle/src/utilities/json.ts
+++ b/packages/drizzle/src/utilities/json.ts
@@ -35,3 +35,10 @@ export function jsonBuildObject<T extends Record<string, Column | SQL>>(
 
   return sql`json_build_object(${sql.join(chunks)})`
 }
+
+export const jsonAggBuildObject = <T extends Record<string, Column | SQL>>(
+  adapter: DrizzleAdapter,
+  shape: T,
+) => {
+  return jsonAgg(adapter, jsonBuildObject(adapter, shape))
+}

--- a/packages/drizzle/src/utilities/rawConstraint.ts
+++ b/packages/drizzle/src/utilities/rawConstraint.ts
@@ -1,0 +1,13 @@
+const RawConstraintSymbol = Symbol('RawConstraint')
+
+/**
+ * You can use this to inject a raw query to where
+ */
+export const rawConstraint = (value: unknown) => ({
+  type: RawConstraintSymbol,
+  value,
+})
+
+export const isRawConstraint = (value: unknown): value is ReturnType<typeof rawConstraint> => {
+  return value && typeof value === 'object' && 'type' in value && value.type === RawConstraintSymbol
+}


### PR DESCRIPTION
PR to https://github.com/payloadcms/payload/pull/9773 
Not only implements join field support relationships inside arrays in Postgres / SQLite, but also:
* Significantly improves `traverseFields` and the `'join'` case with a raw query injection pattern, right now it's internal but we could expose it at some point, for example for querying vectors.
* Fixes potential issues with not passed `locale` to `traverseFields` (it was `undefined` always)
* Adds an empty array fallback for joins with localized relationships

With the improve in `traverseFields` it should be also easy to add blocks support if we want.