### PR TITLE
feat: warn if deploying to vercel and any upload collection missing storage adapter

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -653,6 +653,20 @@ export class BasePayload {
       )
     }
 
+    // Warn if user is deploying to Vercel, and any upload collection is missing a storage adapter
+    if (process.env.VERCEL) {
+      const uploadCollWithoutAdapter = this.config.collections.filter(
+        (c) => c.upload && c.upload.adapter === undefined, // Uploads enabled, but no storage adapter provided
+      )
+
+      if (uploadCollWithoutAdapter) {
+        const slugs = uploadCollWithoutAdapter.map((c) => c.slug).join(', ')
+        this.logger.warn(
+          `Collections with uploads enabled require a storage adapter when deploying to Vercel. Collections without storage adapters: ${slugs}. See https://payloadcms.com/docs/upload/storage-adapters for more info.`,
+        )
+      }
+    }
+
     this.sendEmail = this.email['sendEmail']
 
     serverInitTelemetry(this)


### PR DESCRIPTION
A large number of users have been confused why their upload collection doesn't work as expected when deploying to Vercel. This is because by default, Payload uses local disk storage for file uploads - which will not function properly in that environment.

This adds a warning if a user is deploying on Vercel, and they have any upload collection missing an adapter - aka, writing to disk.

