### PR TITLE
fix(richtext-lexical): editor placeholder had incorrect padding set for small viewports

### DIFF
--- a/packages/richtext-lexical/src/lexical/LexicalEditor.tsx
+++ b/packages/richtext-lexical/src/lexical/LexicalEditor.tsx
@@ -23,9 +23,10 @@ import { LexicalContentEditable } from './ui/ContentEditable.js'
 export const LexicalEditor: React.FC<
   {
     editorContainerRef: React.RefObject<HTMLDivElement | null>
+    isSmallWidthViewport: boolean
   } & Pick<LexicalProviderProps, 'editorConfig' | 'onChange'>
 > = (props) => {
-  const { editorConfig, editorContainerRef, onChange } = props
+  const { editorConfig, editorContainerRef, isSmallWidthViewport, onChange } = props
   const editorConfigContext = useEditorConfigContext()
   const [editor] = useLexicalComposerContext()
 
@@ -77,24 +78,6 @@ export const LexicalEditor: React.FC<
       editorConfigContext.parentEditor?.unregisterChild?.(editorConfigContext.uuid)
     }
   }, [editor, editorConfigContext])
-
-  const [isSmallWidthViewport, setIsSmallWidthViewport] = useState<boolean>(false)
-
-  useEffect(() => {
-    const updateViewPortWidth = () => {
-      const isNextSmallWidthViewport = window.matchMedia('(max-width: 768px)').matches
-
-      if (isNextSmallWidthViewport !== isSmallWidthViewport) {
-        setIsSmallWidthViewport(isNextSmallWidthViewport)
-      }
-    }
-    updateViewPortWidth()
-    window.addEventListener('resize', updateViewPortWidth)
-
-    return () => {
-      window.removeEventListener('resize', updateViewPortWidth)
-    }
-  }, [isSmallWidthViewport])
 
   return (
     <React.Fragment>

--- a/packages/richtext-lexical/src/lexical/LexicalProvider.tsx
+++ b/packages/richtext-lexical/src/lexical/LexicalProvider.tsx
@@ -21,6 +21,7 @@ export type LexicalProviderProps = {
   composerKey: string
   editorConfig: SanitizedClientEditorConfig
   fieldProps: LexicalRichTextFieldProps
+  isSmallWidthViewport: boolean
   onChange: (editorState: EditorState, editor: LexicalEditor, tags: Set<string>) => void
   readOnly: boolean
   value: SerializedEditorState
@@ -49,7 +50,8 @@ const NestProviders = ({
 }
 
 export const LexicalProvider: React.FC<LexicalProviderProps> = (props) => {
-  const { composerKey, editorConfig, fieldProps, onChange, readOnly, value } = props
+  const { composerKey, editorConfig, fieldProps, isSmallWidthViewport, onChange, readOnly, value } =
+    props
 
   const parentContext = useEditorConfigContext()
 
@@ -113,6 +115,7 @@ export const LexicalProvider: React.FC<LexicalProviderProps> = (props) => {
           <LexicalEditorComponent
             editorConfig={editorConfig}
             editorContainerRef={editorContainerRef}
+            isSmallWidthViewport={isSmallWidthViewport}
             onChange={onChange}
           />
         </NestProviders>

--- a/packages/richtext-lexical/src/lexical/ui/ContentEditable.scss
+++ b/packages/richtext-lexical/src/lexical/ui/ContentEditable.scss
@@ -12,7 +12,8 @@ $lexical-contenteditable-bottom-padding: 8px;
     outline: 0;
     padding-top: $lexical-contenteditable-top-padding;
     padding-bottom: $lexical-contenteditable-bottom-padding;
-    //min-height: base(10);
+    padding-left: 0;
+    padding-right: 0;
 
     &:focus-visible {
       outline: none !important;
@@ -24,32 +25,23 @@ $lexical-contenteditable-bottom-padding: 8px;
     }
   }
 
-  @media (max-width: 768px) {
-    .ContentEditable__root {
-      padding-left: 0;
-      padding-right: 0;
+  .rich-text-lexical--show-gutter
+    > .rich-text-lexical__wrap
+    > .editor-container
+    > .editor-scroller
+    > .editor {
+    > .ContentEditable__root {
+      padding-left: 3rem;
     }
-  }
-
-  @media (min-width: 769px) {
-    .rich-text-lexical--show-gutter
-      > .rich-text-lexical__wrap
-      > .editor-container
-      > .editor-scroller
-      > .editor {
-      > .ContentEditable__root {
-        padding-left: 3rem;
-      }
-      > .ContentEditable__root::before {
-        content: ' ';
-        position: absolute;
-        top: $lexical-contenteditable-top-padding;
-        left: 0;
-        height: calc(
-          100% - #{$lexical-contenteditable-top-padding} - #{$lexical-contenteditable-bottom-padding}
-        );
-        border-left: 1px solid var(--theme-elevation-100);
-      }
+    > .ContentEditable__root::before {
+      content: ' ';
+      position: absolute;
+      top: $lexical-contenteditable-top-padding;
+      left: 0;
+      height: calc(
+        100% - #{$lexical-contenteditable-top-padding} - #{$lexical-contenteditable-bottom-padding}
+      );
+      border-left: 1px solid var(--theme-elevation-100);
     }
   }
 


### PR DESCRIPTION
On small viewports, we hide the gutter on the left side to save on space. However, we did not account for adjusting the padding of the editor placeholder.

## Before
![CleanShot 2025-01-12 at 19 01 56@2x](https://github.com/user-attachments/assets/7f35bb0f-0dad-4976-8205-feef3a073914)

## After
![CleanShot 2025-01-12 at 18 59 36@2x](https://github.com/user-attachments/assets/0b34caea-f7bf-4312-a4bb-de508d2c056c)
