### PR TITLE
fix(next): returns proper verb tenses from update and delete routes

### DIFF
--- a/packages/next/src/routes/rest/collections/delete.ts
+++ b/packages/next/src/routes/rest/collections/delete.ts
@@ -37,7 +37,7 @@ export const deleteDoc: CollectionRouteHandler = async ({ collection, req }) => 
     const message = req.t('general:deletedCountSuccessfully', {
       count: result.docs.length,
       label: getTranslation(
-        collection.config.labels[result.docs.length > 1 ? 'plural' : 'singular'],
+        collection.config.labels[result.docs.length === 1 ? 'singular' : 'plural'],
         req.i18n,
       ),
     })

--- a/packages/next/src/routes/rest/collections/delete.ts
+++ b/packages/next/src/routes/rest/collections/delete.ts
@@ -58,7 +58,7 @@ export const deleteDoc: CollectionRouteHandler = async ({ collection, req }) => 
 
   const message = req.t('error:unableToDeleteCount', {
     count: result.errors.length,
-    label: getTranslation(collection.config.labels[total > 1 ? 'plural' : 'singular'], req.i18n),
+    label: getTranslation(collection.config.labels[total === 1 ? 'singular' : 'plural'], req.i18n),
     total,
   })
 

--- a/packages/next/src/routes/rest/collections/update.ts
+++ b/packages/next/src/routes/rest/collections/update.ts
@@ -42,7 +42,7 @@ export const update: CollectionRouteHandler = async ({ collection, req }) => {
     const message = req.t('general:updatedCountSuccessfully', {
       count: result.docs.length,
       label: getTranslation(
-        collection.config.labels[result.docs.length > 1 ? 'plural' : 'singular'],
+        collection.config.labels[result.docs.length === 1 ? 'singular' : 'plural'],
         req.i18n,
       ),
     })
@@ -62,7 +62,7 @@ export const update: CollectionRouteHandler = async ({ collection, req }) => {
   const total = result.docs.length + result.errors.length
   const message = req.t('error:unableToUpdateCount', {
     count: result.errors.length,
-    label: getTranslation(collection.config.labels[total > 1 ? 'plural' : 'singular'], req.i18n),
+    label: getTranslation(collection.config.labels[total === 1 ? 'singular' : 'plural'], req.i18n),
     total,
   })
 


### PR DESCRIPTION
When hitting the delete or updates routes and no docs were effected, the API returns success messages with improper verb tenses, i.e. `Deleted 0 Post successfully`.