### PR TITLE
fix(templates): handle enableLink condition safely

### DIFF
--- a/templates/website/src/blocks/Content/config.ts
+++ b/templates/website/src/blocks/Content/config.ts
@@ -55,7 +55,9 @@ const columnFields: Field[] = [
   link({
     overrides: {
       admin: {
-        condition: (_, { enableLink }) => Boolean(enableLink),
+        condition: (_data, siblingData) => {
+          return Boolean(siblingData?.enableLink);
+        },
       },
     },
   }),


### PR DESCRIPTION
Ensures type-safe conditional visibility for the enableLink functionality in the block. It resolves issues with incorrect type assumptions in the condition function and prevents runtime errors by safely handling optional data with TypeScript.

![{C1AED1C0-9A44-4857-8E63-16328D687E31}](https://github.com/user-attachments/assets/31ffd55e-0f05-4440-b0c2-41df7e926ef7)

### What?
The condition function incorrectly assumed the presence of enableLink using destructuring, causing type errors and potential runtime issues.

**blocks/content/config.ts on templates.**

[Content Block - Website Template](https://github.com/payloadcms/payload/blob/main/templates/website/src/blocks/Content/config.ts)
[Content Block - Vercel Website Template](https://github.com/payloadcms/payload/blob/main/templates/with-vercel-website/src/blocks/Content/config.ts)

`condition: (_: void, { enableLink }: { enableLink: boolean }) => Boolean(enableLink)`

### Why?
- Destructuring enableLink directly assumes its presence, which conflicts with Payload’s type system and can lead to runtime errors if siblingData is undefined.
- Fixing this ensures compatibility with Payload’s Condition type and improves code safety.

### How?
- Updated the condition function to safely access enableLink using optional chaining (siblingData?.enableLink).
- Replaced the destructuring approach with a safer and more robust implementation.

Fixes #
blocks/content/config.ts on templates.

```
        condition: (_data, siblingData) => {
          return Boolean(siblingData?.enableLink);
        },
```