### PR TITLE
templates: use `cross-env` in the plugin template to achieve compatibility with Windows

### DIFF
--- a/templates/plugin/package.json
+++ b/templates/plugin/package.json
@@ -58,6 +58,7 @@
     "@types/react": "19.0.1",
     "@types/react-dom": "19.0.1",
     "copyfiles": "2.4.1",
+    "cross-env": "^7.0.3",
     "eslint": "^9.16.0",
     "eslint-config-next": "15.1.0",
     "graphql": "^16.8.1",

--- a/templates/plugin/package.json
+++ b/templates/plugin/package.json
@@ -35,7 +35,7 @@
     "dev": "payload run ./dev/server.ts",
     "dev:generate-importmap": "pnpm dev:payload generate:importmap",
     "dev:generate-types": "pnpm dev:payload generate:types",
-    "dev:payload": "PAYLOAD_CONFIG_PATH=./dev/payload.config.ts payload",
+    "dev:payload": "cross-env PAYLOAD_CONFIG_PATH=./dev/payload.config.ts payload",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "prepublishOnly": "pnpm clean && pnpm build",


### PR DESCRIPTION
### What?
Uses `cross-env` for the `dev:payload` script in the plugin template.

### Why?
To achieve compatibility with Windows. 

### How?
Adds `cross-env` as a dev dependency and modifies the `dev:payload` script.