### PR TITLE
ci: disable integration tests retrying

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,17 +254,11 @@ jobs:
         if: matrix.database == 'supabase'
 
       - name: Integration Tests
-        uses: nick-fields/retry@v3
+        run: pnpm test:int
         env:
           NODE_OPTIONS: --max-old-space-size=8096
           PAYLOAD_DATABASE: ${{ matrix.database }}
           POSTGRES_URL: ${{ env.POSTGRES_URL }}
-        with:
-          retry_on: any
-          max_attempts: 5
-          timeout_minutes: 15
-          command: pnpm test:int
-          on_retry_command: pnpm clean:build && pnpm install --no-frozen-lockfile
 
   tests-e2e:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Reverts https://github.com/payloadcms/payload/pull/9652 for int tests, mongodb issues seem to be fixed with the mongodb-memory-server update