### PR TITLE
perf: ensure deepCopy in beforeValidate hook does not run unnecessarily for rest and graphQL API

### DIFF
--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto'
 
-import type { CollectionSlug, JsonObject } from '../../index.js'
 import type {
   Document,
   PayloadRequest,
@@ -27,6 +26,7 @@ import { afterChange } from '../../fields/hooks/afterChange/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { beforeChange } from '../../fields/hooks/beforeChange/index.js'
 import { beforeValidate } from '../../fields/hooks/beforeValidate/index.js'
+import { type CollectionSlug, type JsonObject } from '../../index.js'
 import { generateFileData } from '../../uploads/generateFileData.js'
 import { unlinkTempFiles } from '../../uploads/unlinkTempFiles.js'
 import { uploadFiles } from '../../uploads/uploadFiles.js'

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -1,4 +1,3 @@
-import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type {
   Document,
   PayloadRequest,
@@ -14,6 +13,13 @@ import type {
 } from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'
+import {
+  type CollectionSlug,
+  deepCopyObjectSimple,
+  type Payload,
+  type RequestContext,
+  type TypedLocale,
+} from '../../../index.js'
 import { getFileByPath } from '../../../uploads/getFileByPath.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { createOperation } from '../create.js'
@@ -80,7 +86,7 @@ export default async function createLocal<
 
   return createOperation<TSlug, TSelect>({
     collection,
-    data,
+    data: deepCopyObjectSimple(data), // Ensure mutation of data in create operation hooks doesn't affect the original data
     depth,
     disableTransaction,
     disableVerificationEmail,

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -3,7 +3,6 @@ import type { DeepPartial } from 'ts-essentials'
 import { status as httpStatus } from 'http-status'
 
 import type { AccessResult } from '../../config/types.js'
-import type { CollectionSlug } from '../../index.js'
 import type { PayloadRequest, PopulateType, SelectType, Where } from '../../types/index.js'
 import type {
   BulkOperationResult,
@@ -17,6 +16,7 @@ import executeAccess from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
 import { APIError } from '../../errors/index.js'
+import { type CollectionSlug, deepCopyObjectSimple } from '../../index.js'
 import { generateFileData } from '../../uploads/generateFileData.js'
 import { unlinkTempFiles } from '../../uploads/unlinkTempFiles.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
@@ -191,7 +191,7 @@ export const updateOperation = async <
           autosave: false,
           collectionConfig,
           config,
-          data,
+          data: deepCopyObjectSimple(data),
           depth,
           docWithLocales,
           draftArg,

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -3,7 +3,6 @@ import type { DeepPartial } from 'ts-essentials'
 import { status as httpStatus } from 'http-status'
 
 import type { FindOneArgs } from '../../database/types.js'
-import type { CollectionSlug } from '../../index.js'
 import type {
   PayloadRequest,
   PopulateType,
@@ -20,6 +19,7 @@ import executeAccess from '../../auth/executeAccess.js'
 import { hasWhereAccessResult } from '../../auth/types.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { APIError, Forbidden, NotFound } from '../../errors/index.js'
+import { type CollectionSlug, deepCopyObjectSimple } from '../../index.js'
 import { generateFileData } from '../../uploads/generateFileData.js'
 import { unlinkTempFiles } from '../../uploads/unlinkTempFiles.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
@@ -168,7 +168,7 @@ export const updateByIDOperation = async <
       autosave,
       collectionConfig,
       config,
-      data: newFileData,
+      data: deepCopyObjectSimple(newFileData),
       depth,
       docWithLocales,
       draftArg,

--- a/packages/payload/src/fields/hooks/beforeValidate/index.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/index.ts
@@ -1,8 +1,8 @@
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
-import type { RequestContext } from '../../../index.js'
 import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 
+import { type RequestContext } from '../../../index.js'
 import { traverseFields } from './traverseFields.js'
 
 type Args<T extends JsonObject> = {

--- a/packages/payload/src/fields/hooks/beforeValidate/index.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/index.ts
@@ -3,7 +3,6 @@ import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
 import type { RequestContext } from '../../../index.js'
 import type { JsonObject, PayloadRequest } from '../../../types/index.js'
 
-import { deepCopyObjectSimple } from '../../../utilities/deepCopyObject.js'
 import { traverseFields } from './traverseFields.js'
 
 type Args<T extends JsonObject> = {
@@ -38,12 +37,11 @@ export const beforeValidate = async <T extends JsonObject>({
   overrideAccess,
   req,
 }: Args<T>): Promise<T> => {
-  const data = deepCopyObjectSimple(incomingData)
   await traverseFields({
     id,
     collection,
     context,
-    data,
+    data: incomingData,
     doc,
     fields: collection?.fields || global?.fields,
     global,
@@ -52,9 +50,9 @@ export const beforeValidate = async <T extends JsonObject>({
     path: [],
     req,
     schemaPath: [],
-    siblingData: data,
+    siblingData: incomingData,
     siblingDoc: doc,
   })
 
-  return data
+  return incomingData
 }

--- a/packages/payload/src/globals/operations/local/update.ts
+++ b/packages/payload/src/globals/operations/local/update.ts
@@ -1,6 +1,5 @@
 import type { DeepPartial } from 'ts-essentials'
 
-import type { GlobalSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type {
   Document,
   PayloadRequest,
@@ -11,6 +10,13 @@ import type {
 import type { DataFromGlobalSlug, SelectFromGlobalSlug } from '../../config/types.js'
 
 import { APIError } from '../../../errors/index.js'
+import {
+  deepCopyObjectSimple,
+  type GlobalSlug,
+  type Payload,
+  type RequestContext,
+  type TypedLocale,
+} from '../../../index.js'
 import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { updateOperation } from '../update.js'
 
@@ -60,7 +66,7 @@ export default async function updateLocal<
 
   return updateOperation<TSlug, TSelect>({
     slug: globalSlug as string,
-    data,
+    data: deepCopyObjectSimple(data), // Ensure mutation of data in create operation hooks doesn't affect the original data
     depth,
     draft,
     globalConfig,


### PR DESCRIPTION
Previously, the beforeValidate hook was deepCopying input data. This indirectly ensured that the passed input data was not mutated.

E.g., if you run the `payload.create` local API, you do not want that to mutate the `data` object that is passed as an argument. This will create issues if you attempt to use it multiple times.


This PR moves the deepCopy logic from the beforeValidate hook to the start of the local API operation. This ensures that
- Input data is intentionally copied at the beginning which makes more sense. Comment was added to explain why
- GraphQL and Rest operations are now faster, as we don't need to ensure that the input data is not mutated for those => deepCopy only runs for local API