### PR TITLE
fix(ui): adds title attribute to Logout button for tooltip

### DIFF
--- a/packages/ui/src/elements/Logout/index.tsx
+++ b/packages/ui/src/elements/Logout/index.tsx
@@ -30,6 +30,7 @@ export const Logout: React.FC<{
     className: `${baseClass}__log-out`,
     prefetch: Link ? false : undefined,
     tabIndex,
+    title: t('authentication:logOut'),
   }
 
   return (


### PR DESCRIPTION
Native tooltip was missing from the `Logout` button because it was missing the `title` attribute.

Adds `title` attribute to the `Logout` button to display native tooltip.

![Screenshot 2025-01-28 at 2 11 07 PM](https://github.com/user-attachments/assets/01f42877-8e01-4cd2-a064-e6c6eb77f216)

Fixes #10773 

