### PR TITLE
fix(ui): passes serverProps to custom label components within table columns

### DIFF
--- a/packages/ui/src/elements/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/elements/TableColumns/buildColumnState.tsx
@@ -10,6 +10,7 @@ import type {
   PaginatedDocs,
   Payload,
   SanitizedCollectionConfig,
+  ServerComponentProps,
   StaticLabel,
 } from 'payload'
 
@@ -170,11 +171,23 @@ export const buildColumnState = (args: Args): Column[] => {
       field,
     }
 
+    const serverProps: Pick<
+      ServerComponentProps,
+      'clientField' | 'collectionSlug' | 'field' | 'i18n' | 'payload'
+    > = {
+      clientField: field,
+      collectionSlug: collectionConfig.slug,
+      field: _field,
+      i18n,
+      payload,
+    }
+
     const CustomLabel = CustomLabelToRender
       ? RenderServerComponent({
           clientProps,
           Component: CustomLabelToRender,
           importMap: payload.importMap,
+          serverProps,
         })
       : undefined
 
@@ -199,12 +212,6 @@ export const buildColumnState = (args: Args): Column[] => {
       customCellProps,
       field,
       rowData: undefined,
-    }
-
-    const serverProps: Pick<DefaultServerCellComponentProps, 'field' | 'i18n' | 'payload'> = {
-      field: _field,
-      i18n,
-      payload,
     }
 
     const column: Column = {


### PR DESCRIPTION
Continuation of #10540. Passes server props to custom label components rendered within table columns, such as the list view. This way custom server components can have access to `payload`, `i18n`, etc. as expected.