### PR TITLE
chore: bind async local storage in `dev.ts` to `globalThis`

### DIFF
--- a/test/dev.ts
+++ b/test/dev.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'async_hooks'
 import chalk from 'chalk'
 import { createServer } from 'http'
 import minimist from 'minimist'
@@ -14,6 +15,8 @@ import startMemoryDB from './helpers/startMemoryDB.js'
 import { runInit } from './runInit.js'
 import { child, safelyRunScriptFunction } from './safelyRunScript.js'
 import { createTestHooks } from './testHooks.js'
+
+globalThis.AsyncLocalStorage = AsyncLocalStorage
 
 const prod = process.argv.includes('--prod')
 if (prod) {


### PR DESCRIPTION
Without this, `pnpm dev _community` doesn't work with these errors 
<img width="608" alt="image" src="https://github.com/user-attachments/assets/f3bc7cca-0201-439e-bd06-12c6c5b16185" />
![image](https://github.com/user-attachments/assets/182181e9-42fb-47b7-9aa3-5522b6e117f3)

Possibly because `globalThis.AsyncLocalStorage` is not defined which next tries to access https://github.com/vercel/next.js/blob/1ea3ba06edecdbbf8d670861298a373322094993/packages/next/src/server/app-render/async-local-storage.ts#L36-L37