### PR TITLE
fix: better messaging when no arg passed to payload cli

### DIFF
--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { Cron } from 'croner'
 import minimist from 'minimist'
 import { pathToFileURL } from 'node:url'
@@ -11,7 +12,18 @@ import { generateImportMap } from './generateImportMap/index.js'
 import { generateTypes } from './generateTypes.js'
 import { info } from './info.js'
 import { loadEnv } from './loadEnv.js'
-import { migrate } from './migrate.js'
+import { migrate, availableCommands as migrateCommands } from './migrate.js'
+
+// Note: this does not account for any user bin scripts
+const availableScripts = [
+  'generate:db-schema',
+  'generate:importmap',
+  'generate:types',
+  'info',
+  'jobs:run',
+  'run',
+  ...migrateCommands,
+] as const
 
 export const bin = async () => {
   loadEnv()
@@ -137,6 +149,8 @@ export const bin = async () => {
     process.exit(0)
   }
 
-  console.error(`Unknown script: "${script}".`)
+  console.error(script ? `Unknown command: "${script}"` : 'Please provide a command to run')
+  console.log(`\nAvailable commands:\n${availableScripts.map((c) => `  - ${c}`).join('\n')}`)
+
   process.exit(1)
 }

--- a/packages/payload/src/bin/migrate.ts
+++ b/packages/payload/src/bin/migrate.ts
@@ -14,7 +14,7 @@ const prettySyncLogger = {
   loggerOptions: {},
 }
 
-const availableCommands = [
+export const availableCommands = [
   'migrate',
   'migrate:create',
   'migrate:down',


### PR DESCRIPTION
Better error message when no argument is passed to `pnpm payload`.

Before:
```
Unknown script: "".
```

After:
```
Please provide a command to run
Available commands:
  - command-1
  - command-2
  - etc.
```