### PR TITLE
fix(ui): scheduled publish not showing related events in postgres

### DIFF
--- a/packages/payload/src/versions/schedule/types.ts
+++ b/packages/payload/src/versions/schedule/types.ts
@@ -3,7 +3,7 @@ import type { CollectionSlug, GlobalSlug } from '../../index.js'
 export type SchedulePublishTaskInput = {
   doc?: {
     relationTo: CollectionSlug
-    value: number | string
+    value: string
   }
   global?: GlobalSlug
   locale?: string


### PR DESCRIPTION
Since postgres uses number IDs by default, when we were storing the relationship field value with postgres we weren't able to query it

This fixes that problem by casting the ID to always a string making it safe for querying inside the JSON field