### PR TITLE
fix(templates): prevent image priority and lazy loading incompatibility

### DIFF
--- a/templates/website/src/components/Media/ImageMedia/index.tsx
+++ b/templates/website/src/components/Media/ImageMedia/index.tsx
@@ -50,7 +50,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
     src = `${getClientSideURL()}${url}`
   }
 
-  const loading = loadingFromProps || 'lazy'
+  const loading = loadingFromProps || (!priority ? 'lazy' : undefined)
 
   // NOTE: this is used by the browser to determine which image to download at different screen sizes
   const sizes = sizeFromProps

--- a/templates/with-vercel-website/src/components/Media/ImageMedia/index.tsx
+++ b/templates/with-vercel-website/src/components/Media/ImageMedia/index.tsx
@@ -50,7 +50,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
     src = `${getClientSideURL()}${url}`
   }
 
-  const loading = loadingFromProps || 'lazy'
+  const loading = loadingFromProps || (!priority ? 'lazy' : undefined)
 
   // NOTE: this is used by the browser to determine which image to download at different screen sizes
   const sizes = sizeFromProps


### PR DESCRIPTION
### What?

This PR fixes an issue in the hero banner of website templates where priority props was passed to `Media` component but was incompatible with NextImage `loading="lazy"` causing error

### Why?

To prevent error when displaying hero banners

### How?

By adding a ternary condition of loading props passed to NextImage checking if `priority` prop is passed