### PR TITLE
perf(richtext-lexical): ensure internal link nodes do not store url field, and vice versa

### DIFF
--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/link.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/link.tsx
@@ -26,7 +26,7 @@ export const LinkJSXConverter: (args: {
     const rel: string | undefined = node.fields.newTab ? 'noopener noreferrer' : undefined
     const target: string | undefined = node.fields.newTab ? '_blank' : undefined
 
-    let href: string = node.fields.url
+    let href: string = node.fields.url ?? ''
     if (node.fields.linkType === 'internal') {
       if (internalDocToHref) {
         href = internalDocToHref({ linkNode: node })

--- a/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.tsx
+++ b/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.tsx
@@ -357,7 +357,7 @@ function handleBadNeighbors(
 
   if ($isAutoLinkNode(previousSibling)) {
     const isEmailURI = previousSibling.getFields()?.url
-      ? previousSibling.getFields()?.url?.startsWith('mailto:')
+      ? (previousSibling.getFields()?.url?.startsWith('mailto:') ?? false)
       : false
     if (!startsWithSeparator(text) || startsWithTLD(text, isEmailURI)) {
       previousSibling.append(textNode)

--- a/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/LinkNode.ts
@@ -35,10 +35,8 @@ export class LinkNode extends ElementNode {
   constructor({
     id,
     fields = {
-      doc: null,
       linkType: 'custom',
       newTab: false,
-      url: '',
     },
     key,
   }: {
@@ -127,10 +125,18 @@ export class LinkNode extends ElementNode {
   }
 
   exportJSON(): SerializedLinkNode {
+    const fields = this.getFields()
+
+    if (fields?.linkType === 'internal') {
+      delete fields.url
+    } else if (fields?.linkType === 'custom') {
+      delete fields.doc
+    }
+
     const returnObject: SerializedLinkNode = {
       ...super.exportJSON(),
       type: 'link',
-      fields: this.getFields(),
+      fields,
       version: 3,
     }
     const id = this.getID()

--- a/packages/richtext-lexical/src/features/link/nodes/types.ts
+++ b/packages/richtext-lexical/src/features/link/nodes/types.ts
@@ -3,7 +3,7 @@ import type { DefaultDocumentIDType, JsonValue } from 'payload'
 
 export type LinkFields = {
   [key: string]: JsonValue
-  doc: {
+  doc?: {
     relationTo: string
     value:
       | {
@@ -15,7 +15,7 @@ export type LinkFields = {
   } | null
   linkType: 'custom' | 'internal'
   newTab: boolean
-  url: string
+  url?: string
 }
 
 export type SerializedLinkNode<T extends SerializedLexicalNode = SerializedLexicalNode> = Spread<

--- a/packages/richtext-lexical/src/features/link/server/baseFields.ts
+++ b/packages/richtext-lexical/src/features/link/server/baseFields.ts
@@ -67,6 +67,10 @@ export const getBaseFields = (
       hooks: {
         beforeChange: [
           ({ value }) => {
+            if (!value) {
+              return
+            }
+
             if (!validateUrl(value)) {
               return encodeURIComponent(value)
             }
@@ -77,7 +81,10 @@ export const getBaseFields = (
       label: ({ t }) => t('fields:enterURL'),
       required: true,
       // @ts-expect-error - TODO: fix this
-      validate: (value: string) => {
+      validate: (value: string, options) => {
+        if (options?.siblingData?.linkType === 'internal') {
+          return // no validation needed, as no url should exist for internal links
+        }
         if (!validateUrlMinimal(value)) {
           return 'Invalid URL'
         }

--- a/packages/richtext-lexical/src/features/link/server/index.ts
+++ b/packages/richtext-lexical/src/features/link/server/index.ts
@@ -180,7 +180,7 @@ export const LinkFeature = createServerFeature<
                 const rel: string = node.fields.newTab ? ' rel="noopener noreferrer"' : ''
                 const target: string = node.fields.newTab ? ' target="_blank"' : ''
 
-                let href: string = node.fields.url
+                let href: string = node.fields.url ?? ''
                 if (node.fields.linkType === 'internal') {
                   href =
                     typeof node.fields.doc?.value !== 'object'


### PR DESCRIPTION
Previously, the url field of a link was stored and outputted despite the link being an internal link. This PR ensures that either the link url, or the link doc is stored and outputted - never both.