### PR TITLE
docs: improves grammar in vercel postgres usage note

### DIFF
--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -52,7 +52,7 @@ export default buildConfig({
 
 <Banner type="info">
   **Note:**
-  If when using `vercelPostgresAdapter` your `process.env.POSTGRES_URL` or `pool.connectionString` points to a local database (e.g hostname has `localhost` or `127.0.0.1`) we use the `pg` module for pooling instead of `@vercel/postgres`. This is because `@vercel/postgres` doesn't work with local databases, if you want to disable that behavior, you can pass `forceUseVercelPostgres: true` to adapter's 'args and follow [Vercel guide](https://vercel.com/docs/storage/vercel-postgres/local-development#option-2:-local-postgres-instance-with-docker) for a Docker Neon DB setup.
+  If you're using `vercelPostgresAdapter` your `process.env.POSTGRES_URL` or `pool.connectionString` points to a local database (e.g hostname has `localhost` or `127.0.0.1`) we use the `pg` module for pooling instead of `@vercel/postgres`. This is because `@vercel/postgres` doesn't work with local databases, if you want to disable that behavior, you can pass `forceUseVercelPostgres: true` to adapter's 'args and follow [Vercel guide](https://vercel.com/docs/storage/vercel-postgres/local-development#option-2:-local-postgres-instance-with-docker) for a Docker Neon DB setup.
 </Banner>
 
 ## Options


### PR DESCRIPTION
Refined the grammar and structure of the usage note for `vercelPostgresAdapter`. Replaced the ambiguous phrase "If when using" with "If you are using" for better readability and clarity.