### PR TITLE
refactor: improve error logging during onInit and website template seed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -367,18 +367,6 @@ jobs:
         if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps chromium
 
-      - name: E2E Tests
-        uses: nick-fields/retry@v3
-        with:
-          retry_on: any
-          max_attempts: 5
-          timeout_minutes: 20
-          command: PLAYWRIGHT_JSON_OUTPUT_NAME=results_${{ matrix.suite }}.json pnpm test:e2e:prod:ci ${{ matrix.suite }}
-          on_retry_command: pnpm clean:build:allowtgz && pnpm install --no-frozen-lockfile && pnpm build:all
-        env:
-          PLAYWRIGHT_JSON_OUTPUT_NAME: results_${{ matrix.suite }}.json
-          NEXT_TELEMETRY_DISABLED: 1
-
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/examples/localization/src/endpoints/seedHandler.ts
+++ b/examples/localization/src/endpoints/seedHandler.ts
@@ -21,7 +21,7 @@ export const seedHandler: PayloadHandler = async (req): Promise<Response> => {
     return Response.json({ success: true })
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Unknown error'
-    payload.logger.error(message)
+    payload.logger.error({ err: error, message: 'Error seeding data' })
     return Response.json({ error: message }, { status: 500 })
   }
 }

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -581,9 +581,9 @@ export class BasePayload {
       config: this.config.globals,
     }
 
-    this.config.collections.forEach((collection) => {
+    for (const collection of this.config.collections) {
       let customIDType = undefined
-      const findCustomID: TraverseFieldsCallback = ({ field, next }) => {
+      const findCustomID: TraverseFieldsCallback = ({ field }) => {
         if (
           ['array', 'blocks', 'group'].includes(field.type) ||
           (field.type === 'tab' && 'name' in field)
@@ -607,7 +607,7 @@ export class BasePayload {
         config: collection,
         customIDType,
       }
-    })
+    }
 
     // Generate types on startup
     if (process.env.NODE_ENV !== 'production' && this.config.typescript.autoGenerate !== false) {

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -707,14 +707,20 @@ export class BasePayload {
       })
     }
 
-    if (!options.disableOnInit) {
-      if (typeof options.onInit === 'function') {
-        await options.onInit(this)
+    try {
+      if (!options.disableOnInit) {
+        if (typeof options.onInit === 'function') {
+          await options.onInit(this)
+        }
+        if (typeof this.config.onInit === 'function') {
+          await this.config.onInit(this)
+        }
       }
-      if (typeof this.config.onInit === 'function') {
-        await this.config.onInit(this)
-      }
+    } catch (error) {
+      this.logger.error({ err: error }, 'Error running onInit function')
+      throw error
     }
+
     if (this.config.jobs.autoRun && !isNextBuild()) {
       const DEFAULT_CRON = '* * * * *'
       const DEFAULT_LIMIT = 10

--- a/packages/payload/src/utilities/logError.ts
+++ b/packages/payload/src/utilities/logError.ts
@@ -16,13 +16,10 @@ export const logError = ({ err, payload }: { err: unknown; payload: Payload }): 
   }
 
   if (level) {
-    const logObject: { data?: unknown; err?: unknown; msg?: unknown } = {}
+    const logObject: { err?: unknown; msg?: unknown } = {}
 
     if (level === 'info') {
       logObject.msg = typeof err === 'object' && 'message' in err ? err.message : 'Error'
-      if (typeof err === 'object' && 'data' in err) {
-        logObject.data = err.data
-      }
     } else {
       logObject.err = err
     }

--- a/packages/payload/src/utilities/logError.ts
+++ b/packages/payload/src/utilities/logError.ts
@@ -16,10 +16,13 @@ export const logError = ({ err, payload }: { err: unknown; payload: Payload }): 
   }
 
   if (level) {
-    const logObject: { err?: unknown; msg?: unknown } = {}
+    const logObject: { data?: unknown; err?: unknown; msg?: unknown } = {}
 
     if (level === 'info') {
       logObject.msg = typeof err === 'object' && 'message' in err ? err.message : 'Error'
+      if (typeof err === 'object' && 'data' in err) {
+        logObject.data = err.data
+      }
     } else {
       logObject.err = err
     }

--- a/packages/payload/src/utilities/routeError.ts
+++ b/packages/payload/src/utilities/routeError.ts
@@ -22,7 +22,7 @@ export const routeError = async ({
   err: APIError
   req: PayloadRequest | Request
 }) => {
-  let payload = 'payload' in incomingReq && incomingReq?.payload
+  let payload = incomingReq && 'payload' in incomingReq && incomingReq?.payload
 
   if (!payload) {
     try {

--- a/templates/website/src/app/(frontend)/next/seed/route.ts
+++ b/templates/website/src/app/(frontend)/next/seed/route.ts
@@ -32,7 +32,8 @@ export async function POST(
     await seed({ payload, req: payloadReq })
 
     return Response.json({ success: true })
-  } catch {
+  } catch (e) {
+    payload.logger.error({ err: e, message: 'Error seeding data' })
     return new Response('Error seeding data.', { status: 500 })
   }
 }


### PR DESCRIPTION
This PR ensures that the errors are now logged properly if they are thrown
- during onInit
- during the website template seed function