### PR TITLE
fix(ui): pagination resets perPage

### DIFF
--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -109,6 +109,7 @@ export const DefaultListView: React.FC<ListViewClientProps> = (props) => {
     handlePerPageChange,
     query,
   } = useListQuery()
+
   const { openModal } = useModal()
   const { setCollectionSlug, setCurrentActivePath, setOnSuccess } = useBulkUpload()
   const { drawerSlug: bulkUploadDrawerSlug } = useBulkUpload()

--- a/test/admin/e2e/2/e2e.spec.ts
+++ b/test/admin/e2e/2/e2e.spec.ts
@@ -440,9 +440,15 @@ describe('admin2', () => {
       test('should reset page when filters are applied', async () => {
         await deleteAllPosts()
 
-        await mapAsync([...Array(12)], async () => {
-          await createPost()
-        })
+        await Promise.all(
+          Array.from({ length: 12 }, async (_, i) => {
+            if (i < 6) {
+              await createPost()
+            } else {
+              await createPost({ title: 'test' })
+            }
+          }),
+        )
 
         await page.reload()
 

--- a/test/admin/e2e/2/e2e.spec.ts
+++ b/test/admin/e2e/2/e2e.spec.ts
@@ -714,7 +714,7 @@ describe('admin2', () => {
           .click()
 
         await expect(tableItems).toHaveCount(25)
-        await expect(page.locator('.per-page')).toContainText('Per Page: 25')
+        await expect(page.locator('.per-page .per-page__base-button')).toContainText('Per Page: 25')
         await page.locator('.paginator button').nth(1).click()
         await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('page=2')
         await expect(tableItems).toHaveCount(1)

--- a/test/admin/e2e/2/e2e.spec.ts
+++ b/test/admin/e2e/2/e2e.spec.ts
@@ -439,27 +439,19 @@ describe('admin2', () => {
 
       test('should reset page when filters are applied', async () => {
         await deleteAllPosts()
-        await mapAsync([...Array(6)], async () => {
+
+        await mapAsync([...Array(12)], async () => {
           await createPost()
         })
-        await page.reload()
-        await mapAsync([...Array(6)], async () => {
-          await createPost({ title: 'test' })
-        })
+
         await page.reload()
 
-        const pageInfo = page.locator('.collection-list__page-info')
-        const perPage = page.locator('.per-page')
         const tableItems = page.locator(tableRowLocator)
 
         await expect(tableItems).toHaveCount(10)
-        await expect(pageInfo).toHaveText('1-10 of 12')
-        await expect(perPage).toContainText('Per Page: 10')
-
-        // go to page 2
+        await expect(page.locator('.collection-list__page-info')).toHaveText('1-10 of 12')
+        await expect(page.locator('.per-page')).toContainText('Per Page: 10')
         await page.goto(`${postsUrl.list}?limit=10&page=2`)
-
-        // add filter
         await openListFilters(page, {})
         await page.locator('.where-builder__add-first-filter').click()
         await page.locator('.condition__field .rs__control').click()
@@ -468,9 +460,7 @@ describe('admin2', () => {
         await page.locator('.condition__operator .rs__control').click()
         await options.locator('text=equals').click()
         await page.locator('.condition__value input').fill('test')
-
-        // expect to be on page 1
-        await expect(pageInfo).toHaveText('1-6 of 6')
+        await expect(page.locator('.collection-list__page-info')).toHaveText('1-6 of 6')
       })
     })
 
@@ -685,27 +675,51 @@ describe('admin2', () => {
     describe('pagination', () => {
       test('should paginate', async () => {
         await deleteAllPosts()
+
         await mapAsync([...Array(11)], async () => {
           await createPost()
         })
+
         await page.reload()
-
-        const pageInfo = page.locator('.collection-list__page-info')
-        const perPage = page.locator('.per-page')
-        const paginator = page.locator('.paginator')
         const tableItems = page.locator(tableRowLocator)
-
         await expect(tableItems).toHaveCount(10)
-        await expect(pageInfo).toHaveText('1-10 of 11')
-        await expect(perPage).toContainText('Per Page: 10')
-
-        // Forward one page and back using numbers
-        await paginator.locator('button').nth(1).click()
+        await expect(page.locator('.collection-list__page-info')).toHaveText('1-10 of 11')
+        await expect(page.locator('.per-page')).toContainText('Per Page: 10')
+        await page.locator('.paginator button').nth(1).click()
         await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('page=2')
         await expect(tableItems).toHaveCount(1)
-        await paginator.locator('button').nth(0).click()
+        await page.locator('.paginator button').nth(0).click()
         await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('page=1')
         await expect(tableItems).toHaveCount(10)
+      })
+
+      test('should paginate and maintain perPage', async () => {
+        await deleteAllPosts()
+
+        await mapAsync([...Array(26)], async () => {
+          await createPost()
+        })
+
+        await page.reload()
+        const tableItems = page.locator(tableRowLocator)
+        await expect(tableItems).toHaveCount(10)
+        await expect(page.locator('.collection-list__page-info')).toHaveText('1-10 of 26')
+        await expect(page.locator('.per-page')).toContainText('Per Page: 10')
+        await page.locator('.per-page .popup-button').click()
+
+        await page
+          .locator('.per-page button.per-page__button', {
+            hasText: '25',
+          })
+          .click()
+
+        await expect(tableItems).toHaveCount(25)
+        await expect(page.locator('.per-page')).toContainText('Per Page: 25')
+        await page.locator('.paginator button').nth(1).click()
+        await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('page=2')
+        await expect(tableItems).toHaveCount(1)
+        await expect(page.locator('.per-page')).toContainText('Per Page: 25')
+        await expect(page.locator('.collection-list__page-info')).toHaveText('25-26 of 26')
       })
     })
 

--- a/test/admin/e2e/2/e2e.spec.ts
+++ b/test/admin/e2e/2/e2e.spec.ts
@@ -719,7 +719,7 @@ describe('admin2', () => {
         await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('page=2')
         await expect(tableItems).toHaveCount(1)
         await expect(page.locator('.per-page')).toContainText('Per Page: 25')
-        await expect(page.locator('.collection-list__page-info')).toHaveText('25-26 of 26')
+        await expect(page.locator('.collection-list__page-info')).toHaveText('26-26 of 26')
       })
     })
 

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -125,8 +125,6 @@ export interface Upload {
   focalY?: number | null;
 }
 /**
- * This is a custom collection description.
- *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "posts".
  */
@@ -167,9 +165,6 @@ export interface Post {
   defaultValueField?: string | null;
   relationship?: (string | null) | Post;
   customCell?: string | null;
-  /**
-   * This is a very long description that takes many characters to complete and hopefully will wrap instead of push the sidebar open, lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum voluptates. Quisquam, voluptatum voluptates.
-   */
   sidebarField?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -251,13 +246,7 @@ export interface CustomField {
   id: string;
   customTextServerField?: string | null;
   customTextClientField?: string | null;
-  /**
-   * Static field description.
-   */
   descriptionAsString?: string | null;
-  /**
-   * Function description
-   */
   descriptionAsFunction?: string | null;
   descriptionAsComponent?: string | null;
   customSelectField?: string | null;
@@ -336,34 +325,6 @@ export interface Geo {
    * @maxItems 2
    */
   point?: [number, number] | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * Description
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "customIdTab".
- */
-export interface CustomIdTab {
-  title?: string | null;
-  id: string;
-  description?: string | null;
-  number?: number | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * Description
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "customIdRow".
- */
-export interface CustomIdRow {
-  title?: string | null;
-  id: string;
-  description?: string | null;
-  number?: number | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,7 +28,7 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/access-control/config.ts"],
+      "@payload-config": ["./test/admin/config.ts"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
       "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -27,7 +27,7 @@
         "name": "next"
       }
     ],
-    "paths": {=======
+    "paths": {
       "@payload-config": ["./test/_community/config.ts"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],


### PR DESCRIPTION
When using various controls within the List View, those selections are sometimes not persisted. This is especially evident when selecting `perPage` from the List View, where the URL and UI would reflect this selection, but the controls would be stale. Similarly, after changing `perPage` then navigating to another page through the pagination controls, `perPage` would reset back to the original value. Same with the sort controls, where sorting by a particular column would not be reflected in the UI. This was because although we modify the URL search params and fire off a new query with those changes, we were not updating local component state.