### PR TITLE
fix: generate types when no `en` language is defined in i18n

### DIFF
--- a/packages/payload/src/bin/generateTypes.ts
+++ b/packages/payload/src/bin/generateTypes.ts
@@ -1,3 +1,5 @@
+import type { AcceptedLanguages } from '@payloadcms/translations'
+
 import { initI18n } from '@payloadcms/translations'
 import fs from 'fs'
 import { compile } from 'json-schema-to-typescript'
@@ -20,7 +22,12 @@ export async function generateTypes(
   if (shouldLog) {
     logger.info('Compiling TS types for Collections and Globals...')
   }
-  const i18n = await initI18n({ config: config.i18n, context: 'api', language: 'en' })
+
+  const languages = Object.keys(config.i18n.supportedLanguages) as AcceptedLanguages[]
+
+  const language = languages.includes('en') ? 'en' : config.i18n.fallbackLanguage
+
+  const i18n = await initI18n({ config: config.i18n, context: 'api', language })
 
   const jsonSchema = configToJSONSchema(config, config.db.defaultIDType, i18n)
 

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -200,11 +200,9 @@ export function withNullableJSONSchemaType(
 }
 
 function entityOrFieldToJsDocs({
-  config,
   entity,
   i18n,
 }: {
-  config: SanitizedConfig
   entity: FlattenedField | SanitizedCollectionConfig | SanitizedGlobalConfig
   i18n?: I18n
 }): string | undefined {
@@ -213,11 +211,10 @@ function entityOrFieldToJsDocs({
     if (typeof entity?.admin?.description === 'string') {
       description = entity?.admin?.description
     } else if (typeof entity?.admin?.description === 'object') {
-      const defaultLocale = config?.localization ? config?.localization?.defaultLocale : undefined
       if (entity?.admin?.description?.en) {
         description = entity?.admin?.description?.en
-      } else if (entity?.admin?.description?.[defaultLocale]) {
-        description = entity?.admin?.description?.[defaultLocale]
+      } else if (entity?.admin?.description?.[i18n.language]) {
+        description = entity?.admin?.description?.[i18n.language]
       }
     } else if (typeof entity?.admin?.description === 'function' && i18n) {
       description = entity?.admin?.description(i18n)
@@ -255,7 +252,7 @@ export function fieldsToJSONSchema(
           requiredFieldNames.add(field.name)
         }
 
-        const fieldDescription = entityOrFieldToJsDocs({ config, entity: field, i18n })
+        const fieldDescription = entityOrFieldToJsDocs({ entity: field, i18n })
         const baseFieldSchema: JSONSchema4 = {}
         if (fieldDescription) {
           baseFieldSchema.description = fieldDescription
@@ -710,7 +707,7 @@ export function entityToJSONSchema(
     ),
   }
 
-  const entityDescription = entityOrFieldToJsDocs({ config, entity, i18n })
+  const entityDescription = entityOrFieldToJsDocs({ entity, i18n })
 
   if (entityDescription) {
     jsonSchema.description = entityDescription


### PR DESCRIPTION
Previously, if you had for example only `de` in `i18n` - `generate:types` would fail
Fixes https://github.com/payloadcms/payload/issues/10145