### PR TITLE
docs: warn when using `defaultPopulate` on collections with uploads enabled

### DIFF
--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -137,6 +137,11 @@ export const Pages: CollectionConfig<'pages'> = {
 }
 ```
 
+<Banner type="warning">
+  <strong>Important:</strong>
+  When using `defaultPopulate` on collections with a [Upload](/docs/fields/upload) field, it is important to specify `filename: true` and `url: true`, otherwise Payload will not be able to fetch the correct image URL and populate the URL field in your queries, instead returning `url: null`.
+</Banner>
+
 ## populate
 
 Setting `defaultPopulate` will enforce that each time Payload performs a "population" of a related document, only the fields specified will be queried and returned. However, you can override `defaultPopulate` with the `populate` property in the Local and REST API:

--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -139,7 +139,7 @@ export const Pages: CollectionConfig<'pages'> = {
 
 <Banner type="warning">
   <strong>Important:</strong>
-  When using `defaultPopulate` on collections with a [Upload](/docs/fields/upload) field, it is important to specify `filename: true` and `url: true`, otherwise Payload will not be able to fetch the correct image URL and populate the URL field in your queries, instead returning `url: null`.
+  When using `defaultPopulate` on a collection with [Uploads](/docs/fields/upload) enabled and you want to select the `url` field, it is important to specify `filename: true` as well, otherwise Payload will not be able to construct the correct file URL, instead returning `url: null`.
 </Banner>
 
 ## populate


### PR DESCRIPTION
When `defaultPopulate` is enabled without specifying `filename: true` and `url: true` for collections with an upload field. The upload will not have a valid URL when returned from Payload APIs and will instead be returned with a value of `null`

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
