### PR TITLE
fix: extends type `all` to the locale type definition in req

### DIFF
--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -29,8 +29,11 @@ export type CustomPayloadRequestProperties = {
   /**
    * The requested locale if specified
    * Only available for localized collections
+   *
+   * Suppressing warning below as it is a valid use case - won't be an issue if generated types exist
    */
-  locale?: TypedLocale
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  locale?: 'all' | TypedLocale
   /**
    * The payload object
    */


### PR DESCRIPTION
### What?

If you query with all locales using the `'all'` value for locales, the `req.locale` value is `'all'` but the type definition only contains the available locales.

### Why?

The `CustomPayloadRequestProperties.locale` property was only being typed as `TypedLocale` and was not extending `'all'.`

### How?

Extends type all to the locale type definition in req

Fixes #10244 
