### PR TITLE
docs: fix typo on overview.mdx

### DIFF
--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -6,7 +6,7 @@ desc: Plugins provide a great way to modularize Payload functionalities into eas
 keywords: plugins, config, configuration, extensions, custom, documentation, Content Management System, cms, headless, javascript, node, react, nextjs
 ---
 
-Payload Plugins take full advantage of the modularity of the [Payload Config](../configuration/overview), allowing developers developers to easily inject custom—sometimes complex—functionality into Payload apps from a very small touch-point. This is especially useful is sharing your work across multiple projects or with the greater Payload community.
+Payload Plugins take full advantage of the modularity of the [Payload Config](../configuration/overview), allowing developers to easily inject custom—sometimes complex—functionality into Payload apps from a very small touch-point. This is especially useful is sharing your work across multiple projects or with the greater Payload community.
 
 There are many [Official Plugins](#official-plugins) available that solve for some of the most common uses cases, such as the [Form Builder Plugin](./form-builder) or [SEO Plugin](./seo). There are also [Community Plugins](#community-plugins) available, maintained entirely by contributing members. To extend Payload's functionality in some other way, you can easily [build your own plugin](./build-your-own).
 


### PR DESCRIPTION
Remove repeated `developers` word.

### What?
There was a typo on the plugins overview page, where `developers developers` was used twice in a row. Mb that was a quote from Steve Balmer idk.

### Why?
Docs should be pristine.

### How?
Removed the word.