### PR TITLE
fix(richtext-lexical): incorrect string interpolation in the upload converter

### DIFF
--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
@@ -63,7 +63,7 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
       pictureJSX.push(
         <source
           key={size}
-          media="(max-width: ${imageSize.width}px)"
+          media={`(max-width: ${imageSize.width}px)`}
           srcSet={imageSizeURL}
           type={imageSize.mimeType}
         ></source>,


### PR DESCRIPTION
This fixes the incorrect `<source>` `media` attribute value generation within the upload converter.

<img width="919" alt="Zrzut ekranu 2024-12-19 o 12 21 10" src="https://github.com/user-attachments/assets/6f26de7e-26e0-446a-83c5-6e5a776fac1e" />