### PR TITLE
fix:  added token credential to azure-storage if rbac is used

### DIFF
--- a/packages/storage-azure/README.md
+++ b/packages/storage-azure/README.md
@@ -48,4 +48,5 @@ export default buildConfig({
 | `allowContainerCreate` | Whether or not to allow the container to be created if it does not exist | `false` |
 | `baseURL`              | Base URL for the Azure Blob storage account                              |         |
 | `connectionString`     | Azure Blob storage connection string                                     |         |
+| `credential`           | Alternative to connection string you can use TokenCredential to connect  |         |
 | `containerName`        | Azure Blob storage container name                                        |         |

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -1,3 +1,4 @@
+import type { BatchSubRequest } from '@azure/storage-blob'
 import type {
   Adapter,
   PluginOptions as CloudStoragePluginOptions,
@@ -35,12 +36,16 @@ export type AzureStorageOptions = {
   /**
    * Azure Blob storage connection string
    */
-  connectionString: string
-
+  connectionString?: string
   /**
    * Azure Blob storage container name
    */
   containerName: string
+
+  /**
+   * Instead of a connection string you can chose to use any object that implements the TokenCredential interface if you are securing your storage with RBAC, such as AnonymousCredential, StorageSharedKeyCredential or any credential from the `@azure/identity` package to authenticate requests to the service.
+   */
+  credential?: BatchSubRequest['credential']
 
   /**
    * Whether or not to enable the plugin
@@ -103,14 +108,21 @@ function azureStorageInternal({
   baseURL,
   connectionString,
   containerName,
+  credential,
 }: AzureStorageOptions): Adapter {
   const createContainerIfNotExists = () => {
-    void getStorageClientFunc({ connectionString, containerName }).createIfNotExists({
+    void getStorageClientFunc({
+      baseURL,
+      connectionString,
+      containerName,
+      credential,
+    }).createIfNotExists({
       access: 'blob',
     })
   }
 
-  const getStorageClient = () => getStorageClientFunc({ connectionString, containerName })
+  const getStorageClient = () =>
+    getStorageClientFunc({ baseURL, connectionString, containerName, credential })
 
   return ({ collection, prefix }): GeneratedAdapter => {
     return {

--- a/packages/storage-azure/src/utils/getStorageClient.ts
+++ b/packages/storage-azure/src/utils/getStorageClient.ts
@@ -7,15 +7,25 @@ import type { AzureStorageOptions } from '../index.js'
 let storageClient: ContainerClient | null = null
 
 export function getStorageClient(
-  options: Pick<AzureStorageOptions, 'connectionString' | 'containerName'>,
+  options: Pick<
+    AzureStorageOptions,
+    'baseURL' | 'connectionString' | 'containerName' | 'credential'
+  >,
 ): ContainerClient {
   if (storageClient) {
     return storageClient
   }
 
-  const { connectionString, containerName } = options
-
-  const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString)
+  const { baseURL, connectionString, containerName, credential } = options
+  let blobServiceClient: BlobServiceClient | undefined = undefined
+  if (typeof connectionString === 'string') {
+    blobServiceClient = BlobServiceClient.fromConnectionString(connectionString)
+  } else if (typeof credential === 'object') {
+    blobServiceClient = new BlobServiceClient(baseURL, credential, {})
+  }
+  if (!blobServiceClient) {
+    throw new Error('connectionString or credential must be provided')
+  }
   storageClient = blobServiceClient.getContainerClient(containerName)
   return storageClient
 }


### PR DESCRIPTION
### What?

Made the connectionString configuration in storage-azure optional and added an option to use TokenCredential for connecting to StorageClient.


### Why?

This enables organizations to move away from connectionString and use RBAC for resource access, as recommended by Azure.

### How?

Added credential as an optional configuration and checked for it in the getStorageClient function.

```ts

import type { ContainerClient } from '@azure/storage-blob'

import { BlobServiceClient } from '@azure/storage-blob'

import type { AzureStorageOptions } from '../index.js'

let storageClient: ContainerClient | null = null

export function getStorageClient(
  options: Pick<
    AzureStorageOptions,
    'baseURL' | 'connectionString' | 'containerName' | 'credential'
  >,
): ContainerClient {
  if (storageClient) {
    return storageClient
  }
  //
  // Change which firsts checks if the connectionString is present and if not checks if credential is provided otherwise throws.
  const { baseURL, connectionString, containerName, credential } = options
  let blobServiceClient: BlobServiceClient | undefined = undefined
  if (typeof connectionString === 'string') {
    blobServiceClient = BlobServiceClient.fromConnectionString(connectionString)
  } else if (typeof credential === 'object') {
    blobServiceClient = new BlobServiceClient(baseURL, credential, {})
  }
  if (!blobServiceClient) {
    throw new Error('connectionString or credential must be provided')
  }
  //
  storageClient = blobServiceClient.getContainerClient(containerName)
  return storageClient
}
```

**Configuration change example**

```ts
export default buildConfig({
  collections: [Media, MediaWithPrefix],
  plugins: [
    azureStorage({
      collections: {
        media: true,
        'media-with-prefix': {
          prefix,
        },
      },
      allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
      baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL,
    //   connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
    credential: new ChainedTokenCredential(
      ...[
        new VisualStudioCodeCredential(),
        new VisualStudioCodeCredential(),
        new DefaultAzureCredential(),
      ], // Or any TokenCredential
containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
    }),
  ],
})
```

