### PR TITLE
fix: collection access endpoint optional ID and use 404 for not found response

### DIFF
--- a/packages/payload/src/collections/endpoints/docAccess.ts
+++ b/packages/payload/src/collections/endpoints/docAccess.ts
@@ -7,7 +7,7 @@ import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { docAccessOperation } from '../operations/docAccess.js'
 
 export const docAccessHandler: PayloadHandler = async (req) => {
-  const { id, collection } = getRequestCollectionWithID(req)
+  const { id, collection } = getRequestCollectionWithID(req, { optionalID: true })
   const result = await docAccessOperation({
     id,
     collection,

--- a/packages/payload/src/collections/endpoints/index.ts
+++ b/packages/payload/src/collections/endpoints/index.ts
@@ -43,12 +43,7 @@ export const defaultCollectionEndpoints: Endpoint[] = [
     {
       handler: docAccessHandler,
       method: 'post',
-      path: '/access',
-    },
-    {
-      handler: docAccessHandler,
-      method: 'post',
-      path: '/access/:id',
+      path: '/access/:id?',
     },
     {
       handler: duplicateHandler,

--- a/packages/payload/src/collections/endpoints/index.ts
+++ b/packages/payload/src/collections/endpoints/index.ts
@@ -43,6 +43,11 @@ export const defaultCollectionEndpoints: Endpoint[] = [
     {
       handler: docAccessHandler,
       method: 'post',
+      path: '/access',
+    },
+    {
+      handler: docAccessHandler,
+      method: 'post',
       path: '/access/:id',
     },
     {

--- a/packages/payload/src/utilities/getRequestEntity.ts
+++ b/packages/payload/src/utilities/getRequestEntity.ts
@@ -24,8 +24,10 @@ export const getRequestCollectionWithID = <T extends boolean>(
   req: PayloadRequest,
   {
     disableSanitize,
+    optionalID,
   }: {
     disableSanitize?: T
+    optionalID?: boolean
   } = {},
 ): {
   collection: Collection
@@ -35,6 +37,13 @@ export const getRequestCollectionWithID = <T extends boolean>(
   const id = req.routeParams.id
 
   if (typeof id !== 'string') {
+    if (optionalID) {
+      return {
+        id: undefined,
+        collection,
+      }
+    }
+
     throw new APIError(`ID was not specified`, 400)
   }
 

--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -12,13 +12,15 @@ import { routeError } from './routeError.js'
 
 const notFoundResponse = (req: PayloadRequest) => {
   return Response.json(
-    {},
+    {
+      message: `Route not found "${new URL(req.url).pathname}"`,
+    },
     {
       headers: headersWithCors({
         headers: new Headers(),
         req,
       }),
-      status: 200,
+      status: httpStatus.NOT_FOUND,
     },
   )
 }


### PR DESCRIPTION
The collection access endpoint, apparently, can be used without an ID as well and the correct status code in `notFoundResponse` was missing.
Huge thanks to @akhrarovsaid 