### PR TITLE
fix: schedule publish allowed before saving draft

### DIFF
--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -59,16 +59,20 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
     }
   }, [collectionSlug, globalSlug, config])
 
-  const scheduledPublishEnabled =
-    typeof entityConfig?.versions?.drafts === 'object' &&
-    entityConfig?.versions?.drafts.schedulePublish
-
   const hasNewerVersions = unpublishedVersionCount > 0
 
   const canPublish =
     hasPublishPermission &&
     (modified || hasNewerVersions || !hasPublishedDoc) &&
     uploadStatus !== 'uploading'
+
+  const scheduledPublishEnabled =
+    typeof entityConfig?.versions?.drafts === 'object' &&
+    entityConfig?.versions?.drafts.schedulePublish
+
+  const canSchedulePublish = Boolean(
+    scheduledPublishEnabled && hasPublishPermission && (globalSlug || (collectionSlug && id)),
+  )
 
   const operation = useOperation()
 
@@ -173,11 +177,11 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
         onClick={publish}
         size="medium"
         SubMenuPopupContent={
-          localization || scheduledPublishEnabled
+          localization || canSchedulePublish
             ? ({ close }) => {
                 return (
                   <React.Fragment>
-                    {scheduledPublishEnabled && (
+                    {canSchedulePublish && (
                       <PopupList.ButtonGroup key="schedule-publish">
                         <PopupList.Button onClick={() => [toggleModal(drawerSlug), close()]}>
                           {t('version:schedulePublish')}
@@ -220,7 +224,7 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
       >
         {label}
       </FormSubmit>
-      {scheduledPublishEnabled && isModalOpen(drawerSlug) && <ScheduleDrawer slug={drawerSlug} />}
+      {canSchedulePublish && isModalOpen(drawerSlug) && <ScheduleDrawer slug={drawerSlug} />}
     </React.Fragment>
   )
 }


### PR DESCRIPTION
### What?

In the scheduled publish feature, it is possible to open the modal to schedule publishing a document even before you have saved a draft. This change removes the option to open the drawer to even attempt this.
This also fixes an issue if you do not have permission to publish, you cannot schedule publish either.

### Why?

There were numerous problems:
1. The schedule publish events would show all other publish events for the collection without an ID in the query
2. Scheduling a publish would not work without an ID for a document to publish

### How?
Removes the Schedule Publish menu item and drawer if you are on a collection without an ID or you do not have permission to publish.

Without an ID:
![Screenshot 2025-01-08 162850](https://github.com/user-attachments/assets/fae0b8d4-6dac-45d7-a565-63fede7aa372)

With an ID:
![Screenshot 2025-01-08 162918](https://github.com/user-attachments/assets/c1f4d4f5-1321-43c1-991d-29747db1685d)

Perviously, you would always have the option to Schedule Publish.