### PR TITLE
fix(translations): update etTranslations type to DefaultTranslationsObject

### DIFF
--- a/packages/translations/README.md
+++ b/packages/translations/README.md
@@ -31,7 +31,7 @@ The home of Payloads API and Admin Panel translations.
 #### Adding a new language
 
 1. Create a new TS file in the `<payload-repo-root>/packages/translations/src/languages` folder, use the language code as the file name (e.g. `<payload-repo-root>/packages/translations/src/languages/en.ts` for English)
-2. Copy all translations from an existing language file and update all of the translations to match your new language
+2. Copy all translations from an existing language file and update all of the translations to match your new language. Make sure the translation object containing all the translations is type `DefaultTranslationsObject`.
 3. Run one of the following:
    ```sh
    yarn build

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -1,6 +1,6 @@
-import type { Language } from '../types.js'
+import type { DefaultTranslationsObject, Language } from '../types.js'
 
-export const etTranslations = {
+export const etTranslations: DefaultTranslationsObject = {
   authentication: {
     account: 'Konto',
     accountOfCurrentUser: 'Praeguse kasutaja konto',


### PR DESCRIPTION
After merging this PR: https://github.com/payloadcms/payload/pull/10169 the estonian language pack has been published, but since the translation type was not correct, it meant en wasn't used as a fallback lanugage, which resulted the whole app to crash:
In the Browser the following error is shown, if Estonian language is picked.
```
Error: Cannot read properties of undefined (reading 'default')
    at resolveErrorDev (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@15.1.3_react-dom@19.0.0_react@19.0.0__react@19.0.0_sass@1.77.4/node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js:1792:63)
    at processFullStringRow (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@15.1.3_react-dom@19.0.0_react@19.0.0__react@19.0.0_sass@1.77.4/node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js:2071:17)
    at processFullBinaryRow (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@15.1.3_react-dom@19.0.0_react@19.0.0__react@19.0.0_sass@1.77.4/node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js:2059:7)
    at progress (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@15.1.3_react-dom@19.0.0_react@19.0.0__react@19.0.0_sass@1.77.4/node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js:2262:17)
```

Fixes #

This is now fixed by adding the correct type to the translation object.
