### PR TITLE
test: ensures server errors are hidden from rest response when not using config.debug

### DIFF
--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -73,7 +73,7 @@ export const handleEndpoints = async ({
 
   // This can be used against GET request search params size limit.
   // Instead you can do POST request with a text body as search params.
-  // We use this interally for relationships querying on the frontend
+  // We use this internally for relationships querying on the frontend
   // packages/ui/src/fields/Relationship/index.tsx
   if (
     request.method.toLowerCase() === 'post' &&
@@ -217,17 +217,20 @@ export const handleEndpoints = async ({
     }
 
     const response = await handler(req)
+
     return new Response(response.body, {
       headers: mergeHeaders(req.responseHeaders ?? new Headers(), response.headers),
       status: response.status,
       statusText: response.statusText,
     })
   } catch (err) {
-    return routeError({
+    const result = await routeError({
       collection,
       config: incomingConfig,
       err,
       req,
     })
+
+    return result
   }
 }

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -51,7 +51,7 @@ export default buildConfigWithDefaults({
   },
   collections: [
     {
-      slug,
+      slug: postsSlug,
       access: openAccess,
       fields: [
         {
@@ -346,14 +346,14 @@ export default buildConfigWithDefaults({
 
     // Relation - hasMany
     await payload.create({
-      collection: slug,
+      collection: postsSlug,
       data: {
         relationHasManyField: rel1.id,
         title: 'rel to hasMany',
       },
     })
     await payload.create({
-      collection: slug,
+      collection: postsSlug,
       data: {
         relationHasManyField: rel2.id,
         title: 'rel to hasMany 2',
@@ -362,7 +362,7 @@ export default buildConfigWithDefaults({
 
     // Relation - relationTo multi
     await payload.create({
-      collection: slug,
+      collection: postsSlug,
       data: {
         relationMultiRelationTo: {
           relationTo: relationSlug,
@@ -374,7 +374,7 @@ export default buildConfigWithDefaults({
 
     // Relation - relationTo multi hasMany
     await payload.create({
-      collection: slug,
+      collection: postsSlug,
       data: {
         relationMultiRelationToHasMany: [
           {

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -34,7 +34,7 @@ const collectionWithName = (collectionSlug: string): CollectionConfig => {
   }
 }
 
-export const slug = 'posts'
+export const postsSlug = 'posts'
 export const relationSlug = 'relation'
 export const pointSlug = 'point'
 export const customIdSlug = 'custom-id'


### PR DESCRIPTION
Adds test for to ensure that REST API errors are hidden from the response. This is because internal server errors can contain anything, including potentially sensitive data. Therefore, error details will be hidden from the response unless `config.debug` is `true`. 