### PR TITLE
fix(plugin-stripe): hooks did not use api key from plugin config

### DIFF
--- a/packages/plugin-stripe/src/hooks/createNewInStripe.ts
+++ b/packages/plugin-stripe/src/hooks/createNewInStripe.ts
@@ -7,10 +7,6 @@ import type { StripePluginConfig } from '../types.js'
 
 import { deepen } from '../utilities/deepen.js'
 
-const stripeSecretKey = process.env.STRIPE_SECRET_KEY
-// api version can only be the latest, stripe recommends ts ignoring it
-const stripe = new Stripe(stripeSecretKey || '', { apiVersion: '2022-08-01' })
-
 type HookArgsWithCustomCollection = {
   collection: CollectionConfig
 } & Omit<Parameters<CollectionBeforeValidateHook>[0], 'collection'>
@@ -63,6 +59,9 @@ export const createNewInStripe: CollectionBeforeValidateHookWithArgs = async (ar
         )
 
         syncedFields = deepen(syncedFields)
+
+        // api version can only be the latest, stripe recommends ts ignoring it
+        const stripe = new Stripe(pluginConfig.stripeSecretKey || '', { apiVersion: '2022-08-01' })
 
         if (operation === 'update') {
           if (logs) {

--- a/packages/plugin-stripe/src/hooks/deleteFromStripe.ts
+++ b/packages/plugin-stripe/src/hooks/deleteFromStripe.ts
@@ -5,10 +5,6 @@ import Stripe from 'stripe'
 
 import type { StripePluginConfig } from '../types.js'
 
-const stripeSecretKey = process.env.STRIPE_SECRET_KEY
-// api version can only be the latest, stripe recommends ts ignoring it
-const stripe = new Stripe(stripeSecretKey || '', { apiVersion: '2022-08-01' })
-
 type HookArgsWithCustomCollection = {
   collection: CollectionConfig
 } & Omit<Parameters<CollectionAfterDeleteHook>[0], 'collection'>
@@ -43,6 +39,9 @@ export const deleteFromStripe: CollectionAfterDeleteHookWithArgs = async (args) 
 
     if (syncConfig) {
       try {
+        // api version can only be the latest, stripe recommends ts ignoring it
+        const stripe = new Stripe(pluginConfig.stripeSecretKey || '', { apiVersion: '2022-08-01' })
+
         const found = await stripe?.[syncConfig.stripeResourceType]?.retrieve(doc.stripeID)
 
         if (found) {

--- a/packages/plugin-stripe/src/hooks/syncExistingWithStripe.ts
+++ b/packages/plugin-stripe/src/hooks/syncExistingWithStripe.ts
@@ -7,10 +7,6 @@ import type { StripePluginConfig } from '../types.js'
 
 import { deepen } from '../utilities/deepen.js'
 
-const stripeSecretKey = process.env.STRIPE_SECRET_KEY
-// api version can only be the latest, stripe recommends ts ignoring it
-const stripe = new Stripe(stripeSecretKey || '', { apiVersion: '2022-08-01' })
-
 type HookArgsWithCustomCollection = {
   collection: CollectionConfig
 } & Omit<Parameters<CollectionBeforeChangeHook>[0], 'collection'>
@@ -66,6 +62,11 @@ export const syncExistingWithStripe: CollectionBeforeChangeHookWithArgs = async 
           }
 
           try {
+            // api version can only be the latest, stripe recommends ts ignoring it
+            const stripe = new Stripe(pluginConfig.stripeSecretKey || '', {
+              apiVersion: '2022-08-01',
+            })
+
             const stripeResource = await stripe?.[syncConfig?.stripeResourceType]?.update(
               data.stripeID,
               syncedFields,

--- a/packages/plugin-stripe/src/index.ts
+++ b/packages/plugin-stripe/src/index.ts
@@ -59,57 +59,55 @@ export const stripePlugin =
       })
     }
 
-    return {
-      ...config,
-      collections: collections?.map((collection) => {
-        const { hooks: existingHooks } = collection
+    for (const collection of collections) {
+      const { hooks: existingHooks } = collection
 
-        const syncConfig = pluginConfig.sync?.find((sync) => sync.collection === collection.slug)
+      const syncConfig = pluginConfig.sync?.find((sync) => sync.collection === collection.slug)
 
-        if (syncConfig) {
-          const fields = getFields({
+      if (!syncConfig) {
+        continue
+      }
+      const fields = getFields({
+        collection,
+        pluginConfig,
+        syncConfig,
+      })
+      collection.fields = fields
+
+      if (!collection.hooks) {
+        collection.hooks = {}
+      }
+
+      collection.hooks.afterDelete = [
+        ...(existingHooks?.afterDelete || []),
+        (args) =>
+          deleteFromStripe({
+            ...args,
             collection,
             pluginConfig,
-            syncConfig,
-          })
-          return {
-            ...collection,
-            fields,
-            hooks: {
-              ...collection.hooks,
-              afterDelete: [
-                ...(existingHooks?.afterDelete || []),
-                (args) =>
-                  deleteFromStripe({
-                    ...args,
-                    collection,
-                    pluginConfig,
-                  }),
-              ],
-              beforeChange: [
-                ...(existingHooks?.beforeChange || []),
-                (args) =>
-                  syncExistingWithStripe({
-                    ...args,
-                    collection,
-                    pluginConfig,
-                  }),
-              ],
-              beforeValidate: [
-                ...(existingHooks?.beforeValidate || []),
-                (args) =>
-                  createNewInStripe({
-                    ...args,
-                    collection,
-                    pluginConfig,
-                  }),
-              ],
-            },
-          }
-        }
-
-        return collection
-      }),
-      endpoints,
+          }),
+      ]
+      collection.hooks.beforeChange = [
+        ...(existingHooks?.beforeChange || []),
+        (args) =>
+          syncExistingWithStripe({
+            ...args,
+            collection,
+            pluginConfig,
+          }),
+      ]
+      collection.hooks.beforeValidate = [
+        ...(existingHooks?.beforeValidate || []),
+        (args) =>
+          createNewInStripe({
+            ...args,
+            collection,
+            pluginConfig,
+          }),
+      ]
     }
+
+    config.endpoints = endpoints
+
+    return config
   }


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/10668

As the stripe key is a required config property, the plugin should not have to fall back to the env variable