### PR TITLE
docs: fix all missing vertical lines in tables

### DIFF
--- a/docs/admin/collections.mdx
+++ b/docs/admin/collections.mdx
@@ -65,18 +65,18 @@ export const MyCollection: SanitizedCollectionConfig = {
 
 The following options are available:
 
-| Path                       | Description                                                                                                            |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **`beforeList`**           | An array of components to inject _before_ the built-in List View                                                          |
-| **`beforeListTable`**      | An array of components to inject _before_ the built-in List View's table                                                  |
-| **`afterList`**            | An array of components to inject _after_ the built-in List View                                                           |
-| **`afterListTable`**       | An array of components to inject _after_ the built-in List View's table
-| **`Description`**          | A component to render below the Collection label in the List View. An alternative to the `admin.description` property. |
-| **`edit.SaveButton`**      | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled.                                     |
+| Path                       | Description                                                                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`beforeList`**           | An array of components to inject _before_ the built-in List View                                                                           |
+| **`beforeListTable`**      | An array of components to inject _before_ the built-in List View's table                                                                   |
+| **`afterList`**            | An array of components to inject _after_ the built-in List View                                                                            |
+| **`afterListTable`**       | An array of components to inject _after_ the built-in List View's table                                                                    |
+| **`Description`**          | A component to render below the Collection label in the List View. An alternative to the `admin.description` property.                     |
+| **`edit.SaveButton`**      | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled.                                    |
 | **`edit.SaveDraftButton`** | Replace the default Save Draft Button with a Custom Component. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. |
 | **`edit.PublishButton`**   | Replace the default Publish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled.                                  |
-| **`edit.PreviewButton`**   | Replace the default Preview Button with a Custom Component. [Preview](#preview) must be enabled.                                         |
-| **`views`**                | Override or create new views within the Admin Panel. [More details](./views).                                     |
+| **`edit.PreviewButton`**   | Replace the default Preview Button with a Custom Component. [Preview](#preview) must be enabled.                                           |
+| **`views`**                | Override or create new views within the Admin Panel. [More details](./views).                                                              |
 
 <Banner type="success">
   **Note:**

--- a/docs/admin/fields.mdx
+++ b/docs/admin/fields.mdx
@@ -242,31 +242,31 @@ _For details on how to build Custom Components, see [Building Custom Components]
 
 All Field Components receive the following props by default:
 
-| Property         | Description                                                                                                                                                                                                                      |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`docPreferences`** | An object that contains the [Preferences](./preferences) for the document.
-| **`field`** | In Client Components, this is the sanitized Client Field Config. In Server Components, this is the original Field Config. Server Components will also receive the sanitized field config through the`clientField` prop (see below). |
-| **`locale`**     | The locale of the field. [More details](../configuration/localization).                                                                                                                                                                   |
-| **`readOnly`**   | A boolean value that represents if the field is read-only or not.                                                                                                                                                                  |
-| **`user`**       | The currently authenticated user. [More details](../authentication/overview). |
-| **`validate`**   | A function that can be used to validate the field.                                                                                                                                                                                 |
-| **`path`**       | A string representing the direct, dynamic path to the field at runtime, i.e. `myGroup.myArray.0.myField`. |
-| **`schemaPath`** | A string representing the direct, static path to the [Field Config](../fields/overview), i.e. `posts.myGroup.myArray.myField`. |
-| **`indexPath`**  | A hyphen-notated string representing the path to the field _within the nearest named ancestor field_, i.e. `0-0` |
+| Property             | Description                                                                                                                                                                                                                         |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`docPreferences`** | An object that contains the [Preferences](./preferences) for the document.                                                                                                                                                          |
+| **`field`**          | In Client Components, this is the sanitized Client Field Config. In Server Components, this is the original Field Config. Server Components will also receive the sanitized field config through the`clientField` prop (see below). |
+| **`locale`**         | The locale of the field. [More details](../configuration/localization).                                                                                                                                                             |
+| **`readOnly`**       | A boolean value that represents if the field is read-only or not.                                                                                                                                                                   |
+| **`user`**           | The currently authenticated user. [More details](../authentication/overview).                                                                                                                                                       |
+| **`validate`**       | A function that can be used to validate the field.                                                                                                                                                                                  |
+| **`path`**           | A string representing the direct, dynamic path to the field at runtime, i.e. `myGroup.myArray.0.myField`.                                                                                                                           |
+| **`schemaPath`**     | A string representing the direct, static path to the [Field Config](../fields/overview), i.e. `posts.myGroup.myArray.myField`.                                                                                                      |
+| **`indexPath`**      | A hyphen-notated string representing the path to the field _within the nearest named ancestor field_, i.e. `0-0`                                                                                                                    |
 
 In addition to the above props, all Server Components will also receive the following props:
 
-| Property         | Description                                                                                                                                                                                                                      |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`clientField`** | The serializable Client Field Config. |
-| **`field`** | The Field Config. [More details](../fields/overview). |
-| **`data`**       | The current document being edited.                                                                                                                                                                                                   |
-| **`i18n`**       | The [i18n](../configuration/i18n) object.
-| **`payload`**    | The [Payload](../local-api/overview) class.                                                           |
-| **`permissions`** | The field permissions based on the currently authenticated user.                                                                                                                                                                                                   |
-| **`siblingData`** | The data of the field's siblings.                                                                                                                                                                                                   |
-| **`user`**       | The currently authenticated user. [More details](../authentication/overview). |
-| **`value`**      | The value of the field at render-time.                                                                                                                                                                                                   |
+| Property          | Description                                                                   |
+| ----------------- | ----------------------------------------------------------------------------- |
+| **`clientField`** | The serializable Client Field Config.                                         |
+| **`field`**       | The Field Config. [More details](../fields/overview).                         |
+| **`data`**        | The current document being edited.                                            |
+| **`i18n`**        | The [i18n](../configuration/i18n) object.                                     |
+| **`payload`**     | The [Payload](../local-api/overview) class.                                   |
+| **`permissions`** | The field permissions based on the currently authenticated user.              |
+| **`siblingData`** | The data of the field's siblings.                                             |
+| **`user`**        | The currently authenticated user. [More details](../authentication/overview). |
+| **`value`**       | The value of the field at render-time.                                        |
 
 #### Sending and receiving values from the form
 

--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -145,14 +145,14 @@ Blocks are defined as separate configs of their own.
 
 | Option                     | Description                                                                                                                                                                         |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`slug`** *              | Identifier for this block type. Will be saved on each block as the `blockType` property.                                                                                            |
-| **`fields`** *            | Array of fields to be stored in this block.                                                                                                                                         |
+| **`slug`** *               | Identifier for this block type. Will be saved on each block as the `blockType` property.                                                                                            |
+| **`fields`** *             | Array of fields to be stored in this block.                                                                                                                                         |
 | **`labels`**               | Customize the block labels that appear in the Admin dashboard. Auto-generated from slug if not defined.                                                                             |
 | **`imageURL`**             | Provide a custom image thumbnail to help editors identify this block in the Admin UI.                                                                                               |
 | **`imageAltText`**         | Customize this block's image thumbnail alt text.                                                                                                                                    |
 | **`interfaceName`**        | Create a top level, reusable [Typescript interface](/docs/typescript/generating-types#custom-field-interfaces) & [GraphQL type](/docs/graphql/graphql-schema#custom-field-schemas). |
 | **`graphQL.singularName`** | Text to use for the GraphQL schema name. Auto-generated from slug if not defined. NOTE: this is set for deprecation, prefer `interfaceName`.                                        |
-| **`dbName`**               | Custom table name for this block type when using SQL Database Adapter ([Postgres](/docs/database/postgres)). Auto-generated from slug if not defined.
+| **`dbName`**               | Custom table name for this block type when using SQL Database Adapter ([Postgres](/docs/database/postgres)). Auto-generated from slug if not defined.                               |
 | **`custom`**               | Extension point for adding custom data (e.g. for plugins)                                                                                                                           |
 
 ### Auto-generated data per block

--- a/docs/hooks/collections.mdx
+++ b/docs/hooks/collections.mdx
@@ -186,13 +186,13 @@ const beforeReadHook: CollectionBeforeReadHook = async ({
 
 The following arguments are provided to the `beforeRead` hook:
 
-| Option                   | Description                                                                                                                                                                                                           |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`collection`**         | The [Collection](../configuration/collections) in which this Hook is running against.                                                                                                                       |
-| **`context`**            | Custom context passed between hooks. [More details](./context).                                                                                                                              |
-| **`doc`**               | The resulting Document after changes are applied. |
-| **`query`**          | The [Query](../queries/overview) of the request.
-| **`req`**                | The [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. This is mocked for [Local API](../local-api/overview) operations.                                                                                                                                                  |
+| Option           | Description                                                                                                                                           |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`collection`** | The [Collection](../configuration/collections) in which this Hook is running against.                                                                 |
+| **`context`**    | Custom context passed between hooks. [More details](./context).                                                                                       |
+| **`doc`**        | The resulting Document after changes are applied.                                                                                                     |
+| **`query`**      | The [Query](../queries/overview) of the request.                                                                                                      |
+| **`req`**        | The [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. This is mocked for [Local API](../local-api/overview) operations. |
 
 ### afterRead
 
@@ -210,13 +210,13 @@ const afterReadHook: CollectionAfterReadHook = async ({
 
 The following arguments are provided to the `afterRead` hook:
 
-| Option                   | Description                                                                                                                                                                                                           |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`collection`**         | The [Collection](../configuration/collections) in which this Hook is running against.                                                                                                                       |
-| **`context`**            | Custom context passed between hooks. [More details](./context).                                                                                                                              |
-| **`doc`**               | The resulting Document after changes are applied. |
-| **`query`**          | The [Query](../queries/overview) of the request.
-| **`req`**                | The [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. This is mocked for [Local API](../local-api/overview) operations.                                                                                                                                                  |
+| Option           | Description                                                                                                                                           |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`collection`** | The [Collection](../configuration/collections) in which this Hook is running against.                                                                 |
+| **`context`**    | Custom context passed between hooks. [More details](./context).                                                                                       |
+| **`doc`**        | The resulting Document after changes are applied.                                                                                                     |
+| **`query`**      | The [Query](../queries/overview) of the request.                                                                                                      |
+| **`req`**        | The [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. This is mocked for [Local API](../local-api/overview) operations. |
 
 ### beforeDelete
 

--- a/docs/hooks/globals.mdx
+++ b/docs/hooks/globals.mdx
@@ -163,14 +163,14 @@ const afterReadHook: GlobalAfterReadHook = async ({
 
 The following arguments are provided to the `beforeRead` hook:
 
-| Option                   | Description                                                                                                                                                                                                           |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`global`**         | The [Global](../configuration/globals) in which this Hook is running against.                                                                                                                       |
-| **`context`**            | Custom context passed between hooks. [More details](./context).                                                                                                                              |
-| **`findMany`**            | Boolean to denote if this hook is running against finding one, or finding many (useful in versions).                                                                                                                              |
-| **`doc`**               | The resulting Document after changes are applied. |
-| **`query`**          | The [Query](../queries/overview) of the request.
-| **`req`**                | The [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. This is mocked for [Local API](../local-api/overview) operations.                                                                                                                                                  |
+| Option         | Description                                                                                                                                           |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`global`**   | The [Global](../configuration/globals) in which this Hook is running against.                                                                         |
+| **`context`**  | Custom context passed between hooks. [More details](./context).                                                                                       |
+| **`findMany`** | Boolean to denote if this hook is running against finding one, or finding many (useful in versions).                                                  |
+| **`doc`**      | The resulting Document after changes are applied.                                                                                                     |
+| **`query`**    | The [Query](../queries/overview) of the request.                                                                                                      |
+| **`req`**      | The [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. This is mocked for [Local API](../local-api/overview) operations. |
 
 ## TypeScript
 

--- a/docs/plugins/stripe.mdx
+++ b/docs/plugins/stripe.mdx
@@ -65,14 +65,14 @@ export default config
 
 | Option                         | Type               | Default     | Description                                                                                                              |
 | ------------------------------ | ------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `stripeSecretKey` \*           | string             | `undefined` | Your Stripe secret key                                                                                                   |
+| `stripeSecretKey` *            | string             | `undefined` | Your Stripe secret key                                                                                                   |
 | `stripeWebhooksEndpointSecret` | string             | `undefined` | Your Stripe webhook endpoint secret                                                                                      |
 | `rest`                         | boolean            | `false`     | When `true`, opens the `/api/stripe/rest` endpoint                                                                       |
-| `webhooks`                     | object \| function | `undefined` | Either a function to handle all webhooks events, or an object of Stripe webhook handlers, keyed to the name of the event |
+| `webhooks`                     | object or function | `undefined` | Either a function to handle all webhooks events, or an object of Stripe webhook handlers, keyed to the name of the event |
 | `sync`                         | array              | `undefined` | An array of sync configs                                                                                                 |
 | `logs`                         | boolean            | `false`     | When `true`, logs sync events to the console as they happen                                                              |
 
-_\* An asterisk denotes that a property is required._
+_* An asterisk denotes that a property is required._
 
 ## Endpoints
 

--- a/docs/queries/pagination.mdx
+++ b/docs/queries/pagination.mdx
@@ -10,18 +10,18 @@ All collection `find` queries are paginated automatically. Responses are returne
 
 **`Find` response properties:**
 
-| Property      | Description                                               |
-| ------------- | --------------------------------------------------------- |
-| docs          | Array of documents in the collection                      |
-| totalDocs     | Total available documents within the collection           |
-| limit         | Limit query parameter - defaults to `10`                  |
-| totalPages    | Total pages available, based upon the `limit` queried for |
-| page          | Current page number                                       |
-| pagingCounter | `number` of the first doc on the current page             |
-| hasPrevPage   | `true/false` if previous page exists                      |
-| hasNextPage   | `true/false` if next page exists                          |
-| prevPage      | `number` of previous page, `null` if it doesn't exist     |
-| nextPage      | `number` of next page, `null` if it doesn't exist         |
+| Property        | Description                                               |
+| --------------- | --------------------------------------------------------- |
+| `docs`          | Array of documents in the collection                      |
+| `totalDocs`     | Total available documents within the collection           |
+| `limit`         | Limit query parameter - defaults to `10`                  |
+| `totalPages`    | Total pages available, based upon the `limit` queried for |
+| `page`          | Current page number                                       |
+| `pagingCounter` | `number` of the first doc on the current page             |
+| `hasPrevPage`   | `true/false` if previous page exists                      |
+| `hasNextPage`   | `true/false` if next page exists                          |
+| `prevPage`      | `number` of previous page, `null` if it doesn't exist     |
+| `nextPage`      | `number` of next page, `null` if it doesn't exist         |
 
 **Example response:**
 

--- a/docs/rich-text/building-custom-features.mdx
+++ b/docs/rich-text/building-custom-features.mdx
@@ -191,8 +191,7 @@ import { lexicalEditor } from '@payloadcms/richtext-lexical';
  },
 ```
 
-By default, this server feature does nothing - you haven't added any functionality yet. Depending on what you want your
-feature to do, the ServerFeature type exposes various properties you can set to inject custom functionality into the lexical editor.
+By default, this server feature does nothing - you haven't added any functionality yet. Depending on what you want your feature to do, the ServerFeature type exposes various properties you can set to inject custom functionality into the lexical editor.
 
 ### i18n
 

--- a/docs/troubleshooting/troubleshooting.mdx
+++ b/docs/troubleshooting/troubleshooting.mdx
@@ -10,7 +10,7 @@ keywords: admin, components, custom, customize, documentation, Content Managemen
 
 ### "Unauthorized, you must be logged in to make this request" when attempting to log in
 
-This means that your auth cookie is not being set or accepted correctly upon logging in. To resolve heck the following settings in your Payload Config:
+This means that your auth cookie is not being set or accepted correctly upon logging in. To resolve check the following settings in your Payload Config:
 
 - CORS - If you are using the '*', try to explicitly only allow certain domains instead including the one you have specified.
 - CSRF - Do you have this set? if so, make sure your domain is whitelisted within the csrf domains. If not, probably not the issue, but probably can't hurt to whitelist it anyway.

--- a/docs/versions/overview.mdx
+++ b/docs/versions/overview.mdx
@@ -56,7 +56,7 @@ Configuring Versions is done by adding the `versions` key to your Collection con
 | Option      | Description                                                                                                                                                        |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `maxPerDoc` | Use this setting to control how many versions to keep on a document by document basis. Must be an integer. Defaults to 100, use 0 to save all versions.            |
-| `drafts `   | Enable [Drafts](/docs/versions/drafts) mode for this collection. To enable, set to `true` or pass an object with `draft` [options](/docs/versions/drafts#options). |
+| `drafts`    | Enable [Drafts](/docs/versions/drafts) mode for this collection. To enable, set to `true` or pass an object with `draft` [options](/docs/versions/drafts#options). |
 
 ## Global config
 


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR aims to fix a number of formatting issues around the docs. Namely, missing vertical lines in markdown tables, but also some stray accidental escapes, a spelling issue, and others.

### Why?
To properly format the docs for consumption as they were meant to be in one PR as opposed to many smaller ones.

### How?
Changes to a number of `mdx` files in docs folder.