### PR TITLE
chore(examples): change to useClickableCard to use AbortController

### DIFF
--- a/examples/localization/src/utilities/useClickableCard.ts
+++ b/examples/localization/src/utilities/useClickableCard.ts
@@ -78,18 +78,19 @@ function useClickableCard<T extends HTMLElement>({
   useEffect(() => {
     const cardNode = card.current
 
+    const abortController = new AbortController()
+
     if (cardNode) {
-      cardNode.addEventListener('mousedown', handleMouseDown)
-      cardNode.addEventListener('mouseup', handleMouseUp)
+      cardNode.addEventListener('mousedown', handleMouseDown, {
+        signal: abortController.signal,
+      })
+      cardNode.addEventListener('mouseup', handleMouseUp, {
+        signal: abortController.signal,
+      })
     }
 
     return () => {
-      if (cardNode) {
-        if (cardNode) {
-          cardNode?.removeEventListener('mousedown', handleMouseDown)
-          cardNode?.removeEventListener('mouseup', handleMouseUp)
-        }
-      }
+      abortController.abort()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [card, link, router])

--- a/templates/website/src/utilities/useClickableCard.ts
+++ b/templates/website/src/utilities/useClickableCard.ts
@@ -78,18 +78,19 @@ function useClickableCard<T extends HTMLElement>({
   useEffect(() => {
     const cardNode = card.current
 
+    const abortController = new AbortController()
+
     if (cardNode) {
-      cardNode.addEventListener('mousedown', handleMouseDown)
-      cardNode.addEventListener('mouseup', handleMouseUp)
+      cardNode.addEventListener('mousedown', handleMouseDown, {
+        signal: abortController.signal,
+      })
+      cardNode.addEventListener('mouseup', handleMouseUp, {
+        signal: abortController.signal,
+      })
     }
 
     return () => {
-      if (cardNode) {
-        if (cardNode) {
-          cardNode?.removeEventListener('mousedown', handleMouseDown)
-          cardNode?.removeEventListener('mouseup', handleMouseUp)
-        }
-      }
+      abortController.abort()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [card, link, router])

--- a/templates/with-vercel-website/src/utilities/useClickableCard.ts
+++ b/templates/with-vercel-website/src/utilities/useClickableCard.ts
@@ -78,18 +78,19 @@ function useClickableCard<T extends HTMLElement>({
   useEffect(() => {
     const cardNode = card.current
 
+    const abortController = new AbortController()
+
     if (cardNode) {
-      cardNode.addEventListener('mousedown', handleMouseDown)
-      cardNode.addEventListener('mouseup', handleMouseUp)
+      cardNode.addEventListener('mousedown', handleMouseDown, {
+        signal: abortController.signal,
+      })
+      cardNode.addEventListener('mouseup', handleMouseUp, {
+        signal: abortController.signal,
+      })
     }
 
     return () => {
-      if (cardNode) {
-        if (cardNode) {
-          cardNode?.removeEventListener('mousedown', handleMouseDown)
-          cardNode?.removeEventListener('mouseup', handleMouseUp)
-        }
-      }
+      abortController.abort()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [card, link, router])


### PR DESCRIPTION
* introduce AbortController to the event listeners in useClickableCard
* in an attempt to avoid ugly boolean check
* suggested pattern from https://kettanaito.com/blog/dont-sleep-on-abort-controller

### What?

Add AbortController to event listeners in useClickableCard.

### Why?

Following Theo's [video](https://www.youtube.com/watch?v=2sdXSczmvNc) about the [blog post](https://kettanaito.com/blog/dont-sleep-on-abort-controller) about AbortController I came across a bit of code in examples that looked a bit ugly and thought the AbortController could simplify it a bit (especially the checks for the DOM node in the removal part).

### How?

Just re-writing the code in a different way. Though, I admit I'm not wholly sure where the Cards are being used and for what purpose so I haven't checked that there is no difference to the behaviour of the code.

### Fixes:
Not so much a fix but a different way to write the removal of event listeners. 
