### PR TITLE
fix(storage-vercel-blob): fixes issue where files with spaces in their name would not be retrieved correctly

### DIFF
--- a/packages/storage-vercel-blob/src/generateURL.ts
+++ b/packages/storage-vercel-blob/src/generateURL.ts
@@ -9,6 +9,6 @@ type GenerateUrlArgs = {
 
 export const getGenerateUrl = ({ baseUrl }: GenerateUrlArgs): GenerateURL => {
   return ({ filename, prefix = '' }) => {
-    return `${baseUrl}/${path.posix.join(prefix, filename)}`
+    return `${baseUrl}/${path.posix.join(prefix, encodeURIComponent(filename))}`
   }
 }

--- a/packages/storage-vercel-blob/src/staticHandler.ts
+++ b/packages/storage-vercel-blob/src/staticHandler.ts
@@ -18,7 +18,7 @@ export const getStaticHandler = (
   return async (req, { params: { filename } }) => {
     try {
       const prefix = await getFilePrefix({ collection, filename, req })
-      const fileKey = path.posix.join(prefix, filename)
+      const fileKey = path.posix.join(prefix, encodeURIComponent(filename))
 
       const fileUrl = `${baseUrl}/${fileKey}`
       const etagFromHeaders = req.headers.get('etag') || req.headers.get('if-none-match')


### PR DESCRIPTION
URI encodes filenames so that they're retrieved correctly from Vercel's blob storage. Sometimes spaces would cause problems only in certain file names