### PR TITLE
chore: adds tests for `forceRenderAllFields` admin prop

### DIFF
--- a/packages/payload/src/admin/components/forms/RenderFields/index.tsx
+++ b/packages/payload/src/admin/components/forms/RenderFields/index.tsx
@@ -33,15 +33,21 @@ const intersectionObserverOptions = {
  * All this component does is render the field's Field Components, and pass them the props they need to function.
  **/
 const RenderFields: React.FC<Props> = (props) => {
-  const { className, fieldTypes, forceRender, forceRenderAllFields, margins } = props
+  const {
+    className,
+    fieldTypes,
+    forceRender: forceRenderFromProps,
+    forceRenderAllFields,
+    margins,
+  } = props
 
   const { i18n, t } = useTranslation('general')
-  const [hasRendered, setHasRendered] = useState(Boolean(forceRender))
-  const [intersectionRef, entry] = useIntersect(intersectionObserverOptions, forceRender)
+  const [hasRendered, setHasRendered] = useState(Boolean(forceRenderFromProps))
+  const [intersectionRef, entry] = useIntersect(intersectionObserverOptions, forceRenderFromProps)
 
   const isIntersecting = Boolean(entry?.isIntersecting)
   const isAboveViewport = entry?.boundingClientRect?.top < 0
-  const shouldRender = forceRender || isIntersecting || isAboveViewport
+  const shouldRender = forceRenderFromProps || isIntersecting || isAboveViewport
   const operation = useOperation()
 
   useEffect(() => {
@@ -105,7 +111,7 @@ const RenderFields: React.FC<Props> = (props) => {
                       readOnly,
                     },
                     fieldTypes,
-                    forceRender: forceRenderAllFields || forceRender,
+                    forceRender: forceRenderAllFields || forceRenderFromProps,
                     indexPath:
                       'indexPath' in props ? `${props?.indexPath}.${fieldIndex}` : `${fieldIndex}`,
                     path: field.path || (isFieldAffectingData && 'name' in field ? field.name : ''),

--- a/packages/payload/src/admin/components/forms/field-types/Array/ArrayRow.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/ArrayRow.tsx
@@ -42,7 +42,7 @@ export const ArrayRow: React.FC<ArrayRowProps> = ({
   duplicateRow,
   fieldTypes,
   fields,
-  forceRender = false,
+  forceRender,
   hasMaxRows,
   indexPath,
   isSortable,

--- a/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Array/index.tsx
@@ -32,8 +32,7 @@ const ArrayFieldType: React.FC<Props> = (props) => {
     admin: { className, components, condition, description, isSortable = true, readOnly },
     fieldTypes,
     fields,
-    forceRender: forceRenderFromProps = false,
-    forceRenderAllFields,
+    forceRender = false,
     indexPath,
     localized,
     maxRows,
@@ -50,8 +49,6 @@ const ArrayFieldType: React.FC<Props> = (props) => {
   const label = props?.label ?? props?.labels?.singular
 
   const CustomRowLabel = components?.RowLabel || undefined
-
-  const forceRender = forceRenderFromProps || forceRenderAllFields
 
   const { setDocFieldPreferences } = useDocumentInfo()
   const { addFieldRow, dispatchFields, removeFieldRow, setModified } = useForm()

--- a/packages/payload/src/admin/components/forms/field-types/Array/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Array/types.ts
@@ -5,7 +5,6 @@ import type { ArrayField } from '../../../../../fields/config/types'
 export type Props = Omit<ArrayField, 'type'> & {
   fieldTypes: FieldTypes
   forceRender?: boolean
-  forceRenderAllFields?: boolean
   indexPath: string
   label: false | string
   path?: string

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/index.tsx
@@ -37,8 +37,7 @@ const BlocksField: React.FC<Props> = (props) => {
     admin: { className, condition, description, isSortable = true, readOnly },
     blocks,
     fieldTypes,
-    forceRender: forceRenderFromProps = false,
-    forceRenderAllFields,
+    forceRender = false,
     indexPath,
     label,
     labels: labelsFromProps,
@@ -59,8 +58,6 @@ const BlocksField: React.FC<Props> = (props) => {
   const { localization } = useConfig()
   const drawerSlug = useDrawerSlug('blocks-drawer')
   const submitted = useFormSubmitted()
-
-  const forceRender = forceRenderFromProps || forceRenderAllFields
 
   const labels = {
     plural: t('blocks'),

--- a/packages/payload/src/admin/components/forms/field-types/Blocks/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Blocks/types.ts
@@ -5,7 +5,6 @@ import type { BlockField } from '../../../../../fields/config/types'
 export type Props = Omit<BlockField, 'type'> & {
   fieldTypes: FieldTypes
   forceRender?: boolean
-  forceRenderAllFields?: boolean
   indexPath: string
   path?: string
   permissions: FieldPermissions

--- a/packages/payload/src/admin/components/forms/field-types/Collapsible/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Collapsible/index.tsx
@@ -24,6 +24,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
     admin: { className, description, initCollapsed, readOnly },
     fieldTypes,
     fields,
+    forceRender = false,
     indexPath,
     label,
     path,
@@ -125,7 +126,7 @@ const CollapsibleField: React.FC<Props> = (props) => {
             path: createNestedFieldPath(path, field),
           }))}
           fieldTypes={fieldTypes}
-          forceRender
+          forceRender={forceRender}
           indexPath={indexPath}
           margins="small"
           permissions={permissions}

--- a/packages/payload/src/admin/components/forms/field-types/Collapsible/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Collapsible/types.ts
@@ -4,6 +4,7 @@ import type { CollapsibleField } from '../../../../../fields/config/types'
 
 export type Props = Omit<CollapsibleField, 'type'> & {
   fieldTypes: FieldTypes
+  forceRender?: boolean
   indexPath: string
   path?: string
   permissions: FieldPermissions

--- a/packages/payload/src/admin/components/forms/field-types/Group/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Group/index.tsx
@@ -26,8 +26,7 @@ const Group: React.FC<Props> = (props) => {
     admin: { className, description, hideGutter = false, readOnly, style, width },
     fieldTypes,
     fields,
-    forceRender: forceRenderFromProps = false,
-    forceRenderAllFields,
+    forceRender = false,
     indexPath,
     label,
     path: pathFromProps,
@@ -45,7 +44,6 @@ const Group: React.FC<Props> = (props) => {
 
   const path = pathFromProps || name
   const isTopLevel = !(withinCollapsible || isWithinGroup || isWithinRow)
-  const forceRender = forceRenderFromProps || forceRenderAllFields
 
   return (
     <div

--- a/packages/payload/src/admin/components/forms/field-types/Group/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Group/types.ts
@@ -5,7 +5,6 @@ import type { GroupField } from '../../../../../fields/config/types'
 export type Props = Omit<GroupField, 'type'> & {
   fieldTypes: FieldTypes
   forceRender?: boolean
-  forceRenderAllFields?: boolean
   indexPath: string
   path?: string
   permissions: FieldPermissions

--- a/packages/payload/src/admin/components/forms/field-types/Row/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Row/index.tsx
@@ -16,14 +16,11 @@ const Row: React.FC<Props> = (props) => {
     admin: { className, readOnly },
     fieldTypes,
     fields,
-    forceRender: forceRenderFromProps = false,
-    forceRenderAllFields,
+    forceRender = false,
     indexPath,
     path,
     permissions,
   } = props
-
-  const forceRender = forceRenderFromProps || forceRenderAllFields
 
   return (
     <RowProvider>

--- a/packages/payload/src/admin/components/forms/field-types/Row/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Row/types.ts
@@ -5,7 +5,6 @@ import type { RowField } from '../../../../../fields/config/types'
 export type Props = Omit<RowField, 'type'> & {
   fieldTypes: FieldTypes
   forceRender?: boolean
-  forceRenderAllFields?: boolean
   indexPath: string
   path?: string
   permissions: FieldPermissions

--- a/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
+++ b/packages/payload/src/admin/components/forms/field-types/Tabs/index.tsx
@@ -72,8 +72,7 @@ const TabsField: React.FC<Props> = (props) => {
   const {
     admin: { className, readOnly },
     fieldTypes,
-    forceRender: forceRenderFromProps = false,
-    forceRenderAllFields,
+    forceRender = false,
     indexPath,
     path,
     permissions,
@@ -87,7 +86,6 @@ const TabsField: React.FC<Props> = (props) => {
   const { withinCollapsible } = useCollapsible()
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0)
   const tabsPrefKey = `tabs-${indexPath}`
-  const forceRender = forceRenderFromProps || forceRenderAllFields
 
   useEffect(() => {
     if (preferencesKey) {

--- a/packages/payload/src/admin/components/forms/field-types/Tabs/types.ts
+++ b/packages/payload/src/admin/components/forms/field-types/Tabs/types.ts
@@ -5,7 +5,6 @@ import type { TabsField } from '../../../../../fields/config/types'
 export type Props = Omit<TabsField, 'type'> & {
   fieldTypes: FieldTypes
   forceRender?: boolean
-  forceRenderAllFields?: boolean
   indexPath: string
   path?: string
   permissions: FieldPermissions

--- a/test/admin/collections/CustomIdTab.ts
+++ b/test/admin/collections/CustomIdTab.ts
@@ -1,7 +1,5 @@
 import type { CollectionConfig } from 'payload/dist/collections/config/types'
 
-import { customIdCollectionSlug } from '../slugs'
-
 export const CustomIdTab: CollectionConfig = {
   slug: 'customIdTab',
   labels: {

--- a/test/admin/collections/ForceRender.ts
+++ b/test/admin/collections/ForceRender.ts
@@ -1,0 +1,532 @@
+import type { CollectionConfig } from 'payload/dist/collections/config/types'
+
+import { forceRenderCollectionSlug } from '../slugs'
+
+export const CollectionForceRender: CollectionConfig = {
+  slug: forceRenderCollectionSlug,
+  admin: {
+    forceRenderAllFields: true,
+  },
+  fields: [
+    {
+      name: 'groupOne',
+      type: 'group',
+      fields: [
+        {
+          name: 'field1',
+          type: 'text',
+        },
+        {
+          name: 'field2',
+          type: 'text',
+        },
+        {
+          name: 'field3',
+          type: 'text',
+        },
+        {
+          name: 'field4',
+          type: 'text',
+        },
+        {
+          name: 'field5',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwo',
+      type: 'group',
+      fields: [
+        {
+          name: 'field6',
+          type: 'text',
+        },
+        {
+          name: 'field7',
+          type: 'text',
+        },
+        {
+          name: 'field8',
+          type: 'text',
+        },
+        {
+          name: 'field9',
+          type: 'text',
+        },
+        {
+          name: 'field10',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupThree',
+      type: 'group',
+      fields: [
+        {
+          name: 'field11',
+          type: 'text',
+        },
+        {
+          name: 'field12',
+          type: 'text',
+        },
+        {
+          name: 'field13',
+          type: 'text',
+        },
+        {
+          name: 'field14',
+          type: 'text',
+        },
+        {
+          name: 'field15',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFour',
+      type: 'group',
+      fields: [
+        {
+          name: 'field16',
+          type: 'text',
+        },
+        {
+          name: 'field17',
+          type: 'text',
+        },
+        {
+          name: 'field18',
+          type: 'text',
+        },
+        {
+          name: 'field19',
+          type: 'text',
+        },
+        {
+          name: 'field20',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFive',
+      type: 'group',
+      fields: [
+        {
+          name: 'field21',
+          type: 'text',
+        },
+        {
+          name: 'field22',
+          type: 'text',
+        },
+        {
+          name: 'field23',
+          type: 'text',
+        },
+        {
+          name: 'field24',
+          type: 'text',
+        },
+        {
+          name: 'field25',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSix',
+      type: 'group',
+      fields: [
+        {
+          name: 'field26',
+          type: 'text',
+        },
+        {
+          name: 'field27',
+          type: 'text',
+        },
+        {
+          name: 'field28',
+          type: 'text',
+        },
+        {
+          name: 'field29',
+          type: 'text',
+        },
+        {
+          name: 'field30',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSeven',
+      type: 'group',
+      fields: [
+        {
+          name: 'field31',
+          type: 'text',
+        },
+        {
+          name: 'field32',
+          type: 'text',
+        },
+        {
+          name: 'field33',
+          type: 'text',
+        },
+        {
+          name: 'field34',
+          type: 'text',
+        },
+        {
+          name: 'field35',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEight',
+      type: 'group',
+      fields: [
+        {
+          name: 'field36',
+          type: 'text',
+        },
+        {
+          name: 'field37',
+          type: 'text',
+        },
+        {
+          name: 'field38',
+          type: 'text',
+        },
+        {
+          name: 'field39',
+          type: 'text',
+        },
+        {
+          name: 'field40',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupNine',
+      type: 'group',
+      fields: [
+        {
+          name: 'field41',
+          type: 'text',
+        },
+        {
+          name: 'field42',
+          type: 'text',
+        },
+        {
+          name: 'field43',
+          type: 'text',
+        },
+        {
+          name: 'field44',
+          type: 'text',
+        },
+        {
+          name: 'field45',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field46',
+          type: 'text',
+        },
+        {
+          name: 'field47',
+          type: 'text',
+        },
+        {
+          name: 'field48',
+          type: 'text',
+        },
+        {
+          name: 'field49',
+          type: 'text',
+        },
+        {
+          name: 'field50',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEleven',
+      type: 'group',
+      fields: [
+        {
+          name: 'field51',
+          type: 'text',
+        },
+        {
+          name: 'field52',
+          type: 'text',
+        },
+        {
+          name: 'field53',
+          type: 'text',
+        },
+        {
+          name: 'field54',
+          type: 'text',
+        },
+        {
+          name: 'field55',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwelve',
+      type: 'group',
+      fields: [
+        {
+          name: 'field56',
+          type: 'text',
+        },
+        {
+          name: 'field57',
+          type: 'text',
+        },
+        {
+          name: 'field58',
+          type: 'text',
+        },
+        {
+          name: 'field59',
+          type: 'text',
+        },
+        {
+          name: 'field60',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupThirteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field61',
+          type: 'text',
+        },
+        {
+          name: 'field62',
+          type: 'text',
+        },
+        {
+          name: 'field63',
+          type: 'text',
+        },
+        {
+          name: 'field64',
+          type: 'text',
+        },
+        {
+          name: 'field65',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFourteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field66',
+          type: 'text',
+        },
+        {
+          name: 'field67',
+          type: 'text',
+        },
+        {
+          name: 'field68',
+          type: 'text',
+        },
+        {
+          name: 'field69',
+          type: 'text',
+        },
+        {
+          name: 'field70',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFifteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field71',
+          type: 'text',
+        },
+        {
+          name: 'field72',
+          type: 'text',
+        },
+        {
+          name: 'field73',
+          type: 'text',
+        },
+        {
+          name: 'field74',
+          type: 'text',
+        },
+        {
+          name: 'field75',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSixteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field76',
+          type: 'text',
+        },
+        {
+          name: 'field77',
+          type: 'text',
+        },
+        {
+          name: 'field78',
+          type: 'text',
+        },
+        {
+          name: 'field79',
+          type: 'text',
+        },
+        {
+          name: 'field80',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSeventeen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field81',
+          type: 'text',
+        },
+        {
+          name: 'field82',
+          type: 'text',
+        },
+        {
+          name: 'field83',
+          type: 'text',
+        },
+        {
+          name: 'field84',
+          type: 'text',
+        },
+        {
+          name: 'field85',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEighteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field86',
+          type: 'text',
+        },
+        {
+          name: 'field87',
+          type: 'text',
+        },
+        {
+          name: 'field88',
+          type: 'text',
+        },
+        {
+          name: 'field89',
+          type: 'text',
+        },
+        {
+          name: 'field90',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupNineteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field91',
+          type: 'text',
+        },
+        {
+          name: 'field92',
+          type: 'text',
+        },
+        {
+          name: 'field93',
+          type: 'text',
+        },
+        {
+          name: 'field94',
+          type: 'text',
+        },
+        {
+          name: 'field95',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwenty',
+      type: 'group',
+      fields: [
+        {
+          name: 'field96',
+          type: 'text',
+        },
+        {
+          name: 'field97',
+          type: 'text',
+        },
+        {
+          name: 'field98',
+          type: 'text',
+        },
+        {
+          name: 'field99',
+          type: 'text',
+        },
+        {
+          name: 'field100',
+          type: 'text',
+        },
+      ],
+    },
+  ],
+}

--- a/test/admin/collections/NoForceRender.ts
+++ b/test/admin/collections/NoForceRender.ts
@@ -1,0 +1,532 @@
+import type { CollectionConfig } from 'payload/dist/collections/config/types'
+
+import { noForceRenderCollectionSlug } from '../slugs'
+
+export const CollectionNoForceRender: CollectionConfig = {
+  slug: noForceRenderCollectionSlug,
+  admin: {
+    forceRenderAllFields: false,
+  },
+  fields: [
+    {
+      name: 'groupOne',
+      type: 'group',
+      fields: [
+        {
+          name: 'field1',
+          type: 'text',
+        },
+        {
+          name: 'field2',
+          type: 'text',
+        },
+        {
+          name: 'field3',
+          type: 'text',
+        },
+        {
+          name: 'field4',
+          type: 'text',
+        },
+        {
+          name: 'field5',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwo',
+      type: 'group',
+      fields: [
+        {
+          name: 'field6',
+          type: 'text',
+        },
+        {
+          name: 'field7',
+          type: 'text',
+        },
+        {
+          name: 'field8',
+          type: 'text',
+        },
+        {
+          name: 'field9',
+          type: 'text',
+        },
+        {
+          name: 'field10',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupThree',
+      type: 'group',
+      fields: [
+        {
+          name: 'field11',
+          type: 'text',
+        },
+        {
+          name: 'field12',
+          type: 'text',
+        },
+        {
+          name: 'field13',
+          type: 'text',
+        },
+        {
+          name: 'field14',
+          type: 'text',
+        },
+        {
+          name: 'field15',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFour',
+      type: 'group',
+      fields: [
+        {
+          name: 'field16',
+          type: 'text',
+        },
+        {
+          name: 'field17',
+          type: 'text',
+        },
+        {
+          name: 'field18',
+          type: 'text',
+        },
+        {
+          name: 'field19',
+          type: 'text',
+        },
+        {
+          name: 'field20',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFive',
+      type: 'group',
+      fields: [
+        {
+          name: 'field21',
+          type: 'text',
+        },
+        {
+          name: 'field22',
+          type: 'text',
+        },
+        {
+          name: 'field23',
+          type: 'text',
+        },
+        {
+          name: 'field24',
+          type: 'text',
+        },
+        {
+          name: 'field25',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSix',
+      type: 'group',
+      fields: [
+        {
+          name: 'field26',
+          type: 'text',
+        },
+        {
+          name: 'field27',
+          type: 'text',
+        },
+        {
+          name: 'field28',
+          type: 'text',
+        },
+        {
+          name: 'field29',
+          type: 'text',
+        },
+        {
+          name: 'field30',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSeven',
+      type: 'group',
+      fields: [
+        {
+          name: 'field31',
+          type: 'text',
+        },
+        {
+          name: 'field32',
+          type: 'text',
+        },
+        {
+          name: 'field33',
+          type: 'text',
+        },
+        {
+          name: 'field34',
+          type: 'text',
+        },
+        {
+          name: 'field35',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEight',
+      type: 'group',
+      fields: [
+        {
+          name: 'field36',
+          type: 'text',
+        },
+        {
+          name: 'field37',
+          type: 'text',
+        },
+        {
+          name: 'field38',
+          type: 'text',
+        },
+        {
+          name: 'field39',
+          type: 'text',
+        },
+        {
+          name: 'field40',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupNine',
+      type: 'group',
+      fields: [
+        {
+          name: 'field41',
+          type: 'text',
+        },
+        {
+          name: 'field42',
+          type: 'text',
+        },
+        {
+          name: 'field43',
+          type: 'text',
+        },
+        {
+          name: 'field44',
+          type: 'text',
+        },
+        {
+          name: 'field45',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field46',
+          type: 'text',
+        },
+        {
+          name: 'field47',
+          type: 'text',
+        },
+        {
+          name: 'field48',
+          type: 'text',
+        },
+        {
+          name: 'field49',
+          type: 'text',
+        },
+        {
+          name: 'field50',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEleven',
+      type: 'group',
+      fields: [
+        {
+          name: 'field51',
+          type: 'text',
+        },
+        {
+          name: 'field52',
+          type: 'text',
+        },
+        {
+          name: 'field53',
+          type: 'text',
+        },
+        {
+          name: 'field54',
+          type: 'text',
+        },
+        {
+          name: 'field55',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwelve',
+      type: 'group',
+      fields: [
+        {
+          name: 'field56',
+          type: 'text',
+        },
+        {
+          name: 'field57',
+          type: 'text',
+        },
+        {
+          name: 'field58',
+          type: 'text',
+        },
+        {
+          name: 'field59',
+          type: 'text',
+        },
+        {
+          name: 'field60',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupThirteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field61',
+          type: 'text',
+        },
+        {
+          name: 'field62',
+          type: 'text',
+        },
+        {
+          name: 'field63',
+          type: 'text',
+        },
+        {
+          name: 'field64',
+          type: 'text',
+        },
+        {
+          name: 'field65',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFourteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field66',
+          type: 'text',
+        },
+        {
+          name: 'field67',
+          type: 'text',
+        },
+        {
+          name: 'field68',
+          type: 'text',
+        },
+        {
+          name: 'field69',
+          type: 'text',
+        },
+        {
+          name: 'field70',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFifteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field71',
+          type: 'text',
+        },
+        {
+          name: 'field72',
+          type: 'text',
+        },
+        {
+          name: 'field73',
+          type: 'text',
+        },
+        {
+          name: 'field74',
+          type: 'text',
+        },
+        {
+          name: 'field75',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSixteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field76',
+          type: 'text',
+        },
+        {
+          name: 'field77',
+          type: 'text',
+        },
+        {
+          name: 'field78',
+          type: 'text',
+        },
+        {
+          name: 'field79',
+          type: 'text',
+        },
+        {
+          name: 'field80',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSeventeen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field81',
+          type: 'text',
+        },
+        {
+          name: 'field82',
+          type: 'text',
+        },
+        {
+          name: 'field83',
+          type: 'text',
+        },
+        {
+          name: 'field84',
+          type: 'text',
+        },
+        {
+          name: 'field85',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEighteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field86',
+          type: 'text',
+        },
+        {
+          name: 'field87',
+          type: 'text',
+        },
+        {
+          name: 'field88',
+          type: 'text',
+        },
+        {
+          name: 'field89',
+          type: 'text',
+        },
+        {
+          name: 'field90',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupNineteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field91',
+          type: 'text',
+        },
+        {
+          name: 'field92',
+          type: 'text',
+        },
+        {
+          name: 'field93',
+          type: 'text',
+        },
+        {
+          name: 'field94',
+          type: 'text',
+        },
+        {
+          name: 'field95',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwenty',
+      type: 'group',
+      fields: [
+        {
+          name: 'field96',
+          type: 'text',
+        },
+        {
+          name: 'field97',
+          type: 'text',
+        },
+        {
+          name: 'field98',
+          type: 'text',
+        },
+        {
+          name: 'field99',
+          type: 'text',
+        },
+        {
+          name: 'field100',
+          type: 'text',
+        },
+      ],
+    },
+  ],
+}

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -1,17 +1,19 @@
 import path from 'path'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults'
+import { CustomIdRow } from './collections/CustomIdRow'
+import { CustomIdTab } from './collections/CustomIdTab'
 import { CustomViews1 } from './collections/CustomViews1'
 import { CustomViews2 } from './collections/CustomViews2'
+import { CollectionForceRender } from './collections/ForceRender'
 import { Geo } from './collections/Geo'
 import { CollectionGroup1A } from './collections/Group1A'
 import { CollectionGroup1B } from './collections/Group1B'
 import { CollectionGroup2A } from './collections/Group2A'
 import { CollectionGroup2B } from './collections/Group2B'
 import { CollectionHidden } from './collections/Hidden'
-import { CustomIdTab } from './collections/CustomIdTab'
-import { CustomIdRow } from './collections/CustomIdRow'
 import { CollectionNoApiView } from './collections/NoApiView'
+import { CollectionNoForceRender } from './collections/NoForceRender'
 import { Posts } from './collections/Posts'
 import { Users } from './collections/Users'
 import AdminButton from './components/AdminButton'
@@ -25,11 +27,13 @@ import CustomView from './components/views/CustomView'
 import CustomNestedView from './components/views/CustomViewNested'
 import { CustomGlobalViews1 } from './globals/CustomViews1'
 import { CustomGlobalViews2 } from './globals/CustomViews2'
+import { GlobalForceRender } from './globals/ForceRender'
 import { Global } from './globals/Global'
 import { GlobalGroup1A } from './globals/Group1A'
 import { GlobalGroup1B } from './globals/Group1B'
 import { GlobalHidden } from './globals/Hidden'
 import { GlobalNoApiView } from './globals/NoApiView'
+import { GlobalNoForceRender } from './globals/NoForceRender'
 import { clearAndSeedEverything } from './seed'
 import { customNestedViewPath, customViewPath } from './shared'
 
@@ -120,6 +124,8 @@ export default buildConfigWithDefaults({
     Geo,
     CustomIdTab,
     CustomIdRow,
+    CollectionForceRender,
+    CollectionNoForceRender,
   ],
   globals: [
     GlobalHidden,
@@ -129,6 +135,8 @@ export default buildConfigWithDefaults({
     CustomGlobalViews2,
     GlobalGroup1A,
     GlobalGroup1B,
+    GlobalForceRender,
+    GlobalNoForceRender,
   ],
   onInit: async (payload) => {
     await clearAndSeedEverything(payload)

--- a/test/admin/globals/ForceRender.ts
+++ b/test/admin/globals/ForceRender.ts
@@ -1,0 +1,532 @@
+import type { GlobalConfig } from '../../../packages/payload/src/globals/config/types'
+
+import { forceRenderGlobalSlug } from '../slugs'
+
+export const GlobalForceRender: GlobalConfig = {
+  slug: forceRenderGlobalSlug,
+  admin: {
+    forceRenderAllFields: true,
+  },
+  fields: [
+    {
+      name: 'groupOne',
+      type: 'group',
+      fields: [
+        {
+          name: 'field1',
+          type: 'text',
+        },
+        {
+          name: 'field2',
+          type: 'text',
+        },
+        {
+          name: 'field3',
+          type: 'text',
+        },
+        {
+          name: 'field4',
+          type: 'text',
+        },
+        {
+          name: 'field5',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwo',
+      type: 'group',
+      fields: [
+        {
+          name: 'field6',
+          type: 'text',
+        },
+        {
+          name: 'field7',
+          type: 'text',
+        },
+        {
+          name: 'field8',
+          type: 'text',
+        },
+        {
+          name: 'field9',
+          type: 'text',
+        },
+        {
+          name: 'field10',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupThree',
+      type: 'group',
+      fields: [
+        {
+          name: 'field11',
+          type: 'text',
+        },
+        {
+          name: 'field12',
+          type: 'text',
+        },
+        {
+          name: 'field13',
+          type: 'text',
+        },
+        {
+          name: 'field14',
+          type: 'text',
+        },
+        {
+          name: 'field15',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFour',
+      type: 'group',
+      fields: [
+        {
+          name: 'field16',
+          type: 'text',
+        },
+        {
+          name: 'field17',
+          type: 'text',
+        },
+        {
+          name: 'field18',
+          type: 'text',
+        },
+        {
+          name: 'field19',
+          type: 'text',
+        },
+        {
+          name: 'field20',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFive',
+      type: 'group',
+      fields: [
+        {
+          name: 'field21',
+          type: 'text',
+        },
+        {
+          name: 'field22',
+          type: 'text',
+        },
+        {
+          name: 'field23',
+          type: 'text',
+        },
+        {
+          name: 'field24',
+          type: 'text',
+        },
+        {
+          name: 'field25',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSix',
+      type: 'group',
+      fields: [
+        {
+          name: 'field26',
+          type: 'text',
+        },
+        {
+          name: 'field27',
+          type: 'text',
+        },
+        {
+          name: 'field28',
+          type: 'text',
+        },
+        {
+          name: 'field29',
+          type: 'text',
+        },
+        {
+          name: 'field30',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSeven',
+      type: 'group',
+      fields: [
+        {
+          name: 'field31',
+          type: 'text',
+        },
+        {
+          name: 'field32',
+          type: 'text',
+        },
+        {
+          name: 'field33',
+          type: 'text',
+        },
+        {
+          name: 'field34',
+          type: 'text',
+        },
+        {
+          name: 'field35',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEight',
+      type: 'group',
+      fields: [
+        {
+          name: 'field36',
+          type: 'text',
+        },
+        {
+          name: 'field37',
+          type: 'text',
+        },
+        {
+          name: 'field38',
+          type: 'text',
+        },
+        {
+          name: 'field39',
+          type: 'text',
+        },
+        {
+          name: 'field40',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupNine',
+      type: 'group',
+      fields: [
+        {
+          name: 'field41',
+          type: 'text',
+        },
+        {
+          name: 'field42',
+          type: 'text',
+        },
+        {
+          name: 'field43',
+          type: 'text',
+        },
+        {
+          name: 'field44',
+          type: 'text',
+        },
+        {
+          name: 'field45',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field46',
+          type: 'text',
+        },
+        {
+          name: 'field47',
+          type: 'text',
+        },
+        {
+          name: 'field48',
+          type: 'text',
+        },
+        {
+          name: 'field49',
+          type: 'text',
+        },
+        {
+          name: 'field50',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEleven',
+      type: 'group',
+      fields: [
+        {
+          name: 'field51',
+          type: 'text',
+        },
+        {
+          name: 'field52',
+          type: 'text',
+        },
+        {
+          name: 'field53',
+          type: 'text',
+        },
+        {
+          name: 'field54',
+          type: 'text',
+        },
+        {
+          name: 'field55',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwelve',
+      type: 'group',
+      fields: [
+        {
+          name: 'field56',
+          type: 'text',
+        },
+        {
+          name: 'field57',
+          type: 'text',
+        },
+        {
+          name: 'field58',
+          type: 'text',
+        },
+        {
+          name: 'field59',
+          type: 'text',
+        },
+        {
+          name: 'field60',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupThirteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field61',
+          type: 'text',
+        },
+        {
+          name: 'field62',
+          type: 'text',
+        },
+        {
+          name: 'field63',
+          type: 'text',
+        },
+        {
+          name: 'field64',
+          type: 'text',
+        },
+        {
+          name: 'field65',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFourteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field66',
+          type: 'text',
+        },
+        {
+          name: 'field67',
+          type: 'text',
+        },
+        {
+          name: 'field68',
+          type: 'text',
+        },
+        {
+          name: 'field69',
+          type: 'text',
+        },
+        {
+          name: 'field70',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFifteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field71',
+          type: 'text',
+        },
+        {
+          name: 'field72',
+          type: 'text',
+        },
+        {
+          name: 'field73',
+          type: 'text',
+        },
+        {
+          name: 'field74',
+          type: 'text',
+        },
+        {
+          name: 'field75',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSixteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field76',
+          type: 'text',
+        },
+        {
+          name: 'field77',
+          type: 'text',
+        },
+        {
+          name: 'field78',
+          type: 'text',
+        },
+        {
+          name: 'field79',
+          type: 'text',
+        },
+        {
+          name: 'field80',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSeventeen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field81',
+          type: 'text',
+        },
+        {
+          name: 'field82',
+          type: 'text',
+        },
+        {
+          name: 'field83',
+          type: 'text',
+        },
+        {
+          name: 'field84',
+          type: 'text',
+        },
+        {
+          name: 'field85',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEighteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field86',
+          type: 'text',
+        },
+        {
+          name: 'field87',
+          type: 'text',
+        },
+        {
+          name: 'field88',
+          type: 'text',
+        },
+        {
+          name: 'field89',
+          type: 'text',
+        },
+        {
+          name: 'field90',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupNineteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field91',
+          type: 'text',
+        },
+        {
+          name: 'field92',
+          type: 'text',
+        },
+        {
+          name: 'field93',
+          type: 'text',
+        },
+        {
+          name: 'field94',
+          type: 'text',
+        },
+        {
+          name: 'field95',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwenty',
+      type: 'group',
+      fields: [
+        {
+          name: 'field96',
+          type: 'text',
+        },
+        {
+          name: 'field97',
+          type: 'text',
+        },
+        {
+          name: 'field98',
+          type: 'text',
+        },
+        {
+          name: 'field99',
+          type: 'text',
+        },
+        {
+          name: 'field100',
+          type: 'text',
+        },
+      ],
+    },
+  ],
+}

--- a/test/admin/globals/NoForceRender.ts
+++ b/test/admin/globals/NoForceRender.ts
@@ -1,0 +1,532 @@
+import type { GlobalConfig } from '../../../packages/payload/src/globals/config/types'
+
+import { noForceRenderGlobalSlug } from '../slugs'
+
+export const GlobalNoForceRender: GlobalConfig = {
+  slug: noForceRenderGlobalSlug,
+  admin: {
+    forceRenderAllFields: false,
+  },
+  fields: [
+    {
+      name: 'groupOne',
+      type: 'group',
+      fields: [
+        {
+          name: 'field1',
+          type: 'text',
+        },
+        {
+          name: 'field2',
+          type: 'text',
+        },
+        {
+          name: 'field3',
+          type: 'text',
+        },
+        {
+          name: 'field4',
+          type: 'text',
+        },
+        {
+          name: 'field5',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwo',
+      type: 'group',
+      fields: [
+        {
+          name: 'field6',
+          type: 'text',
+        },
+        {
+          name: 'field7',
+          type: 'text',
+        },
+        {
+          name: 'field8',
+          type: 'text',
+        },
+        {
+          name: 'field9',
+          type: 'text',
+        },
+        {
+          name: 'field10',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupThree',
+      type: 'group',
+      fields: [
+        {
+          name: 'field11',
+          type: 'text',
+        },
+        {
+          name: 'field12',
+          type: 'text',
+        },
+        {
+          name: 'field13',
+          type: 'text',
+        },
+        {
+          name: 'field14',
+          type: 'text',
+        },
+        {
+          name: 'field15',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFour',
+      type: 'group',
+      fields: [
+        {
+          name: 'field16',
+          type: 'text',
+        },
+        {
+          name: 'field17',
+          type: 'text',
+        },
+        {
+          name: 'field18',
+          type: 'text',
+        },
+        {
+          name: 'field19',
+          type: 'text',
+        },
+        {
+          name: 'field20',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFive',
+      type: 'group',
+      fields: [
+        {
+          name: 'field21',
+          type: 'text',
+        },
+        {
+          name: 'field22',
+          type: 'text',
+        },
+        {
+          name: 'field23',
+          type: 'text',
+        },
+        {
+          name: 'field24',
+          type: 'text',
+        },
+        {
+          name: 'field25',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSix',
+      type: 'group',
+      fields: [
+        {
+          name: 'field26',
+          type: 'text',
+        },
+        {
+          name: 'field27',
+          type: 'text',
+        },
+        {
+          name: 'field28',
+          type: 'text',
+        },
+        {
+          name: 'field29',
+          type: 'text',
+        },
+        {
+          name: 'field30',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSeven',
+      type: 'group',
+      fields: [
+        {
+          name: 'field31',
+          type: 'text',
+        },
+        {
+          name: 'field32',
+          type: 'text',
+        },
+        {
+          name: 'field33',
+          type: 'text',
+        },
+        {
+          name: 'field34',
+          type: 'text',
+        },
+        {
+          name: 'field35',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEight',
+      type: 'group',
+      fields: [
+        {
+          name: 'field36',
+          type: 'text',
+        },
+        {
+          name: 'field37',
+          type: 'text',
+        },
+        {
+          name: 'field38',
+          type: 'text',
+        },
+        {
+          name: 'field39',
+          type: 'text',
+        },
+        {
+          name: 'field40',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupNine',
+      type: 'group',
+      fields: [
+        {
+          name: 'field41',
+          type: 'text',
+        },
+        {
+          name: 'field42',
+          type: 'text',
+        },
+        {
+          name: 'field43',
+          type: 'text',
+        },
+        {
+          name: 'field44',
+          type: 'text',
+        },
+        {
+          name: 'field45',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field46',
+          type: 'text',
+        },
+        {
+          name: 'field47',
+          type: 'text',
+        },
+        {
+          name: 'field48',
+          type: 'text',
+        },
+        {
+          name: 'field49',
+          type: 'text',
+        },
+        {
+          name: 'field50',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEleven',
+      type: 'group',
+      fields: [
+        {
+          name: 'field51',
+          type: 'text',
+        },
+        {
+          name: 'field52',
+          type: 'text',
+        },
+        {
+          name: 'field53',
+          type: 'text',
+        },
+        {
+          name: 'field54',
+          type: 'text',
+        },
+        {
+          name: 'field55',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwelve',
+      type: 'group',
+      fields: [
+        {
+          name: 'field56',
+          type: 'text',
+        },
+        {
+          name: 'field57',
+          type: 'text',
+        },
+        {
+          name: 'field58',
+          type: 'text',
+        },
+        {
+          name: 'field59',
+          type: 'text',
+        },
+        {
+          name: 'field60',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupThirteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field61',
+          type: 'text',
+        },
+        {
+          name: 'field62',
+          type: 'text',
+        },
+        {
+          name: 'field63',
+          type: 'text',
+        },
+        {
+          name: 'field64',
+          type: 'text',
+        },
+        {
+          name: 'field65',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFourteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field66',
+          type: 'text',
+        },
+        {
+          name: 'field67',
+          type: 'text',
+        },
+        {
+          name: 'field68',
+          type: 'text',
+        },
+        {
+          name: 'field69',
+          type: 'text',
+        },
+        {
+          name: 'field70',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupFifteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field71',
+          type: 'text',
+        },
+        {
+          name: 'field72',
+          type: 'text',
+        },
+        {
+          name: 'field73',
+          type: 'text',
+        },
+        {
+          name: 'field74',
+          type: 'text',
+        },
+        {
+          name: 'field75',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSixteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field76',
+          type: 'text',
+        },
+        {
+          name: 'field77',
+          type: 'text',
+        },
+        {
+          name: 'field78',
+          type: 'text',
+        },
+        {
+          name: 'field79',
+          type: 'text',
+        },
+        {
+          name: 'field80',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupSeventeen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field81',
+          type: 'text',
+        },
+        {
+          name: 'field82',
+          type: 'text',
+        },
+        {
+          name: 'field83',
+          type: 'text',
+        },
+        {
+          name: 'field84',
+          type: 'text',
+        },
+        {
+          name: 'field85',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupEighteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field86',
+          type: 'text',
+        },
+        {
+          name: 'field87',
+          type: 'text',
+        },
+        {
+          name: 'field88',
+          type: 'text',
+        },
+        {
+          name: 'field89',
+          type: 'text',
+        },
+        {
+          name: 'field90',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupNineteen',
+      type: 'group',
+      fields: [
+        {
+          name: 'field91',
+          type: 'text',
+        },
+        {
+          name: 'field92',
+          type: 'text',
+        },
+        {
+          name: 'field93',
+          type: 'text',
+        },
+        {
+          name: 'field94',
+          type: 'text',
+        },
+        {
+          name: 'field95',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'groupTwenty',
+      type: 'group',
+      fields: [
+        {
+          name: 'field96',
+          type: 'text',
+        },
+        {
+          name: 'field97',
+          type: 'text',
+        },
+        {
+          name: 'field98',
+          type: 'text',
+        },
+        {
+          name: 'field99',
+          type: 'text',
+        },
+        {
+          name: 'field100',
+          type: 'text',
+        },
+      ],
+    },
+  ],
+}

--- a/test/admin/slugs.ts
+++ b/test/admin/slugs.ts
@@ -9,6 +9,8 @@ export const group2Collection1Slug = 'group-two-collection-ones' as const
 export const group2Collection2Slug = 'group-two-collection-twos' as const
 export const hiddenCollectionSlug = 'hidden-collection' as const
 export const noApiViewCollectionSlug = 'collection-no-api-view' as const
+export const forceRenderCollectionSlug = 'collection-force-render' as const
+export const noForceRenderCollectionSlug = 'collection-no-force-render' as const
 export const collectionSlugs = [
   usersCollectionSlug,
   customViews1CollectionSlug,
@@ -30,6 +32,8 @@ export const group1GlobalSlug = 'group-globals-one' as const
 export const group2GlobalSlug = 'group-globals-two' as const
 export const hiddenGlobalSlug = 'hidden-global' as const
 export const noApiViewGlobalSlug = 'global-no-api-view'
+export const forceRenderGlobalSlug = 'global-force-render' as const
+export const noForceRenderGlobalSlug = 'global-no-force-render' as const
 export const globalSlugs = [
   customGlobalViews1GlobalSlug,
   customGlobalViews2GlobalSlug,


### PR DESCRIPTION
### What?

Adds `e2e` tests for previously new collection / global config admin prop: `forceRenderAllFields`
