### PR TITLE
fix: do not autorun jobs during next build process

### DIFF
--- a/packages/payload/src/exports/shared.ts
+++ b/packages/payload/src/exports/shared.ts
@@ -66,6 +66,8 @@ export { getSiblingData } from '../utilities/getSiblingData.js'
 
 export { getUniqueListBy } from '../utilities/getUniqueListBy.js'
 
+export { isNextBuild } from '../utilities/isNextBuild.js'
+
 export { isNumber } from '../utilities/isNumber.js'
 
 export { isPlainObject } from '../utilities/isPlainObject.js'
@@ -83,7 +85,6 @@ export { setsAreEqual } from '../utilities/setsAreEqual.js'
 export { default as toKebabCase } from '../utilities/toKebabCase.js'
 
 export { unflatten } from '../utilities/unflatten.js'
-
 export { validateMimeType } from '../utilities/validateMimeType.js'
 export { wait } from '../utilities/wait.js'
 export { default as wordBoundariesRegex } from '../utilities/wordBoundariesRegex.js'

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -77,6 +77,7 @@ import { consoleEmailAdapter } from './email/consoleEmailAdapter.js'
 import { fieldAffectsData } from './fields/config/types.js'
 import localGlobalOperations from './globals/operations/local/index.js'
 import { getJobsLocalAPI } from './queues/localAPI.js'
+import { isNextBuild } from './utilities/isNextBuild.js'
 import { getLogger } from './utilities/logger.js'
 import { serverInit as serverInitTelemetry } from './utilities/telemetry/events/serverInit.js'
 import { traverseFields } from './utilities/traverseFields.js'
@@ -714,7 +715,7 @@ export class BasePayload {
         await this.config.onInit(this)
       }
     }
-    if (this.config.jobs.autoRun) {
+    if (this.config.jobs.autoRun && !isNextBuild()) {
       const DEFAULT_CRON = '* * * * *'
       const DEFAULT_LIMIT = 10
 

--- a/packages/payload/src/utilities/isNextBuild.ts
+++ b/packages/payload/src/utilities/isNextBuild.ts
@@ -1,0 +1,9 @@
+/**
+ * Utility function to determine if the code is being executed during the Next.js build process.
+ */
+export function isNextBuild() {
+  return (
+    process.env.NEXT_PHASE === 'phase-production-build' ||
+    process.env.npm_lifecycle_event === 'build'
+  )
+}


### PR DESCRIPTION
This PR ensures that jobs do not auto-run during `next build`, as that previously caused mongo errors during build