### PR TITLE
chore(cpa): remove success message outline

### DIFF
--- a/packages/create-payload-app/src/main.ts
+++ b/packages/create-payload-app/src/main.ts
@@ -281,7 +281,8 @@ export class Main {
       }
 
       info('Payload project successfully created!')
-      p.note(successMessage(projectDir, packageManager), chalk.bgGreen(chalk.black(' Next Steps ')))
+      p.log.step(chalk.bgGreen(chalk.black(' Next Steps ')))
+      p.log.message(successMessage(projectDir, packageManager))
       p.outro(feedbackOutro())
     } catch (err: unknown) {
       error(err instanceof Error ? err.message : 'An error occurred')

--- a/packages/create-payload-app/src/utils/messages.ts
+++ b/packages/create-payload-app/src/utils/messages.ts
@@ -59,12 +59,7 @@ export function successMessage(projectDir: string, packageManager: PackageManage
 ${header('Launch Application:')}
 
   - cd ./${relativePath}
-  - ${
-    packageManager === 'npm' ? 'npm run' : packageManager
-  } dev or follow directions in ${createTerminalLink(
-    'README.md',
-    `file://${path.resolve(projectDir, 'README.md')}`,
-  )}
+  - ${packageManager === 'npm' ? 'npm run' : packageManager} dev or follow directions in README.md
 
 ${header('Documentation:')}
 


### PR DESCRIPTION
The usage of clack's `note` on the success message (contains long urls) would often wrap on terminals that did not have a very wide window and/or do not support [terminal hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)

This swaps the usage of `note` for more plain log output that does not have an outline and eliminates the possibility for this issue.

Before:
<img width="726" alt="CleanShot 2024-12-29 at 02 54 18" src="https://github.com/user-attachments/assets/4fcb028c-58f0-4102-9268-53aca8124111" />


After:
<img width="716" alt="CleanShot 2024-12-29 at 02 54 39" src="https://github.com/user-attachments/assets/30615fa8-5f2c-43f5-a6a5-9f0b9cc415fb" />
