### PR TITLE
fix:  'oldValue' must be a string error when viewing version diffs in postgres

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/fields/Relationship/index.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/fields/Relationship/index.tsx
@@ -34,11 +34,12 @@ const generateLabelFromValue = (
   }
 
   let relatedDoc: RelationshipValue
-  let valueToReturn = '' as any
+  let valueToReturn: RelationshipValue | string = ''
 
   const relationTo = 'relationTo' in field ? field.relationTo : undefined
 
   if (value === null || typeof value === 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string -- We want to return a string specifilly for null and undefined
     return String(value)
   }
 
@@ -76,19 +77,22 @@ const generateLabelFromValue = (
       valueToReturn = relatedDoc
     }
 
-    if (typeof valueToReturn === 'object' && titleFieldIsLocalized) {
+    if (typeof valueToReturn === 'object' && titleFieldIsLocalized && valueToReturn?.[locale]) {
       valueToReturn = valueToReturn[locale]
     }
   } else if (relatedDoc) {
     // Handle non-polymorphic `hasMany` relationships or fallback
     if (typeof relatedDoc?.id !== 'undefined') {
-      valueToReturn = relatedDoc.id
+      valueToReturn = String(relatedDoc.id)
     } else {
       valueToReturn = relatedDoc
     }
   }
 
-  if (typeof valueToReturn === 'object' && valueToReturn !== null) {
+  if (
+    (valueToReturn && typeof valueToReturn === 'object' && valueToReturn !== null) ||
+    typeof valueToReturn !== 'string'
+  ) {
     valueToReturn = JSON.stringify(valueToReturn)
   }
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/10068

We were accidentally not catching that in postgres IDs return as strings but the react diff viewer expects a string