### PR TITLE
fix(richtext-lexical): ensure jsx and html converters do not output linebreak if editor is empty

### DIFF
--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/index.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/index.tsx
@@ -5,6 +5,8 @@ import React from 'react'
 import type { SerializedBlockNode, SerializedInlineBlockNode } from '../../../../../nodeTypes.js'
 import type { JSXConverter, JSXConverters, SerializedLexicalNodeWithParent } from './types.js'
 
+import { hasText } from '../../../../../validate/hasText.js'
+
 export type ConvertLexicalToHTMLArgs = {
   converters: JSXConverters
   data: SerializedEditorState
@@ -18,7 +20,7 @@ export function convertLexicalToJSX({
   disableIndent,
   disableTextAlign,
 }: ConvertLexicalToHTMLArgs): React.ReactNode {
-  if (data?.root?.children?.length) {
+  if (hasText(data)) {
     return convertLexicalNodesToJSX({
       converters,
       disableIndent,

--- a/packages/richtext-lexical/src/features/converters/html/converter/index.ts
+++ b/packages/richtext-lexical/src/features/converters/html/converter/index.ts
@@ -5,6 +5,8 @@ import { createLocalReq } from 'payload'
 
 import type { HTMLConverter, SerializedLexicalNodeWithParent } from './types.js'
 
+import { hasText } from '../../../../validate/hasText.js'
+
 export type ConvertLexicalToHTMLArgs = {
   converters: HTMLConverter[]
   currentDepth?: number
@@ -53,7 +55,7 @@ export async function convertLexicalToHTML({
   req,
   showHiddenFields,
 }: ConvertLexicalToHTMLArgs): Promise<string> {
-  if (data?.root?.children?.length) {
+  if (hasText(data)) {
     if (req === undefined && payload) {
       req = await createLocalReq({}, payload)
     }


### PR DESCRIPTION
If you add text to the editor, then delete it using ctrl+a + delete, one empty paragraph that cannot be removed remains in the editor state.

In order to account for this, we have a `hasText()` function - this, however, was not used in our JSX and HTML converters. This caused the converters to incorrectly output a linebreak if said empty editor state was passed in.