### PR TITLE
fix: commit transaction if a user isnt found in forgotPassword operation

### DIFF
--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -132,6 +132,7 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
     // as doing so could lead to the exposure of registered emails.
     // Therefore, we prefer to fail silently.
     if (!user) {
+      await killTransaction(args.req)
       return null
     }
 

--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -132,7 +132,7 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
     // as doing so could lead to the exposure of registered emails.
     // Therefore, we prefer to fail silently.
     if (!user) {
-      await killTransaction(args.req)
+      await commitTransaction(args.req)
       return null
     }
 


### PR DESCRIPTION
The forgotPassword operation exits silently if no user is found, but because we don't throw an error the transaction never gets committed leading to a timeout.