### PR TITLE
templates: use `publishConfig` for the plugin template

### DIFF
--- a/templates/plugin/package.json
+++ b/templates/plugin/package.json
@@ -38,7 +38,7 @@
     "dev:payload": "PAYLOAD_CONFIG_PATH=./dev/payload.config.ts payload",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
-    "prepublishOnly": "pnpm clean && pnpm turbo build",
+    "prepublishOnly": "pnpm clean && pnpm build",
     "test": "jest"
   },
   "devDependencies": {

--- a/templates/plugin/package.json
+++ b/templates/plugin/package.json
@@ -6,23 +6,23 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "import": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./client": {
-      "import": "./dist/exports/client.js",
-      "types": "./dist/exports/client.d.ts",
-      "default": "./dist/exports/client.js"
+      "import": "./src/exports/client.ts",
+      "types": "./src/exports/client.ts",
+      "default": "./src/exports/client.ts"
     },
     "./rsc": {
-      "import": "./dist/exports/rsc.js",
-      "types": "./dist/exports/rsc.d.ts",
-      "default": "./dist/exports/rsc.js"
+      "import": "./src/exports/rsc.ts",
+      "types": "./src/exports/rsc.ts",
+      "default": "./src/exports/rsc.ts"
     }
   },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "files": [
     "dist"
   ],
@@ -80,6 +80,27 @@
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "import": "./dist/index.js",
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "./client": {
+        "import": "./dist/exports/client.js",
+        "types": "./dist/exports/client.d.ts",
+        "default": "./dist/exports/client.js"
+      },
+      "./rsc": {
+        "import": "./dist/exports/rsc.js",
+        "types": "./dist/exports/rsc.d.ts",
+        "default": "./dist/exports/rsc.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "registry": "https://registry.npmjs.org/"
 }


### PR DESCRIPTION
Separates `exports`, `main`, `types` for publish / dev with `publishConfig` for the plugin template. Previously, you needed a `dist` folder to run payload bin scripts.