### PR TITLE
fix(translations): add missing Catalan translations

### DIFF
--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -196,7 +196,7 @@ export const caTranslations: DefaultTranslationsObject = {
     clearAll: 'Esborra-ho tot',
     close: 'Tanca',
     collapse: 'Replegar',
-    collections: 'Collections',
+    collections: 'Col·leccions',
     columns: 'Columnes',
     columnToSort: 'Columna per ordenar',
     confirm: 'Confirma',
@@ -204,7 +204,7 @@ export const caTranslations: DefaultTranslationsObject = {
     confirmDeletion: "Confirma l'eliminació",
     confirmDuplication: 'Confirma duplicacat',
     confirmReindex: 'Reindexa {{collections}}?',
-    confirmReindexAll: 'Reindexa totes les collections?',
+    confirmReindexAll: 'Reindexa totes les col·leccions?',
     confirmReindexDescription:
       'Aixo eliminarà els índexs existents i reindexarà els documents de les col·leccions {{collections}}.',
     confirmReindexDescriptionAll:

--- a/packages/translations/src/utilities/languages.ts
+++ b/packages/translations/src/utilities/languages.ts
@@ -52,7 +52,6 @@ export const acceptedLanguages = [
    * 'bn-BD',
    * 'bn-IN',
    * 'bs',
-   * 'ca',
    * 'ca-ES-valencia',
    * 'cy',
    * 'el',


### PR DESCRIPTION
### What?
There are some missing translations in Catalan, both related to the word Collections, which in Catalan is "Col·leccions".
### Why?
To contribute to the Catalan language as a developer and native speaker ;)
### How?
Updated the wording in the `ca.ts` translations object, also removed `catalan` from `not implemented languages` comment