### PR TITLE
feat(storage-s3): add cacheControlMaxAge option

### DIFF
--- a/docs/upload/storage-adapters.mdx
+++ b/docs/upload/storage-adapters.mdx
@@ -113,6 +113,15 @@ export default buildConfig({
 
 See the the [AWS SDK Package](https://github.com/aws/aws-sdk-js-v3) and [`S3ClientConfig`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3) object for guidance on AWS S3 configuration.
 
+
+| Option               | Description                                                          | Default                                    |
+| -------------------- | -------------------------------------------------------------------- | ------------------------------------------ |
+| `enabled`            | Whether or not to enable the plugin                                  | `true`                                     |
+| `collections`        | Collections to apply the s3 adapter to                               |                                            |
+| `cacheControlMaxAge` | Cache-Control max-age in seconds                                     | `undefined` (Cache-Control header omitted) |
+
+
+
 ## Azure Blob Storage
 [`@payloadcms/storage-azure`](https://www.npmjs.com/package/@payloadcms/storage-azure)
 

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -20,13 +20,20 @@ export type S3StorageOptions = {
    */
 
   acl?: 'private' | 'public-read'
+
   /**
    * Bucket name to upload files to.
    *
    * Must follow [AWS S3 bucket naming conventions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
    */
-
   bucket: string
+
+  /**
+   * Cache-Control max-age in seconds
+   *
+   * @defaultvalue undefined
+   */
+  cacheControlMaxAge?: number
 
   /**
    * Collection options to apply the S3 adapter to.
@@ -102,7 +109,12 @@ export const s3Storage: S3StoragePlugin =
     })(config)
   }
 
-function s3StorageInternal({ acl, bucket, config = {} }: S3StorageOptions): Adapter {
+function s3StorageInternal({
+  acl,
+  bucket,
+  cacheControlMaxAge,
+  config = {},
+}: S3StorageOptions): Adapter {
   return ({ collection, prefix }): GeneratedAdapter => {
     let storageClient: AWS.S3 | null = null
     const getStorageClient: () => AWS.S3 = () => {
@@ -124,7 +136,12 @@ function s3StorageInternal({ acl, bucket, config = {} }: S3StorageOptions): Adap
         getStorageClient,
         prefix,
       }),
-      staticHandler: getHandler({ bucket, collection, getStorageClient }),
+      staticHandler: getHandler({
+        bucket,
+        cacheControlMaxAge,
+        collection,
+        getStorageClient,
+      }),
     }
   }
 }


### PR DESCRIPTION
## Description
This PR introduces a new configuration option for the S3 storage plugin, allowing users to specify a `cacheControlMaxAge` value in seconds.

The default value is `undefined` which omits the Cache-Header keeping this change non-breaking.

### Before changes

No `Cache-Control` header present on uploads beging returned.

### After changes

If `cacheControlMaxAge` is set, `Cache-Control: public, max-age={cacheControlMaxAge}` is added to uploads returned.

### Using plugin
```
s3Storage({
      ...
      cacheControlMaxAge: 31536000,
    }),
```

<!-- Please include a summary of the pull request and any related issues
it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the
[CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md)
document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation