### PR TITLE
fix(ui): stale doc status when publishing, reverting and unpublishing

### DIFF
--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -48,6 +48,7 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
     mostRecentVersionIsAutosaved,
     setLastUpdateTime,
     setMostRecentVersionIsAutosaved,
+    setUnpublishedVersionCount,
   } = useDocumentInfo()
   const queueRef = useRef([])
   const isProcessingRef = useRef(false)
@@ -177,6 +178,7 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
                       if (!mostRecentVersionIsAutosaved) {
                         incrementVersionCount()
                         setMostRecentVersionIsAutosaved(true)
+                        setUnpublishedVersionCount((prev) => prev + 1)
                       }
                     } else {
                       return res.json()

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -25,6 +25,7 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
     hasPublishedDoc,
     hasPublishPermission,
     setHasPublishedDoc,
+    setMostRecentVersionIsAutosaved,
     setUnpublishedVersionCount,
     unpublishedVersionCount,
     uploadStatus,
@@ -122,8 +123,15 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
     })
 
     setUnpublishedVersionCount(0)
+    setMostRecentVersionIsAutosaved(false)
     setHasPublishedDoc(true)
-  }, [setHasPublishedDoc, submit, setUnpublishedVersionCount, uploadStatus])
+  }, [
+    setHasPublishedDoc,
+    submit,
+    setUnpublishedVersionCount,
+    uploadStatus,
+    setMostRecentVersionIsAutosaved,
+  ])
 
   const publishSpecificLocale = useCallback(
     (locale) => {

--- a/packages/ui/src/elements/Status/index.tsx
+++ b/packages/ui/src/elements/Status/index.tsx
@@ -24,6 +24,9 @@ export const Status: React.FC = () => {
     globalSlug,
     hasPublishedDoc,
     incrementVersionCount,
+    setHasPublishedDoc,
+    setMostRecentVersionIsAutosaved,
+    setUnpublishedVersionCount,
     unpublishedVersionCount,
   } = useDocumentInfo()
   const { toggleModal } = useModal()
@@ -110,8 +113,14 @@ export const Status: React.FC = () => {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         resetForm(data)
         toast.success(json.message)
-
         incrementVersionCount()
+        setMostRecentVersionIsAutosaved(false)
+
+        if (action === 'unpublish') {
+          setHasPublishedDoc(false)
+        } else if (action === 'revert') {
+          setUnpublishedVersionCount(0)
+        }
       } else {
         toast.error(t('error:unPublishingDocument'))
       }
@@ -128,17 +137,19 @@ export const Status: React.FC = () => {
     [
       api,
       collectionSlug,
-      incrementVersionCount,
       globalSlug,
-      i18n.language,
       id,
+      i18n.language,
+      incrementVersionCount,
       locale,
       resetForm,
-      revertModalSlug,
       serverURL,
+      setUnpublishedVersionCount,
       t,
       toggleModal,
+      revertModalSlug,
       unPublishModalSlug,
+      setHasPublishedDoc,
     ],
   )
 


### PR DESCRIPTION
### What?
The status indicator was not updating properly when users were clicking "unpublish" and "revert changes"

### Why?
hasPublishedDoc, unpublishedVersionCount and mostRecentVersionIsAutosaved states were not being updated properly.

### How?
This PR updates the variables when interacting with the status actions and sets mostRecentVersionIsAutosaved to false when the publish button is clicked.

Fixes https://github.com/payloadcms/payload/issues/9531
