### PR TITLE
fix(richtext-lexical): setting hideInsertParagraphAtEnd to true did not hide insert paragraph button

### DIFF
--- a/packages/richtext-lexical/src/field/rscEntry.tsx
+++ b/packages/richtext-lexical/src/field/rscEntry.tsx
@@ -81,6 +81,9 @@ export const RscEntryLexicalField: React.FC<
   if (args.admin?.hideGutter) {
     admin.hideGutter = true
   }
+  if (args.admin?.hideInsertParagraphAtEnd) {
+    admin.hideInsertParagraphAtEnd = true
+  }
 
   const props: LexicalRichTextFieldProps = {
     clientFeatures,


### PR DESCRIPTION
The `hideInsertParagraphAtEnd` property was not functional. While the client-side check was there, we were not sending the configured `hideInsertParagraphAtEnd` property from the server config to the client