### PR TITLE
fix(next): remove toString coercion inside getDocumentPermissions

### DIFF
--- a/packages/next/src/views/Document/getDocumentPermissions.tsx
+++ b/packages/next/src/views/Document/getDocumentPermissions.tsx
@@ -31,7 +31,7 @@ export const getDocumentPermissions = async (args: {
   if (collectionConfig) {
     try {
       docPermissions = await docAccessOperation({
-        id: id?.toString(),
+        id,
         collection: {
           config: collectionConfig,
         },
@@ -46,7 +46,7 @@ export const getDocumentPermissions = async (args: {
 
       if (collectionConfig.versions?.drafts) {
         hasPublishPermission = await docAccessOperation({
-          id: id?.toString(),
+          id,
           collection: {
             config: collectionConfig,
           },


### PR DESCRIPTION
### What?
When the doc permissions were retrieved from the DB, we were coercing them into strings even when they should not have been.

### Why?
Usage of `id.toString()`

### How?
Remove `id.toString()`. The id will be correct by this point and we should never coerce id's like this.

Fixes https://github.com/payloadcms/payload/issues/8218