### PR TITLE
docs: added missing step from multi tentant example quick start

### DIFF
--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -6,15 +6,45 @@ This example demonstrates how to achieve a multi-tenancy in [Payload](https://gi
 
 To spin up this example locally, follow these steps:
 
-1. Run the following command to create a project from the example:
+### 1. Create the Project  
+Run the following command to set up the project:  
 
-- `npx create-payload-app --example multi-tenant`
+```bash  
+npx create-payload-app --example multi-tenant
+```
 
-2. `pnpm dev`, `yarn dev` or `npm run dev` to start the server
-   - Press `y` when prompted to seed the database
-3. `open http://localhost:3000` to access the home page
-4. `open http://localhost:3000/admin` to access the admin panel
-   - Login with email `demo@payloadcms.com` and password `demo`
+### 2. Configure Environment Variables
+Duplicate the .env.example file and rename it to .env.
+
+
+```bash  
+DATABASE_URI=mongodb://127.0.0.1/payload-example-multi-tenant
+PAYLOAD_SECRET=PAYLOAD_MULTI_TENANT_EXAMPLE_SECRET_KEY
+PAYLOAD_PUBLIC_SERVER_URL=http://localhost:3000
+```
+
+### 3. Start the Development Server
+
+Use your preferred package manager to start the server:
+
+```bash  
+pnpm dev
+```
+```bash  
+yarn dev
+```
+```bash  
+npm dev
+```
+
+> When prompted, press y to seed the database.
+
+### 4. Access the Application
+
+- Home Page: Open http://localhost:3000 in your browser.
+- Admin Panel: Open http://localhost:3000/admin and log in with the following credentials:
+	-	Email: demo@payloadcms.com
+	-	Password: demo
 
 ## How it works
 

--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -14,17 +14,13 @@ npx create-payload-app --example multi-tenant
 ```
 
 ### 2. Configure Environment Variables
-Duplicate the .env.example file and rename it to .env.
-
+Duplicate the .env.example file and rename it to .env
 
 ```bash  
-DATABASE_URI=mongodb://127.0.0.1/payload-example-multi-tenant
-PAYLOAD_SECRET=PAYLOAD_MULTI_TENANT_EXAMPLE_SECRET_KEY
-PAYLOAD_PUBLIC_SERVER_URL=http://localhost:3000
+cp .env.example .env
 ```
 
 ### 3. Start the Development Server
-
 Use your preferred package manager to start the server:
 
 ```bash  


### PR DESCRIPTION
Following the README.md of the multi tenant example, I tried to run the project and got an error of a missing secret key. I didn't understand instantly that its because I didn't setup the .env file so I thought it would be a good addition to the documentation.

Additionaly minor "beautification" of the quick start section.

Before (screenshot):
![before](https://github.com/user-attachments/assets/a2f85d5a-dd8b-466d-a958-e7d1e580fb68)


After (screenshot):
![after](https://github.com/user-attachments/assets/0172ff13-ca3c-45d7-bbe6-13ca89c7a6de)

