### PR TITLE
feat(db-postgres, db-sqlite): customizable column names

### DIFF
--- a/packages/db-sqlite/src/schema/setColumnID.ts
+++ b/packages/db-sqlite/src/schema/setColumnID.ts
@@ -4,10 +4,17 @@ import type { SQLiteAdapter } from '../types.js'
 
 export const setColumnID: SetColumnID = ({ adapter, columns, fields }) => {
   const idField = fields.find((field) => field.name === 'id')
+
+  let name: string = 'id'
+
+  if (idField && (idField.type === 'number' || idField.type === 'text') && idField.dbColumnName) {
+    name = idField.dbColumnName
+  }
+
   if (idField) {
     if (idField.type === 'number') {
       columns.id = {
-        name: 'id',
+        name,
         type: 'numeric',
         primaryKey: true,
       }
@@ -16,7 +23,7 @@ export const setColumnID: SetColumnID = ({ adapter, columns, fields }) => {
 
     if (idField.type === 'text') {
       columns.id = {
-        name: 'id',
+        name,
         type: 'text',
         primaryKey: true,
       }
@@ -26,7 +33,7 @@ export const setColumnID: SetColumnID = ({ adapter, columns, fields }) => {
 
   if (adapter.idType === 'uuid') {
     columns.id = {
-      name: 'id',
+      name,
       type: 'uuid',
       defaultRandom: true,
       primaryKey: true,

--- a/packages/drizzle/src/postgres/schema/setColumnID.ts
+++ b/packages/drizzle/src/postgres/schema/setColumnID.ts
@@ -2,10 +2,17 @@ import type { SetColumnID } from '../../types.js'
 
 export const setColumnID: SetColumnID = ({ adapter, columns, fields }) => {
   const idField = fields.find((field) => field.name === 'id')
+
+  let name: string = 'id'
+
+  if (idField && (idField.type === 'number' || idField.type === 'text') && idField.dbColumnName) {
+    name = idField.dbColumnName
+  }
+
   if (idField) {
     if (idField.type === 'number') {
       columns.id = {
-        name: 'id',
+        name,
         type: 'numeric',
         primaryKey: true,
       }
@@ -15,7 +22,7 @@ export const setColumnID: SetColumnID = ({ adapter, columns, fields }) => {
 
     if (idField.type === 'text') {
       columns.id = {
-        name: 'id',
+        name,
         type: 'varchar',
         primaryKey: true,
       }
@@ -25,7 +32,7 @@ export const setColumnID: SetColumnID = ({ adapter, columns, fields }) => {
 
   if (adapter.idType === 'uuid') {
     columns.id = {
-      name: 'id',
+      name,
       type: 'uuid',
       defaultRandom: true,
       primaryKey: true,

--- a/packages/drizzle/src/schema/traverseFields.ts
+++ b/packages/drizzle/src/schema/traverseFields.ts
@@ -114,9 +114,11 @@ export const traverseFields = ({
     let targetTable = columns
     let targetIndexes = indexes
 
-    const columnName = `${columnPrefix || ''}${field.name[0] === '_' ? '_' : ''}${toSnakeCase(
-      field.name,
-    )}`
+    const columnName =
+      'dbColumnName' in field && field.dbColumnName
+        ? field.dbColumnName
+        : `${columnPrefix || ''}${field.name[0] === '_' ? '_' : ''}${toSnakeCase(field.name)}`
+
     const fieldName = `${fieldPrefix?.replace('.', '_') || ''}${field.name}`
 
     // If field is localized,

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -400,6 +400,7 @@ export interface FieldBase {
   admin?: Admin
   /** Extension point to add your custom data. Server only. */
   custom?: Record<string, any>
+  dbColumnName?: string
   defaultValue?: DefaultValue
   hidden?: boolean
   hooks?: {
@@ -663,7 +664,10 @@ export type RowField = {
   admin?: Omit<Admin, 'description'>
   fields: Field[]
   type: 'row'
-} & Omit<FieldBase, 'admin' | 'label' | 'localized' | 'name' | 'validate' | 'virtual'>
+} & Omit<
+  FieldBase,
+  'admin' | 'dbColumnName' | 'label' | 'localized' | 'name' | 'validate' | 'virtual'
+>
 
 export type RowFieldClient = {
   admin?: Omit<AdminClient, 'description'>
@@ -702,7 +706,7 @@ export type CollapsibleField = {
       label: Required<FieldBase['label']>
     }
 ) &
-  Omit<FieldBase, 'label' | 'localized' | 'name' | 'validate' | 'virtual'>
+  Omit<FieldBase, 'dbColumnName' | 'label' | 'localized' | 'name' | 'validate' | 'virtual'>
 
 export type CollapsibleFieldClient = {
   admin?: {
@@ -744,7 +748,7 @@ export type UnnamedTab = {
     | LabelFunction
     | string
   localized?: never
-} & Omit<TabBase, 'name' | 'virtual'>
+} & Omit<TabBase, 'dbColumnName' | 'name' | 'virtual'>
 
 export type Tab = NamedTab | UnnamedTab
 

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -54,7 +54,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {
     'hidden-global': HiddenGlobal;
@@ -110,7 +110,7 @@ export interface UserAuthOperations {
  * via the `definition` "uploads".
  */
 export interface Upload {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -135,13 +135,11 @@ export interface Upload {
   };
 }
 /**
- * This is a custom collection description.
- *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "posts".
  */
 export interface Post {
-  id: number;
+  id: string;
   title?: string | null;
   description?: string | null;
   number?: number | null;
@@ -175,15 +173,12 @@ export interface Post {
       }[]
     | null;
   defaultValueField?: string | null;
-  relationship?: (number | null) | Post;
+  relationship?: (string | null) | Post;
   customCell?: string | null;
   hiddenField?: string | null;
   adminHiddenField?: string | null;
   disableListColumnText?: string | null;
   disableListFilterText?: string | null;
-  /**
-   * This is a very long description that takes many characters to complete and hopefully will wrap instead of push the sidebar open, lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum voluptates. Quisquam, voluptatum voluptates.
-   */
   sidebarField?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -194,7 +189,7 @@ export interface Post {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   textField?: string | null;
   sidebarField?: string | null;
   updatedAt: string;
@@ -213,7 +208,7 @@ export interface User {
  * via the `definition` "hidden-collection".
  */
 export interface HiddenCollection {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -223,7 +218,7 @@ export interface HiddenCollection {
  * via the `definition` "not-in-view-collection".
  */
 export interface NotInViewCollection {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -233,7 +228,7 @@ export interface NotInViewCollection {
  * via the `definition` "collection-no-api-view".
  */
 export interface CollectionNoApiView {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
 }
@@ -242,7 +237,7 @@ export interface CollectionNoApiView {
  * via the `definition` "custom-views-one".
  */
 export interface CustomViewsOne {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -252,7 +247,7 @@ export interface CustomViewsOne {
  * via the `definition` "custom-views-two".
  */
 export interface CustomViewsTwo {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -262,20 +257,14 @@ export interface CustomViewsTwo {
  * via the `definition` "custom-fields".
  */
 export interface CustomField {
-  id: number;
+  id: string;
   customTextServerField?: string | null;
   customTextClientField?: string | null;
-  /**
-   * Static field description.
-   */
   descriptionAsString?: string | null;
-  /**
-   * Function description
-   */
   descriptionAsFunction?: string | null;
   descriptionAsComponent?: string | null;
   customSelectField?: string | null;
-  relationshipFieldWithBeforeAfterInputs?: (number | null) | Post;
+  relationshipFieldWithBeforeAfterInputs?: (string | null) | Post;
   arrayFieldWithBeforeAfterInputs?:
     | {
         someTextField?: string | null;
@@ -304,7 +293,7 @@ export interface CustomField {
  * via the `definition` "group-one-collection-ones".
  */
 export interface GroupOneCollectionOne {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -314,7 +303,7 @@ export interface GroupOneCollectionOne {
  * via the `definition` "group-one-collection-twos".
  */
 export interface GroupOneCollectionTwo {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -324,7 +313,7 @@ export interface GroupOneCollectionTwo {
  * via the `definition` "group-two-collection-ones".
  */
 export interface GroupTwoCollectionOne {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -334,7 +323,7 @@ export interface GroupTwoCollectionOne {
  * via the `definition` "group-two-collection-twos".
  */
 export interface GroupTwoCollectionTwo {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -344,7 +333,7 @@ export interface GroupTwoCollectionTwo {
  * via the `definition` "geo".
  */
 export interface Geo {
-  id: number;
+  id: string;
   /**
    * @minItems 2
    * @maxItems 2
@@ -358,7 +347,7 @@ export interface Geo {
  * via the `definition` "disable-duplicate".
  */
 export interface DisableDuplicate {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -368,7 +357,7 @@ export interface DisableDuplicate {
  * via the `definition` "base-list-filters".
  */
 export interface BaseListFilter {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -378,76 +367,76 @@ export interface BaseListFilter {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'uploads';
-        value: number | Upload;
+        value: string | Upload;
       } | null)
     | ({
         relationTo: 'posts';
-        value: number | Post;
+        value: string | Post;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null)
     | ({
         relationTo: 'hidden-collection';
-        value: number | HiddenCollection;
+        value: string | HiddenCollection;
       } | null)
     | ({
         relationTo: 'not-in-view-collection';
-        value: number | NotInViewCollection;
+        value: string | NotInViewCollection;
       } | null)
     | ({
         relationTo: 'collection-no-api-view';
-        value: number | CollectionNoApiView;
+        value: string | CollectionNoApiView;
       } | null)
     | ({
         relationTo: 'custom-views-one';
-        value: number | CustomViewsOne;
+        value: string | CustomViewsOne;
       } | null)
     | ({
         relationTo: 'custom-views-two';
-        value: number | CustomViewsTwo;
+        value: string | CustomViewsTwo;
       } | null)
     | ({
         relationTo: 'custom-fields';
-        value: number | CustomField;
+        value: string | CustomField;
       } | null)
     | ({
         relationTo: 'group-one-collection-ones';
-        value: number | GroupOneCollectionOne;
+        value: string | GroupOneCollectionOne;
       } | null)
     | ({
         relationTo: 'group-one-collection-twos';
-        value: number | GroupOneCollectionTwo;
+        value: string | GroupOneCollectionTwo;
       } | null)
     | ({
         relationTo: 'group-two-collection-ones';
-        value: number | GroupTwoCollectionOne;
+        value: string | GroupTwoCollectionOne;
       } | null)
     | ({
         relationTo: 'group-two-collection-twos';
-        value: number | GroupTwoCollectionTwo;
+        value: string | GroupTwoCollectionTwo;
       } | null)
     | ({
         relationTo: 'geo';
-        value: number | Geo;
+        value: string | Geo;
       } | null)
     | ({
         relationTo: 'disable-duplicate';
-        value: number | DisableDuplicate;
+        value: string | DisableDuplicate;
       } | null)
     | ({
         relationTo: 'base-list-filters';
-        value: number | BaseListFilter;
+        value: string | BaseListFilter;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -457,10 +446,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -480,7 +469,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -769,7 +758,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "hidden-global".
  */
 export interface HiddenGlobal {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -779,7 +768,7 @@ export interface HiddenGlobal {
  * via the `definition` "not-in-view-global".
  */
 export interface NotInViewGlobal {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -789,7 +778,7 @@ export interface NotInViewGlobal {
  * via the `definition` "global-no-api-view".
  */
 export interface GlobalNoApiView {
-  id: number;
+  id: string;
   updatedAt?: string | null;
   createdAt?: string | null;
 }
@@ -798,7 +787,7 @@ export interface GlobalNoApiView {
  * via the `definition` "global".
  */
 export interface Global {
-  id: number;
+  id: string;
   title?: string | null;
   sidebarField?: string | null;
   _status?: ('draft' | 'published') | null;
@@ -810,7 +799,7 @@ export interface Global {
  * via the `definition` "custom-global-views-one".
  */
 export interface CustomGlobalViewsOne {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -820,7 +809,7 @@ export interface CustomGlobalViewsOne {
  * via the `definition` "custom-global-views-two".
  */
 export interface CustomGlobalViewsTwo {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -830,7 +819,7 @@ export interface CustomGlobalViewsTwo {
  * via the `definition` "group-globals-one".
  */
 export interface GroupGlobalsOne {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -840,7 +829,7 @@ export interface GroupGlobalsOne {
  * via the `definition` "group-globals-two".
  */
 export interface GroupGlobalsTwo {
-  id: number;
+  id: string;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -850,7 +839,7 @@ export interface GroupGlobalsTwo {
  * via the `definition` "settings".
  */
 export interface Setting {
-  id: number;
+  id: string;
   canAccessProtected?: boolean | null;
   updatedAt?: string | null;
   createdAt?: string | null;

--- a/test/admin/payload-types.ts
+++ b/test/admin/payload-types.ts
@@ -54,7 +54,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   globals: {
     'hidden-global': HiddenGlobal;
@@ -110,7 +110,7 @@ export interface UserAuthOperations {
  * via the `definition` "uploads".
  */
 export interface Upload {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -135,11 +135,13 @@ export interface Upload {
   };
 }
 /**
+ * This is a custom collection description.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "posts".
  */
 export interface Post {
-  id: string;
+  id: number;
   title?: string | null;
   description?: string | null;
   number?: number | null;
@@ -173,12 +175,15 @@ export interface Post {
       }[]
     | null;
   defaultValueField?: string | null;
-  relationship?: (string | null) | Post;
+  relationship?: (number | null) | Post;
   customCell?: string | null;
   hiddenField?: string | null;
   adminHiddenField?: string | null;
   disableListColumnText?: string | null;
   disableListFilterText?: string | null;
+  /**
+   * This is a very long description that takes many characters to complete and hopefully will wrap instead of push the sidebar open, lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum voluptates. Quisquam, voluptatum voluptates.
+   */
   sidebarField?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -189,7 +194,7 @@ export interface Post {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   textField?: string | null;
   sidebarField?: string | null;
   updatedAt: string;
@@ -208,7 +213,7 @@ export interface User {
  * via the `definition` "hidden-collection".
  */
 export interface HiddenCollection {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -218,7 +223,7 @@ export interface HiddenCollection {
  * via the `definition` "not-in-view-collection".
  */
 export interface NotInViewCollection {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -228,7 +233,7 @@ export interface NotInViewCollection {
  * via the `definition` "collection-no-api-view".
  */
 export interface CollectionNoApiView {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
 }
@@ -237,7 +242,7 @@ export interface CollectionNoApiView {
  * via the `definition` "custom-views-one".
  */
 export interface CustomViewsOne {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -247,7 +252,7 @@ export interface CustomViewsOne {
  * via the `definition` "custom-views-two".
  */
 export interface CustomViewsTwo {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -257,14 +262,20 @@ export interface CustomViewsTwo {
  * via the `definition` "custom-fields".
  */
 export interface CustomField {
-  id: string;
+  id: number;
   customTextServerField?: string | null;
   customTextClientField?: string | null;
+  /**
+   * Static field description.
+   */
   descriptionAsString?: string | null;
+  /**
+   * Function description
+   */
   descriptionAsFunction?: string | null;
   descriptionAsComponent?: string | null;
   customSelectField?: string | null;
-  relationshipFieldWithBeforeAfterInputs?: (string | null) | Post;
+  relationshipFieldWithBeforeAfterInputs?: (number | null) | Post;
   arrayFieldWithBeforeAfterInputs?:
     | {
         someTextField?: string | null;
@@ -293,7 +304,7 @@ export interface CustomField {
  * via the `definition` "group-one-collection-ones".
  */
 export interface GroupOneCollectionOne {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -303,7 +314,7 @@ export interface GroupOneCollectionOne {
  * via the `definition` "group-one-collection-twos".
  */
 export interface GroupOneCollectionTwo {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -313,7 +324,7 @@ export interface GroupOneCollectionTwo {
  * via the `definition` "group-two-collection-ones".
  */
 export interface GroupTwoCollectionOne {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -323,7 +334,7 @@ export interface GroupTwoCollectionOne {
  * via the `definition` "group-two-collection-twos".
  */
 export interface GroupTwoCollectionTwo {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -333,7 +344,7 @@ export interface GroupTwoCollectionTwo {
  * via the `definition` "geo".
  */
 export interface Geo {
-  id: string;
+  id: number;
   /**
    * @minItems 2
    * @maxItems 2
@@ -347,7 +358,7 @@ export interface Geo {
  * via the `definition` "disable-duplicate".
  */
 export interface DisableDuplicate {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -357,7 +368,7 @@ export interface DisableDuplicate {
  * via the `definition` "base-list-filters".
  */
 export interface BaseListFilter {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -367,76 +378,76 @@ export interface BaseListFilter {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'uploads';
-        value: string | Upload;
+        value: number | Upload;
       } | null)
     | ({
         relationTo: 'posts';
-        value: string | Post;
+        value: number | Post;
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null)
     | ({
         relationTo: 'hidden-collection';
-        value: string | HiddenCollection;
+        value: number | HiddenCollection;
       } | null)
     | ({
         relationTo: 'not-in-view-collection';
-        value: string | NotInViewCollection;
+        value: number | NotInViewCollection;
       } | null)
     | ({
         relationTo: 'collection-no-api-view';
-        value: string | CollectionNoApiView;
+        value: number | CollectionNoApiView;
       } | null)
     | ({
         relationTo: 'custom-views-one';
-        value: string | CustomViewsOne;
+        value: number | CustomViewsOne;
       } | null)
     | ({
         relationTo: 'custom-views-two';
-        value: string | CustomViewsTwo;
+        value: number | CustomViewsTwo;
       } | null)
     | ({
         relationTo: 'custom-fields';
-        value: string | CustomField;
+        value: number | CustomField;
       } | null)
     | ({
         relationTo: 'group-one-collection-ones';
-        value: string | GroupOneCollectionOne;
+        value: number | GroupOneCollectionOne;
       } | null)
     | ({
         relationTo: 'group-one-collection-twos';
-        value: string | GroupOneCollectionTwo;
+        value: number | GroupOneCollectionTwo;
       } | null)
     | ({
         relationTo: 'group-two-collection-ones';
-        value: string | GroupTwoCollectionOne;
+        value: number | GroupTwoCollectionOne;
       } | null)
     | ({
         relationTo: 'group-two-collection-twos';
-        value: string | GroupTwoCollectionTwo;
+        value: number | GroupTwoCollectionTwo;
       } | null)
     | ({
         relationTo: 'geo';
-        value: string | Geo;
+        value: number | Geo;
       } | null)
     | ({
         relationTo: 'disable-duplicate';
-        value: string | DisableDuplicate;
+        value: number | DisableDuplicate;
       } | null)
     | ({
         relationTo: 'base-list-filters';
-        value: string | BaseListFilter;
+        value: number | BaseListFilter;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -446,10 +457,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -469,7 +480,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -758,7 +769,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "hidden-global".
  */
 export interface HiddenGlobal {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -768,7 +779,7 @@ export interface HiddenGlobal {
  * via the `definition` "not-in-view-global".
  */
 export interface NotInViewGlobal {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -778,7 +789,7 @@ export interface NotInViewGlobal {
  * via the `definition` "global-no-api-view".
  */
 export interface GlobalNoApiView {
-  id: string;
+  id: number;
   updatedAt?: string | null;
   createdAt?: string | null;
 }
@@ -787,7 +798,7 @@ export interface GlobalNoApiView {
  * via the `definition` "global".
  */
 export interface Global {
-  id: string;
+  id: number;
   title?: string | null;
   sidebarField?: string | null;
   _status?: ('draft' | 'published') | null;
@@ -799,7 +810,7 @@ export interface Global {
  * via the `definition` "custom-global-views-one".
  */
 export interface CustomGlobalViewsOne {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -809,7 +820,7 @@ export interface CustomGlobalViewsOne {
  * via the `definition` "custom-global-views-two".
  */
 export interface CustomGlobalViewsTwo {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -819,7 +830,7 @@ export interface CustomGlobalViewsTwo {
  * via the `definition` "group-globals-one".
  */
 export interface GroupGlobalsOne {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -829,7 +840,7 @@ export interface GroupGlobalsOne {
  * via the `definition` "group-globals-two".
  */
 export interface GroupGlobalsTwo {
-  id: string;
+  id: number;
   title?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -839,7 +850,7 @@ export interface GroupGlobalsTwo {
  * via the `definition` "settings".
  */
 export interface Setting {
-  id: string;
+  id: number;
   canAccessProtected?: boolean | null;
   updatedAt?: string | null;
   createdAt?: string | null;

--- a/test/database/config.ts
+++ b/test/database/config.ts
@@ -464,6 +464,16 @@ export default buildConfigWithDefaults({
       ],
       versions: true,
     },
+    {
+      slug: 'custom-column-names',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          dbColumnName: 'custom_title',
+        },
+      ],
+    },
   ],
   globals: [
     {

--- a/test/database/config.ts
+++ b/test/database/config.ts
@@ -4,6 +4,7 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 import type { TextField } from 'payload'
 
+import { randomUUID } from 'node:crypto'
 import { v4 as uuid } from 'uuid'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
@@ -467,6 +468,20 @@ export default buildConfigWithDefaults({
     {
       slug: 'custom-column-names',
       fields: [
+        {
+          name: 'id',
+          type: 'text',
+          dbColumnName: 'custom_id',
+          hooks: {
+            beforeChange: [
+              ({ value }) => {
+                if (!value) {
+                  return randomUUID()
+                }
+              },
+            ],
+          },
+        },
         {
           name: 'title',
           type: 'text',

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -959,6 +959,8 @@ describe('database', () => {
       expect(payload.db.rawTables.custom_column_names.columns.title.name).toStrictEqual(
         'custom_title',
       )
+
+      expect(payload.db.rawTables.custom_column_names.columns.id.name).toStrictEqual('custom_id')
     })
 
     it('should create and read doc with custom column names', async () => {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -951,6 +951,26 @@ describe('database', () => {
     }
   })
 
+  describe('Custom column names', () => {
+    const sqlIt = process.env.PAYLOAD_DATABASE === 'mongodb' ? it.skip : it
+
+    sqlIt('schema should have custom column names', () => {
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(payload.db.rawTables.custom_column_names.columns.title.name).toStrictEqual(
+        'custom_title',
+      )
+    })
+
+    it('should create and read doc with custom column names', async () => {
+      const doc = await payload.create({
+        collection: 'custom-column-names',
+        data: { title: 'hello' },
+      })
+
+      expect(doc.title).toStrictEqual('hello')
+    })
+  })
+
   describe('drizzle: schema hooks', () => {
     beforeAll(() => {
       process.env.PAYLOAD_FORCE_DRIZZLE_PUSH = 'true'

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -22,6 +22,7 @@ export interface Config {
     'custom-ids': CustomId;
     'fake-custom-ids': FakeCustomId;
     'relationships-migration': RelationshipsMigration;
+    'custom-column-names': CustomColumnName;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -40,6 +41,7 @@ export interface Config {
     'custom-ids': CustomIdsSelect<false> | CustomIdsSelect<true>;
     'fake-custom-ids': FakeCustomIdsSelect<false> | FakeCustomIdsSelect<true>;
     'relationships-migration': RelationshipsMigrationSelect<false> | RelationshipsMigrationSelect<true>;
+    'custom-column-names': CustomColumnNamesSelect<false> | CustomColumnNamesSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -322,6 +324,16 @@ export interface RelationshipsMigration {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "custom-column-names".
+ */
+export interface CustomColumnName {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -387,6 +399,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'relationships-migration';
         value: string | RelationshipsMigration;
+      } | null)
+    | ({
+        relationTo: 'custom-column-names';
+        value: string | CustomColumnName;
       } | null)
     | ({
         relationTo: 'users';
@@ -642,6 +658,15 @@ export interface FakeCustomIdsSelect<T extends boolean = true> {
 export interface RelationshipsMigrationSelect<T extends boolean = true> {
   relationship?: T;
   relationship_2?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "custom-column-names_select".
+ */
+export interface CustomColumnNamesSelect<T extends boolean = true> {
+  title?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
Allows you to customize column names with the `dbColumnName` field config property, works for custom IDs as well. Currently doesn't work with MongoDB.