### PR TITLE
fix(ui): filter out fields with disableListFilter in whereBuilder prior to adding conditions

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
@@ -65,10 +65,6 @@ export const Condition: React.FC<Props> = (props) => {
     updateCondition,
   } = props
 
-  const options = useMemo(() => {
-    return fields.filter(({ field }) => !field.admin.disableListFilter)
-  }, [fields])
-
   const [internalField, setInternalField] = useState<FieldCondition>(() =>
     fields.find((field) => fieldName === field.value),
   )
@@ -135,7 +131,7 @@ export const Condition: React.FC<Props> = (props) => {
                 setInternalOperatorOption(undefined)
                 setInternalQueryValue(undefined)
               }}
-              options={options}
+              options={fields}
               value={
                 fields.find((field) => internalField?.value === field.value) || {
                   value: internalField?.value,

--- a/packages/ui/src/elements/WhereBuilder/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/index.tsx
@@ -33,6 +33,10 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
     setReducedColumns(reduceClientFields({ fields, i18n }))
   }, [fields, i18n])
 
+  const filterableFields = React.useMemo(() => {
+    return reducedFields.filter((condition) => !condition.field?.admin?.disableListFilter)
+  }, [reducedFields])
+
   const { handleWhereChange, query } = useListQuery()
   const [shouldUpdateQuery, setShouldUpdateQuery] = React.useState(false)
 
@@ -185,7 +189,7 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
                               addCondition={addCondition}
                               andIndex={andIndex}
                               fieldName={initialFieldName}
-                              fields={reducedFields}
+                              fields={filterableFields}
                               initialValue={initialValue}
                               operator={initialOperator}
                               orIndex={orIndex}
@@ -208,12 +212,14 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
             iconPosition="left"
             iconStyle="with-border"
             onClick={() => {
-              addCondition({
-                andIndex: 0,
-                fieldName: reducedFields[0].value,
-                orIndex: conditions.length,
-                relation: 'or',
-              })
+              if (filterableFields.length > 0) {
+                addCondition({
+                  andIndex: 0,
+                  fieldName: filterableFields[0].value,
+                  orIndex: conditions.length,
+                  relation: 'or',
+                })
+              }
             }}
           >
             {t('general:or')}
@@ -230,10 +236,10 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
             iconPosition="left"
             iconStyle="with-border"
             onClick={() => {
-              if (reducedFields.length > 0) {
+              if (filterableFields.length > 0) {
                 addCondition({
                   andIndex: 0,
-                  fieldName: reducedFields[0].value,
+                  fieldName: filterableFields[0].value,
                   orIndex: conditions.length,
                   relation: 'or',
                 })


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes an issue with the WhereBuilder where if the first field in a collection had `disableListFilter` enabled, the select in that fields `Condition` would be rendered disabled, making it impossible to query docs in list view.

### Why?
To allow users to query their documents while still being able to set `disableListFilter` on fields regardless of where they are in the collection hierarchy.

### How?
By filtering out unfilterable fields earlier in WhereBuilder and Condition components.

Fixes #10110

Before:
[Dashboard-wherebuilder-before--Payload.webm](https://github.com/user-attachments/assets/233fe3c8-e936-4f60-9a58-4f1243b23418)

After:
[Dashboard-wherebuilder-after--Payload.webm](https://github.com/user-attachments/assets/0244c8b0-51a5-4294-afa6-fb1224133577)
