### PR TITLE
docs: fix backtick escaping in TableWithDrawers blocks

### DIFF
--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -351,7 +351,7 @@ The `useForm` hook returns an object with the following properties: |
       ],
       [
         {
-          value: "**\\\`data<\\\`**",
+          value: "**\\\`data\\\`**",
         },
         {
           value: "The data to add to the row",
@@ -361,8 +361,8 @@ The `useForm` hook returns an object with the following properties: |
   />
 
 
-\\\`\\\`\\\`tsx
-  {\\\`import { useForm } from "payload/components/forms";
+\`\`\`tsx
+import { useForm } from "payload/components/forms";
 
 export const CustomArrayManager = () => {
   const { addFieldRow } = useForm()
@@ -385,13 +385,13 @@ export const CustomArrayManager = () => {
       Add Row
     </button>
   )
-}\\\`}
-\\\`\\\`\\\`
+}
+\`\`\`
 
 An example config to go along with the Custom Component
 
-\\\`\\\`\\\`tsx
-{\\\`const ExampleCollection = {
+\`\`\`tsx
+const ExampleCollection = {
   slug: "example-collection",
   fields: [
     {
@@ -414,8 +414,8 @@ An example config to go along with the Custom Component
       },
     },
   ],
-}\\\`}
-\\\`\\\`\\\`
+}
+\`\`\`
 `
       }
     ],
@@ -458,8 +458,8 @@ An example config to go along with the Custom Component
 
 
 
-\\\`\\\`\\\`tsx
-  {\\\`import { useForm } from "payload/components/forms";
+\`\`\`tsx
+import { useForm } from "payload/components/forms";
 
 export const CustomArrayManager = () => {
   const { removeFieldRow } = useForm()
@@ -477,13 +477,13 @@ export const CustomArrayManager = () => {
       Remove Row
     </button>
   )
-}\\\`}
-\\\`\\\`\\\`
+}
+\`\`\`
 
 An example config to go along with the Custom Component
 
-\\\`\\\`\\\`tsx
-{\\\`const ExampleCollection = {
+\`\`\`tsx
+const ExampleCollection = {
   slug: "example-collection",
   fields: [
     {
@@ -506,8 +506,8 @@ An example config to go along with the Custom Component
       },
     },
   ],
-}\\\`}
-\\\`\\\`\\\`
+}
+\`\`\`
 `
       }
     ],
@@ -559,8 +559,8 @@ An example config to go along with the Custom Component
 
 
 
-\\\`\\\`\\\`tsx
-  {\\\`import { useForm } from "payload/components/forms";
+\`\`\`tsx
+import { useForm } from "payload/components/forms";
 
 export const CustomArrayManager = () => {
   const { replaceFieldRow } = useForm()
@@ -583,13 +583,13 @@ export const CustomArrayManager = () => {
       Replace Row
     </button>
   )
-}\\\`}
-\\\`\\\`\\\`
+}
+\`\`\`
 
 An example config to go along with the Custom Component
 
-\\\`\\\`\\\`tsx
-{\\\`const ExampleCollection = {
+\`\`\`tsx
+const ExampleCollection = {
   slug: "example-collection",
   fields: [
     {
@@ -612,9 +612,9 @@ An example config to go along with the Custom Component
       },
     },
   ],
-}\\\`}
-\\\`\\\`\\\`
-         `
+}
+\`\`\`
+`
       }
     ],
   ]}


### PR DESCRIPTION
The way we previously escaped characters in our docs does not work with our new MDX parser.