### PR TITLE
chore: improves routeError log safety

### DIFF
--- a/packages/payload/src/utilities/routeError.ts
+++ b/packages/payload/src/utilities/routeError.ts
@@ -37,6 +37,12 @@ export const routeError = async ({
     }
   }
 
+  let response = formatErrors(err)
+
+  let status = err.status || httpStatus.INTERNAL_SERVER_ERROR
+
+  logError({ err, payload })
+
   const req = incomingReq as PayloadRequest
 
   req.payload = payload
@@ -46,12 +52,6 @@ export const routeError = async ({
   })
 
   const { config } = payload
-
-  let response = formatErrors(err)
-
-  let status = err.status || httpStatus.INTERNAL_SERVER_ERROR
-
-  logError({ err, payload })
 
   // Internal server errors can contain anything, including potentially sensitive data.
   // Therefore, error details will be hidden from the response unless `config.debug` is `true`


### PR DESCRIPTION
Improves the logging that `routeError` throws.

Logs were sometimes being swallowed if there was a problem with the incoming request. Now they will surface.