### PR TITLE
fix(plugin-search): gets api route from useConfig

### DIFF
--- a/packages/plugin-search/src/Search/index.ts
+++ b/packages/plugin-search/src/Search/index.ts
@@ -8,7 +8,6 @@ import { generateReindexHandler } from '../utilities/generateReindexHandler.js'
 export const generateSearchCollection = (
   pluginConfig: SearchPluginConfigWithLocales,
 ): CollectionConfig => {
-  const apiBasePath = pluginConfig?.apiBasePath || '/api'
   const searchSlug = pluginConfig?.searchOverrides?.slug || 'search'
   const searchCollections = pluginConfig?.collections || []
   const collectionLabels = pluginConfig?.labels
@@ -71,7 +70,6 @@ export const generateSearchCollection = (
               {
                 path: '@payloadcms/plugin-search/client#ReindexButton',
                 serverProps: {
-                  apiBasePath,
                   collectionLabels,
                   searchCollections,
                   searchSlug,

--- a/packages/plugin-search/src/Search/ui/ReindexButton/index.client.tsx
+++ b/packages/plugin-search/src/Search/ui/ReindexButton/index.client.tsx
@@ -5,6 +5,7 @@ import {
   Popup,
   PopupList,
   toast,
+  useConfig,
   useLocale,
   useModal,
   useTranslation,
@@ -20,11 +21,11 @@ import { ReindexConfirmModal } from './ReindexConfirmModal/index.js'
 const confirmReindexModalSlug = 'confirm-reindex-modal'
 
 export const ReindexButtonClient: React.FC<ReindexButtonProps> = ({
-  apiBasePath,
   collectionLabels,
   searchCollections,
   searchSlug,
 }) => {
+  const apiBasePath = useConfig().config.routes.api
   const { closeModal, openModal } = useModal()
   const {
     i18n: { t },

--- a/packages/plugin-search/src/Search/ui/ReindexButton/index.tsx
+++ b/packages/plugin-search/src/Search/ui/ReindexButton/index.tsx
@@ -3,7 +3,7 @@ import type { SearchReindexButtonServerComponent } from './types.js'
 import { ReindexButtonClient } from './index.client.js'
 
 export const ReindexButton: SearchReindexButtonServerComponent = (props) => {
-  const { apiBasePath, collectionLabels, i18n, searchCollections, searchSlug } = props
+  const { collectionLabels, i18n, searchCollections, searchSlug } = props
 
   const getStaticLocalizedPluralLabels = () => {
     return Object.fromEntries(
@@ -26,7 +26,6 @@ export const ReindexButton: SearchReindexButtonServerComponent = (props) => {
 
   return (
     <ReindexButtonClient
-      apiBasePath={apiBasePath}
       collectionLabels={getStaticLocalizedPluralLabels()}
       searchCollections={searchCollections}
       searchSlug={searchSlug}

--- a/packages/plugin-search/src/Search/ui/ReindexButton/types.ts
+++ b/packages/plugin-search/src/Search/ui/ReindexButton/types.ts
@@ -3,7 +3,6 @@ import type { CustomComponent, PayloadServerReactComponent, StaticLabel } from '
 import type { CollectionLabels } from '../../../types.js'
 
 export type ReindexButtonProps = {
-  apiBasePath: string
   collectionLabels: Record<string, StaticLabel>
   searchCollections: string[]
   searchSlug: string


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

This fixes #10631.

Originally the api basepath for the reindex button is resolved during plugin initialization. Looks like this happens before payload overrides the config with the `basePath `from the next config.
I've changed it so that it uses the `useConfig` hook, and manually tested that it works.

![CleanShot 2568-01-17 at 16 03 16@2x](https://github.com/user-attachments/assets/c931577b-2717-4635-b5c6-17aa1b4eb734)
