### PR TITLE
docs: remove stray backtick from Nested Docs Plugin page

### DIFF
--- a/docs/plugins/nested-docs.mdx
+++ b/docs/plugins/nested-docs.mdx
@@ -196,7 +196,7 @@ const examplePageConfig: CollectionConfig = {
         },
         // Note: if you override the `filterOptions` of the `parent` field,
         // be sure to continue to prevent the document from referencing itself as the parent like this:
-        // filterOptions: ({ id }) => ({ id: {not_equals: id }})`
+        // filterOptions: ({ id }) => ({ id: {not_equals: id }})
       },
     ),
     createBreadcrumbsField(


### PR DESCRIPTION
### What?
Remove erroneous backtick from comment in code snippet from https://payloadcms.com/docs/plugins/nested-docs#overrides
