### PR TITLE
chore: prevent `tsconfig.base.json` from changing for dev and e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -317,3 +317,5 @@ test/databaseAdapter.js
 /filename-compound-index
 /media-with-relation-preview
 /media-without-relation-preview
+
+tsconfig.generated.json

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "reinstall": "pnpm clean:all && pnpm install",
     "release": "pnpm runts ./scripts/release.ts --tag latest",
     "release:beta": "pnpm runts ./scripts/release.ts --bump prerelease --tag beta",
-    "runts": "cross-env NODE_OPTIONS=--no-deprecation node --no-deprecation --import @swc-node/register/esm-register",
+    "runts": "node ./scripts/ensure-generated-tsconfig.js && cross-env NODE_OPTIONS=--no-deprecation node --no-deprecation --import @swc-node/register/esm-register",
     "script:gen-templates": "pnpm runts ./scripts/generate-template-variations.ts",
     "script:list-published": "pnpm runts scripts/lib/getPackageRegistryVersions.ts",
     "script:pack": "pnpm runts scripts/pack-all-to-dest.ts",

--- a/package.json
+++ b/package.json
@@ -104,8 +104,7 @@
       "eslint --cache --fix"
     ],
     "templates/website/**/*": "sh -c \"cd templates/website; pnpm install --no-frozen-lockfile --ignore-workspace; pnpm run lint --fix\"",
-    "templates/**/pnpm-lock.yaml": "pnpm runts scripts/remove-template-lock-files.ts",
-    "tsconfig.json": "node scripts/reset-tsconfig.js"
+    "templates/**/pnpm-lock.yaml": "pnpm runts scripts/remove-template-lock-files.ts"
   },
   "devDependencies": {
     "@jest/globals": "29.7.0",

--- a/packages/richtext-slate/tsconfig.json
+++ b/packages/richtext-slate/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true, // Make sure typescript knows that this module depends on their references
     "noEmit": false /* Do not emit outputs. */,

--- a/packages/storage-azure/tsconfig.json
+++ b/packages/storage-azure/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true, // Make sure typescript knows that this module depends on their references
     "noEmit": false /* Do not emit outputs. */,

--- a/packages/storage-gcs/tsconfig.json
+++ b/packages/storage-gcs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true, // Make sure typescript knows that this module depends on their references
     "noEmit": false /* Do not emit outputs. */,

--- a/scripts/ensure-generated-tsconfig.js
+++ b/scripts/ensure-generated-tsconfig.js
@@ -1,0 +1,14 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { existsSync, writeFileSync, readFileSync } from 'fs'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+const tsConfigBasePath = path.resolve(dirname, '../tsconfig.base.json')
+const tsconfigGeneratedPath = path.resolve(dirname, '../tsconfig.generated.json')
+
+if (!existsSync(tsconfigGeneratedPath)) {
+  const tsConfigContent = readFileSync(tsConfigBasePath, 'utf8')
+  writeFileSync(tsconfigGeneratedPath, tsConfigContent, 'utf-8')
+}

--- a/test/testHooks.ts
+++ b/test/testHooks.ts
@@ -38,7 +38,10 @@ export const createTestHooks = async (testSuiteName = '_community') => {
           ? `./${testSuiteName}/config.ts`
           : `./test/${testSuiteName}/config.ts`,
       ]
-      await writeFile(tsConfigPath, stringify(tsConfig, null, 2) + '\n')
+      await writeFile(
+        path.resolve(path.dirname(tsConfigPath), 'tsconfig.generated.json'),
+        stringify(tsConfig, null, 2) + '\n',
+      )
 
       process.env.PAYLOAD_CONFIG_PATH = path.resolve(dirname, testSuiteName, 'config.ts')
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.base.json",
+  "extends": ["./tsconfig.base.json", "./tsconfig.generated.json"],
   "compilerOptions": {
     "composite": false,
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "noEmit": true,
-    "baseUrl": ".",
-
+    "baseUrl": "."
   },
   "references": [
     {
@@ -76,6 +75,8 @@
   ],
   "include": [
     "${configDir}/src",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "scripts/**/*.ts",
+    "scripts/**/*.js",
   ]
 }


### PR DESCRIPTION
Prevents `tsconfig.base.json` from changing every time you run dev / e2e, instead `testHooks.ts` writes gitignored `tsconfig.generated.json` (from `tsconfig.base.json`). Adds it to `extends` to the root `tsconfig.json` file and so `compilerOptions.paths` (which is needed for `@payload-config`) from `tsconfig.generated.json` overrides `tsconfig.base.json`.