### PR TITLE
fix(ui): table custom label missing client field props

### DIFF
--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -165,7 +165,7 @@ export const buildColumnState = (args: Args): Column[] => {
         : undefined
 
     const CustomLabel = CustomLabelToRender
-      ? RenderServerComponent({ Component: CustomLabelToRender, importMap: payload.importMap })
+      ? RenderServerComponent({ Component: CustomLabelToRender, importMap: payload.importMap, clientProps: { field } })
       : undefined
 
     const fieldAffectsDataSubFields =

--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -164,8 +164,18 @@ export const buildColumnState = (args: Args): Column[] => {
         ? _field.admin.components.Label
         : undefined
 
+    const customLabelClientProps: {
+      field: ClientField
+    } = {
+      field,
+    }
+
     const CustomLabel = CustomLabelToRender
-      ? RenderServerComponent({ Component: CustomLabelToRender, importMap: payload.importMap, clientProps: { field } })
+      ? RenderServerComponent({
+          clientProps: customLabelClientProps,
+          Component: CustomLabelToRender,
+          importMap: payload.importMap,
+        })
       : undefined
 
     const fieldAffectsDataSubFields =

--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -1,6 +1,7 @@
 import type { I18nClient } from '@payloadcms/translations'
 import type {
   ClientCollectionConfig,
+  ClientComponentProps,
   ClientField,
   DefaultCellComponentProps,
   DefaultServerCellComponentProps,
@@ -164,15 +165,14 @@ export const buildColumnState = (args: Args): Column[] => {
         ? _field.admin.components.Label
         : undefined
 
-    const customLabelClientProps: {
-      field: ClientField
-    } = {
+    // TODO: customComponent will be optional in v4
+    const clientProps: Omit<ClientComponentProps, 'customComponents'> = {
       field,
     }
 
     const CustomLabel = CustomLabelToRender
       ? RenderServerComponent({
-          clientProps: customLabelClientProps,
+          clientProps,
           Component: CustomLabelToRender,
           importMap: payload.importMap,
         })


### PR DESCRIPTION
Fixes #9663. The `field` prop was not passed to custom label components within the list view table. 

<img width="1366" alt="Screenshot 2025-01-13 at 16 05 34" src="https://github.com/user-attachments/assets/efae9f92-ffad-46dd-aec8-e1f968f9f278" />
