### PR TITLE
fix(cpa): do not overwrite custom.scss file on update

### DIFF
--- a/packages/create-payload-app/src/lib/update-payload-in-project.ts
+++ b/packages/create-payload-app/src/lib/update-payload-in-project.ts
@@ -87,6 +87,7 @@ export async function updatePayloadInProject(
   copyRecursiveSync(
     templateSrcDir,
     path.resolve(projectDir, appDetails.isSrcDir ? 'src/app' : 'app', '(payload)'),
+    ['custom.scss$'], // Do not overwrite user's custom.scss
   )
 
   return { message: 'Payload updated successfully.', success: true }


### PR DESCRIPTION
No longer overwrite an existing `custom.scss` file if using `create-payload-app` to update an existing project.

Fixes #9983 