### PR TITLE
feat(v2): allows filtering on group field types from list view

### DIFF
--- a/packages/payload/src/admin/components/elements/FieldSelect/index.tsx
+++ b/packages/payload/src/admin/components/elements/FieldSelect/index.tsx
@@ -18,7 +18,7 @@ type Props = {
   setSelected: (fields: FieldWithPath[]) => void
 }
 
-const combineLabel = (prefix, field, i18n): string =>
+export const combineLabel = (prefix, field, i18n): string =>
   `${prefix === '' ? '' : `${prefix} > `}${getTranslation(field.label || field.name, i18n) || ''}`
 const reduceFields = (
   fields: Field[],

--- a/test/admin/e2e.spec.ts
+++ b/test/admin/e2e.spec.ts
@@ -1221,7 +1221,7 @@ describe('admin', () => {
         await page.locator('.where-builder__add-first-filter').click()
         await page.locator('.condition__field .rs__control').click()
         const options = page.locator('.rs__option')
-        await expect(options.locator('text=Title')).toHaveText('Title')
+        await expect(options.locator('text=Title').first()).toHaveText('Title')
 
         // list columns
         await expect(page.locator('#heading-title .sort-column__label')).toHaveText('Title')


### PR DESCRIPTION
### What?
**V2 Update** – Adds support for using group fields when filtering the list view.

### Why?
This feature was originally introduced in V3. Due to popular demand from V2 users, we are backporting it into V2.

### How?
Updates the `WhereBuilder` to map over fields within a group and prefix them with the parent field name. Similar to V3 PR [here](https://github.com/payloadcms/payload/pull/6647).

#### Review & Testing
Use the `admin` test suite and the `posts` collection to see this change.