### PR TITLE
docs: fixes typo `removeTokenFromRepsonse` to `removeTokenFromResponse`

### DIFF
--- a/docs/authentication/jwt.mdx
+++ b/docs/authentication/jwt.mdx
@@ -45,7 +45,7 @@ import type { CollectionConfig } from 'payload'
 export const UsersWithoutJWTs: CollectionConfig = {
   slug: 'users-without-jwts',
   auth: {
-    removeTokenFromRepsonse: true, // highlight-line
+    removeTokenFromResponse: true, // highlight-line
   },
 }
 ```


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

## What?
Corrected a typo in the documentation example where removeTokenFromRepsponse was misspelled. It is now properly spelled as removeTokenFromResponse.

## Why?
The typo could confuse developers copying the example code, leading to errors or invalid configurations. 

## How?
Updated the example code in the documentation to replace:
`removeTokenFromRepsponse: true` → `removeTokenFromResponse: true`

Fixes #10025 
