### PR TITLE
fix: missing find collection versions REST endpoint

### DIFF
--- a/packages/payload/src/collections/endpoints/index.ts
+++ b/packages/payload/src/collections/endpoints/index.ts
@@ -11,6 +11,7 @@ import { duplicateHandler } from './duplicate.js'
 import { findHandler } from './find.js'
 import { findByIDHandler } from './findByID.js'
 import { findVersionByIDHandler } from './findVersionByID.js'
+import { findVersionsHandler } from './findVersions.js'
 import { getFileHandler } from './getFile.js'
 import { previewHandler } from './preview.js'
 import { restoreVersionHandler } from './restoreVersion.js'
@@ -44,6 +45,11 @@ export const defaultCollectionEndpoints: Endpoint[] = [
       handler: docAccessHandler,
       method: 'post',
       path: '/access/:id?',
+    },
+    {
+      handler: findVersionsHandler,
+      method: 'get',
+      path: '/versions',
     },
     {
       handler: duplicateHandler,

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -1436,6 +1436,20 @@ describe('Versions', () => {
     })
   })
 
+  describe('Collections - REST', () => {
+    it('sholud query versions', async () => {
+      const response = await restClient.GET(`/${collection}/versions`)
+      expect(response.status).toBe(200)
+      const json = await response.json()
+      expect(json.docs[0].parent).toBe(collectionLocalPostID)
+
+      const responseByID = await restClient.GET(`/${collection}/versions/${json.docs[0].id}`)
+      expect(responseByID.status).toBe(200)
+      const jsonByID = await responseByID.json()
+      expect(jsonByID.parent).toBe(collectionLocalPostID)
+    })
+  })
+
   describe('Globals - Local', () => {
     beforeEach(async () => {
       const title2 = 'Here is an updated global title in EN'


### PR DESCRIPTION
The `/api/:collection/versions` endpoint was missing, added a test to prevent regressions like this.