### PR TITLE
fix: add error handling to populateAuthors

### DIFF
--- a/templates/website/src/collections/Posts/hooks/populateAuthors.ts
+++ b/templates/website/src/collections/Posts/hooks/populateAuthors.ts
@@ -10,15 +10,25 @@ export const populateAuthors: CollectionAfterReadHook = async ({ doc, req, req: 
     const authorDocs: User[] = []
 
     for (const author of doc.authors) {
-      const authorDoc = await payload.findByID({
-        id: typeof author === 'object' ? author?.id : author,
-        collection: 'users',
-        depth: 0,
-        req,
-      })
+      const authorId = typeof author === 'object' ? author?.id : author
 
-      if (authorDoc) {
-        authorDocs.push(authorDoc)
+      try {
+        if (!authorId) {
+          continue
+        }
+
+        const authorDoc = await payload?.findByID({
+          id: authorId,
+          collection: 'users',
+          depth: 0,
+          req,
+        })
+
+        if (authorDoc) {
+          authorDocs.push(authorDoc)
+        }
+      } catch (error) {
+        payload.logger.error({ err: error }, `Error fetching author with ID: ${authorId}`)
       }
     }
 


### PR DESCRIPTION
**Summary**
While setting up a Payload project using the following steps:

1. Run `pnpx create-payload-app@latest`.
- Template: `website`
- Database: `MongoDB`

2. Start the app with `yarn dev.`
3. Create an account and populate the database using the default seed.

The application successfully initializes with default posts and pages. However, an issue arises when navigating to pages in both normal preview and live preview after removing all users except the one created during setup. The following error is displayed:
![image](https://github.com/user-attachments/assets/a87a33aa-64bd-4040-b8bb-5644db8bd3b2)

**Problem**
Upon investigation, the issue stems from the `populateAuthors.ts` file. Payload does not currently handle the case where a deleted user is still referenced in posts. This causes a failure when attempting to interact with the pages, especially when adding an archive block.

Since I'm new to Payload, I reviewed the seed files but couldn't identify any related issues. Additionally, I couldn't find a similar issue reported in the existing PRs.

**Solution**
I added error handling in the `populateAuthors.ts` file to gracefully manage cases where a deleted user is referenced. After implementing this fix, the application no longer crashes, and the pages render correctly.

Updated behavior:
![image](https://github.com/user-attachments/assets/090b18d3-317f-448d-9e55-157fdabad0a9)

**Request for Review**
Please let me know if I’ve missed anything or if there are additional steps I should take to ensure this fix aligns with the Payload project’s conventions.
