### PR TITLE
fix(richtext-lexical): incorrect lexical version in dependency checker

### DIFF
--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -54,7 +54,7 @@ export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapte
             '@lexical/selection',
             '@lexical/utils',
           ],
-          targetVersion: '0.20.0',
+          targetVersion: '0.21.0',
         },
       ],
     })


### PR DESCRIPTION
Our previous lexical dependency version bump did not account for bumping the lexical version in the dependency checker.

This actually had no real world implications, as dependencies declared under `dependencyGroups` were only checked for version **mismatches**. However, this resulted in an incorrect version number being mentioned in the error message, thrown by version mismatches