### PR TITLE
fix: revert "feat: allow publish and publish specific locale buttons to be swapped"

### DIFF
--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -129,10 +129,6 @@ export const createClientConfig = ({
           if (config.localization.defaultLocale) {
             clientConfig.localization.defaultLocale = config.localization.defaultLocale
           }
-          if (config.localization.defaultLocalePublishOption) {
-            clientConfig.localization.defaultLocalePublishOption =
-              config.localization.defaultLocalePublishOption
-          }
           if (config.localization.fallback) {
             clientConfig.localization.fallback = config.localization.fallback
           }

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -455,14 +455,6 @@ export type BaseLocalizationConfig = {
    * @example `"en"`
    */
   defaultLocale: string
-  /**
-   * Change the locale used by the default Publish button.
-   * If set to `all`, all locales will be published.
-   * If set to `active`, only the locale currently being edited will be published.
-   * The non-default option will be available via the secondary button.
-   * @default 'all'
-   */
-  defaultLocalePublishOption?: 'active' | 'all'
   /** Set to `true` to let missing values in localised fields fall back to the values in `defaultLocale`
    *
    * If false, then no requests will fallback unless a fallbackLocale is specified in the request.

--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -370,7 +370,6 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'version:previouslyPublished',
   'version:problemRestoringVersion',
   'version:publish',
-  'version:publishAllLocales',
   'version:publishChanges',
   'version:published',
   'version:publishIn',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -455,7 +455,6 @@ export const arTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'نشر سابقا',
     problemRestoringVersion: 'حدث خطأ في استعادة هذه النّسخة',
     publish: 'نشر',
-    publishAllLocales: 'نشر جميع المواقع',
     publishChanges: 'نشر التّغييرات',
     published: 'تمّ النّشر',
     publishIn: 'نشر في {{locale}}',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -464,7 +464,6 @@ export const azTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Daha əvvəl nəşr olunmuş',
     problemRestoringVersion: 'Bu versiyanın bərpasında problem yaşandı',
     publish: 'Dərc et',
-    publishAllLocales: 'Bütün lokalizasiyaları dərc edin',
     publishChanges: 'Dəyişiklikləri dərc et',
     published: 'Dərc edilmiş',
     publishIn: '{{locale}} dili ilə nəşr edin',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -463,7 +463,6 @@ export const bgTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Предишно публикувано',
     problemRestoringVersion: 'Имаше проблем при възстановяването на тази версия',
     publish: 'Публикувай',
-    publishAllLocales: 'Публикувайте всички локали',
     publishChanges: 'Публикувай промените',
     published: 'Публикувано',
     publishIn: 'Публикувайте в {{locale}}',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -466,7 +466,6 @@ export const caTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Publicat anteriorment',
     problemRestoringVersion: 'Hi ha hagut un problema en restaurar aquesta versió',
     publish: 'Publicar',
-    publishAllLocales: 'Publica totes les configuracions regionals',
     publishChanges: 'Publicar canvis',
     published: 'Publicat',
     publishIn: 'Publicar en {{locale}}',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -460,7 +460,6 @@ export const csTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Dříve publikováno',
     problemRestoringVersion: 'Při obnovování této verze došlo k problému',
     publish: 'Publikovat',
-    publishAllLocales: 'Publikujte všechny lokalizace',
     publishChanges: 'Publikovat změny',
     published: 'Publikováno',
     publishIn: 'Publikovat v {{locale}}',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -462,7 +462,6 @@ export const daTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Tidligere offentliggjort',
     problemRestoringVersion: 'Der opstod et problem med at gendanne denne version',
     publish: 'Offentliggør',
-    publishAllLocales: 'Udgiv alle lokalindstillinger',
     publishChanges: 'Offentliggør ændringer',
     published: 'Offentliggjort',
     publishIn: 'Offentliggør i',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -468,7 +468,6 @@ export const deTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Zuvor Veröffentlicht',
     problemRestoringVersion: 'Es gab ein Problem bei der Wiederherstellung dieser Version',
     publish: 'Veröffentlichen',
-    publishAllLocales: 'Veröffentlichen Sie alle Lokalisierungen',
     publishChanges: 'Änderungen veröffentlichen',
     published: 'Veröffentlicht',
     publishIn: 'Veröffentlichen in {{locale}}',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -464,7 +464,6 @@ export const enTranslations = {
     previouslyPublished: 'Previously Published',
     problemRestoringVersion: 'There was a problem restoring this version',
     publish: 'Publish',
-    publishAllLocales: 'Publish all locales',
     publishChanges: 'Publish changes',
     published: 'Published',
     publishIn: 'Publish in {{locale}}',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -468,7 +468,6 @@ export const esTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Publicado Anteriormente',
     problemRestoringVersion: 'Ocurrió un problema al restaurar esta versión',
     publish: 'Publicar',
-    publishAllLocales: 'Publicar todas las configuraciones regionales',
     publishChanges: 'Publicar cambios',
     published: 'Publicado',
     publishIn: 'Publicar en {{locale}}',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -457,7 +457,6 @@ export const etTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Varem avaldatud',
     problemRestoringVersion: 'Selle versiooni taastamisel tekkis probleem',
     publish: 'Avalda',
-    publishAllLocales: 'Avaldage kõik lokaadid',
     publishChanges: 'Avalda muudatused',
     published: 'Avaldatud',
     publishIn: 'Avalda keeles {{locale}}',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -459,7 +459,6 @@ export const faTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'قبلا منتشر شده',
     problemRestoringVersion: 'مشکلی در بازیابی این نگارش وجود دارد',
     publish: 'انتشار',
-    publishAllLocales: 'انتشار در تمام مکان‌های محلی',
     publishChanges: 'انتشار تغییرات',
     published: 'انتشار یافته',
     publishIn: 'منتشر کنید در {{locale}}',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -476,7 +476,6 @@ export const frTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Précédemment publié',
     problemRestoringVersion: 'Un problème est survenu lors de la restauration de cette version',
     publish: 'Publier',
-    publishAllLocales: 'Publier toutes les localités',
     publishChanges: 'Publier les modifications',
     published: 'Publié',
     publishIn: 'Publier en {{locale}}',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -449,7 +449,6 @@ export const heTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'פורסם בעבר',
     problemRestoringVersion: 'הייתה בעיה בשחזור הגרסה הזו',
     publish: 'פרסם',
-    publishAllLocales: 'פרסם את כל המיקומים',
     publishChanges: 'פרסם שינויים',
     published: 'פורסם',
     publishIn: 'פרסם ב-{{locale}}',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -460,7 +460,6 @@ export const hrTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Prethodno objavljeno',
     problemRestoringVersion: 'Nastao je problem pri vraćanju ove verzije',
     publish: 'Objaviti',
-    publishAllLocales: 'Objavi sve lokalne postavke',
     publishChanges: 'Objavi promjene',
     published: 'Objavljeno',
     publishIn: 'Objavi na {{locale}}',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -468,7 +468,6 @@ export const huTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Korábban Közzétéve',
     problemRestoringVersion: 'Hiba történt a verzió visszaállításakor',
     publish: 'Közzététel',
-    publishAllLocales: 'Közzétesz az összes helyszínen',
     publishChanges: 'Módosítások közzététele',
     published: 'Közzétett',
     publishIn: 'Közzététel ebben a {{locale}} területkódban',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -468,7 +468,6 @@ export const itTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Precedentemente Pubblicato',
     problemRestoringVersion: 'Si è verificato un problema durante il ripristino di questa versione',
     publish: 'Pubblicare',
-    publishAllLocales: 'Pubblica tutte le località',
     publishChanges: 'Pubblica modifiche',
     published: 'Pubblicato',
     publishIn: 'Pubblica in {{locale}}',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -461,7 +461,6 @@ export const jaTranslations: DefaultTranslationsObject = {
     previouslyPublished: '以前に公開された',
     problemRestoringVersion: 'このバージョンの復元に問題がありました。',
     publish: '公開する',
-    publishAllLocales: 'すべてのロケールを公開する',
     publishChanges: '変更内容を公開',
     published: '公開済み',
     publishIn: '{{locale}}で公開する',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -456,7 +456,6 @@ export const koTranslations: DefaultTranslationsObject = {
     previouslyPublished: '이전에 발표된',
     problemRestoringVersion: '이 버전을 복원하는 중 문제가 발생했습니다.',
     publish: '게시',
-    publishAllLocales: '모든 로케일을 게시하십시오',
     publishChanges: '변경 사항 게시',
     published: '게시됨',
     publishIn: '{{locale}}에서 게시하십시오.',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -471,7 +471,6 @@ export const myTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'တိုင်းရင်းသားထုတ်ဝေခဲ့',
     problemRestoringVersion: 'ဤဗားရှင်းကို ပြန်လည်ရယူရာတွင် ပြဿနာရှိနေသည်။',
     publish: 'ထုတ်ဝေသည်။',
-    publishAllLocales: 'နိုင်ငံတကာစာလုံးအားလုံးကို ထုတ်ဝေပါ',
     publishChanges: 'အပြောင်းအလဲများကို တင်ခဲ့သည်။',
     published: 'တင်ပြီးပြီ။',
     publishIn: 'Terbitkan di {{locale}}',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -464,7 +464,6 @@ export const nbTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Tidligere Publisert',
     problemRestoringVersion: 'Det oppstod et problem med gjenoppretting av denne versjonen',
     publish: 'Publisere',
-    publishAllLocales: 'Publiser alle språk',
     publishChanges: 'Publiser endringer',
     published: 'Publisert',
     publishIn: 'Publiser i {{locale}}',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -468,7 +468,6 @@ export const nlTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Eerder gepubliceerd',
     problemRestoringVersion: 'Er was een probleem bij het herstellen van deze versie',
     publish: 'Publiceren',
-    publishAllLocales: 'Publiceer alle taalinstellingen',
     publishChanges: 'Publiceer wijzigingen',
     published: 'Gepubliceerd',
     publishIn: 'Publiceer in {{locale}}',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -463,7 +463,6 @@ export const plTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Wcześniej opublikowane',
     problemRestoringVersion: 'Wystąpił problem podczas przywracania tej wersji',
     publish: 'Publikuj',
-    publishAllLocales: 'Opublikuj wszystkie lokalizacje',
     publishChanges: 'Opublikuj zmiany',
     published: 'Opublikowano',
     publishIn: 'Opublikuj w {{locale}}',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -464,7 +464,6 @@ export const ptTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Publicado Anteriormente',
     problemRestoringVersion: 'Ocorreu um problema ao restaurar essa versão',
     publish: 'Publicar',
-    publishAllLocales: 'Publicar todas as localidades',
     publishChanges: 'Publicar alterações',
     published: 'Publicado',
     publishIn: 'Publicar em {{locale}}',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -471,7 +471,6 @@ export const roTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Publicat anterior',
     problemRestoringVersion: 'A existat o problemă la restaurarea acestei versiuni',
     publish: 'Publicați',
-    publishAllLocales: 'Publicați toate configurările regionale și lingvistice',
     publishChanges: 'Publicați modificările',
     published: 'Publicat',
     publishIn: 'Publicați în {{locale}}',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -459,7 +459,6 @@ export const rsTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Prethodno objavljeno',
     problemRestoringVersion: 'Настао је проблем при враћању ове верзије',
     publish: 'Објавити',
-    publishAllLocales: 'Objavi sve lokalitete',
     publishChanges: 'Објави промене',
     published: 'Објављено',
     publishIn: 'Objavi na {{locale}}',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -461,7 +461,6 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Prethodno objavljeno',
     problemRestoringVersion: 'Nastao je problem pri vraćanju ove verzije',
     publish: 'Objaviti',
-    publishAllLocales: 'Objavi sve lokalne postavke',
     publishChanges: 'Objavljivanje',
     published: 'Objavljeno',
     publishIn: 'Objavite na {{locale}}',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -466,7 +466,6 @@ export const ruTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Ранее опубликовано',
     problemRestoringVersion: 'Возникла проблема с восстановлением этой версии',
     publish: 'Публиковать',
-    publishAllLocales: 'Опубликовать все локали',
     publishChanges: 'Опубликовать изменения',
     published: 'Опубликовано',
     publishIn: 'Опубликовать на {{locale}}',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -463,7 +463,6 @@ export const skTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Predtým publikované',
     problemRestoringVersion: 'Pri obnovovaní tejto verzie došlo k problému',
     publish: 'Publikovať',
-    publishAllLocales: 'Publikujte všetky lokality',
     publishChanges: 'Publikovať zmeny',
     published: 'Publikované',
     publishIn: 'Publikujte v {{locale}}',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -460,7 +460,6 @@ export const slTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Predhodno objavljeno',
     problemRestoringVersion: 'Pri obnavljanju te različice je prišlo do težave',
     publish: 'Objavi',
-    publishAllLocales: 'Objavi vse jezike',
     publishChanges: 'Objavi spremembe',
     published: 'Objavljeno',
     publishIn: 'Objavi v {{locale}}',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -463,7 +463,6 @@ export const svTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Tidigare publicerad',
     problemRestoringVersion: 'Det uppstod ett problem när den här versionen skulle återställas',
     publish: 'Publicera',
-    publishAllLocales: 'Publicera alla lokaliseringsinställningar',
     publishChanges: 'Publicera ändringar',
     published: 'Publicerad',
     publishIn: 'Publicera i {{locale}}',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -454,7 +454,6 @@ export const thTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'เผยแพร่ก่อนหน้านี้',
     problemRestoringVersion: 'เกิดปัญหาระหว่างการกู้คืนเวอร์ชันนี้',
     publish: 'เผยแพร่',
-    publishAllLocales: 'เผยแพร่ทุกสถานที่',
     publishChanges: 'เผยแพร่การแก้ไข',
     published: 'เผยแพร่แล้ว',
     publishIn: 'เผยแพร่ใน {{locale}}',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -465,7 +465,6 @@ export const trTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Daha Önce Yayınlanmış',
     problemRestoringVersion: 'Bu sürüme geri döndürürken bir hatayla karşılaşıldı.',
     publish: 'Yayınla',
-    publishAllLocales: 'Tüm yerel ayarları yayınla',
     publishChanges: 'Değişiklikleri yayınla',
     published: 'Yayınlandı',
     publishIn: '{{locale}} dilinde yayınlayın.',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -461,7 +461,6 @@ export const ukTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Раніше опубліковано',
     problemRestoringVersion: 'Виникла проблема з відновленням цієї версії',
     publish: 'Опублікувати',
-    publishAllLocales: 'Опублікуйте всі локалі',
     publishChanges: 'Опублікувати зміни',
     published: 'Опубліковано',
     publishIn: 'Опублікувати в {{locale}}',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -458,7 +458,6 @@ export const viTranslations: DefaultTranslationsObject = {
     previouslyPublished: 'Đã xuất bản trước đây',
     problemRestoringVersion: 'Đã xảy ra vấn đề khi khôi phục phiên bản này',
     publish: 'Công bố',
-    publishAllLocales: 'Xuất bản tất cả địa phương',
     publishChanges: 'Xuất bản tài liệu',
     published: 'Đã xuất bản',
     publishIn: 'Xuất bản trong {{locale}}',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -444,7 +444,6 @@ export const zhTranslations: DefaultTranslationsObject = {
     previouslyPublished: '先前发布过的',
     problemRestoringVersion: '恢复这个版本时发生了问题',
     publish: '发布',
-    publishAllLocales: '发布所有地区设置',
     publishChanges: '发布修改',
     published: '已发布',
     publishIn: '在{{locale}}发布',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -444,7 +444,6 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     previouslyPublished: '先前出版過的',
     problemRestoringVersion: '回復這個版本時發生了問題',
     publish: '發佈',
-    publishAllLocales: '發布所有地區設定',
     publishChanges: '發佈修改',
     published: '已發佈',
     publishIn: '在 {{locale}} 發佈',

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -46,7 +46,7 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
     serverURL,
   } = config
 
-  const { t } = useTranslation()
+  const { i18n, t } = useTranslation()
   const label = labelProp || t('version:publishChanges')
 
   const entityConfig = React.useMemo(() => {
@@ -165,28 +165,6 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
     [api, collectionSlug, globalSlug, id, serverURL, setHasPublishedDoc, submit, uploadStatus],
   )
 
-  const publishAll =
-    localization && localization.defaultLocalePublishOption !== 'active' ? true : false
-
-  const activeLocale =
-    localization &&
-    localization?.locales.find((locale) =>
-      typeof locale === 'string' ? locale === localeCode : locale.code === localeCode,
-    )
-
-  const activeLocaleLabel =
-    typeof activeLocale.label === 'string'
-      ? activeLocale.label
-      : (activeLocale.label?.[localeCode] ?? undefined)
-
-  const defaultPublish = publishAll ? publish : () => publishSpecificLocale(activeLocale.code)
-  const defaultLabel = publishAll ? label : t('version:publishIn', { locale: activeLocaleLabel })
-
-  const secondaryPublish = publishAll ? () => publishSpecificLocale(activeLocale.code) : publish
-  const secondaryLabel = publishAll
-    ? t('version:publishIn', { locale: activeLocaleLabel })
-    : t('version:publishAllLocales')
-
   if (!hasPublishPermission) {
     return null
   }
@@ -196,7 +174,7 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
       <FormSubmit
         buttonId="action-save"
         disabled={!canPublish}
-        onClick={defaultPublish}
+        onClick={publish}
         size="medium"
         SubMenuPopupContent={
           localization || canSchedulePublish
@@ -210,13 +188,33 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
                         </PopupList.Button>
                       </PopupList.ButtonGroup>
                     )}
-                    {localization && (
-                      <PopupList.ButtonGroup>
-                        <PopupList.Button onClick={secondaryPublish}>
-                          {secondaryLabel}
-                        </PopupList.Button>
-                      </PopupList.ButtonGroup>
-                    )}
+                    {localization
+                      ? localization.locales.map((locale) => {
+                          const formattedLabel =
+                            typeof locale.label === 'string'
+                              ? locale.label
+                              : locale.label && locale.label[i18n?.language]
+
+                          const isActive =
+                            typeof locale === 'string'
+                              ? locale === localeCode
+                              : locale.code === localeCode
+
+                          if (isActive) {
+                            return (
+                              <PopupList.ButtonGroup key={locale.code}>
+                                <PopupList.Button
+                                  onClick={() => [publishSpecificLocale(locale.code), close()]}
+                                >
+                                  {t('version:publishIn', {
+                                    locale: formattedLabel || locale.code,
+                                  })}
+                                </PopupList.Button>
+                              </PopupList.ButtonGroup>
+                            )
+                          }
+                        })
+                      : null}
                   </React.Fragment>
                 )
               }
@@ -224,7 +222,7 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
         }
         type="button"
       >
-        {localization ? defaultLabel : label}
+        {label}
       </FormSubmit>
       {canSchedulePublish && isModalOpen(drawerSlug) && <ScheduleDrawer slug={drawerSlug} />}
     </React.Fragment>

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -179,7 +179,6 @@ export default buildConfigWithDefaults({
     },
   },
   localization: {
-    defaultLocalePublishOption: 'active',
     defaultLocale: 'en',
     locales: [
       {

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -531,15 +531,6 @@ describe('Document View', () => {
       })
     })
   })
-
-  describe('publish button', () => {
-    test('should show publish active locale button with defaultLocalePublishOption', async () => {
-      await navigateToDoc(page, postsUrl)
-      const publishButton = await page.locator('#action-save')
-      await expect(publishButton).toBeVisible()
-      await expect(publishButton).toContainText('Publish in English')
-    })
-  })
 })
 
 async function createPost(overrides?: Partial<Post>): Promise<Post> {


### PR DESCRIPTION
Reverts payloadcms/payload#9438

I get this error when I run `pnpm dev _community` and try to access http://localhost:3000/admin/collections/posts/create
```
packages/ui/src/elements/PublishButton/index.tsx (178:25) @ label

  176 |
  177 |   const activeLocaleLabel =
> 178 |     typeof activeLocale.label === 'string'
      |                         ^
  179 |       ? activeLocale.label
  180 |       : (activeLocale.label?.[localeCode] ?? undefined)
  181 |
  
  ```

I tried to figure it out and found some more details to fix in the PR.
My suggestion to debug this error is to add `"strictNullChecks": true` in `packages/ui/tsconfig.json`

I'll leave comments in the code below as well.
