### PR TITLE
docs: removed unnecessary visible <br/> tag in fields/blocks

### DIFF
--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -96,7 +96,7 @@ This is super handy if you'd like to present your editors with a very deliberate
 For example, if you have a `gallery` block, you might want to actually render the gallery of images directly in your Lexical block. With the `admin.components.Block` property, you can do exactly that!
 
 <Banner type="success">
-  **Tip:**<br/>
+  **Tip:**
   If you customize the way your block is rendered in Lexical, you can import utility components to easily edit / remove your block - so that you don't have to build all of this yourself.
 </Banner>
 
@@ -135,7 +135,6 @@ Blocks are defined as separate configs of their own.
 
 <Banner type="success">
   **Tip:**
-
   Best practice is to define each block config in its own file, and then import them into your
   Blocks field as necessary. This way each block config can be easily shared between fields. For
   instance, using the "layout builder" example, you might want to feature a few of the same blocks


### PR DESCRIPTION
There was a `<br/>` tag, which was visible on the docs page. Also, I removed spacing from the second tip box, to keep in consistent with tips in other places in docs.
