### PR TITLE
fix: form state read access control args

### DIFF
--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -5,7 +5,6 @@ import type {
   Field,
   FieldSchemaMap,
   FieldState,
-  FormFieldWithoutComponents,
   FormState,
   FormStateWithoutComponents,
   PayloadRequest,
@@ -21,7 +20,6 @@ import {
   fieldIsHiddenOrDisabled,
   fieldIsID,
   fieldIsLocalized,
-  fieldIsSidebar,
   getFieldPaths,
   tabHasName,
 } from 'payload/shared'
@@ -160,7 +158,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       fieldPermissions === true || deepCopyObjectSimple(fieldPermissions?.read)
 
     if (typeof field?.access?.read === 'function') {
-      hasPermission = await field.access.read({ doc: fullData, req, siblingData: data })
+      hasPermission = await field.access.read({ id, data: fullData, req, siblingData: data })
     } else {
       hasPermission = true
     }


### PR DESCRIPTION
The `access.read` function executed within form state was missing the `id` arg, and was also incorrectly setting `data` as `doc`. When building form state, there is no concept of a "doc" because it is possible to build form state using only a subset of fields. There is "data", however, which represents the schema path at the entry point of the function. Similarly, when building form state on within an `onChange` function, for example, we do not send the original doc through the request, which is what "doc" would represent. Instead, we send either `data` or `formState`, both of which could represent a _modified_ doc. This particular invocation of read access does not effect the visibility of fields themselves, but rather their return values from the form state endpoint. Field visibility is determined at the request level.