### PR TITLE
refactor: consistent caps for acronyms in variable names

### DIFF
--- a/packages/db-mongodb/src/create.ts
+++ b/packages/db-mongodb/src/create.ts
@@ -27,8 +27,8 @@ export const create: Create = async function create(
   })
 
   try {
-    const { insertedId } = await Model.collection.insertOne(data, { session })
-    data._id = insertedId
+    const { insertedId: insertedID } = await Model.collection.insertOne(data, { session })
+    data._id = insertedID
 
     transform({
       adapter: this,

--- a/packages/db-mongodb/src/createGlobal.ts
+++ b/packages/db-mongodb/src/createGlobal.ts
@@ -25,8 +25,8 @@ export const createGlobal: CreateGlobal = async function createGlobal(
 
   const session = await getSession(this, req)
 
-  const { insertedId } = await Model.collection.insertOne(data, { session })
-  ;(data as any)._id = insertedId
+  const { insertedId: insertedID } = await Model.collection.insertOne(data, { session })
+  ;(data as any)._id = insertedID
 
   transform({
     adapter: this,

--- a/packages/db-mongodb/src/createGlobalVersion.ts
+++ b/packages/db-mongodb/src/createGlobalVersion.ts
@@ -46,15 +46,15 @@ export const createGlobalVersion: CreateGlobalVersion = async function createGlo
     operation: 'create',
   })
 
-  const { insertedId } = await VersionModel.collection.insertOne(data, { session })
-  ;(data as any)._id = insertedId
+  const { insertedId: insertedID } = await VersionModel.collection.insertOne(data, { session })
+  ;(data as any)._id = insertedID
 
   await VersionModel.collection.updateMany(
     {
       $and: [
         {
           _id: {
-            $ne: insertedId,
+            $ne: insertedID,
           },
         },
         {

--- a/packages/db-mongodb/src/createVersion.ts
+++ b/packages/db-mongodb/src/createVersion.ts
@@ -47,8 +47,8 @@ export const createVersion: CreateVersion = async function createVersion(
     operation: 'create',
   })
 
-  const { insertedId } = await VersionModel.collection.insertOne(data, { session })
-  data._id = insertedId
+  const { insertedId: insertedID } = await VersionModel.collection.insertOne(data, { session })
+  data._id = insertedID
 
   const parentQuery = {
     $or: [
@@ -72,7 +72,7 @@ export const createVersion: CreateVersion = async function createVersion(
       $and: [
         {
           _id: {
-            $ne: insertedId,
+            $ne: insertedID,
           },
         },
         parentQuery,

--- a/packages/db-mongodb/src/predefinedMigrations/migrateVersionsV1_V2.ts
+++ b/packages/db-mongodb/src/predefinedMigrations/migrateVersionsV1_V2.ts
@@ -106,12 +106,12 @@ async function migrateCollectionDocs({
     return
   }
 
-  const remainingDocIds = remainingDocs.map((doc) => doc._versionID)
+  const remainingDocIDs = remainingDocs.map((doc) => doc._versionID)
 
   await VersionsModel.updateMany(
     {
       _id: {
-        $in: remainingDocIds,
+        $in: remainingDocIDs,
       },
     },
     {

--- a/packages/next/src/views/LivePreview/index.client.tsx
+++ b/packages/next/src/views/LivePreview/index.client.tsx
@@ -214,7 +214,7 @@ const PreviewView: React.FC<Props> = ({
       setDocumentIsLocked(true)
 
       if (isLockingEnabled) {
-        const previousOwnerId =
+        const previousOwnerID =
           typeof documentLockStateRef.current?.user === 'object'
             ? documentLockStateRef.current?.user?.id
             : documentLockStateRef.current?.user
@@ -225,8 +225,8 @@ const PreviewView: React.FC<Props> = ({
               ? lockedState.user
               : lockedState.user.id
 
-          if (!documentLockStateRef.current || lockedUserID !== previousOwnerId) {
-            if (previousOwnerId === user.id && lockedUserID !== user.id) {
+          if (!documentLockStateRef.current || lockedUserID !== previousOwnerID) {
+            if (previousOwnerID === user.id && lockedUserID !== user.id) {
               setShowTakeOverModal(true)
               documentLockStateRef.current.hasShownLockedModal = true
             }
@@ -270,7 +270,7 @@ const PreviewView: React.FC<Props> = ({
 
       const currentPath = window.location.pathname
 
-      const documentId = id || globalSlug
+      const documentID = id || globalSlug
 
       // Routes where we do NOT want to unlock the document
       const stayWithinDocumentPaths = ['preview', 'api', 'versions']
@@ -280,7 +280,7 @@ const PreviewView: React.FC<Props> = ({
       )
 
       // Unlock the document only if we're actually navigating away from the document
-      if (documentId && documentIsLocked && !isStayingWithinDocument) {
+      if (documentID && documentIsLocked && !isStayingWithinDocument) {
         // Check if this user is still the current editor
         if (
           typeof documentLockStateRef.current?.user === 'object'

--- a/packages/next/src/views/Root/getViewFromConfig.ts
+++ b/packages/next/src/views/Root/getViewFromConfig.ts
@@ -241,7 +241,7 @@ export const getViewFromConfig = ({
         // --> /collections/:collectionSlug/:id/api
         // --> /collections/:collectionSlug/:id/preview
         // --> /collections/:collectionSlug/:id/versions
-        // --> /collections/:collectionSlug/:id/versions/:versionId
+        // --> /collections/:collectionSlug/:id/versions/:versionID
 
         ViewToRender = {
           Component: DocumentView,
@@ -311,7 +311,7 @@ export const getViewFromConfig = ({
         // Custom Views
         // --> /globals/:globalSlug/versions
         // --> /globals/:globalSlug/preview
-        // --> /globals/:globalSlug/versions/:versionId
+        // --> /globals/:globalSlug/versions/:versionID
         // --> /globals/:globalSlug/api
 
         ViewToRender = {

--- a/packages/richtext-lexical/src/features/experimental_table/client/utils/debounce.ts
+++ b/packages/richtext-lexical/src/features/experimental_table/client/utils/debounce.ts
@@ -124,7 +124,7 @@ function debounce(func, wait, options) {
     maxing = false,
     maxWait,
     result,
-    timerId,
+    timerID,
     trailing = true
 
   if (typeof func != 'function') {
@@ -152,7 +152,7 @@ function debounce(func, wait, options) {
     // Reset any `maxWait` timer.
     lastInvokeTime = time
     // Start the timer for the trailing edge.
-    timerId = setTimeout(timerExpired, wait)
+    timerID = setTimeout(timerExpired, wait)
     // Invoke the leading edge.
     return leading ? invokeFunc(time) : result
   }
@@ -186,11 +186,11 @@ function debounce(func, wait, options) {
       return trailingEdge(time)
     }
     // Restart the timer.
-    timerId = setTimeout(timerExpired, remainingWait(time))
+    timerID = setTimeout(timerExpired, remainingWait(time))
   }
 
   function trailingEdge(time) {
-    timerId = undefined
+    timerID = undefined
 
     // Only invoke if we have `lastArgs` which means `func` has been
     // debounced at least once.
@@ -202,15 +202,15 @@ function debounce(func, wait, options) {
   }
 
   function cancel() {
-    if (timerId !== undefined) {
-      clearTimeout(timerId)
+    if (timerID !== undefined) {
+      clearTimeout(timerID)
     }
     lastInvokeTime = 0
-    lastArgs = lastCallTime = lastThis = timerId = undefined
+    lastArgs = lastCallTime = lastThis = timerID = undefined
   }
 
   function flush() {
-    return timerId === undefined ? result : trailingEdge(Date.now())
+    return timerID === undefined ? result : trailingEdge(Date.now())
   }
 
   function debounced() {
@@ -224,18 +224,18 @@ function debounce(func, wait, options) {
     lastCallTime = time
 
     if (isInvoking) {
-      if (timerId === undefined) {
+      if (timerID === undefined) {
         return leadingEdge(lastCallTime)
       }
       if (maxing) {
         // Handle invocations in a tight loop.
-        clearTimeout(timerId)
-        timerId = setTimeout(timerExpired, wait)
+        clearTimeout(timerID)
+        timerID = setTimeout(timerExpired, wait)
         return invokeFunc(lastCallTime)
       }
     }
-    if (timerId === undefined) {
-      timerId = setTimeout(timerExpired, wait)
+    if (timerID === undefined) {
+      timerID = setTimeout(timerExpired, wait)
     }
     return result
   }

--- a/packages/ui/src/elements/Tooltip/index.tsx
+++ b/packages/ui/src/elements/Tooltip/index.tsx
@@ -45,11 +45,11 @@ export const Tooltip: React.FC<Props> = (props) => {
   )
 
   useEffect(() => {
-    let timerId: NodeJS.Timeout
+    let timerID: NodeJS.Timeout
 
     // do not use the delay on transition-out
     if (delay && showFromProps) {
-      timerId = setTimeout(() => {
+      timerID = setTimeout(() => {
         setShow(showFromProps)
       }, delay)
     } else {
@@ -57,8 +57,8 @@ export const Tooltip: React.FC<Props> = (props) => {
     }
 
     return () => {
-      if (timerId) {
-        clearTimeout(timerId)
+      if (timerID) {
+        clearTimeout(timerID)
       }
     }
   }, [showFromProps, delay])

--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -447,24 +447,24 @@ const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => 
       })
 
       const currentValue = valueRef.current
-      const docId = args.doc.id
+      const docID = args.doc.id
 
       if (hasMany) {
         const unchanged = (currentValue as Option[]).some((option) =>
-          typeof option === 'string' ? option === docId : option.value === docId,
+          typeof option === 'string' ? option === docID : option.value === docID,
         )
 
         const valuesToSet = (currentValue as Option[]).map((option) =>
-          option.value === docId
-            ? { relationTo: args.collectionConfig.slug, value: docId }
+          option.value === docID
+            ? { relationTo: args.collectionConfig.slug, value: docID }
             : option,
         )
 
         setValue(valuesToSet, unchanged)
       } else {
-        const unchanged = currentValue === docId
+        const unchanged = currentValue === docID
 
-        setValue({ relationTo: args.collectionConfig.slug, value: docId }, unchanged)
+        setValue({ relationTo: args.collectionConfig.slug, value: docID }, unchanged)
       }
     },
     [i18n, config, hasMany, setValue],

--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -133,21 +133,21 @@ const DocumentInfo: React.FC<
   }
 
   const unlockDocument = useCallback(
-    async (docId: number | string, slug: string) => {
+    async (docID: number | string, slug: string) => {
       try {
         const isGlobal = slug === globalSlug
 
         const query = isGlobal
           ? `where[globalSlug][equals]=${slug}`
-          : `where[document.value][equals]=${docId}&where[document.relationTo][equals]=${slug}`
+          : `where[document.value][equals]=${docID}&where[document.relationTo][equals]=${slug}`
 
         const request = await requests.get(`${serverURL}${api}/payload-locked-documents?${query}`)
 
         const { docs } = await request.json()
 
         if (docs.length > 0) {
-          const lockId = docs[0].id
-          await requests.delete(`${serverURL}${api}/payload-locked-documents/${lockId}`, {
+          const lockID = docs[0].id
+          await requests.delete(`${serverURL}${api}/payload-locked-documents/${lockID}`, {
             headers: {
               'Content-Type': 'application/json',
             },
@@ -163,13 +163,13 @@ const DocumentInfo: React.FC<
   )
 
   const updateDocumentEditor = useCallback(
-    async (docId: number | string, slug: string, user: ClientUser | number | string) => {
+    async (docID: number | string, slug: string, user: ClientUser | number | string) => {
       try {
         const isGlobal = slug === globalSlug
 
         const query = isGlobal
           ? `where[globalSlug][equals]=${slug}`
-          : `where[document.value][equals]=${docId}&where[document.relationTo][equals]=${slug}`
+          : `where[document.value][equals]=${docID}&where[document.relationTo][equals]=${slug}`
 
         // Check if the document is already locked
         const request = await requests.get(`${serverURL}${api}/payload-locked-documents?${query}`)
@@ -177,7 +177,7 @@ const DocumentInfo: React.FC<
         const { docs } = await request.json()
 
         if (docs.length > 0) {
-          const lockId = docs[0].id
+          const lockID = docs[0].id
 
           const userData =
             typeof user === 'object'
@@ -185,7 +185,7 @@ const DocumentInfo: React.FC<
               : { relationTo: 'users', value: user }
 
           // Send a patch request to update the _lastEdited info
-          await requests.patch(`${serverURL}${api}/payload-locked-documents/${lockId}`, {
+          await requests.patch(`${serverURL}${api}/payload-locked-documents/${lockID}`, {
             body: JSON.stringify({
               user: userData,
             }),

--- a/packages/ui/src/providers/DocumentInfo/types.ts
+++ b/packages/ui/src/providers/DocumentInfo/types.ts
@@ -70,9 +70,9 @@ export type DocumentInfoContext = {
   setMostRecentVersionIsAutosaved: React.Dispatch<React.SetStateAction<boolean>>
   setUnpublishedVersionCount: React.Dispatch<React.SetStateAction<number>>
   title: string
-  unlockDocument: (docId: number | string, slug: string) => Promise<void>
+  unlockDocument: (docID: number | string, slug: string) => Promise<void>
   unpublishedVersionCount: number
-  updateDocumentEditor: (docId: number | string, slug: string, user: ClientUser) => Promise<void>
+  updateDocumentEditor: (docID: number | string, slug: string, user: ClientUser) => Promise<void>
   updateSavedDocumentData: (data: Data) => void
   versionCount: number
 } & DocumentInfoProps

--- a/packages/ui/src/utilities/handleFormStateLocking.ts
+++ b/packages/ui/src/utilities/handleFormStateLocking.ts
@@ -74,12 +74,12 @@ export const handleFormStateLocking = async ({
           user: lockedDocument.docs[0]?.user?.value,
         }
 
-        const lockOwnerId =
+        const lockOwnerID =
           typeof lockedDocument.docs[0]?.user?.value === 'object'
             ? lockedDocument.docs[0]?.user?.value?.id
             : lockedDocument.docs[0]?.user?.value
         // Should only update doc if the incoming / current user is also the owner of the locked doc
-        if (updateLastEdited && req.user && lockOwnerId === req.user.id) {
+        if (updateLastEdited && req.user && lockOwnerID === req.user.id) {
           await req.payload.db.updateOne({
             id: lockedDocument.docs[0].id,
             collection: 'payload-locked-documents',

--- a/packages/ui/src/utilities/handleTakeOver.tsx
+++ b/packages/ui/src/utilities/handleTakeOver.tsx
@@ -7,7 +7,7 @@ export const handleTakeOver = (
   user: ClientUser | number | string,
   isWithinDoc: boolean,
   updateDocumentEditor: (
-    docId: number | string,
+    docID: number | string,
     slug: string,
     user: ClientUser | number | string,
   ) => Promise<void>,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -207,7 +207,7 @@ export const DefaultEditView: React.FC<ClientSideEditViewProps> = ({
   const handleDocumentLocking = useCallback(
     (lockedState: LockedState) => {
       setDocumentIsLocked(true)
-      const previousOwnerId =
+      const previousOwnerID =
         typeof documentLockStateRef.current?.user === 'object'
           ? documentLockStateRef.current?.user?.id
           : documentLockStateRef.current?.user
@@ -218,8 +218,8 @@ export const DefaultEditView: React.FC<ClientSideEditViewProps> = ({
             ? lockedState.user
             : lockedState.user.id
 
-        if (!documentLockStateRef.current || lockedUserID !== previousOwnerId) {
-          if (previousOwnerId === user.id && lockedUserID !== user.id) {
+        if (!documentLockStateRef.current || lockedUserID !== previousOwnerID) {
+          if (previousOwnerID === user.id && lockedUserID !== user.id) {
             setShowTakeOverModal(true)
             documentLockStateRef.current.hasShownLockedModal = true
           }

--- a/test/fields-relationship/PrePopulateFieldUI/index.tsx
+++ b/test/fields-relationship/PrePopulateFieldUI/index.tsx
@@ -19,7 +19,7 @@ export const PrePopulateFieldUI: React.FC<{
       )
       const json = await res.json()
       if (hasMany) {
-        const docIds = json.docs.map((doc) => {
+        const docIDs = json.docs.map((doc) => {
           if (hasMultipleRelations) {
             return {
               relationTo: collection1Slug,
@@ -29,7 +29,7 @@ export const PrePopulateFieldUI: React.FC<{
 
           return doc.id
         })
-        setValue(docIds)
+        setValue(docIDs)
       } else {
         // value that does not appear in first 10 docs fetch
         setValue(json.docs[6].id)

--- a/test/plugin-nested-docs/e2e.spec.ts
+++ b/test/plugin-nested-docs/e2e.spec.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url'
 
 import type { Config, Page as PayloadPage } from './payload-types.js'
 
-import { ensureCompilationIsDone, initPageConsoleErrorCatch, saveDocAndAssert } from '../helpers.js'
+import { ensureCompilationIsDone, initPageConsoleErrorCatch } from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
 import { TEST_TIMEOUT_LONG } from '../playwright.config.js'
@@ -16,10 +16,10 @@ const dirname = path.dirname(filename)
 const { beforeAll, describe } = test
 let url: AdminUrlUtil
 let page: Page
-let draftParentId: string
-let parentId: string
-let draftChildId: string
-let childId: string
+let draftParentID: string
+let parentID: string
+let draftChildID: string
+let childID: string
 
 describe('Nested Docs Plugin', () => {
   beforeAll(async ({ browser }, testInfo) => {
@@ -50,25 +50,25 @@ describe('Nested Docs Plugin', () => {
     }
 
     const parentPage = await createPage({ slug: 'parent-slug' })
-    parentId = parentPage.id
+    parentID = parentPage.id
 
     const childPage = await createPage({
       slug: 'child-slug',
       title: 'Child page',
-      parent: parentId,
+      parent: parentID,
     })
-    childId = childPage.id
+    childID = childPage.id
 
     const draftParentPage = await createPage({ slug: 'parent-slug-draft', _status: 'draft' })
-    draftParentId = draftParentPage.id
+    draftParentID = draftParentPage.id
 
     const draftChildPage = await createPage({
       slug: 'child-slug-draft',
       title: 'Child page',
-      parent: draftParentId,
+      parent: draftParentID,
       _status: 'draft',
     })
-    draftChildId = draftChildPage.id
+    draftChildID = draftChildPage.id
   })
 
   describe('Core functionality', () => {
@@ -77,7 +77,7 @@ describe('Nested Docs Plugin', () => {
     const draftButtonClass = '#action-save-draft'
 
     test('Parent slug updates breadcrumbs in child', async () => {
-      await page.goto(url.edit(childId))
+      await page.goto(url.edit(childID))
       let slug = page.locator(slugClass).nth(0)
       await expect(slug).toHaveValue('child-slug')
 
@@ -92,13 +92,13 @@ describe('Nested Docs Plugin', () => {
       // const parentSlugInChild = page.locator(parentSlugInChildClass).nth(0)
       // await expect(parentSlugInChild).toHaveValue('/parent-slug')
 
-      await page.goto(url.edit(parentId))
+      await page.goto(url.edit(parentID))
       slug = page.locator(slugClass).nth(0)
       await slug.fill('updated-parent-slug')
       await expect(slug).toHaveValue('updated-parent-slug')
       await page.locator(publishButtonClass).nth(0).click()
       await expect(page.locator('.payload-toast-container')).toContainText('successfully')
-      await page.goto(url.edit(childId))
+      await page.goto(url.edit(childID))
 
       // TODO: remove when error states are fixed
       await apiTabButton.click()
@@ -110,7 +110,7 @@ describe('Nested Docs Plugin', () => {
     })
 
     test('Draft parent slug does not update child', async () => {
-      await page.goto(url.edit(draftChildId))
+      await page.goto(url.edit(draftChildID))
 
       // TODO: remove when error states are fixed
       const apiTabButton = page.locator('text=API')
@@ -123,11 +123,11 @@ describe('Nested Docs Plugin', () => {
       // const parentSlugInChild = page.locator(parentSlugInChildClass).nth(0)
       // await expect(parentSlugInChild).toHaveValue('/parent-slug-draft')
 
-      await page.goto(url.edit(parentId))
+      await page.goto(url.edit(parentID))
       await page.locator(slugClass).nth(0).fill('parent-updated-draft')
       await page.locator(draftButtonClass).nth(0).click()
       await expect(page.locator('.payload-toast-container')).toContainText('successfully')
-      await page.goto(url.edit(draftChildId))
+      await page.goto(url.edit(draftChildID))
 
       await apiTabButton.click()
       const updatedBreadcrumbs = page.locator('text=/parent-slug-draft').first()
@@ -138,15 +138,15 @@ describe('Nested Docs Plugin', () => {
     })
 
     test('Publishing parent doc should not publish child', async () => {
-      await page.goto(url.edit(childId))
+      await page.goto(url.edit(childID))
       await page.locator(slugClass).nth(0).fill('child-updated-draft')
       await page.locator(draftButtonClass).nth(0).click()
 
-      await page.goto(url.edit(parentId))
+      await page.goto(url.edit(parentID))
       await page.locator(slugClass).nth(0).fill('parent-updated-published')
       await page.locator(publishButtonClass).nth(0).click()
 
-      await page.goto(url.edit(childId))
+      await page.goto(url.edit(childID))
       await expect(page.locator(slugClass).nth(0)).toHaveValue('child-updated-draft')
     })
   })


### PR DESCRIPTION
Improves consistency for variable names like `docID`, `insertedID`, `parentID`
For example: `docId` -> `docID` 
