### PR TITLE
fix(richtext-lexical): formatted inline code resulted in incorrect markdown export

### DIFF
--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownExport.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownExport.ts
@@ -33,9 +33,20 @@ export function createMarkdownExport(
 
   // Export only uses text formats that are responsible for single format
   // e.g. it will filter out *** (bold, italic) and instead use separate ** and *
-  const textFormatTransformers = byType.textFormat.filter(
-    (transformer) => transformer.format.length === 1,
-  )
+  const textFormatTransformers = byType.textFormat
+    .filter((transformer) => transformer.format.length === 1)
+    // Make sure all text transformers that contain 'code' in their format are at the end of the array. Otherwise, formatted code like
+    // <strong><code>code</code></strong> will be exported as `**Bold Code**`, as the code format will be applied first, and the bold format
+    // will be applied second and thus skipped entirely, as the code format will prevent any further formatting.
+    .sort((a, b) => {
+      if (a.format[0] === 'code' && b.format[0] !== 'code') {
+        return 1
+      } else if (a.format[0] !== 'code' && b.format[0] === 'code') {
+        return -1
+      } else {
+        return 0
+      }
+    })
 
   return (node) => {
     const output = []

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownExport.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownExport.ts
@@ -39,9 +39,9 @@ export function createMarkdownExport(
     // <strong><code>code</code></strong> will be exported as `**Bold Code**`, as the code format will be applied first, and the bold format
     // will be applied second and thus skipped entirely, as the code format will prevent any further formatting.
     .sort((a, b) => {
-      if (a.format[0] === 'code' && b.format[0] !== 'code') {
+      if (a.format.includes('code') && !b.format.includes('code')) {
         return 1
-      } else if (a.format[0] !== 'code' && b.format[0] === 'code') {
+      } else if (!a.format.includes('code') && b.format.includes('code')) {
         return -1
       } else {
         return 0


### PR DESCRIPTION
If the following markdown:

```md
**`text`**
```

was imported and then re-exported, the result was

```md
`**text**`
```

Which would have been rendered as

```html
<code>**text**</code>
```

Instead of

```html
<strong><code>text</code></strong>
```