### PR TITLE
templates: update `Dockerfile` for the website template, use the LTS version for Node.js image

### DIFF
--- a/templates/blank/Dockerfile
+++ b/templates/blank/Dockerfile
@@ -1,6 +1,7 @@
+# To use this Dockerfile, you have to set `output: 'standalone'` in your next.config.mjs file.
 # From https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
-FROM node:18-alpine AS base
+FROM node:22.12.0-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/templates/website/Dockerfile
+++ b/templates/website/Dockerfile
@@ -1,24 +1,71 @@
-FROM node:18.8-alpine as base
+# To use this Dockerfile, you have to set `output: 'standalone'` in your next.config.js file.
+# From https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
-FROM base as builder
+FROM node:22.12.0-alpine AS base
 
-WORKDIR /home/node/app
-COPY package*.json ./
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
 
+# Install dependencies based on the preferred package manager
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+RUN \
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
+
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN yarn install
-RUN yarn build
 
-FROM base as runtime
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+# ENV NEXT_TELEMETRY_DISABLED 1
 
-ENV NODE_ENV=production
+RUN \
+  if [ -f yarn.lock ]; then yarn run build; \
+  elif [ -f package-lock.json ]; then npm run build; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
 
-WORKDIR /home/node/app
-COPY package*.json  ./
-COPY yarn.lock ./
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
 
-RUN yarn install --production
+ENV NODE_ENV production
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+# Remove this line if you do not have this folder
+COPY --from=builder /app/public ./public
+
+# Set the correct permission for prerender cache
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
 
 EXPOSE 3000
 
-CMD ["node", "dist/server.js"]
+ENV PORT 3000
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/next-config-js/output
+CMD HOSTNAME="0.0.0.0" node server.js


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/10153

With the current Node.js version  - `18.8.0` Dockerfile in templates doesn't build 
<img width="498" alt="image" src="https://github.com/user-attachments/assets/91229bf2-a760-4f37-913e-6cca3e6806d0" />

Updated to LTS - `22.12.0`. Also updated Dockerfile in the `website` template as it was outdated and added comment that you need to set `output: 'standalone'` in `next.config.mjs`.
<img width="791" alt="image" src="https://github.com/user-attachments/assets/be78d2cc-2489-4a7f-8fa2-8e88fcce4d8f" />