### PR TITLE
feat(plugin-nested-docs): allow polymorphic parent relationships

### DIFF
--- a/packages/plugin-nested-docs/src/utilities/getParents.ts
+++ b/packages/plugin-nested-docs/src/utilities/getParents.ts
@@ -13,14 +13,15 @@ export const getParents = async (
   let parentCollectionSlug = collection.slug
   let parent = doc[parentSlug]
   let retrievedParent
-  
+
+  // If relationship is polymorphic
   if (typeof parent === 'object' && 'relationTo' in parent && 'value' in parent) {
     parentCollectionSlug = parent.relationTo
     parent = parent.value
   }
   
   if (parent) {
-    // If not auto-populated, and we have an ID, or if relationship is polymorphic   
+    // If not auto-populated, and we have an ID
     if (typeof parent === 'string' || typeof parent === 'number') {
       retrievedParent = await req.payload.findByID({
         id: parent,

--- a/packages/plugin-nested-docs/src/utilities/getParents.ts
+++ b/packages/plugin-nested-docs/src/utilities/getParents.ts
@@ -10,15 +10,21 @@ export const getParents = async (
   docs: Array<Record<string, unknown>> = [],
 ): Promise<Array<Record<string, unknown>>> => {
   const parentSlug = pluginConfig?.parentFieldSlug || 'parent'
-  const parent = doc[parentSlug]
+  let parentCollectionSlug = collection.slug
+  let parent = doc[parentSlug]
   let retrievedParent
-
+  
+  if (typeof parent === 'object' && 'relationTo' in parent && 'value' in parent) {
+    parentCollectionSlug = parent.relationTo
+    parent = parent.value
+  }
+  
   if (parent) {
-    // If not auto-populated, and we have an ID
+    // If not auto-populated, and we have an ID, or if relationship is polymorphic   
     if (typeof parent === 'string' || typeof parent === 'number') {
       retrievedParent = await req.payload.findByID({
         id: parent,
-        collection: collection.slug,
+        collection: parentCollectionSlug,
         depth: 0,
         disableErrors: true,
         req,


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

### What?
Supports polymorphic relationship types in the `generate` functions. 

### Why?
The nested-docs plugin only supports single `relationTo` relationships (non-polymorphic) for the `generate` functions (`GenerateURL` and `GenerateLabel`).

### How?
Checks if the relationship is polymorphic, and if so, uses the `value` and `relationTo` fields to find the parent document.