### PR TITLE
fix(ui): create-first-user crashes when users collection has join field

### DIFF
--- a/packages/ui/src/fields/Join/index.tsx
+++ b/packages/ui/src/fields/Join/index.tsx
@@ -161,18 +161,22 @@ const JoinFieldComponent: JoinFieldClientComponent = (props) => {
     }
 
     return where
-  }, [docID, field.targetField.relationTo, field.where, on, docConfig.slug])
+  }, [docID, field.targetField.relationTo, field.where, on, docConfig?.slug])
 
   const initialDrawerData = useMemo(() => {
     const relatedCollection = getEntityConfig({ collectionSlug: field.collection })
 
     return getInitialDrawerData({
-      collectionSlug: docConfig.slug,
+      collectionSlug: docConfig?.slug,
       docID,
       fields: relatedCollection.fields,
       segments: field.on.split('.'),
     })
-  }, [getEntityConfig, field.collection, field.on, docConfig.slug, docID])
+  }, [getEntityConfig, field.collection, field.on, docConfig?.slug, docID])
+
+  if (!docConfig) {
+    return null
+  }
 
   return (
     <div

--- a/test/joins/collections/Posts.ts
+++ b/test/joins/collections/Posts.ts
@@ -14,6 +14,11 @@ export const Posts: CollectionConfig = {
       type: 'text',
     },
     {
+      name: 'author',
+      type: 'relationship',
+      relationTo: 'users',
+    },
+    {
       name: 'isFiltered',
       type: 'checkbox',
       defaultValue: false,

--- a/test/joins/config.ts
+++ b/test/joins/config.ts
@@ -29,8 +29,21 @@ export default buildConfigWithDefaults({
     importMap: {
       baseDir: path.resolve(dirname),
     },
+    user: 'users',
   },
   collections: [
+    {
+      slug: 'users',
+      auth: true,
+      fields: [
+        {
+          type: 'join',
+          collection: 'posts',
+          on: 'author',
+          name: 'posts',
+        },
+      ],
+    },
     Posts,
     Categories,
     HiddenPosts,

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -439,4 +439,11 @@ test.describe('Join Field', () => {
     await expect(rows).toHaveCount(1)
     await expect(joinField.locator('.cell-canRead')).not.toContainText('false')
   })
+
+  test('should render create-first-user with when users collection has a join field and hide it', async () => {
+    await payload.delete({ collection: 'users', where: {} })
+    const url = new AdminUrlUtil(serverURL, 'users')
+    await page.goto(url.admin + '/create-first-user')
+    await expect(page.locator('.field-type.join')).toBeHidden()
+  })
 })

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -11,6 +11,7 @@ export interface Config {
     users: UserAuthOperations;
   };
   collections: {
+    users: User;
     posts: Post;
     categories: Category;
     'hidden-posts': HiddenPost;
@@ -28,12 +29,14 @@ export interface Config {
     'depth-joins-1': DepthJoins1;
     'depth-joins-2': DepthJoins2;
     'depth-joins-3': DepthJoins3;
-    users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
   collectionsJoins: {
+    users: {
+      posts: 'posts';
+    };
     categories: {
       relatedPosts: 'posts';
       hasManyPosts: 'posts';
@@ -78,6 +81,7 @@ export interface Config {
     };
   };
   collectionsSelect: {
+    users: UsersSelect<false> | UsersSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
     'hidden-posts': HiddenPostsSelect<false> | HiddenPostsSelect<true>;
@@ -95,7 +99,6 @@ export interface Config {
     'depth-joins-1': DepthJoins1Select<false> | DepthJoins1Select<true>;
     'depth-joins-2': DepthJoins2Select<false> | DepthJoins2Select<true>;
     'depth-joins-3': DepthJoins3Select<false> | DepthJoins3Select<true>;
-    users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -134,11 +137,33 @@ export interface UserAuthOperations {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users".
+ */
+export interface User {
+  id: string;
+  posts?: {
+    docs?: (string | Post)[] | null;
+    hasNextPage?: boolean | null;
+  } | null;
+  updatedAt: string;
+  createdAt: string;
+  email: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
+  password?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "posts".
  */
 export interface Post {
   id: string;
   title?: string | null;
+  author?: (string | null) | User;
   /**
    * Hides posts for the `filtered` join field in categories
    */
@@ -337,23 +362,6 @@ export interface Singular {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "users".
- */
-export interface User {
-  id: string;
-  updatedAt: string;
-  createdAt: string;
-  email: string;
-  resetPasswordToken?: string | null;
-  resetPasswordExpiration?: string | null;
-  salt?: string | null;
-  hash?: string | null;
-  loginAttempts?: number | null;
-  lockUntil?: string | null;
-  password?: string | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "versions".
  */
 export interface Version {
@@ -519,6 +527,10 @@ export interface PayloadLockedDocument {
   id: string;
   document?:
     | ({
+        relationTo: 'users';
+        value: string | User;
+      } | null)
+    | ({
         relationTo: 'posts';
         value: string | Post;
       } | null)
@@ -585,10 +597,6 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'depth-joins-3';
         value: string | DepthJoins3;
-      } | null)
-    | ({
-        relationTo: 'users';
-        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -634,10 +642,27 @@ export interface PayloadMigration {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users_select".
+ */
+export interface UsersSelect<T extends boolean = true> {
+  posts?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "posts_select".
  */
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
+  author?: T;
   isFiltered?: T;
   restrictedField?: T;
   upload?: T;
@@ -867,21 +892,6 @@ export interface DepthJoins3Select<T extends boolean = true> {
   rel?: T;
   updatedAt?: T;
   createdAt?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "users_select".
- */
-export interface UsersSelect<T extends boolean = true> {
-  updatedAt?: T;
-  createdAt?: T;
-  email?: T;
-  resetPasswordToken?: T;
-  resetPasswordExpiration?: T;
-  salt?: T;
-  hash?: T;
-  loginAttempts?: T;
-  lockUntil?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/10870
Now we hide join fields from the `/create-first-user` view since they're not meaningful there.