### PR TITLE
chore: disable bun run test buttons if bun extension is installed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,5 +52,7 @@
   "jestrunner.jestCommand": "pnpm exec cross-env NODE_OPTIONS=\"--no-deprecation\" node 'node_modules/jest/bin/jest.js'",
   "jestrunner.debugOptions": {
     "runtimeArgs": ["--no-deprecation"]
-  }
+  },
+  // Essentially disables bun test buttons
+  "bun.test.filePattern": "bun.test.ts"
 }


### PR DESCRIPTION
If the bun extension is installed, a "Run Test" button is displayed in int test files. Clicking it will use bun to run those tests, which will always fail.

This PR disables that test button, as it's useless in our repo

![CleanShot 2025-01-23 at 17 39 03@2x](https://github.com/user-attachments/assets/918fa729-8076-4214-a3d2-f824a4fbfc34)

The real button here is "Run". Clicking "Run Test" instead will use bun and fail. Confusing, right?