### PR TITLE
fix(next): check body size before parsing json in `addDataAndFileToRequest`

### DIFF
--- a/packages/next/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/next/src/utilities/addDataAndFileToRequest.ts
@@ -12,9 +12,10 @@ type AddDataAndFileToRequest = (req: PayloadRequest) => Promise<void>
 export const addDataAndFileToRequest: AddDataAndFileToRequest = async (req) => {
   const { body, headers, method, payload } = req
 
-  if (method && ['PATCH', 'POST', 'PUT'].includes(method.toUpperCase()) && body) {
+  const bodyByteSize = parseInt(req.headers.get('Content-Length') || '0', 10)
+
+  if (method && ['PATCH', 'POST', 'PUT'].includes(method.toUpperCase()) && body && bodyByteSize) {
     const [contentType] = (headers.get('Content-Type') || '').split(';')
-    const bodyByteSize = parseInt(req.headers.get('Content-Length') || '0', 10)
 
     if (contentType === 'application/json') {
       let data = {}

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url'
 import path from 'path'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
+import { addDataAndFileToRequest } from '@payloadcms/next/utilities'
 import { APIError, type CollectionConfig, type Endpoint } from 'payload'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
@@ -264,11 +265,21 @@ export default buildConfigWithDefaults({
     {
       slug: endpointsSlug,
       fields: [],
-      endpoints: methods.map((method) => ({
-        method,
-        handler: () => new Response(`${method} response`),
-        path: `/${method}-test`,
-      })),
+      endpoints: [
+        ...methods.map((method) => ({
+          method,
+          handler: () => new Response(`${method} response`),
+          path: `/${method}-test`,
+        })),
+        {
+          path: '/custom',
+          method: 'post',
+          handler: async (req) => {
+            await addDataAndFileToRequest(req)
+            return new Response('success')
+          },
+        },
+      ],
     },
   ],
   endpoints: [


### PR DESCRIPTION
Previously, sending a request with an empty body led to errors in the logs:
<img width="597" alt="image" src="https://github.com/user-attachments/assets/60ae90f9-d4d4-49ca-a1a8-3aa018c478e8" />
We shouldn't try to parse to json if the body is empty by checking `Content-Length`.

Fixes https://github.com/payloadcms/payload/issues/10173
