### PR TITLE
templates: remove unknown CSS values

### DIFF
--- a/examples/localization/src/app/(frontend)/[locale]/globals.css
+++ b/examples/localization/src/app/(frontend)/[locale]/globals.css
@@ -9,8 +9,8 @@
   h4,
   h5,
   h6 {
-    font-size: auto;
-    font-weight: auto;
+    font-size: unset;
+    font-weight: unset;
   }
 
   :root {

--- a/templates/website/src/app/(frontend)/globals.css
+++ b/templates/website/src/app/(frontend)/globals.css
@@ -9,8 +9,8 @@
   h4,
   h5,
   h6 {
-    font-size: auto;
-    font-weight: auto;
+    font-size: unset;
+    font-weight: unset;
   }
 
   :root {

--- a/templates/with-vercel-website/src/app/(frontend)/globals.css
+++ b/templates/with-vercel-website/src/app/(frontend)/globals.css
@@ -9,8 +9,8 @@
   h4,
   h5,
   h6 {
-    font-size: auto;
-    font-weight: auto;
+    font-size: unset;
+    font-weight: unset;
   }
 
   :root {


### PR DESCRIPTION
* set font-size to unset
* set font-weight to unset

### What?

Change CSS values in global.css files in 3 examples

### Why?

Apparently, the CSS value of `auto` does not actually exist in CSS for `font-size` and `font-weight` [mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#syntax) . [Stylelint](https://stylelint.io/user-guide/rules/declaration-property-value-no-unknown/) errors made me aware of this. That rule's description is not specific to `font-size` and `font-weight`.

This is how it looked in the terminal:

```
src/app/(frontend)/globals.css
  12:18  ✖  Unexpected unknown value "auto" for property "font-weight"  declaration-property-value-no-unknown
  13:16  ✖  Unexpected unknown value "auto" for property "font-size"    declaration-property-value-no-unknown
```

### Fixes:

Change `auto` to `unset` since it uses `initial` styles unless the heading CSS values have been changed by a parent html tag. I'm guessing this was reset due to tailwind interrupting this somehow.
