### PR TITLE
docs: fix all other links to live-preview example

### DIFF
--- a/docs/live-preview/client.mdx
+++ b/docs/live-preview/client.mdx
@@ -239,7 +239,7 @@ export const useLivePreview = <T extends any>(props: {
 
 ## Example
 
-For a working demonstration of this, check out the official [Live Preview Example](https://github.com/payloadcms/payload/tree/main/examples/live-preview/payload). There you will find examples of various front-end frameworks and how to integrate each one of them, including:
+For a working demonstration of this, check out the official [Live Preview Example](https://github.com/payloadcms/payload/tree/main/examples/live-preview). There you will find examples of various front-end frameworks and how to integrate each one of them, including:
 
 - [Next.js App Router](https://github.com/payloadcms/payload/tree/main/examples/live-preview/next-app)
 - [Next.js Pages Router](https://github.com/payloadcms/payload/tree/main/examples/live-preview/next-pages)

--- a/docs/live-preview/server.mdx
+++ b/docs/live-preview/server.mdx
@@ -160,7 +160,7 @@ export const RefreshRouteOnSave: React.FC<{
 
 ## Example
 
-For a working demonstration of this, check out the official [Live Preview Example](https://github.com/payloadcms/payload/tree/main/examples/live-preview/payload). There you will find a fully working example of how to implement Live Preview in your Next.js App Router application.
+For a working demonstration of this, check out the official [Live Preview Example](https://github.com/payloadcms/payload/tree/main/examples/live-preview). There you will find a fully working example of how to implement Live Preview in your Next.js App Router application.
 
 ## Troubleshooting
 

--- a/examples/live-preview/README.md
+++ b/examples/live-preview/README.md
@@ -1,6 +1,6 @@
 # Payload Live Preview Example
 
-The [Payload Live Preview Example](https://github.com/payloadcms/payload/tree/main/examples/live-preview/payload) demonstrates how to implement [Live Preview](https://payloadcms.com/docs/live-preview/overview) in [Payload](https://github.com/payloadcms/payload). With Live Preview you can render your front-end application directly within the Admin panel. As you type, your changes take effect in real-time. No need to save a draft or publish your changes.
+The [Payload Live Preview Example](https://github.com/payloadcms/payload/tree/main/examples/live-preview) demonstrates how to implement [Live Preview](https://payloadcms.com/docs/live-preview/overview) in [Payload](https://github.com/payloadcms/payload). With Live Preview you can render your front-end application directly within the Admin panel. As you type, your changes take effect in real-time. No need to save a draft or publish your changes.
 
 **IMPORTANT—This example includes a fully integrated Next.js App Router front-end that runs on the same server as Payload.**
 


### PR DESCRIPTION
I missed some links on the other docs pages in the previous PR that was already merged - #10380