### PR TITLE
fix(richtext-lexical): incorrect table action menu placement

### DIFF
--- a/packages/richtext-lexical/src/features/experimental_table/client/plugins/TableActionMenuPlugin/index.tsx
+++ b/packages/richtext-lexical/src/features/experimental_table/client/plugins/TableActionMenuPlugin/index.tsx
@@ -175,7 +175,7 @@ function TableActionMenu({
       let topPosition = menuButtonRect.top
       if (topPosition + dropDownElementRect.height > window.innerHeight) {
         const position = menuButtonRect.bottom - dropDownElementRect.height
-        topPosition = (position < 0 ? margin : position) + window.pageYOffset
+        topPosition = position < 0 ? margin : position
       }
       dropDownElement.style.top = `${topPosition}px`
     }


### PR DESCRIPTION
Fixes #10626

This was originally fixed in this [lexical PR](https://github.com/facebook/lexical/pull/4301), however it seems both the `TypeAheadMenu` plugin and the `TableActionMenu` plugin are broken in lexical playground again.

I was unable to find any issues with the `SlashMenu` in our case so I left it as is.

## Before

https://github.com/user-attachments/assets/5f8287a2-2875-4eb5-9402-933b0ce30af5

## After

https://github.com/user-attachments/assets/44394923-3dd8-4fd7-9d58-2c29886490e6

