### PR TITLE
fix: increase safety of findConfig

### DIFF
--- a/packages/payload/src/config/find.ts
+++ b/packages/payload/src/config/find.ts
@@ -67,7 +67,7 @@ export const findConfig = (): string => {
   const { configPath, outPath, rootPath, srcPath } = getTSConfigPaths()
 
   // if configPath is absolute file, not folder, return it
-  if (path.extname(configPath) === '.js' || path.extname(configPath) === '.ts') {
+  if (configPath && (path.extname(configPath) === '.js' || path.extname(configPath) === '.ts')) {
     return configPath
   }
 


### PR DESCRIPTION
If `@payload-config` is not set in tsconfig, findConfig could fail when performing a `path.extname` on an undefined value.

Example error in this scenario:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined.
```
