### PR TITLE
fix: deprecates admin.disable property

### DIFF
--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -57,7 +57,7 @@ The `admin` directory contains all the _pages_ related to the interface itself, 
 
 <Banner type="warning">
   **Note:**
-  If you don't intend to use the Admin Panel, [REST API](../rest/overview), or [GraphQL API](../graphql/overview), you can opt-out by simply deleting their corresponding directories. The overhead, however, is completely constrained to these routes, and will not slow down or affect Payload outside when not in use.
+  If you don't intend to use the Admin Panel, [REST API](../rest/overview), or [GraphQL API](../graphql/overview), you can opt-out by simply deleting their corresponding directories within your Next.js app. The overhead, however, is completely constrained to these routes, and will not slow down or affect Payload outside when not in use.
 </Banner>
 
 Finally, the `custom.scss` file is where you can add or override globally-oriented styles in the Admin Panel, such as modify the color palette. Customizing the look and feel through CSS alone is a powerful feature of the Admin Panel, [more on that here](./customizing-css).

--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -57,7 +57,7 @@ The `admin` directory contains all the _pages_ related to the interface itself, 
 
 <Banner type="warning">
   **Note:**
-  If you don't use the [REST API](../rest/overview) or [GraphQL API](../graphql/overview), you can delete the [Next.js files corresponding to those routes](../admin/overview#project-structure), however, the overhead of this API is completely constrained to these endpoints, and will not slow down or affect Payload outside of the endpoints.
+  If you don't intend to use the Admin Panel, [REST API](../rest/overview), or [GraphQL API](../graphql/overview), you can opt-out by simply deleting their corresponding directories. The overhead, however, is completely constrained to these routes, and will not slow down or affect Payload outside when not in use.
 </Banner>
 
 Finally, the `custom.scss` file is where you can add or override globally-oriented styles in the Admin Panel, such as modify the color palette. Customizing the look and feel through CSS alone is a powerful feature of the Admin Panel, [more on that here](./customizing-css).
@@ -94,7 +94,6 @@ The following options are available:
 | **`components`**               | Component overrides that affect the entirety of the Admin Panel. [More details](./components).                                                                        |
 | **`custom`**                   | Any custom properties you wish to pass to the Admin Panel.                                                                                                            |
 | **`dateFormat`**               | The date format that will be used for all dates within the Admin Panel. Any valid [date-fns](https://date-fns.org/) format pattern can be used.                       |
-| **`disable`**                  | If set to `true`, the entire Admin Panel will be disabled.                                                                                                            |
 | **`livePreview`**              | Enable real-time editing for instant visual feedback of your front-end application. [More details](../live-preview/overview).                                         |
 | **`meta`**                     | Base metadata to use for the Admin Panel. [More details](./metadata).                                                                                                 |
 | **`routes`**                   | Replace built-in Admin Panel routes with your own custom routes. [More details](#customizing-routes).                                                                 |

--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -92,7 +92,6 @@ export const createClientConfig = ({
           avatar: config.admin.avatar,
           custom: config.admin.custom,
           dateFormat: config.admin.dateFormat,
-          disable: config.admin.disable,
           importMap: config.admin.importMap,
           meta: config.admin.meta,
           routes: config.admin.routes,

--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -10,7 +10,6 @@ export const defaults: Omit<Config, 'db' | 'editor' | 'secret'> = {
     custom: {},
     dateFormat: 'MMMM do yyyy, h:mm a',
     dependencies: {},
-    disable: false,
     importMap: {
       baseDir: `${typeof process?.cwd === 'function' ? process.cwd() : ''}`,
     },

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -789,7 +789,13 @@ export type Config = {
      * dependency is 'component'
      */
     dependencies?: AdminDependencies
-    /** If set to true, the entire Admin panel will be disabled. */
+    /**
+     * @deprecated
+     * This option is deprecated and will be removed in the next major version.
+     * To disable the admin panel itself, delete your `/app/(payload)/admin` directory.
+     * To disable all REST API and GraphQL endpoints, delete your `/app/(payload)/api` directory.
+     * Note: If you've modified the default paths via `admin.routes`, delete those directories instead.
+     */
     disable?: boolean
     importMap?: {
       /**


### PR DESCRIPTION
Fixes #10284. The `admin.disable` property is no longer supported as of v3. Instead, to opt-out of serving the Admin Panel, REST API, or GraphQL API, you must delete their corresponding directories within your Next.js app. For example, to opt-out of everything, delete the `/app/(payload)` directory entirely. Or to remove specifically the Admin Panel or API routes, delete the `/app/(payload)/admin` or `/app/(payload)/api` directories, respectively. Note: if you've modified the default paths for these routes via `admin.routes`, delete those directories instead.