### PR TITLE
fix(plugin-nested-docs): corrects data shape of breadcrumbs returned in hooks

### DIFF
--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -81,10 +81,7 @@ const resave = async ({ collection, doc, draft, pluginConfig, req }: ResaveArgs)
           await req.payload.update({
             id: child.id,
             collection: collection.slug,
-            data: {
-              ...child,
-              [breadcrumbSlug]: await populateBreadcrumbs(req, pluginConfig, collection, child),
-            },
+            data: populateBreadcrumbs(req, pluginConfig, collection, child),
             depth: 0,
             draft: isDraft,
             locale: req.locale,

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -131,6 +131,17 @@ describe('@payloadcms/plugin-nested-docs', () => {
         },
       })
 
+      // update the parent
+      await payload.update({
+        collection: 'pages',
+        id: parentDoc.id,
+        data: {
+          title: 'parent updated',
+          slug: 'parent-updated',
+          _status: 'published',
+        },
+      })
+
       // expect breadcrumbs to be an array
       expect(childDoc.breadcrumbs).toBeInstanceOf(Array)
       expect(childDoc.breadcrumbs).toBeDefined()

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url'
 
 import { initPayloadInt } from '../helpers/initPayloadInt.js'
 import { Page } from './payload-types.js'
+import { update } from 'node_modules/payload/src/preferences/operations/update.js'
 
 let payload: Payload
 
@@ -109,6 +110,36 @@ describe('@payloadcms/plugin-nested-docs', () => {
       expect(firstUpdatedChildBreadcrumbs).toBeDefined()
       // @ts-ignore
       expect(lastUpdatedChildBreadcrumbs[0].url).toStrictEqual('/11-children-updated')
+    })
+
+    it('should return breadcrumbs as an array of objects', async () => {
+      const parentDoc = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'parent doc',
+          slug: 'parent-doc',
+          _status: 'published',
+        },
+      })
+
+      const childDoc = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'child doc',
+          slug: 'child-doc',
+          parent: parentDoc.id,
+          _status: 'published',
+        },
+      })
+
+      // expect breadcrumbs to be an array
+      expect(childDoc.breadcrumbs).toBeInstanceOf(Array)
+      expect(childDoc.breadcrumbs).toBeDefined()
+
+      // expect each to be objects
+      childDoc.breadcrumbs?.map((breadcrumb) => {
+        expect(breadcrumb).toBeInstanceOf(Object)
+      })
     })
   })
 

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -76,7 +76,6 @@ describe('@payloadcms/plugin-nested-docs', () => {
           },
         })
       }
-
       // update parent doc
       await payload.update({
         collection: 'pages',
@@ -131,17 +130,6 @@ describe('@payloadcms/plugin-nested-docs', () => {
         },
       })
 
-      // update the parent
-      await payload.update({
-        collection: 'pages',
-        id: parentDoc.id,
-        data: {
-          title: 'parent updated',
-          slug: 'parent-updated',
-          _status: 'published',
-        },
-      })
-
       // expect breadcrumbs to be an array
       expect(childDoc.breadcrumbs).toBeInstanceOf(Array)
       expect(childDoc.breadcrumbs).toBeDefined()
@@ -167,6 +155,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
           title: 'child doc',
           slug: 'child',
           parent: parentDoc.id,
+          _status: 'published',
         },
       })
 
@@ -197,6 +186,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // breadcrumbs should be updated
       expect(updatedChild.breadcrumbs).toHaveLength(2)
+
       expect(updatedChild.breadcrumbs?.[0]?.url).toStrictEqual('/parent-updated')
       expect(updatedChild.breadcrumbs?.[1]?.url).toStrictEqual('/parent-updated/child')
 


### PR DESCRIPTION
### What?
The `plugin-nested-docs` returns an array of breadcrumbs - the `resaveChildren` file accidentally processed the breadcrumbs twice, once where the data is updated and once within the `populateBreadcrumbs` function which was causing the objects to be double nested.

### How?
Removes the extra nesting from `resaveChildren` file and allows the `populateBreadcrumbs` to return the final data.

Fixes #10855 
