### PR TITLE
fix: add missing import for 'uploadthingStorage' plugin in code example

### DIFF
--- a/docs/upload/storage-adapters.mdx
+++ b/docs/upload/storage-adapters.mdx
@@ -228,6 +228,8 @@ pnpm add @payloadcms/storage-uploadthing
 - `acl` is optional and defaults to `public-read`.
 
 ```ts
+import { uploadthingStorage } from '@payloadcms/storage-uploadthing'
+
 export default buildConfig({
   collections: [Media],
   plugins: [


### PR DESCRIPTION
In the documentation for 'upload/storage adapters', there is a missing import in the code example for 'uploadthing' which causes the provided code example to throw an error. 