### PR TITLE
fix(ui): close copy locale modal after locale is changed

### DIFF
--- a/packages/ui/src/elements/CopyLocaleData/index.tsx
+++ b/packages/ui/src/elements/CopyLocaleData/index.tsx
@@ -77,10 +77,10 @@ export const CopyLocaleData: React.FC = () => {
         })
 
         setCopying(false)
-        toggleModal(drawerSlug)
         router.push(
           `${serverURL}${admin}/${collectionSlug ? `collections/${collectionSlug}/${id}` : `globals/${globalSlug}`}?locale=${to}`,
         )
+        toggleModal(drawerSlug)
       } catch (error) {
         toast.error(error.message)
       }


### PR DESCRIPTION
Ensures we close the modal _only_ after locale is changed. This caused our localization e2e's to flake: 
![image](https://github.com/user-attachments/assets/41205afe-0e45-499b-9aa6-07734a7f26fc)
