### PR TITLE
feat: export the default JWTAuthentication strategy

### DIFF
--- a/packages/payload/src/auth/executeAuthStrategies.ts
+++ b/packages/payload/src/auth/executeAuthStrategies.ts
@@ -7,6 +7,9 @@ export const executeAuthStrategies = async (
     async (accumulatorPromise, strategy) => {
       const result: AuthStrategyResult = await accumulatorPromise
       if (!result.user) {
+        // add the configured AuthStrategy `name` to the strategy function args
+        args.strategyName = strategy.name
+
         return strategy.authenticate(args)
       }
       return result

--- a/packages/payload/src/auth/extractJWT.ts
+++ b/packages/payload/src/auth/extractJWT.ts
@@ -2,7 +2,7 @@ import type { AuthStrategyFunctionArgs } from './index.js'
 
 import { parseCookies } from '../utilities/parseCookies.js'
 
-export const extractJWT = (args: AuthStrategyFunctionArgs): null | string => {
+export const extractJWT = (args: Omit<AuthStrategyFunctionArgs, 'strategyName'>): null | string => {
   const { headers, payload } = args
 
   const jwtFromHeader = headers.get('Authorization')

--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -161,6 +161,10 @@ export type AuthStrategyFunctionArgs = {
   headers: Request['headers']
   isGraphQL?: boolean
   payload: Payload
+  /**
+   * The AuthStrategy name property from the payload config.
+   */
+  strategyName?: string
 }
 
 export type AuthStrategyResult = {

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -898,6 +898,7 @@ export { registerFirstUserOperation } from './auth/operations/registerFirstUser.
 export { resetPasswordOperation } from './auth/operations/resetPassword.js'
 export { unlockOperation } from './auth/operations/unlock.js'
 export { verifyEmailOperation } from './auth/operations/verifyEmail.js'
+export { JWTAuthentication } from './auth/strategies/jwt.js'
 export type {
   AuthStrategyFunction,
   AuthStrategyFunctionArgs,


### PR DESCRIPTION
### What?
Export the default Payload JWTAuthentication strategy function for extending and using in your own custom auth strategies that need to rely on JWT.

### Why?
This makes it more simple to implement your own custom auth strategy. All you need to do is set a valid JWT token as a cookie and then import the default auth strategy so that the user will be recognized. 

### How?
Exports the function and makes it reusable by adding a to the args a strategyName prop. In the `executeAuthStrategies` function we assign the strategyName from the configured `auth.strategies` own `name` property.