### PR TITLE
chore(templates): improve types for rowLabel custom components

### DIFF
--- a/templates/website/src/Footer/RowLabel.tsx
+++ b/templates/website/src/Footer/RowLabel.tsx
@@ -1,8 +1,9 @@
 'use client'
 import { Header } from '@/payload-types'
-import { RowLabelProps, useRowLabel } from '@payloadcms/ui'
+import { useRowLabel } from '@payloadcms/ui'
+import type { ArrayFieldClientProps } from 'payload'
 
-export const RowLabel: React.FC<RowLabelProps> = () => {
+export const RowLabel: React.FC<ArrayFieldClientProps> = () => {
   const data = useRowLabel<NonNullable<Header['navItems']>[number]>()
 
   const label = data?.data?.link?.label

--- a/templates/website/src/Header/RowLabel.tsx
+++ b/templates/website/src/Header/RowLabel.tsx
@@ -1,8 +1,9 @@
 'use client'
 import { Header } from '@/payload-types'
-import { RowLabelProps, useRowLabel } from '@payloadcms/ui'
+import { useRowLabel } from '@payloadcms/ui'
+import type { ArrayFieldClientProps } from 'payload'
 
-export const RowLabel: React.FC<RowLabelProps> = () => {
+export const RowLabel: React.FC<ArrayFieldClientProps> = () => {
   const data = useRowLabel<NonNullable<Header['navItems']>[number]>()
 
   const label = data?.data?.link?.label

--- a/templates/with-vercel-website/src/Footer/RowLabel.tsx
+++ b/templates/with-vercel-website/src/Footer/RowLabel.tsx
@@ -1,8 +1,9 @@
 'use client'
 import { Header } from '@/payload-types'
-import { RowLabelProps, useRowLabel } from '@payloadcms/ui'
+import { useRowLabel } from '@payloadcms/ui'
+import type { ArrayFieldClientProps } from 'payload'
 
-export const RowLabel: React.FC<RowLabelProps> = (props) => {
+export const RowLabel: React.FC<ArrayFieldClientProps> = () => {
   const data = useRowLabel<NonNullable<Header['navItems']>[number]>()
 
   const label = data?.data?.link?.label

--- a/templates/with-vercel-website/src/Header/RowLabel.tsx
+++ b/templates/with-vercel-website/src/Header/RowLabel.tsx
@@ -1,8 +1,9 @@
 'use client'
 import { Header } from '@/payload-types'
-import { RowLabelProps, useRowLabel } from '@payloadcms/ui'
+import { useRowLabel } from '@payloadcms/ui'
+import type { ArrayFieldClientProps } from 'payload'
 
-export const RowLabel: React.FC<RowLabelProps> = (props) => {
+export const RowLabel: React.FC<ArrayFieldClientProps> = () => {
   const data = useRowLabel<NonNullable<Header['navItems']>[number]>()
 
   const label = data?.data?.link?.label


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR adjusts the types used in the Header and Footer `RowLabel` custom components in the `website` & `with-vercel-website` templates to better suit the actual props passed to these components.

Currently, `RowLabelProps` is not the right type to use as this is the type of the internal props passed to the `RowLabel` component in the `ui` package - not the props that `RowLabel` custom components actually recieve when rendered.

### Why?
To more accurately type props passed to these components for new users who may be confused why their Header/Footer RowLabel props suggest props that are undefined and are irrelevant to them.

### How?
By changing the type from `RowLabelProps` to `ArrayFieldClientProps` as this is a better represenation of the actual props passed to RowLabel client components.

It would be even better to have a more distinct type for these `RowLabel`'s in general, although that may be a part of a larger type refactor.