### PR TITLE
fix(richtext-lexical): modify JSXConvertersFunction type to support block types in strict mode

### DIFF
--- a/packages/richtext-lexical/src/exports/react/components/RichText/index.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/index.tsx
@@ -16,7 +16,7 @@ import './index.css'
 export type JSXConvertersFunction<
   T extends { [key: string]: any; type?: string } =
     | DefaultNodeTypes
-    | SerializedBlockNode<{ blockName?: null | string; blockType: string }>
+    | SerializedBlockNode<{ blockName?: null | string }>
     | SerializedInlineBlockNode<{ blockName?: null | string; blockType: string }>,
 > = (args: { defaultConverters: JSXConverters<DefaultNodeTypes> }) => JSXConverters<T>
 


### PR DESCRIPTION
Reproduction steps:
1. Set `strict: true` in `templates/website/tsconfig.json`
2. You will find a ts error in `templates/website/src/components/RichText/index.tsx`.

This is because the blockType property of blocks is generated by Payload as a literal (e.g. "mediaBlock") and cannot be assigned to a string.

To test this PR, you can make the change to `JSXConvertersFunction` in node_modules of the website template
