### PR TITLE
fix(plugin-seo): loosen some types to restore compatibility between minor versions

### DIFF
--- a/packages/plugin-seo/src/index.tsx
+++ b/packages/plugin-seo/src/index.tsx
@@ -32,7 +32,7 @@ export const seoPlugin =
         ? [
             MetaImageField({
               hasGenerateFn: typeof pluginConfig?.generateImage === 'function',
-              relationTo: pluginConfig.uploadsCollection,
+              relationTo: pluginConfig.uploadsCollection as string,
             }),
           ]
         : []),

--- a/packages/plugin-seo/src/types.ts
+++ b/packages/plugin-seo/src/types.ts
@@ -6,6 +6,7 @@ import type {
   GlobalConfig,
   GlobalSlug,
   PayloadRequest,
+  UploadCollectionSlug,
 } from 'payload'
 
 export type FieldsOverride = (args: { defaultFields: Field[] }) => Field[]
@@ -70,7 +71,7 @@ export type SEOPluginConfig = {
   /**
    * Collections to include the SEO fields in
    */
-  collections?: CollectionSlug[]
+  collections?: ({} | CollectionSlug)[]
   /**
    * Override the default fields inserted by the SEO plugin via a function that receives the default fields and returns the new fields
    *
@@ -87,7 +88,7 @@ export type SEOPluginConfig = {
   /**
    * Globals to include the SEO fields in
    */
-  globals?: GlobalSlug[]
+  globals?: ({} | GlobalSlug)[]
   interfaceName?: string
   /**
    * Group fields into tabs, your content will be automatically put into a general tab and the SEO fields into an SEO tab
@@ -98,7 +99,7 @@ export type SEOPluginConfig = {
   /**
    * The slug of the collection used to handle image uploads
    */
-  uploadsCollection?: CollectionSlug
+  uploadsCollection?: {} | UploadCollectionSlug
 }
 
 export type Meta = {


### PR DESCRIPTION
https://github.com/payloadcms/payload/pull/9962 could be considered a breaking change - this PR restores compatibility by allowing unknown collection slugs, while still providing type suggestions.