### PR TITLE
fix(plugin-multi-tenant): fixed hardcoded user tenants field

### DIFF
--- a/packages/plugin-multi-tenant/src/fields/tenantsArrayField/index.ts
+++ b/packages/plugin-multi-tenant/src/fields/tenantsArrayField/index.ts
@@ -4,14 +4,16 @@ export const tenantsArrayField = (args: {
   arrayFieldAccess?: ArrayField['access']
   rowFields?: ArrayField['fields']
   tenantFieldAccess?: RelationshipField['access']
+  tenantsArrayFieldName: ArrayField['name']
+  tenantsArrayTenantFieldName: RelationshipField['name']
   tenantsCollectionSlug: string
 }): ArrayField => ({
-  name: 'tenants',
+  name: args.tenantsArrayFieldName,
   type: 'array',
   access: args?.arrayFieldAccess,
   fields: [
     {
-      name: 'tenant',
+      name: args.tenantsArrayTenantFieldName,
       type: 'relationship',
       access: args.tenantFieldAccess,
       index: true,

--- a/packages/plugin-multi-tenant/src/hooks/afterTenantDelete.ts
+++ b/packages/plugin-multi-tenant/src/hooks/afterTenantDelete.ts
@@ -18,6 +18,8 @@ type Args = {
   tenantFieldName: string
   tenantsCollectionSlug: string
   usersSlug: string
+  usersTenantsArrayFieldName: string
+  usersTenantsArrayTenantFieldName: string
 }
 /**
  * Add cleanup logic when tenant is deleted
@@ -30,6 +32,8 @@ export const addTenantCleanup = ({
   tenantFieldName,
   tenantsCollectionSlug,
   usersSlug,
+  usersTenantsArrayFieldName,
+  usersTenantsArrayTenantFieldName,
 }: Args) => {
   if (!collection.hooks) {
     collection.hooks = {}
@@ -43,6 +47,8 @@ export const addTenantCleanup = ({
       tenantFieldName,
       tenantsCollectionSlug,
       usersSlug,
+      usersTenantsArrayFieldName,
+      usersTenantsArrayTenantFieldName,
     }),
   )
 }
@@ -53,6 +59,8 @@ export const afterTenantDelete =
     tenantFieldName,
     tenantsCollectionSlug,
     usersSlug,
+    usersTenantsArrayFieldName,
+    usersTenantsArrayTenantFieldName,
   }: Omit<Args, 'collection'>): CollectionAfterDeleteHook =>
   async ({ id, req }) => {
     const idType = getCollectionIDType({
@@ -95,7 +103,7 @@ export const afterTenantDelete =
         depth: 0,
         limit: 0,
         where: {
-          'tenants.tenant': {
+          [`${usersTenantsArrayFieldName}.${usersTenantsArrayTenantFieldName}`]: {
             equals: id,
           },
         },

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -12,7 +12,8 @@ import { withTenantListFilter } from './utilities/withTenantListFilter.js'
 const defaults = {
   tenantCollectionSlug: 'tenants',
   tenantFieldName: 'tenant',
-  userTenantsArrayFieldName: 'tenants',
+  tenantsArrayFieldName: 'tenants',
+  tenantsArrayTenantFieldName: 'tenant',
 }
 
 export const multiTenantPlugin =
@@ -34,6 +35,10 @@ export const multiTenantPlugin =
     const tenantsCollectionSlug = (pluginConfig.tenantsSlug =
       pluginConfig.tenantsSlug || defaults.tenantCollectionSlug)
     const tenantFieldName = pluginConfig?.tenantField?.name || defaults.tenantFieldName
+    const tenantsArrayFieldName =
+      pluginConfig?.tenantsArrayField?.arrayFieldName || defaults.tenantsArrayFieldName
+    const tenantsArrayTenantFieldName =
+      pluginConfig?.tenantsArrayField?.arrayTenantFieldName || defaults.tenantsArrayTenantFieldName
 
     /**
      * Add defaults for admin properties
@@ -83,6 +88,8 @@ export const multiTenantPlugin =
       adminUsersCollection.fields.push(
         tenantsArrayField({
           ...(pluginConfig?.tenantsArrayField || {}),
+          tenantsArrayFieldName,
+          tenantsArrayTenantFieldName,
           tenantsCollectionSlug,
         }),
       )
@@ -90,7 +97,7 @@ export const multiTenantPlugin =
 
     addCollectionAccess({
       collection: adminUsersCollection,
-      fieldName: 'tenants.tenant',
+      fieldName: `${tenantsArrayFieldName}.${tenantsArrayTenantFieldName}`,
       userHasAccessToAllTenants,
     })
 
@@ -143,6 +150,8 @@ export const multiTenantPlugin =
             tenantFieldName,
             tenantsCollectionSlug,
             usersSlug: adminUsersCollection.slug,
+            usersTenantsArrayFieldName: tenantsArrayFieldName,
+            usersTenantsArrayTenantFieldName: tenantsArrayTenantFieldName,
           })
         }
       } else if (pluginConfig.collections?.[collection.slug]) {

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -72,6 +72,18 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
          */
         arrayFieldAccess?: ArrayField['access']
         /**
+         * Name of the array field
+         *
+         * @default 'tenants'
+         */
+        arrayFieldName?: string
+        /**
+         * Name of the tenant field
+         *
+         * @default 'tenant'
+         */
+        arrayTenantFieldName?: string
+        /**
          * When `includeDefaultField` is `true`, the field will be added to the users collection automatically
          */
         includeDefaultField?: true
@@ -86,6 +98,8 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
       }
     | {
         arrayFieldAccess?: never
+        arrayFieldName?: string
+        arrayTenantFieldName?: string
         /**
          * When `includeDefaultField` is `false`, you must include the field on your users collection manually
          */

--- a/test/hooks/payload-types.ts
+++ b/test/hooks/payload-types.ts
@@ -254,6 +254,7 @@ export interface FieldPath {
               id?: string | null;
             }[]
           | null;
+        fieldWithinRowWithinArray?: string | null;
         id?: string | null;
       }[]
     | null;
@@ -363,6 +364,42 @@ export interface FieldPath {
     | boolean
     | null;
   fieldWithinNestedArray_beforeDuplicate_FieldPaths?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  fieldWithinRowWithinArray_beforeValidate_FieldPaths?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  fieldWithinRowWithinArray_beforeChange_FieldPaths?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  fieldWithinRowWithinArray_afterRead_FieldPaths?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  fieldWithinRowWithinArray_beforeDuplicate_FieldPaths?:
     | {
         [k: string]: unknown;
       }
@@ -772,6 +809,7 @@ export interface FieldPathsSelect<T extends boolean = true> {
               fieldWithinNestedArray?: T;
               id?: T;
             };
+        fieldWithinRowWithinArray?: T;
         id?: T;
       };
   fieldWithinRow?: T;
@@ -794,6 +832,10 @@ export interface FieldPathsSelect<T extends boolean = true> {
   fieldWithinNestedArray_beforeChange_FieldPaths?: T;
   fieldWithinNestedArray_afterRead_FieldPaths?: T;
   fieldWithinNestedArray_beforeDuplicate_FieldPaths?: T;
+  fieldWithinRowWithinArray_beforeValidate_FieldPaths?: T;
+  fieldWithinRowWithinArray_beforeChange_FieldPaths?: T;
+  fieldWithinRowWithinArray_afterRead_FieldPaths?: T;
+  fieldWithinRowWithinArray_beforeDuplicate_FieldPaths?: T;
   fieldWithinRow_beforeValidate_FieldPaths?: T;
   fieldWithinRow_beforeChange_FieldPaths?: T;
   fieldWithinRow_afterRead_FieldPaths?: T;


### PR DESCRIPTION
### What?
When using custom slugs and field names the tenancy field added to the users would still attempt to use `tenants` and fail.

### Why?
The tenant/tenancy are hardcoded in `tenantsArrayField()`

### How?
Added the same args that are used in `tenantsField()` for the field names and relation.
