### PR TITLE
fix(ui): removes useless verified checkbox on user create

### DIFF
--- a/packages/ui/src/views/Edit/Auth/index.tsx
+++ b/packages/ui/src/views/Edit/Auth/index.tsx
@@ -44,7 +44,7 @@ export const Auth: React.FC<Props> = (props) => {
   const dispatchFields = useFormFields((reducer) => reducer[1])
   const modified = useFormModified()
   const { i18n, t } = useTranslation()
-  const { docPermissions, isInitializing } = useDocumentInfo()
+  const { docPermissions, isEditing, isInitializing } = useDocumentInfo()
 
   const {
     config: {
@@ -222,7 +222,7 @@ export const Auth: React.FC<Props> = (props) => {
           {canReadApiKey && <APIKey enabled={!!enableAPIKey?.value} readOnly={apiKeyReadOnly} />}
         </div>
       )}
-      {verify && (
+      {verify && isEditing && (
         <CheckboxField
           field={{
             name: '_verified',


### PR DESCRIPTION
Removes the useless `_verified` checkbox from user creation. We can't make it functional from the admin UI, because if we respected the incoming `_verified` property from a user creation, then any user could auto-verify themselves via REST / GraphQL APIs.

Fixes #10158
