### PR TITLE
feat: add optional name to plugin type

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -122,7 +122,9 @@ type Prettify<T> = {
   [K in keyof T]: T[K]
 } & NonNullable<unknown>
 
-export type Plugin = (config: Config) => Config | Promise<Config>
+export type Plugin = (
+  config: Config,
+) => ({ name?: string } & Config) | Promise<{ name?: string } & Config>
 
 export type LivePreviewConfig = {
   /**


### PR DESCRIPTION
<!--

### What?
Adds an optional name string to plugin type

### Why?
So currently installed plugins can be referenced by a name in payload config (i.e.) a new plugin can see what plugins are already installed.

-->
