### PR TITLE
docs: removes live preview image placeholder comment

### DIFF
--- a/docs/live-preview/overview.mdx
+++ b/docs/live-preview/overview.mdx
@@ -33,8 +33,6 @@ const config = buildConfig({
   Alternatively, you can define the `admin.livePreview` property on individual [Collection Admin Configs](../admin/collections) and [Global Admin Configs](../admin/globals). Settings defined here will be merged into the top-level as overrides.
 </Banner>
 
-{/* IMAGE OF LIVE PREVIEW HERE */}
-
 ## Options
 
 Setting up Live Preview is easy. This can be done either globally through the [Root Admin Config](../admin/overview), or on individual [Collection Admin Configs](../admin/collections) and [Global Admin Configs](../admin/globals). Once configured, a new "Live Preview" tab will appear at the top of enabled Documents. Navigating to this tab opens the preview window and loads your front-end application.


### PR DESCRIPTION
There was a rogue `{/* IMAGE OF LIVE PREVIEW HERE */}` comment being rendered in the live preview docs. Comments in this format used to be hidden, but since moving to a new rendering pattern they now appear.