### PR TITLE
docs: fix typo in join.mdx

### DIFF
--- a/docs/fields/join.mdx
+++ b/docs/fields/join.mdx
@@ -15,7 +15,7 @@ APIs.
 
 The Join field is useful in scenarios including:
 
-- To surface `Order`s for a given `Product`
+- To surface `Orders` for a given `Product`
 - To view and edit `Posts` belonging to a `Category`
 - To work with any bi-directional relationship data
 - Displaying where a document or upload is used in other documents


### PR DESCRIPTION
## Fix typo in documentation

This pull request fixes a small typo in the docs.

![CleanShot 2024-12-26 at 23 59 55](https://github.com/user-attachments/assets/7edb1f98-c8ce-4e79-96a1-b704a21c1be0)
