### PR TITLE
perf(ui): remove unnecessary deepCopy in reduceToSerializableFields

### DIFF
--- a/packages/ui/src/forms/Form/reduceToSerializableFields.ts
+++ b/packages/ui/src/forms/Form/reduceToSerializableFields.ts
@@ -1,35 +1,32 @@
 import { type FormField, type FormState } from 'payload'
-import { deepCopyObjectComplex } from 'payload/shared'
 
 type BlacklistedKeys = 'customComponents' | 'validate'
 const blacklistedKeys: BlacklistedKeys[] = ['validate', 'customComponents']
 
 const sanitizeField = (incomingField: FormField): FormField => {
-  const field = deepCopyObjectComplex(incomingField)
+  const field = { ...incomingField } // shallow copy, as we only need to remove top-level keys
 
-  blacklistedKeys.forEach((key) => {
+  for (const key of blacklistedKeys) {
     delete field[key]
-  })
+  }
 
   return field
 }
 
-/* 
-  Takes in FormState and removes fields that are not serializable.
-  Returns FormState without blacklisted keys.
-**/
+/**
+ * Takes in FormState and removes fields that are not serializable.
+ * Returns FormState without blacklisted keys.
+ */
 export const reduceToSerializableFields = (
   fields: FormState,
 ): {
   [key: string]: Omit<FormField, BlacklistedKeys>
 } => {
-  return Object.keys(fields).reduce(
-    (acc, key) => {
-      acc[key] = sanitizeField(fields[key])
-      return acc
-    },
-    {} as {
-      [key: string]: Omit<FormField, BlacklistedKeys>
-    },
-  )
+  const result: Record<string, Omit<FormField, BlacklistedKeys>> = {}
+
+  for (const key in fields) {
+    result[key] = sanitizeField(fields[key])
+  }
+
+  return result
 }


### PR DESCRIPTION
Previously, we were deepcopying the `FormField`s before deleting unserializable fields - the result of that was then sent to the server.

Since we're only deleting top-level fields, deep copying was unnecessary. It has been replaced with a simple spread operator, which is faster and uses less memory.

Additionally, this replaces the use of `.reduce()` with a simple for loop, improving code readability and performance