### PR TITLE
fix(richtext-slate): link and upload extra field drawers did not render fields if collection has unrelated access control set

### DIFF
--- a/packages/richtext-slate/src/field/elements/link/Button/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/Button/index.tsx
@@ -69,7 +69,7 @@ export const LinkButton: React.FC<{
   const { t } = useTranslation()
   const editor = useSlate()
   const { getFormState } = useServerFunctions()
-  const { collectionSlug, docPermissions, getDocPreferences, globalSlug } = useDocumentInfo()
+  const { collectionSlug, getDocPreferences, globalSlug } = useDocumentInfo()
 
   const { closeModal, openModal } = useModal()
   const drawerSlug = useDrawerSlug('rich-text-link')
@@ -98,7 +98,9 @@ export const LinkButton: React.FC<{
               const { state } = await getFormState({
                 collectionSlug,
                 data,
-                docPermissions,
+                docPermissions: {
+                  fields: true,
+                },
                 docPreferences: await getDocPreferences(),
                 globalSlug,
                 operation: 'update',

--- a/packages/richtext-slate/src/field/elements/link/Element/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/Element/index.tsx
@@ -101,7 +101,9 @@ export const LinkElement = () => {
       const { state } = await getFormState({
         collectionSlug,
         data,
-        docPermissions,
+        docPermissions: {
+          fields: true,
+        },
         docPreferences: await getDocPreferences(),
         globalSlug,
         operation: 'update',

--- a/packages/richtext-slate/src/field/elements/link/LinkDrawer/index.tsx
+++ b/packages/richtext-slate/src/field/elements/link/LinkDrawer/index.tsx
@@ -33,7 +33,7 @@ export const LinkDrawer: React.FC<Props> = ({
   const { t } = useTranslation()
   const fieldMapPath = `${schemaPath}.${linkFieldsSchemaPath}`
 
-  const { id, collectionSlug, docPermissions, getDocPreferences, globalSlug } = useDocumentInfo()
+  const { id, collectionSlug, getDocPreferences, globalSlug } = useDocumentInfo()
 
   const { getFormState } = useServerFunctions()
 
@@ -42,7 +42,9 @@ export const LinkDrawer: React.FC<Props> = ({
       const { state } = await getFormState({
         id,
         collectionSlug,
-        docPermissions,
+        docPermissions: {
+          fields: true,
+        },
         docPreferences: await getDocPreferences(),
         formState: prevFormState,
         globalSlug,
@@ -53,7 +55,7 @@ export const LinkDrawer: React.FC<Props> = ({
       return state
     },
 
-    [getFormState, id, collectionSlug, getDocPreferences, docPermissions, globalSlug, fieldMapPath],
+    [getFormState, id, collectionSlug, getDocPreferences, globalSlug, fieldMapPath],
   )
 
   return (
@@ -72,7 +74,7 @@ export const LinkDrawer: React.FC<Props> = ({
             parentIndexPath=""
             parentPath={''}
             parentSchemaPath=""
-            permissions={docPermissions.fields}
+            permissions={true}
             readOnly={false}
           />
           <LinkSubmit />

--- a/packages/richtext-slate/src/field/elements/upload/Element/UploadDrawer/index.tsx
+++ b/packages/richtext-slate/src/field/elements/upload/Element/UploadDrawer/index.tsx
@@ -41,7 +41,7 @@ export const UploadDrawer: React.FC<{
   const { i18n, t } = useTranslation()
   const { code: locale } = useLocale()
   const { closeModal } = useModal()
-  const { id, collectionSlug, docPermissions, getDocPreferences, globalSlug } = useDocumentInfo()
+  const { id, collectionSlug, getDocPreferences, globalSlug } = useDocumentInfo()
 
   const { getFormState } = useServerFunctions()
 
@@ -75,7 +75,9 @@ export const UploadDrawer: React.FC<{
         id,
         collectionSlug,
         data,
-        docPermissions,
+        docPermissions: {
+          fields: true,
+        },
         docPreferences: await getDocPreferences(),
         globalSlug,
         operation: 'update',
@@ -99,7 +101,6 @@ export const UploadDrawer: React.FC<{
     getFormState,
     globalSlug,
     getDocPreferences,
-    docPermissions,
   ])
 
   const onChange: FormProps['onChange'][0] = useCallback(
@@ -107,7 +108,9 @@ export const UploadDrawer: React.FC<{
       const { state } = await getFormState({
         id,
         collectionSlug,
-        docPermissions,
+        docPermissions: {
+          fields: true,
+        },
         docPreferences: await getDocPreferences(),
         formState: prevFormState,
         globalSlug,
@@ -122,7 +125,6 @@ export const UploadDrawer: React.FC<{
       getFormState,
       id,
       collectionSlug,
-      docPermissions,
       getDocPreferences,
       globalSlug,
       schemaPath,
@@ -150,7 +152,7 @@ export const UploadDrawer: React.FC<{
             parentIndexPath=""
             parentPath=""
             parentSchemaPath=""
-            permissions={docPermissions.fields}
+            permissions={true}
             readOnly={false}
           />
           <FormSubmit>{t('fields:saveChanges')}</FormSubmit>


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/9695