### PR TITLE
fix(ui): build initial drawer data for join field with relationships inside of arrays

### DIFF
--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -39,37 +39,35 @@ const getInitialDrawerData = ({
 }) => {
   const flattenedFields = flattenTopLevelFields(fields)
 
-  for (let i = 0; i < segments.length; i++) {
-    const segment = segments[i]
+  const path = segments[0]
 
-    const field = flattenedFields.find((field) => field.name === segment)
+  const field = flattenedFields.find((field) => field.name === path)
 
-    if (field.type === 'relationship' || field.type === 'upload') {
-      return {
-        [field.name]: field.hasMany ? [docID] : docID,
-      }
+  if (field.type === 'relationship' || field.type === 'upload') {
+    return {
+      [field.name]: field.hasMany ? [docID] : docID,
     }
+  }
 
-    const nextSegments = segments.slice(i + 1, segments.length)
+  const nextSegments = segments.slice(1, segments.length)
 
-    if (field.type === 'tab' || field.type === 'group') {
-      return {
-        [field.name]: getInitialDrawerData({ docID, fields: field.fields, segments: nextSegments }),
-      }
+  if (field.type === 'tab' || field.type === 'group') {
+    return {
+      [field.name]: getInitialDrawerData({ docID, fields: field.fields, segments: nextSegments }),
     }
+  }
 
-    if (field.type === 'array') {
-      const initialData = getInitialDrawerData({
-        docID,
-        fields: field.fields,
-        segments: nextSegments,
-      })
+  if (field.type === 'array') {
+    const initialData = getInitialDrawerData({
+      docID,
+      fields: field.fields,
+      segments: nextSegments,
+    })
 
-      initialData.id = ObjectId().toHexString()
+    initialData.id = ObjectId().toHexString()
 
-      return {
-        [field.name]: [initialData],
-      }
+    return {
+      [field.name]: [initialData],
     }
   }
 }

--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -45,6 +45,7 @@ const getInitialDrawerData = ({
 
   if (field.type === 'relationship' || field.type === 'upload') {
     return {
+      // TODO: Handle polymorphic https://github.com/payloadcms/payload/pull/9990
       [field.name]: field.hasMany ? [docID] : docID,
     }
   }

--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -1,17 +1,78 @@
 'use client'
 
-import type { JoinFieldClient, JoinFieldClientComponent, PaginatedDocs, Where } from 'payload'
+import type {
+  ClientField,
+  JoinFieldClient,
+  JoinFieldClientComponent,
+  PaginatedDocs,
+  Where,
+} from 'payload'
 
+import ObjectIdImport from 'bson-objectid'
+import { flattenTopLevelFields } from 'payload/shared'
 import React, { useMemo } from 'react'
 
 import { RelationshipTable } from '../../elements/RelationshipTable/index.js'
 import { RenderCustomComponent } from '../../elements/RenderCustomComponent/index.js'
 import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
+import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { FieldDescription } from '../FieldDescription/index.js'
 import { FieldLabel } from '../FieldLabel/index.js'
 import { fieldBaseClass } from '../index.js'
+
+const ObjectId = (ObjectIdImport.default ||
+  ObjectIdImport) as unknown as typeof ObjectIdImport.default
+
+/**
+ * Recursively builds the default data for joined collection
+ */
+const getInitialDrawerData = ({
+  docID,
+  fields,
+  segments,
+}: {
+  docID: number | string
+  fields: ClientField[]
+  segments: string[]
+}) => {
+  const flattenedFields = flattenTopLevelFields(fields)
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]
+
+    const field = flattenedFields.find((field) => field.name === segment)
+
+    if (field.type === 'relationship' || field.type === 'upload') {
+      return {
+        [field.name]: field.hasMany ? [docID] : docID,
+      }
+    }
+
+    const nextSegments = segments.slice(i + 1, segments.length)
+
+    if (field.type === 'tab' || field.type === 'group') {
+      return {
+        [field.name]: getInitialDrawerData({ docID, fields: field.fields, segments: nextSegments }),
+      }
+    }
+
+    if (field.type === 'array') {
+      const initialData = getInitialDrawerData({
+        docID,
+        fields: field.fields,
+        segments: nextSegments,
+      })
+
+      initialData.id = ObjectId().toHexString()
+
+      return {
+        [field.name]: [initialData],
+      }
+    }
+  }
+}
 
 const JoinFieldComponent: JoinFieldClientComponent = (props) => {
   const {
@@ -28,6 +89,10 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
   } = props
 
   const { id: docID } = useDocumentInfo()
+
+  const {
+    config: { collections },
+  } = useConfig()
 
   const { customComponents: { AfterInput, BeforeInput, Description, Label } = {}, value } =
     useField<PaginatedDocs>({
@@ -54,6 +119,16 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
     return where
   }, [docID, on, field.where])
 
+  const initialDrawerData = useMemo(() => {
+    const relatedCollection = collections.find((collection) => collection.slug === field.collection)
+
+    return getInitialDrawerData({
+      docID,
+      fields: relatedCollection.fields,
+      segments: field.on.split('.'),
+    })
+  }, [collections, field.on, docID, field.collection])
+
   return (
     <div
       className={[fieldBaseClass, 'join'].filter(Boolean).join(' ')}
@@ -67,9 +142,7 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
         field={field as JoinFieldClient}
         filterOptions={filterOptions}
         initialData={docID && value ? value : ({ docs: [] } as PaginatedDocs)}
-        initialDrawerData={{
-          [on]: docID,
-        }}
+        initialDrawerData={initialDrawerData}
         Label={
           <h4 style={{ margin: 0 }}>
             {Label || (


### PR DESCRIPTION
Correctly builds initial drawer data when clicking "add new" for joins with relationships inside of arrays