### PR TITLE
fix(richtext-lexical): lexical focus propagation

### DIFF
--- a/packages/richtext-lexical/src/features/indent/client/plugins/index.tsx
+++ b/packages/richtext-lexical/src/features/indent/client/plugins/index.tsx
@@ -19,7 +19,7 @@ export const IndentPlugin: PluginComponent<undefined> = () => {
         FOCUS_COMMAND,
         () => {
           setFirefoxFlag(false)
-          return true
+          return false
         },
         COMMAND_PRIORITY_NORMAL,
       ),


### PR DESCRIPTION
### What?

Lexical `FOCUS_COMMAND` propagation

### Why?

Other plugins unable to register their listeners.

### How?

Changes return value to 'true'

Fixes #10049
