### PR TITLE
fix(plugin-nested-docs): cannot update more than 10 child docs

### DIFF
--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -27,6 +27,7 @@ const resave = async ({ collection, doc, draft, pluginConfig, req }: ResaveArgs)
     collection: collection.slug,
     depth: 0,
     draft: true,
+    limit: 0,
     locale: req.locale,
     req,
     where: {
@@ -39,16 +40,14 @@ const resave = async ({ collection, doc, draft, pluginConfig, req }: ResaveArgs)
   const breadcrumbSlug = pluginConfig.breadcrumbsFieldSlug || 'breadcrumbs'
 
   try {
-    await children.docs.reduce(async (priorSave, child) => {
-      await priorSave
-
+    for (const child of children.docs) {
       const childIsPublished =
         typeof collection.versions === 'object' &&
         collection.versions.drafts &&
         child._status === 'published'
 
       if (!parentDocIsPublished && childIsPublished) {
-        return
+        continue
       }
 
       await req.payload.update({
@@ -63,7 +62,7 @@ const resave = async ({ collection, doc, draft, pluginConfig, req }: ResaveArgs)
         locale: req.locale,
         req,
       })
-    }, Promise.resolve())
+    }
   } catch (err: unknown) {
     req.payload.logger.error(
       `Nested Docs plugin has had an error while re-saving a child document${

--- a/packages/plugin-nested-docs/src/utilities/getParents.ts
+++ b/packages/plugin-nested-docs/src/utilities/getParents.ts
@@ -1,9 +1,9 @@
-import type { CollectionConfig } from 'payload'
+import type { CollectionConfig, PayloadRequest } from 'payload'
 
 import type { NestedDocsPluginConfig } from '../types.js'
 
 export const getParents = async (
-  req: any,
+  req: PayloadRequest,
   pluginConfig: NestedDocsPluginConfig,
   collection: CollectionConfig,
   doc: Record<string, unknown>,


### PR DESCRIPTION
`limit` was defaulting to 10 in the call to find children that need to be updated, now limit is 0 to get all children docs.