### PR TITLE
templates: ensure lexical link validation does not break for internal links

### DIFF
--- a/examples/localization/src/payload.config.ts
+++ b/examples/localization/src/payload.config.ts
@@ -109,6 +109,12 @@ export default buildConfig({
                 },
                 label: ({ t }) => t('fields:enterURL'),
                 required: true,
+                validate: (value: any, options: any) => {
+                  if (options?.siblingData?.linkType === 'internal') {
+                    return true // no validation needed, as no url should exist for internal links
+                  }
+                  return value ? true : 'URL is required'
+                },
               },
             ]
           },

--- a/templates/website/src/fields/defaultLexical.ts
+++ b/templates/website/src/fields/defaultLexical.ts
@@ -33,6 +33,12 @@ export const defaultLexical: Config['editor'] = lexicalEditor({
               },
               label: ({ t }) => t('fields:enterURL'),
               required: true,
+              validate: (value: any, options: any) => {
+                if (options?.siblingData?.linkType === 'internal') {
+                  return true // no validation needed, as no url should exist for internal links
+                }
+                return value ? true : 'URL is required'
+              },
             },
           ]
         },

--- a/templates/with-vercel-website/src/fields/defaultLexical.ts
+++ b/templates/with-vercel-website/src/fields/defaultLexical.ts
@@ -33,6 +33,12 @@ export const defaultLexical: Config['editor'] = lexicalEditor({
               },
               label: ({ t }) => t('fields:enterURL'),
               required: true,
+              validate: (value: any, options: any) => {
+                if (options?.siblingData?.linkType === 'internal') {
+                  return true // no validation needed, as no url should exist for internal links
+                }
+                return value ? true : 'URL is required'
+              },
             },
           ]
         },


### PR DESCRIPTION
In a previous PR, I changed the behavior of the link node to delete the `url` data if the link type was set to `internal`. Previously, the stale `url` data would have been kept.

Since that data doesn't exist anymore, this could trigger a validation error due to the field being required. We have alleviated that using a custom validation function on our default url and internal link fields.

As the templates use custom url fields, this PR adds the missing validate function so that no incorrect validation error is thrown