### PR TITLE
feat: extend listSearchableFields relationship fields to include subfields

### DIFF
--- a/test/admin/collections/Posts.ts
+++ b/test/admin/collections/Posts.ts
@@ -11,7 +11,7 @@ export const Posts: CollectionConfig = {
     defaultColumns: ['id', 'number', 'title', 'description', 'demoUIField'],
     description: 'This is a custom collection description.',
     group: 'One',
-    listSearchableFields: ['id', 'title', 'description', 'number'],
+    listSearchableFields: ['id', 'title', 'description', 'number', 'relationship', 'upload'],
     components: {
       beforeListTable: [
         '/components/ResetColumns/index.js#ResetDefaultColumnsButton',


### PR DESCRIPTION
When adding relationships to `admin.listSearchableFields` the search feature doesn't effectively query the relationship field.

This change appends the relationship field name with the `id`, `useAsTitle` or `admin.listSearchableFields` to the relationship's collection in dot notation to support querying the related relationships data to give better search results.

Before `admin.listSearchableFields`: 
```js
[
  'id',
  'title',
  'description',
  'number',
  'relationship', // relationship to self
  'upload' // upload field
]
```

After sanitization:
```js
[
  'id',
  'title',
  'description',
  'number',
  'relationship.id',
  'relationship.title',
  'relationship.description',
  'relationship.number',
  'relationship.relationship',
  'relationship.upload',
  'upload.filename'
]
```

Fixes # https://github.com/payloadcms/payload/issues/10649

TODO:
For some reason the change is resulting in much more results than expected. There might be a bug with querying these relationships. 
![image](https://github.com/user-attachments/assets/bb1be7be-da3b-4369-b38b-1da0a576785d)



