### PR TITLE
fix(ui): correctly show blocks after blocksDrawer close

### DIFF
--- a/packages/ui/src/fields/Blocks/BlocksDrawer/index.tsx
+++ b/packages/ui/src/fields/Blocks/BlocksDrawer/index.tsx
@@ -42,10 +42,10 @@ export const BlocksDrawer: React.FC<Props> = (props) => {
   const { i18n, t } = useTranslation()
 
   useEffect(() => {
-    if (!isModalOpen) {
+    if (!isModalOpen(drawerSlug)) {
       setSearchTerm('')
     }
-  }, [isModalOpen])
+  }, [isModalOpen, drawerSlug])
 
   useEffect(() => {
     const searchTermToUse = searchTerm.toLowerCase()

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -86,6 +86,33 @@ describe('Block fields', () => {
     )
   })
 
+  test('should reset search state in blocks drawer on re-open', async () => {
+    await page.goto(url.create)
+    const addButton = page.locator('#field-blocks > .blocks-field__drawer-toggler')
+    await expect(addButton).toContainText('Add Block')
+    await addButton.click()
+
+    const blocksDrawer = page.locator('[id^=drawer_1_blocks-drawer-]')
+    await expect(blocksDrawer).toBeVisible()
+
+    const searchInput = page.locator('.block-search__input')
+    await searchInput.fill('Number')
+
+    // select the first block in the drawer
+    const firstBlockSelector = blocksDrawer
+      .locator('.blocks-drawer__blocks .blocks-drawer__block')
+      .first()
+
+    await expect(firstBlockSelector).toContainText('Number')
+
+    await page.locator('.drawer__header__close').click()
+    await addButton.click()
+
+    await expect(blocksDrawer).toBeVisible()
+    await expect(searchInput).toHaveValue('')
+    await expect(firstBlockSelector).toContainText('Content')
+  })
+
   test('should open blocks drawer from block row and add below', async () => {
     await page.goto(url.create)
     const firstRow = page.locator('#field-blocks #blocks-row-0')


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes an issue where after closing the `BlocksDrawer` component after performing a search, stale `Blocks` were shown the next time it was open.

### Why?
To properly show all blocks when the `BlocksDrawer` is open after being closed with a filtered search.

### How?
The `BlocksDrawer` was simply checking the existence of the `isModalOpen` function instead of calling it as expected.

Fixes #10843

Before:
https://github.com/user-attachments/assets/5f41012d-ca84-41b4-9861-d5e0cb2579f6


After:
[Editing---Block-Field-after--Payload.webm](https://github.com/user-attachments/assets/4bd1ab11-f9a0-438f-a2e6-2ff0aba3e53d)
