### PR TITLE
fix(db-postgres): added missing quotes and schema name to sql statement in v2-v3 migration

### DIFF
--- a/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/groupUpSQLStatements.ts
+++ b/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/groupUpSQLStatements.ts
@@ -14,10 +14,10 @@ export type Groups =
  */
 function convertAddColumnToAlterColumn(sql) {
   // Regular expression to match the ADD COLUMN statement with its constraints
-  const regex = /ALTER TABLE ("[^"]+") ADD COLUMN ("[^"]+") [\w\s]+ NOT NULL;/
+  const regex = /ALTER TABLE ("[^"]+")\.(".*?") ADD COLUMN ("[^"]+") [\w\s]+ NOT NULL;/
 
   // Replace the matched part with "ALTER COLUMN ... SET NOT NULL;"
-  return sql.replace(regex, 'ALTER TABLE $1 ALTER COLUMN $2 SET NOT NULL;')
+  return sql.replace(regex, 'ALTER TABLE $1.$2 ALTER COLUMN $3 SET NOT NULL;')
 }
 
 export const groupUpSQLStatements = (list: string[]): Record<Groups, string[]> => {

--- a/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/migrateRelationships.ts
+++ b/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/migrateRelationships.ts
@@ -1,3 +1,4 @@
+import type { PgSchema } from 'drizzle-orm/pg-core/schema.js'
 import type { FlattenedField, Payload, PayloadRequest } from 'payload'
 
 import { sql } from 'drizzle-orm'
@@ -49,7 +50,7 @@ export const migrateRelationships = async ({
   }, '')
 
   while (typeof paginationResult === 'undefined' || paginationResult.rows.length > 0) {
-    const paginationStatement = `SELECT DISTINCT parent_id FROM ${tableName}${adapter.relationshipsSuffix} WHERE
+    const paginationStatement = `SELECT DISTINCT parent_id FROM ${(adapter.pgSchema as PgSchema).schemaName}.${tableName}${adapter.relationshipsSuffix} WHERE
     ${where} ORDER BY parent_id LIMIT 500 OFFSET ${offset * 500};
   `
 

--- a/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/migrateRelationships.ts
+++ b/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/migrateRelationships.ts
@@ -1,4 +1,4 @@
-import type { PgSchema } from 'drizzle-orm/pg-core/schema.js'
+import type { PgSchema } from 'drizzle-orm/pg-core'
 import type { FlattenedField, Payload, PayloadRequest } from 'payload'
 
 import { sql } from 'drizzle-orm'
@@ -43,6 +43,8 @@ export const migrateRelationships = async ({
 
   let paginationResult
 
+  const schemaName = (adapter.pgSchema as PgSchema).schemaName
+
   const where = Array.from(pathsToQuery).reduce((statement, path, i) => {
     return (statement += `
 "${tableName}${adapter.relationshipsSuffix}"."path" LIKE '${path}'${pathsToQuery.size !== i + 1 ? ' OR' : ''}
@@ -50,7 +52,7 @@ export const migrateRelationships = async ({
   }, '')
 
   while (typeof paginationResult === 'undefined' || paginationResult.rows.length > 0) {
-    const paginationStatement = `SELECT DISTINCT parent_id FROM ${(adapter.pgSchema as PgSchema).schemaName}.${tableName}${adapter.relationshipsSuffix} WHERE
+    const paginationStatement = `SELECT DISTINCT parent_id FROM ${schemaName}.${tableName}${adapter.relationshipsSuffix} WHERE
     ${where} ORDER BY parent_id LIMIT 500 OFFSET ${offset * 500};
   `
 
@@ -62,8 +64,8 @@ export const migrateRelationships = async ({
 
     offset += 1
 
-    const statement = `SELECT * FROM ${tableName}${adapter.relationshipsSuffix} WHERE
-    (${where}) AND parent_id IN (${paginationResult.rows.map((row) => row.parent_id).join(', ')});
+    const statement = `SELECT * FROM ${schemaName}.${tableName}${adapter.relationshipsSuffix} WHERE
+    (${where}) AND parent_id IN (${paginationResult.rows.map((row) => `'${row.parent_id}'`).join(', ')});
 `
     if (debug) {
       payload.logger.info('FINDING ROWS TO MIGRATE')


### PR DESCRIPTION
### What?

* Added missing schema name to the SQL statement
* Added missing quotes to the `parent_id`'s in the SQL statement

### Why?

* Migrations script isn't working for databases that don't use the `public` schema
* They were missing, causing the database to throw an error.

### Fixes:

- [Discord Discussion](https://discord.com/channels/967097582721572934/1319313926885736448)
- [Discord Discussion](https://discord.com/channels/967097582721572934/1324352204915609661)
- [Discord Discussion](https://discord.com/channels/967097582721572934/1323445259606429716)

