### PR TITLE
fix(ui): reset pagination when typing in WhereBuilder select menu

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -208,14 +208,11 @@ export const RelationshipField: React.FC<Props> = (props) => {
     return undefined
   }, [hasMany, hasMultipleRelations, value, options])
 
-  const handleInputChange = useCallback(
-    (newSearch) => {
-      if (search !== newSearch) {
-        setSearch(newSearch)
-      }
-    },
-    [search],
-  )
+  const handleInputChange = (input: string) => {
+    const relationSlug = partiallyLoadedRelationshipSlugs.current[0]
+    nextPageByRelationshipRef.current.set(relationSlug, 1)
+    setSearch(input)
+  }
 
   const addOptionByID = useCallback(
     async (id, relation) => {


### PR DESCRIPTION
After working on this I found a more accurate way to reproduce the bug:

- in the issue repro, type a letter in the select menu.
- delete the letter and wait for the debounce (300ms)
- type another letter.
- in devtools, you should see that the query increases the pagination by +1. With this change, the pagination is reset when the input changes.

Fixes #10496

I'd like to do integration testing. But since there is no isolated `/ui` test yet, this requires some planning. I have it pending.
