### PR TITLE
fix(richtext-lexical): insert paragraph at end button overlaps floating link toolbar

### DIFF
--- a/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
+++ b/packages/richtext-lexical/src/lexical/plugins/InsertParagraphAtEnd/index.scss
@@ -10,7 +10,7 @@
     height: 24px;
     margin-top: -16px;
     width: 100%;
-    z-index: 2;
+    z-index: 0;
     position: relative;
     padding: 4px 0px 2px 0px;
 


### PR DESCRIPTION
This adjusts the z-index of the new insert paragraph button, so that the floating link toolbar is displayed above the + button.

This happens if the last node contains a link, and that link is then focused, causing both the floating link toolbar and the insert paragraph button to appear while the mouse is hovering over the link toolbar.