### PR TITLE
fix(ui): include check for parent permissions in renderField

### DIFF
--- a/packages/ui/src/fields/Tabs/index.tsx
+++ b/packages/ui/src/fields/Tabs/index.tsx
@@ -198,8 +198,12 @@ const TabsFieldComponent: TabsFieldClientComponent = (props) => {
               parentSchemaPath={activePathSchemaChildrenPath}
               path={activeTabPath}
               permissions={
-                'name' in activeTabConfig && permissions?.[activeTabConfig.name]?.fields
-                  ? permissions[activeTabConfig.name].fields
+                permissions && typeof permissions === 'object' && 'name' in activeTabConfig
+                  ? permissions[activeTabConfig.name] &&
+                    typeof permissions[activeTabConfig.name] === 'object' &&
+                    'fields' in permissions[activeTabConfig.name]
+                    ? permissions[activeTabConfig.name].fields
+                    : permissions[activeTabConfig.name]
                   : permissions
               }
               readOnly={readOnly}

--- a/packages/ui/src/forms/RenderFields/index.tsx
+++ b/packages/ui/src/forms/RenderFields/index.tsx
@@ -108,10 +108,7 @@ export const RenderFields: React.FC<RenderFieldsProps> = (props) => {
               parentSchemaPath={parentSchemaPath}
               path={path}
               permissions={
-                permissions === undefined ||
-                permissions === null ||
-                permissions === true ||
-                permissions?.[parentName] === true
+                permissions === undefined || permissions === null || permissions === true
                   ? true
                   : 'name' in field
                     ? permissions?.[field.name]

--- a/packages/ui/src/forms/RenderFields/index.tsx
+++ b/packages/ui/src/forms/RenderFields/index.tsx
@@ -108,7 +108,10 @@ export const RenderFields: React.FC<RenderFieldsProps> = (props) => {
               parentSchemaPath={parentSchemaPath}
               path={path}
               permissions={
-                permissions === undefined || permissions === null || permissions === true
+                permissions === undefined ||
+                permissions === null ||
+                permissions === true ||
+                permissions?.[parentName] === true
                   ? true
                   : 'name' in field
                     ? permissions?.[field.name]


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes an issue where if a field was nested, then `RenderField` would check for permissions against its' own field name before checking if the parent field was true.

### Why?
To prevent undefined permissions on fields where the parents permission evaluated to true.

### How?
By adding an additional check to the permissions prop passed to `RenderField`.

Fixes #10720