### PR TITLE
fix: delete scheduled publish jobs when deleting documents

### DIFF
--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -23,6 +23,7 @@ import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { deleteCollectionVersions } from '../../versions/deleteCollectionVersions.js'
+import { deleteScheduledPublishJobs } from '../../versions/deleteScheduledPublishJobs.js'
 import { buildAfterOperation } from './utils.js'
 
 export type Arguments = {
@@ -170,6 +171,18 @@ export const deleteOperation = async <
 
         if (collectionConfig.versions) {
           await deleteCollectionVersions({
+            id,
+            slug: collectionConfig.slug,
+            payload,
+            req,
+          })
+        }
+
+        // /////////////////////////////////////
+        // Delete scheduled posts
+        // /////////////////////////////////////
+        if (collectionConfig.versions?.drafts && collectionConfig.versions.drafts.schedulePublish) {
+          await deleteScheduledPublishJobs({
             id,
             slug: collectionConfig.slug,
             payload,

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -19,6 +19,7 @@ import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { deleteCollectionVersions } from '../../versions/deleteCollectionVersions.js'
+import { deleteScheduledPublishJobs } from '../../versions/deleteScheduledPublishJobs.js'
 import { buildAfterOperation } from './utils.js'
 
 export type Arguments = {
@@ -148,6 +149,18 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
 
     if (collectionConfig.versions) {
       await deleteCollectionVersions({
+        id,
+        slug: collectionConfig.slug,
+        payload,
+        req,
+      })
+    }
+
+    // /////////////////////////////////////
+    // Delete scheduled posts
+    // /////////////////////////////////////
+    if (collectionConfig.versions?.drafts && collectionConfig.versions.drafts.schedulePublish) {
+      await deleteScheduledPublishJobs({
         id,
         slug: collectionConfig.slug,
         payload,

--- a/packages/payload/src/versions/deleteCollectionVersions.ts
+++ b/packages/payload/src/versions/deleteCollectionVersions.ts
@@ -21,8 +21,9 @@ export const deleteCollectionVersions = async ({ id, slug, payload, req }: Args)
       },
     })
   } catch (err) {
-    payload.logger.error(
-      `There was an error removing versions for the deleted ${slug} document with ID ${id}.`,
-    )
+    payload.logger.error({
+      err,
+      msg: `There was an error removing versions for the deleted ${slug} document with ID ${id}.`,
+    })
   }
 }

--- a/packages/payload/src/versions/deleteScheduledPublishJobs.ts
+++ b/packages/payload/src/versions/deleteScheduledPublishJobs.ts
@@ -16,12 +16,6 @@ export const deleteScheduledPublishJobs = async ({
   req,
 }: Args): Promise<void> => {
   try {
-    const jobs = await payload.db.find({
-      collection: 'payload-jobs',
-      req,
-    })
-
-    // get the jobs collection
     await payload.db.deleteMany({
       collection: 'payload-jobs',
       req,
@@ -31,6 +25,11 @@ export const deleteScheduledPublishJobs = async ({
           {
             completedAt: {
               exists: false,
+            },
+          },
+          {
+            processing: {
+              equals: false,
             },
           },
           {
@@ -45,8 +44,8 @@ export const deleteScheduledPublishJobs = async ({
           },
           // data.type narrows scheduled publish jobs in case of another job having input.doc.value
           {
-            'input.type': {
-              exists: true,
+            taskSlug: {
+              equals: 'schedulePublish',
             },
           },
         ],

--- a/packages/payload/src/versions/deleteScheduledPublishJobs.ts
+++ b/packages/payload/src/versions/deleteScheduledPublishJobs.ts
@@ -52,8 +52,9 @@ export const deleteScheduledPublishJobs = async ({
       },
     })
   } catch (err) {
-    payload.logger.error(
-      `There was an error deleting scheduled publish jobs from the queue for ${slug} document with ID ${id}.`,
-    )
+    payload.logger.error({
+      err,
+      msg: `There was an error deleting scheduled publish jobs from the queue for ${slug} document with ID ${id}.`,
+    })
   }
 }

--- a/packages/payload/src/versions/deleteScheduledPublishJobs.ts
+++ b/packages/payload/src/versions/deleteScheduledPublishJobs.ts
@@ -1,0 +1,60 @@
+import type { PayloadRequest } from '../types/index.js'
+
+import { type Payload } from '../index.js'
+
+type Args = {
+  id?: number | string
+  payload: Payload
+  req?: PayloadRequest
+  slug: string
+}
+
+export const deleteScheduledPublishJobs = async ({
+  id,
+  slug,
+  payload,
+  req,
+}: Args): Promise<void> => {
+  try {
+    const jobs = await payload.db.find({
+      collection: 'payload-jobs',
+      req,
+    })
+
+    // get the jobs collection
+    await payload.db.deleteMany({
+      collection: 'payload-jobs',
+      req,
+      where: {
+        and: [
+          // only want to delete jobs have not run yet
+          {
+            completedAt: {
+              exists: false,
+            },
+          },
+          {
+            'input.doc.value': {
+              equals: id,
+            },
+          },
+          {
+            'input.doc.relationTo': {
+              equals: slug,
+            },
+          },
+          // data.type narrows scheduled publish jobs in case of another job having input.doc.value
+          {
+            'input.type': {
+              exists: true,
+            },
+          },
+        ],
+      },
+    })
+  } catch (err) {
+    payload.logger.error(
+      `There was an error deleting scheduled publish jobs from the queue for ${slug} document with ID ${id}.`,
+    )
+  }
+}

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -1978,6 +1978,49 @@ describe('Versions', () => {
       expect(docs[0]).toBeUndefined()
     })
 
+    it('should delete scheduled jobs after a document is deleted by ID', async () => {
+      const draft = await payload.create({
+        collection: draftCollectionSlug,
+        data: {
+          title: 'my doc to publish in the future',
+          description: 'hello',
+        },
+        draft: true,
+      })
+
+      expect(draft._status).toStrictEqual('draft')
+
+      const currentDate = new Date()
+
+      await payload.jobs.queue({
+        task: 'schedulePublish',
+        waitUntil: new Date(currentDate.getTime() + 3000),
+        input: {
+          type: 'publish',
+          doc: {
+            relationTo: draftCollectionSlug,
+            value: draft.id,
+          },
+        },
+      })
+
+      await payload.delete({
+        collection: draftCollectionSlug,
+        id: draft.id,
+      })
+
+      const { docs } = await payload.find({
+        collection: 'payload-jobs',
+        where: {
+          'input.doc.value': {
+            equals: draft.id,
+          },
+        },
+      })
+
+      expect(docs[0]).toBeUndefined()
+    })
+
     it('should allow global scheduled publish', async () => {
       const draft = await payload.updateGlobal({
         slug: draftGlobalSlug,

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -1933,6 +1933,51 @@ describe('Versions', () => {
       expect(retrieved._status).toStrictEqual('draft')
     })
 
+    it('should delete scheduled jobs after a document is deleted', async () => {
+      const draft = await payload.create({
+        collection: draftCollectionSlug,
+        data: {
+          title: 'my doc to publish in the future',
+          description: 'hello',
+        },
+        draft: true,
+      })
+
+      expect(draft._status).toStrictEqual('draft')
+
+      const currentDate = new Date()
+
+      await payload.jobs.queue({
+        task: 'schedulePublish',
+        waitUntil: new Date(currentDate.getTime() + 3000),
+        input: {
+          type: 'publish',
+          doc: {
+            relationTo: draftCollectionSlug,
+            value: draft.id,
+          },
+        },
+      })
+
+      await payload.delete({
+        collection: draftCollectionSlug,
+        where: {
+          id: { equals: draft.id },
+        },
+      })
+
+      const { docs } = await payload.find({
+        collection: 'payload-jobs',
+        where: {
+          'input.doc.value': {
+            equals: draft.id,
+          },
+        },
+      })
+
+      expect(docs[0]).toBeUndefined()
+    })
+
     it('should allow global scheduled publish', async () => {
       const draft = await payload.updateGlobal({
         slug: draftGlobalSlug,


### PR DESCRIPTION
### What?

When a document gets deleted we are not cleaning up jobs that would fail if the document doesn't exist. This change makes an extra call to the DB to delete any incomplete jobs for the document.

### Why?

The jobs queue will error and retry needlessly unless these are purged.

### How?

Adds a call to delete jobs from the delete operation.
