### PR TITLE
feat(db-sqlite): add `idType: 'uuid'` support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,6 +180,7 @@ jobs:
           - postgres-uuid
           - supabase
           - sqlite
+          - sqlite-uuid
     env:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -40,6 +40,7 @@ export default buildConfig({
 | `push`                | Disable Drizzle's [`db push`](https://orm.drizzle.team/kit-docs/overview#prototyping-with-db-push) in development mode. By default, `push` is enabled for development mode only. |
 | `migrationDir`        | Customize the directory that migrations are stored.                                                                                                                              |
 | `logger`              | The instance of the logger to be passed to drizzle. By default Payload's will be used.                                                                                           |
+| `idType`              | A string of 'number', or 'uuid' that is used for the data type given to id columns.                                                                                              |
 | `transactionOptions`  | A SQLiteTransactionConfig object for transactions, or set to `false` to disable using transactions. [More details](https://orm.drizzle.team/docs/transactions)                   |
 | `localesSuffix`       | A string appended to the end of table names for storing localized fields. Default is '_locales'.                                                                                 |
 | `relationshipsSuffix` | A string appended to the end of table names for storing relationships. Default is '_rels'.                                                                                       |

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -61,8 +61,8 @@ export { sql } from 'drizzle-orm'
 const filename = fileURLToPath(import.meta.url)
 
 export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
-  const postgresIDType = args.idType || 'serial'
-  const payloadIDType = postgresIDType === 'serial' ? 'number' : 'text'
+  const sqliteIDType = args.idType || 'number'
+  const payloadIDType = sqliteIDType === 'uuid' ? 'text' : 'number'
 
   function adapter({ payload }: { payload: Payload }) {
     const migrationDir = findMigrationDir(args.migrationDir)
@@ -93,7 +93,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
         json: true,
       },
       fieldConstraints: {},
-      idType: postgresIDType,
+      idType: sqliteIDType,
       initializing,
       localesSuffix: args.localesSuffix || '_locales',
       logger: args.logger,

--- a/packages/db-sqlite/src/schema/buildDrizzleTable.ts
+++ b/packages/db-sqlite/src/schema/buildDrizzleTable.ts
@@ -59,9 +59,8 @@ export const buildDrizzleTable: BuildDrizzleTable = ({ adapter, locales, rawTabl
         break
       }
 
-      // Not used yet in SQLite but ready here.
       case 'uuid': {
-        let builder = text(column.name)
+        let builder = text(column.name, { length: 36 })
 
         if (column.defaultRandom) {
           builder = builder.$defaultFn(() => uuidv4())

--- a/packages/db-sqlite/src/schema/setColumnID.ts
+++ b/packages/db-sqlite/src/schema/setColumnID.ts
@@ -1,6 +1,6 @@
 import type { SetColumnID } from '@payloadcms/drizzle/types'
 
-export const setColumnID: SetColumnID = ({ columns, fields }) => {
+export const setColumnID: SetColumnID = ({ adapter, columns, fields }) => {
   const idField = fields.find((field) => field.name === 'id')
   if (idField) {
     if (idField.type === 'number') {
@@ -20,6 +20,17 @@ export const setColumnID: SetColumnID = ({ columns, fields }) => {
       }
       return 'text'
     }
+  }
+
+  if (adapter.idType === 'uuid') {
+    columns.id = {
+      name: 'id',
+      type: 'uuid',
+      defaultRandom: true,
+      primaryKey: true,
+    }
+
+    return 'uuid'
   }
 
   columns.id = {

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -40,7 +40,7 @@ export type Args = {
   client: Config
   /** Generated schema from payload generate:db-schema file path */
   generateSchemaOutputFile?: string
-  idType?: 'serial' | 'uuid'
+  idType?: 'number' | 'uuid'
   localesSuffix?: string
   logger?: DrizzleConfig['logger']
   migrationDir?: string
@@ -106,6 +106,7 @@ type SQLiteDrizzleAdapter = Omit<
   | 'drizzle'
   | 'dropDatabase'
   | 'execute'
+  | 'idType'
   | 'insert'
   | 'operators'
   | 'relations'

--- a/packages/drizzle/src/utilities/pushDevSchema.ts
+++ b/packages/drizzle/src/utilities/pushDevSchema.ts
@@ -71,7 +71,7 @@ export const pushDevSchema = async (adapter: DrizzleAdapter) => {
 
   if (!devPush.length) {
     // Use drizzle for insert so $defaultFn's are called
-    drizzle.insert(adapter.tables.payload_migrations).values({
+    await drizzle.insert(adapter.tables.payload_migrations).values({
       name: 'dev',
       batch: -1,
     })

--- a/test/custom-graphql/int.spec.ts
+++ b/test/custom-graphql/int.spec.ts
@@ -24,7 +24,7 @@ describe('Custom GraphQL', () => {
     }
   })
 
-  if (!['sqlite'].includes(process.env.PAYLOAD_DATABASE || '')) {
+  if (!['sqlite', 'sqlite-uuid'].includes(process.env.PAYLOAD_DATABASE || '')) {
     describe('Isolated Transaction ID', () => {
       it('should isolate transaction IDs between queries in the same request', async () => {
         const query = `query {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -530,7 +530,7 @@ describe('database', () => {
   describe('transactions', () => {
     describe('local api', () => {
       // sqlite cannot handle concurrent write transactions
-      if (!['sqlite'].includes(process.env.PAYLOAD_DATABASE)) {
+      if (!['sqlite', 'sqlite-uuid'].includes(process.env.PAYLOAD_DATABASE)) {
         it('should commit multiple operations in isolation', async () => {
           const req = {
             payload,
@@ -1074,7 +1074,8 @@ describe('database', () => {
         data: { title: 'invalid', relationship: 'not-real-id' },
       })
     } catch (error) {
-      expect(error).toBeInstanceOf(Error)
+      // instanceof checks don't work with libsql
+      expect(error).toBeTruthy()
     }
 
     expect(invalidDoc).toBeUndefined()

--- a/test/generateDatabaseAdapter.ts
+++ b/test/generateDatabaseAdapter.ts
@@ -53,6 +53,15 @@ export const allDatabaseAdapters = {
       url: process.env.SQLITE_URL || 'file:./payloadtests.db',
     },
   })`,
+  'sqlite-uuid': `
+  import { sqliteAdapter } from '@payloadcms/db-sqlite'
+
+  export const databaseAdapter = sqliteAdapter({
+    idType: 'uuid',
+    client: {
+      url: process.env.SQLITE_URL || 'file:./payloadtests.db',
+    },
+  })`,
   supabase: `
   import { postgresAdapter } from '@payloadcms/db-postgres'
 


### PR DESCRIPTION
Adds `idType: 'uuid'` to the SQLite adapter support:
```ts
sqliteAdapter({
  idType: 'uuid',
})
```

Achieved through Drizzle's `$defaultFn()` https://orm.drizzle.team/docs/latest-releases/drizzle-orm-v0283#-added-defaultfn--default-methods-to-column-builders as SQLite doesn't have native UUID support. Added `sqlite-uuid` to CI.