### PR TITLE
fix: apply CORS response headers without `headersWithCors`

### DIFF
--- a/packages/next/src/exports/utilities.ts
+++ b/packages/next/src/exports/utilities.ts
@@ -23,9 +23,7 @@ export const mergeHeaders = _mergeHeaders
 
 /**
  * @deprecated
- * Use:
- * ```ts
- * import { headersWithCors } from 'payload'
+ * This function is not needed anymore for public usage. CORS headers are applied by default to response.
  * ```
  */
 export const headersWithCors = _headersWithCors

--- a/packages/payload/src/auth/endpoints/access.ts
+++ b/packages/payload/src/auth/endpoints/access.ts
@@ -2,22 +2,15 @@ import httpStatus from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'
 
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { accessOperation } from '../operations/access.js'
 
 export const accessHandler: PayloadHandler = async (req) => {
-  const headers = headersWithCors({
-    headers: new Headers(),
-    req,
-  })
-
   try {
     const results = await accessOperation({
       req,
     })
 
     return Response.json(results, {
-      headers,
       status: httpStatus.OK,
     })
   } catch (e: unknown) {
@@ -26,7 +19,6 @@ export const accessHandler: PayloadHandler = async (req) => {
         error: e,
       },
       {
-        headers,
         status: httpStatus.INTERNAL_SERVER_ERROR,
       },
     )

--- a/packages/payload/src/auth/endpoints/forgotPassword.ts
+++ b/packages/payload/src/auth/endpoints/forgotPassword.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { forgotPasswordOperation } from '../operations/forgotPassword.js'
 
 export const forgotPasswordHandler: PayloadHandler = async (req) => {
@@ -33,10 +32,6 @@ export const forgotPasswordHandler: PayloadHandler = async (req) => {
       message: t('general:success'),
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
       status: httpStatus.OK,
     },
   )

--- a/packages/payload/src/auth/endpoints/init.ts
+++ b/packages/payload/src/auth/endpoints/init.ts
@@ -1,7 +1,6 @@
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { initOperation } from '../operations/init.js'
 
 export const initHandler: PayloadHandler = async (req) => {
@@ -10,13 +9,5 @@ export const initHandler: PayloadHandler = async (req) => {
     req,
   })
 
-  return Response.json(
-    { initialized },
-    {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
-    },
-  )
+  return Response.json({ initialized })
 }

--- a/packages/payload/src/auth/endpoints/login.ts
+++ b/packages/payload/src/auth/endpoints/login.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { generatePayloadCookie } from '../cookies.js'
 import { loginOperation } from '../operations/login.js'
@@ -47,11 +46,8 @@ export const loginHandler: PayloadHandler = async (req) => {
       ...result,
     },
     {
-      headers: headersWithCors({
-        headers: new Headers({
-          'Set-Cookie': cookie,
-        }),
-        req,
+      headers: new Headers({
+        'Set-Cookie': cookie,
       }),
       status: httpStatus.OK,
     },

--- a/packages/payload/src/auth/endpoints/logout.ts
+++ b/packages/payload/src/auth/endpoints/logout.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { generateExpiredPayloadCookie } from '../cookies.js'
 import { logoutOperation } from '../operations/logout.js'
 
@@ -15,18 +14,12 @@ export const logoutHandler: PayloadHandler = async (req) => {
     req,
   })
 
-  const headers = headersWithCors({
-    headers: new Headers(),
-    req,
-  })
-
   if (!result) {
     return Response.json(
       {
         message: t('error:logoutFailed'),
       },
       {
-        headers,
         status: httpStatus.BAD_REQUEST,
       },
     )
@@ -38,7 +31,9 @@ export const logoutHandler: PayloadHandler = async (req) => {
     cookiePrefix: req.payload.config.cookiePrefix,
   })
 
-  headers.set('Set-Cookie', expiredCookie)
+  const headers = new Headers({
+    'Set-Cookie': expiredCookie,
+  })
 
   return Response.json(
     {

--- a/packages/payload/src/auth/endpoints/me.ts
+++ b/packages/payload/src/auth/endpoints/me.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { extractJWT } from '../extractJWT.js'
 import { meOperation } from '../operations/me.js'
 
@@ -27,10 +26,6 @@ export const meHandler: PayloadHandler = async (req) => {
       message: req.t('authentication:account'),
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
       status: httpStatus.OK,
     },
   )

--- a/packages/payload/src/auth/endpoints/refresh.ts
+++ b/packages/payload/src/auth/endpoints/refresh.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { generatePayloadCookie } from '../cookies.js'
 import { refreshOperation } from '../operations/refresh.js'
 
@@ -11,10 +10,7 @@ export const refreshHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
   const { t } = req
 
-  const headers = headersWithCors({
-    headers: new Headers(),
-    req,
-  })
+  const headers = new Headers()
 
   const result = await refreshOperation({
     collection,

--- a/packages/payload/src/auth/endpoints/registerFirstUser.ts
+++ b/packages/payload/src/auth/endpoints/registerFirstUser.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { generatePayloadCookie } from '../cookies.js'
 import { registerFirstUserOperation } from '../operations/registerFirstUser.js'
 
@@ -44,11 +43,8 @@ export const registerFirstUserHandler: PayloadHandler = async (req) => {
       user: result.user,
     },
     {
-      headers: headersWithCors({
-        headers: new Headers({
-          'Set-Cookie': cookie,
-        }),
-        req,
+      headers: new Headers({
+        'Set-Cookie': cookie,
       }),
       status: httpStatus.OK,
     },

--- a/packages/payload/src/auth/endpoints/resetPassword.ts
+++ b/packages/payload/src/auth/endpoints/resetPassword.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { generatePayloadCookie } from '../cookies.js'
 import { resetPasswordOperation } from '../operations/resetPassword.js'
 
@@ -38,11 +37,8 @@ export const resetPasswordHandler: PayloadHandler = async (req) => {
       ...result,
     },
     {
-      headers: headersWithCors({
-        headers: new Headers({
-          'Set-Cookie': cookie,
-        }),
-        req,
+      headers: new Headers({
+        'Set-Cookie': cookie,
       }),
       status: httpStatus.OK,
     },

--- a/packages/payload/src/auth/endpoints/unlock.ts
+++ b/packages/payload/src/auth/endpoints/unlock.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { unlockOperation } from '../operations/unlock.js'
 
 export const unlockHandler: PayloadHandler = async (req) => {
@@ -31,10 +30,6 @@ export const unlockHandler: PayloadHandler = async (req) => {
       message: t('general:success'),
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
       status: httpStatus.OK,
     },
   )

--- a/packages/payload/src/auth/endpoints/verifyEmail.ts
+++ b/packages/payload/src/auth/endpoints/verifyEmail.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import verifyEmailOperation from '../operations/verifyEmail.js'
 
 export const verifyEmailHandler: PayloadHandler = async (req) => {
@@ -20,10 +19,6 @@ export const verifyEmailHandler: PayloadHandler = async (req) => {
       message: t('authentication:accountVerified'),
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
       status: httpStatus.OK,
     },
   )

--- a/packages/payload/src/collections/endpoints/create.ts
+++ b/packages/payload/src/collections/endpoints/create.ts
@@ -4,7 +4,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -36,10 +35,6 @@ export const createHandler: PayloadHandler = async (req) => {
       }),
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
       status: httpStatus.CREATED,
     },
   )

--- a/packages/payload/src/collections/endpoints/delete.ts
+++ b/packages/payload/src/collections/endpoints/delete.ts
@@ -5,7 +5,6 @@ import type { PayloadHandler } from '../../config/types.js'
 import type { Where } from '../../types/index.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -31,11 +30,6 @@ export const deleteHandler: PayloadHandler = async (req) => {
     where,
   })
 
-  const headers = headersWithCors({
-    headers: new Headers(),
-    req,
-  })
-
   if (result.errors.length === 0) {
     const message = req.t('general:deletedCountSuccessfully', {
       count: result.docs.length,
@@ -51,7 +45,6 @@ export const deleteHandler: PayloadHandler = async (req) => {
         message,
       },
       {
-        headers,
         status: httpStatus.OK,
       },
     )
@@ -71,7 +64,6 @@ export const deleteHandler: PayloadHandler = async (req) => {
       message,
     },
     {
-      headers,
       status: httpStatus.BAD_REQUEST,
     },
   )

--- a/packages/payload/src/collections/endpoints/deleteByID.ts
+++ b/packages/payload/src/collections/endpoints/deleteByID.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -25,18 +24,12 @@ export const deleteByIDHandler: PayloadHandler = async (req) => {
     select: sanitizeSelectParam(req.query.select),
   })
 
-  const headers = headersWithCors({
-    headers: new Headers(),
-    req,
-  })
-
   if (!doc) {
     return Response.json(
       {
         message: req.t('general:notFound'),
       },
       {
-        headers,
         status: httpStatus.NOT_FOUND,
       },
     )
@@ -48,7 +41,6 @@ export const deleteByIDHandler: PayloadHandler = async (req) => {
       message: req.t('general:deletedSuccessfully'),
     },
     {
-      headers,
       status: httpStatus.OK,
     },
   )

--- a/packages/payload/src/collections/endpoints/docAccess.ts
+++ b/packages/payload/src/collections/endpoints/docAccess.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { docAccessOperation } from '../operations/docAccess.js'
 
 export const docAccessHandler: PayloadHandler = async (req) => {
@@ -15,10 +14,6 @@ export const docAccessHandler: PayloadHandler = async (req) => {
   })
 
   return Response.json(result, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/collections/endpoints/duplicate.ts
+++ b/packages/payload/src/collections/endpoints/duplicate.ts
@@ -4,7 +4,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -38,10 +37,6 @@ export const duplicateHandler: PayloadHandler = async (req) => {
       message,
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
       status: httpStatus.OK,
     },
   )

--- a/packages/payload/src/collections/endpoints/find.ts
+++ b/packages/payload/src/collections/endpoints/find.ts
@@ -4,7 +4,6 @@ import type { PayloadHandler } from '../../config/types.js'
 import type { JoinQuery, Where } from '../../types/index.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizeJoinParams } from '../../utilities/sanitizeJoinParams.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
@@ -43,10 +42,6 @@ export const findHandler: PayloadHandler = async (req) => {
   })
 
   return Response.json(result, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/collections/endpoints/findByID.ts
+++ b/packages/payload/src/collections/endpoints/findByID.ts
@@ -4,7 +4,6 @@ import type { PayloadHandler } from '../../config/types.js'
 import type { JoinQuery } from '../../types/index.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizeJoinParams } from '../../utilities/sanitizeJoinParams.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
@@ -28,10 +27,6 @@ export const findByIDHandler: PayloadHandler = async (req) => {
   })
 
   return Response.json(result, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/collections/endpoints/findVersionByID.ts
+++ b/packages/payload/src/collections/endpoints/findVersionByID.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -25,10 +24,6 @@ export const findVersionByIDHandler: PayloadHandler = async (req) => {
   })
 
   return Response.json(result, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/collections/endpoints/findVersions.ts
+++ b/packages/payload/src/collections/endpoints/findVersions.ts
@@ -4,7 +4,6 @@ import type { PayloadHandler } from '../../config/types.js'
 import type { Where } from '../../types/index.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -37,10 +36,6 @@ export const findVersionsHandler: PayloadHandler = async (req) => {
   })
 
   return Response.json(result, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/collections/endpoints/getFile.ts
+++ b/packages/payload/src/collections/endpoints/getFile.ts
@@ -10,7 +10,6 @@ import { checkFileAccess } from '../../uploads/checkFileAccess.js'
 import { streamFile } from '../../uploads/fetchAPI-stream-file/index.js'
 import { getFileTypeFallback } from '../../uploads/getFileTypeFallback.js'
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 
 export const getFileHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
@@ -65,10 +64,7 @@ export const getFileHandler: PayloadHandler = async (req) => {
     : headers
 
   return new Response(data, {
-    headers: headersWithCors({
-      headers,
-      req,
-    }),
+    headers,
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/collections/endpoints/preview.ts
+++ b/packages/payload/src/collections/endpoints/preview.ts
@@ -4,7 +4,6 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { extractJWT } from '../../auth/extractJWT.js'
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { findByIDOperation } from '../operations/findByID.js'
 
@@ -38,10 +37,6 @@ export const previewHandler: PayloadHandler = async (req) => {
   }
 
   return Response.json(previewURL, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/collections/endpoints/restoreVersion.ts
+++ b/packages/payload/src/collections/endpoints/restoreVersion.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { restoreVersionOperation } from '../operations/restoreVersion.js'
@@ -29,10 +28,6 @@ export const restoreVersionHandler: PayloadHandler = async (req) => {
       message: req.t('version:restoredSuccessfully'),
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
       status: httpStatus.OK,
     },
   )

--- a/packages/payload/src/collections/endpoints/update.ts
+++ b/packages/payload/src/collections/endpoints/update.ts
@@ -5,7 +5,6 @@ import type { PayloadHandler } from '../../config/types.js'
 import type { Where } from '../../types/index.js'
 
 import { getRequestCollection } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -36,11 +35,6 @@ export const updateHandler: PayloadHandler = async (req) => {
     where,
   })
 
-  const headers = headersWithCors({
-    headers: new Headers(),
-    req,
-  })
-
   if (result.errors.length === 0) {
     const message = req.t('general:updatedCountSuccessfully', {
       count: result.docs.length,
@@ -56,7 +50,6 @@ export const updateHandler: PayloadHandler = async (req) => {
         message,
       },
       {
-        headers,
         status: httpStatus.OK,
       },
     )
@@ -75,7 +68,6 @@ export const updateHandler: PayloadHandler = async (req) => {
       message,
     },
     {
-      headers,
       status: httpStatus.BAD_REQUEST,
     },
   )

--- a/packages/payload/src/collections/endpoints/updateByID.ts
+++ b/packages/payload/src/collections/endpoints/updateByID.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestCollectionWithID } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -47,10 +46,6 @@ export const updateByIDHandler: PayloadHandler = async (req) => {
       message,
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
       status: httpStatus.OK,
     },
   )

--- a/packages/payload/src/globals/endpoints/docAccess.ts
+++ b/packages/payload/src/globals/endpoints/docAccess.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestGlobal } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { docAccessOperation } from '../operations/docAccess.js'
 
 export const docAccessHandler: PayloadHandler = async (req) => {
@@ -14,10 +13,6 @@ export const docAccessHandler: PayloadHandler = async (req) => {
   })
 
   return Response.json(result, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/globals/endpoints/findOne.ts
+++ b/packages/payload/src/globals/endpoints/findOne.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestGlobal } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -25,10 +24,6 @@ export const findOneHandler: PayloadHandler = async (req) => {
   })
 
   return Response.json(result, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/globals/endpoints/findVersionByID.ts
+++ b/packages/payload/src/globals/endpoints/findVersionByID.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestGlobal } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -24,10 +23,6 @@ export const findVersionByIDHandler: PayloadHandler = async (req) => {
   })
 
   return Response.json(result, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/globals/endpoints/findVersions.ts
+++ b/packages/payload/src/globals/endpoints/findVersions.ts
@@ -4,7 +4,6 @@ import type { PayloadHandler } from '../../config/types.js'
 import type { Where } from '../../types/index.js'
 
 import { getRequestGlobal } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -37,10 +36,6 @@ export const findVersionsHandler: PayloadHandler = async (req) => {
   })
 
   return Response.json(result, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/globals/endpoints/preview.ts
+++ b/packages/payload/src/globals/endpoints/preview.ts
@@ -4,7 +4,6 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { extractJWT } from '../../auth/extractJWT.js'
 import { getRequestGlobal } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { findOneOperation } from '../operations/findOne.js'
 
@@ -38,10 +37,6 @@ export const previewHandler: PayloadHandler = async (req) => {
   }
 
   return Response.json(previewURL, {
-    headers: headersWithCors({
-      headers: new Headers(),
-      req,
-    }),
     status: httpStatus.OK,
   })
 }

--- a/packages/payload/src/globals/endpoints/restoreVersion.ts
+++ b/packages/payload/src/globals/endpoints/restoreVersion.ts
@@ -4,7 +4,6 @@ import type { PayloadHandler } from '../../config/types.js'
 
 import { restoreVersionOperationGlobal, sanitizePopulateParam } from '../../index.js'
 import { getRequestGlobal } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 
 export const restoreVersionHandler: PayloadHandler = async (req) => {
@@ -28,10 +27,6 @@ export const restoreVersionHandler: PayloadHandler = async (req) => {
       message: req.t('version:restoredSuccessfully'),
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
       status: httpStatus.OK,
     },
   )

--- a/packages/payload/src/globals/endpoints/update.ts
+++ b/packages/payload/src/globals/endpoints/update.ts
@@ -3,7 +3,6 @@ import httpStatus from 'http-status'
 import type { PayloadHandler } from '../../config/types.js'
 
 import { getRequestGlobal } from '../../utilities/getRequestEntity.js'
-import { headersWithCors } from '../../utilities/headersWithCors.js'
 import { isNumber } from '../../utilities/isNumber.js'
 import { sanitizePopulateParam } from '../../utilities/sanitizePopulateParam.js'
 import { sanitizeSelectParam } from '../../utilities/sanitizeSelectParam.js'
@@ -45,10 +44,6 @@ export const updateHandler: PayloadHandler = async (req) => {
       result,
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
       status: httpStatus.OK,
     },
   )

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1404,7 +1404,7 @@ export { getCollectionIDFieldTypes } from './utilities/getCollectionIDFieldTypes
 export { getObjectDotNotation } from './utilities/getObjectDotNotation.js'
 export { getRequestLanguage } from './utilities/getRequestLanguage.js'
 export { handleEndpoints } from './utilities/handleEndpoints.js'
-export { headersWithCors } from './utilities/headersWithCors.js'
+export { headersWithCors_public as headersWithCors } from './utilities/headersWithCors.js'
 export { initTransaction } from './utilities/initTransaction.js'
 export { isEntityHidden } from './utilities/isEntityHidden.js'
 export { default as isolateObjectProperty } from './utilities/isolateObjectProperty.js'

--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -11,16 +11,13 @@ import { headersWithCors } from './headersWithCors.js'
 import { mergeHeaders } from './mergeHeaders.js'
 import { routeError } from './routeError.js'
 
-const notFoundResponse = (req: PayloadRequest) => {
+const notFoundResponse = (req: PayloadRequest, headers: Headers) => {
   return Response.json(
     {
       message: `Route not found "${new URL(req.url).pathname}"`,
     },
     {
-      headers: headersWithCors({
-        headers: new Headers(),
-        req,
-      }),
+      headers,
       status: httpStatus.NOT_FOUND,
     },
   )
@@ -100,14 +97,16 @@ export const handleEndpoints = async ({
   try {
     req = await createPayloadRequest({ config: incomingConfig, request })
 
+    let headers = headersWithCors({
+      headers: new Headers(),
+      req,
+    })
+
     if (req.method.toLowerCase() === 'options') {
       return Response.json(
         {},
         {
-          headers: headersWithCors({
-            headers: new Headers(),
-            req,
-          }),
+          headers,
           status: 200,
         },
       )
@@ -119,7 +118,7 @@ export const handleEndpoints = async ({
     const pathname = `${basePath}${new URL(req.url).pathname}`
 
     if (!pathname.startsWith(config.routes.api)) {
-      return notFoundResponse(req)
+      return notFoundResponse(req, headers)
     }
 
     // /api/posts/route -> /posts/route
@@ -173,10 +172,7 @@ export const handleEndpoints = async ({
           message: `Cannot ${req.method.toUpperCase()} ${req.url}`,
         },
         {
-          headers: headersWithCors({
-            headers: new Headers(),
-            req,
-          }),
+          headers,
           status: httpStatus.NOT_IMPLEMENTED,
         },
       )
@@ -213,12 +209,19 @@ export const handleEndpoints = async ({
     }
 
     if (!handler) {
-      return notFoundResponse(req)
+      return notFoundResponse(req, headers)
+    }
+
+    if (req.responseHeaders) {
+      headers = mergeHeaders(req.responseHeaders, headers)
     }
 
     const response = await handler(req)
+
+    headers = mergeHeaders(response.headers, headers)
+
     return new Response(response.body, {
-      headers: mergeHeaders(req.responseHeaders ?? new Headers(), response.headers),
+      headers,
       status: response.status,
       statusText: response.statusText,
     })

--- a/packages/payload/src/utilities/headersWithCors.ts
+++ b/packages/payload/src/utilities/headersWithCors.ts
@@ -4,6 +4,10 @@ type CorsArgs = {
   headers: Headers
   req: Partial<PayloadRequest>
 }
+
+/**
+ * This function is not needed anymore for public usage. CORS headers are applied by default to response.
+ */
 export const headersWithCors = ({ headers, req }: CorsArgs): Headers => {
   const cors = req?.payload.config.cors
   const requestOrigin = req?.headers.get('Origin')

--- a/packages/payload/src/utilities/headersWithCors.ts
+++ b/packages/payload/src/utilities/headersWithCors.ts
@@ -5,9 +5,6 @@ type CorsArgs = {
   req: Partial<PayloadRequest>
 }
 
-/**
- * This function is not needed anymore for public usage. CORS headers are applied by default to response.
- */
 export const headersWithCors = ({ headers, req }: CorsArgs): Headers => {
   const cors = req?.payload.config.cors
   const requestOrigin = req?.headers.get('Origin')
@@ -50,3 +47,9 @@ export const headersWithCors = ({ headers, req }: CorsArgs): Headers => {
 
   return headers
 }
+
+/**
+ * This function is not needed anymore for public usage. CORS headers are applied by default to response.
+ * @deprecated
+ */
+export const headersWithCors_public = headersWithCors

--- a/packages/payload/src/utilities/routeError.ts
+++ b/packages/payload/src/utilities/routeError.ts
@@ -94,7 +94,6 @@ export const routeError = async ({
   }, Promise.resolve())
 
   return Response.json(response, {
-    // headers with req.responseHeaders are merged in handleEndpoints directly
     status,
   })
 }

--- a/packages/payload/src/utilities/routeError.ts
+++ b/packages/payload/src/utilities/routeError.ts
@@ -7,9 +7,7 @@ import type { PayloadRequest } from '../types/index.js'
 import { APIError } from '../errors/APIError.js'
 import { getPayload } from '../index.js'
 import { formatErrors } from './formatErrors.js'
-import { headersWithCors } from './headersWithCors.js'
 import { logError } from './logError.js'
-import { mergeHeaders } from './mergeHeaders.js'
 
 export const routeError = async ({
   collection,
@@ -40,10 +38,6 @@ export const routeError = async ({
   const req = incomingReq as PayloadRequest
 
   req.payload = payload
-  const headers = headersWithCors({
-    headers: new Headers(),
-    req,
-  })
 
   const { config } = payload
 
@@ -100,7 +94,7 @@ export const routeError = async ({
   }, Promise.resolve())
 
   return Response.json(response, {
-    headers: req.responseHeaders ? mergeHeaders(req.responseHeaders, headers) : headers,
+    // headers with req.responseHeaders are merged in handleEndpoints directly
     status,
   })
 }

--- a/packages/plugin-search/src/utilities/generateReindexHandler.ts
+++ b/packages/plugin-search/src/utilities/generateReindexHandler.ts
@@ -1,6 +1,6 @@
 import type { PayloadHandler } from 'payload'
 
-import { addLocalesToRequestFromData, headersWithCors } from '@payloadcms/next/utilities'
+import { addLocalesToRequestFromData } from '@payloadcms/next/utilities'
 import { commitTransaction, getAccessResults, initTransaction, killTransaction } from 'payload'
 
 import type { SearchPluginConfigWithLocales } from '../types.js'
@@ -50,19 +50,14 @@ export const generateReindexHandler =
         : { isValid: false, message: t('error:invalidRequestArgs', { args: `'collections'` }) }
     }
 
-    const headers = headersWithCors({
-      headers: new Headers(),
-      req,
-    })
-
     const { isValid: hasPermissions, message: permissionError } = await validatePermissions()
     if (!hasPermissions) {
-      return Response.json({ message: permissionError }, { headers, status: 401 })
+      return Response.json({ message: permissionError }, { status: 401 })
     }
 
     const { isValid: validCollections, message: collectionError } = validateCollections()
     if (!validCollections) {
-      return Response.json({ message: collectionError }, { headers, status: 400 })
+      return Response.json({ message: collectionError }, { status: 400 })
     }
 
     const payload = req.payload
@@ -145,7 +140,7 @@ export const generateReindexHandler =
         payload.logger.error({ err, msg: message })
 
         await killTransaction(req)
-        return Response.json({ message }, { headers, status: 500 })
+        return Response.json({ message }, { status: 500 })
       }
     }
 
@@ -157,5 +152,5 @@ export const generateReindexHandler =
 
     await commitTransaction(req)
 
-    return Response.json({ message }, { headers, status: 200 })
+    return Response.json({ message }, { status: 200 })
   }


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/10332

Previously, the `cors` configuration wasn't respected for:
- Custom endpoints without using `headersWithCors` which as described in https://github.com/payloadcms/payload/issues/10332 is not documented.
- Some of our endpoints like `/payload-jobs/run` or from plugins due to missing `headersWithCors` - https://github.com/payloadcms/payload/blob/592f02b3bf2241854202dec99ceb0c66a3fbf771/packages/payload/src/queues/restEndpointRun.ts#L82-L88

In 2.0, you didn't need `headersWithCors` and I think it's expected to handle this logic by default.
This completely removes `headersWithCors` boilerplate from the all endpoints and instead, handles this logic at the end of `handleEndpoints` directly - https://github.com/payloadcms/payload/compare/fix/default-cors?expand=1#diff-82e97630068f9fc40256f3f46e06226215ab150d16012281810586b51b0cfd51

Also deprecates public export of `headersWithCors`