### PR TITLE
docs: adds examples of typed custom field components

### DIFF
--- a/docs/fields/array.mdx
+++ b/docs/fields/array.mdx
@@ -125,18 +125,98 @@ export const ExampleCollection: CollectionConfig = {
           type: 'text',
         },
       ],
-      admin: {
-        components: {
-          RowLabel: '/path/to/ArrayRowLabel#ArrayRowLabel',
-        },
-      },
     },
   ],
 }
 ```
 
-### Example of a custom RowLabel component
+## Custom Components
 
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { ArrayField } from '@payloadcms/ui'
+import type { ArrayFieldServerComponent } from 'payload'
+
+export const CustomArrayFieldServer: ArrayFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions
+}) => {
+  return (
+    <ArrayField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { ArrayField } from '@payloadcms/ui'
+import type { ArrayFieldClientComponent } from 'payload'
+
+export const CustomArrayFieldClient: ArrayFieldClientComponent = (props) => {
+  return <ArrayField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { ArrayFieldLabelServerComponent } from 'payload'
+
+export const CustomArrayFieldLabelServer: ArrayFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+import type { ArrayFieldLabelClientComponent } from 'payload'
+
+import { FieldLabel } from '@payloadcms/ui'
+import React from 'react'
+
+export const CustomArrayFieldLabelClient: ArrayFieldLabelClientComponent = ({
+  field,
+  path
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```
+
+### Row Label
 
 ```tsx
 'use client'

--- a/docs/fields/array.mdx
+++ b/docs/fields/array.mdx
@@ -197,6 +197,7 @@ export const CustomArrayFieldLabelServer: ArrayFieldLabelServerComponent = ({
 #### Client Component
 
 ```tsx
+'use client'
 import type { ArrayFieldLabelClientComponent } from 'payload'
 
 import { FieldLabel } from '@payloadcms/ui'

--- a/docs/fields/blocks.mdx
+++ b/docs/fields/blocks.mdx
@@ -209,6 +209,92 @@ export const ExampleCollection: CollectionConfig = {
 }
 ```
 
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { BlocksField } from '@payloadcms/ui'
+import type { BlocksFieldServerComponent } from 'payload'
+
+export const CustomBlocksFieldServer: BlocksFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions
+}) => {
+  return (
+    <BlocksField field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { BlocksField } from '@payloadcms/ui'
+import type { BlocksFieldClientComponent } from 'payload'
+
+export const CustomBlocksFieldClient: BlocksFieldClientComponent = (props) => {
+  return <BlocksField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { BlocksFieldLabelServerComponent } from 'payload'
+
+export const CustomBlocksFieldLabelServer: BlocksFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { BlocksFieldLabelClientComponent } from 'payload'
+
+export const CustomBlocksFieldLabelClient: BlocksFieldLabelClientComponent = ({
+  label,
+  path,
+  required,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```
+
 ## TypeScript
 
 As you build your own Block configs, you might want to store them in separate files but retain typing accordingly. To do so, you can import and use Payload's `Block` type:

--- a/docs/fields/checkbox.mdx
+++ b/docs/fields/checkbox.mdx
@@ -67,3 +67,90 @@ export const ExampleCollection: CollectionConfig = {
   ],
 }
 ```
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { CheckboxField } from '@payloadcms/ui'
+import type { CheckboxFieldServerComponent } from 'payload'
+
+export const CustomCheckboxFieldServer: CheckboxFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <CheckboxField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { CheckboxField } from '@payloadcms/ui'
+import type { CheckboxFieldClientComponent } from 'payload'
+
+export const CustomCheckboxFieldClient: CheckboxFieldClientComponent = (props) => {
+  return <CheckboxField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { CheckboxFieldLabelServerComponent } from 'payload'
+
+export const CustomCheckboxFieldLabelServer: CheckboxFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { CheckboxFieldLabelClientComponent } from 'payload'
+
+export const CustomCheckboxFieldLabelClient: CheckboxFieldLabelClientComponent = ({
+  label,
+  path,
+  required,
+}) => {
+  return (
+  <FieldLabel
+    label={field?.label || field?.name}
+    path={path}
+    required={field?.required}
+  />
+)
+}
+```

--- a/docs/fields/code.mdx
+++ b/docs/fields/code.mdx
@@ -95,3 +95,85 @@ export const ExampleCollection: CollectionConfig = {
   ],
 }
 ```
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { CodeField } from '@payloadcms/ui'
+import type { CodeFieldServerComponent } from 'payload'
+
+export const CustomCodeFieldServer: CodeFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <CodeField field={clientField} path={path} schemaPath={schemaPath} permissions={permissions} />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { CodeField } from '@payloadcms/ui'
+import type { CodeFieldClientComponent } from 'payload'
+
+export const CustomCodeFieldClient: CodeFieldClientComponent = (props) => {
+  return <CodeField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { CodeFieldLabelServerComponent } from 'payload'
+
+export const CustomCodeFieldLabelServer: CodeFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { CodeFieldLabelClientComponent } from 'payload'
+
+export const CustomCodeFieldLabelClient: CodeFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```
+

--- a/docs/fields/date.mdx
+++ b/docs/fields/date.mdx
@@ -135,3 +135,90 @@ export const ExampleCollection: CollectionConfig = {
   ],
 }
 ```
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { DateTimeField } from '@payloadcms/ui'
+import type { DateFieldServerComponent } from 'payload'
+
+export const CustomDateFieldServer: DateFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <DateTimeField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { DateTimeField } from '@payloadcms/ui'
+import type { DateFieldClientComponent } from 'payload'
+
+export const CustomDateFieldClient: DateFieldClientComponent = (props) => {
+  return <DateTimeField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { DateFieldLabelServerComponent } from 'payload'
+
+export const CustomDateFieldLabelServer: DateFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { DateFieldLabelClientComponent } from 'payload'
+
+export const CustomDateFieldLabelClient: DateFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```
+

--- a/docs/fields/email.mdx
+++ b/docs/fields/email.mdx
@@ -90,3 +90,83 @@ export const ExampleCollection: CollectionConfig = {
   ],
 }
 ```
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { EmailField } from '@payloadcms/ui'
+import type { EmailFieldServerComponent } from 'payload'
+
+export const CustomEmailFieldServer: EmailFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <EmailField field={clientField} path={path} schemaPath={schemaPath} permissions={permissions} />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { EmailField } from '@payloadcms/ui'
+import type { EmailFieldClientComponent } from 'payload'
+
+export const CustomEmailFieldClient: EmailFieldClientComponent = (props) => {
+  return <EmailField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { EmailFieldLabelServerComponent } from 'payload'
+
+export const CustomEmailFieldLabelServer: EmailFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { EmailFieldLabelClientComponent } from 'payload'
+
+export const CustomEmailFieldLabelClient: EmailFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )}
+```

--- a/docs/fields/json.mdx
+++ b/docs/fields/json.mdx
@@ -154,3 +154,89 @@ export const ExampleCollection: CollectionConfig = {
 // {"foo": "bar"} or {"foo": "foobar"} - ok
 // Attempting to create {"foo": "not-bar"} will throw an error
 ```
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { JSONField } from '@payloadcms/ui'
+import type { JSONFieldServerComponent } from 'payload'
+
+export const CustomJSONFieldServer: JSONFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <JSONField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { JSONField } from '@payloadcms/ui'
+import type { JSONFieldClientComponent } from 'payload'
+
+export const CustomJSONFieldClient: JSONFieldClientComponent = (props) => {
+  return <JSONField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { JSONFieldLabelServerComponent } from 'payload'
+
+export const CustomJSONFieldLabelServer: JSONFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { JSONFieldLabelClientComponent } from 'payload'
+
+export const CustomJSONFieldLabelClient: JSONFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```

--- a/docs/fields/number.mdx
+++ b/docs/fields/number.mdx
@@ -98,3 +98,89 @@ export const ExampleCollection: CollectionConfig = {
   ],
 }
 ```
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { NumberField } from '@payloadcms/ui'
+import type { NumberFieldServerComponent } from 'payload'
+
+export const CustomNumberFieldServer: NumberFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <NumberField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { NumberField } from '@payloadcms/ui'
+import type { NumberFieldClientComponent } from 'payload'
+
+export const CustomNumberFieldClient: NumberFieldClientComponent = (props) => {
+  return <NumberField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { NumberFieldLabelServerComponent } from 'payload'
+
+export const CustomNumberFieldLabelServer: NumberFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { NumberFieldLabelClientComponent } from 'payload'
+
+export const CustomNumberFieldLabelClient: NumberFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```

--- a/docs/fields/point.mdx
+++ b/docs/fields/point.mdx
@@ -129,3 +129,84 @@ payload.find({
   },
 })
 ```
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { PointField } from '@payloadcms/ui'
+import type { PointFieldServerComponent } from 'payload'
+
+export const CustomPointFieldServer: PointFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <PointField field={clientField} path={path} schemaPath={schemaPath} permissions={permissions} />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { PointField } from '@payloadcms/ui'
+import type { PointFieldClientComponent } from 'payload'
+
+export const CustomPointFieldClient: PointFieldClientComponent = (props) => {
+  return <PointField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { PointFieldLabelServerComponent } from 'payload'
+
+export const CustomPointFieldLabelServer: PointFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { PointFieldLabelClientComponent } from 'payload'
+
+export const CustomPointFieldLabelClient: PointFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```

--- a/docs/fields/radio.mdx
+++ b/docs/fields/radio.mdx
@@ -117,3 +117,90 @@ export const ExampleCollection: CollectionConfig = {
   ],
 }
 ```
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { RadioGroupField } from '@payloadcms/ui'
+import type { RadioFieldServerComponent } from 'payload'
+
+export const CustomRadioFieldServer: RadioFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <RadioGroupField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { RadioGroupField } from '@payloadcms/ui'
+import type { RadioFieldClientComponent } from 'payload'
+
+export const CustomRadioFieldClient: RadioFieldClientComponent = (props) => {
+  return <RadioGroupField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { RadioFieldLabelServerComponent } from 'payload'
+
+export const CustomRadioFieldLabelServer: RadioFieldLabelServerComponent = ({
+  clientField,
+  path,
+  required,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { RadioFieldLabelClientComponent } from 'payload'
+
+export const CustomRadioFieldLabelClient: RadioFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```

--- a/docs/fields/relationship.mdx
+++ b/docs/fields/relationship.mdx
@@ -373,3 +373,89 @@ Since we are referencing multiple collections, the field you are querying on may
   You **cannot** query on a field within a polymorphic relationship as you would with a
   non-polymorphic relationship.
 </Banner>
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { RelationshipField } from '@payloadcms/ui'
+import type { RelationshipFieldServerComponent } from 'payload'
+
+export const CustomRelationshipFieldServer: RelationshipFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <RelationshipField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { RelationshipField } from '@payloadcms/ui'
+import type { RelationshipFieldClientComponent } from 'payload'
+
+export const CustomRelationshipFieldClient: RelationshipFieldClientComponent = (props) => {
+  return <RelationshipField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { RelationshipFieldLabelServerComponent } from 'payload'
+
+export const CustomRelationshipFieldLabelServer: RelationshipFieldLabelServerComponent = (
+  clientField,
+  path
+) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { RelationshipFieldLabelClientComponent } from 'payload'
+
+export const CustomRelationshipFieldLabelClient: RelationshipFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```

--- a/docs/fields/select.mdx
+++ b/docs/fields/select.mdx
@@ -125,83 +125,90 @@ export const ExampleCollection: CollectionConfig = {
 }
 ```
 
-## Customization
+## Custom Components
 
-The Select field UI component can be customized by providing a custom React component to the `components` object in the Base config.
+### Field
 
-```ts
-export const CustomSelectField: Field = {
-  name: 'customSelectField',
-  type: 'select', // or 'text' if you have dynamic options
-  admin: {
-    components: {
-      Field: CustomSelectComponent({
-        options: [
-          {
-            label: 'Option 1',
-            value: '1',
-          },
-          {
-            label: 'Option 2',
-            value: '2',
-          },
-        ],
-      }),
-    },
-  },
-}
-```
+#### Server Component
 
-You can import the existing Select component directly from Payload, then extend and customize it as needed.
+```tsx
+import type { SelectFieldServerComponent } from 'payload'
+import type React from 'react'
 
-```ts
-import * as React from 'react';
-import { SelectInput, useAuth, useField } from '@payloadcms/ui';
+import { SelectField } from '@payloadcms/ui'
 
-type CustomSelectProps = {
-  path: string;
-  options: {
-    label: string;
-    value: string;
-  }[];
-}
-
-export const CustomSelectComponent: React.FC<CustomSelectProps> = ({ path, options }) => {
-  const { value, setValue } = useField<string>({ path })
-  const { user } = useAuth()
-
-  const adjustedOptions = options.filter((option) => {
-    /*
-      A common use case for a custom select
-      is to show different options based on
-      the current user's role.
-    */
-    return option;
-  });
-
+export const CustomSelectFieldServer: SelectFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
   return (
-    <div>
-      <label className="field-label">
-        Custom Select
-      </label>
-      <SelectInput
-        path={path}
-        name={path}
-        options={adjustedOptions}
-        value={value}
-        onChange={(e) => setValue(e.value)}
-      />
-    </div>
+    <SelectField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
   )
 }
 ```
 
-If you are looking to create a dynamic select field, the following tutorial will walk you through the process of creating a custom select field that fetches its options from an external API.
+#### Client Component
 
-<VideoDrawer
-  id="Efn9OxSjA6Y"
-  label="How to Create a Custom Select Field"
-  drawerTitle="How to Create a Custom Select Field: A Step-by-Step Guide"
-/>
+```tsx
+'use client'
+import type { SelectFieldClientComponent } from 'payload'
 
-If you want to learn more about custom components check out the [Admin > Custom Component](/docs/admin/fields) docs.
+import { SelectField } from '@payloadcms/ui'
+import React from 'react'
+
+export const CustomSelectFieldClient: SelectFieldClientComponent = (props) => {
+  return <SelectField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { SelectFieldLabelServerComponent } from 'payload'
+
+export const CustomSelectFieldLabelServer: SelectFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { SelectFieldLabelClientComponent } from 'payload'
+
+export const CustomSelectFieldLabelClient: SelectFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```

--- a/docs/fields/text.mdx
+++ b/docs/fields/text.mdx
@@ -95,3 +95,85 @@ export const ExampleCollection: CollectionConfig = {
   ],
 }
 ```
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { TextField } from '@payloadcms/ui'
+import type { TextFieldServerComponent } from 'payload'
+
+export const CustomTextFieldServer: TextFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <TextField field={clientField} path={path} schemaPath={schemaPath} permissions={permissions} />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { TextField } from '@payloadcms/ui'
+import type { TextFieldClientComponent } from 'payload'
+
+export const CustomTextFieldClient: TextFieldClientComponent = (props) => {
+  return <TextField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { TextFieldLabelServerComponent } from 'payload'
+
+export const CustomTextFieldLabelServer: TextFieldLabelServerComponent = ({
+  clientField,
+  path,
+  required,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { TextFieldLabelClientComponent } from 'payload'
+
+export const CustomTextFieldLabelClient: TextFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```

--- a/docs/fields/textarea.mdx
+++ b/docs/fields/textarea.mdx
@@ -93,3 +93,89 @@ export const ExampleCollection: CollectionConfig = {
   ],
 }
 ```
+
+## Custom Components
+
+### Field
+
+#### Server Component
+
+```tsx
+import type React from 'react'
+import { TextareaField } from '@payloadcms/ui'
+import type { TextareaFieldServerComponent } from 'payload'
+
+export const CustomTextareaFieldServer: TextareaFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <TextareaField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { TextareaField } from '@payloadcms/ui'
+import type { TextareaFieldClientComponent } from 'payload'
+
+export const CustomTextareaFieldClient: TextareaFieldClientComponent = (props) => {
+  return <TextareaField {...props} />
+}
+```
+
+### Label
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { TextareaFieldLabelServerComponent } from 'payload'
+
+export const CustomTextareaFieldLabelServer: TextareaFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import { FieldLabel } from '@payloadcms/ui'
+import type { TextareaFieldLabelClientComponent } from 'payload'
+
+export const CustomTextareaFieldLabelClient: TextareaFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={field?.label || field?.name}
+      path={path}
+      required={field?.required}
+    />
+  )
+}
+```

--- a/examples/custom-components/pnpm-lock.yaml
+++ b/examples/custom-components/pnpm-lock.yaml
@@ -10,19 +10,19 @@ importers:
     dependencies:
       '@payloadcms/db-mongodb':
         specifier: latest
-        version: 3.17.1(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))
+        version: 3.18.0(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))
       '@payloadcms/graphql':
         specifier: latest
-        version: 3.17.1(graphql@16.10.0)(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(typescript@5.5.2)
+        version: 3.18.0(graphql@16.10.0)(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(typescript@5.5.2)
       '@payloadcms/next':
         specifier: latest
-        version: 3.17.1(@types/react@19.0.7)(graphql@16.10.0)(monaco-editor@0.52.2)(next@15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+        version: 3.18.0(@types/react@19.0.7)(graphql@16.10.0)(monaco-editor@0.52.2)(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
       '@payloadcms/richtext-lexical':
         specifier: latest
-        version: 3.17.1(p7oy7o6ncn3qehd5uorapl4luu)
+        version: 3.18.0(bvirogffrpuzy2e4p57bv2watq)
       '@payloadcms/ui':
         specifier: latest
-        version: 3.17.1(@types/react@19.0.7)(monaco-editor@0.52.2)(next@15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+        version: 3.18.0(@types/react@19.0.7)(monaco-editor@0.52.2)(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -37,10 +37,10 @@ importers:
         version: 0.13.0
       next:
         specifier: ^15.0.0
-        version: 15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+        version: 15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
       payload:
         specifier: latest
-        version: 3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+        version: 3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -50,7 +50,7 @@ importers:
     devDependencies:
       '@swc/core':
         specifier: ^1.6.13
-        version: 1.10.7(@swc/helpers@0.5.15)
+        version: 1.10.9(@swc/helpers@0.5.15)
       '@types/ejs':
         specifier: ^3.1.5
         version: 3.1.5
@@ -65,7 +65,7 @@ importers:
         version: 8.57.1
       eslint-config-next:
         specifier: ^15.0.0
-        version: 15.1.5(eslint@8.57.1)(typescript@5.5.2)
+        version: 15.1.6(eslint@8.57.1)(typescript@5.5.2)
       tsx:
         specifier: ^4.16.2
         version: 4.19.2
@@ -618,56 +618,56 @@ packages:
   '@mongodb-js/saslprep@1.1.9':
     resolution: {integrity: sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==}
 
-  '@next/env@15.1.5':
-    resolution: {integrity: sha512-jg8ygVq99W3/XXb9Y6UQsritwhjc+qeiO7QrGZRYOfviyr/HcdnhdBQu4gbp2rBIh2ZyBYTBMWbPw3JSCb0GHw==}
+  '@next/env@15.1.6':
+    resolution: {integrity: sha512-d9AFQVPEYNr+aqokIiPLNK/MTyt3DWa/dpKveiAaVccUadFbhFEvY6FXYX2LJO2Hv7PHnLBu2oWwB4uBuHjr/w==}
 
-  '@next/eslint-plugin-next@15.1.5':
-    resolution: {integrity: sha512-3cCrXBybsqe94UxD6DBQCYCCiP9YohBMgZ5IzzPYHmPzj8oqNlhBii5b6o1HDDaRHdz2pVnSsAROCtrczy8O0g==}
+  '@next/eslint-plugin-next@15.1.6':
+    resolution: {integrity: sha512-+slMxhTgILUntZDGNgsKEYHUvpn72WP1YTlkmEhS51vnVd7S9jEEy0n9YAMcI21vUG4akTw9voWH02lrClt/yw==}
 
-  '@next/swc-darwin-arm64@15.1.5':
-    resolution: {integrity: sha512-5ttHGE75Nw9/l5S8zR2xEwR8OHEqcpPym3idIMAZ2yo+Edk0W/Vf46jGqPOZDk+m/SJ+vYZDSuztzhVha8rcdA==}
+  '@next/swc-darwin-arm64@15.1.6':
+    resolution: {integrity: sha512-u7lg4Mpl9qWpKgy6NzEkz/w0/keEHtOybmIl0ykgItBxEM5mYotS5PmqTpo+Rhg8FiOiWgwr8USxmKQkqLBCrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.1.5':
-    resolution: {integrity: sha512-8YnZn7vDURUUTInfOcU5l0UWplZGBqUlzvqKKUFceM11SzfNEz7E28E1Arn4/FsOf90b1Nopboy7i7ufc4jXag==}
+  '@next/swc-darwin-x64@15.1.6':
+    resolution: {integrity: sha512-x1jGpbHbZoZ69nRuogGL2MYPLqohlhnT9OCU6E6QFewwup+z+M6r8oU47BTeJcWsF2sdBahp5cKiAcDbwwK/lg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.1.5':
-    resolution: {integrity: sha512-rDJC4ctlYbK27tCyFUhgIv8o7miHNlpCjb2XXfTLQszwAUOSbcMN9q2y3urSrrRCyGVOd9ZR9a4S45dRh6JF3A==}
+  '@next/swc-linux-arm64-gnu@15.1.6':
+    resolution: {integrity: sha512-jar9sFw0XewXsBzPf9runGzoivajeWJUc/JkfbLTC4it9EhU8v7tCRLH7l5Y1ReTMN6zKJO0kKAGqDk8YSO2bg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.1.5':
-    resolution: {integrity: sha512-FG5RApf4Gu+J+pHUQxXPM81oORZrKBYKUaBTylEIQ6Lz17hKVDsLbSXInfXM0giclvXbyiLXjTv42sQMATmZ0A==}
+  '@next/swc-linux-arm64-musl@15.1.6':
+    resolution: {integrity: sha512-+n3u//bfsrIaZch4cgOJ3tXCTbSxz0s6brJtU3SzLOvkJlPQMJ+eHVRi6qM2kKKKLuMY+tcau8XD9CJ1OjeSQQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.1.5':
-    resolution: {integrity: sha512-NX2Ar3BCquAOYpnoYNcKz14eH03XuF7SmSlPzTSSU4PJe7+gelAjxo3Y7F2m8+hLT8ZkkqElawBp7SWBdzwqQw==}
+  '@next/swc-linux-x64-gnu@15.1.6':
+    resolution: {integrity: sha512-SpuDEXixM3PycniL4iVCLyUyvcl6Lt0mtv3am08sucskpG0tYkW1KlRhTgj4LI5ehyxriVVcfdoxuuP8csi3kQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.1.5':
-    resolution: {integrity: sha512-EQgqMiNu3mrV5eQHOIgeuh6GB5UU57tu17iFnLfBEhYfiOfyK+vleYKh2dkRVkV6ayx3eSqbIYgE7J7na4hhcA==}
+  '@next/swc-linux-x64-musl@15.1.6':
+    resolution: {integrity: sha512-L4druWmdFSZIIRhF+G60API5sFB7suTbDRhYWSjiw0RbE+15igQvE2g2+S973pMGvwN3guw7cJUjA/TmbPWTHQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.1.5':
-    resolution: {integrity: sha512-HPULzqR/VqryQZbZME8HJE3jNFmTGcp+uRMHabFbQl63TtDPm+oCXAz3q8XyGv2AoihwNApVlur9Up7rXWRcjg==}
+  '@next/swc-win32-arm64-msvc@15.1.6':
+    resolution: {integrity: sha512-s8w6EeqNmi6gdvM19tqKKWbCyOBvXFbndkGHl+c9YrzsLARRdCHsD9S1fMj8gsXm9v8vhC8s3N8rjuC/XrtkEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.1.5':
-    resolution: {integrity: sha512-n74fUb/Ka1dZSVYfjwQ+nSJ+ifUff7jGurFcTuJNKZmI62FFOxQXUYit/uZXPTj2cirm1rvGWHG2GhbSol5Ikw==}
+  '@next/swc-win32-x64-msvc@15.1.6':
+    resolution: {integrity: sha512-6xomMuu54FAFxttYr5PJbEfu96godcxBTRk1OhAvJq0/EnmFU/Ybiax30Snis4vdWZ9LGpf7Roy5fSs7v/5ROQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -688,28 +688,28 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@payloadcms/db-mongodb@3.17.1':
-    resolution: {integrity: sha512-z/yCM8WmC7/DX/KmHA0oyWyw3E6+pydraR2YmA42PNA8KE3MGFpfrDJHUKz5IlcMb9oFLTIpmKnQcWzi/xF5yw==}
+  '@payloadcms/db-mongodb@3.18.0':
+    resolution: {integrity: sha512-bRoCt89soddE8oTxtV8tXo9WsgEVQ1rOYaSqSTQj5/rzqkNtB5Eab6dlHcpI4ruJW2CbPlyspbqeV3as9HLPBA==}
     peerDependencies:
-      payload: 3.17.1
+      payload: 3.18.0
 
-  '@payloadcms/graphql@3.17.1':
-    resolution: {integrity: sha512-J9mZ12OVbINAgPTuQoP9gg2/SlXaq4culPQg89bRQLjwK/g1DcJWKgFl/7ExrrOqZlaz4lOSuURBLoc6sbvAgQ==}
+  '@payloadcms/graphql@3.18.0':
+    resolution: {integrity: sha512-ktWKKEU/B7PDHUNAIt1rn4MUrVOIEWkWbvjAZONFCA6FMnD319QxISXE2UIjEPyiaRls8+7E4w3u8e6mHaIq2w==}
     hasBin: true
     peerDependencies:
       graphql: ^16.8.1
-      payload: 3.17.1
+      payload: 3.18.0
 
-  '@payloadcms/next@3.17.1':
-    resolution: {integrity: sha512-syOwdQOYTEAO18Jh7k/HAb5Jl3EbUTlYESyrQwzBbwAK6YiAcb5qfm36IpAZhzHb5DOrgQeAgjcCzype6d/Sxg==}
+  '@payloadcms/next@3.18.0':
+    resolution: {integrity: sha512-WQMm9ebywWgdZ83S5jrcJB50Iae512jKGLZyBzPpqbpEkP0W2iwg0S7QXKixwhVc+Af9fndbOF9y+6d0xTYm9Q==}
     engines: {node: ^18.20.2 || >=20.9.0}
     peerDependencies:
       graphql: ^16.8.1
       next: ^15.0.0
-      payload: 3.17.1
+      payload: 3.18.0
 
-  '@payloadcms/richtext-lexical@3.17.1':
-    resolution: {integrity: sha512-ACDjv1aN1of9SkrSNPiR0DKaq597yJvODUNiybo1GLlMT5dq4QBOAf3EvojgIYQqrv2aS9AMBxtR2HcryoNiIQ==}
+  '@payloadcms/richtext-lexical@3.18.0':
+    resolution: {integrity: sha512-3BNPlTF4wTSfhZ7aGQyGMNc1bfpTwl1Zwt4ONl8AYrHk0Zs+hQvZkLLAhrrX076t0r7niYYVp7dihYalXmzcaQ==}
     engines: {node: ^18.20.2 || >=20.9.0}
     peerDependencies:
       '@faceless-ui/modal': 3.0.0-beta.2
@@ -724,21 +724,21 @@ packages:
       '@lexical/selection': 0.21.0
       '@lexical/table': 0.21.0
       '@lexical/utils': 0.21.0
-      '@payloadcms/next': 3.17.1
+      '@payloadcms/next': 3.18.0
       lexical: 0.21.0
-      payload: 3.17.1
+      payload: 3.18.0
       react: ^19.0.0 || ^19.0.0-rc-65a56d0e-20241020
       react-dom: ^19.0.0 || ^19.0.0-rc-65a56d0e-20241020
 
-  '@payloadcms/translations@3.17.1':
-    resolution: {integrity: sha512-Po95yVwOME5TZuKaBylTrHpmrCbLbcviWAAfAU2DBjOv5+s+aev/LmGl3bAFxTL+5ZVLlzy7m/JwBX43gdgaBg==}
+  '@payloadcms/translations@3.18.0':
+    resolution: {integrity: sha512-ZPX3Gf5TSK+nNCtFYTMkQgt8zATSU8fflqzjSc7v64BBpNZoEug0OUtQqwDw4MjDQZZFJ7YuKT3lalDlZFUNxQ==}
 
-  '@payloadcms/ui@3.17.1':
-    resolution: {integrity: sha512-XuqSBzBEkPV9T/ER+FtdMHk77g15cBWwT9lPsaPtCWzeRqEakRVLCsH+5I5q7VID3CoWFMLLqOBExYkBV627ug==}
+  '@payloadcms/ui@3.18.0':
+    resolution: {integrity: sha512-EXX72Q15kzIeCp8itSOu4NgFbVL039l3fDaKO9whPovRPjbgQz197P6WAolTzWCykESiO4eIuJwJIsmkfnqw8w==}
     engines: {node: ^18.20.2 || >=20.9.0}
     peerDependencies:
       next: ^15.0.0
-      payload: 3.17.1
+      payload: 3.18.0
       react: ^19.0.0 || ^19.0.0-rc-65a56d0e-20241020
       react-dom: ^19.0.0 || ^19.0.0-rc-65a56d0e-20241020
 
@@ -748,68 +748,68 @@ packages:
   '@rushstack/eslint-patch@1.10.5':
     resolution: {integrity: sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==}
 
-  '@swc/core-darwin-arm64@1.10.7':
-    resolution: {integrity: sha512-SI0OFg987P6hcyT0Dbng3YRISPS9uhLX1dzW4qRrfqQdb0i75lPJ2YWe9CN47HBazrIA5COuTzrD2Dc0TcVsSQ==}
+  '@swc/core-darwin-arm64@1.10.9':
+    resolution: {integrity: sha512-XTHLtijFervv2B+i1ngM993umhSj9K1IeMomvU/Db84Asjur2XmD4KXt9QPnGDRFgv2kLSjZ+DDL25Qk0f4r+w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/core-darwin-x64@1.10.7':
-    resolution: {integrity: sha512-RFIAmWVicD/l3RzxgHW0R/G1ya/6nyMspE2cAeDcTbjHi0I5qgdhBWd6ieXOaqwEwiCd0Mot1g2VZrLGoBLsjQ==}
+  '@swc/core-darwin-x64@1.10.9':
+    resolution: {integrity: sha512-bi3el9/FV/la8HIsolSjeDar+tM7m9AmSF1w7X6ZByW2qgc4Z1tmq0A4M4H9aH3TfHesZbfq8hgaNtc2/VtzzQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-linux-arm-gnueabihf@1.10.7':
-    resolution: {integrity: sha512-QP8vz7yELWfop5mM5foN6KkLylVO7ZUgWSF2cA0owwIaziactB2hCPZY5QU690coJouk9KmdFsPWDnaCFUP8tg==}
+  '@swc/core-linux-arm-gnueabihf@1.10.9':
+    resolution: {integrity: sha512-xsLHV02S+RTDuI+UJBkA2muNk/s0ETRpoc1K/gNt0i8BqTurPYkrvGDDALN9+leiUPydHvZi9P1qdExbgUJnXw==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.10.7':
-    resolution: {integrity: sha512-NgUDBGQcOeLNR+EOpmUvSDIP/F7i/OVOKxst4wOvT5FTxhnkWrW+StJGKj+DcUVSK5eWOYboSXr1y+Hlywwokw==}
+  '@swc/core-linux-arm64-gnu@1.10.9':
+    resolution: {integrity: sha512-41hJgPoGhIa12U6Tud+yLF/m64YA3mGut3TmBEkj2R7rdJdE0mljdtR0tf4J2RoQaWZPPi0DBSqGdROiAEx9dg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-arm64-musl@1.10.7':
-    resolution: {integrity: sha512-gp5Un3EbeSThBIh6oac5ZArV/CsSmTKj5jNuuUAuEsML3VF9vqPO+25VuxCvsRf/z3py+xOWRaN2HY/rjMeZog==}
+  '@swc/core-linux-arm64-musl@1.10.9':
+    resolution: {integrity: sha512-DUMRhl49b9r7bLg9oNzCdW4lLcDJKrRBn87Iq5APPvixsm1auGnsVQycGkQcDDKvVllxIFSbmCYzjagx3l8Hnw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-x64-gnu@1.10.7':
-    resolution: {integrity: sha512-k/OxLLMl/edYqbZyUNg6/bqEHTXJT15l9WGqsl/2QaIGwWGvles8YjruQYQ9d4h/thSXLT9gd8bExU2D0N+bUA==}
+  '@swc/core-linux-x64-gnu@1.10.9':
+    resolution: {integrity: sha512-xW0y88vQvmzYo3Gn7yFnY03TfHMwuca4aFH3ZmhwDNOYHmTOi6fmhAkg/13F/NrwjMYO+GnF5uJTjdjb3B6tdQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-linux-x64-musl@1.10.7':
-    resolution: {integrity: sha512-XeDoURdWt/ybYmXLCEE8aSiTOzEn0o3Dx5l9hgt0IZEmTts7HgHHVeRgzGXbR4yDo0MfRuX5nE1dYpTmCz0uyA==}
+  '@swc/core-linux-x64-musl@1.10.9':
+    resolution: {integrity: sha512-jYs32BEx+CPVuxN6NdsWEpdehjnmAag25jyJzwjQx+NCGYwHEV3bT5y8TX4eFhaVB1rafmqJOlYQPs4+MSyGCg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-win32-arm64-msvc@1.10.7':
-    resolution: {integrity: sha512-nYAbi/uLS+CU0wFtBx8TquJw2uIMKBnl04LBmiVoFrsIhqSl+0MklaA9FVMGA35NcxSJfcm92Prl2W2LfSnTqQ==}
+  '@swc/core-win32-arm64-msvc@1.10.9':
+    resolution: {integrity: sha512-Uhh5T3Fq3Nyom96Bm3ACBNASH3iqNc76in7ewZz8PooUqeTIO8aZpsghnncjctRNE9T819/8btpiFIhHo3sKtg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@swc/core-win32-ia32-msvc@1.10.7':
-    resolution: {integrity: sha512-+aGAbsDsIxeLxw0IzyQLtvtAcI1ctlXVvVcXZMNXIXtTURM876yNrufRo4ngoXB3jnb1MLjIIjgXfFs/eZTUSw==}
+  '@swc/core-win32-ia32-msvc@1.10.9':
+    resolution: {integrity: sha512-bD5BpbojEsDfrAvT+1qjQPf5RCKLg4UL+3Uwm019+ZR02hd8qO538BlOnQdOqRqccu+75DF6aRglQ7AJ24Cs0Q==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.10.7':
-    resolution: {integrity: sha512-TBf4clpDBjF/UUnkKrT0/th76/zwvudk5wwobiTFqDywMApHip5O0VpBgZ+4raY2TM8k5+ujoy7bfHb22zu17Q==}
+  '@swc/core-win32-x64-msvc@1.10.9':
+    resolution: {integrity: sha512-NwkuUNeBBQnAaXVvcGw8Zr6RR8kylyjFUnlYZZ3G0QkQZ4rYLXYTafAmiRjrfzgVb0LcMF/sBzJvGOk7SwtIDg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@swc/core@1.10.7':
-    resolution: {integrity: sha512-py91kjI1jV5D5W/Q+PurBdGsdU5TFbrzamP7zSCqLdMcHkKi3rQEM5jkQcZr0MXXSJTaayLxS3MWYTBIkzPDrg==}
+  '@swc/core@1.10.9':
+    resolution: {integrity: sha512-MQ97YSXu2oibzm7wi4GNa7hhndjLuVt/lmO2sq53+P37oZmyg/JQ/IYYtSiC6UGK3+cHoiVAykrK+glxLjJbag==}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '*'
@@ -899,51 +899,51 @@ packages:
   '@types/whatwg-url@11.0.5':
     resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
 
-  '@typescript-eslint/eslint-plugin@8.20.0':
-    resolution: {integrity: sha512-naduuphVw5StFfqp4Gq4WhIBE2gN1GEmMUExpJYknZJdRnc+2gDzB8Z3+5+/Kv33hPQRDGzQO/0opHE72lZZ6A==}
+  '@typescript-eslint/eslint-plugin@8.21.0':
+    resolution: {integrity: sha512-eTH+UOR4I7WbdQnG4Z48ebIA6Bgi7WO8HvFEneeYBxG8qCOYgTOFPSg6ek9ITIDvGjDQzWHcoWHCDO2biByNzA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/parser@8.20.0':
-    resolution: {integrity: sha512-gKXG7A5HMyjDIedBi6bUrDcun8GIjnI8qOwVLiY3rx6T/sHP/19XLJOnIq/FgQvWLHja5JN/LSE7eklNBr612g==}
+  '@typescript-eslint/parser@8.21.0':
+    resolution: {integrity: sha512-Wy+/sdEH9kI3w9civgACwabHbKl+qIOu0uFZ9IMKzX3Jpv9og0ZBJrZExGrPpFAY7rWsXuxs5e7CPPP17A4eYA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/scope-manager@8.20.0':
-    resolution: {integrity: sha512-J7+VkpeGzhOt3FeG1+SzhiMj9NzGD/M6KoGn9f4dbz3YzK9hvbhVTmLj/HiTp9DazIzJ8B4XcM80LrR9Dm1rJw==}
+  '@typescript-eslint/scope-manager@8.21.0':
+    resolution: {integrity: sha512-G3IBKz0/0IPfdeGRMbp+4rbjfSSdnGkXsM/pFZA8zM9t9klXDnB/YnKOBQ0GoPmoROa4bCq2NeHgJa5ydsQ4mA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/type-utils@8.20.0':
-    resolution: {integrity: sha512-bPC+j71GGvA7rVNAHAtOjbVXbLN5PkwqMvy1cwGeaxUoRQXVuKCebRoLzm+IPW/NtFFpstn1ummSIasD5t60GA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.8.0'
-
-  '@typescript-eslint/types@8.20.0':
-    resolution: {integrity: sha512-cqaMiY72CkP+2xZRrFt3ExRBu0WmVitN/rYPZErA80mHjHx/Svgp8yfbzkJmDoQ/whcytOPO9/IZXnOc+wigRA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.20.0':
-    resolution: {integrity: sha512-Y7ncuy78bJqHI35NwzWol8E0X7XkRVS4K4P4TCyzWkOJih5NDvtoRDW4Ba9YJJoB2igm9yXDdYI/+fkiiAxPzA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.8.0'
-
-  '@typescript-eslint/utils@8.20.0':
-    resolution: {integrity: sha512-dq70RUw6UK9ei7vxc4KQtBRk7qkHZv447OUZ6RPQMQl71I3NZxQJX/f32Smr+iqWrB02pHKn2yAdHBb0KNrRMA==}
+  '@typescript-eslint/type-utils@8.21.0':
+    resolution: {integrity: sha512-95OsL6J2BtzoBxHicoXHxgk3z+9P3BEcQTpBKriqiYzLKnM2DeSqs+sndMKdamU8FosiadQFT3D+BSL9EKnAJQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/visitor-keys@8.20.0':
-    resolution: {integrity: sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==}
+  '@typescript-eslint/types@8.21.0':
+    resolution: {integrity: sha512-PAL6LUuQwotLW2a8VsySDBwYMm129vFm4tMVlylzdoTybTHaAi0oBp7Ac6LhSrHHOdLM3efH+nAR6hAWoMF89A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.21.0':
+    resolution: {integrity: sha512-x+aeKh/AjAArSauz0GiQZsjT8ciadNMHdkUSwBB9Z6PrKc/4knM4g3UfHml6oDJmKC88a6//cdxnO/+P2LkMcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/utils@8.21.0':
+    resolution: {integrity: sha512-xcXBfcq0Kaxgj7dwejMbFyq7IOHgpNMtVuDveK7w3ZGwG9owKzhALVwKpTF2yrZmEwl9SWdetf3fxNzJQaVuxw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/visitor-keys@8.21.0':
+    resolution: {integrity: sha512-BkLMNpdV6prozk8LlyK/SOoWLmUFi+ZD+pcqti9ILCbVvHGk1ui1g4jJOc2WDLaeExz2qWwojxlPce5PljcT3w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.1':
@@ -1091,8 +1091,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001692:
-    resolution: {integrity: sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==}
+  caniuse-lite@1.0.30001695:
+    resolution: {integrity: sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1341,8 +1341,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@15.1.5:
-    resolution: {integrity: sha512-Awm7iUJY8toOR+fU8yTxZnA7/LyOGUGOd6cENCuDfJ3gucHOSmLdOSGJ4u+nlrs8p5qXemua42bZmq+uOzxl6Q==}
+  eslint-config-next@15.1.6:
+    resolution: {integrity: sha512-Wd1uy6y7nBbXUSg9QAuQ+xYEKli5CgUhLjz1QHW11jLDis5vK5XB3PemL6jEmy7HrdhaRFDz+GTZ/3FoH+EUjg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
       typescript: '>=3.3.1'
@@ -1486,8 +1486,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.0.5:
-    resolution: {integrity: sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==}
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
   fastq@1.18.0:
     resolution: {integrity: sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==}
@@ -1561,6 +1561,9 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.10.0:
+    resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
 
   get-tsconfig@4.8.1:
     resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
@@ -1651,8 +1654,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  http-status@1.6.2:
-    resolution: {integrity: sha512-oUExvfNckrpTpDazph7kNG8sQi5au3BeTo0idaZFXEhTaJKu7GNJCLHI0rYY2wljm548MSTM+Ljj/c6anqu2zQ==}
+  http-status@2.1.0:
+    resolution: {integrity: sha512-O5kPr7AW7wYd/BBiOezTwnVAnmSNFY+J7hlZD2X5IOxVBetjcHAiTXhzj0gMrnojQlwy+UT1/Y3H3vJ3UlmvLA==}
     engines: {node: '>= 0.4.0'}
 
   ieee754@1.2.1:
@@ -2027,8 +2030,8 @@ packages:
   micromark-util-sanitize-uri@2.0.1:
     resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
 
-  micromark-util-subtokenize@2.0.3:
-    resolution: {integrity: sha512-VXJJuNxYWSoYL6AJ6OQECCFGhIU2GGHMw8tahogePBrjkG8aCCas3ibkp7RnVOSTClg2is05/R7maAhF1XyQMg==}
+  micromark-util-subtokenize@2.0.4:
+    resolution: {integrity: sha512-N6hXjrin2GTJDe3MVjf5FuXpm12PGm80BrUAeub9XFXca8JZbP+oIwY4LJSVwFUCL1IPm/WwSVUN7goFHmSGGQ==}
 
   micromark-util-symbol@2.0.1:
     resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
@@ -2059,12 +2062,12 @@ packages:
   mongodb-connection-string-url@3.0.2:
     resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
 
-  mongodb@6.10.0:
-    resolution: {integrity: sha512-gP9vduuYWb9ZkDM546M+MP2qKVk5ZG2wPF63OvSRuUbqCR+11ZCAE1mOfllhlAG0wcoJY5yDL/rV3OmYEwXIzg==}
+  mongodb@6.12.0:
+    resolution: {integrity: sha512-RM7AHlvYfS7jv7+BXund/kR64DryVI+cHbVAy9P61fnb1RcWZqOW1/Wj2YhqMCx+MuYhqTRGv7AwHBzmsCKBfA==}
     engines: {node: '>=16.20.1'}
     peerDependencies:
       '@aws-sdk/credential-providers': ^3.188.0
-      '@mongodb-js/zstd': ^1.1.0
+      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
       gcp-metadata: ^5.2.0
       kerberos: ^2.0.1
       mongodb-client-encryption: '>=6.0.0 <7'
@@ -2094,8 +2097,8 @@ packages:
     resolution: {integrity: sha512-kFxhot+yw9KmpAGSSrF/o+f00aC2uawgNUbhyaM0USS9L7dln1NA77/pLg4lgOaRgXMtfgCENamjqZwIM1Zrig==}
     engines: {node: '>=4.0.0'}
 
-  mongoose@8.8.3:
-    resolution: {integrity: sha512-/I4n/DcXqXyIiLRfAmUIiTjj3vXfeISke8dt4U4Y8Wfm074Wa6sXnQrXN49NFOFf2mM1kUdOXryoBvkuCnr+Qw==}
+  mongoose@8.9.5:
+    resolution: {integrity: sha512-SPhOrgBm0nKV3b+IIHGqpUTOmgVL5Z3OO9AwkFEmvOZznXTvplbomstCnPOGAyungtRXE5pJTgKpKcZTdjeESg==}
     engines: {node: '>=16.20.1'}
 
   mpath@0.9.0:
@@ -2117,8 +2120,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@15.1.5:
-    resolution: {integrity: sha512-Cf/TEegnt01hn3Hoywh6N8fvkhbOuChO4wFje24+a86wKOubgVaWkDqxGVgoWlz2Hp9luMJ9zw3epftujdnUOg==}
+  next@15.1.6:
+    resolution: {integrity: sha512-Hch4wzbaX0vKQtalpXvUiw5sYivBy4cm5rzUKrBnUB/y436LGrvOUqYvlSeNVCWFO/770gDlltR9gqZH62ct4Q==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -2226,9 +2229,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-to-regexp@6.2.1:
-    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
-
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -2236,8 +2236,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  payload@3.17.1:
-    resolution: {integrity: sha512-S7vnuACu/71tVG34Y4i4FU+wsBm4d20u08Aj1ssUsDHfJ4Yc7351hV7sp2jC46Hu1NJdwKB8xipn/rw4PZdGiQ==}
+  payload@3.18.0:
+    resolution: {integrity: sha512-Wwa/DQ6IoQ7DGgQb6/IRkm85kGXX/DYKABaPLlDYRkY44UaHndt2pzUfiSBR9J9QSWsLOk5jBGdDSP4nPT3E5w==}
     engines: {node: ^18.20.2 || >=20.9.0}
     hasBin: true
     peerDependencies:
@@ -3412,34 +3412,34 @@ snapshots:
     dependencies:
       sparse-bitfield: 3.0.3
 
-  '@next/env@15.1.5': {}
+  '@next/env@15.1.6': {}
 
-  '@next/eslint-plugin-next@15.1.5':
+  '@next/eslint-plugin-next@15.1.6':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.1.5':
+  '@next/swc-darwin-arm64@15.1.6':
     optional: true
 
-  '@next/swc-darwin-x64@15.1.5':
+  '@next/swc-darwin-x64@15.1.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.1.5':
+  '@next/swc-linux-arm64-gnu@15.1.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.1.5':
+  '@next/swc-linux-arm64-musl@15.1.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.1.5':
+  '@next/swc-linux-x64-gnu@15.1.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.1.5':
+  '@next/swc-linux-x64-musl@15.1.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.1.5':
+  '@next/swc-win32-arm64-msvc@15.1.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.1.5':
+  '@next/swc-win32-x64-msvc@15.1.6':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -3456,13 +3456,12 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@payloadcms/db-mongodb@3.17.1(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))':
+  '@payloadcms/db-mongodb@3.18.0(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))':
     dependencies:
-      http-status: 1.6.2
-      mongoose: 8.8.3
+      mongoose: 8.9.5
       mongoose-aggregate-paginate-v2: 1.1.2
       mongoose-paginate-v2: 1.8.5
-      payload: 3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+      payload: 3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
       prompts: 2.4.2
       uuid: 10.0.0
     transitivePeerDependencies:
@@ -3475,32 +3474,32 @@ snapshots:
       - socks
       - supports-color
 
-  '@payloadcms/graphql@3.17.1(graphql@16.10.0)(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(typescript@5.5.2)':
+  '@payloadcms/graphql@3.18.0(graphql@16.10.0)(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(typescript@5.5.2)':
     dependencies:
       graphql: 16.10.0
       graphql-scalars: 1.22.2(graphql@16.10.0)
-      payload: 3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+      payload: 3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
       pluralize: 8.0.0
       ts-essentials: 10.0.3(typescript@5.5.2)
       tsx: 4.19.2
     transitivePeerDependencies:
       - typescript
 
-  '@payloadcms/next@3.17.1(@types/react@19.0.7)(graphql@16.10.0)(monaco-editor@0.52.2)(next@15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)':
+  '@payloadcms/next@3.18.0(@types/react@19.0.7)(graphql@16.10.0)(monaco-editor@0.52.2)(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)':
     dependencies:
       '@dnd-kit/core': 6.0.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@payloadcms/graphql': 3.17.1(graphql@16.10.0)(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(typescript@5.5.2)
-      '@payloadcms/translations': 3.17.1
-      '@payloadcms/ui': 3.17.1(@types/react@19.0.7)(monaco-editor@0.52.2)(next@15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+      '@payloadcms/graphql': 3.18.0(graphql@16.10.0)(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(typescript@5.5.2)
+      '@payloadcms/translations': 3.18.0
+      '@payloadcms/ui': 3.18.0(@types/react@19.0.7)(monaco-editor@0.52.2)(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
       busboy: 1.6.0
       file-type: 19.3.0
       graphql: 16.10.0
       graphql-http: 1.22.4(graphql@16.10.0)
       graphql-playground-html: 1.6.30
-      http-status: 1.6.2
-      next: 15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+      http-status: 2.1.0
+      next: 15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
       path-to-regexp: 6.3.0
-      payload: 3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+      payload: 3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
       qs-esm: 7.0.2
       react-diff-viewer-continued: 3.2.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       sass: 1.77.4
@@ -3514,7 +3513,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@payloadcms/richtext-lexical@3.17.1(p7oy7o6ncn3qehd5uorapl4luu)':
+  '@payloadcms/richtext-lexical@3.18.0(bvirogffrpuzy2e4p57bv2watq)':
     dependencies:
       '@faceless-ui/modal': 3.0.0-beta.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@faceless-ui/scroll-info': 2.0.0-beta.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -3528,9 +3527,9 @@ snapshots:
       '@lexical/selection': 0.21.0
       '@lexical/table': 0.21.0
       '@lexical/utils': 0.21.0
-      '@payloadcms/next': 3.17.1(@types/react@19.0.7)(graphql@16.10.0)(monaco-editor@0.52.2)(next@15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
-      '@payloadcms/translations': 3.17.1
-      '@payloadcms/ui': 3.17.1(@types/react@19.0.7)(monaco-editor@0.52.2)(next@15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+      '@payloadcms/next': 3.18.0(@types/react@19.0.7)(graphql@16.10.0)(monaco-editor@0.52.2)(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+      '@payloadcms/translations': 3.18.0
+      '@payloadcms/ui': 3.18.0(@types/react@19.0.7)(monaco-editor@0.52.2)(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
       '@types/uuid': 10.0.0
       acorn: 8.12.1
       bson-objectid: 2.0.4
@@ -3541,7 +3540,7 @@ snapshots:
       mdast-util-from-markdown: 2.0.2
       mdast-util-mdx-jsx: 3.1.3
       micromark-extension-mdx-jsx: 3.0.1
-      payload: 3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+      payload: 3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-error-boundary: 4.1.2(react@19.0.0)
@@ -3554,11 +3553,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@payloadcms/translations@3.17.1':
+  '@payloadcms/translations@3.18.0':
     dependencies:
       date-fns: 4.1.0
 
-  '@payloadcms/ui@3.17.1(@types/react@19.0.7)(monaco-editor@0.52.2)(next@15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)':
+  '@payloadcms/ui@3.18.0(@types/react@19.0.7)(monaco-editor@0.52.2)(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)':
     dependencies:
       '@dnd-kit/core': 6.0.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.0.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
@@ -3566,15 +3565,15 @@ snapshots:
       '@faceless-ui/scroll-info': 2.0.0-beta.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@faceless-ui/window-info': 3.0.0-beta.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@monaco-editor/react': 4.6.0(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@payloadcms/translations': 3.17.1
+      '@payloadcms/translations': 3.18.0
       body-scroll-lock: 4.0.0-beta.0
       bson-objectid: 2.0.4
       date-fns: 4.1.0
       dequal: 2.0.3
       md5: 2.3.0
-      next: 15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+      next: 15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
       object-to-formdata: 4.5.1
-      payload: 3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
+      payload: 3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2)
       qs-esm: 7.0.2
       react: 19.0.0
       react-datepicker: 7.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -3596,51 +3595,51 @@ snapshots:
 
   '@rushstack/eslint-patch@1.10.5': {}
 
-  '@swc/core-darwin-arm64@1.10.7':
+  '@swc/core-darwin-arm64@1.10.9':
     optional: true
 
-  '@swc/core-darwin-x64@1.10.7':
+  '@swc/core-darwin-x64@1.10.9':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.10.7':
+  '@swc/core-linux-arm-gnueabihf@1.10.9':
     optional: true
 
-  '@swc/core-linux-arm64-gnu@1.10.7':
+  '@swc/core-linux-arm64-gnu@1.10.9':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.10.7':
+  '@swc/core-linux-arm64-musl@1.10.9':
     optional: true
 
-  '@swc/core-linux-x64-gnu@1.10.7':
+  '@swc/core-linux-x64-gnu@1.10.9':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.10.7':
+  '@swc/core-linux-x64-musl@1.10.9':
     optional: true
 
-  '@swc/core-win32-arm64-msvc@1.10.7':
+  '@swc/core-win32-arm64-msvc@1.10.9':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.10.7':
+  '@swc/core-win32-ia32-msvc@1.10.9':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.10.7':
+  '@swc/core-win32-x64-msvc@1.10.9':
     optional: true
 
-  '@swc/core@1.10.7(@swc/helpers@0.5.15)':
+  '@swc/core@1.10.9(@swc/helpers@0.5.15)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.17
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.10.7
-      '@swc/core-darwin-x64': 1.10.7
-      '@swc/core-linux-arm-gnueabihf': 1.10.7
-      '@swc/core-linux-arm64-gnu': 1.10.7
-      '@swc/core-linux-arm64-musl': 1.10.7
-      '@swc/core-linux-x64-gnu': 1.10.7
-      '@swc/core-linux-x64-musl': 1.10.7
-      '@swc/core-win32-arm64-msvc': 1.10.7
-      '@swc/core-win32-ia32-msvc': 1.10.7
-      '@swc/core-win32-x64-msvc': 1.10.7
+      '@swc/core-darwin-arm64': 1.10.9
+      '@swc/core-darwin-x64': 1.10.9
+      '@swc/core-linux-arm-gnueabihf': 1.10.9
+      '@swc/core-linux-arm64-gnu': 1.10.9
+      '@swc/core-linux-arm64-musl': 1.10.9
+      '@swc/core-linux-x64-gnu': 1.10.9
+      '@swc/core-linux-x64-musl': 1.10.9
+      '@swc/core-win32-arm64-msvc': 1.10.9
+      '@swc/core-win32-ia32-msvc': 1.10.9
+      '@swc/core-win32-x64-msvc': 1.10.9
       '@swc/helpers': 0.5.15
 
   '@swc/counter@0.1.3': {}
@@ -3721,14 +3720,14 @@ snapshots:
     dependencies:
       '@types/webidl-conversions': 7.0.3
 
-  '@typescript-eslint/eslint-plugin@8.20.0(@typescript-eslint/parser@8.20.0(eslint@8.57.1)(typescript@5.5.2))(eslint@8.57.1)(typescript@5.5.2)':
+  '@typescript-eslint/eslint-plugin@8.21.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.5.2))(eslint@8.57.1)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.20.0(eslint@8.57.1)(typescript@5.5.2)
-      '@typescript-eslint/scope-manager': 8.20.0
-      '@typescript-eslint/type-utils': 8.20.0(eslint@8.57.1)(typescript@5.5.2)
-      '@typescript-eslint/utils': 8.20.0(eslint@8.57.1)(typescript@5.5.2)
-      '@typescript-eslint/visitor-keys': 8.20.0
+      '@typescript-eslint/parser': 8.21.0(eslint@8.57.1)(typescript@5.5.2)
+      '@typescript-eslint/scope-manager': 8.21.0
+      '@typescript-eslint/type-utils': 8.21.0(eslint@8.57.1)(typescript@5.5.2)
+      '@typescript-eslint/utils': 8.21.0(eslint@8.57.1)(typescript@5.5.2)
+      '@typescript-eslint/visitor-keys': 8.21.0
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -3738,27 +3737,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.20.0(eslint@8.57.1)(typescript@5.5.2)':
+  '@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.20.0
-      '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.5.2)
-      '@typescript-eslint/visitor-keys': 8.20.0
+      '@typescript-eslint/scope-manager': 8.21.0
+      '@typescript-eslint/types': 8.21.0
+      '@typescript-eslint/typescript-estree': 8.21.0(typescript@5.5.2)
+      '@typescript-eslint/visitor-keys': 8.21.0
       debug: 4.4.0
       eslint: 8.57.1
       typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.20.0':
+  '@typescript-eslint/scope-manager@8.21.0':
     dependencies:
-      '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/visitor-keys': 8.20.0
+      '@typescript-eslint/types': 8.21.0
+      '@typescript-eslint/visitor-keys': 8.21.0
 
-  '@typescript-eslint/type-utils@8.20.0(eslint@8.57.1)(typescript@5.5.2)':
+  '@typescript-eslint/type-utils@8.21.0(eslint@8.57.1)(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.5.2)
-      '@typescript-eslint/utils': 8.20.0(eslint@8.57.1)(typescript@5.5.2)
+      '@typescript-eslint/typescript-estree': 8.21.0(typescript@5.5.2)
+      '@typescript-eslint/utils': 8.21.0(eslint@8.57.1)(typescript@5.5.2)
       debug: 4.4.0
       eslint: 8.57.1
       ts-api-utils: 2.0.0(typescript@5.5.2)
@@ -3766,12 +3765,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.20.0': {}
+  '@typescript-eslint/types@8.21.0': {}
 
-  '@typescript-eslint/typescript-estree@8.20.0(typescript@5.5.2)':
+  '@typescript-eslint/typescript-estree@8.21.0(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/visitor-keys': 8.20.0
+      '@typescript-eslint/types': 8.21.0
+      '@typescript-eslint/visitor-keys': 8.21.0
       debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -3782,20 +3781,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.20.0(eslint@8.57.1)(typescript@5.5.2)':
+  '@typescript-eslint/utils@8.21.0(eslint@8.57.1)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.20.0
-      '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.5.2)
+      '@typescript-eslint/scope-manager': 8.21.0
+      '@typescript-eslint/types': 8.21.0
+      '@typescript-eslint/typescript-estree': 8.21.0(typescript@5.5.2)
       eslint: 8.57.1
       typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.20.0':
+  '@typescript-eslint/visitor-keys@8.21.0':
     dependencies:
-      '@typescript-eslint/types': 8.20.0
+      '@typescript-eslint/types': 8.21.0
       eslint-visitor-keys: 4.2.0
 
   '@ungap/structured-clone@1.2.1': {}
@@ -3818,7 +3817,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.5
+      fast-uri: 3.0.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3965,7 +3964,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001692: {}
+  caniuse-lite@1.0.30001695: {}
 
   ccount@2.0.1: {}
 
@@ -4292,16 +4291,16 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@15.1.5(eslint@8.57.1)(typescript@5.5.2):
+  eslint-config-next@15.1.6(eslint@8.57.1)(typescript@5.5.2):
     dependencies:
-      '@next/eslint-plugin-next': 15.1.5
+      '@next/eslint-plugin-next': 15.1.6
       '@rushstack/eslint-patch': 1.10.5
-      '@typescript-eslint/eslint-plugin': 8.20.0(@typescript-eslint/parser@8.20.0(eslint@8.57.1)(typescript@5.5.2))(eslint@8.57.1)(typescript@5.5.2)
-      '@typescript-eslint/parser': 8.20.0(eslint@8.57.1)(typescript@5.5.2)
+      '@typescript-eslint/eslint-plugin': 8.21.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.5.2))(eslint@8.57.1)(typescript@5.5.2)
+      '@typescript-eslint/parser': 8.21.0(eslint@8.57.1)(typescript@5.5.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.20.0(eslint@8.57.1)(typescript@5.5.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.5.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.1.0(eslint@8.57.1)
@@ -4327,27 +4326,27 @@ snapshots:
       enhanced-resolve: 5.18.0
       eslint: 8.57.1
       fast-glob: 3.3.3
-      get-tsconfig: 4.8.1
+      get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.20.0(eslint@8.57.1)(typescript@5.5.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.5.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.20.0(eslint@8.57.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.20.0(eslint@8.57.1)(typescript@5.5.2)
+      '@typescript-eslint/parser': 8.21.0(eslint@8.57.1)(typescript@5.5.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.20.0(eslint@8.57.1)(typescript@5.5.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.5.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -4358,7 +4357,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.20.0(eslint@8.57.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4370,7 +4369,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.20.0(eslint@8.57.1)(typescript@5.5.2)
+      '@typescript-eslint/parser': 8.21.0(eslint@8.57.1)(typescript@5.5.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -4526,7 +4525,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.0.5: {}
+  fast-uri@3.0.6: {}
 
   fastq@1.18.0:
     dependencies:
@@ -4615,6 +4614,10 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.2.7
 
+  get-tsconfig@4.10.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   get-tsconfig@4.8.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -4696,7 +4699,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  http-status@1.6.2: {}
+  http-status@2.1.0: {}
 
   ieee754@1.2.1: {}
 
@@ -5049,7 +5052,7 @@ snapshots:
       micromark-util-html-tag-name: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
-      micromark-util-subtokenize: 2.0.3
+      micromark-util-subtokenize: 2.0.4
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.1
 
@@ -5171,7 +5174,7 @@ snapshots:
       micromark-util-encode: 2.0.1
       micromark-util-symbol: 2.0.1
 
-  micromark-util-subtokenize@2.0.3:
+  micromark-util-subtokenize@2.0.4:
     dependencies:
       devlop: 1.1.0
       micromark-util-chunked: 2.0.1
@@ -5198,7 +5201,7 @@ snapshots:
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
       micromark-util-sanitize-uri: 2.0.1
-      micromark-util-subtokenize: 2.0.3
+      micromark-util-subtokenize: 2.0.4
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.1
     transitivePeerDependencies:
@@ -5226,7 +5229,7 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 14.1.0
 
-  mongodb@6.10.0:
+  mongodb@6.12.0:
     dependencies:
       '@mongodb-js/saslprep': 1.1.9
       bson: 6.10.1
@@ -5236,11 +5239,11 @@ snapshots:
 
   mongoose-paginate-v2@1.8.5: {}
 
-  mongoose@8.8.3:
+  mongoose@8.9.5:
     dependencies:
       bson: 6.10.1
       kareem: 2.6.3
-      mongodb: 6.10.0
+      mongodb: 6.12.0
       mpath: 0.9.0
       mquery: 5.0.0
       ms: 2.1.3
@@ -5269,26 +5272,26 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4):
+  next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4):
     dependencies:
-      '@next/env': 15.1.5
+      '@next/env': 15.1.6
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001692
+      caniuse-lite: 1.0.30001695
       postcss: 8.4.31
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       styled-jsx: 5.1.6(react@19.0.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.1.5
-      '@next/swc-darwin-x64': 15.1.5
-      '@next/swc-linux-arm64-gnu': 15.1.5
-      '@next/swc-linux-arm64-musl': 15.1.5
-      '@next/swc-linux-x64-gnu': 15.1.5
-      '@next/swc-linux-x64-musl': 15.1.5
-      '@next/swc-win32-arm64-msvc': 15.1.5
-      '@next/swc-win32-x64-msvc': 15.1.5
+      '@next/swc-darwin-arm64': 15.1.6
+      '@next/swc-darwin-x64': 15.1.6
+      '@next/swc-linux-arm64-gnu': 15.1.6
+      '@next/swc-linux-arm64-musl': 15.1.6
+      '@next/swc-linux-x64-gnu': 15.1.6
+      '@next/swc-linux-x64-musl': 15.1.6
+      '@next/swc-win32-arm64-msvc': 15.1.6
+      '@next/swc-win32-x64-msvc': 15.1.6
       sass: 1.77.4
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -5398,17 +5401,15 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-to-regexp@6.2.1: {}
-
   path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 
-  payload@3.17.1(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2):
+  payload@3.18.0(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.2):
     dependencies:
       '@monaco-editor/react': 4.6.0(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@next/env': 15.1.5
-      '@payloadcms/translations': 3.17.1
+      '@next/env': 15.1.6
+      '@payloadcms/translations': 3.18.0
       '@types/busboy': 1.5.4
       ajv: 8.17.1
       bson-objectid: 2.0.4
@@ -5421,12 +5422,12 @@ snapshots:
       file-type: 19.3.0
       get-tsconfig: 4.8.1
       graphql: 16.10.0
-      http-status: 1.6.2
+      http-status: 2.1.0
       image-size: 1.2.0
       jose: 5.9.6
       json-schema-to-typescript: 15.0.3
       minimist: 1.2.8
-      path-to-regexp: 6.2.1
+      path-to-regexp: 6.3.0
       pino: 9.5.0
       pino-pretty: 13.0.0
       pluralize: 8.0.0
@@ -5953,7 +5954,7 @@ snapshots:
   tsx@4.19.2:
     dependencies:
       esbuild: 0.23.1
-      get-tsconfig: 4.8.1
+      get-tsconfig: 4.10.0
     optionalDependencies:
       fsevents: 2.3.3
 

--- a/examples/custom-components/src/app/(payload)/admin/importMap.js
+++ b/examples/custom-components/src/app/(payload)/admin/importMap.js
@@ -8,6 +8,10 @@ import { CustomCheckboxFieldLabelServer as CustomCheckboxFieldLabelServer_48cd2d
 import { CustomCheckboxFieldServer as CustomCheckboxFieldServer_85023d60242dd4cca7c406a728ec37a8 } from '@/collections/Fields/checkbox/components/server/Field'
 import { CustomCheckboxFieldLabelClient as CustomCheckboxFieldLabelClient_f2b214145c1cbe98957573cf62455194 } from '@/collections/Fields/checkbox/components/client/Label'
 import { CustomCheckboxFieldClient as CustomCheckboxFieldClient_a13e6003bc89da826df764d7234782de } from '@/collections/Fields/checkbox/components/client/Field'
+import { CustomCodeFieldLabelServer as CustomCodeFieldLabelServer_566aaa8491895af5900235f95e62c2cf } from '@/collections/Fields/code/components/server/Label'
+import { CustomCodeFieldServer as CustomCodeFieldServer_e76f292770f788ad4ec46a180ab3c174 } from '@/collections/Fields/code/components/server/Field'
+import { CustomCodeFieldLabelClient as CustomCodeFieldLabelClient_823b02f23d594204cfa7fcfc30aeed46 } from '@/collections/Fields/code/components/client/Label'
+import { CustomCodeFieldClient as CustomCodeFieldClient_2ef913b825e7bb326ec86b0f6ea4dd3c } from '@/collections/Fields/code/components/client/Field'
 import { CustomDateFieldLabelServer as CustomDateFieldLabelServer_ae9eb459b79a1363a40d62b1e463aa6b } from '@/collections/Fields/date/components/server/Label'
 import { CustomDateFieldServer as CustomDateFieldServer_9d448604d99b3b06826ea95986ffd27b } from '@/collections/Fields/date/components/server/Field'
 import { CustomDateFieldLabelClient as CustomDateFieldLabelClient_0b6c1439c63aadfd306cf432713a52d8 } from '@/collections/Fields/date/components/client/Label'
@@ -16,6 +20,10 @@ import { CustomEmailFieldLabelServer as CustomEmailFieldLabelServer_a5097abb06ef
 import { CustomEmailFieldServer as CustomEmailFieldServer_457ae84519701bf0b287c30a994ddab1 } from '@/collections/Fields/email/components/server/Field'
 import { CustomEmailFieldLabelClient as CustomEmailFieldLabelClient_147edabdb378c855b9c8c06b8c627e50 } from '@/collections/Fields/email/components/client/Label'
 import { CustomEmailFieldClient as CustomEmailFieldClient_e22bcec891915f255e5ac6e1850aeb97 } from '@/collections/Fields/email/components/client/Field'
+import { CustomJSONFieldLabelServer as CustomJSONFieldLabelServer_94d8c8f7c699cb282fb912bead88f8b6 } from '@/collections/Fields/json/components/server/Label'
+import { CustomJSONFieldServer as CustomJSONFieldServer_6034ebd8b071080c9e06e4abab7a6fd2 } from '@/collections/Fields/json/components/server/Field'
+import { CustomJSONFieldLabelClient as CustomJSONFieldLabelClient_16798ccfd3eb2cb009c4f0ea34c3c31e } from '@/collections/Fields/json/components/client/Label'
+import { CustomJSONFieldClient as CustomJSONFieldClient_077b2498f1ebe1df34940ffc4ce4f8e6 } from '@/collections/Fields/json/components/client/Field'
 import { CustomNumberFieldLabelServer as CustomNumberFieldLabelServer_1b47d0cd70ad88e23dcf9c4f91bf319f } from '@/collections/Fields/number/components/server/Label'
 import { CustomNumberFieldServer as CustomNumberFieldServer_54fc6ad95d89a3b66b59136e84d20b86 } from '@/collections/Fields/number/components/server/Field'
 import { CustomNumberFieldLabelClient as CustomNumberFieldLabelClient_dd3e3dcfc7b07c3a02f947ac81718a51 } from '@/collections/Fields/number/components/client/Label'
@@ -55,59 +63,130 @@ import { CustomDefaultRootView as CustomDefaultRootView_a2f8ce99b3a1692f7ec03a90
 import { CustomMinimalRootView as CustomMinimalRootView_9211f699dea5524a957f33011b786586 } from '@/components/views/CustomMinimalRootView'
 
 export const importMap = {
-  "@/collections/Fields/array/components/server/Label#CustomArrayFieldLabelServer": CustomArrayFieldLabelServer_f8d063e9b7f25c350451c1865199c947,
-  "@/collections/Fields/array/components/server/Field#CustomArrayFieldServer": CustomArrayFieldServer_4c3c139a9b1a198103c8a2ec2869c837,
-  "@/collections/Fields/array/components/client/Label#CustomArrayFieldLabelClient": CustomArrayFieldLabelClient_c07dc2c547c47aca8e9f471795279e9d,
-  "@/collections/Fields/array/components/client/Field#CustomArrayFieldClient": CustomArrayFieldClient_60ede271f2b85983daf36710010ad8ab,
-  "@/collections/Fields/blocks/components/server/Field#CustomBlocksFieldServer": CustomBlocksFieldServer_61732537ad2c492ac9938959902f6954,
-  "@/collections/Fields/blocks/components/client/Field#CustomBlocksFieldClient": CustomBlocksFieldClient_2ef3a03de3974b6f18f07623af0cd515,
-  "@/collections/Fields/checkbox/components/server/Label#CustomCheckboxFieldLabelServer": CustomCheckboxFieldLabelServer_48cd2d9639f54745ad4cdb6905c825d9,
-  "@/collections/Fields/checkbox/components/server/Field#CustomCheckboxFieldServer": CustomCheckboxFieldServer_85023d60242dd4cca7c406a728ec37a8,
-  "@/collections/Fields/checkbox/components/client/Label#CustomCheckboxFieldLabelClient": CustomCheckboxFieldLabelClient_f2b214145c1cbe98957573cf62455194,
-  "@/collections/Fields/checkbox/components/client/Field#CustomCheckboxFieldClient": CustomCheckboxFieldClient_a13e6003bc89da826df764d7234782de,
-  "@/collections/Fields/date/components/server/Label#CustomDateFieldLabelServer": CustomDateFieldLabelServer_ae9eb459b79a1363a40d62b1e463aa6b,
-  "@/collections/Fields/date/components/server/Field#CustomDateFieldServer": CustomDateFieldServer_9d448604d99b3b06826ea95986ffd27b,
-  "@/collections/Fields/date/components/client/Label#CustomDateFieldLabelClient": CustomDateFieldLabelClient_0b6c1439c63aadfd306cf432713a52d8,
-  "@/collections/Fields/date/components/client/Field#CustomDateFieldClient": CustomDateFieldClient_4ef537c727f5de7c26aaea94024a0b2c,
-  "@/collections/Fields/email/components/server/Label#CustomEmailFieldLabelServer": CustomEmailFieldLabelServer_a5097abb06efbe71fc6ba1636f7194ab,
-  "@/collections/Fields/email/components/server/Field#CustomEmailFieldServer": CustomEmailFieldServer_457ae84519701bf0b287c30a994ddab1,
-  "@/collections/Fields/email/components/client/Label#CustomEmailFieldLabelClient": CustomEmailFieldLabelClient_147edabdb378c855b9c8c06b8c627e50,
-  "@/collections/Fields/email/components/client/Field#CustomEmailFieldClient": CustomEmailFieldClient_e22bcec891915f255e5ac6e1850aeb97,
-  "@/collections/Fields/number/components/server/Label#CustomNumberFieldLabelServer": CustomNumberFieldLabelServer_1b47d0cd70ad88e23dcf9c4f91bf319f,
-  "@/collections/Fields/number/components/server/Field#CustomNumberFieldServer": CustomNumberFieldServer_54fc6ad95d89a3b66b59136e84d20b86,
-  "@/collections/Fields/number/components/client/Label#CustomNumberFieldLabelClient": CustomNumberFieldLabelClient_dd3e3dcfc7b07c3a02f947ac81718a51,
-  "@/collections/Fields/number/components/client/Field#CustomNumberFieldClient": CustomNumberFieldClient_5d5605680426c77470fd74d010fe051f,
-  "@/collections/Fields/point/components/server/Label#CustomPointFieldLabelServer": CustomPointFieldLabelServer_c5fb0c717f353a8c6149238dd7d92ec9,
-  "@/collections/Fields/point/components/server/Field#CustomPointFieldServer": CustomPointFieldServer_a23d13971ed0ff10615e3248bb1ee55d,
-  "@/collections/Fields/point/components/client/Label#CustomPointFieldLabelClient": CustomPointFieldLabelClient_3c6c8c891bc098021e618d5cf4dc3150,
-  "@/collections/Fields/point/components/client/Field#CustomPointFieldClient": CustomPointFieldClient_abb4ee1633cbc83b4cec9b8abb95f132,
-  "@/collections/Fields/radio/components/server/Label#CustomRadioFieldLabelServer": CustomRadioFieldLabelServer_5c732ac2af72bb41657cc9a1a22bc67b,
-  "@/collections/Fields/radio/components/server/Field#CustomRadioFieldServer": CustomRadioFieldServer_b7edb363e225e2976a994da8e8803e60,
-  "@/collections/Fields/radio/components/client/Label#CustomRadioFieldLabelClient": CustomRadioFieldLabelClient_d46d0583023d87065f05972901727bbf,
-  "@/collections/Fields/radio/components/client/Field#CustomRadioFieldClient": CustomRadioFieldClient_42845db96f999817cb9f0a590413d669,
-  "@/collections/Fields/relationship/components/server/Label#CustomRelationshipFieldLabelServer": CustomRelationshipFieldLabelServer_7c45510caabe204587b638c40f0d0a70,
-  "@/collections/Fields/relationship/components/server/Field#CustomRelationshipFieldServer": CustomRelationshipFieldServer_d2e0b17d4b1c00b1fc726f0ea55ddc16,
-  "@/collections/Fields/relationship/components/client/Label#CustomRelationshipFieldLabelClient": CustomRelationshipFieldLabelClient_37b268226ded7dd38d5cb8f2952f4b3a,
-  "@/collections/Fields/relationship/components/client/Field#CustomRelationshipFieldClient": CustomRelationshipFieldClient_eb1bc838beb92b05ba1bb9c1fdfd7869,
-  "@/collections/Fields/select/components/server/Label#CustomSelectFieldLabelServer": CustomSelectFieldLabelServer_653acab80b672fd4ebeeed757e09d4c9,
-  "@/collections/Fields/select/components/server/Field#CustomSelectFieldServer": CustomSelectFieldServer_ee886c859ef756c29ae7383a2be0a08a,
-  "@/collections/Fields/select/components/client/Label#CustomSelectFieldLabelClient": CustomSelectFieldLabelClient_2db542ef2e0a664acaa5679fc14aa54b,
-  "@/collections/Fields/select/components/client/Field#CustomSelectFieldClient": CustomSelectFieldClient_c8b4c7f3e98b5887ca262dd841bffa2f,
-  "@/collections/Fields/text/components/server/Label#CustomTextFieldLabelServer": CustomTextFieldLabelServer_64a4b68861269d69d4c16a0f651b7ac9,
-  "@/collections/Fields/text/components/server/Field#CustomTextFieldServer": CustomTextFieldServer_e0caaef49c00003336b08d834c0c9fe9,
-  "@/collections/Fields/text/components/client/Label#CustomTextFieldLabelClient": CustomTextFieldLabelClient_9af2b9e4733a9fc79fb9dfb1578c18bf,
-  "@/collections/Fields/text/components/client/Field#CustomTextFieldClient": CustomTextFieldClient_c7c0687b5204b201f8b1af831f34fd98,
-  "@/collections/Fields/textarea/components/server/Label#CustomTextareaFieldLabelServer": CustomTextareaFieldLabelServer_5c8f706a3452bccefa9f5044e2cd250c,
-  "@/collections/Fields/textarea/components/server/Field#CustomTextareaFieldServer": CustomTextareaFieldServer_3f7b621f5c4c42971fc099a1fa492d99,
-  "@/collections/Fields/textarea/components/client/Label#CustomTextareaFieldLabelClient": CustomTextareaFieldLabelClient_9959ee64353edb5f2606b52187275823,
-  "@/collections/Fields/textarea/components/client/Field#CustomTextareaFieldClient": CustomTextareaFieldClient_4fd3331c38982e86768c64dcc9a10691,
-  "@/collections/Views/components/CustomTabEditView#CustomTabEditView": CustomTabEditView_0a7acb05a3192ecfa7e07f8b42e7a193,
-  "@/collections/Views/components/CustomDefaultEditView#CustomDefaultEditView": CustomDefaultEditView_2d3c652c5909d3a3dc3464f0547d5424,
-  "@/collections/RootViews/components/CustomRootEditView#CustomRootEditView": CustomRootEditView_ba37229da543ad3c8dc40f7a48771f99,
-  "@/components/afterNavLinks/LinkToCustomView#LinkToCustomView": LinkToCustomView_6f16fe358985478a2ead2354ef2cc9a0,
-  "@/components/afterNavLinks/LinkToCustomMinimalView#LinkToCustomMinimalView": LinkToCustomMinimalView_fd2cefb054695a5b60b860a69d67d15d,
-  "@/components/afterNavLinks/LinkToCustomDefaultView#LinkToCustomDefaultView": LinkToCustomDefaultView_4c5f581c8bfa951ce2f83c24c4f36b3b,
-  "@/components/views/CustomRootView#CustomRootView": CustomRootView_1ebb91ef5ff1ea4dc9a27ceb8e9ee0ab,
-  "@/components/views/CustomDefaultRootView#CustomDefaultRootView": CustomDefaultRootView_a2f8ce99b3a1692f7ec03a907e1ea4ce,
-  "@/components/views/CustomMinimalRootView#CustomMinimalRootView": CustomMinimalRootView_9211f699dea5524a957f33011b786586
+  '@/collections/Fields/array/components/server/Label#CustomArrayFieldLabelServer':
+    CustomArrayFieldLabelServer_f8d063e9b7f25c350451c1865199c947,
+  '@/collections/Fields/array/components/server/Field#CustomArrayFieldServer':
+    CustomArrayFieldServer_4c3c139a9b1a198103c8a2ec2869c837,
+  '@/collections/Fields/array/components/client/Label#CustomArrayFieldLabelClient':
+    CustomArrayFieldLabelClient_c07dc2c547c47aca8e9f471795279e9d,
+  '@/collections/Fields/array/components/client/Field#CustomArrayFieldClient':
+    CustomArrayFieldClient_60ede271f2b85983daf36710010ad8ab,
+  '@/collections/Fields/blocks/components/server/Field#CustomBlocksFieldServer':
+    CustomBlocksFieldServer_61732537ad2c492ac9938959902f6954,
+  '@/collections/Fields/blocks/components/client/Field#CustomBlocksFieldClient':
+    CustomBlocksFieldClient_2ef3a03de3974b6f18f07623af0cd515,
+  '@/collections/Fields/checkbox/components/server/Label#CustomCheckboxFieldLabelServer':
+    CustomCheckboxFieldLabelServer_48cd2d9639f54745ad4cdb6905c825d9,
+  '@/collections/Fields/checkbox/components/server/Field#CustomCheckboxFieldServer':
+    CustomCheckboxFieldServer_85023d60242dd4cca7c406a728ec37a8,
+  '@/collections/Fields/checkbox/components/client/Label#CustomCheckboxFieldLabelClient':
+    CustomCheckboxFieldLabelClient_f2b214145c1cbe98957573cf62455194,
+  '@/collections/Fields/checkbox/components/client/Field#CustomCheckboxFieldClient':
+    CustomCheckboxFieldClient_a13e6003bc89da826df764d7234782de,
+  '@/collections/Fields/code/components/server/Label#CustomCodeFieldLabelServer':
+    CustomCodeFieldLabelServer_566aaa8491895af5900235f95e62c2cf,
+  '@/collections/Fields/code/components/server/Field#CustomCodeFieldServer':
+    CustomCodeFieldServer_e76f292770f788ad4ec46a180ab3c174,
+  '@/collections/Fields/code/components/client/Label#CustomCodeFieldLabelClient':
+    CustomCodeFieldLabelClient_823b02f23d594204cfa7fcfc30aeed46,
+  '@/collections/Fields/code/components/client/Field#CustomCodeFieldClient':
+    CustomCodeFieldClient_2ef913b825e7bb326ec86b0f6ea4dd3c,
+  '@/collections/Fields/date/components/server/Label#CustomDateFieldLabelServer':
+    CustomDateFieldLabelServer_ae9eb459b79a1363a40d62b1e463aa6b,
+  '@/collections/Fields/date/components/server/Field#CustomDateFieldServer':
+    CustomDateFieldServer_9d448604d99b3b06826ea95986ffd27b,
+  '@/collections/Fields/date/components/client/Label#CustomDateFieldLabelClient':
+    CustomDateFieldLabelClient_0b6c1439c63aadfd306cf432713a52d8,
+  '@/collections/Fields/date/components/client/Field#CustomDateFieldClient':
+    CustomDateFieldClient_4ef537c727f5de7c26aaea94024a0b2c,
+  '@/collections/Fields/email/components/server/Label#CustomEmailFieldLabelServer':
+    CustomEmailFieldLabelServer_a5097abb06efbe71fc6ba1636f7194ab,
+  '@/collections/Fields/email/components/server/Field#CustomEmailFieldServer':
+    CustomEmailFieldServer_457ae84519701bf0b287c30a994ddab1,
+  '@/collections/Fields/email/components/client/Label#CustomEmailFieldLabelClient':
+    CustomEmailFieldLabelClient_147edabdb378c855b9c8c06b8c627e50,
+  '@/collections/Fields/email/components/client/Field#CustomEmailFieldClient':
+    CustomEmailFieldClient_e22bcec891915f255e5ac6e1850aeb97,
+  '@/collections/Fields/json/components/server/Label#CustomJSONFieldLabelServer':
+    CustomJSONFieldLabelServer_94d8c8f7c699cb282fb912bead88f8b6,
+  '@/collections/Fields/json/components/server/Field#CustomJSONFieldServer':
+    CustomJSONFieldServer_6034ebd8b071080c9e06e4abab7a6fd2,
+  '@/collections/Fields/json/components/client/Label#CustomJSONFieldLabelClient':
+    CustomJSONFieldLabelClient_16798ccfd3eb2cb009c4f0ea34c3c31e,
+  '@/collections/Fields/json/components/client/Field#CustomJSONFieldClient':
+    CustomJSONFieldClient_077b2498f1ebe1df34940ffc4ce4f8e6,
+  '@/collections/Fields/number/components/server/Label#CustomNumberFieldLabelServer':
+    CustomNumberFieldLabelServer_1b47d0cd70ad88e23dcf9c4f91bf319f,
+  '@/collections/Fields/number/components/server/Field#CustomNumberFieldServer':
+    CustomNumberFieldServer_54fc6ad95d89a3b66b59136e84d20b86,
+  '@/collections/Fields/number/components/client/Label#CustomNumberFieldLabelClient':
+    CustomNumberFieldLabelClient_dd3e3dcfc7b07c3a02f947ac81718a51,
+  '@/collections/Fields/number/components/client/Field#CustomNumberFieldClient':
+    CustomNumberFieldClient_5d5605680426c77470fd74d010fe051f,
+  '@/collections/Fields/point/components/server/Label#CustomPointFieldLabelServer':
+    CustomPointFieldLabelServer_c5fb0c717f353a8c6149238dd7d92ec9,
+  '@/collections/Fields/point/components/server/Field#CustomPointFieldServer':
+    CustomPointFieldServer_a23d13971ed0ff10615e3248bb1ee55d,
+  '@/collections/Fields/point/components/client/Label#CustomPointFieldLabelClient':
+    CustomPointFieldLabelClient_3c6c8c891bc098021e618d5cf4dc3150,
+  '@/collections/Fields/point/components/client/Field#CustomPointFieldClient':
+    CustomPointFieldClient_abb4ee1633cbc83b4cec9b8abb95f132,
+  '@/collections/Fields/radio/components/server/Label#CustomRadioFieldLabelServer':
+    CustomRadioFieldLabelServer_5c732ac2af72bb41657cc9a1a22bc67b,
+  '@/collections/Fields/radio/components/server/Field#CustomRadioFieldServer':
+    CustomRadioFieldServer_b7edb363e225e2976a994da8e8803e60,
+  '@/collections/Fields/radio/components/client/Label#CustomRadioFieldLabelClient':
+    CustomRadioFieldLabelClient_d46d0583023d87065f05972901727bbf,
+  '@/collections/Fields/radio/components/client/Field#CustomRadioFieldClient':
+    CustomRadioFieldClient_42845db96f999817cb9f0a590413d669,
+  '@/collections/Fields/relationship/components/server/Label#CustomRelationshipFieldLabelServer':
+    CustomRelationshipFieldLabelServer_7c45510caabe204587b638c40f0d0a70,
+  '@/collections/Fields/relationship/components/server/Field#CustomRelationshipFieldServer':
+    CustomRelationshipFieldServer_d2e0b17d4b1c00b1fc726f0ea55ddc16,
+  '@/collections/Fields/relationship/components/client/Label#CustomRelationshipFieldLabelClient':
+    CustomRelationshipFieldLabelClient_37b268226ded7dd38d5cb8f2952f4b3a,
+  '@/collections/Fields/relationship/components/client/Field#CustomRelationshipFieldClient':
+    CustomRelationshipFieldClient_eb1bc838beb92b05ba1bb9c1fdfd7869,
+  '@/collections/Fields/select/components/server/Label#CustomSelectFieldLabelServer':
+    CustomSelectFieldLabelServer_653acab80b672fd4ebeeed757e09d4c9,
+  '@/collections/Fields/select/components/server/Field#CustomSelectFieldServer':
+    CustomSelectFieldServer_ee886c859ef756c29ae7383a2be0a08a,
+  '@/collections/Fields/select/components/client/Label#CustomSelectFieldLabelClient':
+    CustomSelectFieldLabelClient_2db542ef2e0a664acaa5679fc14aa54b,
+  '@/collections/Fields/select/components/client/Field#CustomSelectFieldClient':
+    CustomSelectFieldClient_c8b4c7f3e98b5887ca262dd841bffa2f,
+  '@/collections/Fields/text/components/server/Label#CustomTextFieldLabelServer':
+    CustomTextFieldLabelServer_64a4b68861269d69d4c16a0f651b7ac9,
+  '@/collections/Fields/text/components/server/Field#CustomTextFieldServer':
+    CustomTextFieldServer_e0caaef49c00003336b08d834c0c9fe9,
+  '@/collections/Fields/text/components/client/Label#CustomTextFieldLabelClient':
+    CustomTextFieldLabelClient_9af2b9e4733a9fc79fb9dfb1578c18bf,
+  '@/collections/Fields/text/components/client/Field#CustomTextFieldClient':
+    CustomTextFieldClient_c7c0687b5204b201f8b1af831f34fd98,
+  '@/collections/Fields/textarea/components/server/Label#CustomTextareaFieldLabelServer':
+    CustomTextareaFieldLabelServer_5c8f706a3452bccefa9f5044e2cd250c,
+  '@/collections/Fields/textarea/components/server/Field#CustomTextareaFieldServer':
+    CustomTextareaFieldServer_3f7b621f5c4c42971fc099a1fa492d99,
+  '@/collections/Fields/textarea/components/client/Label#CustomTextareaFieldLabelClient':
+    CustomTextareaFieldLabelClient_9959ee64353edb5f2606b52187275823,
+  '@/collections/Fields/textarea/components/client/Field#CustomTextareaFieldClient':
+    CustomTextareaFieldClient_4fd3331c38982e86768c64dcc9a10691,
+  '@/collections/Views/components/CustomTabEditView#CustomTabEditView':
+    CustomTabEditView_0a7acb05a3192ecfa7e07f8b42e7a193,
+  '@/collections/Views/components/CustomDefaultEditView#CustomDefaultEditView':
+    CustomDefaultEditView_2d3c652c5909d3a3dc3464f0547d5424,
+  '@/collections/RootViews/components/CustomRootEditView#CustomRootEditView':
+    CustomRootEditView_ba37229da543ad3c8dc40f7a48771f99,
+  '@/components/afterNavLinks/LinkToCustomView#LinkToCustomView':
+    LinkToCustomView_6f16fe358985478a2ead2354ef2cc9a0,
+  '@/components/afterNavLinks/LinkToCustomMinimalView#LinkToCustomMinimalView':
+    LinkToCustomMinimalView_fd2cefb054695a5b60b860a69d67d15d,
+  '@/components/afterNavLinks/LinkToCustomDefaultView#LinkToCustomDefaultView':
+    LinkToCustomDefaultView_4c5f581c8bfa951ce2f83c24c4f36b3b,
+  '@/components/views/CustomRootView#CustomRootView':
+    CustomRootView_1ebb91ef5ff1ea4dc9a27ceb8e9ee0ab,
+  '@/components/views/CustomDefaultRootView#CustomDefaultRootView':
+    CustomDefaultRootView_a2f8ce99b3a1692f7ec03a907e1ea4ce,
+  '@/components/views/CustomMinimalRootView#CustomMinimalRootView':
+    CustomMinimalRootView_9211f699dea5524a957f33011b786586,
 }

--- a/examples/custom-components/src/collections/Fields/array/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/array/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { ArrayField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomArrayFieldClient: ArrayFieldClientComponent = (props) => {
-  return <ArrayField field={props?.field} path={props?.path} permissions={props?.permissions} />
+  return <ArrayField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/array/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/array/components/client/Label.tsx
@@ -4,6 +4,6 @@ import type { ArrayFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomArrayFieldLabelClient: ArrayFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomArrayFieldLabelClient: ArrayFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/array/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/array/components/server/Field.tsx
@@ -3,7 +3,13 @@ import type React from 'react'
 
 import { ArrayField } from '@payloadcms/ui'
 
-export const CustomArrayFieldServer: ArrayFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <ArrayField field={props.clientField} path={path} permissions={props?.permissions} />
+export const CustomArrayFieldServer: ArrayFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <ArrayField field={clientField} path={path} schemaPath={schemaPath} permissions={permissions} />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/array/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/array/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { ArrayFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomArrayFieldLabelServer: ArrayFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomArrayFieldLabelServer: ArrayFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      required={clientField?.required}
+      path={path}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/blocks/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/blocks/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { BlocksField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomBlocksFieldClient: BlocksFieldClientComponent = (props) => {
-  return <BlocksField field={props?.field} path={props.path} permissions={props?.permissions} />
+  return <BlocksField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/blocks/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/blocks/components/client/Label.tsx
@@ -4,6 +4,6 @@ import type { BlocksFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomBlocksFieldLabelClient: BlocksFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomBlocksFieldLabelClient: BlocksFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/blocks/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/blocks/components/server/Field.tsx
@@ -3,7 +3,18 @@ import type React from 'react'
 
 import { BlocksField } from '@payloadcms/ui'
 
-export const CustomBlocksFieldServer: BlocksFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <BlocksField field={props?.clientField} path={path} permissions={props?.permissions} />
+export const CustomBlocksFieldServer: BlocksFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <BlocksField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/blocks/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/blocks/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { BlocksFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomBlocksFieldLabelServer: BlocksFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomBlocksFieldLabelServer: BlocksFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/checkbox/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/checkbox/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { CheckboxField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomCheckboxFieldClient: CheckboxFieldClientComponent = (props) => {
-  return <CheckboxField field={props?.field} path={props?.path} />
+  return <CheckboxField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/checkbox/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/checkbox/components/client/Label.tsx
@@ -4,6 +4,9 @@ import type { CheckboxFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomCheckboxFieldLabelClient: CheckboxFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomCheckboxFieldLabelClient: CheckboxFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/checkbox/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/checkbox/components/server/Field.tsx
@@ -3,7 +3,18 @@ import type React from 'react'
 
 import { CheckboxField } from '@payloadcms/ui'
 
-export const CustomCheckboxFieldServer: CheckboxFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <CheckboxField field={props?.clientField} path={path} />
+export const CustomCheckboxFieldServer: CheckboxFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <CheckboxField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/checkbox/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/checkbox/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { CheckboxFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomCheckboxFieldLabelServer: CheckboxFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomCheckboxFieldLabelServer: CheckboxFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/code/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/code/components/client/Field.tsx
@@ -1,0 +1,9 @@
+'use client'
+import type { CodeFieldClientComponent } from 'payload'
+
+import { CodeField } from '@payloadcms/ui'
+import React from 'react'
+
+export const CustomCodeFieldClient: CodeFieldClientComponent = (props) => {
+  return <CodeField {...props} />
+}

--- a/examples/custom-components/src/collections/Fields/code/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/code/components/client/Label.tsx
@@ -1,0 +1,9 @@
+'use client'
+import type { CodeFieldLabelClientComponent } from 'payload'
+
+import { FieldLabel } from '@payloadcms/ui'
+import React from 'react'
+
+export const CustomCodeFieldLabelClient: CodeFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
+}

--- a/examples/custom-components/src/collections/Fields/code/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/code/components/server/Field.tsx
@@ -1,0 +1,15 @@
+import type { CodeFieldServerComponent } from 'payload'
+import type React from 'react'
+
+import { CodeField } from '@payloadcms/ui'
+
+export const CustomCodeFieldServer: CodeFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <CodeField field={clientField} path={path} schemaPath={schemaPath} permissions={permissions} />
+  )
+}

--- a/examples/custom-components/src/collections/Fields/code/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/code/components/server/Label.tsx
@@ -1,0 +1,17 @@
+import type { CodeFieldLabelServerComponent } from 'payload'
+
+import { FieldLabel } from '@payloadcms/ui'
+import React from 'react'
+
+export const CustomCodeFieldLabelServer: CodeFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}

--- a/examples/custom-components/src/collections/Fields/code/index.ts
+++ b/examples/custom-components/src/collections/Fields/code/index.ts
@@ -1,0 +1,24 @@
+import type { CollectionConfig } from 'payload'
+
+export const codeFields: CollectionConfig['fields'] = [
+  {
+    name: 'codeFieldServerComponent',
+    type: 'code',
+    admin: {
+      components: {
+        Field: '@/collections/Fields/code/components/server/Field#CustomCodeFieldServer',
+        Label: '@/collections/Fields/code/components/server/Label#CustomCodeFieldLabelServer',
+      },
+    },
+  },
+  {
+    name: 'codeFieldClientComponent',
+    type: 'code',
+    admin: {
+      components: {
+        Field: '@/collections/Fields/code/components/client/Field#CustomCodeFieldClient',
+        Label: '@/collections/Fields/code/components/client/Label#CustomCodeFieldLabelClient',
+      },
+    },
+  },
+]

--- a/examples/custom-components/src/collections/Fields/date/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/date/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { DateTimeField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomDateFieldClient: DateFieldClientComponent = (props) => {
-  return <DateTimeField field={props?.field} path={props?.path} />
+  return <DateTimeField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/date/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/date/components/client/Label.tsx
@@ -4,6 +4,6 @@ import type { DateFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomDateFieldLabelClient: DateFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomDateFieldLabelClient: DateFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/date/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/date/components/server/Field.tsx
@@ -3,7 +3,18 @@ import type React from 'react'
 
 import { DateTimeField } from '@payloadcms/ui'
 
-export const CustomDateFieldServer: DateFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <DateTimeField field={props?.clientField} path={path} />
+export const CustomDateFieldServer: DateFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <DateTimeField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/date/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/date/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { DateFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomDateFieldLabelServer: DateFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomDateFieldLabelServer: DateFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/email/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/email/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { EmailField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomEmailFieldClient: EmailFieldClientComponent = (props) => {
-  return <EmailField field={props?.field} path={props?.path} />
+  return <EmailField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/email/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/email/components/client/Label.tsx
@@ -4,6 +4,6 @@ import type { EmailFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomEmailFieldLabelClient: EmailFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomEmailFieldLabelClient: EmailFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/email/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/email/components/server/Field.tsx
@@ -3,7 +3,13 @@ import type React from 'react'
 
 import { EmailField } from '@payloadcms/ui'
 
-export const CustomEmailFieldServer: EmailFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <EmailField field={props?.clientField} path={path} />
+export const CustomEmailFieldServer: EmailFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <EmailField field={clientField} path={path} schemaPath={schemaPath} permissions={permissions} />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/email/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/email/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { EmailFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomEmailFieldLabelServer: EmailFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomEmailFieldLabelServer: EmailFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/index.ts
+++ b/examples/custom-components/src/collections/Fields/index.ts
@@ -3,8 +3,10 @@ import type { CollectionConfig, Field } from 'payload'
 import { arrayFields } from './array'
 import { blocksFields } from './blocks'
 import { checkboxFields } from './checkbox'
+import { codeFields } from './code'
 import { dateFields } from './date'
 import { emailFields } from './email'
+import { jsonFields } from './json'
 import { numberFields } from './number'
 import { pointFields } from './point'
 import { radioFields } from './radio'
@@ -28,8 +30,10 @@ export const CustomFields: CollectionConfig = {
       arrayFields,
       blocksFields,
       checkboxFields,
+      codeFields,
       dateFields,
       emailFields,
+      jsonFields,
       numberFields,
       pointFields,
       radioFields,

--- a/examples/custom-components/src/collections/Fields/json/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/json/components/client/Field.tsx
@@ -1,0 +1,9 @@
+'use client'
+import type { JSONFieldClientComponent } from 'payload'
+
+import { JSONField } from '@payloadcms/ui'
+import React from 'react'
+
+export const CustomJSONFieldClient: JSONFieldClientComponent = (props) => {
+  return <JSONField {...props} />
+}

--- a/examples/custom-components/src/collections/Fields/json/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/json/components/client/Label.tsx
@@ -1,0 +1,9 @@
+'use client'
+import type { JSONFieldLabelClientComponent } from 'payload'
+
+import { FieldLabel } from '@payloadcms/ui'
+import React from 'react'
+
+export const CustomJSONFieldLabelClient: JSONFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
+}

--- a/examples/custom-components/src/collections/Fields/json/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/json/components/server/Field.tsx
@@ -1,0 +1,15 @@
+import type { JSONFieldServerComponent } from 'payload'
+import type React from 'react'
+
+import { JSONField } from '@payloadcms/ui'
+
+export const CustomJSONFieldServer: JSONFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <JSONField field={clientField} path={path} schemaPath={schemaPath} permissions={permissions} />
+  )
+}

--- a/examples/custom-components/src/collections/Fields/json/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/json/components/server/Label.tsx
@@ -1,0 +1,17 @@
+import type { JSONFieldLabelServerComponent } from 'payload'
+
+import { FieldLabel } from '@payloadcms/ui'
+import React from 'react'
+
+export const CustomJSONFieldLabelServer: JSONFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
+}

--- a/examples/custom-components/src/collections/Fields/json/index.ts
+++ b/examples/custom-components/src/collections/Fields/json/index.ts
@@ -1,0 +1,24 @@
+import type { CollectionConfig } from 'payload'
+
+export const jsonFields: CollectionConfig['fields'] = [
+  {
+    name: 'jsonFieldServerComponent',
+    type: 'json',
+    admin: {
+      components: {
+        Field: '@/collections/Fields/json/components/server/Field#CustomJSONFieldServer',
+        Label: '@/collections/Fields/json/components/server/Label#CustomJSONFieldLabelServer',
+      },
+    },
+  },
+  {
+    name: 'jsonFieldClientComponent',
+    type: 'json',
+    admin: {
+      components: {
+        Field: '@/collections/Fields/json/components/client/Field#CustomJSONFieldClient',
+        Label: '@/collections/Fields/json/components/client/Label#CustomJSONFieldLabelClient',
+      },
+    },
+  },
+]

--- a/examples/custom-components/src/collections/Fields/number/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/number/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { NumberField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomNumberFieldClient: NumberFieldClientComponent = (props) => {
-  return <NumberField field={props?.field} path={props?.path} />
+  return <NumberField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/number/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/number/components/client/Label.tsx
@@ -4,6 +4,6 @@ import type { NumberFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomNumberFieldLabelClient: NumberFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomNumberFieldLabelClient: NumberFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/number/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/number/components/server/Field.tsx
@@ -3,7 +3,18 @@ import type React from 'react'
 
 import { NumberField } from '@payloadcms/ui'
 
-export const CustomNumberFieldServer: NumberFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <NumberField field={props?.clientField} path={path} />
+export const CustomNumberFieldServer: NumberFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <NumberField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/number/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/number/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { NumberFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomNumberFieldLabelServer: NumberFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomNumberFieldLabelServer: NumberFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/point/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/point/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { PointField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomPointFieldClient: PointFieldClientComponent = (props) => {
-  return <PointField field={props?.field} path={props?.path} />
+  return <PointField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/point/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/point/components/client/Label.tsx
@@ -4,6 +4,6 @@ import type { PointFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomPointFieldLabelClient: PointFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomPointFieldLabelClient: PointFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/point/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/point/components/server/Field.tsx
@@ -3,7 +3,13 @@ import type React from 'react'
 
 import { PointField } from '@payloadcms/ui'
 
-export const CustomPointFieldServer: PointFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <PointField field={props?.clientField} path={path} />
+export const CustomPointFieldServer: PointFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <PointField field={clientField} path={path} schemaPath={schemaPath} permissions={permissions} />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/point/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/point/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { PointFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomPointFieldLabelServer: PointFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomPointFieldLabelServer: PointFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/radio/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/radio/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { RadioGroupField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomRadioFieldClient: RadioFieldClientComponent = (props) => {
-  return <RadioGroupField field={props?.field} path={props?.path} />
+  return <RadioGroupField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/radio/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/radio/components/client/Label.tsx
@@ -4,6 +4,6 @@ import type { RadioFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomRadioFieldLabelClient: RadioFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomRadioFieldLabelClient: RadioFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/radio/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/radio/components/server/Field.tsx
@@ -3,7 +3,18 @@ import type React from 'react'
 
 import { RadioGroupField } from '@payloadcms/ui'
 
-export const CustomRadioFieldServer: RadioFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <RadioGroupField field={props?.clientField} path={path} />
+export const CustomRadioFieldServer: RadioFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <RadioGroupField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/radio/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/radio/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { RadioFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomRadioFieldLabelServer: RadioFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomRadioFieldLabelServer: RadioFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/relationship/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/relationship/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { RelationshipField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomRelationshipFieldClient: RelationshipFieldClientComponent = (props) => {
-  return <RelationshipField field={props?.field} path={props?.path} />
+  return <RelationshipField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/relationship/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/relationship/components/client/Label.tsx
@@ -4,8 +4,9 @@ import type { RelationshipFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomRelationshipFieldLabelClient: RelationshipFieldLabelClientComponent = (
-  props,
-) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomRelationshipFieldLabelClient: RelationshipFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/relationship/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/relationship/components/server/Field.tsx
@@ -3,7 +3,18 @@ import type React from 'react'
 
 import { RelationshipField } from '@payloadcms/ui'
 
-export const CustomRelationshipFieldServer: RelationshipFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <RelationshipField field={props?.clientField} path={path} />
+export const CustomRelationshipFieldServer: RelationshipFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <RelationshipField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/relationship/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/relationship/components/server/Label.tsx
@@ -3,8 +3,15 @@ import type { RelationshipFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomRelationshipFieldLabelServer: RelationshipFieldLabelServerComponent = (
-  props,
-) => {
-  return <FieldLabel label={props?.label} />
+export const CustomRelationshipFieldLabelServer: RelationshipFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/select/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/select/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { SelectField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomSelectFieldClient: SelectFieldClientComponent = (props) => {
-  return <SelectField field={props?.field} path={props?.path} />
+  return <SelectField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/select/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/select/components/client/Label.tsx
@@ -4,6 +4,6 @@ import type { SelectFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomSelectFieldLabelClient: SelectFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomSelectFieldLabelClient: SelectFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/select/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/select/components/server/Field.tsx
@@ -3,7 +3,18 @@ import type React from 'react'
 
 import { SelectField } from '@payloadcms/ui'
 
-export const CustomSelectFieldServer: SelectFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <SelectField field={props?.clientField} path={path} />
+export const CustomSelectFieldServer: SelectFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <SelectField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/select/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/select/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { SelectFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomSelectFieldLabelServer: SelectFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomSelectFieldLabelServer: SelectFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/text/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/text/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { TextField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomTextFieldClient: TextFieldClientComponent = (props) => {
-  return <TextField field={props?.field} path={props?.path} />
+  return <TextField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/text/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/text/components/client/Label.tsx
@@ -4,6 +4,6 @@ import type { TextFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomTextFieldLabelClient: TextFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomTextFieldLabelClient: TextFieldLabelClientComponent = ({ field, path }) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/text/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/text/components/server/Field.tsx
@@ -3,7 +3,13 @@ import type React from 'react'
 
 import { TextField } from '@payloadcms/ui'
 
-export const CustomTextFieldServer: TextFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <TextField field={props?.clientField} path={path} />
+export const CustomTextFieldServer: TextFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <TextField field={clientField} path={path} schemaPath={schemaPath} permissions={permissions} />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/text/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/text/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { TextFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomTextFieldLabelServer: TextFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomTextFieldLabelServer: TextFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/textarea/components/client/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/textarea/components/client/Field.tsx
@@ -5,5 +5,5 @@ import { TextareaField } from '@payloadcms/ui'
 import React from 'react'
 
 export const CustomTextareaFieldClient: TextareaFieldClientComponent = (props) => {
-  return <TextareaField field={props?.field} path={props?.path} />
+  return <TextareaField {...props} />
 }

--- a/examples/custom-components/src/collections/Fields/textarea/components/client/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/textarea/components/client/Label.tsx
@@ -4,6 +4,9 @@ import type { TextareaFieldLabelClientComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomTextareaFieldLabelClient: TextareaFieldLabelClientComponent = (props) => {
-  return <FieldLabel label={props?.label} path={props?.path} />
+export const CustomTextareaFieldLabelClient: TextareaFieldLabelClientComponent = ({
+  field,
+  path,
+}) => {
+  return <FieldLabel label={field?.label || field?.name} path={path} required={field?.required} />
 }

--- a/examples/custom-components/src/collections/Fields/textarea/components/server/Field.tsx
+++ b/examples/custom-components/src/collections/Fields/textarea/components/server/Field.tsx
@@ -3,7 +3,18 @@ import type React from 'react'
 
 import { TextareaField } from '@payloadcms/ui'
 
-export const CustomTextareaFieldServer: TextareaFieldServerComponent = (props) => {
-  const path = (props?.path || props?.field?.name || '') as string
-  return <TextareaField field={props?.clientField} path={path} />
+export const CustomTextareaFieldServer: TextareaFieldServerComponent = ({
+  clientField,
+  path,
+  schemaPath,
+  permissions,
+}) => {
+  return (
+    <TextareaField
+      field={clientField}
+      path={path}
+      schemaPath={schemaPath}
+      permissions={permissions}
+    />
+  )
 }

--- a/examples/custom-components/src/collections/Fields/textarea/components/server/Label.tsx
+++ b/examples/custom-components/src/collections/Fields/textarea/components/server/Label.tsx
@@ -3,6 +3,15 @@ import type { TextareaFieldLabelServerComponent } from 'payload'
 import { FieldLabel } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomTextareaFieldLabelServer: TextareaFieldLabelServerComponent = (props) => {
-  return <FieldLabel label={props?.label} />
+export const CustomTextareaFieldLabelServer: TextareaFieldLabelServerComponent = ({
+  clientField,
+  path,
+}) => {
+  return (
+    <FieldLabel
+      label={clientField?.label || clientField?.name}
+      path={path}
+      required={clientField?.required}
+    />
+  )
 }

--- a/examples/custom-components/src/payload-types.ts
+++ b/examples/custom-components/src/payload-types.ts
@@ -98,10 +98,30 @@ export interface CustomField {
     | null;
   checkboxFieldServerComponent?: boolean | null;
   checkboxFieldClientComponent?: boolean | null;
+  codeFieldServerComponent?: string | null;
+  codeFieldClientComponent?: string | null;
   dateFieldServerComponent?: string | null;
   dateFieldClientComponent?: string | null;
   emailFieldServerComponent?: string | null;
   emailFieldClientComponent?: string | null;
+  jsonFieldServerComponent?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  jsonFieldClientComponent?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
   numberFieldServerComponent?: number | null;
   numberFieldClientComponent?: number | null;
   /**
@@ -271,10 +291,14 @@ export interface CustomFieldsSelect<T extends boolean = true> {
       };
   checkboxFieldServerComponent?: T;
   checkboxFieldClientComponent?: T;
+  codeFieldServerComponent?: T;
+  codeFieldClientComponent?: T;
   dateFieldServerComponent?: T;
   dateFieldClientComponent?: T;
   emailFieldServerComponent?: T;
   emailFieldClientComponent?: T;
+  jsonFieldServerComponent?: T;
+  jsonFieldClientComponent?: T;
   numberFieldServerComponent?: T;
   numberFieldClientComponent?: T;
   pointFieldServerComponent?: T;


### PR DESCRIPTION
Although the "customizing fields" doc provides a big picture overview of how to create custom field components, it is not explicit enough for developers to know exactly where to start. For example, it can be challenging to import the correct types when building these components, and the natural place to go looking for this information is on the fields docs themselves. Now, each field doc has its own dedicated "custom components" section which provides concrete examples for fields and field labels in both server and client component format, with more examples to come over time such as using inputs directly, etc. In the same vein, the "customizing fields" doc itself should probably be moved to the fields overview section so it remains as intuitive as possible when searching for this information.