### PR TITLE
feat(richtext-lexical): add new paragraph button below the editor

### DIFF
--- a/docs/rich-text/overview.mdx
+++ b/docs/rich-text/overview.mdx
@@ -305,6 +305,8 @@ The Rich Text Field editor configuration has an `admin` property with the follow
 | --- | --- |
 |   **`placeholder`**                |   Set this property to define a placeholder string for the field.                                                                          |
 |   **`hideGutter`**                 |   Set this property to `true` to hide this field's gutter within the Admin Panel.                                                          |
+|   **`hideInsertParagraphAtEnd`**   |   Set this property to `true` to hide the "+" button that appears at the end of the editor                                                 |
+
 
 ### Disable the gutter
 

--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.scss
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.scss
@@ -90,7 +90,7 @@
     &__tableAddColumns,
     &__tableAddRows {
       position: absolute;
-      background-color: var(--theme-elevation-100);
+      background-color: var(--theme-elevation-50);
       animation: table-controls 0.2s ease;
       border: 0;
       cursor: pointer;
@@ -100,17 +100,18 @@
 
     &__tableAddColumns:after,
     &__tableAddRows:after {
-      background-image: url(../../../../../lexical/ui/icons/Add/index.svg);
-      background-position: center;
-      background-repeat: no-repeat;
-      display: block;
-      content: ' ';
+      display: flex;
+      content: '+';
+      font-size: 1.5rem;
+      border-radius: $style-radius-s;
+      justify-content: center;
+      align-items: center;
       position: absolute;
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
-      opacity: 0.4;
+      color: var(--theme-elevation-500);
     }
 
     &__tableAddColumns:hover,
@@ -176,11 +177,6 @@
       &__tableCellSelected::after {
         background-color: var(--color-success-700);
         mix-blend-mode: screen;
-      }
-
-      &__tableAddColumns:after,
-      &__tableAddRows:after {
-        background-image: url(../../../../../lexical/ui/icons/Add/light.svg);
       }
     }
   }

--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.scss
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TablePlugin/index.scss
@@ -90,7 +90,7 @@
     &__tableAddColumns,
     &__tableAddRows {
       position: absolute;
-      background-color: var(--theme-elevation-50);
+      background-color: var(--theme-elevation-100);
       animation: table-controls 0.2s ease;
       border: 0;
       cursor: pointer;
@@ -102,7 +102,7 @@
     &__tableAddRows:after {
       display: flex;
       content: '+';
-      font-size: 1.5rem;
+      font-size: 1.4rem;
       border-radius: $style-radius-s;
       justify-content: center;
       align-items: center;
@@ -116,7 +116,7 @@
 
     &__tableAddColumns:hover,
     &__tableAddRows:hover {
-      background-color: var(--theme-elevation-200);
+      background-color: var(--theme-elevation-150);
     }
 
     &__tableAddRows {
@@ -177,6 +177,16 @@
       &__tableCellSelected::after {
         background-color: var(--color-success-700);
         mix-blend-mode: screen;
+      }
+
+      &__tableAddColumns,
+      &__tableAddRows {
+        background-color: var(--theme-elevation-50);
+      }
+
+      &__tableAddColumns:hover,
+      &__tableAddRows:hover {
+        background-color: var(--theme-elevation-100);
       }
     }
   }

--- a/packages/richtext-lexical/src/lexical/LexicalEditor.tsx
+++ b/packages/richtext-lexical/src/lexical/LexicalEditor.tsx
@@ -4,7 +4,13 @@ import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary.js'
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin.js'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin.js'
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin.js'
-import { BLUR_COMMAND, COMMAND_PRIORITY_LOW, FOCUS_COMMAND } from 'lexical'
+import {
+  $createParagraphNode,
+  $getRoot,
+  BLUR_COMMAND,
+  COMMAND_PRIORITY_LOW,
+  FOCUS_COMMAND,
+} from 'lexical'
 import * as React from 'react'
 import { useEffect, useState } from 'react'
 
@@ -15,6 +21,7 @@ import { EditorPlugin } from './EditorPlugin.js'
 import './LexicalEditor.scss'
 import { AddBlockHandlePlugin } from './plugins/handles/AddBlockHandlePlugin/index.js'
 import { DraggableBlockPlugin } from './plugins/handles/DraggableBlockPlugin/index.js'
+import { InsertParagraphAtEndPlugin } from './plugins/InsertParagraphAtEnd/index.js'
 import { MarkdownShortcutPlugin } from './plugins/MarkdownShortcut/index.js'
 import { SlashMenuPlugin } from './plugins/SlashMenu/index.js'
 import { TextPlugin } from './plugins/TextPlugin/index.js'
@@ -121,6 +128,7 @@ export const LexicalEditor: React.FC<
           }
           ErrorBoundary={LexicalErrorBoundary}
         />
+        <InsertParagraphAtEndPlugin />
         <TextPlugin features={editorConfig.features} />
         <OnChangePlugin
           // Selection changes can be ignored here, reducing the

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
@@ -14,8 +14,6 @@
     position: relative;
     padding: 4px 0px 2px 0px;
 
-    // background transition:
-
     &-inside {
       width: 100%;
       height: 100%;

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
@@ -21,7 +21,8 @@
       transition: background-color 0.1s ease-in-out;
       display: flex;
       justify-content: center;
-      border-radius: $style-radius-m;
+      border-radius: $style-radius-s;
+      color: var(--theme-elevation-500);
 
       span {
         display: none;

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
@@ -1,0 +1,47 @@
+@import '../../../scss/styles';
+
+@layer payload-default {
+  .rich-text-lexical--show-gutter {
+    .insert-paragraph-at-end {
+      padding: 4px 0px 2px 40px;
+    }
+  }
+  .insert-paragraph-at-end {
+    height: 24px;
+    margin-top: -16px;
+    width: 100%;
+    z-index: 2;
+    position: relative;
+    padding: 4px 0px 2px 0px;
+
+    // background transition:
+
+    &-inside {
+      width: 100%;
+      height: 100%;
+      background-color: var(--theme-elevation-0);
+      transition: background-color 0.1s ease-in-out;
+      display: flex;
+      justify-content: center;
+      border-radius: $style-radius-m;
+
+      span {
+        display: none;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+
+    &:hover {
+      cursor: pointer;
+
+      .insert-paragraph-at-end-inside {
+        background-color: var(--theme-elevation-50);
+
+        span {
+          display: flex;
+        }
+      }
+    }
+  }
+}

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
@@ -35,11 +35,19 @@
       cursor: pointer;
 
       .insert-paragraph-at-end-inside {
-        background-color: var(--theme-elevation-50);
+        background-color: var(--theme-elevation-100);
 
         span {
           display: flex;
         }
+      }
+    }
+  }
+
+  html[data-theme='dark'] {
+    .insert-paragraph-at-end:hover {
+      .insert-paragraph-at-end-inside {
+        background-color: var(--theme-elevation-50);
       }
     }
   }

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
@@ -17,7 +17,7 @@
     &-inside {
       width: 100%;
       height: 100%;
-      background-color: var(--theme-elevation-0);
+      background-color: transparent;
       transition: background-color 0.1s ease-in-out;
       display: flex;
       justify-content: center;

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { $createParagraphNode, $getRoot } from 'lexical'
+
+import './index.scss'
+import { useEditorConfigContext } from '../../config/client/EditorConfigProvider.js'
+const baseClass = 'insert-paragraph-at-end'
+
+export const InsertParagraphAtEndPlugin: React.FC = () => {
+  const [editor] = useLexicalComposerContext()
+  const { editorConfig } = useEditorConfigContext()
+
+  if (editorConfig?.admin?.hideInsertParagraphAtEnd) {
+    return null
+  }
+
+  const onClick = () => {
+    editor.update(() => {
+      const pNode = $createParagraphNode()
+      $getRoot().append(pNode)
+    })
+  }
+
+  return (
+    <div aria-label="Insert Paragraph" className={baseClass} onClick={onClick}>
+      <div className={`${baseClass}-inside`}>
+        <span>+</span>
+      </div>
+    </div>
+  )
+}

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 'use client'
 
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.tsx
@@ -2,6 +2,7 @@
 
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { $createParagraphNode, $getRoot } from 'lexical'
+import React from 'react'
 
 import './index.scss'
 import { useEditorConfigContext } from '../../config/client/EditorConfigProvider.js'

--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.tsx
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.tsx
@@ -20,8 +20,9 @@ export const InsertParagraphAtEndPlugin: React.FC = () => {
 
   const onClick = () => {
     editor.update(() => {
-      const pNode = $createParagraphNode()
-      $getRoot().append(pNode)
+      const paragraphNode = $createParagraphNode()
+      $getRoot().append(paragraphNode)
+      paragraphNode.select()
     })
   }
 

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -25,6 +25,10 @@ export type LexicalFieldAdminProps = {
    */
   hideGutter?: boolean
   /**
+   * Controls if the insert paragraph at the end button should be hidden. @default false
+   */
+  hideInsertParagraphAtEnd?: boolean
+  /**
    * Changes the placeholder text in the editor if no content is present.
    */
   placeholder?: LabelFunction | StaticLabel


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/10448. If the last node in an editor was a block, the only way to add a paragraph below that block was to click the "+" button on the left hand-side of the editor.

This was not apparent enough for most users - thus this PR adds a more prominent, accessible "+" button that appear when hovering close to the end of the editor. This should make it easier to insert additional paragraphs, no matter what the last node is.

## See it in action

https://github.com/user-attachments/assets/dfcd4ab6-8e41-4a1b-b642-876a0737d9ae

