### PR TITLE
fix(richtext-lexical): respect defaultValue config of link feature url and linkType fields

### DIFF
--- a/packages/richtext-lexical/src/features/link/client/index.tsx
+++ b/packages/richtext-lexical/src/features/link/client/index.tsx
@@ -22,7 +22,10 @@ import { FloatingLinkEditorPlugin } from './plugins/floatingLinkEditor/index.js'
 import { TOGGLE_LINK_WITH_MODAL_COMMAND } from './plugins/floatingLinkEditor/LinkEditor/commands.js'
 import { LinkPlugin } from './plugins/link/index.js'
 
-export type ClientProps = ExclusiveLinkCollectionsProps
+export type ClientProps = {
+  defaultLinkType?: string
+  defaultLinkURL?: string
+} & ExclusiveLinkCollectionsProps
 
 const toolbarGroups: ToolbarGroup[] = [
   toolbarFeatureButtonsGroupWithItems([
@@ -57,11 +60,9 @@ const toolbarGroups: ToolbarGroup[] = [
             return
           }
 
-          const linkFields: LinkFields = {
+          const linkFields: Partial<LinkFields> = {
             doc: null,
-            linkType: 'custom',
             newTab: false,
-            url: 'https://',
           }
 
           editor.dispatchCommand(TOGGLE_LINK_WITH_MODAL_COMMAND, {

--- a/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/types.ts
+++ b/packages/richtext-lexical/src/features/link/client/plugins/floatingLinkEditor/types.ts
@@ -7,7 +7,10 @@ import type { LinkFields } from '../../../nodes/types.js'
  * This can be delivered from the link node to the drawer, or from the drawer/anything to the TOGGLE_LINK_COMMAND
  */
 export type LinkPayload = {
-  fields: LinkFields
+  /**
+   * The fields of the link node. Undefined fields will be taken from the default values of the link node
+   */
+  fields: Partial<LinkFields>
   selectedNodes?: LexicalNode[]
   /**
    * The text content of the link node - will be displayed in the drawer

--- a/packages/richtext-lexical/src/features/link/client/plugins/link/index.tsx
+++ b/packages/richtext-lexical/src/features/link/client/plugins/link/index.tsx
@@ -18,7 +18,7 @@ import type { LinkPayload } from '../floatingLinkEditor/types.js'
 import { validateUrl } from '../../../../../lexical/utils/url.js'
 import { $toggleLink, LinkNode, TOGGLE_LINK_COMMAND } from '../../../nodes/LinkNode.js'
 
-export const LinkPlugin: PluginComponent<ClientProps> = () => {
+export const LinkPlugin: PluginComponent<ClientProps> = ({ clientProps }) => {
   const [editor] = useLexicalComposerContext()
 
   useEffect(() => {
@@ -29,7 +29,13 @@ export const LinkPlugin: PluginComponent<ClientProps> = () => {
       editor.registerCommand(
         TOGGLE_LINK_COMMAND,
         (payload: LinkPayload) => {
-          $toggleLink(payload)
+          if (!payload.fields?.linkType) {
+            payload.fields.linkType = clientProps.defaultLinkType as any
+          }
+          if (!payload.fields?.url) {
+            payload.fields.url = clientProps.defaultLinkURL as any
+          }
+          $toggleLink(payload as { fields: LinkFields } & LinkPayload)
           return true
         },
         COMMAND_PRIORITY_LOW,
@@ -70,7 +76,7 @@ export const LinkPlugin: PluginComponent<ClientProps> = () => {
         COMMAND_PRIORITY_LOW,
       ),
     )
-  }, [editor])
+  }, [clientProps.defaultLinkType, clientProps.defaultLinkURL, editor])
 
   return null
 }

--- a/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
@@ -266,7 +266,7 @@ export function $isLinkNode(node: LexicalNode | null | undefined): node is LinkN
 export const TOGGLE_LINK_COMMAND: LexicalCommand<LinkPayload | null> =
   createCommand('TOGGLE_LINK_COMMAND')
 
-export function $toggleLink(payload: LinkPayload): void {
+export function $toggleLink(payload: { fields: LinkFields } & LinkPayload): void {
   const selection = $getSelection()
 
   if (!$isRangeSelection(selection) && !payload.selectedNodes?.length) {

--- a/packages/richtext-lexical/src/features/link/server/index.ts
+++ b/packages/richtext-lexical/src/features/link/server/index.ts
@@ -100,16 +100,25 @@ export const LinkFeature = createServerFeature<
       (field) => !('name' in field) || field.name !== 'text',
     )
 
-    const linkTypeField = sanitizedFields.find(
-      (field) => 'name' in field && field.name === 'linkType',
-    )
+    let linkTypeField: Field | null = null
+    let linkURLField: Field | null = null
+
+    for (const field of sanitizedFields) {
+      if ('name' in field && field.name === 'linkType') {
+        linkTypeField = field
+      }
+
+      if ('name' in field && field.name === 'url') {
+        linkURLField = field
+      }
+    }
+
     const defaultLinkType = linkTypeField
       ? 'defaultValue' in linkTypeField && typeof linkTypeField.defaultValue === 'string'
         ? linkTypeField.defaultValue
         : 'custom'
       : undefined
 
-    const linkURLField = sanitizedFields.find((field) => 'name' in field && field.name === 'url')
     const defaultLinkURL = linkURLField
       ? 'defaultValue' in linkURLField && typeof linkURLField.defaultValue === 'string'
         ? linkURLField.defaultValue

--- a/packages/richtext-lexical/src/features/link/server/index.ts
+++ b/packages/richtext-lexical/src/features/link/server/index.ts
@@ -100,12 +100,30 @@ export const LinkFeature = createServerFeature<
       (field) => !('name' in field) || field.name !== 'text',
     )
 
+    const linkTypeField = sanitizedFields.find(
+      (field) => 'name' in field && field.name === 'linkType',
+    )
+    const defaultLinkType = linkTypeField
+      ? 'defaultValue' in linkTypeField && typeof linkTypeField.defaultValue === 'string'
+        ? linkTypeField.defaultValue
+        : 'custom'
+      : undefined
+
+    const linkURLField = sanitizedFields.find((field) => 'name' in field && field.name === 'url')
+    const defaultLinkURL = linkURLField
+      ? 'defaultValue' in linkURLField && typeof linkURLField.defaultValue === 'string'
+        ? linkURLField.defaultValue
+        : 'https://'
+      : undefined
+
     return {
       ClientFeature: '@payloadcms/richtext-lexical/client#LinkFeatureClient',
       clientFeatureProps: {
+        defaultLinkType,
+        defaultLinkURL,
         disabledCollections: props.disabledCollections,
         enabledCollections: props.enabledCollections,
-      } as ExclusiveLinkCollectionsProps,
+      } as ClientProps,
       generateSchemaMap: () => {
         if (!sanitizedFields || !Array.isArray(sanitizedFields) || sanitizedFields.length === 0) {
           return null


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/10444

For our normal fields, the default values are all calculated on the server and then sent to the client. We cannot do that for lexical link fields, as creating a link (= a button click on the client) immediately converts the selected node into a link node - all on the client - without a separate round trip to the server.

This PR pre-calculates the default values for link type and url fields (those I can see being most commonly adjusted) on the server, and sends them down to the client, so that they are ready to be used when a new link is created