### PR TITLE
docs: update beforeValidate documentation

### DIFF
--- a/docs/hooks/collections.mdx
+++ b/docs/hooks/collections.mdx
@@ -91,9 +91,9 @@ The following arguments are provided to the `beforeOperation` hook:
 
 ### beforeValidate
 
-Runs before the `create` and `update` operations. This hook allows you to add or format data before the incoming data is validated server-side.
+Runs during the `create` and `update` operations. This hook allows you to add or format data before the incoming data is validated server-side.
 
-Please do note that this does not run before the client-side validation. If you added a `validate` function, this would be the lifecycle:
+Please do note that this does not run before client-side validation. If you render a custom field component in your front-end and provide it with a `validate` function, the order that validations will run in is:
 
 1. `validate` runs on the client
 2. if successful, `beforeValidate` runs on the server

--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -80,7 +80,13 @@ The following arguments are provided to all Field Hooks:
 
 ### beforeValidate
 
-Runs before the `update` operation. This hook allows you to pre-process or format field data before it undergoes validation.
+Runs during the `create` and `update` operations. This hook allows you to add or format data before the incoming data is validated server-side.
+
+Please do note that this does not run before client-side validation. If you render a custom field component in your front-end and provide it with a `validate` function, the order that validations will run in is:
+
+1. `validate` runs on the client
+2. if successful, `beforeValidate` runs on the server
+3. `validate` runs on the server
 
 ```ts
 import type { Field } from 'payload'

--- a/docs/hooks/globals.mdx
+++ b/docs/hooks/globals.mdx
@@ -49,7 +49,13 @@ const GlobalWithHooks: GlobalConfig = {
 
 ### beforeValidate
 
-Runs before the `update` operation. This hook allows you to add or format data before the incoming data is validated.
+Runs during the `update` operation. This hook allows you to add or format data before the incoming data is validated server-side.
+
+Please do note that this does not run before client-side validation. If you render a custom field component in your front-end and provide it with a `validate` function, the order that validations will run in is:
+
+1. `validate` runs on the client
+2. if successful, `beforeValidate` runs on the server
+3. `validate` runs on the server
 
 ```ts
 import type { GlobalBeforeValidateHook } from 'payload'


### PR DESCRIPTION
docs: update beforeValidate documentation

These hooks operate similarly across the different contexts they can be
registered in, but were not sufficiently documented as such.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

