### PR TITLE
docs: updates docs to reflect correct array hook usage

### DIFF
--- a/docs/admin/hooks.mdx
+++ b/docs/admin/hooks.mdx
@@ -397,12 +397,17 @@ export const CustomArrayManager = () => {
       onClick={() => {
         addFieldRow({
           path: "arrayField",
-          rowIndex: 0,
-          data: {
-            textField: "text",
-            // blockType: "yourBlockSlug",
-            // ^ if managing a block array, you need to specify the block type
+          schemaPath: "arrayField",
+          rowIndex: 0, // optionally specify the index to add the row at
+          subFieldState: {
+            textField: {
+              initialValue: 'New row text',
+              valid: true,
+              value: 'New row text',
+            },
           },
+          // blockType: "yourBlockSlug",
+          // ^ if managing a block array, you need to specify the block type
         })
       }}
     >
@@ -595,12 +600,17 @@ export const CustomArrayManager = () => {
       onClick={() => {
         replaceFieldRow({
           path: "arrayField",
-          rowIndex: 0,
-          data: {
-            textField: "updated text",
-            // blockType: "yourBlockSlug",
-            // ^ if managing a block array, you need to specify the block type
+          schemaPath: "arrayField",
+          rowIndex: 0, // optionally specify the index to add the row at
+          subFieldState: {
+            textField: {
+              initialValue: 'Updated text',
+              valid: true,
+              value: 'Upddated text',
+            },
           },
+          // blockType: "yourBlockSlug",
+          // ^ if managing a block array, you need to specify the block type
         })
       }}
     >


### PR DESCRIPTION
### What?
The documentation for `addFieldRow` and `replaceFieldRow` was not updated during the v2 -> v3 update.

### How?
Updates the documentation for `addFieldRow` and `replaceFieldRow`.

Fixes #9244 
