### PR TITLE
fix(templates): type narrowing getGlobal

### DIFF
--- a/templates/website/src/utilities/getGlobals.ts
+++ b/templates/website/src/utilities/getGlobals.ts
@@ -6,7 +6,7 @@ import { unstable_cache } from 'next/cache'
 
 type Global = keyof Config['globals']
 
-async function getGlobal(slug: Global, depth = 0) {
+async function getGlobal<T extends Global>(slug: T, depth = 0) {
   const payload = await getPayload({ config: configPromise })
 
   const global = await payload.findGlobal({
@@ -20,7 +20,7 @@ async function getGlobal(slug: Global, depth = 0) {
 /**
  * Returns a unstable_cache function mapped with the cache tag for the slug
  */
-export const getCachedGlobal = (slug: Global, depth = 0) =>
+export const getCachedGlobal = <T extends Global>(slug: T, depth = 0) =>
   unstable_cache(async () => getGlobal(slug, depth), [slug], {
     tags: [`global_${slug}`],
   })


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?

By default when using the getGlobal utility it will not automatically narrow to the type which you specified in the argument. This pull resolves this issue

Before:
![image](https://github.com/user-attachments/assets/a13cbb4a-5e34-4dd2-9330-635d986249cd)
After:
![image](https://github.com/user-attachments/assets/1bc7b247-e06f-410b-91a7-fadb5cc35340)

### Why?
Because it's annoying to manually specify 

### How?
Using generics

---
I used to have this PR open during a beta branch but since so much has changed i decided to remake. the old pr is available [here](https://github.com/payloadcms/payload/pull/7793)