### PR TITLE
fix(ui): adds prev value on form state validat functions

### DIFF
--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -10,6 +10,7 @@ import type {
   PayloadRequest,
   SanitizedFieldPermissions,
   SanitizedFieldsPermissions,
+  Validate,
 } from 'payload'
 
 import ObjectIdImport from 'bson-objectid'
@@ -167,7 +168,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       return
     }
 
-    const validate = field.validate
+    const validate: Validate = field.validate
 
     let validationResult: string | true = true
 
@@ -183,21 +184,21 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       }
 
       try {
-        validationResult = await validate(
-          data?.[field.name] as never,
-          {
-            ...field,
-            id,
-            collectionSlug,
-            data: fullData,
-            event: 'onChange',
-            jsonError,
-            operation,
-            preferences,
-            req,
-            siblingData: data,
-          } as any,
-        )
+        validationResult = await validate(data?.[field.name], {
+          ...field,
+          id,
+          collectionSlug,
+          data: fullData,
+          event: 'onChange',
+          // @AlessioGr added `jsonError` in https://github.com/payloadcms/payload/commit/c7ea62a39473408c3ea912c4fbf73e11be4b538d
+          // @ts-expect-error-next-line
+          jsonError,
+          operation,
+          preferences,
+          previousValue: previousFormState?.[path]?.initialValue,
+          req,
+          siblingData: data,
+        })
       } catch (err) {
         validationResult = `Error validating field at path: ${path}`
 


### PR DESCRIPTION
### What?
When hitting the form-state endpoint, previousValue was undefined.

### Why?
It was not being passed through.

### How?
Sets previousValue as the initial value of the field.

Fixes https://github.com/payloadcms/payload/issues/10826