### PR TITLE
fix: adds path to server field component prop types

### DIFF
--- a/packages/payload/src/admin/fields/Array.ts
+++ b/packages/payload/src/admin/fields/Array.ts
@@ -23,14 +23,18 @@ type ArrayFieldBaseClientProps = {
   readonly validate?: ArrayFieldValidation
 } & FieldPaths
 
+type ArrayFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type ArrayFieldClientProps = ArrayFieldBaseClientProps &
   ClientFieldBase<ArrayFieldClientWithoutType>
 
-export type ArrayFieldServerProps = ServerFieldBase<ArrayField, ArrayFieldClientWithoutType>
+export type ArrayFieldServerProps = ArrayFieldBaseServerProps &
+  ServerFieldBase<ArrayField, ArrayFieldClientWithoutType>
 
 export type ArrayFieldServerComponent = FieldServerComponent<
   ArrayField,
-  ArrayFieldClientWithoutType
+  ArrayFieldClientWithoutType,
+  ArrayFieldBaseServerProps
 >
 
 export type ArrayFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/Blocks.ts
+++ b/packages/payload/src/admin/fields/Blocks.ts
@@ -23,14 +23,18 @@ type BlocksFieldBaseClientProps = {
   readonly validate?: BlocksFieldValidation
 } & FieldPaths
 
+type BlocksFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type BlocksFieldClientProps = BlocksFieldBaseClientProps &
   ClientFieldBase<BlocksFieldClientWithoutType>
 
-export type BlocksFieldServerProps = ServerFieldBase<BlocksField, BlocksFieldClientWithoutType>
+export type BlocksFieldServerProps = BlocksFieldBaseServerProps &
+  ServerFieldBase<BlocksField, BlocksFieldClientWithoutType>
 
 export type BlocksFieldServerComponent = FieldServerComponent<
   BlocksField,
-  BlocksFieldClientWithoutType
+  BlocksFieldClientWithoutType,
+  BlocksFieldBaseServerProps
 >
 
 export type BlocksFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/Checkbox.ts
+++ b/packages/payload/src/admin/fields/Checkbox.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -28,17 +29,18 @@ type CheckboxFieldBaseClientProps = {
   readonly validate?: CheckboxFieldValidation
 }
 
+type CheckboxFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type CheckboxFieldClientProps = CheckboxFieldBaseClientProps &
   ClientFieldBase<CheckboxFieldClientWithoutType>
 
-export type CheckboxFieldServerProps = ServerFieldBase<
-  CheckboxField,
-  CheckboxFieldClientWithoutType
->
+export type CheckboxFieldServerProps = CheckboxFieldBaseServerProps &
+  ServerFieldBase<CheckboxField, CheckboxFieldClientWithoutType>
 
 export type CheckboxFieldServerComponent = FieldServerComponent<
   CheckboxField,
-  CheckboxFieldClientWithoutType
+  CheckboxFieldClientWithoutType,
+  CheckboxFieldBaseServerProps
 >
 
 export type CheckboxFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/Code.ts
+++ b/packages/payload/src/admin/fields/Code.ts
@@ -7,6 +7,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -26,12 +27,19 @@ type CodeFieldBaseClientProps = {
   readonly validate?: CodeFieldValidation
 }
 
+type CodeFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type CodeFieldClientProps = ClientFieldBase<CodeFieldClientWithoutType> &
   CodeFieldBaseClientProps
 
-export type CodeFieldServerProps = ServerFieldBase<CodeField, CodeFieldClientWithoutType>
+export type CodeFieldServerProps = CodeFieldBaseServerProps &
+  ServerFieldBase<CodeField, CodeFieldClientWithoutType>
 
-export type CodeFieldServerComponent = FieldServerComponent<CodeField, CodeFieldClientWithoutType>
+export type CodeFieldServerComponent = FieldServerComponent<
+  CodeField,
+  CodeFieldClientWithoutType,
+  CodeFieldBaseServerProps
+>
 
 export type CodeFieldClientComponent = FieldClientComponent<
   CodeFieldClientWithoutType,

--- a/packages/payload/src/admin/fields/Date.ts
+++ b/packages/payload/src/admin/fields/Date.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -23,12 +24,19 @@ type DateFieldBaseClientProps = {
   readonly validate?: DateFieldValidation
 }
 
+type DateFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type DateFieldClientProps = ClientFieldBase<DateFieldClientWithoutType> &
   DateFieldBaseClientProps
 
-export type DateFieldServerProps = ServerFieldBase<DateField, DateFieldClientWithoutType>
+export type DateFieldServerProps = DateFieldBaseServerProps &
+  ServerFieldBase<DateField, DateFieldClientWithoutType>
 
-export type DateFieldServerComponent = FieldServerComponent<DateField, DateFieldClientWithoutType>
+export type DateFieldServerComponent = FieldServerComponent<
+  DateField,
+  DateFieldClientWithoutType,
+  DateFieldBaseServerProps
+>
 
 export type DateFieldClientComponent = FieldClientComponent<
   DateFieldClientWithoutType,

--- a/packages/payload/src/admin/fields/Email.ts
+++ b/packages/payload/src/admin/fields/Email.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -23,14 +24,18 @@ type EmailFieldBaseClientProps = {
   readonly validate?: EmailFieldValidation
 }
 
+type EmailFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type EmailFieldClientProps = ClientFieldBase<EmailFieldClientWithoutType> &
   EmailFieldBaseClientProps
 
-export type EmailFieldServerProps = ServerFieldBase<EmailField, EmailFieldClientWithoutType>
+export type EmailFieldServerProps = EmailFieldBaseServerProps &
+  ServerFieldBase<EmailField, EmailFieldClientWithoutType>
 
 export type EmailFieldServerComponent = FieldServerComponent<
   EmailField,
-  EmailFieldClientWithoutType
+  EmailFieldClientWithoutType,
+  EmailFieldBaseServerProps
 >
 
 export type EmailFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/Group.ts
+++ b/packages/payload/src/admin/fields/Group.ts
@@ -18,16 +18,20 @@ import type {
 
 type GroupFieldClientWithoutType = MarkOptional<GroupFieldClient, 'type'>
 
+type GroupFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type GroupFieldBaseClientProps = FieldPaths
 
 export type GroupFieldClientProps = ClientFieldBase<GroupFieldClientWithoutType> &
   GroupFieldBaseClientProps
 
-export type GroupFieldServerProps = ServerFieldBase<GroupField, GroupFieldClientWithoutType>
+export type GroupFieldServerProps = GroupFieldBaseServerProps &
+  ServerFieldBase<GroupField, GroupFieldClientWithoutType>
 
 export type GroupFieldServerComponent = FieldServerComponent<
   GroupField,
-  GroupFieldClientWithoutType
+  GroupFieldClientWithoutType,
+  GroupFieldBaseServerProps
 >
 
 export type GroupFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/JSON.ts
+++ b/packages/payload/src/admin/fields/JSON.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -23,12 +24,19 @@ type JSONFieldBaseClientProps = {
   readonly validate?: JSONFieldValidation
 }
 
+type JSONFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type JSONFieldClientProps = ClientFieldBase<JSONFieldClientWithoutType> &
   JSONFieldBaseClientProps
 
-export type JSONFieldServerProps = ServerFieldBase<JSONField, JSONFieldClientWithoutType>
+export type JSONFieldServerProps = JSONFieldBaseServerProps &
+  ServerFieldBase<JSONField, JSONFieldClientWithoutType>
 
-export type JSONFieldServerComponent = FieldServerComponent<JSONField, JSONFieldClientWithoutType>
+export type JSONFieldServerComponent = FieldServerComponent<
+  JSONField,
+  JSONFieldClientWithoutType,
+  JSONFieldBaseServerProps
+>
 
 export type JSONFieldClientComponent = FieldClientComponent<
   JSONFieldClientWithoutType,

--- a/packages/payload/src/admin/fields/Join.ts
+++ b/packages/payload/src/admin/fields/Join.ts
@@ -5,6 +5,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -21,12 +22,18 @@ type JoinFieldBaseClientProps = {
   readonly path: string
 }
 
+type JoinFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type JoinFieldClientProps = ClientFieldBase<JoinFieldClientWithoutType> &
   JoinFieldBaseClientProps
 
-export type JoinFieldServerProps = ServerFieldBase<JoinField>
+export type JoinFieldServerProps = JoinFieldBaseServerProps & ServerFieldBase<JoinField>
 
-export type JoinFieldServerComponent = FieldServerComponent<JoinField>
+export type JoinFieldServerComponent = FieldServerComponent<
+  JoinField,
+  JoinFieldClientWithoutType,
+  JoinFieldBaseServerProps
+>
 
 export type JoinFieldClientComponent = FieldClientComponent<
   JoinFieldClientWithoutType,

--- a/packages/payload/src/admin/fields/Number.ts
+++ b/packages/payload/src/admin/fields/Number.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -24,14 +25,18 @@ type NumberFieldBaseClientProps = {
   readonly validate?: NumberFieldValidation
 }
 
+type NumberFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type NumberFieldClientProps = ClientFieldBase<NumberFieldClientWithoutType> &
   NumberFieldBaseClientProps
 
-export type NumberFieldServerProps = ServerFieldBase<NumberField, NumberFieldClientWithoutType>
+export type NumberFieldServerProps = NumberFieldBaseServerProps &
+  ServerFieldBase<NumberField, NumberFieldClientWithoutType>
 
 export type NumberFieldServerComponent = FieldServerComponent<
   NumberField,
-  NumberFieldClientWithoutType
+  NumberFieldClientWithoutType,
+  NumberFieldBaseServerProps
 >
 
 export type NumberFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/Point.ts
+++ b/packages/payload/src/admin/fields/Point.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -23,14 +24,18 @@ type PointFieldBaseClientProps = {
   readonly validate?: PointFieldValidation
 }
 
+type PointFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type PointFieldClientProps = ClientFieldBase<PointFieldClientWithoutType> &
   PointFieldBaseClientProps
 
-export type PointFieldServerProps = ServerFieldBase<PointField, PointFieldClientWithoutType>
+export type PointFieldServerProps = PointFieldBaseServerProps &
+  ServerFieldBase<PointField, PointFieldClientWithoutType>
 
 export type PointFieldServerComponent = FieldServerComponent<
   PointField,
-  PointFieldClientWithoutType
+  PointFieldClientWithoutType,
+  PointFieldBaseServerProps
 >
 
 export type PointFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/Radio.ts
+++ b/packages/payload/src/admin/fields/Radio.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -29,14 +30,18 @@ type RadioFieldBaseClientProps = {
   readonly value?: string
 }
 
+type RadioFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type RadioFieldClientProps = ClientFieldBase<RadioFieldClientWithoutType> &
   RadioFieldBaseClientProps
 
-export type RadioFieldServerProps = ServerFieldBase<RadioField, RadioFieldClientWithoutType>
+export type RadioFieldServerProps = RadioFieldBaseServerProps &
+  ServerFieldBase<RadioField, RadioFieldClientWithoutType>
 
 export type RadioFieldServerComponent = FieldServerComponent<
   RadioField,
-  RadioFieldClientWithoutType
+  RadioFieldClientWithoutType,
+  RadioFieldBaseServerProps
 >
 
 export type RadioFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/Relationship.ts
+++ b/packages/payload/src/admin/fields/Relationship.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -23,17 +24,18 @@ type RelationshipFieldBaseClientProps = {
   readonly validate?: RelationshipFieldValidation
 }
 
+type RelationshipFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type RelationshipFieldClientProps = ClientFieldBase<RelationshipFieldClientWithoutType> &
   RelationshipFieldBaseClientProps
 
-export type RelationshipFieldServerProps = ServerFieldBase<
-  RelationshipField,
-  RelationshipFieldClientWithoutType
->
+export type RelationshipFieldServerProps = RelationshipFieldBaseServerProps &
+  ServerFieldBase<RelationshipField, RelationshipFieldClientWithoutType>
 
 export type RelationshipFieldServerComponent = FieldServerComponent<
   RelationshipField,
-  RelationshipFieldClientWithoutType
+  RelationshipFieldClientWithoutType,
+  RelationshipFieldBaseServerProps
 >
 
 export type RelationshipFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/RichText.ts
+++ b/packages/payload/src/admin/fields/RichText.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -31,6 +32,8 @@ type RichTextFieldBaseClientProps<
   readonly validate?: RichTextFieldValidation
 }
 
+type RichTextFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type RichTextFieldClientProps<
   TValue extends object = any,
   TAdapterProps = any,
@@ -38,14 +41,13 @@ export type RichTextFieldClientProps<
 > = ClientFieldBase<RichTextFieldClientWithoutType<TValue, TAdapterProps, TExtraProperties>> &
   RichTextFieldBaseClientProps<TValue, TAdapterProps, TExtraProperties>
 
-export type RichTextFieldServerProps = ServerFieldBase<
-  RichTextField,
-  RichTextFieldClientWithoutType
->
+export type RichTextFieldServerProps = RichTextFieldBaseServerProps &
+  ServerFieldBase<RichTextField, RichTextFieldClientWithoutType>
 
 export type RichTextFieldServerComponent = FieldServerComponent<
   RichTextField,
-  RichTextFieldClientWithoutType
+  RichTextFieldClientWithoutType,
+  RichTextFieldBaseServerProps
 >
 
 export type RichTextFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/Select.ts
+++ b/packages/payload/src/admin/fields/Select.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -25,14 +26,18 @@ type SelectFieldBaseClientProps = {
   readonly value?: string
 }
 
+type SelectFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type SelectFieldClientProps = ClientFieldBase<SelectFieldClientWithoutType> &
   SelectFieldBaseClientProps
 
-export type SelectFieldServerProps = ServerFieldBase<SelectField, SelectFieldClientWithoutType>
+export type SelectFieldServerProps = SelectFieldBaseServerProps &
+  ServerFieldBase<SelectField, SelectFieldClientWithoutType>
 
 export type SelectFieldServerComponent = FieldServerComponent<
   SelectField,
-  SelectFieldClientWithoutType
+  SelectFieldClientWithoutType,
+  SelectFieldBaseServerProps
 >
 
 export type SelectFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/Text.ts
+++ b/packages/payload/src/admin/fields/Text.ts
@@ -7,6 +7,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -26,12 +27,19 @@ type TextFieldBaseClientProps = {
   readonly validate?: TextFieldValidation
 }
 
+type TextFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type TextFieldClientProps = ClientFieldBase<TextFieldClientWithoutType> &
   TextFieldBaseClientProps
 
-export type TextFieldServerProps = ServerFieldBase<TextField, TextFieldClientWithoutType>
+export type TextFieldServerProps = ServerFieldBase<TextField, TextFieldClientWithoutType> &
+  TextFieldBaseServerProps
 
-export type TextFieldServerComponent = FieldServerComponent<TextField, TextFieldClientWithoutType>
+export type TextFieldServerComponent = FieldServerComponent<
+  TextField,
+  TextFieldClientWithoutType,
+  TextFieldBaseServerProps
+>
 
 export type TextFieldClientComponent = FieldClientComponent<
   TextFieldClientWithoutType,

--- a/packages/payload/src/admin/fields/Textarea.ts
+++ b/packages/payload/src/admin/fields/Textarea.ts
@@ -7,6 +7,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -26,17 +27,21 @@ type TextareaFieldBaseClientProps = {
   readonly validate?: TextareaFieldValidation
 }
 
+type TextareaFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type TextareaFieldClientProps = ClientFieldBase<TextareaFieldClientWithoutType> &
   TextareaFieldBaseClientProps
 
 export type TextareaFieldServerProps = ServerFieldBase<
   TextareaField,
   TextareaFieldClientWithoutType
->
+> &
+  TextareaFieldBaseServerProps
 
 export type TextareaFieldServerComponent = FieldServerComponent<
   TextareaField,
-  TextareaFieldClientWithoutType
+  TextareaFieldClientWithoutType,
+  TextareaFieldBaseServerProps
 >
 
 export type TextareaFieldClientComponent = FieldClientComponent<

--- a/packages/payload/src/admin/fields/UI.ts
+++ b/packages/payload/src/admin/fields/UI.ts
@@ -4,6 +4,7 @@ import type { UIField, UIFieldClient } from '../../fields/config/types.js'
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../types.js'
@@ -14,13 +15,20 @@ type UIFieldBaseClientProps = {
   readonly path: string
 }
 
+type UIFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type UIFieldClientProps = ClientFieldBase<UIFieldClientWithoutType> & UIFieldBaseClientProps
 
-export type UIFieldServerProps = ServerFieldBase<UIField, UIFieldClientWithoutType>
+export type UIFieldServerProps = ServerFieldBase<UIField, UIFieldClientWithoutType> &
+  UIFieldBaseServerProps
 
 export type UIFieldClientComponent = FieldClientComponent<
   UIFieldClientWithoutType,
   UIFieldBaseClientProps
 >
 
-export type UIFieldServerComponent = FieldServerComponent<UIField, UIFieldClientWithoutType>
+export type UIFieldServerComponent = FieldServerComponent<
+  UIField,
+  UIFieldClientWithoutType,
+  UIFieldBaseServerProps
+>

--- a/packages/payload/src/admin/fields/Upload.ts
+++ b/packages/payload/src/admin/fields/Upload.ts
@@ -6,6 +6,7 @@ import type { FieldErrorClientComponent, FieldErrorServerComponent } from '../fo
 import type {
   ClientFieldBase,
   FieldClientComponent,
+  FieldPaths,
   FieldServerComponent,
   ServerFieldBase,
 } from '../forms/Field.js'
@@ -23,14 +24,18 @@ type UploadFieldBaseClientProps = {
   readonly validate?: UploadFieldValidation
 }
 
+type UploadFieldBaseServerProps = Pick<FieldPaths, 'path'>
+
 export type UploadFieldClientProps = ClientFieldBase<UploadFieldClientWithoutType> &
   UploadFieldBaseClientProps
 
-export type UploadFieldServerProps = ServerFieldBase<UploadField, UploadFieldClientWithoutType>
+export type UploadFieldServerProps = ServerFieldBase<UploadField, UploadFieldClientWithoutType> &
+  UploadFieldBaseServerProps
 
 export type UploadFieldServerComponent = FieldServerComponent<
   UploadField,
-  UploadFieldClientWithoutType
+  UploadFieldClientWithoutType,
+  UploadFieldBaseServerProps
 >
 
 export type UploadFieldClientComponent = FieldClientComponent<


### PR DESCRIPTION
### What?
`path` was missing in server component prop types.

### How?
Adds a BaseFieldServerProps for each field type that accepts takes `path` as a prop.
