### PR TITLE
fix(ui): ensures list drawer does not change underlying step nav

### DIFF
--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -163,7 +163,7 @@ export const DefaultListView: React.FC<ListViewClientProps> = (props) => {
   ])
 
   useEffect(() => {
-    if (drawerDepth <= 1) {
+    if (!drawerDepth) {
       setStepNav([
         {
           label: labels?.plural,

--- a/test/admin/collections/Posts.ts
+++ b/test/admin/collections/Posts.ts
@@ -3,7 +3,7 @@ import type { CollectionConfig } from 'payload'
 import { slateEditor } from '@payloadcms/richtext-slate'
 
 import { slugPluralLabel, slugSingularLabel } from '../shared.js'
-import { postsCollectionSlug } from '../slugs.js'
+import { postsCollectionSlug, uploadCollectionSlug } from '../slugs.js'
 
 export const Posts: CollectionConfig = {
   slug: postsCollectionSlug,
@@ -181,6 +181,11 @@ export const Posts: CollectionConfig = {
           Cell: '/components/CustomCell/index.js#CustomCell',
         },
       },
+    },
+    {
+      name: 'upload',
+      type: 'upload',
+      relationTo: uploadCollectionSlug,
     },
     {
       name: 'hiddenField',

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -51,7 +51,7 @@ import { fileURLToPath } from 'url'
 import type { PayloadTestSDK } from '../../../helpers/sdk/index.js'
 
 import { reInitializeDB } from '../../../helpers/reInitializeDB.js'
-import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
+import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
 const filename = fileURLToPath(import.meta.url)
 const currentFolder = path.dirname(filename)
 const dirname = path.resolve(currentFolder, '../../')

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -51,7 +51,7 @@ import { fileURLToPath } from 'url'
 import type { PayloadTestSDK } from '../../../helpers/sdk/index.js'
 
 import { reInitializeDB } from '../../../helpers/reInitializeDB.js'
-import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
+import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
 const filename = fileURLToPath(import.meta.url)
 const currentFolder = path.dirname(filename)
 const dirname = path.resolve(currentFolder, '../../')
@@ -259,6 +259,28 @@ describe('Document View', () => {
       await globalLabel.click()
       await checkPageTitle(page, label)
       await checkBreadcrumb(page, label)
+    })
+  })
+
+  describe('breadcrumbs', () => {
+    test('List drawer should not effect underlying breadcrumbs', async () => {
+      await navigateToDoc(page, postsUrl)
+
+      expect(await page.locator('.step-nav.app-header__step-nav a').nth(1).innerText()).toBe(
+        'Posts',
+      )
+
+      await page.locator('#field-upload button.upload__listToggler').click()
+      await expect(page.locator('[id^=list-drawer_1_]')).toBeVisible()
+      await wait(100) // wait for the component to re-render
+
+      await expect(
+        page.locator('.step-nav.app-header__step-nav .step-nav__last'),
+      ).not.toContainText('Uploads')
+
+      expect(await page.locator('.step-nav.app-header__step-nav a').nth(1).innerText()).toBe(
+        'Posts',
+      )
     })
   })
 


### PR DESCRIPTION
When opening the list drawer, such as when selecting an existing upload, the underlying step nav of the document view changes but shouldn't.