### PR TITLE
fix: unique error message regression

### DIFF
--- a/packages/db-mongodb/src/utilities/handleError.ts
+++ b/packages/db-mongodb/src/utilities/handleError.ts
@@ -18,7 +18,7 @@ export const handleError = ({
     throw error
   }
 
-  const message = req?.t ? 'error:valueMustBeUnique' : 'Value must be unique'
+  const message = req?.t ? req.t('error:valueMustBeUnique') : 'Value must be unique'
 
   // Handle uniqueness error from MongoDB
   if ('code' in error && error.code === 11000 && 'keyValue' in error && error.keyValue) {

--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -394,7 +394,7 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
           id,
           errors: [
             {
-              message: req?.t ? 'error:valueMustBeUnique' : 'Value must be unique',
+              message: req?.t ? req.t('error:valueMustBeUnique') : 'Value must be unique',
               path: fieldName,
             },
           ],


### PR DESCRIPTION
Regression from https://github.com/payloadcms/payload/pull/9935, we need to call `req.t` with `''error:valueMustBeUnique''` instead of just  `''error:valueMustBeUnique''`