### PR TITLE
fix: checks for localization to prevent publish button breaking

### DIFF
--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -166,7 +166,7 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
   )
 
   const publishAll =
-    localization && localization.defaultLocalePublishOption !== 'active' ? true : false
+    !localization || (localization && localization.defaultLocalePublishOption !== 'active')
 
   const activeLocale =
     localization &&
@@ -175,9 +175,10 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
     )
 
   const activeLocaleLabel =
-    typeof activeLocale.label === 'string'
+    activeLocale &&
+    (typeof activeLocale.label === 'string'
       ? activeLocale.label
-      : (activeLocale.label?.[localeCode] ?? undefined)
+      : (activeLocale.label?.[localeCode] ?? undefined))
 
   const defaultPublish = publishAll ? publish : () => publishSpecificLocale(activeLocale.code)
   const defaultLabel = publishAll ? label : t('version:publishIn', { locale: activeLocaleLabel })


### PR DESCRIPTION
This [PR](https://github.com/payloadcms/payload/pull/9438) introduced a bug with the publish button, an error was being thrown when localization is false. Updated the logic breaking the publish button to safely check whether localization exists.