### PR TITLE
feat: exports ListPreferences from payload

### DIFF
--- a/packages/next/src/views/List/handleServerFunction.tsx
+++ b/packages/next/src/views/List/handleServerFunction.tsx
@@ -1,5 +1,4 @@
-import type { ListPreferences } from '@payloadcms/ui'
-import type { ListQuery, PayloadRequest, VisibleEntities } from 'payload'
+import type { ListPreferences, ListQuery, PayloadRequest, VisibleEntities } from 'payload'
 
 import { getClientConfig } from '@payloadcms/ui/utilities/getClientConfig'
 import { headers as getHeaders } from 'next/headers.js'

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -74,7 +74,10 @@ export const renderListView = async (
   const listPreferences = await upsertPreferences<ListPreferences>({
     key: `${collectionSlug}-list`,
     req,
-    value: { limit: isNumber(query?.limit) ? Number(query.limit) : undefined, sort: query?.sort },
+    value: {
+      limit: isNumber(query?.limit) ? Number(query.limit) : undefined,
+      sort: query?.sort as string,
+    },
   })
 
   const {

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1315,9 +1315,11 @@ export { restoreVersionOperation as restoreVersionOperationGlobal } from './glob
 export { updateOperation as updateOperationGlobal } from './globals/operations/update.js'
 export type {
   CollapsedPreferences,
+  ColumnPreferences,
   DocumentPreferences,
   FieldsPreferences,
   InsideFieldsPreferences,
+  ListPreferences,
   PreferenceRequest,
   PreferenceUpdateRequest,
   TabsPreferences,

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1315,7 +1315,6 @@ export { restoreVersionOperation as restoreVersionOperationGlobal } from './glob
 export { updateOperation as updateOperationGlobal } from './globals/operations/update.js'
 export type {
   CollapsedPreferences,
-  ColumnPreferences,
   DocumentPreferences,
   FieldsPreferences,
   InsideFieldsPreferences,

--- a/packages/payload/src/preferences/types.ts
+++ b/packages/payload/src/preferences/types.ts
@@ -28,10 +28,8 @@ export type DocumentPreferences = {
   fields: FieldsPreferences
 }
 
-export type ColumnPreferences = { accessor: string; active: boolean }[]
-
 export type ListPreferences = {
-  columns?: ColumnPreferences
+  columns?: { accessor: string; active: boolean }[]
   limit?: number
   sort?: string
 }

--- a/packages/payload/src/preferences/types.ts
+++ b/packages/payload/src/preferences/types.ts
@@ -19,10 +19,19 @@ export type InsideFieldsPreferences = {
   collapsed: CollapsedPreferences
   tabIndex: number
 }
+
 export type FieldsPreferences = {
   [key: string]: InsideFieldsPreferences
 }
 
 export type DocumentPreferences = {
   fields: FieldsPreferences
+}
+
+export type ColumnPreferences = { accessor: string; active: boolean }[]
+
+export type ListPreferences = {
+  columns?: ColumnPreferences
+  limit?: number
+  sort?: string
 }

--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -114,7 +114,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
         newQuery.where = hoistQueryParamsToAnd(newQuery.where, filterOptions)
       }
 
-      // map columns from string[] to ColumnPreferences
+      // map columns from string[] to ListPreferences['columns']
       const defaultColumns = field.admin.defaultColumns
         ? field.admin.defaultColumns.map((accessor) => ({
             accessor,

--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -2,6 +2,7 @@ import type { I18nClient } from '@payloadcms/translations'
 import type {
   ClientCollectionConfig,
   ClientField,
+  ColumnPreferences,
   DefaultCellComponentProps,
   DefaultServerCellComponentProps,
   Field,
@@ -21,7 +22,6 @@ import {
 } from 'payload/shared'
 import React from 'react'
 
-import type { ColumnPreferences } from '../../providers/ListQuery/index.js'
 import type { SortColumnProps } from '../SortColumn/index.js'
 import type { Column } from '../Table/index.js'
 

--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -2,10 +2,10 @@ import type { I18nClient } from '@payloadcms/translations'
 import type {
   ClientCollectionConfig,
   ClientField,
-  ColumnPreferences,
   DefaultCellComponentProps,
   DefaultServerCellComponentProps,
   Field,
+  ListPreferences,
   PaginatedDocs,
   Payload,
   SanitizedCollectionConfig,
@@ -38,8 +38,8 @@ type Args = {
   beforeRows?: Column[]
   clientCollectionConfig: ClientCollectionConfig
   collectionConfig: SanitizedCollectionConfig
-  columnPreferences: ColumnPreferences
-  columns?: ColumnPreferences
+  columnPreferences: ListPreferences['columns']
+  columns?: ListPreferences['columns']
   customCellProps: DefaultCellComponentProps['customCellProps']
   docs: PaginatedDocs['docs']
   enableRowSelections: boolean

--- a/packages/ui/src/elements/TableColumns/getInitialColumns.ts
+++ b/packages/ui/src/elements/TableColumns/getInitialColumns.ts
@@ -1,11 +1,11 @@
-import type { ClientField, CollectionConfig, ColumnPreferences, Field } from 'payload'
+import type { ClientField, CollectionConfig, Field, ListPreferences } from 'payload'
 
 import { fieldAffectsData } from 'payload/shared'
 
 const getRemainingColumns = <T extends ClientField[] | Field[]>(
   fields: T,
   useAsTitle: string,
-): ColumnPreferences =>
+): ListPreferences['columns'] =>
   fields?.reduce((remaining, field) => {
     if (fieldAffectsData(field) && field.name === useAsTitle) {
       return remaining
@@ -40,7 +40,7 @@ export const getInitialColumns = <T extends ClientField[] | Field[]>(
   fields: T,
   useAsTitle: CollectionConfig['admin']['useAsTitle'],
   defaultColumns: CollectionConfig['admin']['defaultColumns'],
-): ColumnPreferences => {
+): ListPreferences['columns'] => {
   let initialColumns = []
 
   if (Array.isArray(defaultColumns) && defaultColumns.length >= 1) {

--- a/packages/ui/src/elements/TableColumns/getInitialColumns.ts
+++ b/packages/ui/src/elements/TableColumns/getInitialColumns.ts
@@ -1,8 +1,6 @@
-import type { ClientField, CollectionConfig, Field } from 'payload'
+import type { ClientField, CollectionConfig, ColumnPreferences, Field } from 'payload'
 
 import { fieldAffectsData } from 'payload/shared'
-
-import type { ColumnPreferences } from '../../providers/ListQuery/index.js'
 
 const getRemainingColumns = <T extends ClientField[] | Field[]>(
   fields: T,

--- a/packages/ui/src/elements/TableColumns/index.tsx
+++ b/packages/ui/src/elements/TableColumns/index.tsx
@@ -1,9 +1,8 @@
 'use client'
-import type { ClientCollectionConfig, SanitizedCollectionConfig } from 'payload'
+import type { ClientCollectionConfig, ColumnPreferences, SanitizedCollectionConfig } from 'payload'
 
 import React, { createContext, useCallback, useContext, useEffect } from 'react'
 
-import type { ColumnPreferences } from '../../providers/ListQuery/index.js'
 import type { SortColumnProps } from '../SortColumn/index.js'
 import type { Column } from '../Table/index.js'
 

--- a/packages/ui/src/elements/TableColumns/index.tsx
+++ b/packages/ui/src/elements/TableColumns/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientCollectionConfig, ColumnPreferences, SanitizedCollectionConfig } from 'payload'
+import type { ClientCollectionConfig, ListPreferences, SanitizedCollectionConfig } from 'payload'
 
 import React, { createContext, useCallback, useContext, useEffect } from 'react'
 
@@ -23,10 +23,6 @@ export interface ITableColumns {
 export const TableColumnContext = createContext<ITableColumns>({} as ITableColumns)
 
 export const useTableColumns = (): ITableColumns => useContext(TableColumnContext)
-
-export type ListPreferences = {
-  columns: ColumnPreferences
-}
 
 type Props = {
   readonly children: React.ReactNode
@@ -241,7 +237,7 @@ export const TableColumnsProvider: React.FC<Props> = ({
 
       if (collectionHasChanged || !listPreferences) {
         const currentPreferences = await getPreference<{
-          columns: ColumnPreferences
+          columns: ListPreferences['columns']
         }>(preferenceKey)
 
         prevCollection.current = collectionSlug

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -289,11 +289,14 @@ export {
   type ListViewSlots,
 } from '../../views/List/index.js'
 
-export type {
-  ListComponentClientProps,
-  ListComponentServerProps,
-  ListPreferences,
-} from '../../views/List/types.js'
+export type { ListComponentClientProps, ListComponentServerProps } from '../../views/List/types.js'
+
+/*
+  @deprecated
+  This export will be removed in the next major version.
+  Use `import { ListPreferences } from 'payload'` instead.
+*/
+export type { ListPreferences } from 'payload'
 
 export type { ListHeaderProps } from '../../views/List/ListHeader/index.js'
 

--- a/packages/ui/src/providers/ListQuery/index.tsx
+++ b/packages/ui/src/providers/ListQuery/index.tsx
@@ -6,13 +6,9 @@ import { isNumber } from 'payload/shared'
 import * as qs from 'qs-esm'
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 
-import type { Column } from '../../elements/Table/index.js'
-
 import { useListDrawerContext } from '../../elements/ListDrawer/Provider.js'
 import { parseSearchParams } from '../../utilities/parseSearchParams.js'
 import { usePreferences } from '../Preferences/index.js'
-
-export type ColumnPreferences = Pick<Column, 'accessor' | 'active'>[]
 
 type ContextHandlers = {
   handlePageChange?: (page: number) => Promise<void>

--- a/packages/ui/src/utilities/buildTableState.ts
+++ b/packages/ui/src/utilities/buildTableState.ts
@@ -3,6 +3,7 @@ import type {
   ClientCollectionConfig,
   ClientConfig,
   ErrorResult,
+  ListPreferences,
   PaginatedDocs,
   SanitizedCollectionConfig,
 } from 'payload'
@@ -11,7 +12,6 @@ import { formatErrors } from 'payload'
 import { isNumber } from 'payload/shared'
 
 import type { Column } from '../elements/Table/index.js'
-import type { ListPreferences } from '../elements/TableColumns/index.js'
 
 import { getClientConfig } from './getClientConfig.js'
 import { renderFilters, renderTable } from './renderTable.js'

--- a/packages/ui/src/utilities/renderTable.tsx
+++ b/packages/ui/src/utilities/renderTable.tsx
@@ -1,18 +1,19 @@
-import { getTranslation, type I18nClient } from '@payloadcms/translations'
-import {
-  type ClientCollectionConfig,
-  type CollectionConfig,
-  type Field,
-  type ImportMap,
-  type PaginatedDocs,
-  type Payload,
-  type SanitizedCollectionConfig,
+import type {
+  ClientCollectionConfig,
+  CollectionConfig,
+  ColumnPreferences,
+  Field,
+  ImportMap,
+  PaginatedDocs,
+  Payload,
+  SanitizedCollectionConfig,
 } from 'payload'
+
+import { getTranslation, type I18nClient } from '@payloadcms/translations'
 import { fieldIsHiddenOrDisabled, flattenTopLevelFields } from 'payload/shared'
 
 // eslint-disable-next-line payload/no-imports-from-exports-dir
 import type { Column } from '../exports/client/index.js'
-import type { ColumnPreferences } from '../providers/ListQuery/index.js'
 
 import { RenderServerComponent } from '../elements/RenderServerComponent/index.js'
 import { buildColumnState } from '../elements/TableColumns/buildColumnState.js'

--- a/packages/ui/src/utilities/renderTable.tsx
+++ b/packages/ui/src/utilities/renderTable.tsx
@@ -1,9 +1,9 @@
 import type {
   ClientCollectionConfig,
   CollectionConfig,
-  ColumnPreferences,
   Field,
   ImportMap,
+  ListPreferences,
   PaginatedDocs,
   Payload,
   SanitizedCollectionConfig,
@@ -63,8 +63,8 @@ export const renderTable = ({
 }: {
   clientCollectionConfig: ClientCollectionConfig
   collectionConfig: SanitizedCollectionConfig
-  columnPreferences: ColumnPreferences
-  columns?: ColumnPreferences
+  columnPreferences: ListPreferences['columns']
+  columns?: ListPreferences['columns']
   customCellProps?: Record<string, any>
   docs: PaginatedDocs['docs']
   drawerSlug?: string

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ClientCollectionConfig } from 'payload'
+import type { ClientCollectionConfig, ListPreferences } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
 import LinkImport from 'next/link.js'
@@ -9,7 +9,6 @@ import { formatFilesize, isNumber } from 'payload/shared'
 import React, { Fragment, useEffect, useState } from 'react'
 
 import type { Column } from '../../elements/Table/index.js'
-import type { ListPreferences } from './types.js'
 
 import { useBulkUpload } from '../../elements/BulkUpload/index.js'
 import { Button } from '../../elements/Button/index.js'

--- a/packages/ui/src/views/List/types.ts
+++ b/packages/ui/src/views/List/types.ts
@@ -8,8 +8,6 @@ import type {
   User,
 } from 'payload'
 
-import type { ColumnPreferences } from '../../providers/ListQuery/index.js'
-
 export type DefaultListViewProps = {
   collectionSlug: SanitizedCollectionConfig['slug']
   listSearchableFields: SanitizedCollectionConfig['admin']['listSearchableFields']
@@ -17,12 +15,6 @@ export type DefaultListViewProps = {
 
 export type ListIndexProps = {
   collection: SanitizedCollectionConfig
-}
-
-export type ListPreferences = {
-  columns: ColumnPreferences
-  limit: number
-  sort: string
 }
 
 export type ListComponentClientProps = {


### PR DESCRIPTION
The `ListPreferences` and `ColumnPreferences` types were defined multiple times in different places, making it difficult to make changes across the board. Now, the `ListPreferences` type is exported directly from `payload` alongside the other preferences types, and `ColumnPreferences` has been merged directly into this type to simplify usage as this is not a standalone preference.