### PR TITLE
fix(richtext-lexical): adds support for localized placeholder

### DIFF
--- a/packages/richtext-lexical/src/field/rscEntry.tsx
+++ b/packages/richtext-lexical/src/field/rscEntry.tsx
@@ -7,6 +7,7 @@ import type {
   ServerComponentProps,
 } from 'payload'
 
+import { getTranslation } from '@payloadcms/translations'
 import { renderField } from '@payloadcms/ui/forms/renderField'
 import React from 'react'
 
@@ -64,8 +65,16 @@ export const RscEntryLexicalField: React.FC<
     })
   }
 
+  const placeholderFromArgs = args.admin?.placeholder
+  const placeholder = placeholderFromArgs
+    ? getTranslation(placeholderFromArgs, args.i18n)
+    : undefined
+
   const props: LexicalRichTextFieldProps = {
-    admin: args.admin,
+    admin: {
+      hideGutter: args.admin?.hideGutter,
+      placeholder,
+    },
     clientFeatures,
     featureClientSchemaMap, // TODO: Does client need this? Why cant this just live in the server
     field: args.clientField as RichTextFieldClient,

--- a/packages/richtext-lexical/src/field/rscEntry.tsx
+++ b/packages/richtext-lexical/src/field/rscEntry.tsx
@@ -12,7 +12,11 @@ import { renderField } from '@payloadcms/ui/forms/renderField'
 import React from 'react'
 
 import type { SanitizedServerEditorConfig } from '../lexical/config/types.js'
-import type { LexicalFieldAdminProps, LexicalRichTextFieldProps } from '../types.js'
+import type {
+  LexicalFieldAdminClientProps,
+  LexicalFieldAdminProps,
+  LexicalRichTextFieldProps,
+} from '../types.js'
 
 // eslint-disable-next-line payload/no-imports-from-exports-dir
 import { RichTextField } from '../exports/client/index.js'
@@ -70,11 +74,15 @@ export const RscEntryLexicalField: React.FC<
     ? getTranslation(placeholderFromArgs, args.i18n)
     : undefined
 
+  const admin: LexicalFieldAdminClientProps = {}
+  if (placeholder) {
+    admin.placeholder = placeholder
+  }
+  if (args.admin?.hideGutter) {
+    admin.hideGutter = true
+  }
+
   const props: LexicalRichTextFieldProps = {
-    admin: {
-      hideGutter: args.admin?.hideGutter,
-      placeholder,
-    },
     clientFeatures,
     featureClientSchemaMap, // TODO: Does client need this? Why cant this just live in the server
     field: args.clientField as RichTextFieldClient,
@@ -86,6 +94,9 @@ export const RscEntryLexicalField: React.FC<
     readOnly: args.readOnly,
     renderedBlocks: args.renderedBlocks,
     schemaPath,
+  }
+  if (Object.keys(admin).length) {
+    props.admin = admin
   }
 
   for (const key in props) {

--- a/packages/richtext-lexical/src/lexical/config/client/sanitize.ts
+++ b/packages/richtext-lexical/src/lexical/config/client/sanitize.ts
@@ -6,7 +6,7 @@ import type {
   ResolvedClientFeatureMap,
   SanitizedClientFeatures,
 } from '../../../features/typesClient.js'
-import type { LexicalFieldAdminProps } from '../../../types.js'
+import type { LexicalFieldAdminClientProps } from '../../../types.js'
 import type { SanitizedClientEditorConfig } from '../types.js'
 
 export const sanitizeClientFeatures = (
@@ -219,7 +219,7 @@ export const sanitizeClientFeatures = (
 export function sanitizeClientEditorConfig(
   resolvedClientFeatureMap: ResolvedClientFeatureMap,
   lexical?: LexicalEditorConfig,
-  admin?: LexicalFieldAdminProps,
+  admin?: LexicalFieldAdminClientProps,
 ): SanitizedClientEditorConfig {
   return {
     admin,

--- a/packages/richtext-lexical/src/lexical/config/types.ts
+++ b/packages/richtext-lexical/src/lexical/config/types.ts
@@ -10,7 +10,7 @@ import type {
   ResolvedServerFeatureMap,
   SanitizedServerFeatures,
 } from '../../features/typesServer.js'
-import type { LexicalFieldAdminProps } from '../../types.js'
+import type { LexicalFieldAdminClientProps } from '../../types.js'
 
 export type ServerEditorConfig = {
   features: FeatureProviderServer<any, any, any>[]
@@ -29,7 +29,7 @@ export type ClientEditorConfig = {
 }
 
 export type SanitizedClientEditorConfig = {
-  admin?: LexicalFieldAdminProps
+  admin?: LexicalFieldAdminClientProps
   features: SanitizedClientFeatures
   lexical: LexicalEditorConfig
   resolvedFeatureMap: ResolvedClientFeatureMap

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -98,7 +98,7 @@ export type FeatureClientSchemaMap = {
 }
 
 export type LexicalRichTextFieldProps = {
-  admin: LexicalFieldAdminProps
+  admin: LexicalFieldAdminClientProps
   // clientFeatures is added through the rsc field
   clientFeatures: {
     [featureKey: string]: {

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -98,7 +98,7 @@ export type FeatureClientSchemaMap = {
 }
 
 export type LexicalRichTextFieldProps = {
-  admin: LexicalFieldAdminClientProps
+  admin?: LexicalFieldAdminClientProps
   // clientFeatures is added through the rsc field
   clientFeatures: {
     [featureKey: string]: {

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -2,11 +2,13 @@ import type { EditorConfig as LexicalEditorConfig, SerializedEditorState } from 
 import type {
   ClientField,
   DefaultCellComponentProps,
+  LabelFunction,
   RichTextAdapter,
   RichTextFieldClient,
   RichTextFieldClientProps,
   SanitizedConfig,
   ServerFieldBase,
+  StaticLabel,
 } from 'payload'
 
 import type {
@@ -25,8 +27,12 @@ export type LexicalFieldAdminProps = {
   /**
    * Changes the placeholder text in the editor if no content is present.
    */
-  placeholder?: string
+  placeholder?: LabelFunction | StaticLabel
 }
+
+export type LexicalFieldAdminClientProps = {
+  placeholder?: string
+} & Omit<LexicalFieldAdminProps, 'placeholder'>
 
 export type LexicalEditorProps = {
   admin?: LexicalFieldAdminProps


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes a minor issue in `richtext-lexical` where editor placeholders were not localized.

### Why?
To allow users to localize placeholders accordingly with their language preferences in config.

### How?
By evaluating the placeholder in the editor RSC, if any is provided. The `ContentEditable` component falls back to a default in the event that no placeholder was provided as this was the existing behavior.

Fixes #10518