### PR TITLE
chore(templates): fix eslint errors in plugin template

### DIFF
--- a/templates/plugin/dev/payload.config.ts
+++ b/templates/plugin/dev/payload.config.ts
@@ -17,7 +17,6 @@ if (!process.env.ROOT_DIR) {
   process.env.ROOT_DIR = dirname
 }
 
-// eslint-disable-next-line no-restricted-exports
 export default buildConfig({
   admin: {
     autoLogin: devUser,

--- a/templates/plugin/dev/tsconfig.json
+++ b/templates/plugin/dev/tsconfig.json
@@ -2,6 +2,10 @@
   "extends": "../tsconfig.json",
   "exclude": [],
   "include": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.mjs",
+    "**/*.cjs",
     "**/*.ts",
     "**/*.tsx",
     "../src/**/*.ts",
@@ -25,6 +29,7 @@
         "../src/exports/rsc.ts"
       ]
     },
-    "noEmit": true
+    "noEmit": true,
+    "emitDeclarationOnly": false,
   }
 }

--- a/templates/plugin/eslint.config.js
+++ b/templates/plugin/eslint.config.js
@@ -25,6 +25,11 @@ export const defaultESLintIgnores = [
 export default [
   ...payloadEsLintConfig,
   {
+    rules: {
+      'no-restricted-exports': 'off',
+    },
+  },
+  {
     languageOptions: {
       parserOptions: {
         sourceType: 'module',

--- a/templates/plugin/package.json
+++ b/templates/plugin/package.json
@@ -36,7 +36,7 @@
     "dev:generate-importmap": "pnpm dev:payload generate:importmap",
     "dev:generate-types": "pnpm dev:payload generate:types",
     "dev:payload": "cross-env PAYLOAD_CONFIG_PATH=./dev/payload.config.ts payload",
-    "lint": "eslint ./src",
+    "lint": "eslint",
     "lint:fix": "eslint ./src --fix",
     "prepublishOnly": "pnpm clean && pnpm build",
     "test": "jest"


### PR DESCRIPTION
Additionally, the scope of `pnpm eslint` has been expanded to cover the entire project, not only src.