### PR TITLE
fix(ui): public users unable to log out

### DIFF
--- a/packages/next/src/utilities/initPage/handleAuthRedirect.ts
+++ b/packages/next/src/utilities/initPage/handleAuthRedirect.ts
@@ -9,6 +9,7 @@ type Args = {
   searchParams: { [key: string]: string | string[] }
   user?: User
 }
+
 export const handleAuthRedirect = ({ config, route, searchParams, user }: Args): string => {
   const {
     admin: {

--- a/packages/next/src/utilities/initPage/index.ts
+++ b/packages/next/src/utilities/initPage/index.ts
@@ -110,7 +110,7 @@ export const initPage = async ({
             },
           })
           ?.then((res) => res.docs?.[0]?.value as string)
-      } catch (error) {} // eslint-disable-line no-empty
+      } catch (_err) {} // eslint-disable-line no-empty
     }
 
     locale = findLocaleFromCode(localization, localeCode)

--- a/packages/next/src/views/Login/index.tsx
+++ b/packages/next/src/views/Login/index.tsx
@@ -28,8 +28,12 @@ export const LoginView: React.FC<AdminViewProps> = ({ initPageResult, params, se
     routes: { admin },
   } = config
 
+  // && permissions.canAccessAdmin
+
   if (user) {
     redirect((searchParams.redirect as string) || admin)
+  } else if (user && !permissions.canAccessAdmin) {
+    // Do something else, like present a message with a logout button
   }
 
   const collectionConfig = collections.find(({ slug }) => slug === userSlug)

--- a/packages/next/src/views/Login/index.tsx
+++ b/packages/next/src/views/Login/index.tsx
@@ -28,12 +28,8 @@ export const LoginView: React.FC<AdminViewProps> = ({ initPageResult, params, se
     routes: { admin },
   } = config
 
-  // && permissions.canAccessAdmin
-
   if (user) {
     redirect((searchParams.redirect as string) || admin)
-  } else if (user && !permissions.canAccessAdmin) {
-    // Do something else, like present a message with a logout button
   }
 
   const collectionConfig = collections.find(({ slug }) => slug === userSlug)

--- a/packages/next/src/views/Logout/LogoutClient.tsx
+++ b/packages/next/src/views/Logout/LogoutClient.tsx
@@ -19,8 +19,11 @@ export const LogoutClient: React.FC<{
   const { adminRoute, inactivity, redirect } = props
 
   const { logOut, user } = useAuth()
+
   const [isLoggedOut, setIsLoggedOut] = React.useState<boolean>(!user)
+
   const logOutSuccessRef = React.useRef(false)
+
   const [loginRoute] = React.useState(() =>
     formatAdminURL({
       adminRoute,

--- a/packages/next/src/views/Logout/LogoutClient.tsx
+++ b/packages/next/src/views/Logout/LogoutClient.tsx
@@ -52,8 +52,10 @@ export const LogoutClient: React.FC<{
   useEffect(() => {
     if (!isLoggedOut) {
       void handleLogOut()
+    } else {
+      router.push(loginRoute)
     }
-  }, [handleLogOut, isLoggedOut])
+  }, [handleLogOut, isLoggedOut, loginRoute, router])
 
   if (isLoggedOut && inactivity) {
     return (

--- a/packages/next/src/views/Unauthorized/index.scss
+++ b/packages/next/src/views/Unauthorized/index.scss
@@ -2,8 +2,9 @@
 
 @layer payload-default {
   .unauthorized {
-    &__button {
+    &__button.btn {
       margin: 0;
+      margin-block: 0;
     }
   }
 }

--- a/packages/next/src/views/Unauthorized/index.tsx
+++ b/packages/next/src/views/Unauthorized/index.tsx
@@ -18,6 +18,7 @@ export const UnauthorizedView: PayloadServerReactComponent<AdminViewComponent> =
   initPageResult,
 }) => {
   const {
+    permissions,
     req: {
       i18n,
       payload: {
@@ -28,6 +29,7 @@ export const UnauthorizedView: PayloadServerReactComponent<AdminViewComponent> =
           routes: { admin: adminRoute },
         },
       },
+      user,
     },
   } = initPageResult
 
@@ -35,9 +37,10 @@ export const UnauthorizedView: PayloadServerReactComponent<AdminViewComponent> =
     <div className={baseClass}>
       <FormHeader
         description={i18n.t('error:notAllowedToAccessPage')}
-        heading={i18n.t('error:unauthorized')}
+        heading={i18n.t(
+          user && !permissions.canAccessAdmin ? 'error:unauthorizedAdmin' : 'error:unauthorized',
+        )}
       />
-
       <Button
         className={`${baseClass}__button`}
         el="link"

--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -78,6 +78,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'error:unableToReindexCollection',
   'error:unableToUpdateCount',
   'error:unauthorized',
+  'error:unauthorizedAdmin',
   'error:unknown',
   'error:unspecific',
   'error:userEmailAlreadyRegistered',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -115,7 +115,7 @@ export const arTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: 'خطأ في إعادة فهرسة المجموعة {{collection}}. تم إيقاف العملية.',
     unableToUpdateCount: 'يتعذّر تحديث {{count}} من {{total}} {{label}}.',
     unauthorized: 'غير مصرّح لك ، عليك أن تقوم بتسجيل الدّخول لتتمكّن من تقديم هذا الطّلب.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'غير مصرّح لك بالوصول إلى لوحة التحكّم.',
     unknown: 'حدث خطأ غير معروف.',
     unPublishingDocument: 'حدث خطأ أثناء إلغاء نشر هذا المستند.',
     unspecific: 'حدث خطأ.',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -115,6 +115,7 @@ export const arTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: 'خطأ في إعادة فهرسة المجموعة {{collection}}. تم إيقاف العملية.',
     unableToUpdateCount: 'يتعذّر تحديث {{count}} من {{total}} {{label}}.',
     unauthorized: 'غير مصرّح لك ، عليك أن تقوم بتسجيل الدّخول لتتمكّن من تقديم هذا الطّلب.',
+    unauthorizedAdmin: undefined,
     unknown: 'حدث خطأ غير معروف.',
     unPublishingDocument: 'حدث خطأ أثناء إلغاء نشر هذا المستند.',
     unspecific: 'حدث خطأ.',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -116,6 +116,7 @@ export const azTranslations: DefaultTranslationsObject = {
       '{{collection}} kolleksiyasının yenidən indekslənməsi zamanı səhv baş verdi. Əməliyyat dayandırıldı.',
     unableToUpdateCount: '{{count}} dən {{total}} {{label}} yenilənə bilmir.',
     unauthorized: 'İcazəniz yoxdur, bu tələbi yerinə yetirmək üçün daxil olmalısınız.',
+    unauthorizedAdmin: undefined,
     unknown: 'Naməlum bir xəta baş verdi.',
     unPublishingDocument: 'Bu sənədin nəşrini ləğv etmək zamanı problem baş verdi.',
     unspecific: 'Xəta baş verdi.',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -116,7 +116,7 @@ export const azTranslations: DefaultTranslationsObject = {
       '{{collection}} kolleksiyasının yenidən indekslənməsi zamanı səhv baş verdi. Əməliyyat dayandırıldı.',
     unableToUpdateCount: '{{count}} dən {{total}} {{label}} yenilənə bilmir.',
     unauthorized: 'İcazəniz yoxdur, bu tələbi yerinə yetirmək üçün daxil olmalısınız.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Bu əməliyyatı yerinə yetirmək üçün admin olmalısınız.',
     unknown: 'Naməlum bir xəta baş verdi.',
     unPublishingDocument: 'Bu sənədin nəşrini ləğv etmək zamanı problem baş verdi.',
     unspecific: 'Xəta baş verdi.',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -116,6 +116,7 @@ export const bgTranslations: DefaultTranslationsObject = {
       'Грешка при преиндексиране на колекцията {{collection}}. Операцията е прекратена.',
     unableToUpdateCount: 'Не беше възможно да се обновят {{count}} от {{total}} {{label}}.',
     unauthorized: 'Неоторизиран, трябва да влезеш, за да извършиш тази заявка.',
+    unauthorizedAdmin: undefined,
     unknown: 'Неизвестна грешка.',
     unPublishingDocument: 'Имаше проблем при скриването на този документ.',
     unspecific: 'Грешка.',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -116,7 +116,7 @@ export const bgTranslations: DefaultTranslationsObject = {
       'Грешка при преиндексиране на колекцията {{collection}}. Операцията е прекратена.',
     unableToUpdateCount: 'Не беше възможно да се обновят {{count}} от {{total}} {{label}}.',
     unauthorized: 'Неоторизиран, трябва да влезеш, за да извършиш тази заявка.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Неоторизиран, трябва да си администратор, за да извършиш тази заявка.',
     unknown: 'Неизвестна грешка.',
     unPublishingDocument: 'Имаше проблем при скриването на този документ.',
     unspecific: 'Грешка.',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -116,7 +116,7 @@ export const csTranslations: DefaultTranslationsObject = {
       'Chyba při přeindexování kolekce {{collection}}. Operace byla přerušena.',
     unableToUpdateCount: 'Nelze aktualizovat {{count}} z {{total}} {{label}}.',
     unauthorized: 'Neautorizováno, pro zadání tohoto požadavku musíte být přihlášeni.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Neautorizováno, tento uživatel nemá přístup k administraci.',
     unknown: 'Došlo k neznámé chybě.',
     unPublishingDocument: 'Při zrušení publikování tohoto dokumentu došlo k chybě.',
     unspecific: 'Došlo k chybě.',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -116,6 +116,7 @@ export const csTranslations: DefaultTranslationsObject = {
       'Chyba při přeindexování kolekce {{collection}}. Operace byla přerušena.',
     unableToUpdateCount: 'Nelze aktualizovat {{count}} z {{total}} {{label}}.',
     unauthorized: 'Neautorizováno, pro zadání tohoto požadavku musíte být přihlášeni.',
+    unauthorizedAdmin: undefined,
     unknown: 'Došlo k neznámé chybě.',
     unPublishingDocument: 'Při zrušení publikování tohoto dokumentu došlo k chybě.',
     unspecific: 'Došlo k chybě.',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -115,6 +115,7 @@ export const daTranslations: DefaultTranslationsObject = {
       'Fejl ved genindeksering af samling {{collection}}. Operationen blev afbrudt.',
     unableToUpdateCount: 'Kunne ikke slette {{count}} mangler {{total}} {{label}}.',
     unauthorized: 'Uautoriseret, log in for at gennemføre handlingen.',
+    unauthorizedAdmin: undefined,
     unknown: 'En ukendt fejl er opstået.',
     unPublishingDocument: 'Der opstod et problem med at ophæve udgivelsen af dette dokument.',
     unspecific: 'En fejl er opstået.',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -115,7 +115,7 @@ export const daTranslations: DefaultTranslationsObject = {
       'Fejl ved genindeksering af samling {{collection}}. Operationen blev afbrudt.',
     unableToUpdateCount: 'Kunne ikke slette {{count}} mangler {{total}} {{label}}.',
     unauthorized: 'Uautoriseret, log in for at gennemføre handlingen.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Uautoriseret, denne bruger har ikke adgang til adminpanelet.',
     unknown: 'En ukendt fejl er opstået.',
     unPublishingDocument: 'Der opstod et problem med at ophæve udgivelsen af dette dokument.',
     unspecific: 'En fejl er opstået.',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -118,7 +118,7 @@ export const deTranslations: DefaultTranslationsObject = {
       'Fehler beim Neuindizieren der Sammlung {{collection}}. Vorgang abgebrochen.',
     unableToUpdateCount: '{{count}} von {{total}} {{label}} konnte nicht aktualisiert werden.',
     unauthorized: 'Nicht autorisiert - du musst angemeldet sein, um diese Anfrage zu stellen.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Nicht autorisiert, dieser Benutzer hat keinen Zugriff auf das Admin-Panel.',
     unknown: 'Ein unbekannter Fehler ist aufgetreten.',
     unPublishingDocument: 'Es gab ein Problem, dieses Dokument auf Entwurf zu setzen.',
     unspecific: 'Ein Fehler ist aufgetreten.',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -118,6 +118,7 @@ export const deTranslations: DefaultTranslationsObject = {
       'Fehler beim Neuindizieren der Sammlung {{collection}}. Vorgang abgebrochen.',
     unableToUpdateCount: '{{count}} von {{total}} {{label}} konnte nicht aktualisiert werden.',
     unauthorized: 'Nicht autorisiert - du musst angemeldet sein, um diese Anfrage zu stellen.',
+    unauthorizedAdmin: undefined,
     unknown: 'Ein unbekannter Fehler ist aufgetreten.',
     unPublishingDocument: 'Es gab ein Problem, dieses Dokument auf Entwurf zu setzen.',
     unspecific: 'Ein Fehler ist aufgetreten.',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -116,6 +116,7 @@ export const enTranslations = {
     unableToReindexCollection: 'Error reindexing collection {{collection}}. Operation aborted.',
     unableToUpdateCount: 'Unable to update {{count}} out of {{total}} {{label}}.',
     unauthorized: 'Unauthorized, you must be logged in to make this request.',
+    unauthorizedAdmin: 'Unauthorized, this user does not have access to the admin panel.',
     unknown: 'An unknown error has occurred.',
     unPublishingDocument: 'There was a problem while un-publishing this document.',
     unspecific: 'An error has occurred.',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -116,7 +116,7 @@ export const esTranslations: DefaultTranslationsObject = {
       'Error al reindexar la colección {{collection}}. Operación abortada.',
     unableToUpdateCount: 'No se puede actualizar {{count}} de {{total}} {{label}}.',
     unauthorized: 'No autorizado, debes iniciar sesión para realizar esta solicitud.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'No autorizado, este usuario no tiene acceso al panel de administración.',
     unknown: 'Ocurrió un error desconocido.',
     unPublishingDocument: 'Ocurrió un error al despublicar este documento.',
     unspecific: 'Ocurrió un error.',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -116,6 +116,7 @@ export const esTranslations: DefaultTranslationsObject = {
       'Error al reindexar la colección {{collection}}. Operación abortada.',
     unableToUpdateCount: 'No se puede actualizar {{count}} de {{total}} {{label}}.',
     unauthorized: 'No autorizado, debes iniciar sesión para realizar esta solicitud.',
+    unauthorizedAdmin: undefined,
     unknown: 'Ocurrió un error desconocido.',
     unPublishingDocument: 'Ocurrió un error al despublicar este documento.',
     unspecific: 'Ocurrió un error.',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -114,7 +114,7 @@ export const faTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: 'خطا در بازنمایه‌سازی مجموعه {{collection}}. عملیات متوقف شد.',
     unableToUpdateCount: 'امکان به روز رسانی {{count}} خارج از {{total}} {{label}} وجود ندارد.',
     unauthorized: 'درخواست نامعتبر، جهت فرستادن این درخواست باید وارد شوید.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'دسترسی به پیشخوان برای این کاربر مجاز نیست.',
     unknown: 'یک خطای ناشناخته رخ داد.',
     unPublishingDocument: 'هنگام لغو انتشار این سند خطایی رخ داد.',
     unspecific: 'خطایی رخ داد.',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -114,6 +114,7 @@ export const faTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: 'خطا در بازنمایه‌سازی مجموعه {{collection}}. عملیات متوقف شد.',
     unableToUpdateCount: 'امکان به روز رسانی {{count}} خارج از {{total}} {{label}} وجود ندارد.',
     unauthorized: 'درخواست نامعتبر، جهت فرستادن این درخواست باید وارد شوید.',
+    unauthorizedAdmin: undefined,
     unknown: 'یک خطای ناشناخته رخ داد.',
     unPublishingDocument: 'هنگام لغو انتشار این سند خطایی رخ داد.',
     unspecific: 'خطایی رخ داد.',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -119,6 +119,7 @@ export const frTranslations: DefaultTranslationsObject = {
       'Erreur lors de la réindexation de la collection {{collection}}. Opération annulée.',
     unableToUpdateCount: 'Impossible de mettre à jour {{count}} sur {{total}} {{label}}.',
     unauthorized: 'Non autorisé, vous devez être connecté pour effectuer cette demande.',
+    unauthorizedAdmin: undefined,
     unknown: 'Une erreur inconnue s’est produite.',
     unPublishingDocument:
       'Un problème est survenu lors de l’annulation de la publication de ce document.',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -119,7 +119,7 @@ export const frTranslations: DefaultTranslationsObject = {
       'Erreur lors de la réindexation de la collection {{collection}}. Opération annulée.',
     unableToUpdateCount: 'Impossible de mettre à jour {{count}} sur {{total}} {{label}}.',
     unauthorized: 'Non autorisé, vous devez être connecté pour effectuer cette demande.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Non autorisé, cet utilisateur n’a pas accès au panneau d’administration.',
     unknown: 'Une erreur inconnue s’est produite.',
     unPublishingDocument:
       'Un problème est survenu lors de l’annulation de la publication de ce document.',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -113,7 +113,7 @@ export const heTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: 'שגיאה בהחזרת אינדקס של אוסף {{collection}}. הפעולה בוטלה.',
     unableToUpdateCount: 'לא ניתן לעדכן {{count}} מתוך {{total}} {{label}}.',
     unauthorized: 'אין הרשאה, עליך להתחבר כדי לבצע בקשה זו.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'אין הרשאה, משתמש זה אינו יכול לגשת לפאנל הניהול.',
     unknown: 'אירעה שגיאה לא ידועה.',
     unPublishingDocument: 'אירעה בעיה בביטול הפרסום של מסמך זה.',
     unspecific: 'אירעה שגיאה.',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -113,6 +113,7 @@ export const heTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: 'שגיאה בהחזרת אינדקס של אוסף {{collection}}. הפעולה בוטלה.',
     unableToUpdateCount: 'לא ניתן לעדכן {{count}} מתוך {{total}} {{label}}.',
     unauthorized: 'אין הרשאה, עליך להתחבר כדי לבצע בקשה זו.',
+    unauthorizedAdmin: undefined,
     unknown: 'אירעה שגיאה לא ידועה.',
     unPublishingDocument: 'אירעה בעיה בביטול הפרסום של מסמך זה.',
     unspecific: 'אירעה שגיאה.',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -117,7 +117,7 @@ export const hrTranslations: DefaultTranslationsObject = {
       'Pogreška pri ponovnom indeksiranju kolekcije {{collection}}. Operacija je prekinuta.',
     unableToUpdateCount: 'Nije moguće ažurirati {{count}} od {{total}} {{label}}.',
     unauthorized: 'Neovlašteno, morate biti prijavljeni da biste uputili ovaj zahtjev.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Neovlašteno, ovaj korisnik nema pristup administratorskom panelu.',
     unknown: 'Došlo je do nepoznate pogreške.',
     unPublishingDocument: 'Došlo je do problema pri poništavanju objave ovog dokumenta.',
     unspecific: 'Došlo je do pogreške.',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -117,6 +117,7 @@ export const hrTranslations: DefaultTranslationsObject = {
       'Pogreška pri ponovnom indeksiranju kolekcije {{collection}}. Operacija je prekinuta.',
     unableToUpdateCount: 'Nije moguće ažurirati {{count}} od {{total}} {{label}}.',
     unauthorized: 'Neovlašteno, morate biti prijavljeni da biste uputili ovaj zahtjev.',
+    unauthorizedAdmin: undefined,
     unknown: 'Došlo je do nepoznate pogreške.',
     unPublishingDocument: 'Došlo je do problema pri poništavanju objave ovog dokumenta.',
     unspecific: 'Došlo je do pogreške.',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -118,7 +118,7 @@ export const huTranslations: DefaultTranslationsObject = {
       'Hiba a(z) {{collection}} gyűjtemény újraindexelésekor. A művelet megszakítva.',
     unableToUpdateCount: 'Nem sikerült frissíteni {{count}}/{{total}} {{label}}.',
     unauthorized: 'Jogosulatlan, a kéréshez be kell jelentkeznie.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Jogosulatlan, ez a felhasználó nem fér hozzá az admin panelhez.',
     unknown: 'Ismeretlen hiba történt.',
     unPublishingDocument: 'Hiba történt a dokumentum közzétételének visszavonása közben.',
     unspecific: 'Hiba történt.',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -118,6 +118,7 @@ export const huTranslations: DefaultTranslationsObject = {
       'Hiba a(z) {{collection}} gyűjtemény újraindexelésekor. A művelet megszakítva.',
     unableToUpdateCount: 'Nem sikerült frissíteni {{count}}/{{total}} {{label}}.',
     unauthorized: 'Jogosulatlan, a kéréshez be kell jelentkeznie.',
+    unauthorizedAdmin: undefined,
     unknown: 'Ismeretlen hiba történt.',
     unPublishingDocument: 'Hiba történt a dokumentum közzétételének visszavonása közben.',
     unspecific: 'Hiba történt.',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -118,7 +118,8 @@ export const itTranslations: DefaultTranslationsObject = {
       'Errore durante la reindicizzazione della collezione {{collection}}. Operazione annullata.',
     unableToUpdateCount: 'Impossibile aggiornare {{count}} su {{total}} {{label}}.',
     unauthorized: 'Non autorizzato, devi essere loggato per effettuare questa richiesta.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin:
+      'Non autorizzato, questo utente non ha accesso al pannello di amministrazione.',
     unknown: 'Si è verificato un errore sconosciuto.',
     unPublishingDocument:
       "Si è verificato un problema durante l'annullamento della pubblicazione di questo documento.",

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -118,6 +118,7 @@ export const itTranslations: DefaultTranslationsObject = {
       'Errore durante la reindicizzazione della collezione {{collection}}. Operazione annullata.',
     unableToUpdateCount: 'Impossibile aggiornare {{count}} su {{total}} {{label}}.',
     unauthorized: 'Non autorizzato, devi essere loggato per effettuare questa richiesta.',
+    unauthorizedAdmin: undefined,
     unknown: 'Si è verificato un errore sconosciuto.',
     unPublishingDocument:
       "Si è verificato un problema durante l'annullamento della pubblicazione di questo documento.",

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -117,6 +117,7 @@ export const jaTranslations: DefaultTranslationsObject = {
       'コレクション {{collection}} の再インデックス中にエラーが発生しました。操作は中止されました。',
     unableToUpdateCount: '{{total}} {{label}} のうち {{count}} 個を更新できません。',
     unauthorized: '認証されていません。このリクエストを行うにはログインが必要です。',
+    unauthorizedAdmin: undefined,
     unknown: '不明なエラーが発生しました。',
     unPublishingDocument: 'このデータを非公開する際に問題が発生しました。',
     unspecific: 'エラーが発生しました。',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -117,7 +117,7 @@ export const jaTranslations: DefaultTranslationsObject = {
       'コレクション {{collection}} の再インデックス中にエラーが発生しました。操作は中止されました。',
     unableToUpdateCount: '{{total}} {{label}} のうち {{count}} 個を更新できません。',
     unauthorized: '認証されていません。このリクエストを行うにはログインが必要です。',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: '管理画面へのアクセス権がないため、認証されていません。',
     unknown: '不明なエラーが発生しました。',
     unPublishingDocument: 'このデータを非公開する際に問題が発生しました。',
     unspecific: 'エラーが発生しました。',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -116,7 +116,7 @@ export const koTranslations: DefaultTranslationsObject = {
       '{{collection}} 컬렉션의 재인덱싱 중 오류가 발생했습니다. 작업이 중단되었습니다.',
     unableToUpdateCount: '총 {{total}}개 중 {{count}}개의 {{label}}을(를) 업데이트할 수 없습니다.',
     unauthorized: '권한 없음, 이 요청을 수행하려면 로그인해야 합니다.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: '관리자 패널에 액세스할 수 없습니다.',
     unknown: '알 수 없는 오류가 발생했습니다.',
     unPublishingDocument: '이 문서의 게시 취소 중에 문제가 발생했습니다.',
     unspecific: '오류가 발생했습니다.',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -116,6 +116,7 @@ export const koTranslations: DefaultTranslationsObject = {
       '{{collection}} 컬렉션의 재인덱싱 중 오류가 발생했습니다. 작업이 중단되었습니다.',
     unableToUpdateCount: '총 {{total}}개 중 {{count}}개의 {{label}}을(를) 업데이트할 수 없습니다.',
     unauthorized: '권한 없음, 이 요청을 수행하려면 로그인해야 합니다.',
+    unauthorizedAdmin: undefined,
     unknown: '알 수 없는 오류가 발생했습니다.',
     unPublishingDocument: '이 문서의 게시 취소 중에 문제가 발생했습니다.',
     unspecific: '오류가 발생했습니다.',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -116,7 +116,7 @@ export const myTranslations: DefaultTranslationsObject = {
       '{{collection}} စုစည်းမှုကို ပြန်လည်အညွှန်းပြုလုပ်ခြင်း အမှားရှိနေသည်။ လုပ်ဆောင်မှုကို ဖျက်သိမ်းခဲ့သည်။',
     unableToUpdateCount: '{{total}} {{label}} မှ {{count}} ကို အပ်ဒိတ်လုပ်၍မရပါ။',
     unauthorized: 'အခွင့်မရှိပါ။ ဤတောင်းဆိုချက်ကို လုပ်ဆောင်နိုင်ရန် သင်သည် လော့ဂ်အင်ဝင်ရပါမည်။',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'အခွင့်မရှိပါ။ ဤအကောင့်အသုံးပြုသူသည် အဆင့်မပြုပါနိုင်ပါ။',
     unknown: 'ဘာမှန်းမသိသော error တက်သွားပါသည်။',
     unPublishingDocument: 'ဖိုင်ကို ပြန်လည့် သိမ်းဆည်းခြင်းမှာ ပြဿနာရှိနေသည်။',
     unspecific: 'Error တက်နေပါသည်။',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -116,6 +116,7 @@ export const myTranslations: DefaultTranslationsObject = {
       '{{collection}} စုစည်းမှုကို ပြန်လည်အညွှန်းပြုလုပ်ခြင်း အမှားရှိနေသည်။ လုပ်ဆောင်မှုကို ဖျက်သိမ်းခဲ့သည်။',
     unableToUpdateCount: '{{total}} {{label}} မှ {{count}} ကို အပ်ဒိတ်လုပ်၍မရပါ။',
     unauthorized: 'အခွင့်မရှိပါ။ ဤတောင်းဆိုချက်ကို လုပ်ဆောင်နိုင်ရန် သင်သည် လော့ဂ်အင်ဝင်ရပါမည်။',
+    unauthorizedAdmin: undefined,
     unknown: 'ဘာမှန်းမသိသော error တက်သွားပါသည်။',
     unPublishingDocument: 'ဖိုင်ကို ပြန်လည့် သိမ်းဆည်းခြင်းမှာ ပြဿနာရှိနေသည်။',
     unspecific: 'Error တက်နေပါသည်။',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -116,7 +116,7 @@ export const nbTranslations: DefaultTranslationsObject = {
       'Feil ved reindeksering av samlingen {{collection}}. Operasjonen ble avbrutt.',
     unableToUpdateCount: 'Kan ikke oppdatere {{count}} av {{total}} {{label}}.',
     unauthorized: 'Uautorisert, du må være innlogget for å gjøre denne forespørselen.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Uautorisert, denne brukeren har ikke tilgang til kontrollpanelet.',
     unknown: 'En ukjent feil har oppstått.',
     unPublishingDocument: 'Det oppstod et problem under avpublisering av dokumentet.',
     unspecific: 'En feil har oppstått.',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -116,6 +116,7 @@ export const nbTranslations: DefaultTranslationsObject = {
       'Feil ved reindeksering av samlingen {{collection}}. Operasjonen ble avbrutt.',
     unableToUpdateCount: 'Kan ikke oppdatere {{count}} av {{total}} {{label}}.',
     unauthorized: 'Uautorisert, du må være innlogget for å gjøre denne forespørselen.',
+    unauthorizedAdmin: undefined,
     unknown: 'En ukjent feil har oppstått.',
     unPublishingDocument: 'Det oppstod et problem under avpublisering av dokumentet.',
     unspecific: 'En feil har oppstått.',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -117,6 +117,7 @@ export const nlTranslations: DefaultTranslationsObject = {
       'Fout bij het herindexeren van de collectie {{collection}}. De operatie is afgebroken.',
     unableToUpdateCount: 'Kan {{count}} van {{total}} {{label}} niet updaten.',
     unauthorized: 'Ongeautoriseerd, u moet ingelogd zijn om dit verzoek te doen.',
+    unauthorizedAdmin: undefined,
     unknown: 'Er is een onbekende fout opgetreden.',
     unPublishingDocument: 'Er was een probleem met het depubliceren van dit document.',
     unspecific: 'Er is een fout opgetreden.',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -117,7 +117,8 @@ export const nlTranslations: DefaultTranslationsObject = {
       'Fout bij het herindexeren van de collectie {{collection}}. De operatie is afgebroken.',
     unableToUpdateCount: 'Kan {{count}} van {{total}} {{label}} niet updaten.',
     unauthorized: 'Ongeautoriseerd, u moet ingelogd zijn om dit verzoek te doen.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin:
+      'Ongeautoriseerd, deze gebruiker heeft geen toegang tot het beheerderspaneel.',
     unknown: 'Er is een onbekende fout opgetreden.',
     unPublishingDocument: 'Er was een probleem met het depubliceren van dit document.',
     unspecific: 'Er is een fout opgetreden.',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -116,7 +116,7 @@ export const plTranslations: DefaultTranslationsObject = {
       'Błąd podczas ponownego indeksowania kolekcji {{collection}}. Operacja została przerwana.',
     unableToUpdateCount: 'Nie można zaktualizować {{count}} z {{total}} {{label}}.',
     unauthorized: 'Brak dostępu, musisz być zalogowany.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Brak dostępu, ten użytkownik nie ma dostępu do panelu administracyjnego.',
     unknown: 'Wystąpił nieznany błąd.',
     unPublishingDocument: 'Wystąpił problem podczas cofania publikacji tego dokumentu.',
     unspecific: 'Wystąpił błąd',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -116,6 +116,7 @@ export const plTranslations: DefaultTranslationsObject = {
       'Błąd podczas ponownego indeksowania kolekcji {{collection}}. Operacja została przerwana.',
     unableToUpdateCount: 'Nie można zaktualizować {{count}} z {{total}} {{label}}.',
     unauthorized: 'Brak dostępu, musisz być zalogowany.',
+    unauthorizedAdmin: undefined,
     unknown: 'Wystąpił nieznany błąd.',
     unPublishingDocument: 'Wystąpił problem podczas cofania publikacji tego dokumentu.',
     unspecific: 'Wystąpił błąd',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -116,7 +116,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: 'Erro ao reindexar a coleção {{collection}}. Operação abortada.',
     unableToUpdateCount: 'Não foi possível atualizar {{count}} de {{total}} {{label}}.',
     unauthorized: 'Não autorizado. Você deve estar logado para fazer essa requisição',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Não autorizado, esse usuário não tem acesso ao painel de administração.',
     unknown: 'Ocorreu um erro desconhecido.',
     unPublishingDocument: 'Ocorreu um problema ao despublicar esse documento',
     unspecific: 'Ocorreu um erro.',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -116,6 +116,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: 'Erro ao reindexar a coleção {{collection}}. Operação abortada.',
     unableToUpdateCount: 'Não foi possível atualizar {{count}} de {{total}} {{label}}.',
     unauthorized: 'Não autorizado. Você deve estar logado para fazer essa requisição',
+    unauthorizedAdmin: undefined,
     unknown: 'Ocorreu um erro desconhecido.',
     unPublishingDocument: 'Ocorreu um problema ao despublicar esse documento',
     unspecific: 'Ocorreu um erro.',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -118,6 +118,7 @@ export const roTranslations: DefaultTranslationsObject = {
       'Eroare la reindexarea colecției {{collection}}. Operațiune anulată.',
     unableToUpdateCount: 'Nu se poate șterge {{count}} din {{total}} {{label}}.',
     unauthorized: 'neautorizat, trebuie să vă conectați pentru a face această cerere.',
+    unauthorizedAdmin: undefined,
     unknown: 'S-a produs o eroare necunoscută.',
     unPublishingDocument: 'A existat o problemă în timpul nepublicării acestui document.',
     unspecific: 'S-a produs o eroare.',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -117,8 +117,8 @@ export const roTranslations: DefaultTranslationsObject = {
     unableToReindexCollection:
       'Eroare la reindexarea colecției {{collection}}. Operațiune anulată.',
     unableToUpdateCount: 'Nu se poate șterge {{count}} din {{total}} {{label}}.',
-    unauthorized: 'neautorizat, trebuie să vă conectați pentru a face această cerere.',
-    unauthorizedAdmin: undefined,
+    unauthorized: 'Neautorizat, trebuie să vă conectați pentru a face această cerere.',
+    unauthorizedAdmin: 'Neautorizat, acest utilizator nu are acces la panoul de administrare.',
     unknown: 'S-a produs o eroare necunoscută.',
     unPublishingDocument: 'A existat o problemă în timpul nepublicării acestui document.',
     unspecific: 'S-a produs o eroare.',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -117,7 +117,7 @@ export const rsTranslations: DefaultTranslationsObject = {
       'Грешка при реиндексирању колекције {{collection}}. Операција је прекинута.',
     unableToUpdateCount: 'Није могуће ажурирати {{count}} од {{total}} {{label}}.',
     unauthorized: 'Нисте ауторизовани да бисте упутили овај захтев.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Немате приступ администраторском панелу.',
     unknown: 'Дошло је до непознате грешке.',
     unPublishingDocument: 'Постоји проблем при поништавању објаве овог документа.',
     unspecific: 'Дошло је до грешке.',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -117,6 +117,7 @@ export const rsTranslations: DefaultTranslationsObject = {
       'Грешка при реиндексирању колекције {{collection}}. Операција је прекинута.',
     unableToUpdateCount: 'Није могуће ажурирати {{count}} од {{total}} {{label}}.',
     unauthorized: 'Нисте ауторизовани да бисте упутили овај захтев.',
+    unauthorizedAdmin: undefined,
     unknown: 'Дошло је до непознате грешке.',
     unPublishingDocument: 'Постоји проблем при поништавању објаве овог документа.',
     unspecific: 'Дошло је до грешке.',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -117,6 +117,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
       'Greška pri reindeksiranju kolekcije {{collection}}. Operacija je prekinuta.',
     unableToUpdateCount: 'Nije moguće ažurirati {{count}} od {{total}} {{label}}.',
     unauthorized: 'Niste autorizovani da biste uputili ovaj zahtev.',
+    unauthorizedAdmin: undefined,
     unknown: 'Došlo je do nepoznate greške.',
     unPublishingDocument: 'Postoji problem pri poništavanju objave ovog dokumenta.',
     unspecific: 'Došlo je do greške.',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -117,7 +117,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
       'Greška pri reindeksiranju kolekcije {{collection}}. Operacija je prekinuta.',
     unableToUpdateCount: 'Nije moguće ažurirati {{count}} od {{total}} {{label}}.',
     unauthorized: 'Niste autorizovani da biste uputili ovaj zahtev.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Nemate pristup administratorskom panelu.',
     unknown: 'Došlo je do nepoznate greške.',
     unPublishingDocument: 'Postoji problem pri poništavanju objave ovog dokumenta.',
     unspecific: 'Došlo je do greške.',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -117,6 +117,7 @@ export const ruTranslations: DefaultTranslationsObject = {
       'Ошибка при переиндексации коллекции {{collection}}. Операция прервана.',
     unableToUpdateCount: 'Не удалось обновить {{count}} из {{total}} {{label}}.',
     unauthorized: 'Нет доступа, вы должны войти, чтобы сделать этот запрос.',
+    unauthorizedAdmin: undefined,
     unknown: 'Произошла неизвестная ошибка.',
     unPublishingDocument: 'При отмене публикации этого документа возникла проблема.',
     unspecific: 'Произошла ошибка.',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -117,7 +117,7 @@ export const ruTranslations: DefaultTranslationsObject = {
       'Ошибка при переиндексации коллекции {{collection}}. Операция прервана.',
     unableToUpdateCount: 'Не удалось обновить {{count}} из {{total}} {{label}}.',
     unauthorized: 'Нет доступа, вы должны войти, чтобы сделать этот запрос.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Нет доступа, этот пользователь не имеет доступа к панели администратора.',
     unknown: 'Произошла неизвестная ошибка.',
     unPublishingDocument: 'При отмене публикации этого документа возникла проблема.',
     unspecific: 'Произошла ошибка.',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -117,6 +117,7 @@ export const skTranslations: DefaultTranslationsObject = {
       'Chyba pri reindexácii kolekcie {{collection}}. Operácia bola prerušená.',
     unableToUpdateCount: 'Nie je možné aktualizovať {{count}} z {{total}} {{label}}.',
     unauthorized: 'Neautorizováno, pro zadání tohoto požadavku musíte být přihlášeni.',
+    unauthorizedAdmin: undefined,
     unknown: 'Došlo k neznámej chybe.',
     unPublishingDocument: 'Pri zrušení publikovania tohto dokumentu došlo k chybe.',
     unspecific: 'Došlo k chybe.',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -117,7 +117,8 @@ export const skTranslations: DefaultTranslationsObject = {
       'Chyba pri reindexácii kolekcie {{collection}}. Operácia bola prerušená.',
     unableToUpdateCount: 'Nie je možné aktualizovať {{count}} z {{total}} {{label}}.',
     unauthorized: 'Neautorizováno, pro zadání tohoto požadavku musíte být přihlášeni.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin:
+      'Neoprávnený prístup, tento používateľ nemá prístup k administrátorskému panelu.',
     unknown: 'Došlo k neznámej chybe.',
     unPublishingDocument: 'Pri zrušení publikovania tohto dokumentu došlo k chybe.',
     unspecific: 'Došlo k chybe.',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -116,6 +116,7 @@ export const slTranslations: DefaultTranslationsObject = {
       'Napaka pri reindeksiranju zbirke {{collection}}. Operacija je bila prekinjena.',
     unableToUpdateCount: 'Ni bilo mogoče posodobiti {{count}} od {{total}} {{label}}.',
     unauthorized: 'Neavtorizirano, za to zahtevo morate biti prijavljeni.',
+    unauthorizedAdmin: undefined,
     unknown: 'Prišlo je do neznane napake.',
     unPublishingDocument: 'Pri umiku objave tega dokumenta je prišlo do težave.',
     unspecific: 'Prišlo je do napake.',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -116,7 +116,7 @@ export const slTranslations: DefaultTranslationsObject = {
       'Napaka pri reindeksiranju zbirke {{collection}}. Operacija je bila prekinjena.',
     unableToUpdateCount: 'Ni bilo mogoče posodobiti {{count}} od {{total}} {{label}}.',
     unauthorized: 'Neavtorizirano, za to zahtevo morate biti prijavljeni.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Neavtorizirano, ta uporabnik nima dostopa do skrbniškega vmesnika.',
     unknown: 'Prišlo je do neznane napake.',
     unPublishingDocument: 'Pri umiku objave tega dokumenta je prišlo do težave.',
     unspecific: 'Prišlo je do napake.',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -116,6 +116,7 @@ export const svTranslations: DefaultTranslationsObject = {
       'Fel vid omindexering av samlingen {{collection}}. Operationen avbröts.',
     unableToUpdateCount: 'Det gick inte att uppdatera {{count}} av {{total}} {{label}}.',
     unauthorized: 'Obehörig, du måste vara inloggad för att göra denna begäran.',
+    unauthorizedAdmin: undefined,
     unknown: 'Ett okänt fel har uppstått.',
     unPublishingDocument: 'Det uppstod ett problem när det här dokumentet skulle avpubliceras.',
     unspecific: 'Ett fel har uppstått.',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -116,7 +116,7 @@ export const svTranslations: DefaultTranslationsObject = {
       'Fel vid omindexering av samlingen {{collection}}. Operationen avbröts.',
     unableToUpdateCount: 'Det gick inte att uppdatera {{count}} av {{total}} {{label}}.',
     unauthorized: 'Obehörig, du måste vara inloggad för att göra denna begäran.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Obehörig, denna användare har inte åtkomst till adminpanelen.',
     unknown: 'Ett okänt fel har uppstått.',
     unPublishingDocument: 'Det uppstod ett problem när det här dokumentet skulle avpubliceras.',
     unspecific: 'Ett fel har uppstått.',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -114,7 +114,7 @@ export const thTranslations: DefaultTranslationsObject = {
       'เกิดข้อผิดพลาดในการจัดทำดัชนีใหม่ของคอลเลกชัน {{collection}}. การดำเนินการถูกยกเลิก',
     unableToUpdateCount: 'ไม่สามารถอัปเดต {{count}} จาก {{total}} {{label}}',
     unauthorized: 'คุณไม่ได้รับอนุญาต กรุณาเข้าสู่ระบบเพื่อทำคำขอนี้',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'คุณไม่ได้รับอนุญาตให้เข้าถึงแผงผู้ดูแล',
     unknown: 'เกิดปัญหาบางอย่างที่ไม่ทราบสาเหตุ',
     unPublishingDocument: 'เกิดปัญหาระหว่างการยกเลิกการเผยแพร่เอกสารนี้',
     unspecific: 'เกิดปัญหาบางอย่าง',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -114,6 +114,7 @@ export const thTranslations: DefaultTranslationsObject = {
       'เกิดข้อผิดพลาดในการจัดทำดัชนีใหม่ของคอลเลกชัน {{collection}}. การดำเนินการถูกยกเลิก',
     unableToUpdateCount: 'ไม่สามารถอัปเดต {{count}} จาก {{total}} {{label}}',
     unauthorized: 'คุณไม่ได้รับอนุญาต กรุณาเข้าสู่ระบบเพื่อทำคำขอนี้',
+    unauthorizedAdmin: undefined,
     unknown: 'เกิดปัญหาบางอย่างที่ไม่ทราบสาเหตุ',
     unPublishingDocument: 'เกิดปัญหาระหว่างการยกเลิกการเผยแพร่เอกสารนี้',
     unspecific: 'เกิดปัญหาบางอย่าง',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -117,6 +117,7 @@ export const trTranslations: DefaultTranslationsObject = {
       '{{collection}} koleksiyonunun yeniden indekslenmesinde hata oluştu. İşlem durduruldu.',
     unableToUpdateCount: '{{total}} {{label}} içinden {{count}} güncellenemiyor.',
     unauthorized: 'Bu işlemi gerçekleştirmek için lütfen giriş yapın.',
+    unauthorizedAdmin: undefined,
     unknown: 'Bilinmeyen bir hata oluştu.',
     unPublishingDocument: 'Geçerli döküman yayından kaldırılırken bir sorun oluştu.',
     unspecific: 'Bir hata oluştu.',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -117,7 +117,7 @@ export const trTranslations: DefaultTranslationsObject = {
       '{{collection}} koleksiyonunun yeniden indekslenmesinde hata oluştu. İşlem durduruldu.',
     unableToUpdateCount: '{{total}} {{label}} içinden {{count}} güncellenemiyor.',
     unauthorized: 'Bu işlemi gerçekleştirmek için lütfen giriş yapın.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Bu kullanıcı yönetici paneline erişim iznine sahip değil.',
     unknown: 'Bilinmeyen bir hata oluştu.',
     unPublishingDocument: 'Geçerli döküman yayından kaldırılırken bir sorun oluştu.',
     unspecific: 'Bir hata oluştu.',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -117,7 +117,7 @@ export const ukTranslations: DefaultTranslationsObject = {
       'Помилка при повторному індексуванні колекції {{collection}}. Операцію скасовано.',
     unableToUpdateCount: 'Не вдалося оновити {{count}} із {{total}} {{label}}.',
     unauthorized: 'Немає доступу, ви повинні увійти, щоб виконати цей запит.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Немає доступу, цей користувач не має доступу до панелі адміністратора.',
     unknown: 'Виникла невідома помилка.',
     unPublishingDocument: 'Під час скасування публікації даного документа виникла помилка.',
     unspecific: 'Виникла помилка.',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -117,6 +117,7 @@ export const ukTranslations: DefaultTranslationsObject = {
       'Помилка при повторному індексуванні колекції {{collection}}. Операцію скасовано.',
     unableToUpdateCount: 'Не вдалося оновити {{count}} із {{total}} {{label}}.',
     unauthorized: 'Немає доступу, ви повинні увійти, щоб виконати цей запит.',
+    unauthorizedAdmin: undefined,
     unknown: 'Виникла невідома помилка.',
     unPublishingDocument: 'Під час скасування публікації даного документа виникла помилка.',
     unspecific: 'Виникла помилка.',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -116,6 +116,7 @@ export const viTranslations: DefaultTranslationsObject = {
       'Lỗi khi tái lập chỉ mục bộ sưu tập {{collection}}. Quá trình bị hủy.',
     unableToUpdateCount: 'Không thể cập nhật {{count}} trên {{total}} {{label}}.',
     unauthorized: 'Lỗi - Bạn cần phải đăng nhập trước khi gửi request sau.',
+    unauthorizedAdmin: undefined,
     unknown: 'Lỗi - Không xác định (unknown error).',
     unPublishingDocument: 'Lỗi - Đã xảy ra vấn để khi ẩn bản tài liệu.',
     unspecific: 'Lỗi - Đã xảy ra (unspecific error).',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -116,7 +116,7 @@ export const viTranslations: DefaultTranslationsObject = {
       'Lỗi khi tái lập chỉ mục bộ sưu tập {{collection}}. Quá trình bị hủy.',
     unableToUpdateCount: 'Không thể cập nhật {{count}} trên {{total}} {{label}}.',
     unauthorized: 'Lỗi - Bạn cần phải đăng nhập trước khi gửi request sau.',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: 'Lỗi - Người dùng không có quyền truy cập vào bảng điều khiển.',
     unknown: 'Lỗi - Không xác định (unknown error).',
     unPublishingDocument: 'Lỗi - Đã xảy ra vấn để khi ẩn bản tài liệu.',
     unspecific: 'Lỗi - Đã xảy ra (unspecific error).',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -111,7 +111,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: '重新索引集合 {{collection}} 时出错。操作已中止。',
     unableToUpdateCount: '无法更新 {{count}} 个，共 {{total}} 个 {{label}}。',
     unauthorized: '未经授权，您必须登录才能提出这个请求。',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: '未经授权，此用户无权访问管理面板。',
     unknown: '发生了一个未知的错误。',
     unPublishingDocument: '取消发布此文件时出现了问题。',
     unspecific: '发生了一个错误。',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -111,6 +111,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: '重新索引集合 {{collection}} 时出错。操作已中止。',
     unableToUpdateCount: '无法更新 {{count}} 个，共 {{total}} 个 {{label}}。',
     unauthorized: '未经授权，您必须登录才能提出这个请求。',
+    unauthorizedAdmin: undefined,
     unknown: '发生了一个未知的错误。',
     unPublishingDocument: '取消发布此文件时出现了问题。',
     unspecific: '发生了一个错误。',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -111,7 +111,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: '重新索引集合 {{collection}} 時出現錯誤。操作已中止。',
     unableToUpdateCount: '無法從 {{total}} 個中更新 {{count}} 個 {{label}}。',
     unauthorized: '未經授權，您必須登錄才能提出這個請求。',
-    unauthorizedAdmin: undefined,
+    unauthorizedAdmin: '未經授權，此使用者無法訪問管理面板。',
     unknown: '發生了一個未知的錯誤。',
     unPublishingDocument: '取消發布此文件時出現了問題。',
     unspecific: '發生了一個錯誤。',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -111,6 +111,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     unableToReindexCollection: '重新索引集合 {{collection}} 時出現錯誤。操作已中止。',
     unableToUpdateCount: '無法從 {{total}} 個中更新 {{count}} 個 {{label}}。',
     unauthorized: '未經授權，您必須登錄才能提出這個請求。',
+    unauthorizedAdmin: undefined,
     unknown: '發生了一個未知的錯誤。',
     unPublishingDocument: '取消發布此文件時出現了問題。',
     unspecific: '發生了一個錯誤。',

--- a/packages/ui/src/providers/Auth/index.tsx
+++ b/packages/ui/src/providers/Auth/index.tsx
@@ -196,7 +196,7 @@ export function AuthProvider({
 
   const logOut = useCallback(async () => {
     try {
-      await requests.post(`${serverURL}${apiRoute}/${userSlug}/logout`)
+      await requests.post(`${serverURL}${apiRoute}/${user.collection}/logout`)
       setNewUser(null)
       revokeTokenAndExpire()
       return true
@@ -204,7 +204,7 @@ export function AuthProvider({
       toast.error(`Logging out failed: ${e.message}`)
       return false
     }
-  }, [apiRoute, revokeTokenAndExpire, serverURL, setNewUser, userSlug])
+  }, [apiRoute, revokeTokenAndExpire, serverURL, setNewUser, user])
 
   const refreshPermissions = useCallback(
     async ({ locale }: { locale?: string } = {}) => {
@@ -309,7 +309,7 @@ export function AuthProvider({
         clearTimeout(forceLogOut)
       }
     }
-  }, [tokenExpiration, openModal, i18n, setNewUser, user])
+  }, [tokenExpiration, openModal, i18n, setNewUser, user, redirectToInactivityRoute])
 
   return (
     <Context.Provider

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -21,9 +21,11 @@ import {
   hiddenAccessCountSlug,
   hiddenAccessSlug,
   hiddenFieldsSlug,
-  noAdminAccessEmail,
+  nonAdminEmail,
   nonAdminUserEmail,
   nonAdminUserSlug,
+  publicUserEmail,
+  publicUsersSlug,
   readNotUpdateGlobalSlug,
   readOnlyGlobalSlug,
   readOnlySlug,
@@ -80,7 +82,7 @@ export default buildConfigWithDefaults({
       access: {
         // admin:  () => true,
         admin: async ({ req }) => {
-          if (req.user?.email === noAdminAccessEmail) {
+          if (req.user?.email === nonAdminEmail) {
             return false
           }
 
@@ -109,7 +111,7 @@ export default buildConfigWithDefaults({
       ],
     },
     {
-      slug: nonAdminUserSlug,
+      slug: publicUsersSlug,
       auth: true,
       fields: [],
     },
@@ -617,15 +619,15 @@ export default buildConfigWithDefaults({
     await payload.create({
       collection: 'users',
       data: {
-        email: noAdminAccessEmail,
+        email: nonAdminEmail,
         password: 'test',
       },
     })
 
     await payload.create({
-      collection: nonAdminUserSlug,
+      collection: publicUsersSlug,
       data: {
-        email: nonAdminUserEmail,
+        email: publicUserEmail,
         password: 'test',
       },
     })

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -68,667 +68,672 @@ function isUser(user: Config['user']): user is {
   return user?.collection === 'users'
 }
 
-export default buildConfigWithDefaults({
-  admin: {
-    autoLogin: false,
-    user: 'users',
-    importMap: {
-      baseDir: path.resolve(dirname),
+export default buildConfigWithDefaults(
+  {
+    admin: {
+      autoLogin: false,
+      user: 'users',
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
-  },
-  collections: [
-    {
-      slug: 'users',
-      access: {
-        // admin:  () => true,
-        admin: async ({ req }) => {
-          if (req.user?.email === nonAdminEmail) {
-            return false
-          }
+    collections: [
+      {
+        slug: 'users',
+        access: {
+          // admin:  () => true,
+          admin: async ({ req }) => {
+            if (req.user?.email === nonAdminEmail) {
+              return false
+            }
 
-          return new Promise((resolve) => {
-            // Simulate a request to an external service to determine access, i.e. another instance of Payload
-            setTimeout(resolve, 50, true) // set to 'true' or 'false' here to simulate the response
-          })
-        },
-      },
-      auth: true,
-      fields: [
-        {
-          name: 'roles',
-          type: 'select',
-          access: {
-            create: ({ req }) => isUser(req.user) && req.user?.roles?.includes('admin'),
-            read: () => false,
-            update: ({ req }) => {
-              return isUser(req.user) && req.user?.roles?.includes('admin')
-            },
-          },
-          defaultValue: ['user'],
-          hasMany: true,
-          options: ['admin', 'user'],
-        },
-      ],
-    },
-    {
-      slug: publicUsersSlug,
-      auth: true,
-      fields: [],
-    },
-    {
-      slug,
-      access: {
-        ...openAccess,
-        update: () => false,
-      },
-      fields: [
-        {
-          name: 'restrictedField',
-          type: 'text',
-          access: {
-            read: () => false,
-            update: () => false,
+            return new Promise((resolve) => {
+              // Simulate a request to an external service to determine access, i.e. another instance of Payload
+              setTimeout(resolve, 50, true) // set to 'true' or 'false' here to simulate the response
+            })
           },
         },
-        {
-          name: 'group',
-          type: 'group',
-          fields: [
-            {
-              name: 'restrictedGroupText',
-              type: 'text',
-              access: {
-                create: () => false,
-                read: () => false,
-                update: () => false,
+        auth: true,
+        fields: [
+          {
+            name: 'roles',
+            type: 'select',
+            access: {
+              create: ({ req }) => isUser(req.user) && req.user?.roles?.includes('admin'),
+              read: () => false,
+              update: ({ req }) => {
+                return isUser(req.user) && req.user?.roles?.includes('admin')
               },
             },
-          ],
-        },
-        {
-          type: 'row',
-          fields: [
-            {
-              name: 'restrictedRowText',
-              type: 'text',
-              access: {
-                create: () => false,
-                read: () => false,
-                update: () => false,
-              },
-            },
-          ],
-        },
-        {
-          type: 'collapsible',
-          fields: [
-            {
-              name: 'restrictedCollapsibleText',
-              type: 'text',
-              access: {
-                create: () => false,
-                read: () => false,
-                update: () => false,
-              },
-            },
-          ],
-          label: 'Access',
-        },
-      ],
-    },
-    {
-      slug: unrestrictedSlug,
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-        {
-          name: 'userRestrictedDocs',
-          type: 'relationship',
-          hasMany: true,
-          relationTo: userRestrictedCollectionSlug,
-        },
-        {
-          name: 'createNotUpdateDocs',
-          type: 'relationship',
-          hasMany: true,
-          relationTo: createNotUpdateCollectionSlug,
-        },
-      ],
-    },
-    {
-      slug: 'relation-restricted',
-      access: {
-        read: () => true,
-      },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-        {
-          name: 'post',
-          type: 'relationship',
-          relationTo: slug,
-        },
-      ],
-    },
-    {
-      slug: fullyRestrictedSlug,
-      access: {
-        create: () => false,
-        delete: () => false,
-        read: () => false,
-        update: () => false,
-      },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-    },
-    {
-      slug: readOnlySlug,
-      access: {
-        create: () => false,
-        delete: () => false,
-        read: () => true,
-        update: () => false,
-      },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-    },
-    {
-      slug: userRestrictedCollectionSlug,
-      access: {
-        create: () => true,
-        delete: () => false,
-        read: () => true,
-        update: ({ req }) => ({
-          name: {
-            equals: req.user?.email,
+            defaultValue: ['user'],
+            hasMany: true,
+            options: ['admin', 'user'],
           },
-        }),
+        ],
       },
-      admin: {
-        useAsTitle: 'name',
+      {
+        slug: publicUsersSlug,
+        auth: true,
+        fields: [],
       },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
+      {
+        slug,
+        access: {
+          ...openAccess,
+          update: () => false,
         },
-      ],
-    },
-    {
-      slug: createNotUpdateCollectionSlug,
-      access: {
-        create: () => true,
-        delete: () => false,
-        read: () => true,
-        update: () => false,
-      },
-      admin: {
-        useAsTitle: 'name',
-      },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-    },
-    {
-      slug: restrictedVersionsSlug,
-      access: {
-        read: ({ req: { user } }) => {
-          if (user) {
-            return true
-          }
-
-          return {
-            hidden: {
-              not_equals: true,
+        fields: [
+          {
+            name: 'restrictedField',
+            type: 'text',
+            access: {
+              read: () => false,
+              update: () => false,
             },
-          }
-        },
-        readVersions: ({ req: { user } }) => {
-          if (user) {
-            return true
-          }
-
-          return {
-            'version.hidden': {
-              not_equals: true,
-            },
-          }
-        },
-      },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-        {
-          name: 'hidden',
-          type: 'checkbox',
-          hidden: true,
-        },
-      ],
-      versions: true,
-    },
-    {
-      slug: siblingDataSlug,
-      access: openAccess,
-      fields: [
-        {
-          name: 'array',
-          type: 'array',
-          fields: [
-            {
-              type: 'row',
-              fields: [
-                {
-                  name: 'allowPublicReadability',
-                  type: 'checkbox',
-                  label: 'Allow Public Readability',
+          },
+          {
+            name: 'group',
+            type: 'group',
+            fields: [
+              {
+                name: 'restrictedGroupText',
+                type: 'text',
+                access: {
+                  create: () => false,
+                  read: () => false,
+                  update: () => false,
                 },
-                {
-                  name: 'text',
-                  type: 'text',
-                  access: {
-                    read: PublicReadabilityAccess,
-                  },
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      slug: relyOnRequestHeadersSlug,
-      access: {
-        create: UseRequestHeadersAccess,
-        delete: UseRequestHeadersAccess,
-        read: UseRequestHeadersAccess,
-        update: UseRequestHeadersAccess,
-      },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-    },
-    {
-      slug: docLevelAccessSlug,
-      access: {
-        delete: () => ({
-          and: [
-            {
-              approvedForRemoval: {
-                equals: true,
               },
-            },
-          ],
-        }),
+            ],
+          },
+          {
+            type: 'row',
+            fields: [
+              {
+                name: 'restrictedRowText',
+                type: 'text',
+                access: {
+                  create: () => false,
+                  read: () => false,
+                  update: () => false,
+                },
+              },
+            ],
+          },
+          {
+            type: 'collapsible',
+            fields: [
+              {
+                name: 'restrictedCollapsibleText',
+                type: 'text',
+                access: {
+                  create: () => false,
+                  read: () => false,
+                  update: () => false,
+                },
+              },
+            ],
+            label: 'Access',
+          },
+        ],
       },
-      fields: [
-        {
-          name: 'approvedForRemoval',
-          type: 'checkbox',
-          defaultValue: false,
+      {
+        slug: unrestrictedSlug,
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+          {
+            name: 'userRestrictedDocs',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: userRestrictedCollectionSlug,
+          },
+          {
+            name: 'createNotUpdateDocs',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: createNotUpdateCollectionSlug,
+          },
+        ],
+      },
+      {
+        slug: 'relation-restricted',
+        access: {
+          read: () => true,
         },
-        {
-          name: 'approvedTitle',
-          type: 'text',
-          access: {
-            update: (args) => {
-              if (args?.doc?.lockTitle) {
-                return false
-              }
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+          {
+            name: 'post',
+            type: 'relationship',
+            relationTo: slug,
+          },
+        ],
+      },
+      {
+        slug: fullyRestrictedSlug,
+        access: {
+          create: () => false,
+          delete: () => false,
+          read: () => false,
+          update: () => false,
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+      },
+      {
+        slug: readOnlySlug,
+        access: {
+          create: () => false,
+          delete: () => false,
+          read: () => true,
+          update: () => false,
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+      },
+      {
+        slug: userRestrictedCollectionSlug,
+        access: {
+          create: () => true,
+          delete: () => false,
+          read: () => true,
+          update: ({ req }) => ({
+            name: {
+              equals: req.user?.email,
+            },
+          }),
+        },
+        admin: {
+          useAsTitle: 'name',
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+      },
+      {
+        slug: createNotUpdateCollectionSlug,
+        access: {
+          create: () => true,
+          delete: () => false,
+          read: () => true,
+          update: () => false,
+        },
+        admin: {
+          useAsTitle: 'name',
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+      },
+      {
+        slug: restrictedVersionsSlug,
+        access: {
+          read: ({ req: { user } }) => {
+            if (user) {
               return true
+            }
+
+            return {
+              hidden: {
+                not_equals: true,
+              },
+            }
+          },
+          readVersions: ({ req: { user } }) => {
+            if (user) {
+              return true
+            }
+
+            return {
+              'version.hidden': {
+                not_equals: true,
+              },
+            }
+          },
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+          {
+            name: 'hidden',
+            type: 'checkbox',
+            hidden: true,
+          },
+        ],
+        versions: true,
+      },
+      {
+        slug: siblingDataSlug,
+        access: openAccess,
+        fields: [
+          {
+            name: 'array',
+            type: 'array',
+            fields: [
+              {
+                type: 'row',
+                fields: [
+                  {
+                    name: 'allowPublicReadability',
+                    type: 'checkbox',
+                    label: 'Allow Public Readability',
+                  },
+                  {
+                    name: 'text',
+                    type: 'text',
+                    access: {
+                      read: PublicReadabilityAccess,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        slug: relyOnRequestHeadersSlug,
+        access: {
+          create: UseRequestHeadersAccess,
+          delete: UseRequestHeadersAccess,
+          read: UseRequestHeadersAccess,
+          update: UseRequestHeadersAccess,
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+      },
+      {
+        slug: docLevelAccessSlug,
+        access: {
+          delete: () => ({
+            and: [
+              {
+                approvedForRemoval: {
+                  equals: true,
+                },
+              },
+            ],
+          }),
+        },
+        fields: [
+          {
+            name: 'approvedForRemoval',
+            type: 'checkbox',
+            defaultValue: false,
+          },
+          {
+            name: 'approvedTitle',
+            type: 'text',
+            access: {
+              update: (args) => {
+                if (args?.doc?.lockTitle) {
+                  return false
+                }
+                return true
+              },
+            },
+            localized: true,
+          },
+          {
+            name: 'lockTitle',
+            type: 'checkbox',
+            defaultValue: false,
+          },
+        ],
+        labels: {
+          plural: 'Doc Level Access',
+          singular: 'Doc Level Access',
+        },
+      },
+      {
+        slug: hiddenFieldsSlug,
+        access: openAccess,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'partiallyHiddenGroup',
+            type: 'group',
+            fields: [
+              {
+                name: 'name',
+                type: 'text',
+              },
+              {
+                name: 'value',
+                type: 'text',
+                hidden: true,
+              },
+            ],
+          },
+          {
+            name: 'partiallyHiddenArray',
+            type: 'array',
+            fields: [
+              {
+                name: 'name',
+                type: 'text',
+              },
+              {
+                name: 'value',
+                type: 'text',
+                hidden: true,
+              },
+            ],
+          },
+          {
+            name: 'hidden',
+            type: 'checkbox',
+            hidden: true,
+          },
+        ],
+      },
+      {
+        slug: hiddenAccessSlug,
+        access: {
+          read: ({ req: { user } }) => {
+            if (user) {
+              return true
+            }
+
+            return {
+              hidden: {
+                not_equals: true,
+              },
+            }
+          },
+        },
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            required: true,
+          },
+          {
+            name: 'hidden',
+            type: 'checkbox',
+            hidden: true,
+          },
+        ],
+      },
+      {
+        slug: hiddenAccessCountSlug,
+        access: {
+          read: ({ req: { user } }) => {
+            if (user) {
+              return true
+            }
+
+            return {
+              hidden: {
+                not_equals: true,
+              },
+            }
+          },
+        },
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            required: true,
+          },
+          {
+            name: 'hidden',
+            type: 'checkbox',
+            hidden: true,
+          },
+        ],
+      },
+      {
+        slug: 'fields-and-top-access',
+        access: {
+          readVersions: () => ({
+            'version.secret': {
+              equals: 'will-success-access-read',
+            },
+          }),
+          read: () => ({
+            secret: {
+              equals: 'will-success-access-read',
+            },
+          }),
+        },
+        versions: { drafts: true },
+        fields: [
+          {
+            type: 'text',
+            name: 'secret',
+            access: { read: () => false },
+          },
+        ],
+      },
+      Disabled,
+      RichText,
+      Regression1,
+      Regression2,
+    ],
+    globals: [
+      {
+        slug: 'settings',
+        admin: {
+          components: {
+            elements: {
+              SaveButton: '/TestButton.js#TestButton',
             },
           },
-          localized: true,
         },
-        {
-          name: 'lockTitle',
-          type: 'checkbox',
-          defaultValue: false,
-        },
-      ],
-      labels: {
-        plural: 'Doc Level Access',
-        singular: 'Doc Level Access',
+        fields: [
+          {
+            name: 'test',
+            type: 'checkbox',
+            label: 'Allow access to test global',
+          },
+        ],
       },
-    },
-    {
-      slug: hiddenFieldsSlug,
-      access: openAccess,
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
+      {
+        slug: 'test',
+        access: {
+          read: async ({ req: { payload } }) => {
+            const access = await payload.findGlobal({ slug: 'settings' })
+            return Boolean(access.test)
+          },
         },
-        {
-          name: 'partiallyHiddenGroup',
-          type: 'group',
-          fields: [
+        fields: [],
+      },
+      {
+        slug: readOnlyGlobalSlug,
+        access: {
+          read: () => true,
+          update: () => false,
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+      },
+      {
+        slug: userRestrictedGlobalSlug,
+        access: {
+          read: () => true,
+          update: ({ data, req }) => data?.name === req.user?.email,
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+      },
+      {
+        slug: readNotUpdateGlobalSlug,
+        access: {
+          read: () => true,
+          update: () => false,
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+      },
+    ],
+    onInit: async (payload) => {
+      await payload.create({
+        collection: 'users',
+        data: {
+          email: devUser.email,
+          password: devUser.password,
+        },
+      })
+
+      await payload.create({
+        collection: 'users',
+        data: {
+          email: nonAdminEmail,
+          password: 'test',
+        },
+      })
+
+      await payload.create({
+        collection: publicUsersSlug,
+        data: {
+          email: publicUserEmail,
+          password: 'test',
+        },
+      })
+
+      await payload.create({
+        collection: slug,
+        data: {
+          restrictedField: 'restricted',
+        },
+      })
+
+      await payload.create({
+        collection: readOnlySlug,
+        data: {
+          name: 'read-only',
+        },
+      })
+
+      await payload.create({
+        collection: restrictedVersionsSlug,
+        data: {
+          name: 'versioned',
+        },
+      })
+
+      await payload.create({
+        collection: siblingDataSlug,
+        data: {
+          array: [
             {
-              name: 'name',
-              type: 'text',
+              allowPublicReadability: true,
+              text: firstArrayText,
             },
             {
-              name: 'value',
-              type: 'text',
-              hidden: true,
+              allowPublicReadability: false,
+              text: secondArrayText,
             },
           ],
         },
-        {
-          name: 'partiallyHiddenArray',
-          type: 'array',
-          fields: [
+      })
+
+      await payload.updateGlobal({
+        slug: userRestrictedGlobalSlug,
+        data: {
+          name: 'dev@payloadcms.com',
+        },
+      })
+
+      await payload.create({
+        collection: 'regression1',
+        data: {
+          richText4: textToLexicalJSON({ text: 'Text1' }),
+          array: [{ art: textToLexicalJSON({ text: 'Text2' }) }],
+          arrayWithAccessFalse: [{ richText6: textToLexicalJSON({ text: 'Text3' }) }],
+          group1: {
+            text: 'Text4',
+            richText1: textToLexicalJSON({ text: 'Text5' }),
+          },
+          blocks: [
             {
-              name: 'name',
-              type: 'text',
-            },
-            {
-              name: 'value',
-              type: 'text',
-              hidden: true,
+              blockType: 'myBlock3',
+              richText7: textToLexicalJSON({ text: 'Text6' }),
+              blockName: 'My Block 1',
             },
           ],
-        },
-        {
-          name: 'hidden',
-          type: 'checkbox',
-          hidden: true,
-        },
-      ],
-    },
-    {
-      slug: hiddenAccessSlug,
-      access: {
-        read: ({ req: { user } }) => {
-          if (user) {
-            return true
-          }
-
-          return {
-            hidden: {
-              not_equals: true,
-            },
-          }
-        },
-      },
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          required: true,
-        },
-        {
-          name: 'hidden',
-          type: 'checkbox',
-          hidden: true,
-        },
-      ],
-    },
-    {
-      slug: hiddenAccessCountSlug,
-      access: {
-        read: ({ req: { user } }) => {
-          if (user) {
-            return true
-          }
-
-          return {
-            hidden: {
-              not_equals: true,
-            },
-          }
-        },
-      },
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          required: true,
-        },
-        {
-          name: 'hidden',
-          type: 'checkbox',
-          hidden: true,
-        },
-      ],
-    },
-    {
-      slug: 'fields-and-top-access',
-      access: {
-        readVersions: () => ({
-          'version.secret': {
-            equals: 'will-success-access-read',
-          },
-        }),
-        read: () => ({
-          secret: {
-            equals: 'will-success-access-read',
-          },
-        }),
-      },
-      versions: { drafts: true },
-      fields: [
-        {
-          type: 'text',
-          name: 'secret',
-          access: { read: () => false },
-        },
-      ],
-    },
-    Disabled,
-    RichText,
-    Regression1,
-    Regression2,
-  ],
-  globals: [
-    {
-      slug: 'settings',
-      admin: {
-        components: {
-          elements: {
-            SaveButton: '/TestButton.js#TestButton',
-          },
-        },
-      },
-      fields: [
-        {
-          name: 'test',
-          type: 'checkbox',
-          label: 'Allow access to test global',
-        },
-      ],
-    },
-    {
-      slug: 'test',
-      access: {
-        read: async ({ req: { payload } }) => {
-          const access = await payload.findGlobal({ slug: 'settings' })
-          return Boolean(access.test)
-        },
-      },
-      fields: [],
-    },
-    {
-      slug: readOnlyGlobalSlug,
-      access: {
-        read: () => true,
-        update: () => false,
-      },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-    },
-    {
-      slug: userRestrictedGlobalSlug,
-      access: {
-        read: () => true,
-        update: ({ data, req }) => data?.name === req.user?.email,
-      },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-    },
-    {
-      slug: readNotUpdateGlobalSlug,
-      access: {
-        read: () => true,
-        update: () => false,
-      },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-    },
-  ],
-  onInit: async (payload) => {
-    await payload.create({
-      collection: 'users',
-      data: {
-        email: devUser.email,
-        password: devUser.password,
-      },
-    })
-
-    await payload.create({
-      collection: 'users',
-      data: {
-        email: nonAdminEmail,
-        password: 'test',
-      },
-    })
-
-    await payload.create({
-      collection: publicUsersSlug,
-      data: {
-        email: publicUserEmail,
-        password: 'test',
-      },
-    })
-
-    await payload.create({
-      collection: slug,
-      data: {
-        restrictedField: 'restricted',
-      },
-    })
-
-    await payload.create({
-      collection: readOnlySlug,
-      data: {
-        name: 'read-only',
-      },
-    })
-
-    await payload.create({
-      collection: restrictedVersionsSlug,
-      data: {
-        name: 'versioned',
-      },
-    })
-
-    await payload.create({
-      collection: siblingDataSlug,
-      data: {
-        array: [
-          {
-            allowPublicReadability: true,
-            text: firstArrayText,
-          },
-          {
-            allowPublicReadability: false,
-            text: secondArrayText,
-          },
-        ],
-      },
-    })
-
-    await payload.updateGlobal({
-      slug: userRestrictedGlobalSlug,
-      data: {
-        name: 'dev@payloadcms.com',
-      },
-    })
-
-    await payload.create({
-      collection: 'regression1',
-      data: {
-        richText4: textToLexicalJSON({ text: 'Text1' }),
-        array: [{ art: textToLexicalJSON({ text: 'Text2' }) }],
-        arrayWithAccessFalse: [{ richText6: textToLexicalJSON({ text: 'Text3' }) }],
-        group1: {
-          text: 'Text4',
-          richText1: textToLexicalJSON({ text: 'Text5' }),
-        },
-        blocks: [
-          {
-            blockType: 'myBlock3',
-            richText7: textToLexicalJSON({ text: 'Text6' }),
-            blockName: 'My Block 1',
-          },
-        ],
-        blocks3: [
-          {
-            blockType: 'myBlock2',
-            richText5: textToLexicalJSON({ text: 'Text7' }),
-            blockName: 'My Block 2',
-          },
-        ],
-        tab1: {
-          richText2: textToLexicalJSON({ text: 'Text8' }),
-          blocks2: [
+          blocks3: [
             {
-              blockType: 'myBlock',
-              richText3: textToLexicalJSON({ text: 'Text9' }),
-              blockName: 'My Block 3',
+              blockType: 'myBlock2',
+              richText5: textToLexicalJSON({ text: 'Text7' }),
+              blockName: 'My Block 2',
             },
           ],
-        },
-      },
-    })
-
-    await payload.create({
-      collection: 'regression2',
-      data: {
-        array: [
-          {
-            richText2: textToLexicalJSON({ text: 'Text1' }),
+          tab1: {
+            richText2: textToLexicalJSON({ text: 'Text8' }),
+            blocks2: [
+              {
+                blockType: 'myBlock',
+                richText3: textToLexicalJSON({ text: 'Text9' }),
+                blockName: 'My Block 3',
+              },
+            ],
           },
-        ],
-        group: {
-          text: 'Text2',
-          richText1: textToLexicalJSON({ text: 'Text3' }),
         },
-      },
-    })
+      })
+
+      await payload.create({
+        collection: 'regression2',
+        data: {
+          array: [
+            {
+              richText2: textToLexicalJSON({ text: 'Text1' }),
+            },
+          ],
+          group: {
+            text: 'Text2',
+            richText1: textToLexicalJSON({ text: 'Text3' }),
+          },
+        },
+      })
+    },
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
   },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
+  {
+    disableAutoLogin: true,
   },
-})
+)

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -9,12 +9,7 @@ import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
 
 import type { PayloadTestSDK } from '../helpers/sdk/index.js'
-import type {
-  Config,
-  NonAdminUser,
-  ReadOnlyCollection,
-  RestrictedVersion,
-} from './payload-types.js'
+import type { Config, ReadOnlyCollection, RestrictedVersion } from './payload-types.js'
 
 import {
   closeNav,
@@ -34,9 +29,9 @@ import {
   disabledSlug,
   docLevelAccessSlug,
   fullyRestrictedSlug,
-  noAdminAccessEmail,
-  nonAdminUserEmail,
-  nonAdminUserSlug,
+  nonAdminEmail,
+  publicUserEmail,
+  publicUsersSlug,
   readNotUpdateGlobalSlug,
   readOnlyGlobalSlug,
   readOnlySlug,
@@ -610,56 +605,49 @@ describe('access control', () => {
   })
 
   describe('admin access', () => {
-    test('should block admin access to admin user', async () => {
-      const adminURL = `${serverURL}/admin`
-      await page.goto(adminURL)
-      await page.waitForURL(adminURL)
+    test('unauthenticated users should not have access to the admin panel', async () => {
+      await page.goto(url.logout)
+      await page.waitForURL(url.logout)
+      await page.goto(url.admin)
+      await page.waitForURL(url.login)
+      expect(page.url()).toEqual(url.login)
+    })
 
-      await expect(page.locator('.dashboard')).toBeVisible()
-
-      await page.goto(logoutURL)
-      await page.waitForURL(logoutURL)
+    test('non-admin users should not have access to the admin panel', async () => {
+      await page.goto(url.logout)
+      await page.waitForURL(url.logout)
 
       await login({
         data: {
-          email: noAdminAccessEmail,
+          email: nonAdminEmail,
           password: 'test',
         },
         page,
         serverURL,
       })
 
-      await expect(page.locator('.unauthorized')).toBeVisible()
+      await expect(page.locator('.unauthorized .form-header h1')).toHaveText(
+        'Unauthorized, this user does not have access to the admin panel.',
+      )
 
-      // Log back in for the next test
-      await page.goto(logoutURL)
-      await login({
-        data: {
-          email: devUser.email,
-          password: devUser.password,
-        },
-        page,
-        serverURL,
-      })
+      await page.goto(url.logout)
+      await page.waitForURL(url.logout)
+
+      await expect(page.locator('.payload-toast-container')).toContainText(
+        'You have been logged out successfully.',
+      )
+
+      await expect(page.locator('form.login__form')).toBeVisible()
     })
 
-    test('should block admin access to non-admin user', async () => {
-      const adminURL = `${serverURL}/admin`
-      const unauthorizedURL = `${serverURL}/admin/unauthorized`
-      await page.goto(adminURL)
-      await page.waitForURL(adminURL)
+    test('public users should not have access to access admin', async () => {
+      await page.goto(url.logout)
+      await page.waitForURL(url.logout)
 
-      await expect(page.locator('.dashboard')).toBeVisible()
-
-      await page.goto(logoutURL)
-      await page.waitForURL(logoutURL)
-
-      const nonAdminUser: {
-        token?: string
-      } & NonAdminUser = await payload.login({
-        collection: nonAdminUserSlug,
+      const user = await payload.login({
+        collection: publicUsersSlug,
         data: {
-          email: nonAdminUserEmail,
+          email: publicUserEmail,
           password: devUser.password,
         },
       })
@@ -667,20 +655,36 @@ describe('access control', () => {
       await context.addCookies([
         {
           name: 'payload-token',
-          url: serverURL,
-          value: nonAdminUser.token,
+          value: user.token,
+          domain: 'localhost',
+          path: '/',
+          httpOnly: true,
+          secure: true,
         },
       ])
 
-      await page.goto(adminURL)
-      await page.waitForURL(unauthorizedURL)
+      await page.reload()
 
-      await expect(page.locator('.unauthorized')).toBeVisible()
+      await page.goto(url.admin)
+      await page.waitForURL(/unauthorized$/)
 
-      // Log back in for the next test
-      await context.clearCookies()
-      await page.goto(logoutURL)
-      await page.waitForURL(logoutURL)
+      await expect(page.locator('.unauthorized .form-header h1')).toHaveText(
+        'Unauthorized, this user does not have access to the admin panel.',
+      )
+
+      await page.goto(url.logout)
+      await page.waitForURL(url.logout)
+
+      await expect(page.locator('.payload-toast-container')).toContainText(
+        'You have been logged out successfully.',
+      )
+
+      await expect(page.locator('form.login__form')).toBeVisible()
+    })
+  })
+
+  describe('read-only from access control', () => {
+    beforeAll(async () => {
       await login({
         data: {
           email: devUser.email,
@@ -690,9 +694,7 @@ describe('access control', () => {
         serverURL,
       })
     })
-  })
 
-  describe('read-only from access control', () => {
     test('should be read-only when update returns false', async () => {
       await page.goto(disabledFields.create)
 

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -608,6 +608,13 @@ describe('access control', () => {
     test('unauthenticated users should not have access to the admin panel', async () => {
       await page.goto(url.logout)
       await page.waitForURL(url.logout)
+
+      await expect(page.locator('.payload-toast-container')).toContainText(
+        'You have been logged out successfully.',
+      )
+
+      await expect(page.locator('form.login__form')).toBeVisible()
+
       await page.goto(url.admin)
       await page.waitForURL(url.login)
       expect(page.url()).toEqual(url.login)

--- a/test/access-control/payload-types.ts
+++ b/test/access-control/payload-types.ts
@@ -9,11 +9,11 @@
 export interface Config {
   auth: {
     users: UserAuthOperations;
-    'non-admin-user': NonAdminUserAuthOperations;
+    'public-users': PublicUserAuthOperations;
   };
   collections: {
     users: User;
-    'non-admin-user': NonAdminUser;
+    'public-users': PublicUser;
     posts: Post;
     unrestricted: Unrestricted;
     'relation-restricted': RelationRestricted;
@@ -40,7 +40,7 @@ export interface Config {
   collectionsJoins: {};
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
-    'non-admin-user': NonAdminUserSelect<false> | NonAdminUserSelect<true>;
+    'public-users': PublicUsersSelect<false> | PublicUsersSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
     unrestricted: UnrestrictedSelect<false> | UnrestrictedSelect<true>;
     'relation-restricted': RelationRestrictedSelect<false> | RelationRestrictedSelect<true>;
@@ -86,8 +86,8 @@ export interface Config {
     | (User & {
         collection: 'users';
       })
-    | (NonAdminUser & {
-        collection: 'non-admin-user';
+    | (PublicUser & {
+        collection: 'public-users';
       });
   jobs: {
     tasks: unknown;
@@ -112,7 +112,7 @@ export interface UserAuthOperations {
     password: string;
   };
 }
-export interface NonAdminUserAuthOperations {
+export interface PublicUserAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -150,9 +150,9 @@ export interface User {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "non-admin-user".
+ * via the `definition` "public-users".
  */
-export interface NonAdminUser {
+export interface PublicUser {
   id: string;
   updatedAt: string;
   createdAt: string;
@@ -624,8 +624,8 @@ export interface PayloadLockedDocument {
         value: string | User;
       } | null)
     | ({
-        relationTo: 'non-admin-user';
-        value: string | NonAdminUser;
+        relationTo: 'public-users';
+        value: string | PublicUser;
       } | null)
     | ({
         relationTo: 'posts';
@@ -710,8 +710,8 @@ export interface PayloadLockedDocument {
         value: string | User;
       }
     | {
-        relationTo: 'non-admin-user';
-        value: string | NonAdminUser;
+        relationTo: 'public-users';
+        value: string | PublicUser;
       };
   updatedAt: string;
   createdAt: string;
@@ -728,8 +728,8 @@ export interface PayloadPreference {
         value: string | User;
       }
     | {
-        relationTo: 'non-admin-user';
-        value: string | NonAdminUser;
+        relationTo: 'public-users';
+        value: string | PublicUser;
       };
   key?: string | null;
   value?:
@@ -773,9 +773,9 @@ export interface UsersSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "non-admin-user_select".
+ * via the `definition` "public-users_select".
  */
-export interface NonAdminUserSelect<T extends boolean = true> {
+export interface PublicUsersSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   email?: T;

--- a/test/access-control/shared.ts
+++ b/test/access-control/shared.ts
@@ -18,11 +18,8 @@ export const docLevelAccessSlug = 'doc-level-access'
 export const hiddenFieldsSlug = 'hidden-fields'
 export const hiddenAccessSlug = 'hidden-access'
 export const hiddenAccessCountSlug = 'hidden-access-count'
-
-export const noAdminAccessEmail = 'no-admin-access@payloadcms.com'
-
-export const nonAdminUserEmail = 'non-admin-user@payloadcms.com'
-
-export const nonAdminUserSlug = 'non-admin-user'
-
 export const disabledSlug = 'disabled'
+
+export const nonAdminEmail = 'no-admin-access@payloadcms.com'
+export const publicUserEmail = 'public-user@payloadcms.com'
+export const publicUsersSlug = 'public-users'

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -15,286 +15,271 @@ import {
   slug,
 } from './shared.js'
 
-export default buildConfigWithDefaults(
-  {
-    admin: {
-      autoLogin: {
+export default buildConfigWithDefaults({
+  admin: {
+    autoLogin: {
+      email: devUser.email,
+      password: devUser.password,
+      prefillOnly: true,
+    },
+    importMap: {
+      baseDir: path.resolve(dirname),
+    },
+    user: 'users',
+  },
+  collections: [
+    {
+      slug,
+      admin: {
+        useAsTitle: 'custom',
+      },
+      auth: {
+        cookies: {
+          domain: undefined,
+          sameSite: 'Lax',
+          secure: false,
+        },
+        depth: 0,
+        lockTime: 600 * 1000, // lock time in ms
+        maxLoginAttempts: 2,
+        tokenExpiration: 7200, // 2 hours
+        useAPIKey: true,
+        verify: false,
+        forgotPassword: {
+          expiration: 300000, // 5 minutes
+        },
+      },
+      fields: [
+        {
+          name: 'adminOnlyField',
+          type: 'text',
+          access: {
+            read: ({ req: { user } }) => {
+              return user?.roles?.includes('admin')
+            },
+          },
+        },
+        {
+          name: 'roles',
+          type: 'select',
+          defaultValue: ['user'],
+          hasMany: true,
+          label: 'Role',
+          options: ['admin', 'editor', 'moderator', 'user', 'viewer'],
+          required: true,
+          saveToJWT: true,
+        },
+        {
+          name: 'namedSaveToJWT',
+          type: 'text',
+          defaultValue: namedSaveToJWTValue,
+          label: 'Named Save To JWT',
+          saveToJWT: saveToJWTKey,
+        },
+        {
+          name: 'group',
+          type: 'group',
+          fields: [
+            {
+              name: 'liftedSaveToJWT',
+              type: 'text',
+              defaultValue: 'lifted from group',
+              label: 'Lifted Save To JWT',
+              saveToJWT: 'x-lifted-from-group',
+            },
+          ],
+        },
+        {
+          name: 'groupSaveToJWT',
+          type: 'group',
+          fields: [
+            {
+              name: 'saveToJWTString',
+              type: 'text',
+              defaultValue: 'nested property',
+              label: 'Save To JWT String',
+              saveToJWT: 'x-test',
+            },
+            {
+              name: 'saveToJWTFalse',
+              type: 'text',
+              defaultValue: 'nested property',
+              label: 'Save To JWT False',
+              saveToJWT: false,
+            },
+          ],
+          label: 'Group Save To JWT',
+          saveToJWT: 'x-group',
+        },
+        {
+          type: 'tabs',
+          tabs: [
+            {
+              name: 'saveToJWTTab',
+              fields: [
+                {
+                  name: 'test',
+                  type: 'text',
+                  defaultValue: 'yes',
+                  saveToJWT: 'x-field',
+                },
+              ],
+              label: 'Save To JWT Tab',
+              saveToJWT: true,
+            },
+            {
+              name: 'tabSaveToJWTString',
+              fields: [
+                {
+                  name: 'includedByDefault',
+                  type: 'text',
+                  defaultValue: 'yes',
+                },
+              ],
+              label: 'Tab Save To JWT String',
+              saveToJWT: 'tab-test',
+            },
+            {
+              fields: [
+                {
+                  name: 'tabLiftedSaveToJWT',
+                  type: 'text',
+                  defaultValue: 'lifted from unnamed tab',
+                  label: 'Tab Lifted Save To JWT',
+                  saveToJWT: true,
+                },
+                {
+                  name: 'unnamedTabSaveToJWTString',
+                  type: 'text',
+                  defaultValue: 'text',
+                  label: 'Unnamed Tab Save To JWT String',
+                  saveToJWT: 'x-tab-field',
+                },
+                {
+                  name: 'unnamedTabSaveToJWTFalse',
+                  type: 'text',
+                  defaultValue: 'false',
+                  label: 'Unnamed Tab Save To JWT False',
+                  saveToJWT: false,
+                },
+              ],
+              label: 'No Name',
+            },
+          ],
+        },
+        {
+          name: 'custom',
+          type: 'text',
+          label: 'Custom',
+        },
+        {
+          name: 'authDebug',
+          type: 'ui',
+          admin: {
+            components: {
+              Field: '/AuthDebug.js#AuthDebug',
+            },
+          },
+          label: 'Auth Debug',
+        },
+      ],
+    },
+    {
+      slug: partialDisableLocaleStrategiesSlug,
+      auth: {
+        disableLocalStrategy: {
+          // optionalPassword: true,
+          enableFields: true,
+        },
+      },
+      fields: [
+        // with `enableFields: true`, the following DB columns will be created:
+        // email
+        // reset_password_token
+        // reset_password_expiration
+        // salt
+        // hash
+        // login_attempts
+        // lock_until
+      ],
+    },
+    {
+      slug: apiKeysSlug,
+      access: {
+        read: ({ req: { user } }) => {
+          if (!user) {
+            return false
+          }
+          if (user?.collection === apiKeysSlug) {
+            return {
+              id: {
+                equals: user.id,
+              },
+            }
+          }
+          return true
+        },
+      },
+      auth: {
+        disableLocalStrategy: true,
+        useAPIKey: true,
+      },
+      fields: [],
+      labels: {
+        plural: 'API Keys',
+        singular: 'API Key',
+      },
+    },
+    {
+      slug: publicUsersSlug,
+      auth: {
+        verify: true,
+      },
+      fields: [],
+    },
+    {
+      slug: 'relationsCollection',
+      fields: [
+        {
+          name: 'rel',
+          type: 'relationship',
+          relationTo: 'users',
+        },
+        {
+          name: 'text',
+          type: 'text',
+        },
+      ],
+    },
+  ],
+  onInit: async (payload) => {
+    await payload.create({
+      collection: 'users',
+      data: {
+        custom: 'Hello, world!',
         email: devUser.email,
         password: devUser.password,
-        prefillOnly: true,
+        roles: ['admin'],
       },
-      importMap: {
-        baseDir: path.resolve(dirname),
-      },
-      user: 'users',
-    },
-    collections: [
-      {
-        slug,
-        admin: {
-          useAsTitle: 'custom',
-        },
-        auth: {
-          cookies: {
-            domain: undefined,
-            sameSite: 'Lax',
-            secure: false,
-          },
-          depth: 0,
-          lockTime: 600 * 1000, // lock time in ms
-          maxLoginAttempts: 2,
-          tokenExpiration: 7200, // 2 hours
-          useAPIKey: true,
-          verify: false,
-          forgotPassword: {
-            expiration: 300000, // 5 minutes
-          },
-        },
-        fields: [
-          {
-            name: 'adminOnlyField',
-            type: 'text',
-            access: {
-              read: ({ req: { user } }) => {
-                return user?.roles?.includes('admin')
-              },
-            },
-          },
-          {
-            name: 'roles',
-            type: 'select',
-            defaultValue: ['user'],
-            hasMany: true,
-            label: 'Role',
-            options: ['admin', 'editor', 'moderator', 'user', 'viewer'],
-            required: true,
-            saveToJWT: true,
-          },
-          {
-            name: 'namedSaveToJWT',
-            type: 'text',
-            defaultValue: namedSaveToJWTValue,
-            label: 'Named Save To JWT',
-            saveToJWT: saveToJWTKey,
-          },
-          {
-            name: 'group',
-            type: 'group',
-            fields: [
-              {
-                name: 'liftedSaveToJWT',
-                type: 'text',
-                defaultValue: 'lifted from group',
-                label: 'Lifted Save To JWT',
-                saveToJWT: 'x-lifted-from-group',
-              },
-            ],
-          },
-          {
-            name: 'groupSaveToJWT',
-            type: 'group',
-            fields: [
-              {
-                name: 'saveToJWTString',
-                type: 'text',
-                defaultValue: 'nested property',
-                label: 'Save To JWT String',
-                saveToJWT: 'x-test',
-              },
-              {
-                name: 'saveToJWTFalse',
-                type: 'text',
-                defaultValue: 'nested property',
-                label: 'Save To JWT False',
-                saveToJWT: false,
-              },
-            ],
-            label: 'Group Save To JWT',
-            saveToJWT: 'x-group',
-          },
-          {
-            type: 'tabs',
-            tabs: [
-              {
-                name: 'saveToJWTTab',
-                fields: [
-                  {
-                    name: 'test',
-                    type: 'text',
-                    defaultValue: 'yes',
-                    saveToJWT: 'x-field',
-                  },
-                ],
-                label: 'Save To JWT Tab',
-                saveToJWT: true,
-              },
-              {
-                name: 'tabSaveToJWTString',
-                fields: [
-                  {
-                    name: 'includedByDefault',
-                    type: 'text',
-                    defaultValue: 'yes',
-                  },
-                ],
-                label: 'Tab Save To JWT String',
-                saveToJWT: 'tab-test',
-              },
-              {
-                fields: [
-                  {
-                    name: 'tabLiftedSaveToJWT',
-                    type: 'text',
-                    defaultValue: 'lifted from unnamed tab',
-                    label: 'Tab Lifted Save To JWT',
-                    saveToJWT: true,
-                  },
-                  {
-                    name: 'unnamedTabSaveToJWTString',
-                    type: 'text',
-                    defaultValue: 'text',
-                    label: 'Unnamed Tab Save To JWT String',
-                    saveToJWT: 'x-tab-field',
-                  },
-                  {
-                    name: 'unnamedTabSaveToJWTFalse',
-                    type: 'text',
-                    defaultValue: 'false',
-                    label: 'Unnamed Tab Save To JWT False',
-                    saveToJWT: false,
-                  },
-                ],
-                label: 'No Name',
-              },
-            ],
-          },
-          {
-            name: 'custom',
-            type: 'text',
-            label: 'Custom',
-          },
-          {
-            name: 'authDebug',
-            type: 'ui',
-            admin: {
-              components: {
-                Field: '/AuthDebug.js#AuthDebug',
-              },
-            },
-            label: 'Auth Debug',
-          },
-        ],
-      },
-      {
-        slug: partialDisableLocaleStrategiesSlug,
-        auth: {
-          disableLocalStrategy: {
-            // optionalPassword: true,
-            enableFields: true,
-          },
-        },
-        fields: [
-          // with `enableFields: true`, the following DB columns will be created:
-          // email
-          // reset_password_token
-          // reset_password_expiration
-          // salt
-          // hash
-          // login_attempts
-          // lock_until
-        ],
-      },
-      {
-        slug: apiKeysSlug,
-        access: {
-          read: ({ req: { user } }) => {
-            if (!user) {
-              return false
-            }
-            if (user?.collection === apiKeysSlug) {
-              return {
-                id: {
-                  equals: user.id,
-                },
-              }
-            }
-            return true
-          },
-        },
-        auth: {
-          disableLocalStrategy: true,
-          useAPIKey: true,
-        },
-        fields: [],
-        labels: {
-          plural: 'API Keys',
-          singular: 'API Key',
-        },
-      },
-      {
-        slug: publicUsersSlug,
-        auth: {
-          verify: true,
-        },
-        fields: [],
-      },
-      {
-        slug: 'relationsCollection',
-        fields: [
-          {
-            name: 'rel',
-            type: 'relationship',
-            relationTo: 'users',
-          },
-          {
-            name: 'text',
-            type: 'text',
-          },
-        ],
-      },
-    ],
-    onInit: async (payload) => {
-      await payload.create({
-        collection: 'users',
-        data: {
-          custom: 'Hello, world!',
-          email: devUser.email,
-          password: devUser.password,
-          roles: ['admin'],
-        },
-      })
+    })
 
-      await payload.create({
-        collection: apiKeysSlug,
-        data: {
-          apiKey: uuid(),
-          enableAPIKey: true,
-        },
-      })
+    await payload.create({
+      collection: apiKeysSlug,
+      data: {
+        apiKey: uuid(),
+        enableAPIKey: true,
+      },
+    })
 
-      await payload.create({
-        collection: apiKeysSlug,
-        data: {
-          apiKey: uuid(),
-          enableAPIKey: true,
-        },
-      })
-
-      await payload.create({
-        collection: publicUsersSlug,
-        data: {
-          email: 'public-user@payloadcms.com',
-          password: devUser.password,
-          _verified: true,
-        },
-        disableVerificationEmail: true,
-      })
-    },
-    typescript: {
-      outputFile: path.resolve(dirname, 'payload-types.ts'),
-    },
+    await payload.create({
+      collection: apiKeysSlug,
+      data: {
+        apiKey: uuid(),
+        enableAPIKey: true,
+      },
+    })
   },
-  {
-    disableAutoLogin: true,
+  typescript: {
+    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
-)
+})

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -10,275 +10,291 @@ import {
   apiKeysSlug,
   namedSaveToJWTValue,
   partialDisableLocaleStrategiesSlug,
+  publicUsersSlug,
   saveToJWTKey,
   slug,
 } from './shared.js'
 
-export default buildConfigWithDefaults({
-  admin: {
-    autoLogin: {
-      email: devUser.email,
-      password: devUser.password,
-      prefillOnly: true,
-    },
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-    user: 'users',
-  },
-  collections: [
-    {
-      slug,
-      admin: {
-        useAsTitle: 'custom',
-      },
-      auth: {
-        cookies: {
-          domain: undefined,
-          sameSite: 'Lax',
-          secure: false,
-        },
-        depth: 0,
-        lockTime: 600 * 1000, // lock time in ms
-        maxLoginAttempts: 2,
-        tokenExpiration: 7200, // 2 hours
-        useAPIKey: true,
-        verify: false,
-        forgotPassword: {
-          expiration: 300000, // 5 minutes
-        },
-      },
-      fields: [
-        {
-          name: 'adminOnlyField',
-          type: 'text',
-          access: {
-            read: ({ req: { user } }) => {
-              return user?.roles?.includes('admin')
-            },
-          },
-        },
-        {
-          name: 'roles',
-          type: 'select',
-          defaultValue: ['user'],
-          hasMany: true,
-          label: 'Role',
-          options: ['admin', 'editor', 'moderator', 'user', 'viewer'],
-          required: true,
-          saveToJWT: true,
-        },
-        {
-          name: 'namedSaveToJWT',
-          type: 'text',
-          defaultValue: namedSaveToJWTValue,
-          label: 'Named Save To JWT',
-          saveToJWT: saveToJWTKey,
-        },
-        {
-          name: 'group',
-          type: 'group',
-          fields: [
-            {
-              name: 'liftedSaveToJWT',
-              type: 'text',
-              defaultValue: 'lifted from group',
-              label: 'Lifted Save To JWT',
-              saveToJWT: 'x-lifted-from-group',
-            },
-          ],
-        },
-        {
-          name: 'groupSaveToJWT',
-          type: 'group',
-          fields: [
-            {
-              name: 'saveToJWTString',
-              type: 'text',
-              defaultValue: 'nested property',
-              label: 'Save To JWT String',
-              saveToJWT: 'x-test',
-            },
-            {
-              name: 'saveToJWTFalse',
-              type: 'text',
-              defaultValue: 'nested property',
-              label: 'Save To JWT False',
-              saveToJWT: false,
-            },
-          ],
-          label: 'Group Save To JWT',
-          saveToJWT: 'x-group',
-        },
-        {
-          type: 'tabs',
-          tabs: [
-            {
-              name: 'saveToJWTTab',
-              fields: [
-                {
-                  name: 'test',
-                  type: 'text',
-                  defaultValue: 'yes',
-                  saveToJWT: 'x-field',
-                },
-              ],
-              label: 'Save To JWT Tab',
-              saveToJWT: true,
-            },
-            {
-              name: 'tabSaveToJWTString',
-              fields: [
-                {
-                  name: 'includedByDefault',
-                  type: 'text',
-                  defaultValue: 'yes',
-                },
-              ],
-              label: 'Tab Save To JWT String',
-              saveToJWT: 'tab-test',
-            },
-            {
-              fields: [
-                {
-                  name: 'tabLiftedSaveToJWT',
-                  type: 'text',
-                  defaultValue: 'lifted from unnamed tab',
-                  label: 'Tab Lifted Save To JWT',
-                  saveToJWT: true,
-                },
-                {
-                  name: 'unnamedTabSaveToJWTString',
-                  type: 'text',
-                  defaultValue: 'text',
-                  label: 'Unnamed Tab Save To JWT String',
-                  saveToJWT: 'x-tab-field',
-                },
-                {
-                  name: 'unnamedTabSaveToJWTFalse',
-                  type: 'text',
-                  defaultValue: 'false',
-                  label: 'Unnamed Tab Save To JWT False',
-                  saveToJWT: false,
-                },
-              ],
-              label: 'No Name',
-            },
-          ],
-        },
-        {
-          name: 'custom',
-          type: 'text',
-          label: 'Custom',
-        },
-        {
-          name: 'authDebug',
-          type: 'ui',
-          admin: {
-            components: {
-              Field: '/AuthDebug.js#AuthDebug',
-            },
-          },
-          label: 'Auth Debug',
-        },
-      ],
-    },
-    {
-      slug: partialDisableLocaleStrategiesSlug,
-      auth: {
-        disableLocalStrategy: {
-          // optionalPassword: true,
-          enableFields: true,
-        },
-      },
-      fields: [
-        // with `enableFields: true`, the following DB columns will be created:
-        // email
-        // reset_password_token
-        // reset_password_expiration
-        // salt
-        // hash
-        // login_attempts
-        // lock_until
-      ],
-    },
-    {
-      slug: apiKeysSlug,
-      access: {
-        read: ({ req: { user } }) => {
-          if (!user) {
-            return false
-          }
-          if (user?.collection === 'api-keys') {
-            return {
-              id: {
-                equals: user.id,
-              },
-            }
-          }
-          return true
-        },
-      },
-      auth: {
-        disableLocalStrategy: true,
-        useAPIKey: true,
-      },
-      fields: [],
-      labels: {
-        plural: 'API Keys',
-        singular: 'API Key',
-      },
-    },
-    {
-      slug: 'public-users',
-      auth: {
-        verify: true,
-      },
-      fields: [],
-    },
-    {
-      slug: 'relationsCollection',
-      fields: [
-        {
-          name: 'rel',
-          type: 'relationship',
-          relationTo: 'users',
-        },
-        {
-          name: 'text',
-          type: 'text',
-        },
-      ],
-    },
-  ],
-  onInit: async (payload) => {
-    await payload.create({
-      collection: 'users',
-      data: {
-        custom: 'Hello, world!',
+export default buildConfigWithDefaults(
+  {
+    admin: {
+      autoLogin: {
         email: devUser.email,
         password: devUser.password,
-        roles: ['admin'],
+        prefillOnly: true,
       },
-    })
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+      user: 'users',
+    },
+    collections: [
+      {
+        slug,
+        admin: {
+          useAsTitle: 'custom',
+        },
+        auth: {
+          cookies: {
+            domain: undefined,
+            sameSite: 'Lax',
+            secure: false,
+          },
+          depth: 0,
+          lockTime: 600 * 1000, // lock time in ms
+          maxLoginAttempts: 2,
+          tokenExpiration: 7200, // 2 hours
+          useAPIKey: true,
+          verify: false,
+          forgotPassword: {
+            expiration: 300000, // 5 minutes
+          },
+        },
+        fields: [
+          {
+            name: 'adminOnlyField',
+            type: 'text',
+            access: {
+              read: ({ req: { user } }) => {
+                return user?.roles?.includes('admin')
+              },
+            },
+          },
+          {
+            name: 'roles',
+            type: 'select',
+            defaultValue: ['user'],
+            hasMany: true,
+            label: 'Role',
+            options: ['admin', 'editor', 'moderator', 'user', 'viewer'],
+            required: true,
+            saveToJWT: true,
+          },
+          {
+            name: 'namedSaveToJWT',
+            type: 'text',
+            defaultValue: namedSaveToJWTValue,
+            label: 'Named Save To JWT',
+            saveToJWT: saveToJWTKey,
+          },
+          {
+            name: 'group',
+            type: 'group',
+            fields: [
+              {
+                name: 'liftedSaveToJWT',
+                type: 'text',
+                defaultValue: 'lifted from group',
+                label: 'Lifted Save To JWT',
+                saveToJWT: 'x-lifted-from-group',
+              },
+            ],
+          },
+          {
+            name: 'groupSaveToJWT',
+            type: 'group',
+            fields: [
+              {
+                name: 'saveToJWTString',
+                type: 'text',
+                defaultValue: 'nested property',
+                label: 'Save To JWT String',
+                saveToJWT: 'x-test',
+              },
+              {
+                name: 'saveToJWTFalse',
+                type: 'text',
+                defaultValue: 'nested property',
+                label: 'Save To JWT False',
+                saveToJWT: false,
+              },
+            ],
+            label: 'Group Save To JWT',
+            saveToJWT: 'x-group',
+          },
+          {
+            type: 'tabs',
+            tabs: [
+              {
+                name: 'saveToJWTTab',
+                fields: [
+                  {
+                    name: 'test',
+                    type: 'text',
+                    defaultValue: 'yes',
+                    saveToJWT: 'x-field',
+                  },
+                ],
+                label: 'Save To JWT Tab',
+                saveToJWT: true,
+              },
+              {
+                name: 'tabSaveToJWTString',
+                fields: [
+                  {
+                    name: 'includedByDefault',
+                    type: 'text',
+                    defaultValue: 'yes',
+                  },
+                ],
+                label: 'Tab Save To JWT String',
+                saveToJWT: 'tab-test',
+              },
+              {
+                fields: [
+                  {
+                    name: 'tabLiftedSaveToJWT',
+                    type: 'text',
+                    defaultValue: 'lifted from unnamed tab',
+                    label: 'Tab Lifted Save To JWT',
+                    saveToJWT: true,
+                  },
+                  {
+                    name: 'unnamedTabSaveToJWTString',
+                    type: 'text',
+                    defaultValue: 'text',
+                    label: 'Unnamed Tab Save To JWT String',
+                    saveToJWT: 'x-tab-field',
+                  },
+                  {
+                    name: 'unnamedTabSaveToJWTFalse',
+                    type: 'text',
+                    defaultValue: 'false',
+                    label: 'Unnamed Tab Save To JWT False',
+                    saveToJWT: false,
+                  },
+                ],
+                label: 'No Name',
+              },
+            ],
+          },
+          {
+            name: 'custom',
+            type: 'text',
+            label: 'Custom',
+          },
+          {
+            name: 'authDebug',
+            type: 'ui',
+            admin: {
+              components: {
+                Field: '/AuthDebug.js#AuthDebug',
+              },
+            },
+            label: 'Auth Debug',
+          },
+        ],
+      },
+      {
+        slug: partialDisableLocaleStrategiesSlug,
+        auth: {
+          disableLocalStrategy: {
+            // optionalPassword: true,
+            enableFields: true,
+          },
+        },
+        fields: [
+          // with `enableFields: true`, the following DB columns will be created:
+          // email
+          // reset_password_token
+          // reset_password_expiration
+          // salt
+          // hash
+          // login_attempts
+          // lock_until
+        ],
+      },
+      {
+        slug: apiKeysSlug,
+        access: {
+          read: ({ req: { user } }) => {
+            if (!user) {
+              return false
+            }
+            if (user?.collection === apiKeysSlug) {
+              return {
+                id: {
+                  equals: user.id,
+                },
+              }
+            }
+            return true
+          },
+        },
+        auth: {
+          disableLocalStrategy: true,
+          useAPIKey: true,
+        },
+        fields: [],
+        labels: {
+          plural: 'API Keys',
+          singular: 'API Key',
+        },
+      },
+      {
+        slug: publicUsersSlug,
+        auth: {
+          verify: true,
+        },
+        fields: [],
+      },
+      {
+        slug: 'relationsCollection',
+        fields: [
+          {
+            name: 'rel',
+            type: 'relationship',
+            relationTo: 'users',
+          },
+          {
+            name: 'text',
+            type: 'text',
+          },
+        ],
+      },
+    ],
+    onInit: async (payload) => {
+      await payload.create({
+        collection: 'users',
+        data: {
+          custom: 'Hello, world!',
+          email: devUser.email,
+          password: devUser.password,
+          roles: ['admin'],
+        },
+      })
 
-    await payload.create({
-      collection: 'api-keys',
-      data: {
-        apiKey: uuid(),
-        enableAPIKey: true,
-      },
-    })
+      await payload.create({
+        collection: apiKeysSlug,
+        data: {
+          apiKey: uuid(),
+          enableAPIKey: true,
+        },
+      })
 
-    await payload.create({
-      collection: 'api-keys',
-      data: {
-        apiKey: uuid(),
-        enableAPIKey: true,
-      },
-    })
+      await payload.create({
+        collection: apiKeysSlug,
+        data: {
+          apiKey: uuid(),
+          enableAPIKey: true,
+        },
+      })
+
+      await payload.create({
+        collection: publicUsersSlug,
+        data: {
+          email: 'public-user@payloadcms.com',
+          password: devUser.password,
+          _verified: true,
+        },
+        disableVerificationEmail: true,
+      })
+    },
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
   },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
+  {
+    disableAutoLogin: true,
   },
-})
+)

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -22,7 +22,7 @@ import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
 import { reInitializeDB } from '../helpers/reInitializeDB.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
-import { apiKeysSlug, publicUsersSlug, slug } from './shared.js'
+import { apiKeysSlug, slug } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -124,15 +124,6 @@ describe('auth', () => {
       },
     })
 
-    await payload.create({
-      collection: publicUsersSlug,
-      data: {
-        email: 'public-user@payloadcms.com',
-        password: devUser.password,
-        _verified: true,
-      },
-    })
-
     await createFirstUser({ page, serverURL })
 
     await ensureCompilationIsDone({ page, serverURL })
@@ -206,54 +197,6 @@ describe('auth', () => {
       await saveDocAndAssert(page)
       await expect(page.locator('#users-api-result')).toHaveText('Goodbye, world!')
       await expect(page.locator('#use-auth-result')).toHaveText('Goodbye, world!')
-    })
-  })
-
-  describe('unauthorized users', () => {
-    test('unauthenticated users should not have access to the admin panel', async () => {
-      await page.goto(url.logout)
-      await page.goto(url.admin)
-
-      await expect(page.locator('.unauthorized .form-header h1')).toHaveText(
-        'Unauthorized, you must be logged in to make this request.',
-      )
-    })
-
-    test('public users should not have access to access admin', async () => {
-      await page.goto(url.logout)
-
-      const user = await payload.login({
-        collection: publicUsersSlug,
-        data: {
-          email: 'public-user@payloadcms.com',
-          password: devUser.password,
-        },
-      })
-
-      await context.addCookies([
-        {
-          name: 'payload-token',
-          value: user.token,
-          domain: 'localhost',
-          path: '/',
-          httpOnly: true,
-          secure: true,
-        },
-      ])
-
-      await page.reload()
-
-      await page.goto(url.admin)
-
-      await expect(page.locator('.unauthorized .form-header h1')).toHaveText(
-        'Unauthorized, this user does not have access to the admin panel.',
-      )
-
-      await page.goto(url.logout)
-
-      await expect(page.locator('.payload-toast-container')).toContainText(
-        'You have been logged out successfully.',
-      )
     })
   })
 

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -248,6 +248,12 @@ describe('auth', () => {
       await expect(page.locator('.unauthorized .form-header h1')).toHaveText(
         'Unauthorized, this user does not have access to the admin panel.',
       )
+
+      await page.goto(url.logout)
+
+      await expect(page.locator('.payload-toast-container')).toContainText(
+        'You have been logged out successfully.',
+      )
     })
   })
 

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -13,6 +13,7 @@ import {
   apiKeysSlug,
   namedSaveToJWTValue,
   partialDisableLocaleStrategiesSlug,
+  publicUsersSlug,
   saveToJWTKey,
   slug,
 } from './shared.js'
@@ -276,7 +277,7 @@ describe('Auth', () => {
 
       it('should allow verification of a user', async () => {
         const emailToVerify = 'verify@me.com'
-        const response = await restClient.POST(`/public-users`, {
+        const response = await restClient.POST(`/${publicUsersSlug}`, {
           body: JSON.stringify({
             email: emailToVerify,
             password,
@@ -290,7 +291,7 @@ describe('Auth', () => {
         expect(response.status).toBe(201)
 
         const userResult = await payload.find({
-          collection: 'public-users',
+          collection: publicUsersSlug,
           limit: 1,
           showHiddenFields: true,
           where: {
@@ -306,13 +307,13 @@ describe('Auth', () => {
         expect(_verificationToken).toBeDefined()
 
         const verificationResponse = await restClient.POST(
-          `/public-users/verify/${_verificationToken}`,
+          `/${publicUsersSlug}/verify/${_verificationToken}`,
         )
 
         expect(verificationResponse.status).toBe(200)
 
         const afterVerifyResult = await payload.find({
-          collection: 'public-users',
+          collection: publicUsersSlug,
           limit: 1,
           showHiddenFields: true,
           where: {
@@ -782,24 +783,24 @@ describe('Auth', () => {
   describe('API Key', () => {
     it('should authenticate via the correct API key user', async () => {
       const usersQuery = await payload.find({
-        collection: 'api-keys',
+        collection: apiKeysSlug,
       })
 
       const [user1, user2] = usersQuery.docs
 
       const success = await restClient
-        .GET(`/api-keys/${user2.id}`, {
+        .GET(`/${apiKeysSlug}/${user2.id}`, {
           headers: {
-            Authorization: `api-keys API-Key ${user2.apiKey}`,
+            Authorization: `${apiKeysSlug} API-Key ${user2.apiKey}`,
           },
         })
         .then((res) => res.json())
 
       expect(success.apiKey).toStrictEqual(user2.apiKey)
 
-      const fail = await restClient.GET(`/api-keys/${user1.id}`, {
+      const fail = await restClient.GET(`/${apiKeysSlug}/${user1.id}`, {
         headers: {
-          Authorization: `api-keys API-Key ${user2.apiKey}`,
+          Authorization: `${apiKeysSlug} API-Key ${user2.apiKey}`,
         },
       })
 
@@ -809,7 +810,7 @@ describe('Auth', () => {
     it('should not remove an API key from a user when updating other fields', async () => {
       const apiKey = uuid()
       const user = await payload.create({
-        collection: 'api-keys',
+        collection: apiKeysSlug,
         data: {
           apiKey,
           enableAPIKey: true,
@@ -818,14 +819,14 @@ describe('Auth', () => {
 
       const updatedUser = await payload.update({
         id: user.id,
-        collection: 'api-keys',
+        collection: apiKeysSlug,
         data: {
           enableAPIKey: true,
         },
       })
 
       const userResult = await payload.find({
-        collection: 'api-keys',
+        collection: apiKeysSlug,
         where: {
           id: {
             equals: user.id,
@@ -857,7 +858,7 @@ describe('Auth', () => {
 
       // use the api key in a fetch to assert that it is disabled
       const response = await restClient
-        .GET(`/api-keys/me`, {
+        .GET(`/${apiKeysSlug}/me`, {
           headers: {
             Authorization: `${apiKeysSlug} API-Key ${apiKey}`,
           },
@@ -888,7 +889,7 @@ describe('Auth', () => {
 
       // use the api key in a fetch to assert that it is disabled
       const response = await restClient
-        .GET(`/api-keys/me`, {
+        .GET(`/${apiKeysSlug}/me`, {
           headers: {
             Authorization: `${apiKeysSlug} API-Key ${apiKey}`,
           },

--- a/test/auth/shared.ts
+++ b/test/auth/shared.ts
@@ -1,4 +1,7 @@
 export const slug = 'users'
+
+export const publicUsersSlug = 'public-users'
+
 export const apiKeysSlug = 'api-keys'
 
 export const partialDisableLocaleStrategiesSlug = 'partial-disable-locale-strategies'

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -28,6 +28,7 @@ type LoginArgs = {
   page: Page
   serverURL: string
 }
+
 const random = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min
 
 const networkConditions = {

--- a/test/helpers/adminUrlUtil.ts
+++ b/test/helpers/adminUrlUtil.ts
@@ -1,8 +1,8 @@
+import type { Config } from 'payload'
+
 // IMPORTANT: ensure that imports do not contain React components, etc. as this breaks Playwright tests
 // Instead of pointing to the bundled code, which will include React components, use direct import paths
 import { formatAdminURL } from '../../packages/ui/src/utilities/formatAdminURL.js' // eslint-disable-line payload/no-relative-monorepo-imports
-
-import type { Config } from 'payload'
 
 export class AdminUrlUtil {
   account: string
@@ -15,9 +15,14 @@ export class AdminUrlUtil {
 
   list: string
 
+  login: string
+
+  logout: string
+
   routes: Config['routes']
 
   serverURL: string
+
   constructor(serverURL: string, slug: string, routes?: Config['routes']) {
     this.routes = {
       admin: routes?.admin || '/admin',
@@ -36,6 +41,18 @@ export class AdminUrlUtil {
     this.account = formatAdminURL({
       adminRoute: this.routes.admin,
       path: '/account',
+      serverURL: this.serverURL,
+    })
+
+    this.login = formatAdminURL({
+      adminRoute: this.routes.admin,
+      path: '/login',
+      serverURL: this.serverURL,
+    })
+
+    this.logout = formatAdminURL({
+      adminRoute: this.routes.admin,
+      path: '/logout',
       serverURL: this.serverURL,
     })
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,7 +28,7 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/live-preview/config.ts"],
+      "@payload-config": ["./test/access-control/config.ts"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
       "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,13 +12,21 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "preserve",
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2022"
+    ],
     "outDir": "${configDir}/dist",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "emitDeclarationOnly": true,
     "sourceMap": true,
-    "types": ["jest", "node", "@types/jest"],
+    "types": [
+      "jest",
+      "node",
+      "@types/jest"
+    ],
     "incremental": true,
     "isolatedModules": true,
     "strict": false,
@@ -28,33 +36,72 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/live-preview/config.ts"],
-      "@payloadcms/live-preview": ["./packages/live-preview/src"],
-      "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
-      "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],
-      "@payloadcms/ui": ["./packages/ui/src/exports/client/index.ts"],
-      "@payloadcms/ui/shared": ["./packages/ui/src/exports/shared/index.ts"],
-      "@payloadcms/ui/scss": ["./packages/ui/src/scss.scss"],
-      "@payloadcms/ui/scss/app.scss": ["./packages/ui/src/scss/app.scss"],
-      "@payloadcms/next/*": ["./packages/next/src/exports/*.ts"],
+      "@payload-config": [
+        "./test/auth/config.ts"
+      ],
+      "@payloadcms/live-preview": [
+        "./packages/live-preview/src"
+      ],
+      "@payloadcms/live-preview-react": [
+        "./packages/live-preview-react/src/index.ts"
+      ],
+      "@payloadcms/live-preview-vue": [
+        "./packages/live-preview-vue/src/index.ts"
+      ],
+      "@payloadcms/ui": [
+        "./packages/ui/src/exports/client/index.ts"
+      ],
+      "@payloadcms/ui/shared": [
+        "./packages/ui/src/exports/shared/index.ts"
+      ],
+      "@payloadcms/ui/scss": [
+        "./packages/ui/src/scss.scss"
+      ],
+      "@payloadcms/ui/scss/app.scss": [
+        "./packages/ui/src/scss/app.scss"
+      ],
+      "@payloadcms/next/*": [
+        "./packages/next/src/exports/*.ts"
+      ],
       "@payloadcms/richtext-lexical/client": [
         "./packages/richtext-lexical/src/exports/client/index.ts"
       ],
-      "@payloadcms/richtext-lexical/rsc": ["./packages/richtext-lexical/src/exports/server/rsc.ts"],
-      "@payloadcms/richtext-slate/rsc": ["./packages/richtext-slate/src/exports/server/rsc.ts"],
+      "@payloadcms/richtext-lexical/rsc": [
+        "./packages/richtext-lexical/src/exports/server/rsc.ts"
+      ],
+      "@payloadcms/richtext-slate/rsc": [
+        "./packages/richtext-slate/src/exports/server/rsc.ts"
+      ],
       "@payloadcms/richtext-slate/client": [
         "./packages/richtext-slate/src/exports/client/index.ts"
       ],
-      "@payloadcms/plugin-seo/client": ["./packages/plugin-seo/src/exports/client.ts"],
-      "@payloadcms/plugin-sentry/client": ["./packages/plugin-sentry/src/exports/client.ts"],
-      "@payloadcms/plugin-stripe/client": ["./packages/plugin-stripe/src/exports/client.ts"],
-      "@payloadcms/plugin-search/client": ["./packages/plugin-search/src/exports/client.ts"],
+      "@payloadcms/plugin-seo/client": [
+        "./packages/plugin-seo/src/exports/client.ts"
+      ],
+      "@payloadcms/plugin-sentry/client": [
+        "./packages/plugin-sentry/src/exports/client.ts"
+      ],
+      "@payloadcms/plugin-stripe/client": [
+        "./packages/plugin-stripe/src/exports/client.ts"
+      ],
+      "@payloadcms/plugin-search/client": [
+        "./packages/plugin-search/src/exports/client.ts"
+      ],
       "@payloadcms/plugin-form-builder/client": [
         "./packages/plugin-form-builder/src/exports/client.ts"
       ],
-      "@payloadcms/next": ["./packages/next/src/exports/*"]
+      "@payloadcms/next": [
+        "./packages/next/src/exports/*"
+      ]
     }
   },
-  "include": ["${configDir}/src"],
-  "exclude": ["${configDir}/dist", "${configDir}/build", "${configDir}/temp", "**/*.spec.ts"]
+  "include": [
+    "${configDir}/src"
+  ],
+  "exclude": [
+    "${configDir}/dist",
+    "${configDir}/build",
+    "${configDir}/temp",
+    "**/*.spec.ts"
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,21 +12,13 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "preserve",
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ES2022"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "outDir": "${configDir}/dist",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "emitDeclarationOnly": true,
     "sourceMap": true,
-    "types": [
-      "jest",
-      "node",
-      "@types/jest"
-    ],
+    "types": ["jest", "node", "@types/jest"],
     "incremental": true,
     "isolatedModules": true,
     "strict": false,
@@ -36,72 +28,33 @@
       }
     ],
     "paths": {
-      "@payload-config": [
-        "./test/auth/config.ts"
-      ],
-      "@payloadcms/live-preview": [
-        "./packages/live-preview/src"
-      ],
-      "@payloadcms/live-preview-react": [
-        "./packages/live-preview-react/src/index.ts"
-      ],
-      "@payloadcms/live-preview-vue": [
-        "./packages/live-preview-vue/src/index.ts"
-      ],
-      "@payloadcms/ui": [
-        "./packages/ui/src/exports/client/index.ts"
-      ],
-      "@payloadcms/ui/shared": [
-        "./packages/ui/src/exports/shared/index.ts"
-      ],
-      "@payloadcms/ui/scss": [
-        "./packages/ui/src/scss.scss"
-      ],
-      "@payloadcms/ui/scss/app.scss": [
-        "./packages/ui/src/scss/app.scss"
-      ],
-      "@payloadcms/next/*": [
-        "./packages/next/src/exports/*.ts"
-      ],
+      "@payload-config": ["./test/live-preview/config.ts"],
+      "@payloadcms/live-preview": ["./packages/live-preview/src"],
+      "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
+      "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],
+      "@payloadcms/ui": ["./packages/ui/src/exports/client/index.ts"],
+      "@payloadcms/ui/shared": ["./packages/ui/src/exports/shared/index.ts"],
+      "@payloadcms/ui/scss": ["./packages/ui/src/scss.scss"],
+      "@payloadcms/ui/scss/app.scss": ["./packages/ui/src/scss/app.scss"],
+      "@payloadcms/next/*": ["./packages/next/src/exports/*.ts"],
       "@payloadcms/richtext-lexical/client": [
         "./packages/richtext-lexical/src/exports/client/index.ts"
       ],
-      "@payloadcms/richtext-lexical/rsc": [
-        "./packages/richtext-lexical/src/exports/server/rsc.ts"
-      ],
-      "@payloadcms/richtext-slate/rsc": [
-        "./packages/richtext-slate/src/exports/server/rsc.ts"
-      ],
+      "@payloadcms/richtext-lexical/rsc": ["./packages/richtext-lexical/src/exports/server/rsc.ts"],
+      "@payloadcms/richtext-slate/rsc": ["./packages/richtext-slate/src/exports/server/rsc.ts"],
       "@payloadcms/richtext-slate/client": [
         "./packages/richtext-slate/src/exports/client/index.ts"
       ],
-      "@payloadcms/plugin-seo/client": [
-        "./packages/plugin-seo/src/exports/client.ts"
-      ],
-      "@payloadcms/plugin-sentry/client": [
-        "./packages/plugin-sentry/src/exports/client.ts"
-      ],
-      "@payloadcms/plugin-stripe/client": [
-        "./packages/plugin-stripe/src/exports/client.ts"
-      ],
-      "@payloadcms/plugin-search/client": [
-        "./packages/plugin-search/src/exports/client.ts"
-      ],
+      "@payloadcms/plugin-seo/client": ["./packages/plugin-seo/src/exports/client.ts"],
+      "@payloadcms/plugin-sentry/client": ["./packages/plugin-sentry/src/exports/client.ts"],
+      "@payloadcms/plugin-stripe/client": ["./packages/plugin-stripe/src/exports/client.ts"],
+      "@payloadcms/plugin-search/client": ["./packages/plugin-search/src/exports/client.ts"],
       "@payloadcms/plugin-form-builder/client": [
         "./packages/plugin-form-builder/src/exports/client.ts"
       ],
-      "@payloadcms/next": [
-        "./packages/next/src/exports/*"
-      ]
+      "@payloadcms/next": ["./packages/next/src/exports/*"]
     }
   },
-  "include": [
-    "${configDir}/src"
-  ],
-  "exclude": [
-    "${configDir}/dist",
-    "${configDir}/build",
-    "${configDir}/temp",
-    "**/*.spec.ts"
-  ]
+  "include": ["${configDir}/src"],
+  "exclude": ["${configDir}/dist", "${configDir}/build", "${configDir}/temp", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Fixes #10180. When logged in as an unauthorized user who cannot access the admin panel, the user is unable to log out through the prompted `/admin/logout` page. This was because that page was using an incorrect API endpoint, reading from `admin.user` instead of `user.collection` when formatting the route. This page was also able to get stuck in an infinite loading state when attempting to log out without any user at all. Now, public users can properly log out and then back in with another user who might have access. The messaging around this was also misleading. Instead of displaying the "Unauthorized, you must be logged in to make this request" message, we now display a new "Unauthorized, this user does not have access to the admin panel" message for added clarity.