### PR TITLE
chore: make TypeScript strict in test folder. Simplify tsconfig

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "compilerOptions": {
+    /* Strictness */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
     "noEmit": true,
     "rootDir": ".",
-    "declaration": true,
-    "declarationMap": true,
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
@@ -12,20 +15,10 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "preserve",
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ES2022"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "types": [
-      "jest",
-      "node",
-      "@types/jest"
-    ],
+    "types": ["jest", "node", "@types/jest"],
     "incremental": true,
     "isolatedModules": true,
     "plugins": [
@@ -35,9 +28,7 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@payload-config": [
-        "./_community/config.ts"
-      ]
+      "@payload-config": ["./_community/config.ts"]
     }
   },
   "exclude": [
@@ -48,12 +39,6 @@
     "dist/**/*.js",
     "**/dist/**/*.js"
   ],
-  "include": [
-    "./**/*.ts",
-    "./**/*.tsx",
-    "next-env.d.ts",
-    ".next/types/**/*.ts",
-    "setup.js"
-  ],
+  "include": ["./**/*.ts", "./**/*.tsx", "next-env.d.ts", ".next/types/**/*.ts", "setup.js"],
   "references": []
 }

--- a/test/tsconfig.typecheck.json
+++ b/test/tsconfig.typecheck.json
@@ -1,30 +1,7 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": true,
-    "rootDir": ".",
-    "baseUrl": ".",
-    "target": "esnext",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "allowJs": true,
-    "checkJs": false,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "jsx": "preserve",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "types": ["jest", "node", "@types/jest"],
-    // "incremental": true,
-    "isolatedModules": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@payload-config": ["./_community/config.ts"]
-    }
+    "incremental": false
   },
   "exclude": ["dist", "build", "temp", "node_modules"],
   "include": [

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "strict": true,
-    "exactOptionalPropertyTypes": true,
-    "noUncheckedIndexedAccess": true
-  }
+  "extends": "../tsconfig.json"
 }


### PR DESCRIPTION
This PR makes the "test" folder strict in typescript.

`pnpm build:test` before: Found 3275 errors in 174 files.
`pnpm build:test` after: Found 4912 errors in 268 files.

At some point we should bring that number to 0 and make it a requirement in the CI. Currently `pnpm build:test` is not run anywhere in the CI.

Additionally, I took the opportunity to combine the duplicate configurations from `tsconfig.json` and `tsconfig.typecheck.json` using "extend". 

declaration, declarationMap and sourceMap have been removed as they have no reason to exist in noEmit.

The settings I left in `tsconfig.typecheck.json` are ones that I'm not sure why they are there. Perhaps the file could be removed or at least reduced further.
