### PR TITLE
fix(ui): disableListColumn on first field breaks filter condition selection

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/index.tsx
@@ -194,7 +194,7 @@ export const Condition: React.FC<Props> = (props) => {
             onClick={() =>
               addCondition({
                 andIndex: andIndex + 1,
-                fieldName: fields[0].value,
+                fieldName: fields.find((field) => !field.field.admin?.disableListFilter).value,
                 orIndex,
                 relation: 'and',
               })

--- a/packages/ui/src/elements/WhereBuilder/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/index.tsx
@@ -233,7 +233,8 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
               if (reducedFields.length > 0) {
                 addCondition({
                   andIndex: 0,
-                  fieldName: reducedFields[0].value,
+                  fieldName: reducedFields.find((field) => !field.field.admin?.disableListFilter)
+                    .value,
                   orIndex: conditions.length,
                   relation: 'or',
                 })


### PR DESCRIPTION
What?
This PR fixes an issue with the WhereBuilder where if the first field in a collection had disableListFilter enabled, the select in that fields Condition would be rendered disabled, making it impossible to query docs in list view.

Why?
To allow users to query their documents while still being able to set disableListFilter on fields regardless of where they are in the collection hierarchy.

How?
By setting the intitial field selection to the first `admin.listDisabledColumn: false` field when clicking the Add Condition button in the WhereBuilder and Condition components.

Fixes https://github.com/payloadcms/payload/issues/10110
