### PR TITLE
fix(richtext-lexical): remove alteration of lexical text format constant

### DIFF
--- a/packages/richtext-lexical/src/features/typesClient.ts
+++ b/packages/richtext-lexical/src/features/typesClient.ts
@@ -104,7 +104,7 @@ export type ClientFeature<ClientFeatureProps> = {
   /**
    * The text formats which are enabled by this feature.
    */
-  enableFormats?: Array<Omit<TextFormatType, 'highlight'>>
+  enableFormats?: TextFormatType[]
   markdownTransformers?: (
     | ((props: {
         allNodes: Array<Klass<LexicalNode> | LexicalNodeReplacement>
@@ -214,7 +214,7 @@ export type ClientFeatureProviderMap = Map<string, FeatureProviderClient<any, an
 export type SanitizedClientFeatures = {
   /** The keys of all enabled features */
   enabledFeatures: string[]
-  enabledFormats: Array<Omit<TextFormatType, 'highlight'>>
+  enabledFormats: TextFormatType[]
   markdownTransformers: Transformer[]
 
   /**

--- a/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/TextPlugin/index.tsx
@@ -33,10 +33,6 @@ export function TextPlugin({ features }: { features: SanitizedClientFeatures }) 
 }
 
 function getDisabledFormats(enabledFormats: TextFormatType[]): TextFormatType[] {
-  // not sure why Lexical added highlight as TextNode format.
-  // see https://github.com/facebook/lexical/pull/3583
-  // We are going to implement it in other way to support multiple colors
-  delete TEXT_TYPE_TO_FORMAT.highlight
   const allFormats = Object.keys(TEXT_TYPE_TO_FORMAT) as TextFormatType[]
   const enabledSet = new Set(enabledFormats)
 


### PR DESCRIPTION
In PR https://github.com/payloadcms/payload/pull/9507, which aims to enable only used formats to be enabled in lexical, the `TEXT_TYPE_TO_FORMAT` constant in the lexical library was altered. This means it becomes impossible to create a feature relying on the `highlight` format. I am of the opinion that this should not be the case; and have used this for a lexical feature in one of my projects. The type of `enabledFormats` of the `createClientFeature` function should also be updated to reflect the availability of the format.

This PR aims to:
- Remove the alteration to the library constant
- Update type of `enabledFormats`