### PR TITLE
chore(examples): set HTML dir attribute for RTL locales #10344 

### DIFF
--- a/examples/localization/src/app/(frontend)/[locale]/layout.tsx
+++ b/examples/localization/src/app/(frontend)/[locale]/layout.tsx
@@ -20,6 +20,7 @@ import { getMessages, setRequestLocale } from 'next-intl/server'
 import { NextIntlClientProvider } from 'next-intl'
 import { routing } from '@/i18n/routing'
 import { notFound } from 'next/navigation'
+import localization from '@/i18n/localization'
 
 type Args = {
   children: React.ReactNode
@@ -30,6 +31,8 @@ type Args = {
 
 export default async function RootLayout({ children, params }: Args) {
   const { locale } = await params
+  const currentLocale = localization.locales.find((loc) => loc.code === locale)
+  const direction = currentLocale?.rtl ? 'rtl' : 'ltr'
 
   if (!routing.locales.includes(locale as any)) {
     notFound()
@@ -43,6 +46,7 @@ export default async function RootLayout({ children, params }: Args) {
     <html
       className={cn(GeistSans.variable, GeistMono.variable)}
       lang={locale}
+      dir={direction}
       suppressHydrationWarning
     >
       <head>

--- a/examples/localization/src/globals/Header/Component.client.tsx
+++ b/examples/localization/src/globals/Header/Component.client.tsx
@@ -45,7 +45,7 @@ export const HeaderClient: React.FC<HeaderClientProps> = ({ header }) => {
       className="container relative z-20 py-8 flex justify-end gap-2"
       {...(theme ? { 'data-theme': theme } : {})}
     >
-      <Link href="/" className="mr-auto">
+      <Link href="/" className="me-auto">
         <Logo />
       </Link>
       <LocaleSwitcher />


### PR DESCRIPTION
fix [#10344](https://github.com/payloadcms/payload/issues/10344)

The template was missing defining direction.

direction property is necessary because HTML direction will be LTR for RTL languages by default.