### PR TITLE
feat: add shouldRestore config to job queue tasks

### DIFF
--- a/docs/jobs-queue/tasks.mdx
+++ b/docs/jobs-queue/tasks.mdx
@@ -141,3 +141,65 @@ export const createPostHandler: TaskHandler<'createPost'> = async ({ input, job,
   }
 }
 ```
+
+### Configuring task restoration
+
+By default, if a task has passed previously and a workflow is re-run, the task will not be re-run. Instead, the output from the previous task run will be returned. This is to prevent unnecessary re-runs of tasks that have already passed.
+
+You can configure this behavior through the `retries.shouldRestore` property. This property accepts a boolean or a function.
+
+If `shouldRestore` is set to true, the task will only be re-run if it previously failed. This is the default behavior.
+
+If `shouldRestore` this is set to false, the task will be re-run even if it previously succeeded, ignoring the maximum number of retries.
+
+If `shouldRestore` is a function, the return value of the function will determine whether the task should be re-run. This can be used for more complex restore logic, e.g you may want to re-run a task up to X amount of times and then restore it for consecutive runs, or only re-run a task if the input has changed.
+
+Example:
+
+```ts
+export default buildConfig({
+  // ...
+  jobs: {
+    tasks: [
+      {
+        slug: 'myTask',
+        retries: {
+          shouldRestore: false,
+        }
+        // ...
+      } as TaskConfig<'myTask'>,
+    ]
+  }
+})
+```
+
+Example - determine whether a task should be restored based on the input data:
+
+```ts
+export default buildConfig({
+  // ...
+  jobs: {
+    tasks: [
+      {
+        slug: 'myTask',
+        inputSchema: [
+          {
+            name: 'someDate',
+            type: 'date',
+            required: true,
+          },
+        ],
+        retries: {
+          shouldRestore: ({ input }) => {
+            if(new Date(input.someDate) > new Date()) {
+              return false
+            }
+            return true
+          },
+        }
+        // ...
+      } as TaskConfig<'myTask'>,
+    ]
+  }
+})
+```


### PR DESCRIPTION
By default, if a task has passed previously and a workflow is re-run, the task will not be re-run. Instead, the output from the previous task run will be returned. This is to prevent unnecessary re-runs of tasks that have already passed.

This PR allows you to configure this behavior through the `retries.shouldRestore` property. This property accepts a boolean or a function for more complex restore behaviors.