### PR TITLE
fix(payload-cloud): infinite recursion on init

### DIFF
--- a/packages/payload-cloud/src/plugin.ts
+++ b/packages/payload-cloud/src/plugin.ts
@@ -128,6 +128,8 @@ export const payloadCloudPlugin =
       return config
     }
 
+    const oldAutoRunCopy = config.jobs.autoRun
+
     const newAutoRun = async (payload: Payload) => {
       const instance = generateRandomString()
 
@@ -150,9 +152,8 @@ export const payloadCloudPlugin =
       if (!config.jobs?.autoRun) {
         return [DEFAULT_CRON_JOB]
       }
-      return typeof config.jobs.autoRun === 'function'
-        ? await config.jobs.autoRun(payload)
-        : config.jobs.autoRun
+
+      return typeof oldAutoRunCopy === 'function' ? await oldAutoRunCopy(payload) : oldAutoRunCopy
     }
 
     config.jobs.autoRun = newAutoRun


### PR DESCRIPTION
If autorunning jobs was enabled, the previous approach to automatically handling this in our payload-cloud plugin was causing infinite recursion in the autorun function added by payload-cloud

The goal was to call user-defined `config.jobs.autoRun` functions - not the function inserted by payload-cloud. This PR fixes this behavior