### PR TITLE
perf(db-postgres): do not push database schema if not changed

### DIFF
--- a/packages/drizzle/src/schema/buildRawSchema.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.ts
@@ -16,6 +16,8 @@ export const buildRawSchema = ({
   adapter: DrizzleAdapter
   setColumnID: SetColumnID
 }) => {
+  adapter.indexes = new Set()
+
   adapter.payload.config.collections.forEach((collection) => {
     createTableName({
       adapter,

--- a/packages/drizzle/src/utilities/pushDevSchema.ts
+++ b/packages/drizzle/src/utilities/pushDevSchema.ts
@@ -19,23 +19,25 @@ const previousSchema: {
  * @returns {Promise<void>} - A promise that resolves once the schema push is complete.
  */
 export const pushDevSchema = async (adapter: DrizzleAdapter) => {
-  const localeCodes =
-    adapter.payload.config.localization && adapter.payload.config.localization.localeCodes
+  if (process.env.PAYLOAD_FORCE_DRIZZLE_PUSH !== 'true') {
+    const localeCodes =
+      adapter.payload.config.localization && adapter.payload.config.localization.localeCodes
 
-  try {
-    deepStrictEqual(previousSchema, {
-      localeCodes,
-      rawTables: adapter.rawTables,
-    })
+    try {
+      deepStrictEqual(previousSchema, {
+        localeCodes,
+        rawTables: adapter.rawTables,
+      })
 
-    if (adapter.logger) {
-      adapter.payload.logger.info('No changes detected in schema, skipping schema push.')
+      if (adapter.logger) {
+        adapter.payload.logger.info('No changes detected in schema, skipping schema push.')
+      }
+
+      return
+    } catch {
+      previousSchema.localeCodes = localeCodes
+      previousSchema.rawTables = adapter.rawTables
     }
-
-    return
-  } catch {
-    previousSchema.localeCodes = localeCodes
-    previousSchema.rawTables = adapter.rawTables
   }
 
   const { pushSchema } = adapter.requireDrizzleKit()

--- a/packages/drizzle/src/utilities/pushDevSchema.ts
+++ b/packages/drizzle/src/utilities/pushDevSchema.ts
@@ -1,7 +1,16 @@
+import { deepStrictEqual } from 'assert'
 import prompts from 'prompts'
 
 import type { BasePostgresAdapter } from '../postgres/types.js'
-import type { DrizzleAdapter, PostgresDB } from '../types.js'
+import type { DrizzleAdapter, PostgresDB, RawTable } from '../types.js'
+
+const previousSchema: {
+  localeCodes: null | string[]
+  rawTables: null | Record<string, RawTable>
+} = {
+  localeCodes: null,
+  rawTables: null,
+}
 
 /**
  * Pushes the development schema to the database using Drizzle.
@@ -10,6 +19,25 @@ import type { DrizzleAdapter, PostgresDB } from '../types.js'
  * @returns {Promise<void>} - A promise that resolves once the schema push is complete.
  */
 export const pushDevSchema = async (adapter: DrizzleAdapter) => {
+  const localeCodes =
+    adapter.payload.config.localization && adapter.payload.config.localization.localeCodes
+
+  try {
+    deepStrictEqual(previousSchema, {
+      localeCodes,
+      rawTables: adapter.rawTables,
+    })
+
+    if (adapter.logger) {
+      adapter.payload.logger.info('No changes detected in schema, skipping schema push.')
+    }
+
+    return
+  } catch {
+    previousSchema.localeCodes = localeCodes
+    previousSchema.rawTables = adapter.rawTables
+  }
+
   const { pushSchema } = adapter.requireDrizzleKit()
 
   const { extensions = {}, tablesFilter } = adapter as BasePostgresAdapter

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -952,6 +952,10 @@ describe('database', () => {
   })
 
   describe('drizzle: schema hooks', () => {
+    beforeAll(() => {
+      process.env.PAYLOAD_FORCE_DRIZZLE_PUSH = 'true'
+    })
+
     it('should add tables with hooks', async () => {
       // eslint-disable-next-line jest/no-conditional-in-test
       if (payload.db.name === 'mongoose') {


### PR DESCRIPTION
Based on https://github.com/payloadcms/payload/pull/10154

If the actual database schema is not changed (no new columns, enums, indexes, tables) - skip calling Drizzle push. This, potentially can significantly reduce overhead on reloads in development mode especially when using remote databases.

If for whatever reason you need to preserve the current behavior you can use `PAYLOAD_FORCE_DRIZZLE_PUSH=true` env flag.
