### PR TITLE
templates: fix website template not building

### DIFF
--- a/templates/website/src/blocks/Form/Component.tsx
+++ b/templates/website/src/blocks/Form/Component.tsx
@@ -32,7 +32,7 @@ export const FormBlock: React.FC<
   } = props
 
   const formMethods = useForm({
-    defaultValues: formFromProps.fields,
+    defaultValues: formFromProps.fields as any,
   })
   const {
     control,

--- a/templates/with-vercel-website/src/blocks/Form/Component.tsx
+++ b/templates/with-vercel-website/src/blocks/Form/Component.tsx
@@ -32,7 +32,7 @@ export const FormBlock: React.FC<
   } = props
 
   const formMethods = useForm({
-    defaultValues: formFromProps.fields,
+    defaultValues: formFromProps.fields as any,
   })
   const {
     control,


### PR DESCRIPTION
After our 3.20.0 release, we can remove the `as any` assertion again.

Fixes https://github.com/payloadcms/payload/issues/10840