### PR TITLE
fix(plugin-multi-tenant): prevent throwing when no user exists

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -53,6 +53,7 @@ jobs:
             plugin-cloud
             plugin-cloud-storage
             plugin-form-builder
+            plugin-multi-tenant
             plugin-nested-docs
             plugin-redirects
             plugin-search

--- a/examples/multi-tenant/package.json
+++ b/examples/multi-tenant/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@payloadcms/db-mongodb": "latest",
     "@payloadcms/next": "latest",
-    "@payloadcms/plugin-multi-tenant": "file:payloadcms-plugin-multi-tenant-3.15.1.tgz",
+    "@payloadcms/plugin-multi-tenant": "latest",
     "@payloadcms/richtext-lexical": "latest",
     "@payloadcms/ui": "latest",
     "cross-env": "^7.0.3",

--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
@@ -2,6 +2,7 @@
 
 import type { OptionObject } from 'payload'
 
+import { useAuth } from '@payloadcms/ui'
 import { useRouter } from 'next/navigation.js'
 import React, { createContext } from 'react'
 
@@ -34,6 +35,8 @@ export const TenantSelectionProviderClient = ({
     initialValue || SELECT_ALL,
   )
   const [preventRefreshOnChange, setPreventRefreshOnChange] = React.useState(false)
+  const { user } = useAuth()
+  const userID = React.useMemo(() => user?.id, [user?.id])
 
   const router = useRouter()
 
@@ -71,6 +74,10 @@ export const TenantSelectionProviderClient = ({
       }
     }
   }, [initialValue, setTenant, selectedTenantID, tenantOptions])
+
+  React.useEffect(() => {
+    router.refresh()
+  }, [userID, router])
 
   return (
     <Context.Provider

--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.tsx
@@ -19,19 +19,26 @@ export const TenantSelectionProvider = async ({
   useAsTitle,
   user,
 }: Args) => {
-  const { docs: userTenants } = await payload.find({
-    collection: tenantsCollectionSlug,
-    depth: 0,
-    limit: 1000,
-    overrideAccess: false,
-    sort: useAsTitle,
-    user,
-  })
+  let tenantOptions: OptionObject[] = []
 
-  const tenantOptions: OptionObject[] = userTenants.map((doc) => ({
-    label: String(doc[useAsTitle]),
-    value: String(doc.id),
-  }))
+  try {
+    const { docs: userTenants } = await payload.find({
+      collection: tenantsCollectionSlug,
+      depth: 0,
+      limit: 1000,
+      overrideAccess: false,
+      sort: useAsTitle,
+      user,
+    })
+
+    tenantOptions = userTenants.map((doc) => ({
+      label: String(doc[useAsTitle]),
+      value: String(doc.id),
+    }))
+  } catch (_) {
+    // user likely does not have access
+  }
+
   const cookies = await getCookies()
   const tenantCookie = cookies.get('payload-tenant')?.value
   const selectedTenant =


### PR DESCRIPTION
### What?
Fixes issue where the provider would throw an error and prevent the login screen from loading if there was no user.

### Why?
Missing try/catch around tenant find for the provider. (Missed because test suites have autoLogin: true)

### How?
Adds try/catch around find query.

Fixes #10602
Fixes #10714