### PR TITLE
docs: migrate to new mdx rendering

### DIFF
--- a/docs/access-control/overview.mdx
+++ b/docs/access-control/overview.mdx
@@ -34,16 +34,14 @@ const defaultPayloadAccess = ({ req: { user } }) => {
 ```
 
 <Banner type="success">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   In the Local API, all Access Control functions are skipped by default, allowing your server to do
   whatever it needs. But, you can opt back in by setting the option
-  {' '}
-  <strong>
-    overrideAccess
-  </strong>
-  {' '}
-  to <strong>false</strong>.
+
+  **overrideAccess**
+
+  to **false**.
 </Banner>
 
 ### Access Control Types
@@ -57,8 +55,8 @@ You can manage access within Payload on three different levels:
 ### When Access Control is Executed
 
 <Banner type="success">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   Access control functions are utilized in two places. It's important to understand how and when
   your access control is executed.
 </Banner>
@@ -76,10 +74,10 @@ To accomplish this, Payload ships with an `Access` operation, which is executed 
 ### Argument Availability
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
-  When your access control functions are executed via the <strong>access</strong> operation, the{' '}
-  <strong>id</strong> and <strong>data</strong> arguments will be <strong>undefined</strong>,
+  **Important:**
+
+  When your access control functions are executed via the **access** operation, the{' '}
+  **id** and **data** arguments will be **undefined**,
   because Payload is executing your functions without referencing a specific document.
 </Banner>
 

--- a/docs/admin/bundlers.mdx
+++ b/docs/admin/bundlers.mdx
@@ -46,8 +46,8 @@ At their core, a bundler's main goal is to take a bunch of files and turn them i
 Since the bundled file is sent to the browser, it can't include any server-only code. You will need to remove any server-only code from your admin UI before bundling it. You can learn more about [excluding server code](/docs/admin/excluding-server-code) section.
 
 <Banner type="warning">
-  <strong>Using environment variables in the admin UI</strong>
-  <br />
+  **Using environment variables in the admin UI**
+
   Bundles should not contain sensitive information. By default, Payload
   excludes env variables from the bundle. If you need to use env variables in your payload config,
   you need to prefix them with `PAYLOAD_PUBLIC_` to make them available to the client-side code.

--- a/docs/admin/components.mdx
+++ b/docs/admin/components.mdx
@@ -11,8 +11,8 @@ While designing the Payload Admin panel, we determined it should be as minimal a
 To swap in your own React component, first, consult the list of available component overrides below. Determine the scope that corresponds to what you are trying to accomplish, and then author your React component accordingly.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   Custom components will automatically be provided with all props that the default component normally
   accepts.
 </Banner>
@@ -133,8 +133,8 @@ To add a _new_ view to the Admin Panel, simply add another key to the `views` ob
 ```
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   Routes are cascading. This means that unless explicitly given the `exact` property, they will match on URLs that simply _start_ with the route's path. This is helpful when creating catch-all routes in your application. Alternatively, you could define your nested route _before_ your parent route.
 </Banner>
 
@@ -451,8 +451,8 @@ Your custom view components will be given all the props that a React Router `<Ro
 | **`canAccessAdmin`** \* | If the currently logged in user is allowed to access the admin panel or not. |
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   It's up to you to secure your custom views. If your view requires a user to be logged in or to
   have certain access rights, you should handle that within your view component yourself.
 </Banner>
@@ -471,8 +471,8 @@ To see how to pass in your custom views to create custom views of your own, take
 All Payload fields support the ability to swap in your own React components. So, for example, instead of rendering a default Text input, you might need to render a color picker that provides the editor with a custom color picker interface to restrict the data entered to colors only.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   Don't see a built-in field type that you need? Build it! Using a combination of custom validation
   and custom components, you can override the entirety of how a component functions within the admin
   panel and effectively create your own field type.
@@ -546,7 +546,7 @@ const CustomTextField: React.FC<{ path: string }> = ({ path }) => {
 
 <Banner type="success">
   For more information regarding the hooks that are available to you while you build custom
-  components, including the <strong>useField</strong> hook, [click here](/docs/admin/hooks).
+  components, including the **useField** hook, [click here](/docs/admin/hooks).
 </Banner>
 
 ## Label Component
@@ -651,7 +651,7 @@ export default titleField;
 As your admin customizations gets more complex you may want to share state between fields or other components. You can add custom providers to add your own context to any Payload app for use in other custom components within the admin panel. Within your config add `admin.components.providers`, these can be used to share context or provide other custom functionality. Read the [React context](https://reactjs.org/docs/context.html) docs to learn more.
 
 <Banner type="warning">
-  <strong>Reminder:</strong> Don't forget to pass the **children** prop through the provider
+  **Reminder:** Don't forget to pass the **children** prop through the provider
   component for the admin UI to show
 </Banner>
 

--- a/docs/admin/environment-vars.mdx
+++ b/docs/admin/environment-vars.mdx
@@ -8,8 +8,8 @@ desc: NEEDS TO BE WRITTEN
 ## Admin environment vars
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   Be careful about what variables you provide to your client-side code. Analyze every single one to
   make sure that you're not accidentally leaking anything that an attacker could exploit. Only keys
   that are safe for anyone to read in plain text should be provided to your Admin panel.

--- a/docs/admin/excluding-server-code.mdx
+++ b/docs/admin/excluding-server-code.mdx
@@ -69,8 +69,8 @@ export const createStripeSubscription = async ({ data, operation }) => {
 ```
 
 <Banner type="error">
-  <strong>Warning:</strong>
-  <br />
+  **Warning:**
+
   The above code is NOT production-ready and should not be referenced to create Stripe
   subscriptions. Although creating a beforeChange hook is a completely valid spot to do things like
   create subscriptions, the code above is incomplete and insecure, meant for explanation purposes

--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -57,7 +57,7 @@ const {
 There are times when a custom field component needs to have access to data from other fields, and you have a few options to do so. The `useFormFields` hook is a powerful and highly performant way to retrieve a form's field state, as well as to retrieve the `dispatchFields` method, which can be helpful for setting other fields' form states from anywhere within a form.
 
 <Banner type="success">
-  <strong>This hook is great for retrieving only certain fields from form state</strong> because it
+  **This hook is great for retrieving only certain fields from form state** because it
   ensures that it will only cause a rerender when the items that you ask for change.
 </Banner>
 
@@ -133,8 +133,8 @@ To see types for each action supported within the `dispatchFields` hook, check o
 The `useForm` hook can be used to interact with the form itself, and sends back many methods that can be used to reactively fetch form state without causing rerenders within your components each time a field is changed. This is useful if you have action-based callbacks that your components fire, and need to interact with form state _based on a user action_.
 
 <Banner type="warning">
-  <strong>Warning:</strong>
-  <br />
+  **Warning:**
+
   This hook is optimized to avoid causing rerenders when fields change, and as such, its `fields`
   property will be out of date. You should only leverage this hook if you need to perform actions
   against the form in response to your users' actions. Do not rely on its returned "fields" as being
@@ -152,7 +152,7 @@ The `useForm` hook returns an object with the following properties: |
   rows={[
     [
       {
-        value: <strong><code>fields</code></strong>,
+        value: "**`fields`**",
       },
       {
         value: "Deprecated. This property cannot be relied on as up-to-date.",
@@ -163,7 +163,7 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>submit</code></strong>,
+        value: "**`submit`**",
       },
       {
         value: "Method to trigger the form to submit",
@@ -174,7 +174,7 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>dispatchFields</code></strong>,
+        value: "**`dispatchFields`**",
       },
       {
         value: "Dispatch actions to the form field state",
@@ -185,7 +185,7 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>validateForm</code></strong>,
+        value: "**`validateForm`**",
       },
       {
         value: "Trigger a validation of the form state",
@@ -196,10 +196,10 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>createFormData</code></strong>,
+        value: "**`createFormData`**",
       },
       {
-        value: <>Create a <code>multipart/form-data</code> object from the current form's state</>,
+        value: "Create a `multipart/form-data` object from the current form's state",
       },
       {
         value: ''
@@ -207,7 +207,7 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>disabled</code></strong>,
+        value: "**`disabled`**",
       },
       {
         value: "Boolean denoting whether or not the form is disabled",
@@ -218,7 +218,7 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>getFields</code></strong>,
+        value: "**`getFields`**",
       },
       {
         value: 'Gets all fields from state',
@@ -229,7 +229,7 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>getField</code></strong>,
+        value: "**`getField`**",
       },
       {
         value: 'Gets a single field from state by path',
@@ -240,7 +240,7 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>getData</code></strong>,
+        value: "**`getData`**",
       },
       {
         value: 'Returns the data stored in the form',
@@ -251,7 +251,7 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>getSiblingData</code></strong>,
+        value: "**`getSiblingData`**",
       },
       {
         value: 'Returns form sibling data for the given field path',
@@ -262,21 +262,10 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>setModified</code></strong>,
+        value: "**`setModified`**",
       },
       {
-        value: <>Set the form\'s <code>modified</code> state</>,
-      },
-      {
-        value: '',
-      },
-    ],
-    [
-      {
-        value: <strong><code>setProcessing</code></strong>,
-      },
-      {
-        value: <>Set the form\'s <code>processing</code> state</>,
+        value: "Set the form\'s `modified` state",
       },
       {
         value: '',
@@ -284,10 +273,10 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>setSubmitted</code></strong>,
+        value: "**`setProcessing`**",
       },
       {
-        value: <>Set the form\'s <code>submitted</code> state</>,
+        value: "Set the form\'s `processing` state",
       },
       {
         value: '',
@@ -295,7 +284,18 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>formRef</code></strong>,
+        value: "**`setSubmitted`**",
+      },
+      {
+        value: "Set the form\'s `submitted` state",
+      },
+      {
+        value: '',
+      },
+    ],
+    [
+      {
+        value: "**`formRef`**",
       },
       {
         value: 'The ref from the form HTML element',
@@ -306,7 +306,7 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>reset</code></strong>,
+        value: "**`reset`**",
       },
       {
         value: 'Method to reset the form to its initial state',
@@ -317,7 +317,7 @@ The `useForm` hook returns an object with the following properties: |
     ],
     [
       {
-        value: <strong><code>addFieldRow</code></strong>,
+        value: "**`addFieldRow`**",
       },
       {
         value: "Method to add a row on an array or block field",
@@ -326,8 +326,7 @@ The `useForm` hook returns an object with the following properties: |
         drawerTitle: 'addFieldRow',
         drawerDescription: 'A useful method to programmatically add a row to an array or block field.',
         drawerSlug: 'addFieldRow',
-        drawerContent: (
-<>
+        drawerContent: `
   <TableWithDrawers
     columns={[
       'Prop',
@@ -336,7 +335,7 @@ The `useForm` hook returns an object with the following properties: |
     rows={[
       [
         {
-          value: <strong><code>path</code></strong>,
+          value: "**\\\`path\\\`**",
         },
         {
           value: "The path to the array or block field",
@@ -344,7 +343,7 @@ The `useForm` hook returns an object with the following properties: |
       ],
       [
         {
-          value: <strong><code>rowIndex</code></strong>,
+          value: "**\\\`rowIndex\\\`**",
         },
         {
           value: "The index of the row to add. If omitted, the row will be added to the end of the array.",
@@ -352,7 +351,7 @@ The `useForm` hook returns an object with the following properties: |
       ],
       [
         {
-          value: <strong><code>data</code></strong>,
+          value: "**\\\`data<\\\`**",
         },
         {
           value: "The data to add to the row",
@@ -361,14 +360,9 @@ The `useForm` hook returns an object with the following properties: |
     ]}
   />
 
-{' '}
 
-<br />
-
-{' '}
-
-<pre>
-  {`import { useForm } from "payload/components/forms";
+\\\`\\\`\\\`tsx
+  {\\\`import { useForm } from "payload/components/forms";
 
 export const CustomArrayManager = () => {
   const { addFieldRow } = useForm()
@@ -391,12 +385,13 @@ export const CustomArrayManager = () => {
       Add Row
     </button>
   )
-}`}
-</pre>
+}\\\`}
+\\\`\\\`\\\`
 
-  <p>An example config to go along with the custom component</p>
-  <pre>
-{`const ExampleCollection = {
+An example config to go along with the Custom Component
+
+\\\`\\\`\\\`tsx
+{\\\`const ExampleCollection = {
   slug: "example-collection",
   fields: [
     {
@@ -414,20 +409,19 @@ export const CustomArrayManager = () => {
       name: "customArrayManager",
       admin: {
         components: {
-          Field: CustomArrayManager,
+          Field: '/path/to/CustomArrayManagerField',
         },
       },
     },
   ],
-}`}
-  </pre>
-</>
-        )
+}\\\`}
+\\\`\\\`\\\`
+`
       }
     ],
     [
       {
-        value: <strong><code>removeFieldRow</code></strong>,
+        value: "**`removeFieldRow`**",
       },
       {
         value: "Method to remove a row from an array or block field",
@@ -436,8 +430,7 @@ export const CustomArrayManager = () => {
         drawerTitle: 'removeFieldRow',
         drawerDescription: 'A useful method to programmatically remove a row from an array or block field.',
         drawerSlug: 'removeFieldRow',
-        drawerContent: (
-<>
+        drawerContent:  `
   <TableWithDrawers
     columns={[
       'Prop',
@@ -446,7 +439,7 @@ export const CustomArrayManager = () => {
     rows={[
       [
         {
-          value: <strong><code>path</code></strong>,
+          value: "**\\\`path\\\`**",
         },
         {
           value: "The path to the array or block field",
@@ -454,7 +447,7 @@ export const CustomArrayManager = () => {
       ],
       [
         {
-          value: <strong><code>rowIndex</code></strong>,
+          value: "**\\\`rowIndex\\\`**",
         },
         {
           value: "The index of the row to remove",
@@ -463,14 +456,10 @@ export const CustomArrayManager = () => {
     ]}
   />
 
-{' '}
 
-<br />
 
-{' '}
-
-<pre>
-  {`import { useForm } from "payload/components/forms";
+\\\`\\\`\\\`tsx
+  {\\\`import { useForm } from "payload/components/forms";
 
 export const CustomArrayManager = () => {
   const { removeFieldRow } = useForm()
@@ -488,12 +477,13 @@ export const CustomArrayManager = () => {
       Remove Row
     </button>
   )
-}`}
-</pre>
+}\\\`}
+\\\`\\\`\\\`
 
-  <p>An example config to go along with the custom component</p>
-  <pre>
-{`const ExampleCollection = {
+An example config to go along with the Custom Component
+
+\\\`\\\`\\\`tsx
+{\\\`const ExampleCollection = {
   slug: "example-collection",
   fields: [
     {
@@ -511,20 +501,19 @@ export const CustomArrayManager = () => {
       name: "customArrayManager",
       admin: {
         components: {
-          Field: CustomArrayManager,
+          Field: '/path/to/CustomArrayManagerField',
         },
       },
     },
   ],
-}`}
-  </pre>
-</>
-        )
+}\\\`}
+\\\`\\\`\\\`
+`
       }
     ],
     [
       {
-        value: <strong><code>replaceFieldRow</code></strong>,
+        value: "**`replaceFieldRow`**",
       },
       {
         value: "Method to replace a row from an array or block field",
@@ -533,8 +522,7 @@ export const CustomArrayManager = () => {
         drawerTitle: 'replaceFieldRow',
         drawerDescription: 'A useful method to programmatically replace a row from an array or block field.',
         drawerSlug: 'replaceFieldRow',
-        drawerContent: (
-<>
+        drawerContent:  `
   <TableWithDrawers
     columns={[
       'Prop',
@@ -543,7 +531,7 @@ export const CustomArrayManager = () => {
     rows={[
       [
         {
-          value: <strong><code>path</code></strong>,
+          value: "**\\\`path\\\`**",
         },
         {
           value: "The path to the array or block field",
@@ -551,7 +539,7 @@ export const CustomArrayManager = () => {
       ],
       [
         {
-          value: <strong><code>rowIndex</code></strong>,
+          value: "**\\\`rowIndex\\\`**",
         },
         {
           value: "The index of the row to replace",
@@ -559,7 +547,7 @@ export const CustomArrayManager = () => {
       ],
       [
         {
-          value: <strong><code>data</code></strong>,
+         value: "**\\\`data\\\`**",
         },
         {
           value: "The data to replace within the row",
@@ -568,14 +556,11 @@ export const CustomArrayManager = () => {
     ]}
   />
 
-{' '}
 
-<br />
 
-{' '}
 
-<pre>
-  {`import { useForm } from "payload/components/forms";
+\\\`\\\`\\\`tsx
+  {\\\`import { useForm } from "payload/components/forms";
 
 export const CustomArrayManager = () => {
   const { replaceFieldRow } = useForm()
@@ -598,12 +583,13 @@ export const CustomArrayManager = () => {
       Replace Row
     </button>
   )
-}`}
-</pre>
+}\\\`}
+\\\`\\\`\\\`
 
-  <p>An example config to go along with the custom component</p>
-  <pre>
-{`const ExampleCollection = {
+An example config to go along with the Custom Component
+
+\\\`\\\`\\\`tsx
+{\\\`const ExampleCollection = {
   slug: "example-collection",
   fields: [
     {
@@ -621,15 +607,14 @@ export const CustomArrayManager = () => {
       name: "customArrayManager",
       admin: {
         components: {
-          Field: CustomArrayManager,
+          Field: '/path/to/CustomArrayManagerField',
         },
       },
     },
   ],
-}`}
-  </pre>
-</>
-        )
+}\\\`}
+\\\`\\\`\\\`
+         `
       }
     ],
   ]}

--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -51,8 +51,8 @@ All options for the Admin panel are defined in your base Payload config file.
 ### The Admin User Collection
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   The Payload Admin panel can only be used by one Collection that supports
   [Authentication](/docs/authentication/overview).
 </Banner>

--- a/docs/admin/preferences.mdx
+++ b/docs/admin/preferences.mdx
@@ -15,8 +15,8 @@ Out of the box, Payload handles the persistence of your users' preferences in a 
 1. The "collapsed" state of blocks, on a document level, as users edit or interact with documents
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   All preferences are stored on an individual user basis. Payload automatically recognizes the user
   that is reading or setting a preference via all provided authentication methods.
 </Banner>

--- a/docs/admin/vite.mdx
+++ b/docs/admin/vite.mdx
@@ -45,7 +45,7 @@ Here are the main differences between how Vite aliases work and how Webpack alia
 
 **Vite aliases do not work with absolute paths.**
 
-In Vite, alias keys must <strong>exactly match</strong> a import paths. If you have 2 files that import the same server-only module, but have different import paths, you would need to add 2 aliases to support both import paths.
+In Vite, alias keys must **exactly match** a import paths. If you have 2 files that import the same server-only module, but have different import paths, you would need to add 2 aliases to support both import paths.
 
 ```ts
 // File A

--- a/docs/admin/webpack.mdx
+++ b/docs/admin/webpack.mdx
@@ -59,8 +59,8 @@ export default buildConfig({
 ```
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   If changes to your Webpack aliases are not surfacing, they might be
   [cached](https://webpack.js.org/configuration/cache/) in `node_modules/.cache/webpack`. Try
   deleting that folder and restarting your server.

--- a/docs/authentication/config.mdx
+++ b/docs/authentication/config.mdx
@@ -46,9 +46,9 @@ To enable API keys on a collection, set the `useAPIKey` auth option to `true`. F
 </Banner>
 
 <Banner type="warning">
-  <strong>Important:</strong>
+  **Important:**
   If you change your `PAYLOAD_SECRET`, you will need to regenerate your API keys.
-  <br />
+
   The secret key is used to encrypt the API keys, so if you change the secret, existing API keys will no longer be valid.
 </Banner>
 
@@ -95,8 +95,8 @@ You can customize how the Forgot Password workflow operates with the following o
 Function that accepts one argument, containing `{ req, token, user }`, that allows for overriding the HTML within emails that are sent to users attempting to reset their password. The function should return a string that supports HTML, which can be a full HTML email.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   HTML templating can be used to create custom email templates, inline CSS automatically, and more.
   You can make a reusable function that standardizes all email sent from Payload, which makes
   sending custom emails more DRY. Payload doesn't ship with an HTML templating engine, so you are
@@ -138,8 +138,8 @@ export const Customers: CollectionConfig = {
 ```
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   If you specify a different URL to send your users to for resetting their password, such as a page
   on the frontend of your app or similar, you need to handle making the call to the Payload REST or
   GraphQL reset-password operation yourself on your frontend, using the token that was provided for
@@ -198,8 +198,8 @@ export const Customers: CollectionConfig = {
 ```
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   If you specify a different URL to send your users to for email verification, such as a page on the
   frontend of your app or similar, you need to handle making the call to the Payload REST or GraphQL
   verification operation yourself on your frontend, using the token that was provided for you.

--- a/docs/authentication/operations.mdx
+++ b/docs/authentication/operations.mdx
@@ -351,8 +351,8 @@ const token = await payload.forgotPassword({
 ```
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   You can stop the reset-password email from being sent via using the local API. This is helpful if
   you need to create user accounts programmatically, but not set their password for them. This
   effectively generates a reset password token which you can then use to send to a page you create,

--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -87,10 +87,10 @@ Successfully logging in returns a `JWT` (JSON web token) which is how a user wil
 You can specify what data gets encoded to the JWT token by setting `saveToJWT` to true in your auth collection fields. If you wish to use a different key other than the field `name`, you can provide it to `saveToJWT` as a string. It is also possible to use `saveToJWT` on fields that are nested in inside groups and tabs. If a group has a `saveToJWT` set it will include the object with all sub-fields in the token. You can set `saveToJWT: false` for any fields you wish to omit. If a field inside a group has `saveToJWT` set, but the group does not, the field will be included at the top level of the token.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   You can access the logged-in user from access control functions and hooks via the Express{' '}
-  <strong>req</strong>. The logged-in user is automatically added as the <strong>user</strong>{' '}
+  **req**. The logged-in user is automatically added as the **user**
   property.
 </Banner>
 
@@ -119,8 +119,8 @@ const pages = await response.json()
 For more about how to automatically include cookies in requests from your app to your Payload API, [click here](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Sending_a_request_with_credentials_included).
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   To make sure you have a Payload cookie set properly in your browser after logging in, you can use
   Chrome's Developer Tools - Application - Cookies - [your-domain-here]. The Chrome Developer tools
   will still show HTTP-only cookies, even when JavaScript running on the page can't.
@@ -135,10 +135,10 @@ For example, let's say you have a very popular app running at coolsite.com. This
 So, if a user of coolsite.com is logged in and just browsing around on the internet, they might stumble onto a page with bad intentions. That bad page might automatically make requests to all sorts of sites to see if they can find one that they can log into - and coolsite.com might be on their list. If your user was logged in while they visited that evil site, the attacker could do whatever they wanted as if they were your coolsite.com user by just sending requests to the coolsite API (which would automatically include the auth cookie). They could send themselves a bunch of money from your user's account, change the user's password, etc. This is what a CSRF attack is.
 
 <Banner type="warning">
-  <strong>
+  **
     To protect against CSRF attacks, Payload only accepts cookie-based authentication from domains
     that you explicitly whitelist.
-  </strong>
+  **
 </Banner>
 
 To define domains that should allow users to identify themselves via the Payload HTTP-only cookie, use the `csrf` option on the base Payload config to whitelist domains that you trust.

--- a/docs/cloud/configuration.mdx
+++ b/docs/cloud/configuration.mdx
@@ -54,7 +54,7 @@ Any of the features in Payload Cloud that require environment variables will aut
 Payment methods can be set per project and can be updated any time. You can use team’s default payment method, or add a new one. Modify your payment methods in your Project settings / Team settings.
 
 <Banner type="success">
-  <strong>Note:</strong> All Payload Cloud teams that deploy a project require a card on file. This
+  **Note:** All Payload Cloud teams that deploy a project require a card on file. This
   helps us prevent fraud and abuse on our platform. If you select a plan with a free trial, you will
   not be charged until your trial period is over. We’ll remind you 7 days before your trial ends and
   you can cancel anytime.

--- a/docs/cloud/creating-a-project.mdx
+++ b/docs/cloud/creating-a-project.mdx
@@ -31,7 +31,7 @@ Next, select your `GitHub Scope`. If you belong to multiple organizations, they 
 After selecting your scope, create a unique `repository name` and select whether you want your repository to be public or private on GitHub.
 
 <Banner type="warning">
-  <strong>Note:</strong> Public repositories can be accessed by anyone online, while private
+  **Note:** Public repositories can be accessed by anyone online, while private
   repositories grant access only to you and anyone you explicitly authorize.
 </Banner>
 
@@ -45,7 +45,7 @@ Payload Cloud works for any Node.js + MongoDB app. From the New Project page, se
 _Creating a new project from an existing repository._
 
 <Banner type="warning">
-  <strong>Note:</strong> In order to make use of the features of Payload Cloud in your own codebase,
+  **Note:** In order to make use of the features of Payload Cloud in your own codebase,
   you will need to add the [Cloud Plugin](https://github.com/payloadcms/plugin-cloud) to your
   Payload app.
 </Banner>

--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -164,9 +164,9 @@ add `admin.listSearchableFields: ['title', 'metaDescription', 'tags']` - and the
 those three fields plus the ID field.
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
-  If you are adding <strong>listSearchableFields</strong>, make sure you index each of these fields
+  **Note:**
+
+  If you are adding **listSearchableFields**, make sure you index each of these fields
   so your admin queries can remain performant.
 </Banner>
 

--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -62,8 +62,8 @@ The Payload admin panel reads the language settings of a user's browser and disp
 After a user logs in, they can change their language selection in the `/account` view.
 
 <Banner>
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   If there is a language that Payload does not yet support, we accept code
   [contributions](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md).
 </Banner>

--- a/docs/configuration/localization.mdx
+++ b/docs/configuration/localization.mdx
@@ -149,8 +149,8 @@ All field types with a `name` property support the `localized` property—even t
 and `block`s.
 
 <Banner>
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   Enabling localization for field types that support nested fields will automatically create
   localized "sets" of all fields contained within the field. For example, if you have a page layout
   using a blocks field type, you have the choice of either localizing the full layout, by enabling
@@ -158,8 +158,8 @@ and `block`s.
 </Banner>
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   When converting an existing field to or from `localized: true` the data structure in the document
   will change for this field and so existing data for this field will be lost. Before changing the
   localization setting on fields with existing data, you may need to consider a field migration
@@ -235,9 +235,9 @@ const posts = await payload.find({
 ```
 
 <Banner type="alert">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   The REST and Local APIs can return all localization data in one request by passing 'all' or '*' as
-  the <strong>locale</strong> parameter. The response will be structured so that field values come
+  the **locale** parameter. The response will be structured so that field values come
   back as the full objects keyed for each locale instead of the single, translated value.
 </Banner>

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -11,8 +11,8 @@ Payload is a _config-based_, code-first CMS and application framework. The Paylo
 **Also, because the Payload source code is fully written in TypeScript, its configs are strongly typed—meaning that even if you aren't using TypeScript, your IDE (such as VSCode) may still provide helpful information like type-ahead suggestions while you write your config.**
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   This file is included in the Payload admin bundle, so make sure you do not embed any sensitive
   information.
 </Banner>
@@ -135,8 +135,8 @@ project-name
 ```
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   If you use an environment variable to configure any properties that are required for the Admin
   panel to function (ex. serverURL or any routes), you need to make sure that your Admin panel code
   can access it. [Click here](/docs/admin/webpack#admin-environment-vars) for more info.

--- a/docs/database/transactions.mdx
+++ b/docs/database/transactions.mdx
@@ -11,8 +11,8 @@ Database transactions allow your application to make a series of database change
 By default, Payload will use transactions for all operations, as long as it is supported by the configured database. Database changes are contained within all Payload operations and any errors thrown will result in all changes being rolled back without being committed. When transactions are not supported by the database, Payload will continue to operate as expected without them.
 
 <Banner type="info">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   MongoDB requires a connection to a replicaset in order to make use of transactions.
 </Banner>
 

--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -7,8 +7,8 @@ keywords: blocks, fields, config, configuration, documentation, Content Manageme
 ---
 
 <Banner>
-  The Blocks field type is <strong>incredibly powerful</strong> and can be used as a{' '}
-  <em>layout builder</em> as well as to define any other flexible content model you can think of. It
+  The Blocks field type is **incredibly powerful** and can be used as a
+  *layout builder* as well as to define any other flexible content model you can think of. It
   stores an array of objects, where each object must match the shape of one of your provided block
   configs.
 </Banner>
@@ -65,8 +65,8 @@ properties:
 Blocks are defined as separate configs of their own.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   Best practice is to define each block config in its own file, and then import them into your
   Blocks field as necessary. This way each block config can be easily shared between fields. For
   instance, using the "layout builder" example, you might want to feature a few of the same blocks

--- a/docs/fields/point.mdx
+++ b/docs/fields/point.mdx
@@ -13,7 +13,7 @@ keywords: point, geolocation, geospatial, geojson, 2dsphere, config, configurati
 </Banner>
 
 <Banner type="warning">
-  <strong>Note:</strong> The Point field type is currently only supported in MongoDB.
+  **Note:** The Point field type is currently only supported in MongoDB.
 </Banner>
 
 <LightDarkImage
@@ -47,7 +47,7 @@ The data structure in the database matches the GeoJSON structure to represent po
 _\* An asterisk denotes that a property is required._
 
 <Banner type="warning">
-  <strong>Note:</strong> The Point field type is currently only supported in MongoDB.
+  **Note:** The Point field type is currently only supported in MongoDB.
 </Banner>
 
 ### Example

--- a/docs/fields/radio.mdx
+++ b/docs/fields/radio.mdx
@@ -41,8 +41,8 @@ keywords: radio, fields, config, configuration, documentation, Content Managemen
 _\* An asterisk denotes that a property is required._
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   Option values should be strings that do not contain hyphens or special characters due to GraphQL
   enumeration naming constraints. Underscores are allowed. If you determine you need your option
   values to be non-strings or contain special characters, they will be formatted accordingly before

--- a/docs/fields/relationship.mdx
+++ b/docs/fields/relationship.mdx
@@ -52,8 +52,8 @@ caption="Admin panel screenshot of a Relationship field"
 _\* An asterisk denotes that a property is required._
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   The [Depth](/docs/getting-started/concepts#depth) parameter can be used to automatically populate
   related documents that are returned by the API.
 </Banner>
@@ -173,12 +173,12 @@ export const ExampleCollection: CollectionConfig = {
 You can learn more about writing queries [here](/docs/queries/overview).
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
-  When a relationship field has both <strong>filterOptions</strong> and a custom{' '}
-  <strong>validate</strong> function, the api will not validate <strong>filterOptions</strong>{' '}
+  **Note:**
+
+  When a relationship field has both **filterOptions** and a custom{' '}
+  **validate** function, the api will not validate **filterOptions**{' '}
   unless you call the default relationship field validation function imported from{' '}
-  <strong>payload/fields/validations</strong> in your validate function.
+  **payload/fields/validations** in your validate function.
 </Banner>
 
 ### How the data is saved
@@ -360,7 +360,7 @@ However, you **cannot** query on any field values within the related document.
 Since we are referencing multiple collections, the field you are querying on may not exist and break the query.
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
-  You <strong>cannot</strong> query on a field within a polymorphic relationship as you would with a non-polymorphic relationship.
+  **Note:**
+
+  You **cannot** query on a field within a polymorphic relationship as you would with a non-polymorphic relationship.
 </Banner>

--- a/docs/fields/rich-text.mdx
+++ b/docs/fields/rich-text.mdx
@@ -18,7 +18,7 @@ keywords: rich text, fields, config, configuration, documentation, Content Manag
   caption="Admin panel screenshot of a Rich Text field"
 />
 
-Payload's rich text field is built on an "adapter pattern" which lets you specify which rich text editor you'd like to use. 
+Payload's rich text field is built on an "adapter pattern" which lets you specify which rich text editor you'd like to use.
 
 Right now, Payload is officially supporting two rich text editors:
 
@@ -26,7 +26,7 @@ Right now, Payload is officially supporting two rich text editors:
 2. [Lexical](/docs/rich-text/lexical) - beta, where things will be moving
 
 <Banner type="success">
-  <strong>Consistent with Payload's goal of making you learn as little of Payload as possible, customizing and using the Rich Text Editor does not involve learning how to develop for a <em>Payload</em> rich text editor.</strong> Instead, you can invest your time and effort into learning the underlying open-source tools that will allow you to apply your learnings elsewhere as well.
+  **Consistent with Payload's goal of making you learn as little of Payload as possible, customizing and using the Rich Text Editor does not involve learning how to develop for a __Payload__ rich text editor.** Instead, you can invest your time and effort into learning the underlying open-source tools that will allow you to apply your learnings elsewhere as well.
 </Banner>
 
 ### Config

--- a/docs/fields/select.mdx
+++ b/docs/fields/select.mdx
@@ -44,8 +44,8 @@ caption="Admin panel screenshot of a Select field"
 _\* An asterisk denotes that a property is required._
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   Option values should be strings that do not contain hyphens or special characters due to GraphQL
   enumeration naming constraints. Underscores are allowed. If you determine you need your option
   values to be non-strings or contain special characters, they will be formatted accordingly before

--- a/docs/fields/upload.mdx
+++ b/docs/fields/upload.mdx
@@ -12,8 +12,8 @@ keywords: upload, images media, fields, config, configuration, documentation, Co
 </Banner>
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   To use this field, you need to have a Collection configured to allow Uploads. For more
   information, [click here](/docs/upload/overview) to read about how to enable Uploads on a
   collection by collection basis.
@@ -37,7 +37,7 @@ caption="Admin panel screenshot of an Upload field"
 | Option               | Description                                                                                                                                                                 |
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **`name`** \*        | To be used as the property name when stored and retrieved from the database. [More](/docs/fields/overview#field-names)                                                      |
-| **`*relationTo`** \* | Provide a single collection `slug` to allow this field to accept a relation to. <strong>Note: the related collection must be configured to support Uploads.</strong>        |
+| **`*relationTo`** \* | Provide a single collection `slug` to allow this field to accept a relation to. **Note: the related collection must be configured to support Uploads.**        |
 | **`filterOptions`**  | A query to filter which options appear in the UI and validate against. [More](#filtering-upload-options).                                                                   |
 | **`maxDepth`**       | Sets a number limit on iterations of related documents to populate when queried. [Depth](/docs/getting-started/concepts#depth)                                              |
 | **`label`**          | Text used as a field label in the Admin panel or an object with keys for each language.                                                                                     |
@@ -110,10 +110,10 @@ const uploadField = {
 You can learn more about writing queries [here](/docs/queries/overview).
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
-  When an upload field has both <strong>filterOptions</strong> and a custom{' '}
-  <strong>validate</strong> function, the api will not validate <strong>filterOptions</strong>{' '}
+  **Note:**
+
+  When an upload field has both **filterOptions** and a custom{' '}
+  **validate** function, the api will not validate **filterOptions**{' '}
   unless you call the default upload field validation function imported from{' '}
-  <strong>payload/fields/validations</strong> in your validate function.
+  **payload/fields/validations** in your validate function.
 </Banner>

--- a/docs/getting-started/concepts.mdx
+++ b/docs/getting-started/concepts.mdx
@@ -157,8 +157,8 @@ To populate `post.author.department` in it's entirety you could specify `?depth=
 ```
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   When access control on collections prevents relationship fields from populating, the API response
   will contain the relationship id instead of the full document.
 </Banner>

--- a/docs/getting-started/what-is-payload.mdx
+++ b/docs/getting-started/what-is-payload.mdx
@@ -15,8 +15,8 @@ Payload is a headless CMS and application framework. It's meant to provide a mas
 development process, but importantly, stay out of your way as your apps get more complex.
 
 <Banner type="success">
-  <strong>Payload 2.0 has been released!</strong>
-  <br />
+  **Payload 2.0 has been released!**
+
   Includes Postgres support, Live Preview, Lexical Editor, and more. <a href="/blog/payload-2-0">Read the announcement</a>.
 </Banner>
 

--- a/docs/graphql/graphql-schema.mdx
+++ b/docs/graphql/graphql-schema.mdx
@@ -72,8 +72,8 @@ The above example outputs all your definitions to a file relative from your payl
 #### Adding an NPM script
 
 <Banner type="warning">
-  <strong>Important</strong>
-  <br />
+  **Important**
+
   Payload needs to be able to find your config to generate your GraphQL schema.
 </Banner>
 

--- a/docs/graphql/overview.mdx
+++ b/docs/graphql/overview.mdx
@@ -116,8 +116,8 @@ GraphQL Playground is enabled by default for development purposes, but disabled 
 You can even log in using the `login[collection-singular-label-here]` mutation to use the Playground as an authenticated user.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   To see more regarding how the above queries and mutations are used, visit your GraphQL playground
   (by default at
   [http://localhost:3000/api/graphql-playground](http://localhost:3000/api/graphql-playground))

--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -51,12 +51,12 @@ All field-level hooks are formatted to accept the same arguments, although some 
 which field hook you are utilizing.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   It's a good idea to conditionally scope your logic based on which operation is executing. For
-  example, if you are writing a <strong>beforeChange</strong> hook, you may want to perform
-  different logic based on if the current <strong>operation</strong> is <strong>create</strong> or{' '}
-  <strong>update</strong>.
+  example, if you are writing a **beforeChange** hook, you may want to perform
+  different logic based on if the current **operation** is **create** or
+  **update**.
 </Banner>
 
 #### Arguments
@@ -86,8 +86,8 @@ All field hooks can optionally modify the return value of the field before the o
 optionally return the value that should be used within the field.
 
 <Banner type="warning">
-  <strong>Important</strong>
-  <br />
+  **Important**
+
   Due to GraphQL's typed nature, you should never change the type of data that you return from a
   field, otherwise GraphQL will produce errors. If you need to change the shape or type of data,
   reconsider Field Hooks and instead evaluate if Collection / Global hooks might suit you better.

--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -11,8 +11,8 @@ within Node, directly on your server. Here, you don't need to deal with server l
 can interact directly with your database.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   The Local API is incredibly powerful when used with server-side rendering app frameworks like
   NextJS. With other headless CMS, you need to request your data from third-party servers which can
   add significant loading time to your server-rendered pages. With Payload, you don't have to leave
@@ -85,8 +85,8 @@ executed in.
 _There are more options available on an operation by operation basis outlined below._
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   By default, all access control checks are disabled in the Local API, but you can re-enable them if
   you'd like, as well as pass a specific user to run the operation with.
 </Banner>

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -191,7 +191,7 @@ formBuilder({
 Each field represents a form input. To override default settings pass either a boolean value or a partial [Payload Block](https://payloadcms.com/docs/fields/blocks) _keyed to the block's slug_. See [Field Overrides](#field-overrides) for more details on how to do this.
 
 <Banner type="info">
-  <strong>Note:</strong>
+  **Note:**
   "Fields" here is in reference to the _fields to build forms with_, not to be confused with the _fields of a collection_ which are set via `formOverrides.fields`.
 </Banner>
 
@@ -388,13 +388,13 @@ Below are some common troubleshooting tips. To help other developers, please con
 ## Screenshots
 
 ![screenshot 1](https://github.com/payloadcms/plugin-form-builder/blob/main/images/screenshot-1.jpg?raw=true)
-<br />
+
 ![screenshot 2](https://github.com/payloadcms/plugin-form-builder/blob/main/images/screenshot-2.jpg?raw=true)
-<br />
+
 ![screenshot 3](https://github.com/payloadcms/plugin-form-builder/blob/main/images/screenshot-3.jpg?raw=true)
-<br />
+
 ![screenshot 4](https://github.com/payloadcms/plugin-form-builder/blob/main/images/screenshot-4.jpg?raw=true)
-<br />
+
 ![screenshot 5](https://github.com/payloadcms/plugin-form-builder/blob/main/images/screenshot-5.jpg?raw=true)
-<br />
+
 ![screenshot 6](https://github.com/payloadcms/plugin-form-builder/blob/main/images/screenshot-6.jpg?raw=true)

--- a/docs/plugins/nested-docs.mdx
+++ b/docs/plugins/nested-docs.mdx
@@ -159,8 +159,8 @@ When defined, the `breadcrumbs` field will not be provided for you, and instead,
 own `breadcrumbs` field to each collection manually. Set this property to the `name` of your custom field.
 
 <Banner type="info">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   If you opt out of automatically being provided a `parent` or `breadcrumbs` field, you need to make sure that both fields are placed at the top-level of your document. They cannot exist within any nested data structures like a `group`, `array`, or `blocks`.
 </Banner>
 
@@ -209,8 +209,8 @@ const examplePageConfig: CollectionConfig = {
 ```
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   If overriding the `name` of either `breadcrumbs` or `parent` fields, you must specify the `breadcrumbsFieldSlug` or `parentFieldSlug` respectively.
 </Banner>
 

--- a/docs/plugins/stripe.mdx
+++ b/docs/plugins/stripe.mdx
@@ -102,8 +102,8 @@ const res = await fetch(`/api/stripe/rest`, {
 ```
 
 <Banner type="info">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   The `/api` part of these routes may be different based on the settings defined in your Payload config.
 </Banner>
 
@@ -218,8 +218,8 @@ export const MyFunction = async () => {
 This option will setup a basic sync between Payload collections and Stripe resources for you automatically. It will create all the necessary hooks and webhooks handlers, so the only thing you have to do is map your Payload fields to their corresponding Stripe properties. As documents are created, updated, and deleted from either Stripe or Payload, the changes are reflected on either side.
 
 <Banner type="info">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   If you wish to enable a _two-way_ sync, be sure to setup [`webhooks`](#webhooks) and pass the `stripeWebhooksEndpointSecret` through your config.
 </Banner>
 
@@ -253,8 +253,8 @@ export default config
 ```
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   Due to limitations in the Stripe API, this currently only works with top-level fields. This is because every Stripe object is a separate entity, making it difficult to abstract into a simple reusable library. In the future, we may find a pattern around this. But for now, cases like that will need to be hard-coded.
 </Banner>
 

--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -8,7 +8,7 @@ keywords: deployment, production, config, configuration, documentation, Content 
 
 <Banner type="success">
   So you've developed a Payload app, it's fully tested, and running great locally. Now it's time to
-  launch. <strong>Awesome! Great work!</strong> Now, what's next?
+  launch. **Awesome! Great work!** Now, what's next?
 </Banner>
 
 There are many ways to deploy Payload to a production environment. When evaluating how you will deploy Payload, you need
@@ -44,9 +44,9 @@ Because _**you**_ are in complete control of who can do what with your data, you
 wield that power responsibly before deploying to Production.
 
 <Banner type="error">
-  <strong>By default, all Access Control functions require that a user is successfully logged in to Payload to create, read, update, or delete data.</strong>{' '}
+  **By default, all Access Control functions require that a user is successfully logged in to Payload to create, read, update, or delete data.**{' '}
   But, if you allow public user registration, for example, you will want to make sure that your
-  access control functions are more strict - permitting <strong>only appropriate users</strong> to
+  access control functions are more strict - permitting **only appropriate users** to
   perform appropriate actions.
 </Banner>
 
@@ -110,8 +110,8 @@ or a similar cloud provider, you can trust them to take care of your database's 
 backups.
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   If versions are enabled and a collection has many documents you may need a minimum of an m10
   mongoDB atlas cluster if you reach a sorting `exceeded memory limit` error to view a collection
   list in the admin UI. The limitations of the m2 and m5 tier clusters are here: [Atlas M0 (Free
@@ -160,9 +160,9 @@ perpetually.
 - Many other more traditional web hosts
 
 <Banner type="error">
-  <strong>Warning:</strong>
-  <br />
-  If you rely on Payload's <strong>Upload</strong> functionality, make sure you either use a host
+  **Warning:**
+
+  If you rely on Payload's **Upload** functionality, make sure you either use a host
   with a persistent filesystem or have an integration with a third-party file host like Amazon S3.
 </Banner>
 

--- a/docs/production/preventing-abuse.mdx
+++ b/docs/production/preventing-abuse.mdx
@@ -26,13 +26,13 @@ To prevent DDoS, brute-force, and similar attacks, you can set IP-based rate lim
 | **`trustProxy`** | True or false, to enable to allow requests to pass through a proxy such as a load balancer or an `nginx` reverse proxy. |
 
 <Banner type="warning">
-  <strong>Warning:</strong>
-  <br />
+  **Warning:**
+
   Very commonly, NodeJS apps are served behind `nginx` reverse proxies and similar. If you use
-  rate-limiting while you're behind a proxy, <strong>all</strong> IP addresses from everyone that
+  rate-limiting while you're behind a proxy, **all** IP addresses from everyone that
   uses your API will appear as if they are from a local origin (127.0.0.1), and your users will get
   rate-limited very quickly without cause. If you plan to host your app behind a proxy, make sure
-  you set <strong>trustProxy</strong> to <strong>true</strong>.
+  you set **trustProxy** to **true**.
 </Banner>
 
 ### Max Depth

--- a/docs/queries/overview.mdx
+++ b/docs/queries/overview.mdx
@@ -9,7 +9,7 @@ keywords: query, documents, overview, documentation, Content Management System, 
 Payload provides an extremely granular querying language through all APIs. Each API takes the same syntax and fully supports all options.
 
 <Banner>
-  <strong>Here, "querying" relates to filtering or searching through documents within a Collection.</strong>{' '}
+  **Here, "querying" relates to filtering or searching through documents within a Collection.**
   You can build queries to pass to Find operations as well as to [restrict which documents certain
   users can access](/docs/access-control/overview) via access control functions.
 </Banner>
@@ -69,10 +69,9 @@ The above example demonstrates a simple query but you can get much more complex.
 | `near`               | For distance related to a [point field](/docs/fields/point) comma separated as `<longitude>, <latitude>, <maxDistance in meters (nullable)>, <minDistance in meters (nullable)>`. |
 
 <Banner type="success">
-  <strong>Tip</strong>:<br />
-  If you know your users will be querying on certain fields a lot, you can add <strong>
-    index: true
-  </strong> to a field's config which will speed up searches using that field immensely.
+  **Tip**:
+  If you know your users will be querying on certain fields a lot, you can add **index: true**
+  to a field's config which will speed up searches using that field immensely.
 </Banner>
 
 ### And / Or Logic

--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -47,29 +47,16 @@ Note: Collection slugs must be formatted in kebab-case
             updatedAt: "2023-04-27T11:27:32.419Z",
           },
         },
-        drawerContent: (
-          <>
-            <h6>Additional <code>find</code> query parameters</h6>
-            The <code>find</code> endpoint supports the following additional query parameters:
-            <ul>
-              <li>
-                <a href="/docs/queries/overview#sort">sort</a> - sort by field
-              </li>
-              <li>
-                <a href="/docs/queries/overview">where</a> - pass a where query to constrain returned
-                documents
-              </li>
-              <li>
-                <a href="/docs/queries/pagination#pagination-controls">limit</a> - limit the returned
-                documents to a certain number
-              </li>
-              <li>
-                <a href="/docs/queries/pagination#pagination-controls">page</a> - get a specific page of
-                documents
-              </li>
-            </ul>
-          </>
-        ),
+        drawerContent: `
+#### Additional \`find\` query parameters
+
+The \`find\` endpoint supports the following additional query parameters:
+
+-  [sort](/docs/queries/overview#sort) - sort by field
+-  [where](/docs/queries/overview) - pass a where query to constrain returned documents
+-  [limit](/docs/queries/pagination#pagination-controls) - limit the returned documents to a certain number
+-  [page](/docs/queries/pagination#pagination-controls) - get a specific page of documents
+        `
       },
     },
     {
@@ -613,8 +600,8 @@ export const Orders: CollectionConfig = {
 ```
 
 <Banner>
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   **req** will have the **payload** object and can be used inside your endpoint handlers for making
   calls like req.payload.find() that will make use of access control and hooks.
 </Banner>

--- a/docs/rich-text/lexical.mdx
+++ b/docs/rich-text/lexical.mdx
@@ -374,8 +374,8 @@ Functions prefixed with a `$` can only be run inside of an `editor.update()` or 
 This has been taken from the [lexical serialization & deserialization docs](https://lexical.dev/docs/concepts/serialization#html---lexical).
 
 <Banner type="success">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   Using the <code>discrete: true</code> flag ensures instant updates to the editor state. If immediate reading of the updated state isn't necessary, you can omit the flag.
 </Banner>
 

--- a/docs/rich-text/slate.mdx
+++ b/docs/rich-text/slate.mdx
@@ -124,12 +124,12 @@ The built-in `relationship` element is a powerful way to reference other Documen
 Similar to the `relationship` element, the `upload` element is a user-friendly way to reference [Upload-enabled collections](/docs/upload/overview) with a UI specifically designed for media / image-based uploads.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />
+  **Tip:**
+
   Collections are automatically allowed to be selected within the Rich Text relationship and upload
   elements by default. If you want to disable a collection from being able to be referenced in Rich
-  Text fields, set the collection admin options of <strong>enableRichTextLink</strong> and{' '}
-  <strong>enableRichTextRelationship</strong> to false.
+  Text fields, set the collection admin options of **enableRichTextLink<** and
+  **enableRichTextRelationship** to false.
 </Banner>
 
 Relationship and Upload elements are populated dynamically into your Rich Text field' content. Within the REST and Local APIs, any present RichText `relationship` or `upload` elements will respect the `depth` option that you pass, and will be populated accordingly. In GraphQL, each `richText` field accepts an argument of `depth` for you to utilize.
@@ -271,7 +271,7 @@ const serialize = (children) =>
       }
 
       if (node.text === '') {
-        text = <br />;
+        text = ;
       }
 
       // Handle other leaf types here...
@@ -311,8 +311,8 @@ const serialize = (children) =>
 ```
 
 <Banner>
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   The above example is for how to render to JSX, although for plain HTML the pattern is similar.
   Just remove the JSX and return HTML strings instead!
 </Banner>

--- a/docs/typescript/generating-types.mdx
+++ b/docs/typescript/generating-types.mdx
@@ -162,8 +162,8 @@ export interface Collection1 {
 ```
 
 <Banner type="warning">
-  <strong>Naming Collisions</strong>
-  <br />
+ **Naming Collisions**
+
   Since these types are hoisted to the top level, you need to be aware that naming collisions can
   occur. For example, if you have a collection with the name of `Meta` and you also create a
   interface with the name `Meta` they will collide. It is recommended to scope your interfaces by
@@ -177,8 +177,8 @@ Now that your types have been generated, payloads local API will now be typed. I
 #### Adding an NPM script
 
 <Banner type="warning">
-  <strong>Important</strong>
-  <br />
+  **Important**
+
   Payload needs to be able to find your config to generate your types.
 </Banner>
 

--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -32,10 +32,10 @@ _Admin panel screenshot depicting a Media Collection with Upload enabled_
 Every Payload Collection can opt-in to supporting Uploads by specifying the `upload` property on the Collection's config to either `true` or to an object containing `upload` options.
 
 <Banner type="success">
-  <strong>Tip:</strong>
-  <br />A common pattern is to create a <strong>Media</strong> collection and enable <strong>
-    upload
-  </strong> on that collection.
+  **Tip:**
+  A common pattern is to create a **Media** collection and enable
+  **upload**
+  on that collection.
 </Banner>
 
 ### Collection Upload Options
@@ -162,8 +162,8 @@ When an uploaded image is smaller than the defined image size, we have 3 options
 3. `true`: if the image is smaller than the image size, return the original image
 
 <Banner type="error">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   By default, the image size will return NULL when the uploaded image is smaller than the defined image size.
   Use the `withoutEnlargement` prop to change this.
 </Banner>
@@ -199,12 +199,12 @@ If no resizing options are specified (`imageSizes` or `resizeOptions`), the foca
 If you are using a plugin to send your files off to a third-party file storage host or CDN, like Amazon S3 or similar, you may not want to store your files locally at all. You can prevent Payload from writing files to disk by specifying `disableLocalStorage: true` on your collection's upload config.
 
 <Banner type="warning">
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   This is a fairly advanced feature. If you do disable local file storage, by default, your admin
   panel's thumbnails will be broken as you will not have stored a file. It will be totally up to you
   to use either a plugin or your own hooks to store your files in a permanent manner, as well as
-  provide your own admin thumbnail using <strong>upload.adminThumbnail</strong>.
+  provide your own admin thumbnail using **upload.adminThumbnail**.
 </Banner>
 
 ### Admin Thumbnails
@@ -236,8 +236,8 @@ export const Media: CollectionConfig = {
 ```
 
 <Banner>
-  <strong>Note:</strong>
-  <br />
+  **Note:**
+
   This function runs in the browser. If your function returns `null` or `false` Payload will show
   the default generic file thumbnail instead.
 </Banner>
@@ -266,8 +266,8 @@ export const Media: CollectionConfig = {
 ### Uploading Files
 
 <Banner type="warning">
-  <strong>Important:</strong>
-  <br />
+  **Important:**
+
   Uploading files is currently only possible through the REST and Local APIs due to how GraphQL
   works. It's difficult and fairly nonsensical to support uploading files through GraphQL.
 </Banner>

--- a/docs/versions/autosave.mdx
+++ b/docs/versions/autosave.mdx
@@ -70,6 +70,6 @@ If we created a new version for each autosave, you'd quickly find a ton of autos
 
 <Banner type="success">
   Instead of creating a new version each time a document is autosaved, Payload smartly only creates{' '}
-  <strong>one</strong> autosave version, and then updates that specific version with each autosave
+  **one** autosave version, and then updates that specific version with each autosave
   performed. This makes sure that your versions remain nice and tidy.
 </Banner>

--- a/docs/versions/drafts.mdx
+++ b/docs/versions/drafts.mdx
@@ -26,16 +26,16 @@ Collections and Globals both support the same options for configuring drafts. Yo
 
 ### Database changes
 
-By enabling drafts on a collection or a global, Payload will <strong>automatically inject a new field into your schema</strong> called `_status`. The `_status` field is used internally by Payload to store if a document is set to `draft` or `published`.
+By enabling drafts on a collection or a global, Payload will **automatically inject a new field into your schema** called `_status`. The `_status` field is used internally by Payload to store if a document is set to `draft` or `published`.
 
 **Admin UI status indication**
 
 Within the Admin UI, if drafts are enabled, a document can be shown with one of three "statuses":
 
-1. <strong>Draft</strong> - if a document has never been published, and only draft versions of the document
+1. **Draft** - if a document has never been published, and only draft versions of the document
    are present
-1. <strong>Published</strong> - if a document is published and there are no newer drafts available
-1. <strong>Changed</strong> - if a document has been published, but there are newer drafts available
+1. **Published** - if a document is published and there are no newer drafts available
+1. **Changed** - if a document has been published, but there are newer drafts available
    and not yet published
 
 ### Draft API
@@ -48,7 +48,7 @@ Within the Admin UI, if drafts are enabled, a document can be shown with one of 
 
 ##### Updating or creating drafts
 
-If you enable drafts on a collection or global, the `create` and `update` operations for REST, GraphQL, and Local APIs expose a new option called `draft` which allows you to specify if you are creating or updating a <strong>draft</strong>, or if you're just sending your changes straight to the published document. For example, if you pass the query parameter `?draft=true` to a REST `create` or `update` operation, your action will be treated as if you are creating a `draft` and not a published document. By default, the `draft` argument is set to `false`.
+If you enable drafts on a collection or global, the `create` and `update` operations for REST, GraphQL, and Local APIs expose a new option called `draft` which allows you to specify if you are creating or updating a **draft**, or if you're just sending your changes straight to the published document. For example, if you pass the query parameter `?draft=true` to a REST `create` or `update` operation, your action will be treated as if you are creating a `draft` and not a published document. By default, the `draft` argument is set to `false`.
 
 **Required fields**
 
@@ -58,9 +58,9 @@ If `draft` is enabled while creating or updating a document, all fields are cons
 
 In addition to the `draft` argument within `create` and `update` operations, a `draft` argument is also exposed for `find` and `findByID` operations.
 
-If `draft` is set to `true` while reading a document, <strong>Payload will automatically replace returned document(s) with their newest drafts</strong> if any newer drafts are available.
+If `draft` is set to `true` while reading a document, **Payload will automatically replace returned document(s) with their newest drafts** if any newer drafts are available.
 
-<strong>For example, let's take the following scenario:</strong>
+**For example, let's take the following scenario:**
 
 1. You create a new collection document and publish it right away
 1. You then make some updates, and save the updates as a draft
@@ -75,7 +75,7 @@ But, if you specify `draft` as `true`, Payload will automatically replace your p
 ### Controlling who can see Collection drafts
 
 <Banner type="warning">
-  If you're using the <strong>drafts</strong> feature, it's important for you to consider who can
+  If you're using the **drafts** feature, it's important for you to consider who can
   view your drafts, and who can view only published documents. Luckily, Payload makes this extremely
   simple and puts the power completely in your hands.
 </Banner>
@@ -115,15 +115,15 @@ export const Pages: CollectionConfig = {
 ```
 
 <Banner type="warning">
-  <strong>Note regarding adding versions to an existing collection</strong>
-  <br />
+  **Note regarding adding versions to an existing collection**
+
   If you already have a collection with documents, and you <em>opt in</em> to draft functionality
   after you have already created existing documents, all of your old documents{' '}
   <em>will not have a _status field</em> until you resave them. For this reason, if you are{' '}
   <em>adding</em> versions into an existing collection, you might want to write your access control
   function to allow for users to read both documents where{' '}
-  <strong>_status is equal to "published"</strong> as well as where{' '}
-  <strong>_status does not exist</strong>.
+  **_status is equal to "published"** as well as where{' '}
+  **_status does not exist**.
 </Banner>
 
 Here is an example for how to write an access control function that grants access to both documents where `_status` is equal to "published" and where `_status` does not exist:


### PR DESCRIPTION
We have merged in our new MDX renderer in our website. This requires some adjustments in our docs, as not all syntax is supported anymore.