### PR TITLE
feat(storage-vercel-blob): allow fallback to disk if token not set

### DIFF
--- a/packages/storage-vercel-blob/src/index.ts
+++ b/packages/storage-vercel-blob/src/index.ts
@@ -52,8 +52,10 @@ export type VercelBlobStorageOptions = {
    * Vercel Blob storage read/write token
    *
    * Usually process.env.BLOB_READ_WRITE_TOKEN set by Vercel
+   *
+   * If unset, the plugin will be disabled and will fallback to local storage
    */
-  token: string
+  token: string | undefined
 }
 
 const defaultUploadOptions: Partial<VercelBlobStorageOptions> = {
@@ -68,12 +70,9 @@ type VercelBlobStoragePlugin = (vercelBlobStorageOpts: VercelBlobStorageOptions)
 export const vercelBlobStorage: VercelBlobStoragePlugin =
   (options: VercelBlobStorageOptions) =>
   (incomingConfig: Config): Config => {
-    if (options.enabled === false) {
+    // If the plugin is disabled or no token is provided, do not enable the plugin
+    if (options.enabled === false || !options.token) {
       return incomingConfig
-    }
-
-    if (!options.token) {
-      throw new Error('The token argument is required for the Vercel Blob adapter.')
     }
 
     // Parse storeId from token
@@ -136,10 +135,15 @@ function vercelBlobStorageInternal(
 ): Adapter {
   return ({ collection, prefix }): GeneratedAdapter => {
     const { access, addRandomSuffix, baseUrl, cacheControlMaxAge, token } = options
+
+    if (!token) {
+      throw new Error('Vercel Blob storage token is required')
+    }
+
     return {
       name: 'vercel-blob',
       generateURL: getGenerateUrl({ baseUrl, prefix }),
-      handleDelete: getHandleDelete({ baseUrl, prefix, token: options.token }),
+      handleDelete: getHandleDelete({ baseUrl, prefix, token }),
       handleUpload: getHandleUpload({
         access,
         addRandomSuffix,

--- a/test/storage-vercel-blob/collections/Media.ts
+++ b/test/storage-vercel-blob/collections/Media.ts
@@ -3,7 +3,6 @@ import type { CollectionConfig } from 'payload'
 export const Media: CollectionConfig = {
   slug: 'media',
   upload: {
-    disableLocalStorage: true,
     resizeOptions: {
       position: 'center',
       width: 200,


### PR DESCRIPTION
Previously with `@payloadcms/plugin-storage-blob`, if token was not set, the plugin would throw an error. This caused a less-than-ideal developer experience.

With this change, if the `token` value is undefined:
- Local storage will be used as a fallback
- The error will no longer be thrown.