### PR TITLE
fix(examples): awaits getHeaders in auth example

### DIFF
--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -44,7 +44,7 @@ See the [Collections](https://payloadcms.com/docs/configuration/collections) doc
     import config from '../../payload.config'
 
     export default async function AccountPage({ searchParams }) {
-      const headers = getHeaders()
+      const headers = await getHeaders()
       const payload = await getPayload({ config: configPromise })
       const { permissions, user } = await payload.auth({ headers })
 

--- a/examples/auth/src/app/(app)/account/page.tsx
+++ b/examples/auth/src/app/(app)/account/page.tsx
@@ -13,7 +13,7 @@ import { AccountForm } from './AccountForm'
 import classes from './index.module.scss'
 
 export default async function Account() {
-  const headers = getHeaders()
+  const headers = await getHeaders()
   const payload = await getPayload({ config })
   const { permissions, user } = await payload.auth({ headers })
 

--- a/examples/auth/src/app/(app)/create-account/page.tsx
+++ b/examples/auth/src/app/(app)/create-account/page.tsx
@@ -10,7 +10,7 @@ import { CreateAccountForm } from './CreateAccountForm'
 import classes from './index.module.scss'
 
 export default async function CreateAccount() {
-  const headers = getHeaders()
+  const headers = await getHeaders()
   const payload = await getPayload({ config })
   const { user } = await payload.auth({ headers })
 

--- a/examples/auth/src/app/(app)/login/page.tsx
+++ b/examples/auth/src/app/(app)/login/page.tsx
@@ -10,7 +10,7 @@ import classes from './index.module.scss'
 import { LoginForm } from './LoginForm'
 
 export default async function Login() {
-  const headers = getHeaders()
+  const headers = await getHeaders()
   const payload = await getPayload({ config })
   const { user } = await payload.auth({ headers })
 

--- a/examples/auth/src/app/(app)/logout/page.tsx
+++ b/examples/auth/src/app/(app)/logout/page.tsx
@@ -9,7 +9,7 @@ import classes from './index.module.scss'
 import { LogoutPage } from './LogoutPage'
 
 export default async function Logout() {
-  const headers = getHeaders()
+  const headers = await getHeaders()
   const payload = await getPayload({ config })
   const { user } = await payload.auth({ headers })
 

--- a/examples/auth/src/app/(app)/page.tsx
+++ b/examples/auth/src/app/(app)/page.tsx
@@ -8,7 +8,7 @@ import { Gutter } from './_components/Gutter'
 import { HydrateClientUser } from './_components/HydrateClientUser'
 
 export default async function HomePage() {
-  const headers = getHeaders()
+  const headers = await getHeaders()
   const payload = await getPayload({ config })
   const { permissions, user } = await payload.auth({ headers })
 

--- a/examples/auth/src/app/(app)/recover-password/page.tsx
+++ b/examples/auth/src/app/(app)/recover-password/page.tsx
@@ -9,7 +9,7 @@ import classes from './index.module.scss'
 import { RecoverPasswordForm } from './RecoverPasswordForm'
 
 export default async function RecoverPassword() {
-  const headers = getHeaders()
+  const headers = await getHeaders()
   const payload = await getPayload({ config })
   const { user } = await payload.auth({ headers })
 

--- a/examples/auth/src/app/(app)/reset-password/page.tsx
+++ b/examples/auth/src/app/(app)/reset-password/page.tsx
@@ -9,7 +9,7 @@ import classes from './index.module.scss'
 import { ResetPasswordForm } from './ResetPasswordForm'
 
 export default async function ResetPassword() {
-  const headers = getHeaders()
+  const headers = await getHeaders()
   const payload = await getPayload({ config })
   const { user } = await payload.auth({ headers })
 

--- a/examples/auth/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/examples/auth/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -15,6 +15,7 @@ type Args = {
     [key: string]: string | string[]
   }>
 }
+
 export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
   generatePageMetadata({ config, params, searchParams })
 


### PR DESCRIPTION
The auth example was not properly awaiting `getHeaders` from `next/navigation`. This was simply outdated, as this function was changed to async over the course of the various RC versions during our beta phase.