### PR TITLE
fix(richtext-lexical): update Thai translations for blockquote and horizontal rule

### DIFF
--- a/packages/richtext-lexical/src/features/blockquote/server/i18n.ts
+++ b/packages/richtext-lexical/src/features/blockquote/server/i18n.ts
@@ -89,7 +89,7 @@ export const i18n: Partial<GenericLanguages> = {
     label: 'Blockcitat',
   },
   th: {
-    label: '[SKIPPED]',
+    label: 'ข้อความอ้างอิง',
   },
   tr: {
     label: 'Alıntı',

--- a/packages/richtext-lexical/src/features/horizontalRule/server/i18n.ts
+++ b/packages/richtext-lexical/src/features/horizontalRule/server/i18n.ts
@@ -89,7 +89,7 @@ export const i18n: Partial<GenericLanguages> = {
     label: 'Horisontell linje',
   },
   th: {
-    label: 'กฎขีดตรง',
+    label: 'เส้นแนวนอน',
   },
   tr: {
     label: 'Yatay Çizgi',

--- a/packages/richtext-lexical/src/features/horizontalRule/server/i18n.ts
+++ b/packages/richtext-lexical/src/features/horizontalRule/server/i18n.ts
@@ -89,7 +89,7 @@ export const i18n: Partial<GenericLanguages> = {
     label: 'Horisontell linje',
   },
   th: {
-    label: 'เส้นแนวนอน',
+    label: 'เส้นขอบแนวนอน',
   },
   tr: {
     label: 'Yatay Çizgi',


### PR DESCRIPTION
**Description:**

- [x] Replaces the [SKIPPED] entry with the correct translation for "Blockquote".
- [x] I have read and understand the CONTRIBUTING.md document in this repository.

**Type of Change:**

- [x] Bug fix (non-breaking change which fixes an issue).


**Fixes:**  

1. fix the translation issue by replacing the [SKIPPED] entry with the correct Thai translation for "Blockquote". Which I choose "ข้อความอ้างอิง" However one might prefer other form of translation like "คำอ้างอิง" or "กล่องข้อความอ้างอิง" which represent the 'block' with in the 'Blockquote'
2. corrects the Thai translation for "Horizontal Rule." The translation has been changed from "กฎแนวนอน," which was a mistranslation, to "เส้นขอบแนวนอน" to better reflect the meaning of "Horizontal Rule" as a visual divider or border. 