### PR TITLE
test: ensure data strictness

### DIFF
--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -242,6 +242,57 @@ describe('database', () => {
     })
   })
 
+  describe('Data strictness', () => {
+    it('should not save and leak password, confirm-password from Local API', async () => {
+      const createdUser = await payload.create({
+        collection: 'users',
+        data: {
+          password: 'some-password',
+          // @ts-expect-error
+          'confirm-password': 'some-password',
+          email: 'user1@payloadcms.com',
+        },
+      })
+
+      let keys = Object.keys(createdUser)
+
+      expect(keys).not.toContain('password')
+      expect(keys).not.toContain('confirm-password')
+
+      const foundUser = await payload.findByID({ id: createdUser.id, collection: 'users' })
+
+      keys = Object.keys(foundUser)
+
+      expect(keys).not.toContain('password')
+      expect(keys).not.toContain('confirm-password')
+    })
+
+    it('should not save and leak password, confirm-password from payload.db', async () => {
+      const createdUser = await payload.db.create({
+        collection: 'users',
+        data: {
+          password: 'some-password',
+          'confirm-password': 'some-password',
+          email: 'user2@payloadcms.com',
+        },
+      })
+
+      let keys = Object.keys(createdUser)
+
+      expect(keys).not.toContain('password')
+      expect(keys).not.toContain('confirm-password')
+
+      const foundUser = await payload.db.findOne({
+        collection: 'users',
+        where: { id: createdUser.id },
+      })
+
+      keys = Object.keys(foundUser)
+      expect(keys).not.toContain('password')
+      expect(keys).not.toContain('confirm-password')
+    })
+  })
+
   describe('migrations', () => {
     let ranFreshTest = false
 


### PR DESCRIPTION
Ensures we don't save and read additional properties to the database with both, Local API and `payload.db`.