### PR TITLE
chore(ui): exports parseSearchParams

### DIFF
--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -288,13 +288,17 @@ export {
   type ListViewClientProps,
   type ListViewSlots,
 } from '../../views/List/index.js'
+
 export type {
   ListComponentClientProps,
   ListComponentServerProps,
   ListPreferences,
 } from '../../views/List/types.js'
+
 export type { ListHeaderProps } from '../../views/List/ListHeader/index.js'
 
 export { DefaultEditView } from '../../views/Edit/index.js'
 export { SetDocumentStepNav } from '../../views/Edit/SetDocumentStepNav/index.js'
 export { SetDocumentTitle } from '../../views/Edit/SetDocumentTitle/index.js'
+
+export { parseSearchParams } from '../../utilities/parseSearchParams.js'

--- a/packages/ui/src/utilities/parseSearchParams.ts
+++ b/packages/ui/src/utilities/parseSearchParams.ts
@@ -2,8 +2,16 @@ import type { ReadonlyURLSearchParams } from 'next/navigation.js'
 
 import * as qs from 'qs-esm'
 
-export function parseSearchParams(params: ReadonlyURLSearchParams): qs.ParsedQs {
-  const search = params.toString()
+/**
+ * A utility function to parse URLSearchParams into a ParsedQs object.
+ * This function is a wrapper around the `qs` library.
+ * In Next.js, the `useSearchParams()` hook from `next/navigation` returns a `URLSearchParams` object.
+ * This function can be used to parse that object into a more usable format.
+ * @param {ReadonlyURLSearchParams} searchParams - The URLSearchParams object to parse.
+ * @returns {qs.ParsedQs} - The parsed query string object.
+ */
+export function parseSearchParams(searchParams: ReadonlyURLSearchParams): qs.ParsedQs {
+  const search = searchParams.toString()
 
   return qs.parse(search, {
     depth: 10,


### PR DESCRIPTION
As pointed out in #10164, parsing a `where` query from search params is not exactly straightforward. Internally we rely on the `qs` module for this, but it comes with a couple small nuances that are undocumented, like the need to stringify them and specify depth. To standardize this, we use a `parseSearchParams` utility internally that accepts the `URLSearchParams` object that the `useSearchParams()` hook returns from `next/navigation`. This PR exports that function for reuse and adds JSDocs accordingly. Usage looks something like this:

```tsx
'use client'
import { useSearchParams } from 'next/navigation'
import { parseSearchParams } from '@payloadcms/ui'

function MyComponent() {
  const searchParams = useSearchParams()
  const parsedSearchParams = parseSearchParams(searchParams)
}
```