### PR TITLE
feat: adds more control over how to disable graphql for collections /…

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -68,7 +68,7 @@ The following options are available:
 | **`dbName`**           | Custom table or Collection name depending on the Database Adapter. Auto-generated from slug if not defined.                                                                                                          |
 | **`endpoints`**        | Add custom routes to the REST API. Set to `false` to disable routes. [More details](../rest-api/overview#custom-endpoints).                                                                                          |
 | **`fields`** \*        | Array of field types that will determine the structure and functionality of the data stored within this Collection. [More details](../fields/overview).                                                              |
-| **`graphQL`**          | An object with `singularName` and `pluralName` strings used in schema generation. Auto-generated from slug if not defined. Set to `false` to disable GraphQL.                                                        |
+| **`graphQL`**          | Manage GraphQL-related properties for this collection. [More](#graphql)                                                                                                                                              |
 | **`hooks`**            | Entry point for Hooks. [More details](../hooks/overview#collection-hooks).                                                                                                                                           |
 | **`labels`**           | Singular and plural labels for use in identifying this Collection throughout Payload. Auto-generated from slug if not defined.                                                                                       |
 | **`lockDocuments`**    | Enables or disables document locking. By default, document locking is enabled. Set to an object to configure, or set to `false` to disable locking. [More details](../admin/locked-documents).                       |
@@ -77,7 +77,7 @@ The following options are available:
 | **`typescript`**       | An object with property `interface` as the text used in schema generation. Auto-generated from slug if not defined.                                                                                                  |
 | **`upload`**           | Specify options if you would like this Collection to support file uploads. For more, consult the [Uploads](../upload/overview) documentation.                                                                        |
 | **`versions`**         | Set to true to enable default options, or configure with object properties. [More details](../versions/overview#collection-config).                                                                                  |
-| **`defaultPopulate`**  | Specify which fields to select when this Collection is populated from another document. [More Details](../queries/select#defaultpopulate-collection-config-property).                                                  |
+| **`defaultPopulate`**  | Specify which fields to select when this Collection is populated from another document. [More Details](../queries/select#defaultpopulate-collection-config-property).                                                |
 
 _\* An asterisk denotes that a property is required._
 
@@ -96,6 +96,19 @@ Fields define the schema of the Documents within a Collection. To learn more, go
 ### Admin Options
 
 You can customize the way that the [Admin Panel](../admin/overview) behaves on a Collection-by-Collection basis. To learn more, go to the [Collection Admin Options](../admin/collections) documentation.
+
+## GraphQL
+
+You can completely disable GraphQL for this collection by passing `graphQL: false` to your collection config. This will completely disable all queries, mutations, and types from appearing in your GraphQL schema.
+
+You can also pass an object to the collection's `graphQL` property, which allows you to define the following properties:
+
+| Option                 | Description                                                                         |
+| ---------------------- | ----------------------------------------------------------------------------------- |
+| **`singularName`**     | Override the "singular" name that will be used in GraphQL schema generation.        |
+| **`pluralName`**       | Override the "plural" name that will be used in GraphQL schema generation.          |
+| **`disableQueries`**   | Disable all GraphQL queries that correspond to this collection by passing `true`.   |
+| **`disableMutations`** | Disable all GraphQL mutations that correspond to this collection by passing `true`. |
 
 ## TypeScript
 

--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -74,7 +74,7 @@ The following options are available:
 | **`description`**   | Text or React component to display below the Global header to give editors more information.                                                                                                   |
 | **`endpoints`**     | Add custom routes to the REST API. [More details](../rest-api/overview#custom-endpoints).                                                                                                      |
 | **`fields`** \*     | Array of field types that will determine the structure and functionality of the data stored within this Global. [More details](../fields/overview).                                            |
-| **`graphQL.name`**  | Text used in schema generation. Auto-generated from slug if not defined.                                                                                                                       |
+| **`graphQL`**       | Manage GraphQL-related properties related to this global. [More details](#graphql)                                                                                                             |
 | **`hooks`**         | Entry point for Hooks. [More details](../hooks/overview#global-hooks).                                                                                                                         |
 | **`label`**         | Text for the name in the Admin Panel or an object with keys for each language. Auto-generated from slug if not defined.                                                                        |
 | **`lockDocuments`** | Enables or disables document locking. By default, document locking is enabled. Set to an object to configure, or set to `false` to disable locking. [More details](../admin/locked-documents). |
@@ -99,6 +99,18 @@ Fields define the schema of the Global. To learn more, go to the [Fields](../fie
 ### Admin Options
 
 You can customize the way that the [Admin Panel](../admin/overview) behaves on a Global-by-Global basis. To learn more, go to the [Global Admin Options](../admin/globals) documentation.
+
+## GraphQL
+
+You can completely disable GraphQL for this global by passing `graphQL: false` to your global config. This will completely disable all queries, mutations, and types from appearing in your GraphQL schema.
+
+You can also pass an object to the global's `graphQL` property, which allows you to define the following properties:
+
+| Option                 | Description                                                                         |
+| ---------------------- | ----------------------------------------------------------------------------------- |
+| **`name`**             | Override the name that will be used in GraphQL schema generation.                   |
+| **`disableQueries`**   | Disable all GraphQL queries that correspond to this global by passing `true`.       |
+| **`disableMutations`** | Disable all GraphQL mutations that correspond to this global by passing `true`.     |
 
 ## TypeScript
 

--- a/packages/graphql/src/schema/initCollections.ts
+++ b/packages/graphql/src/schema/initCollections.ts
@@ -63,7 +63,9 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
 
     let singularName
     let pluralName
+
     const fromSlug = formatNames(collection.config.slug)
+
     if (graphQL.singularName) {
       singularName = toWords(graphQL.singularName, true)
     } else {
@@ -168,124 +170,133 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
       collection.graphQL.updateMutationInputType = new GraphQLNonNull(updateMutationInputType)
     }
 
-    graphqlResult.Query.fields[singularName] = {
-      type: collection.graphQL.type,
-      args: {
-        id: { type: new GraphQLNonNull(idType) },
-        draft: { type: GraphQLBoolean },
-        ...(config.localization
-          ? {
-              fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
-              locale: { type: graphqlResult.types.localeInputType },
-            }
-          : {}),
-      },
-      resolve: findByIDResolver(collection),
-    }
+    const queriesEnabled =
+      typeof collectionConfig.graphQL !== 'object' || !collectionConfig.graphQL.disableQueries
+    const mutationsEnabled =
+      typeof collectionConfig.graphQL !== 'object' || !collectionConfig.graphQL.disableMutations
 
-    graphqlResult.Query.fields[pluralName] = {
-      type: buildPaginatedListType(pluralName, collection.graphQL.type),
-      args: {
-        draft: { type: GraphQLBoolean },
-        where: { type: collection.graphQL.whereInputType },
-        ...(config.localization
-          ? {
-              fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
-              locale: { type: graphqlResult.types.localeInputType },
-            }
-          : {}),
-        limit: { type: GraphQLInt },
-        page: { type: GraphQLInt },
-        pagination: { type: GraphQLBoolean },
-        sort: { type: GraphQLString },
-      },
-      resolve: findResolver(collection),
-    }
-
-    graphqlResult.Query.fields[`count${pluralName}`] = {
-      type: new GraphQLObjectType({
-        name: `count${pluralName}`,
-        fields: {
-          totalDocs: { type: GraphQLInt },
-        },
-      }),
-      args: {
-        draft: { type: GraphQLBoolean },
-        where: { type: collection.graphQL.whereInputType },
-        ...(config.localization
-          ? {
-              locale: { type: graphqlResult.types.localeInputType },
-            }
-          : {}),
-      },
-      resolve: countResolver(collection),
-    }
-
-    graphqlResult.Query.fields[`docAccess${singularName}`] = {
-      type: buildPolicyType({
-        type: 'collection',
-        entity: collectionConfig,
-        scope: 'docAccess',
-        typeSuffix: 'DocAccess',
-      }),
-      args: {
-        id: { type: new GraphQLNonNull(idType) },
-      },
-      resolve: docAccessResolver(collection),
-    }
-
-    graphqlResult.Mutation.fields[`create${singularName}`] = {
-      type: collection.graphQL.type,
-      args: {
-        ...(createMutationInputType
-          ? { data: { type: collection.graphQL.mutationInputType } }
-          : {}),
-        draft: { type: GraphQLBoolean },
-        ...(config.localization
-          ? {
-              locale: { type: graphqlResult.types.localeInputType },
-            }
-          : {}),
-      },
-      resolve: createResolver(collection),
-    }
-
-    graphqlResult.Mutation.fields[`update${singularName}`] = {
-      type: collection.graphQL.type,
-      args: {
-        id: { type: new GraphQLNonNull(idType) },
-        autosave: { type: GraphQLBoolean },
-        ...(updateMutationInputType
-          ? { data: { type: collection.graphQL.updateMutationInputType } }
-          : {}),
-        draft: { type: GraphQLBoolean },
-        ...(config.localization
-          ? {
-              locale: { type: graphqlResult.types.localeInputType },
-            }
-          : {}),
-      },
-      resolve: updateResolver(collection),
-    }
-
-    graphqlResult.Mutation.fields[`delete${singularName}`] = {
-      type: collection.graphQL.type,
-      args: {
-        id: { type: new GraphQLNonNull(idType) },
-      },
-      resolve: getDeleteResolver(collection),
-    }
-
-    if (collectionConfig.disableDuplicate !== true) {
-      graphqlResult.Mutation.fields[`duplicate${singularName}`] = {
+    if (queriesEnabled) {
+      graphqlResult.Query.fields[singularName] = {
         type: collection.graphQL.type,
         args: {
           id: { type: new GraphQLNonNull(idType) },
+          draft: { type: GraphQLBoolean },
+          ...(config.localization
+            ? {
+                fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
+                locale: { type: graphqlResult.types.localeInputType },
+              }
+            : {}),
+        },
+        resolve: findByIDResolver(collection),
+      }
+
+      graphqlResult.Query.fields[pluralName] = {
+        type: buildPaginatedListType(pluralName, collection.graphQL.type),
+        args: {
+          draft: { type: GraphQLBoolean },
+          where: { type: collection.graphQL.whereInputType },
+          ...(config.localization
+            ? {
+                fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
+                locale: { type: graphqlResult.types.localeInputType },
+              }
+            : {}),
+          limit: { type: GraphQLInt },
+          page: { type: GraphQLInt },
+          pagination: { type: GraphQLBoolean },
+          sort: { type: GraphQLString },
+        },
+        resolve: findResolver(collection),
+      }
+
+      graphqlResult.Query.fields[`count${pluralName}`] = {
+        type: new GraphQLObjectType({
+          name: `count${pluralName}`,
+          fields: {
+            totalDocs: { type: GraphQLInt },
+          },
+        }),
+        args: {
+          draft: { type: GraphQLBoolean },
+          where: { type: collection.graphQL.whereInputType },
+          ...(config.localization
+            ? {
+                locale: { type: graphqlResult.types.localeInputType },
+              }
+            : {}),
+        },
+        resolve: countResolver(collection),
+      }
+
+      graphqlResult.Query.fields[`docAccess${singularName}`] = {
+        type: buildPolicyType({
+          type: 'collection',
+          entity: collectionConfig,
+          scope: 'docAccess',
+          typeSuffix: 'DocAccess',
+        }),
+        args: {
+          id: { type: new GraphQLNonNull(idType) },
+        },
+        resolve: docAccessResolver(collection),
+      }
+    }
+
+    if (mutationsEnabled) {
+      graphqlResult.Mutation.fields[`create${singularName}`] = {
+        type: collection.graphQL.type,
+        args: {
           ...(createMutationInputType
             ? { data: { type: collection.graphQL.mutationInputType } }
             : {}),
+          draft: { type: GraphQLBoolean },
+          ...(config.localization
+            ? {
+                locale: { type: graphqlResult.types.localeInputType },
+              }
+            : {}),
         },
-        resolve: duplicateResolver(collection),
+        resolve: createResolver(collection),
+      }
+
+      graphqlResult.Mutation.fields[`update${singularName}`] = {
+        type: collection.graphQL.type,
+        args: {
+          id: { type: new GraphQLNonNull(idType) },
+          autosave: { type: GraphQLBoolean },
+          ...(updateMutationInputType
+            ? { data: { type: collection.graphQL.updateMutationInputType } }
+            : {}),
+          draft: { type: GraphQLBoolean },
+          ...(config.localization
+            ? {
+                locale: { type: graphqlResult.types.localeInputType },
+              }
+            : {}),
+        },
+        resolve: updateResolver(collection),
+      }
+
+      graphqlResult.Mutation.fields[`delete${singularName}`] = {
+        type: collection.graphQL.type,
+        args: {
+          id: { type: new GraphQLNonNull(idType) },
+        },
+        resolve: getDeleteResolver(collection),
+      }
+
+      if (collectionConfig.disableDuplicate !== true) {
+        graphqlResult.Mutation.fields[`duplicate${singularName}`] = {
+          type: collection.graphQL.type,
+          args: {
+            id: { type: new GraphQLNonNull(idType) },
+            ...(createMutationInputType
+              ? { data: { type: collection.graphQL.mutationInputType } }
+              : {}),
+          },
+          resolve: duplicateResolver(collection),
+        }
       }
     }
 
@@ -318,52 +329,57 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
         parentName: `${singularName}Version`,
       })
 
-      graphqlResult.Query.fields[`version${formatName(singularName)}`] = {
-        type: collection.graphQL.versionType,
-        args: {
-          id: { type: versionIDType },
-          ...(config.localization
-            ? {
-                fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
-                locale: { type: graphqlResult.types.localeInputType },
-              }
-            : {}),
-        },
-        resolve: findVersionByIDResolver(collection),
-      }
-      graphqlResult.Query.fields[`versions${pluralName}`] = {
-        type: buildPaginatedListType(
-          `versions${formatName(pluralName)}`,
-          collection.graphQL.versionType,
-        ),
-        args: {
-          where: {
-            type: buildWhereInputType({
-              name: `versions${singularName}`,
-              fields: versionCollectionFields,
-              parentName: `versions${singularName}`,
-            }),
+      if (queriesEnabled) {
+        graphqlResult.Query.fields[`version${formatName(singularName)}`] = {
+          type: collection.graphQL.versionType,
+          args: {
+            id: { type: versionIDType },
+            ...(config.localization
+              ? {
+                  fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
+                  locale: { type: graphqlResult.types.localeInputType },
+                }
+              : {}),
           },
-          ...(config.localization
-            ? {
-                fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
-                locale: { type: graphqlResult.types.localeInputType },
-              }
-            : {}),
-          limit: { type: GraphQLInt },
-          page: { type: GraphQLInt },
-          pagination: { type: GraphQLBoolean },
-          sort: { type: GraphQLString },
-        },
-        resolve: findVersionsResolver(collection),
+          resolve: findVersionByIDResolver(collection),
+        }
+        graphqlResult.Query.fields[`versions${pluralName}`] = {
+          type: buildPaginatedListType(
+            `versions${formatName(pluralName)}`,
+            collection.graphQL.versionType,
+          ),
+          args: {
+            where: {
+              type: buildWhereInputType({
+                name: `versions${singularName}`,
+                fields: versionCollectionFields,
+                parentName: `versions${singularName}`,
+              }),
+            },
+            ...(config.localization
+              ? {
+                  fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
+                  locale: { type: graphqlResult.types.localeInputType },
+                }
+              : {}),
+            limit: { type: GraphQLInt },
+            page: { type: GraphQLInt },
+            pagination: { type: GraphQLBoolean },
+            sort: { type: GraphQLString },
+          },
+          resolve: findVersionsResolver(collection),
+        }
       }
-      graphqlResult.Mutation.fields[`restoreVersion${formatName(singularName)}`] = {
-        type: collection.graphQL.type,
-        args: {
-          id: { type: versionIDType },
-          draft: { type: GraphQLBoolean },
-        },
-        resolve: restoreVersionResolver(collection),
+
+      if (mutationsEnabled) {
+        graphqlResult.Mutation.fields[`restoreVersion${formatName(singularName)}`] = {
+          type: collection.graphQL.type,
+          args: {
+            id: { type: versionIDType },
+            draft: { type: GraphQLBoolean },
+          },
+          resolve: restoreVersionResolver(collection),
+        }
       }
     }
 
@@ -397,89 +413,19 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
         parentName: formatName(`${slug}JWT`),
       })
 
-      graphqlResult.Query.fields[`me${singularName}`] = {
-        type: new GraphQLObjectType({
-          name: formatName(`${slug}Me`),
-          fields: {
-            collection: {
-              type: GraphQLString,
-            },
-            exp: {
-              type: GraphQLInt,
-            },
-            strategy: {
-              type: GraphQLString,
-            },
-            token: {
-              type: GraphQLString,
-            },
-            user: {
-              type: collection.graphQL.type,
-            },
-          },
-        }),
-        resolve: me(collection),
-      }
-
-      graphqlResult.Query.fields[`initialized${singularName}`] = {
-        type: GraphQLBoolean,
-        resolve: init(collection.config.slug),
-      }
-
-      graphqlResult.Mutation.fields[`refreshToken${singularName}`] = {
-        type: new GraphQLObjectType({
-          name: formatName(`${slug}Refreshed${singularName}`),
-          fields: {
-            exp: {
-              type: GraphQLInt,
-            },
-            refreshedToken: {
-              type: GraphQLString,
-            },
-            strategy: {
-              type: GraphQLString,
-            },
-            user: {
-              type: collection.graphQL.JWT,
-            },
-          },
-        }),
-        resolve: refresh(collection),
-      }
-
-      graphqlResult.Mutation.fields[`logout${singularName}`] = {
-        type: GraphQLString,
-        resolve: logout(collection),
-      }
-
-      if (!collectionConfig.auth.disableLocalStrategy) {
-        const authArgs = {}
-
-        const { canLoginWithEmail, canLoginWithUsername } = getLoginOptions(
-          collectionConfig.auth.loginWithUsername,
-        )
-
-        if (canLoginWithEmail) {
-          authArgs['email'] = { type: new GraphQLNonNull(GraphQLString) }
-        }
-        if (canLoginWithUsername) {
-          authArgs['username'] = { type: new GraphQLNonNull(GraphQLString) }
-        }
-
-        if (collectionConfig.auth.maxLoginAttempts > 0) {
-          graphqlResult.Mutation.fields[`unlock${singularName}`] = {
-            type: new GraphQLNonNull(GraphQLBoolean),
-            args: authArgs,
-            resolve: unlock(collection),
-          }
-        }
-
-        graphqlResult.Mutation.fields[`login${singularName}`] = {
+      if (queriesEnabled) {
+        graphqlResult.Query.fields[`me${singularName}`] = {
           type: new GraphQLObjectType({
-            name: formatName(`${slug}LoginResult`),
+            name: formatName(`${slug}Me`),
             fields: {
+              collection: {
+                type: GraphQLString,
+              },
               exp: {
                 type: GraphQLInt,
+              },
+              strategy: {
+                type: GraphQLString,
               },
               token: {
                 type: GraphQLString,
@@ -489,44 +435,118 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
               },
             },
           }),
-          args: {
-            ...authArgs,
-            password: { type: GraphQLString },
-          },
-          resolve: login(collection),
+          resolve: me(collection),
         }
 
-        graphqlResult.Mutation.fields[`forgotPassword${singularName}`] = {
-          type: new GraphQLNonNull(GraphQLBoolean),
-          args: {
-            disableEmail: { type: GraphQLBoolean },
-            expiration: { type: GraphQLInt },
-            ...authArgs,
-          },
-          resolve: forgotPassword(collection),
+        graphqlResult.Query.fields[`initialized${singularName}`] = {
+          type: GraphQLBoolean,
+          resolve: init(collection.config.slug),
         }
+      }
 
-        graphqlResult.Mutation.fields[`resetPassword${singularName}`] = {
+      if (mutationsEnabled) {
+        graphqlResult.Mutation.fields[`refreshToken${singularName}`] = {
           type: new GraphQLObjectType({
-            name: formatName(`${slug}ResetPassword`),
+            name: formatName(`${slug}Refreshed${singularName}`),
             fields: {
-              token: { type: GraphQLString },
-              user: { type: collection.graphQL.type },
+              exp: {
+                type: GraphQLInt,
+              },
+              refreshedToken: {
+                type: GraphQLString,
+              },
+              strategy: {
+                type: GraphQLString,
+              },
+              user: {
+                type: collection.graphQL.JWT,
+              },
             },
           }),
-          args: {
-            password: { type: GraphQLString },
-            token: { type: GraphQLString },
-          },
-          resolve: resetPassword(collection),
+          resolve: refresh(collection),
         }
 
-        graphqlResult.Mutation.fields[`verifyEmail${singularName}`] = {
-          type: GraphQLBoolean,
-          args: {
-            token: { type: GraphQLString },
-          },
-          resolve: verifyEmail(collection),
+        graphqlResult.Mutation.fields[`logout${singularName}`] = {
+          type: GraphQLString,
+          resolve: logout(collection),
+        }
+
+        if (!collectionConfig.auth.disableLocalStrategy) {
+          const authArgs = {}
+
+          const { canLoginWithEmail, canLoginWithUsername } = getLoginOptions(
+            collectionConfig.auth.loginWithUsername,
+          )
+
+          if (canLoginWithEmail) {
+            authArgs['email'] = { type: new GraphQLNonNull(GraphQLString) }
+          }
+          if (canLoginWithUsername) {
+            authArgs['username'] = { type: new GraphQLNonNull(GraphQLString) }
+          }
+
+          if (collectionConfig.auth.maxLoginAttempts > 0) {
+            graphqlResult.Mutation.fields[`unlock${singularName}`] = {
+              type: new GraphQLNonNull(GraphQLBoolean),
+              args: authArgs,
+              resolve: unlock(collection),
+            }
+          }
+
+          graphqlResult.Mutation.fields[`login${singularName}`] = {
+            type: new GraphQLObjectType({
+              name: formatName(`${slug}LoginResult`),
+              fields: {
+                exp: {
+                  type: GraphQLInt,
+                },
+                token: {
+                  type: GraphQLString,
+                },
+                user: {
+                  type: collection.graphQL.type,
+                },
+              },
+            }),
+            args: {
+              ...authArgs,
+              password: { type: GraphQLString },
+            },
+            resolve: login(collection),
+          }
+
+          graphqlResult.Mutation.fields[`forgotPassword${singularName}`] = {
+            type: new GraphQLNonNull(GraphQLBoolean),
+            args: {
+              disableEmail: { type: GraphQLBoolean },
+              expiration: { type: GraphQLInt },
+              ...authArgs,
+            },
+            resolve: forgotPassword(collection),
+          }
+
+          graphqlResult.Mutation.fields[`resetPassword${singularName}`] = {
+            type: new GraphQLObjectType({
+              name: formatName(`${slug}ResetPassword`),
+              fields: {
+                token: { type: GraphQLString },
+                user: { type: collection.graphQL.type },
+              },
+            }),
+            args: {
+              password: { type: GraphQLString },
+              token: { type: GraphQLString },
+            },
+            resolve: resetPassword(collection),
+          }
+
+          graphqlResult.Mutation.fields[`verifyEmail${singularName}`] = {
+            type: GraphQLBoolean,
+            args: {
+              token: { type: GraphQLString },
+            },
+            resolve: verifyEmail(collection),
+          }
         }
       }
     }

--- a/packages/graphql/src/schema/initGlobals.ts
+++ b/packages/graphql/src/schema/initGlobals.ts
@@ -61,44 +61,51 @@ export function initGlobals({ config, graphqlResult }: InitGlobalsGraphQLArgs): 
         : null,
     }
 
-    graphqlResult.Query.fields[formattedName] = {
-      type: graphqlResult.globals.graphQL[slug].type,
-      args: {
-        draft: { type: GraphQLBoolean },
-        ...(config.localization
-          ? {
-              fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
-              locale: { type: graphqlResult.types.localeInputType },
-            }
-          : {}),
-      },
-      resolve: findOne(global),
+    const queriesEnabled = typeof global.graphQL !== 'object' || !global.graphQL.disableQueries
+    const mutationsEnabled = typeof global.graphQL !== 'object' || !global.graphQL.disableMutations
+
+    if (queriesEnabled) {
+      graphqlResult.Query.fields[formattedName] = {
+        type: graphqlResult.globals.graphQL[slug].type,
+        args: {
+          draft: { type: GraphQLBoolean },
+          ...(config.localization
+            ? {
+                fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
+                locale: { type: graphqlResult.types.localeInputType },
+              }
+            : {}),
+        },
+        resolve: findOne(global),
+      }
+
+      graphqlResult.Query.fields[`docAccess${formattedName}`] = {
+        type: buildPolicyType({
+          type: 'global',
+          entity: global,
+          scope: 'docAccess',
+          typeSuffix: 'DocAccess',
+        }),
+        resolve: docAccessResolver(global),
+      }
     }
 
-    graphqlResult.Mutation.fields[`update${formattedName}`] = {
-      type: graphqlResult.globals.graphQL[slug].type,
-      args: {
-        ...(updateMutationInputType
-          ? { data: { type: graphqlResult.globals.graphQL[slug].mutationInputType } }
-          : {}),
-        draft: { type: GraphQLBoolean },
-        ...(config.localization
-          ? {
-              locale: { type: graphqlResult.types.localeInputType },
-            }
-          : {}),
-      },
-      resolve: update(global),
-    }
-
-    graphqlResult.Query.fields[`docAccess${formattedName}`] = {
-      type: buildPolicyType({
-        type: 'global',
-        entity: global,
-        scope: 'docAccess',
-        typeSuffix: 'DocAccess',
-      }),
-      resolve: docAccessResolver(global),
+    if (mutationsEnabled) {
+      graphqlResult.Mutation.fields[`update${formattedName}`] = {
+        type: graphqlResult.globals.graphQL[slug].type,
+        args: {
+          ...(updateMutationInputType
+            ? { data: { type: graphqlResult.globals.graphQL[slug].mutationInputType } }
+            : {}),
+          draft: { type: GraphQLBoolean },
+          ...(config.localization
+            ? {
+                locale: { type: graphqlResult.types.localeInputType },
+              }
+            : {}),
+        },
+        resolve: update(global),
+      }
     }
 
     if (global.versions) {
@@ -131,53 +138,58 @@ export function initGlobals({ config, graphqlResult }: InitGlobalsGraphQLArgs): 
         parentName: `${formattedName}Version`,
       })
 
-      graphqlResult.Query.fields[`version${formatName(formattedName)}`] = {
-        type: graphqlResult.globals.graphQL[slug].versionType,
-        args: {
-          id: { type: idType },
-          draft: { type: GraphQLBoolean },
-          ...(config.localization
-            ? {
-                fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
-                locale: { type: graphqlResult.types.localeInputType },
-              }
-            : {}),
-        },
-        resolve: findVersionByID(global),
-      }
-      graphqlResult.Query.fields[`versions${formattedName}`] = {
-        type: buildPaginatedListType(
-          `versions${formatName(formattedName)}`,
-          graphqlResult.globals.graphQL[slug].versionType,
-        ),
-        args: {
-          where: {
-            type: buildWhereInputType({
-              name: `versions${formattedName}`,
-              fields: versionGlobalFields,
-              parentName: `versions${formattedName}`,
-            }),
+      if (queriesEnabled) {
+        graphqlResult.Query.fields[`version${formatName(formattedName)}`] = {
+          type: graphqlResult.globals.graphQL[slug].versionType,
+          args: {
+            id: { type: idType },
+            draft: { type: GraphQLBoolean },
+            ...(config.localization
+              ? {
+                  fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
+                  locale: { type: graphqlResult.types.localeInputType },
+                }
+              : {}),
           },
-          ...(config.localization
-            ? {
-                fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
-                locale: { type: graphqlResult.types.localeInputType },
-              }
-            : {}),
-          limit: { type: GraphQLInt },
-          page: { type: GraphQLInt },
-          pagination: { type: GraphQLBoolean },
-          sort: { type: GraphQLString },
-        },
-        resolve: findVersions(global),
+          resolve: findVersionByID(global),
+        }
+        graphqlResult.Query.fields[`versions${formattedName}`] = {
+          type: buildPaginatedListType(
+            `versions${formatName(formattedName)}`,
+            graphqlResult.globals.graphQL[slug].versionType,
+          ),
+          args: {
+            where: {
+              type: buildWhereInputType({
+                name: `versions${formattedName}`,
+                fields: versionGlobalFields,
+                parentName: `versions${formattedName}`,
+              }),
+            },
+            ...(config.localization
+              ? {
+                  fallbackLocale: { type: graphqlResult.types.fallbackLocaleInputType },
+                  locale: { type: graphqlResult.types.localeInputType },
+                }
+              : {}),
+            limit: { type: GraphQLInt },
+            page: { type: GraphQLInt },
+            pagination: { type: GraphQLBoolean },
+            sort: { type: GraphQLString },
+          },
+          resolve: findVersions(global),
+        }
       }
-      graphqlResult.Mutation.fields[`restoreVersion${formatName(formattedName)}`] = {
-        type: graphqlResult.globals.graphQL[slug].type,
-        args: {
-          id: { type: idType },
-          draft: { type: GraphQLBoolean },
-        },
-        resolve: restoreVersion(global),
+
+      if (mutationsEnabled) {
+        graphqlResult.Mutation.fields[`restoreVersion${formatName(formattedName)}`] = {
+          type: graphqlResult.globals.graphQL[slug].type,
+          args: {
+            id: { type: idType },
+            draft: { type: GraphQLBoolean },
+          },
+          resolve: restoreVersion(global),
+        }
       }
     }
   })

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -424,6 +424,8 @@ export type CollectionConfig<TSlug extends CollectionSlug = any> = {
    */
   graphQL?:
     | {
+        disableMutations?: true
+        disableQueries?: true
         pluralName?: string
         singularName?: string
       }

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -160,6 +160,8 @@ export type GlobalConfig = {
   fields: Field[]
   graphQL?:
     | {
+        disableMutations?: true
+        disableQueries?: true
         name?: string
       }
     | false


### PR DESCRIPTION
Adds more control over how you can disable GraphQL queries / mutations for collections and globals.

For example, you might want to disable all GraphQL queries and mutations for a given collection, but you still have relationship fields that relate to that collection, therefore depend on the types being generated.

Now, instead of passing `graphQL: false` (which completely disables everything, including types, which would break relationship fields) you can now specify `graphQL.disableQueries: true` and `graphQL.disableMutations: true`to keep the types, but disable just the queries / mutations.

Closes #9893