### PR TITLE
feat: working hmr for functions tied to the payload object, e.g. find operation

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -761,6 +761,20 @@ export const reload = async (
     config: config.globals,
   }
 
+  const payloadCopy = new BasePayload()
+  // Copy all properties from payload in there other than find
+  for (const key in payload) {
+    if (typeof key !== 'function') {
+      payloadCopy[key] = payload[key]
+    }
+  }
+
+  for (const key in payloadCopy) {
+    if (typeof key === 'function') {
+      payload[key] = payloadCopy[key]
+    }
+  }
+
   // TODO: support HMR for other props in the future (see payload/src/index init()) that may change on Payload singleton
 
   // Generate types

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -762,7 +762,8 @@ export const reload = async (
   }
 
   const payloadCopy = new BasePayload()
-  // Copy all properties from payload in there other than find
+  // Copy all properties from payload that are not functions. We want those reloaded functions from the new payload
+  // instance to be copied over to the old payload instance.
   for (const key in payload) {
     if (typeof key !== 'function') {
       payloadCopy[key] = payload[key]

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -765,13 +765,13 @@ export const reload = async (
   // Copy all properties from payload that are not functions. We want those reloaded functions from the new payload
   // instance to be copied over to the old payload instance.
   for (const key in payload) {
-    if (typeof key !== 'function') {
+    if (typeof payload[key] !== 'function') {
       payloadCopy[key] = payload[key]
     }
   }
 
   for (const key in payloadCopy) {
-    if (typeof key === 'function') {
+    if (typeof payloadCopy[key] === 'function') {
       payload[key] = payloadCopy[key]
     }
   }


### PR DESCRIPTION
As this PR is only really useful for hmr in our monorepo, it might be better to hide this logic behind an env variable condition

PR for payload.db hmr can be found here: https://github.com/payloadcms/payload/pull/9239