### PR TITLE
chore: make TypeScript strict by default in packages and 7 packages stricter

### DIFF
--- a/packages/create-payload-app/tsconfig.json
+++ b/packages/create-payload-app/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+
+    /* TODO: remove the following lines */
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
   },
 }

--- a/packages/create-payload-app/tsconfig.json
+++ b/packages/create-payload-app/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "strict": true,
-
     /* TODO: remove the following lines */
     "noUncheckedIndexedAccess": false,
     "noImplicitOverride": false,

--- a/packages/db-mongodb/tsconfig.json
+++ b/packages/db-mongodb/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }, { "path": "../translations" }]
 }

--- a/packages/db-postgres/tsconfig.json
+++ b/packages/db-postgres/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [
     {
       "path": "../payload"

--- a/packages/db-sqlite/tsconfig.json
+++ b/packages/db-sqlite/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [
     {
       "path": "../payload"

--- a/packages/db-vercel-postgres/tsconfig.json
+++ b/packages/db-vercel-postgres/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [
     {
       "path": "../payload"

--- a/packages/drizzle/tsconfig.json
+++ b/packages/drizzle/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }, { "path": "../translations" }]
 }

--- a/packages/email-nodemailer/tsconfig.json
+++ b/packages/email-nodemailer/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true
-  },
   "references": [{ "path": "../payload" }]
 }

--- a/packages/email-resend/tsconfig.json
+++ b/packages/email-resend/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true
-  },
   "references": [{ "path": "../payload" }]
 }

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }]
 }

--- a/packages/live-preview-react/tsconfig.json
+++ b/packages/live-preview-react/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }]
 }

--- a/packages/live-preview-vue/tsconfig.json
+++ b/packages/live-preview-vue/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }] // db-mongodb depends on payload
 }

--- a/packages/live-preview/tsconfig.json
+++ b/packages/live-preview/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }]
 }

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [
     { "path": "../payload" },
     { "path": "../ui" },

--- a/packages/payload-cloud/tsconfig.json
+++ b/packages/payload-cloud/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true
-  },
   "references": [{ "path": "../payload" }]
 }

--- a/packages/payload/tsconfig.json
+++ b/packages/payload/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../translations" }]
 }

--- a/packages/plugin-cloud-storage/tsconfig.json
+++ b/packages/plugin-cloud-storage/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }]
 }

--- a/packages/plugin-form-builder/tsconfig.json
+++ b/packages/plugin-form-builder/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }, { "path": "../ui" }]
 }

--- a/packages/plugin-nested-docs/tsconfig.json
+++ b/packages/plugin-nested-docs/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }]
 }

--- a/packages/plugin-redirects/tsconfig.json
+++ b/packages/plugin-redirects/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }]
 }

--- a/packages/plugin-search/tsconfig.json
+++ b/packages/plugin-search/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }, { "path": "../ui" }, { "path": "../next" }]
 }

--- a/packages/plugin-seo/tsconfig.json
+++ b/packages/plugin-seo/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }, { "path": "../ui" }, { "path": "../next" }]
 }

--- a/packages/plugin-stripe/tsconfig.json
+++ b/packages/plugin-stripe/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }, { "path": "../ui" }, { "path": "../next" }]
 }

--- a/packages/richtext-lexical/tsconfig.json
+++ b/packages/richtext-lexical/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "strict": true,
-
     /* TODO: remove the following lines */
     "noUncheckedIndexedAccess": false,
     "noImplicitOverride": false

--- a/packages/richtext-lexical/tsconfig.json
+++ b/packages/richtext-lexical/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "strictNullChecks": true,
-    "noImplicitAny": true,
-    "strict": true
+    "strict": true,
+
+    /* TODO: remove the following lines */
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false
   },
   "references": [
     { "path": "../payload" },

--- a/packages/richtext-slate/tsconfig.json
+++ b/packages/richtext-slate/tsconfig.json
@@ -6,7 +6,12 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
   },
   "exclude": [
     "dist",

--- a/packages/storage-azure/tsconfig.json
+++ b/packages/storage-azure/tsconfig.json
@@ -6,7 +6,10 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
-    "strict": true
+
+    /* TODO: remove the following lines */
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
   },
   "exclude": ["dist", "node_modules"],
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "src/**/*.json"],

--- a/packages/storage-gcs/tsconfig.json
+++ b/packages/storage-gcs/tsconfig.json
@@ -6,7 +6,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
-    "strict": true
   },
   "exclude": ["dist", "node_modules"],
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "src/**/*.json"],

--- a/packages/storage-uploadthing/tsconfig.json
+++ b/packages/storage-uploadthing/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }, { "path": "../plugin-cloud-storage" }]
 }

--- a/packages/translations/tsconfig.json
+++ b/packages/translations/tsconfig.json
@@ -1,3 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": false,
+  },
   "references": [{ "path": "../payload" }, { "path": "../translations" }]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    /* Strictness */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
     "composite": true,
     "declaration": true,
     "declarationMap": true,
@@ -21,14 +25,13 @@
     "types": ["jest", "node", "@types/jest"],
     "incremental": true,
     "isolatedModules": true,
-    "strict": false,
     "plugins": [
       {
         "name": "next"
       }
     ],
     "paths": {
-      "@payload-config": ["./test/field-perf/config.ts"],
+      "@payload-config": ["./test/_community/config.ts"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
       "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -32,7 +32,7 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/_community/config.ts"],
+      "@payload-config": ["./test/field-perf/config.ts"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
       "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
+
     "composite": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
This PR modifies `tsconfig.base.json` by setting the following strictness properties to true: `strict`, `noUncheckedIndexedAccess` and `noImplicitOverride`.

In packages where compilation errors were observed, these settings were opted out, and TODO comments were added to make it easier to track the roadmap for converting everything to strict mode.

The following packages now have increased strictness, which prevents new errors from being accidentally introduced:

- storage-vercel-blob
- storage-s3*
- storage-gcs
- plugin-sentry
- payload-cloud*
- email-resend*
- email-nodemailer*

*These packages already had `strict: true`, but now have `noUncheckedIndexedAccess` and `noImplicitOverride`.

Note that this only affects the `/packages` folder, but not `/templates`, `/test` or `/examples` which have a different `tsconfig`.
