### PR TITLE
docs: multi-tenant plugin - remove @beta and fix npm url

### DIFF
--- a/docs/plugins/multi-tenant.mdx
+++ b/docs/plugins/multi-tenant.mdx
@@ -6,7 +6,7 @@ desc: Scaffolds multi-tenancy for your Payload application
 keywords: plugins, multi-tenant, multi-tenancy, plugin, payload, cms, seo, indexing, search, search engine
 ---
 
-[![npm](https://img.shields.io/npm/v/@payloadcms/plugin-multi-tenants)](https://www.npmjs.com/package/@payloadcms/plugin-multi-tenants)
+[![npm](https://img.shields.io/npm/v/@payloadcms/plugin-multi-tenant)](https://www.npmjs.com/package/@payloadcms/plugin-multi-tenant)
 
 This plugin sets up multi-tenancy for your application from within your [Admin Panel](../admin/overview). It does so by adding a `tenant` field to all specified collections. Your front-end application can then query data by tenant. You must add the Tenants collection so you control what fields are available for each tenant.
 
@@ -31,7 +31,7 @@ This plugin sets up multi-tenancy for your application from within your [Admin P
 Install the plugin using any JavaScript package manager like [pnpm](https://pnpm.io), [npm](https://npmjs.com), or [Yarn](https://yarnpkg.com):
 
 ```bash
-  pnpm add @payloadcms/plugin-multi-tenant@beta
+  pnpm add @payloadcms/plugin-multi-tenant
 ```
 
 ### Options

--- a/packages/plugin-multi-tenant/README.md
+++ b/packages/plugin-multi-tenant/README.md
@@ -9,7 +9,7 @@ A plugin for [Payload](https://github.com/payloadcms/payload) to easily manage m
 ## Installation
 
 ```bash
-pnpm add @payloadcms/plugin-multi-tenant@beta
+pnpm add @payloadcms/plugin-multi-tenant
 ```
 
 ## Plugin Types


### PR DESCRIPTION
Running `pnpm add @payloadcms/plugin-multi-tenant@beta` will install `v.0.0.1` which is outdated:
https://www.npmjs.com/package/@payloadcms/plugin-multi-tenant?activeTab=versions

I suspect the intention was to remove `@beta` from the plugin install instructions with yesterday's Payload `v3.18.0` release which also bumped `plugin-multi-tenant` to  `v3.18.0`, but this might have been missed.