### PR TITLE
docs: use local API to upload a local file

### DIFF
--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -330,14 +330,14 @@ fetch('api/:upload-slug', {
 
 ## Uploading Files stored locally
 
-If you want to upload a file stored on your machine directly using the payload.create method, for example, during a seed script, 
+If you want to upload a file stored on your machine directly using the `payload.create` method, for example, during a seed script,
 you can use the `filePath` property to specify the local path of the file.
 
 ```ts
 const localFilePath = path.resolve(__dirname, filename)
 
 await payload.create({
-  collection: 'medias',
+  collection: 'media',
   data: {
     alt,
   },
@@ -345,12 +345,12 @@ await payload.create({
 })
 ```
 
-The `data` property should still include all the required fields of your `medias` collection.
+The `data` property should still include all the required fields of your `media` collection.
 
 <Banner type="warning">
   **Important:**
 
-  Remember that all custom hooks attached to the medias collection will still trigger.
+  Remember that all custom hooks attached to the `media` collection will still trigger.
   Ensure that files match the specified mimeTypes or sizes defined in the collection's `formatOptions` or custom `hooks`.
 </Banner>
 

--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -328,6 +328,32 @@ fetch('api/:upload-slug', {
 })
 ```
 
+## Uploading Files stored locally
+
+If you want to upload a file stored on your machine directly using the payload.create method, for example, during a seed script, 
+you can use the `filePath` property to specify the local path of the file.
+
+```ts
+const localFilePath = path.resolve(__dirname, filename)
+
+await payload.create({
+  collection: 'medias',
+  data: {
+    alt,
+  },
+  filePath: localFilePath,
+})
+```
+
+The `data` property should still include all the required fields of your `medias` collection.
+
+<Banner type="warning">
+  **Important:**
+
+  Remember that all custom hooks attached to the medias collection will still trigger.
+  Ensure that files match the specified mimeTypes or sizes defined in the collection's `formatOptions` or custom `hooks`.
+</Banner>
+
 ## Uploading Files from Remote URLs
 
 The `pasteURL` option allows users to fetch files from remote URLs by pasting them into an Upload field. This option is **enabled by default** and can be configured to either **allow unrestricted client-side fetching** or **restrict server-side fetching** to specific trusted domains.


### PR DESCRIPTION
### What?

This commit updates `docs/upload/overview.mdx` to document how to use the local API for seeding a local file using the `filePath` property with the `payload.create` method. 

### Why?

Previously, this information was only available in Discord: https://discord.com/channels/967097582721572934/1156961134935539885/1156961134935539885

So this change ensures it's part of the official documentation.

### How?

Update the Upload documentation