### PR TITLE
feat(next): interface prefix for generated types

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1110,6 +1110,9 @@ export type Config = {
     /** Filename to write the generated types to */
     outputFile?: string
 
+    /** Prefix to add to the generated interface names */
+    interfacePrefix?: string
+
     /**
      * Allows you to modify the base JSON schema that is generated during generate:types. This JSON schema will be used
      * to generate the TypeScript interfaces.

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -655,7 +655,7 @@ export function entityToJSONSchema(
   const entity: SanitizedCollectionConfig | SanitizedGlobalConfig = deepCopyObject(incomingEntity)
   const title = entity.typescript?.interface
     ? entity.typescript.interface
-    : singular(toWords(entity.slug, true))
+    : `${entity.typescript?.interfacePrefix ?? ''}${singular(toWords(entity.slug, true))}`
 
   const idField: FieldAffectingData = { name: 'id', type: defaultIDType as 'text', required: true }
   const customIdField = entity.flattenedFields.find(


### PR DESCRIPTION
### What?

This adds the option to set an interface prefix in the typescript section of the config. This prefix is then added to the start of all interfaces in the generated types.

### Why?

Users may want to use the generated types themselves and prefixing them allows them to be distinct from other types in their app. (Ex: Users vs PayloadUsers or CMSUsers)

### How?

This PR adds the new optional property to the config and then uses it inside of `entityToJSONSchema` where it is appended to the front of the generated interface name. Please note that this update does not append the prefix to manually defined interface names provided in the schema for greater flexibility.
