### PR TITLE
fix(ui): apply cacheTags upload config property to other admin panel image components

### DIFF
--- a/packages/ui/src/elements/Upload/index.tsx
+++ b/packages/ui/src/elements/Upload/index.tsx
@@ -268,6 +268,8 @@ export const Upload: React.FC<UploadProps> = (props) => {
 
   const acceptMimeTypes = uploadConfig.mimeTypes?.join(', ')
 
+  const imageCacheTag = uploadConfig?.cacheTags && savedDocumentData?.updatedAt
+
   return (
     <div className={[fieldBaseClass, baseClass].filter(Boolean).join(' ')}>
       <FieldError message={errorMessage} showError={showError} />
@@ -279,7 +281,7 @@ export const Upload: React.FC<UploadProps> = (props) => {
           enableAdjustments={showCrop || showFocalPoint}
           handleRemove={canRemoveUpload ? handleFileRemoval : undefined}
           hasImageSizes={hasImageSizes}
-          imageCacheTag={uploadConfig?.cacheTags && savedDocumentData.updatedAt}
+          imageCacheTag={imageCacheTag}
           uploadConfig={uploadConfig}
         />
       )}
@@ -415,7 +417,7 @@ export const Upload: React.FC<UploadProps> = (props) => {
             <EditUpload
               fileName={value?.name || savedDocumentData?.filename}
               fileSrc={savedDocumentData?.url || fileSrc}
-              imageCacheTag={savedDocumentData?.updatedAt}
+              imageCacheTag={imageCacheTag}
               initialCrop={uploadEdits?.crop ?? undefined}
               initialFocalPoint={{
                 x: uploadEdits?.focalPoint?.x || savedDocumentData?.focalX || 50,
@@ -437,7 +439,7 @@ export const Upload: React.FC<UploadProps> = (props) => {
         >
           <PreviewSizes
             doc={savedDocumentData}
-            imageCacheTag={savedDocumentData.updatedAt}
+            imageCacheTag={imageCacheTag}
             uploadConfig={uploadConfig}
           />
         </Drawer>


### PR DESCRIPTION
In https://github.com/payloadcms/payload/pull/10319, the `cacheTags` property was added to the image config. This achieves the goal as described, however, there are still other places where this issue occurs, which should be handled in the same way. This PR aims to apply it to those instances.