### PR TITLE
docs: update draft doc for formatting

### DIFF
--- a/docs/fields/relationship.mdx
+++ b/docs/fields/relationship.mdx
@@ -188,9 +188,9 @@ You can learn more about writing queries [here](/docs/queries/overview).
 <Banner type="warning">
   **Note:**
 
-  When a relationship field has both **filterOptions** and a custom{' '}
-  **validate** function, the api will not validate **filterOptions**{' '}
-  unless you call the default relationship field validation function imported from{' '}
+  When a relationship field has both **filterOptions** and a custom
+  **validate** function, the api will not validate **filterOptions**
+  unless you call the default relationship field validation function imported from
   **payload/shared** in your validate function.
 </Banner>
 

--- a/docs/fields/upload.mdx
+++ b/docs/fields/upload.mdx
@@ -128,9 +128,9 @@ You can learn more about writing queries [here](/docs/queries/overview).
 <Banner type="warning">
   **Note:**
 
-  When an upload field has both **filterOptions** and a custom{' '}
-  **validate** function, the api will not validate **filterOptions**{' '}
-  unless you call the default upload field validation function imported from{' '}
+  When an upload field has both **filterOptions** and a custom
+  **validate** function, the api will not validate **filterOptions**
+  unless you call the default upload field validation function imported from
   **payload/shared** in your validate function.
 </Banner>
 

--- a/docs/rich-text/slate.mdx
+++ b/docs/rich-text/slate.mdx
@@ -127,7 +127,7 @@ Similar to the `relationship` element, the `upload` element is a user-friendly w
 
   Collections are automatically allowed to be selected within the Rich Text relationship and upload
   elements by default. If you want to disable a collection from being able to be referenced in Rich
-  Text fields, set the collection admin options of **enableRichTextLink** and{' '}
+  Text fields, set the collection admin options of **enableRichTextLink** and
   **enableRichTextRelationship** to false.
 </Banner>
 

--- a/docs/versions/autosave.mdx
+++ b/docs/versions/autosave.mdx
@@ -69,7 +69,7 @@ When `autosave` is enabled, all `update` operations within Payload expose a new 
 If we created a new version for each autosave, you'd quickly find a ton of autosaves that clutter up your `_versions` collection within the database. That would be messy quick because `autosave` is typically set to save a document at ~800ms intervals.
 
 <Banner type="success">
-  Instead of creating a new version each time a document is autosaved, Payload smartly only creates{' '}
+  Instead of creating a new version each time a document is autosaved, Payload smartly only creates 
   **one** autosave version, and then updates that specific version with each autosave
   performed. This makes sure that your versions remain nice and tidy.
 </Banner>

--- a/docs/versions/drafts.mdx
+++ b/docs/versions/drafts.mdx
@@ -123,12 +123,12 @@ export const Pages: CollectionConfig = {
   **Note regarding adding versions to an existing collection**
 
   If you already have a collection with documents, and you *opt in* to draft functionality
-  after you have already created existing documents, all of your old documents{' '}
-  *will not have a _status field* until you resave them. For this reason, if you are{' '}
+  after you have already created existing documents, all of your old documents
+  *will not have a `_status` field* until you resave them. For this reason, if you are
   *adding* versions into an existing collection, you might want to write your Access Control
-  function to allow for users to read both documents where{' '}
-  **status is equal to "published"** as well as where{' '}
-  **status does not exis**.
+  function to allow for users to read both documents where
+  **`_status` is equal to `"published"`** as well as where
+  **`_status` does not exist**.
 </Banner>
 
 Here is an example for how to write an [Access Control](../access-control/overview) function that grants access to both documents where `_status` is equal to "published" and where `_status` does not exist:


### PR DESCRIPTION
I think some automatic formatter added the `{' '}` styling, it doesn't render correctly. Update the formatting for this banner to remove it and correctly refer to the `_status` field.

