### PR TITLE
templates: prevent plugin template from including nested next folder in git

### DIFF
--- a/templates/plugin/.gitignore
+++ b/templates/plugin/.gitignore
@@ -13,7 +13,7 @@
 /coverage
 
 # next.js
-/.next/
+**/.next/
 /out/
 
 # production

--- a/templates/plugin/.gitignore
+++ b/templates/plugin/.gitignore
@@ -13,7 +13,7 @@
 /coverage
 
 # next.js
-**/.next/
+.next/
 /out/
 
 # production


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR adjusts the `.gitignore` file in the plugin template to prevent tracking of the nested `.next` folder.

### Why?
The existing rule excludes a top-level `.next` folder. However, in the plugin template, next generates the folder in `/dev` instead.

### How?
Adjusting `.gitignore` to consider that `.next` may be nested in different folders.

Notes:
- Initially I made it explicit, after judging the rest of the file I realized not everyone likes explicit rules so I simplified. Both `**/.next/` & `.next/` should be functionally equivalent though.