### PR TITLE
templates: form fields will now respect 'required' flag from config on website template

### DIFF
--- a/templates/website/src/app/(frontend)/globals.css
+++ b/templates/website/src/app/(frontend)/globals.css
@@ -38,7 +38,7 @@
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 240 6% 90%;
+    --border: 240 6% 80%;
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
 
@@ -74,7 +74,7 @@
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 0, 0%, 15%, 0.5;
+    --border: 0, 0%, 15%, 0.8;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;
 

--- a/templates/website/src/blocks/Form/Checkbox/index.tsx
+++ b/templates/website/src/blocks/Form/Checkbox/index.tsx
@@ -21,8 +21,8 @@ export const Checkbox: React.FC<
     register: UseFormRegister<FieldValues>
     setValue: any
   }
-> = ({ name, defaultValue, errors, label, register, required: requiredFromProps, width }) => {
-  const props = register(name, { required: requiredFromProps })
+> = ({ name, defaultValue, errors, label, register, required, width }) => {
+  const props = register(name, { required: required })
   const { setValue } = useFormContext()
 
   return (
@@ -36,9 +36,16 @@ export const Checkbox: React.FC<
             setValue(props.name, checked)
           }}
         />
-        <Label htmlFor={name}>{label}</Label>
+        <Label htmlFor={name}>
+          {required && (
+            <span className="required">
+              * <span className="sr-only">(required)</span>
+            </span>
+          )}
+          {label}
+        </Label>
       </div>
-      {requiredFromProps && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Country/index.tsx
+++ b/templates/website/src/blocks/Form/Country/index.tsx
@@ -30,6 +30,12 @@ export const Country: React.FC<
     <Width width={width}>
       <Label className="" htmlFor={name}>
         {label}
+
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
       </Label>
       <Controller
         control={control}
@@ -57,7 +63,7 @@ export const Country: React.FC<
         }}
         rules={{ required }}
       />
-      {required && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Email/index.tsx
+++ b/templates/website/src/blocks/Form/Email/index.tsx
@@ -17,18 +17,26 @@ export const Email: React.FC<
     >
     register: UseFormRegister<FieldValues>
   }
-> = ({ name, defaultValue, errors, label, register, required: requiredFromProps, width }) => {
+> = ({ name, defaultValue, errors, label, register, required, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
+      <Label htmlFor={name}>
+        {label}
+
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
       <Input
         defaultValue={defaultValue}
         id={name}
         type="text"
-        {...register(name, { pattern: /^\S[^\s@]*@\S+$/, required: requiredFromProps })}
+        {...register(name, { pattern: /^\S[^\s@]*@\S+$/, required })}
       />
 
-      {requiredFromProps && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Number/index.tsx
+++ b/templates/website/src/blocks/Form/Number/index.tsx
@@ -16,17 +16,25 @@ export const Number: React.FC<
     >
     register: UseFormRegister<FieldValues>
   }
-> = ({ name, defaultValue, errors, label, register, required: requiredFromProps, width }) => {
+> = ({ name, defaultValue, errors, label, register, required, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
+      <Label htmlFor={name}>
+        {label}
+
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
       <Input
         defaultValue={defaultValue}
         id={name}
         type="number"
-        {...register(name, { required: requiredFromProps })}
+        {...register(name, { required })}
       />
-      {requiredFromProps && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Select/index.tsx
+++ b/templates/website/src/blocks/Form/Select/index.tsx
@@ -27,7 +27,14 @@ export const Select: React.FC<
 > = ({ name, control, errors, label, options, required, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
+      <Label htmlFor={name}>
+        {label}
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
       <Controller
         control={control}
         defaultValue=""
@@ -54,7 +61,7 @@ export const Select: React.FC<
         }}
         rules={{ required }}
       />
-      {required && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/State/index.tsx
+++ b/templates/website/src/blocks/Form/State/index.tsx
@@ -28,7 +28,14 @@ export const State: React.FC<
 > = ({ name, control, errors, label, required, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
+      <Label htmlFor={name}>
+        {label}
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
       <Controller
         control={control}
         defaultValue=""
@@ -55,7 +62,7 @@ export const State: React.FC<
         }}
         rules={{ required }}
       />
-      {required && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Text/index.tsx
+++ b/templates/website/src/blocks/Form/Text/index.tsx
@@ -17,17 +17,20 @@ export const Text: React.FC<
     >
     register: UseFormRegister<FieldValues>
   }
-> = ({ name, defaultValue, errors, label, register, required: requiredFromProps, width }) => {
+> = ({ name, defaultValue, errors, label, register, required, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
-      <Input
-        defaultValue={defaultValue}
-        id={name}
-        type="text"
-        {...register(name, { required: requiredFromProps })}
-      />
-      {requiredFromProps && errors[name] && <Error />}
+      <Label htmlFor={name}>
+        {label}
+
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
+      <Input defaultValue={defaultValue} id={name} type="text" {...register(name, { required })} />
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Textarea/index.tsx
+++ b/templates/website/src/blocks/Form/Textarea/index.tsx
@@ -18,28 +18,27 @@ export const Textarea: React.FC<
     register: UseFormRegister<FieldValues>
     rows?: number
   }
-> = ({
-  name,
-  defaultValue,
-  errors,
-  label,
-  register,
-  required: requiredFromProps,
-  rows = 3,
-  width,
-}) => {
+> = ({ name, defaultValue, errors, label, register, required, rows = 3, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
+      <Label htmlFor={name}>
+        {label}
+
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
 
       <TextAreaComponent
         defaultValue={defaultValue}
         id={name}
         rows={rows}
-        {...register(name, { required: requiredFromProps })}
+        {...register(name, { required: required })}
       />
 
-      {requiredFromProps && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/with-vercel-website/src/app/(frontend)/globals.css
+++ b/templates/with-vercel-website/src/app/(frontend)/globals.css
@@ -38,7 +38,7 @@
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 240 6% 90%;
+    --border: 240 6% 80%;
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
 
@@ -74,7 +74,7 @@
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 0, 0%, 15%, 0.5;
+    --border: 0, 0%, 15%, 0.8;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;
 

--- a/templates/with-vercel-website/src/blocks/Form/Checkbox/index.tsx
+++ b/templates/with-vercel-website/src/blocks/Form/Checkbox/index.tsx
@@ -21,8 +21,8 @@ export const Checkbox: React.FC<
     register: UseFormRegister<FieldValues>
     setValue: any
   }
-> = ({ name, defaultValue, errors, label, register, required: requiredFromProps, width }) => {
-  const props = register(name, { required: requiredFromProps })
+> = ({ name, defaultValue, errors, label, register, required, width }) => {
+  const props = register(name, { required: required })
   const { setValue } = useFormContext()
 
   return (
@@ -36,9 +36,16 @@ export const Checkbox: React.FC<
             setValue(props.name, checked)
           }}
         />
-        <Label htmlFor={name}>{label}</Label>
+        <Label htmlFor={name}>
+          {required && (
+            <span className="required">
+              * <span className="sr-only">(required)</span>
+            </span>
+          )}
+          {label}
+        </Label>
       </div>
-      {requiredFromProps && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/with-vercel-website/src/blocks/Form/Country/index.tsx
+++ b/templates/with-vercel-website/src/blocks/Form/Country/index.tsx
@@ -30,6 +30,12 @@ export const Country: React.FC<
     <Width width={width}>
       <Label className="" htmlFor={name}>
         {label}
+
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
       </Label>
       <Controller
         control={control}
@@ -57,7 +63,7 @@ export const Country: React.FC<
         }}
         rules={{ required }}
       />
-      {required && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/with-vercel-website/src/blocks/Form/Email/index.tsx
+++ b/templates/with-vercel-website/src/blocks/Form/Email/index.tsx
@@ -17,18 +17,26 @@ export const Email: React.FC<
     >
     register: UseFormRegister<FieldValues>
   }
-> = ({ name, defaultValue, errors, label, register, required: requiredFromProps, width }) => {
+> = ({ name, defaultValue, errors, label, register, required, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
+      <Label htmlFor={name}>
+        {label}
+
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
       <Input
         defaultValue={defaultValue}
         id={name}
         type="text"
-        {...register(name, { pattern: /^\S[^\s@]*@\S+$/, required: requiredFromProps })}
+        {...register(name, { pattern: /^\S[^\s@]*@\S+$/, required })}
       />
 
-      {requiredFromProps && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/with-vercel-website/src/blocks/Form/Number/index.tsx
+++ b/templates/with-vercel-website/src/blocks/Form/Number/index.tsx
@@ -16,17 +16,25 @@ export const Number: React.FC<
     >
     register: UseFormRegister<FieldValues>
   }
-> = ({ name, defaultValue, errors, label, register, required: requiredFromProps, width }) => {
+> = ({ name, defaultValue, errors, label, register, required, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
+      <Label htmlFor={name}>
+        {label}
+
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
       <Input
         defaultValue={defaultValue}
         id={name}
         type="number"
-        {...register(name, { required: requiredFromProps })}
+        {...register(name, { required })}
       />
-      {requiredFromProps && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/with-vercel-website/src/blocks/Form/Select/index.tsx
+++ b/templates/with-vercel-website/src/blocks/Form/Select/index.tsx
@@ -27,7 +27,14 @@ export const Select: React.FC<
 > = ({ name, control, errors, label, options, required, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
+      <Label htmlFor={name}>
+        {label}
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
       <Controller
         control={control}
         defaultValue=""
@@ -54,7 +61,7 @@ export const Select: React.FC<
         }}
         rules={{ required }}
       />
-      {required && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/with-vercel-website/src/blocks/Form/State/index.tsx
+++ b/templates/with-vercel-website/src/blocks/Form/State/index.tsx
@@ -28,7 +28,14 @@ export const State: React.FC<
 > = ({ name, control, errors, label, required, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
+      <Label htmlFor={name}>
+        {label}
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
       <Controller
         control={control}
         defaultValue=""
@@ -55,7 +62,7 @@ export const State: React.FC<
         }}
         rules={{ required }}
       />
-      {required && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/with-vercel-website/src/blocks/Form/Text/index.tsx
+++ b/templates/with-vercel-website/src/blocks/Form/Text/index.tsx
@@ -17,17 +17,20 @@ export const Text: React.FC<
     >
     register: UseFormRegister<FieldValues>
   }
-> = ({ name, defaultValue, errors, label, register, required: requiredFromProps, width }) => {
+> = ({ name, defaultValue, errors, label, register, required, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
-      <Input
-        defaultValue={defaultValue}
-        id={name}
-        type="text"
-        {...register(name, { required: requiredFromProps })}
-      />
-      {requiredFromProps && errors[name] && <Error />}
+      <Label htmlFor={name}>
+        {label}
+
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
+      <Input defaultValue={defaultValue} id={name} type="text" {...register(name, { required })} />
+      {errors[name] && <Error />}
     </Width>
   )
 }

--- a/templates/with-vercel-website/src/blocks/Form/Textarea/index.tsx
+++ b/templates/with-vercel-website/src/blocks/Form/Textarea/index.tsx
@@ -18,28 +18,27 @@ export const Textarea: React.FC<
     register: UseFormRegister<FieldValues>
     rows?: number
   }
-> = ({
-  name,
-  defaultValue,
-  errors,
-  label,
-  register,
-  required: requiredFromProps,
-  rows = 3,
-  width,
-}) => {
+> = ({ name, defaultValue, errors, label, register, required, rows = 3, width }) => {
   return (
     <Width width={width}>
-      <Label htmlFor={name}>{label}</Label>
+      <Label htmlFor={name}>
+        {label}
+
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
 
       <TextAreaComponent
         defaultValue={defaultValue}
         id={name}
         rows={rows}
-        {...register(name, { required: requiredFromProps })}
+        {...register(name, { required: required })}
       />
 
-      {requiredFromProps && errors[name] && <Error />}
+      {errors[name] && <Error />}
     </Width>
   )
 }


### PR DESCRIPTION
There wasn't a required * indicator previously present in field labels if required: true was set.