### PR TITLE
feat(next): pass through query params from document view to find operations

### DIFF
--- a/packages/next/src/views/Account/index.tsx
+++ b/packages/next/src/views/Account/index.tsx
@@ -51,6 +51,7 @@ export const Account: React.FC<AdminViewProps> = async ({
       collectionSlug: collectionConfig.slug,
       locale,
       payload,
+      req,
       user,
     })
 

--- a/packages/next/src/views/CreateFirstUser/index.tsx
+++ b/packages/next/src/views/CreateFirstUser/index.tsx
@@ -34,6 +34,7 @@ export const CreateFirstUserView: React.FC<AdminViewProps> = async ({ initPageRe
     collectionSlug: collectionConfig.slug,
     locale,
     payload: req.payload,
+    req,
     user: req.user,
   })
 

--- a/packages/next/src/views/Document/getDocumentData.ts
+++ b/packages/next/src/views/Document/getDocumentData.ts
@@ -1,5 +1,12 @@
 import { sanitizeID } from '@payloadcms/ui/shared'
-import { type Locale, logError, type Payload, type TypedUser, type TypeWithID } from 'payload'
+import {
+  type Locale,
+  logError,
+  type Payload,
+  type PayloadRequest,
+  type TypedUser,
+  type TypeWithID,
+} from 'payload'
 
 type Args = {
   collectionSlug?: string
@@ -7,6 +14,7 @@ type Args = {
   id?: number | string
   locale?: Locale
   payload: Payload
+  req?: PayloadRequest
   user?: TypedUser
 }
 
@@ -16,6 +24,7 @@ export const getDocumentData = async ({
   globalSlug,
   locale,
   payload,
+  req,
   user,
 }: Args): Promise<null | Record<string, unknown> | TypeWithID> => {
   const id = sanitizeID(idArg)
@@ -31,6 +40,11 @@ export const getDocumentData = async ({
         fallbackLocale: false,
         locale: locale?.code,
         overrideAccess: false,
+        req: {
+          query: req?.query,
+          search: req?.search,
+          searchParams: req?.searchParams,
+        },
         user,
       })
     }
@@ -43,6 +57,11 @@ export const getDocumentData = async ({
         fallbackLocale: false,
         locale: locale?.code,
         overrideAccess: false,
+        req: {
+          query: req?.query,
+          search: req?.search,
+          searchParams: req?.searchParams,
+        },
         user,
       })
     }

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -87,6 +87,7 @@ export const renderDocument = async ({
       globalSlug,
       locale,
       payload,
+      req,
       user,
     }))
 


### PR DESCRIPTION
Say you opened `http://localhost:3000/admin/collections/posts/67786e917283ec71ce4ab058?branch=main`, the `branch=main` query param would not be passed to the find operation.

This means that reading `req.query` in, say, an `afterRead` hook, you would get an empty object back.

This PR threads through `query`, `search` and `searchParams` with the main goal of making them accessible in hooks.

## Use-case

Custom branch selector component in a collection's edit view.

Select branch => `branch` query param is added to the URL.

Collection `afterRead` hook then fetches the respective content from that branch (which it gets from `req.query`) and returns its data