### PR TITLE
chore: run pnpm dev without dev - this improves error logging on init

### DIFF
--- a/test/dev.ts
+++ b/test/dev.ts
@@ -13,7 +13,7 @@ import { parse } from 'url'
 import { getNextRootDir } from './helpers/getNextRootDir.js'
 import startMemoryDB from './helpers/startMemoryDB.js'
 import { runInit } from './runInit.js'
-import { child, safelyRunScriptFunction } from './safelyRunScript.js'
+import { child } from './safelyRunScript.js'
 import { createTestHooks } from './testHooks.js'
 
 const prod = process.argv.includes('--prod')
@@ -39,7 +39,7 @@ const {
   ...args
 } = minimist(process.argv.slice(2))
 
-if (!fs.existsSync(path.resolve(dirname, testSuiteArg))) {
+if (!testSuiteArg || !fs.existsSync(path.resolve(dirname, testSuiteArg))) {
   console.log(chalk.red(`ERROR: The test folder "${testSuiteArg}" does not exist`))
   process.exit(0)
 }
@@ -53,7 +53,7 @@ await beforeTest()
 
 const { rootDir, adminRoute } = getNextRootDir(testSuiteArg)
 
-await safelyRunScriptFunction(runInit, 4000, testSuiteArg, true)
+await runInit(testSuiteArg, true)
 
 if (shouldStartMemoryDB) {
   await startMemoryDB()


### PR DESCRIPTION
No need for `safelyRunScriptFunction` anymore, as the issue where the dev script abruptly stopped execution has been fixed already.