### PR TITLE
chore(templates): remove console.log that logs payload secret for security

### DIFF
--- a/examples/draft-preview/src/app/(app)/next/preview/route.ts
+++ b/examples/draft-preview/src/app/(app)/next/preview/route.ts
@@ -53,7 +53,6 @@ export async function GET(
         headers: req.headers,
       })
     } catch (error) {
-      console.log({ token, payloadSecret: payload.secret })
       payload.logger.error({ err: error }, 'Error verifying token for live preview')
       return new Response('You are not allowed to preview this page', { status: 403 })
     }

--- a/templates/website/src/app/(frontend)/next/preview/route.ts
+++ b/templates/website/src/app/(frontend)/next/preview/route.ts
@@ -51,7 +51,6 @@ export async function GET(
         headers: req.headers,
       })
     } catch (error) {
-      console.log({ token, payloadSecret: payload.secret })
       payload.logger.error({ err: error }, 'Error verifying token for live preview')
       return new Response('You are not allowed to preview this page', { status: 403 })
     }

--- a/templates/with-vercel-website/src/app/(frontend)/next/preview/route.ts
+++ b/templates/with-vercel-website/src/app/(frontend)/next/preview/route.ts
@@ -51,7 +51,6 @@ export async function GET(
         headers: req.headers,
       })
     } catch (error) {
-      console.log({ token, payloadSecret: payload.secret })
       payload.logger.error({ err: error }, 'Error verifying token for live preview')
       return new Response('You are not allowed to preview this page', { status: 403 })
     }


### PR DESCRIPTION
I noticed that payload.secret was getting logged via console.log, adding a significant security risk.
Removed the console.log statements from three preview/route.ts files.