### PR TITLE
perf: do not send minRows and maxRows undefined values to client

### DIFF
--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -120,14 +120,14 @@ export const sanitizeFields = async ({
         console.warn(
           `(payload): The "min" property is deprecated for the Relationship field "${field.name}" and will be removed in a future version. Please use "minRows" instead.`,
         )
+        field.minRows = field.min
       }
       if (field.max && !field.maxRows) {
         console.warn(
           `(payload): The "max" property is deprecated for the Relationship field "${field.name}" and will be removed in a future version. Please use "maxRows" instead.`,
         )
+        field.maxRows = field.max
       }
-      field.minRows = field.minRows || field.min
-      field.maxRows = field.maxRows || field.max
     }
 
     if (field.type === 'upload') {


### PR DESCRIPTION
This reduced the size of the initial HTML from 3.18 Mb to 2.97 Mb in a large project.

The logic to set the `minRows` and `maxRows` values here was only necessary to automatically migrate usage of the deprecated `min` and `max` properties. It did not have to run if those deprecated properties weren't used in the first place.

Even though the result would have been `undefined`, Next.js unnecessarily sends down literal "undefined" strings to the client.