### PR TITLE
chore(richtext-lexical): add unit test that ensures lexical dependency checker is updated

### DIFF
--- a/packages/richtext-lexical/src/dependencyChecker.spec.ts
+++ b/packages/richtext-lexical/src/dependencyChecker.spec.ts
@@ -1,0 +1,21 @@
+import { jest } from '@jest/globals'
+import { lexicalTargetVersion } from './index'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import fs from 'fs/promises'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+describe('Lexical dependency checker', () => {
+  it('ensure lexical version installed in package.json matches dependency checker version', async () => {
+    const packageJsonString = await fs.readFile(path.resolve(dirname, '../package.json'), 'utf-8')
+    const packageJson = JSON.parse(packageJsonString)
+    const packageJsonLexicalVersion = packageJson.dependencies['lexical']
+
+    expect(packageJsonLexicalVersion).toBe(lexicalTargetVersion)
+
+    const packageJsonLexicalPeerDepVersion = packageJson.peerDependencies['lexical']
+    expect(packageJsonLexicalPeerDepVersion).toBe(lexicalTargetVersion)
+  })
+})

--- a/packages/richtext-lexical/src/index.ts
+++ b/packages/richtext-lexical/src/index.ts
@@ -32,6 +32,8 @@ import { richTextValidateHOC } from './validate/index.js'
 
 let checkedDependencies = false
 
+export const lexicalTargetVersion = '0.21.0'
+
 export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapterProvider {
   if (
     process.env.NODE_ENV !== 'production' &&
@@ -54,7 +56,7 @@ export function lexicalEditor(props?: LexicalEditorProps): LexicalRichTextAdapte
             '@lexical/selection',
             '@lexical/utils',
           ],
-          targetVersion: '0.21.0',
+          targetVersion: lexicalTargetVersion,
         },
       ],
     })


### PR DESCRIPTION
This ensures that we don't accidentally forget to update the lexical version in our runtime dependency checker next time we update the lexical dependency.