### PR TITLE
fix(richtext-lexical): allow external state mutation of block node from outside the form

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/component/index.tsx
@@ -39,13 +39,18 @@ import './index.scss'
 import { removeEmptyArrayValues } from './removeEmptyArrayValues.js'
 
 type Props = {
-  readonly children?: React.ReactNode
+  /**
+   * Can be modified by the node in order to trigger the re-fetch of the initial state based on the
+   * formData. This is useful when node.setFields() is explicitly called from outside of the form - in
+   * this case, the new field state is likely not reflected in the form state, so we need to re-fetch
+   */
+  readonly cacheBuster: number
   readonly formData: BlockFields
   readonly nodeKey: string
 }
 
 export const BlockComponent: React.FC<Props> = (props) => {
-  const { formData, nodeKey } = props
+  const { cacheBuster, formData, nodeKey } = props
   const submitted = useFormSubmitted()
   const { id, collectionSlug, globalSlug } = useDocumentInfo()
   const {
@@ -91,6 +96,10 @@ export const BlockComponent: React.FC<Props> = (props) => {
         }
       : false,
   )
+
+  useEffect(() => {
+    setInitialState(false)
+  }, [cacheBuster])
 
   const [CustomLabel, setCustomLabel] = React.useState<React.ReactNode | undefined>(
     // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
@@ -214,7 +223,7 @@ export const BlockComponent: React.FC<Props> = (props) => {
           if (node && $isBlockNode(node)) {
             const newData = newFormStateData
             newData.blockType = formData.blockType
-            node.setFields(newData)
+            node.setFields(newData, true)
           }
         })
       }, 0)
@@ -484,7 +493,7 @@ export const BlockComponent: React.FC<Props> = (props) => {
           editor.update(() => {
             const node = $getNodeByKey(nodeKey)
             if (node && $isBlockNode(node)) {
-              node.setFields(newData)
+              node.setFields(newData, true)
             }
           })
           toggleDrawer()

--- a/packages/richtext-lexical/src/features/blocks/client/nodes/BlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/nodes/BlocksNode.tsx
@@ -35,7 +35,13 @@ export class BlockNode extends ServerBlockNode {
   }
 
   decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
-    return <BlockComponent formData={this.getFields()} nodeKey={this.getKey()} />
+    return (
+      <BlockComponent
+        cacheBuster={this.getCacheBuster()}
+        formData={this.getFields()}
+        nodeKey={this.getKey()}
+      />
+    )
   }
 
   exportJSON(): SerializedBlockNode {

--- a/packages/richtext-lexical/src/features/blocks/client/nodes/InlineBlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/nodes/InlineBlocksNode.tsx
@@ -32,7 +32,13 @@ export class InlineBlockNode extends ServerInlineBlockNode {
   }
 
   decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
-    return <InlineBlockComponent formData={this.getFields()} nodeKey={this.getKey()} />
+    return (
+      <InlineBlockComponent
+        cacheBuster={this.getCacheBuster()}
+        formData={this.getFields()}
+        nodeKey={this.getKey()}
+      />
+    )
   }
 
   exportJSON(): SerializedInlineBlockNode {

--- a/packages/richtext-lexical/src/features/blocks/server/nodes/BlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/server/nodes/BlocksNode.tsx
@@ -39,23 +39,28 @@ export type SerializedBlockNode<TBlockFields extends JsonObject = JsonObject> = 
 >
 
 export class ServerBlockNode extends DecoratorBlockNode {
+  __cacheBuster: number
   __fields: BlockFields
 
   constructor({
+    cacheBuster,
     fields,
     format,
     key,
   }: {
+    cacheBuster?: number
     fields: BlockFields
     format?: ElementFormatType
     key?: NodeKey
   }) {
     super(format, key)
     this.__fields = fields
+    this.__cacheBuster = cacheBuster || 0
   }
 
   static clone(node: ServerBlockNode): ServerBlockNode {
     return new this({
+      cacheBuster: node.__cacheBuster,
       fields: node.__fields,
       format: node.__format,
       key: node.__key,
@@ -111,6 +116,10 @@ export class ServerBlockNode extends DecoratorBlockNode {
     }
   }
 
+  getCacheBuster(): number {
+    return this.getLatest().__cacheBuster
+  }
+
   getFields(): BlockFields {
     return this.getLatest().__fields
   }
@@ -119,9 +128,12 @@ export class ServerBlockNode extends DecoratorBlockNode {
     return `Block Field`
   }
 
-  setFields(fields: BlockFields): void {
+  setFields(fields: BlockFields, preventFormStateUpdate?: boolean): void {
     const writable = this.getWritable()
     writable.__fields = fields
+    if (!preventFormStateUpdate) {
+      writable.__cacheBuster++
+    }
   }
 }
 

--- a/packages/richtext-lexical/src/features/blocks/server/nodes/InlineBlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/server/nodes/InlineBlocksNode.tsx
@@ -33,14 +33,23 @@ export class ServerInlineBlockNode extends DecoratorNode<null | React.ReactEleme
   __cacheBuster: number
   __fields: InlineBlockFields
 
-  constructor({ fields, key }: { fields: InlineBlockFields; key?: NodeKey }) {
+  constructor({
+    cacheBuster,
+    fields,
+    key,
+  }: {
+    cacheBuster?: number
+    fields: InlineBlockFields
+    key?: NodeKey
+  }) {
     super(key)
     this.__fields = fields
-    this.__cacheBuster = 0
+    this.__cacheBuster = cacheBuster || 0
   }
 
   static clone(node: ServerInlineBlockNode): ServerInlineBlockNode {
     return new this({
+      cacheBuster: node.__cacheBuster,
       fields: node.__fields,
       key: node.__key,
     })

--- a/packages/richtext-lexical/src/features/blocks/server/nodes/InlineBlocksNode.tsx
+++ b/packages/richtext-lexical/src/features/blocks/server/nodes/InlineBlocksNode.tsx
@@ -30,11 +30,13 @@ export type SerializedInlineBlockNode<TBlockFields extends JsonObject = JsonObje
 >
 
 export class ServerInlineBlockNode extends DecoratorNode<null | React.ReactElement> {
+  __cacheBuster: number
   __fields: InlineBlockFields
 
   constructor({ fields, key }: { fields: InlineBlockFields; key?: NodeKey }) {
     super(key)
     this.__fields = fields
+    this.__cacheBuster = 0
   }
 
   static clone(node: ServerInlineBlockNode): ServerInlineBlockNode {
@@ -92,6 +94,10 @@ export class ServerInlineBlockNode extends DecoratorNode<null | React.ReactEleme
     }
   }
 
+  getCacheBuster(): number {
+    return this.getLatest().__cacheBuster
+  }
+
   getFields(): InlineBlockFields {
     return this.getLatest().__fields
   }
@@ -104,9 +110,12 @@ export class ServerInlineBlockNode extends DecoratorNode<null | React.ReactEleme
     return true
   }
 
-  setFields(fields: InlineBlockFields): void {
+  setFields(fields: InlineBlockFields, preventFormStateUpdate?: boolean): void {
     const writable = this.getWritable()
     writable.__fields = fields
+    if (!preventFormStateUpdate) {
+      writable.__cacheBuster++
+    }
   }
 
   updateDOM(): boolean {

--- a/test/fields/collections/Lexical/ModifyInlineBlockFeature/feature.client.ts
+++ b/test/fields/collections/Lexical/ModifyInlineBlockFeature/feature.client.ts
@@ -1,0 +1,57 @@
+'use client'
+
+import { $isInlineBlockNode, createClientFeature } from '@payloadcms/richtext-lexical/client'
+import { $getSelection } from '@payloadcms/richtext-lexical/lexical'
+import { CloseMenuIcon } from '@payloadcms/ui'
+
+import { ModifyInlineBlockPlugin } from './plugin.js'
+
+export const ModifyInlineBlockFeatureClient = createClientFeature({
+  plugins: [
+    {
+      Component: ModifyInlineBlockPlugin,
+      position: 'normal',
+    },
+  ],
+  toolbarFixed: {
+    groups: [
+      {
+        key: 'debug',
+        items: [
+          {
+            ChildComponent: CloseMenuIcon,
+            key: 'setKeyToDebug',
+            label: 'Set Key To Debug',
+            onSelect({ editor }) {
+              editor.update(() => {
+                const selection = $getSelection()
+
+                // Check if selection consist of 1 node and that its an inlineblocknode
+                const nodes = selection.getNodes()
+
+                if (nodes.length !== 1) {
+                  return
+                }
+
+                const node = nodes[0]
+
+                if (!$isInlineBlockNode(node)) {
+                  return
+                }
+
+                const fields = node.getFields()
+
+                node.setFields({
+                  blockType: fields.blockType,
+                  id: fields.id,
+                  key: 'value2',
+                })
+              })
+            },
+          },
+        ],
+        type: 'buttons',
+      },
+    ],
+  },
+})

--- a/test/fields/collections/Lexical/ModifyInlineBlockFeature/feature.server.ts
+++ b/test/fields/collections/Lexical/ModifyInlineBlockFeature/feature.server.ts
@@ -1,0 +1,9 @@
+import { createServerFeature } from '@payloadcms/richtext-lexical'
+
+export const ModifyInlineBlockFeature = createServerFeature({
+  key: 'ModifyInlineBlockFeature',
+  feature: {
+    ClientFeature:
+      './collections/Lexical/ModifyInlineBlockFeature/feature.client.js#ModifyInlineBlockFeatureClient',
+  },
+})

--- a/test/fields/collections/Lexical/ModifyInlineBlockFeature/plugin.tsx
+++ b/test/fields/collections/Lexical/ModifyInlineBlockFeature/plugin.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import type { PluginComponent } from '@payloadcms/richtext-lexical'
+
+export const ModifyInlineBlockPlugin: PluginComponent = () => {
+  return null
+}

--- a/test/fields/collections/Lexical/index.ts
+++ b/test/fields/collections/Lexical/index.ts
@@ -32,6 +32,7 @@ import {
   TextBlock,
   UploadAndRichTextBlock,
 } from './blocks.js'
+import { ModifyInlineBlockFeature } from './ModifyInlineBlockFeature/feature.server.js'
 
 const editorConfig: ServerEditorConfig = {
   features: [
@@ -69,6 +70,7 @@ const editorConfig: ServerEditorConfig = {
         },
       },
     }),
+    ModifyInlineBlockFeature(),
     BlocksFeature({
       blocks: [
         RichTextBlock,


### PR DESCRIPTION
Previously, updates of the node fields from outside the form using `setFields` did not trigger re-fetching the initial state, and thus providing updated values to the Form. This is to avoid unnecessary re-renders of the Form and unnecessary requests when `setFields` is triggered from within the Form.

This PR resets the initial state, thus triggering a re-render and re-fetch of the initial state, if `node.setFields` is called from outside the Form. This preserves the performance optimization

