### PR TITLE
chore: adds plugin-multi-tenant scope for pr title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -53,6 +53,7 @@ jobs:
             plugin-cloud
             plugin-cloud-storage
             plugin-form-builder
+            plugin-multi-tenant
             plugin-nested-docs
             plugin-redirects
             plugin-search


### PR DESCRIPTION
### What?
Adds `plugin-multi-tenant` scope for PR titles

### Why?
Cannot scope multi-tenant PR's properly
