### PR TITLE
feat: export defaultLoggerOptions

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1356,6 +1356,7 @@ export { default as isolateObjectProperty } from './utilities/isolateObjectPrope
 export { isPlainObject } from './utilities/isPlainObject.js'
 export { isValidID } from './utilities/isValidID.js'
 export { killTransaction } from './utilities/killTransaction.js'
+export { defaultLoggerOptions } from './utilities/logger.js'
 export { mapAsync } from './utilities/mapAsync.js'
 export { sanitizeFallbackLocale } from './utilities/sanitizeFallbackLocale.js'
 export { sanitizeJoinParams } from './utilities/sanitizeJoinParams.js'


### PR DESCRIPTION
Make `defaultLoggerOptions` available. Useful if you need to only tweak the defaults for your logger.

