### PR TITLE
fix(translations): adds et to import file

### DIFF
--- a/packages/translations/src/importDateFNSLocale.ts
+++ b/packages/translations/src/importDateFNSLocale.ts
@@ -40,6 +40,10 @@ export const importDateFNSLocale = async (locale: string): Promise<Locale> => {
       result = (await import('date-fns/locale/es')).es
 
       break
+    case 'et':
+      result = (await import('date-fns/locale/et')).et
+
+      break
     case 'fa-IR':
       result = (await import('date-fns/locale/fa-IR')).faIR
 


### PR DESCRIPTION
### What?
Error thrown when initiating the Estonian language (`et`) from `@payloadcms/translations`
<img width="896" alt="Screenshot 2025-01-27 at 3 17 49 PM" src="https://github.com/user-attachments/assets/27603c75-d713-4f11-b141-dc293d51800c" />

### How?
`et` needed to be added to `importDateFNSLocale`. Tested after this change and the error is no longer present.

Fixes #10817 
