### PR TITLE
fix: beforeValidate previousValue argument

### DIFF
--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -282,7 +282,7 @@ export const promise = async <T>({
           overrideAccess,
           path: fieldPath,
           previousSiblingDoc: siblingDoc,
-          previousValue: siblingData[field.name],
+          previousValue: siblingDoc[field.name],
           req,
           schemaPath: fieldSchemaPath,
           siblingData,

--- a/test/hooks/collections/BeforeValidate/index.ts
+++ b/test/hooks/collections/BeforeValidate/index.ts
@@ -16,5 +16,36 @@ export const BeforeValidateCollection: CollectionConfig = {
         ],
       },
     },
+    {
+      type: 'select',
+      name: 'selection',
+      options: [
+        {
+          label: 'A',
+          value: 'a',
+        },
+        {
+          label: 'B',
+          value: 'b',
+        },
+      ],
+      hooks: {
+        beforeValidate: [
+          ({ value, previousValue, context }) => {
+            if (context.beforeValidateTest) {
+              if (value !== 'a') {
+                return 'beforeValidate value is incorrect'
+              }
+
+              if (previousValue !== 'b') {
+                return 'beforeValidate previousValue is incorrect'
+              }
+
+              return value
+            }
+          },
+        ],
+      },
+    },
   ],
 }

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -21,6 +21,7 @@ import {
 import { relationsSlug } from './collections/Relations/index.js'
 import { transformSlug } from './collections/Transform/index.js'
 import { hooksUsersSlug } from './collections/Users/index.js'
+import { beforeValidateSlug } from './collectionSlugs.js'
 import { HooksConfig } from './config.js'
 import { dataHooksGlobalSlug } from './globals/Data/index.js'
 
@@ -524,6 +525,30 @@ describe('Hooks', () => {
       const body = await response.json()
       expect(response.status).toEqual(418)
       expect(body).toEqual({ errors: [{ message: "I'm a teapot" }] })
+    })
+  })
+
+  describe('beforeValidate', () => {
+    it('should have correct arguments', async () => {
+      const doc = await payload.create({
+        collection: beforeValidateSlug,
+        data: {
+          selection: 'b',
+        },
+      })
+
+      const updateResult = await payload.update({
+        id: doc.id,
+        collection: beforeValidateSlug,
+        data: {
+          selection: 'a',
+        },
+        context: {
+          beforeValidateTest: true,
+        },
+      })
+
+      expect(updateResult).toBeDefined()
     })
   })
 })

--- a/test/hooks/payload-types.ts
+++ b/test/hooks/payload-types.ts
@@ -84,6 +84,7 @@ export interface HooksUserAuthOperations {
 export interface BeforeValidate {
   id: string;
   title?: string | null;
+  selection?: ('a' | 'b') | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -318,6 +319,7 @@ export interface PayloadMigration {
  */
 export interface BeforeValidateSelect<T extends boolean = true> {
   title?: T;
+  selection?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
### What?
`previousValue` was incorrect. It would always return the current value.

### Why?
It was accessing siblingData instead of siblingDoc. Other hooks use siblingDoc, but this one was using siblingData.
