### PR TITLE
chore(deps): bumps path-to-regexp

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -91,7 +91,7 @@
     "graphql-http": "^1.22.0",
     "graphql-playground-html": "1.6.30",
     "http-status": "1.6.2",
-    "path-to-regexp": "^6.2.1",
+    "path-to-regexp": "6.3.0",
     "qs-esm": "7.0.2",
     "react-diff-viewer-continued": "3.2.6",
     "sass": "1.77.4",

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -103,7 +103,7 @@
     "jose": "5.9.6",
     "json-schema-to-typescript": "15.0.3",
     "minimist": "1.2.8",
-    "path-to-regexp": "6.2.1",
+    "path-to-regexp": "6.3.0",
     "pino": "9.5.0",
     "pino-pretty": "13.0.0",
     "pluralize": "8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,7 +723,7 @@ importers:
         specifier: ^15.0.0
         version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
       path-to-regexp:
-        specifier: ^6.2.1
+        specifier: 6.3.0
         version: 6.3.0
       qs-esm:
         specifier: 7.0.2
@@ -856,8 +856,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       path-to-regexp:
-        specifier: 6.2.1
-        version: 6.2.1
+        specifier: 6.3.0
+        version: 6.3.0
       pino:
         specifier: 9.5.0
         version: 9.5.0
@@ -8556,9 +8556,6 @@ packages:
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
-
-  path-to-regexp@6.2.1:
-    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -18678,8 +18675,6 @@ snapshots:
     dependencies:
       lru-cache: 11.0.2
       minipass: 7.1.2
-
-  path-to-regexp@6.2.1: {}
 
   path-to-regexp@6.3.0: {}
 


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR bumps the minimum package version for `path-to-regexp` to v6.3.0

### Why?
To avoid a high severity cve as specified [here](https://github.com/advisories/GHSA-9wv6-86v2-598j).

### How?
Changes to `payload/package.json` and `next/package.json`

Credit to @Malderan for pointing it out.