### PR TITLE
fix: use `depth: 0` in `findOperation`

### DIFF
--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -196,7 +196,7 @@ export const findOperation = async <
 
         const lockedDocuments = await payload.find({
           collection: 'payload-locked-documents',
-          depth: 1,
+          depth: 0,
           limit: sanitizedLimit,
           overrideAccess: false,
           pagination: false,

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -162,7 +162,7 @@ export const findByIDOperation = async <
 
         const lockedDocument = await req.payload.find({
           collection: 'payload-locked-documents',
-          depth: 1,
+          depth: 0,
           limit: 1,
           overrideAccess: false,
           pagination: false,

--- a/packages/ui/src/utilities/handleFormStateLocking.ts
+++ b/packages/ui/src/utilities/handleFormStateLocking.ts
@@ -59,7 +59,7 @@ export const handleFormStateLocking = async ({
 
       const lockedDocument = await req.payload.find({
         collection: 'payload-locked-documents',
-        depth: 1,
+        depth: 0,
         limit: 1,
         overrideAccess: false,
         pagination: false,


### PR DESCRIPTION
### What?
In `findOperation` we used, probably accidentally `depth: 1`. Not only that it can cause huge performance problems, it also leads to another bug that this is never `true`, since `value` is an object.
https://github.com/payloadcms/payload/blob/415fbf1341feded9ff646301511eaaa7969cda10/packages/payload/src/collections/operations/find.ts#L236