### PR TITLE
chore(templates): improves and simplifies draft preview

### DIFF
--- a/templates/website/.env.example
+++ b/templates/website/.env.example
@@ -12,3 +12,6 @@ NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 
 # Secret used to authenticate cron jobs
 CRON_SECRET=YOUR_CRON_SECRET_HERE
+
+# Used to validate preview requests
+PREVIEW_SECRET=YOUR_SECRET_HERE

--- a/templates/website/src/app/(frontend)/next/exit-preview/GET.ts
+++ b/templates/website/src/app/(frontend)/next/exit-preview/GET.ts
@@ -1,7 +1,0 @@
-import { draftMode } from 'next/headers'
-
-export async function GET(): Promise<Response> {
-  const draft = await draftMode()
-  draft.disable()
-  return new Response('Draft mode is disabled')
-}

--- a/templates/website/src/app/(frontend)/next/preview/route.ts
+++ b/templates/website/src/app/(frontend)/next/preview/route.ts
@@ -1,91 +1,63 @@
+import type { CollectionSlug, PayloadRequest } from 'payload'
+import { getPayload } from 'payload'
+
 import { draftMode } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { getPayload, type PayloadRequest } from 'payload'
+
 import configPromise from '@payload-config'
-import { CollectionSlug } from 'payload'
 
 export async function GET(
-  req: Request & {
+  req: {
     cookies: {
       get: (name: string) => {
         value: string
       }
     }
-  },
+  } & Request,
 ): Promise<Response> {
   const payload = await getPayload({ config: configPromise })
+
   const { searchParams } = new URL(req.url)
+
   const path = searchParams.get('path')
   const collection = searchParams.get('collection') as CollectionSlug
   const slug = searchParams.get('slug')
-
   const previewSecret = searchParams.get('previewSecret')
 
-  if (previewSecret) {
+  if (previewSecret !== process.env.PREVIEW_SECRET) {
     return new Response('You are not allowed to preview this page', { status: 403 })
-  } else {
-    if (!path) {
-      return new Response('No path provided', { status: 404 })
-    }
-
-    if (!collection) {
-      return new Response('No path provided', { status: 404 })
-    }
-
-    if (!slug) {
-      return new Response('No path provided', { status: 404 })
-    }
-
-    if (!path.startsWith('/')) {
-      return new Response('This endpoint can only be used for internal previews', { status: 500 })
-    }
-
-    let user
-
-    try {
-      user = await payload.auth({
-        req: req as unknown as PayloadRequest,
-        headers: req.headers,
-      })
-    } catch (error) {
-      payload.logger.error({ err: error }, 'Error verifying token for live preview')
-      return new Response('You are not allowed to preview this page', { status: 403 })
-    }
-
-    const draft = await draftMode()
-
-    // You can add additional checks here to see if the user is allowed to preview this page
-    if (!user) {
-      draft.disable()
-      return new Response('You are not allowed to preview this page', { status: 403 })
-    }
-
-    // Verify the given slug exists
-    try {
-      const docs = await payload.find({
-        collection,
-        draft: true,
-        limit: 1,
-        // pagination: false reduces overhead if you don't need totalDocs
-        pagination: false,
-        depth: 0,
-        select: {},
-        where: {
-          slug: {
-            equals: slug,
-          },
-        },
-      })
-
-      if (!docs.docs.length) {
-        return new Response('Document not found', { status: 404 })
-      }
-    } catch (error) {
-      payload.logger.error({ err: error }, 'Error verifying token for live preview')
-    }
-
-    draft.enable()
-
-    redirect(path)
   }
+
+  if (!path || !collection || !slug) {
+    return new Response('Insufficient search params', { status: 404 })
+  }
+
+  if (!path.startsWith('/')) {
+    return new Response('This endpoint can only be used for relative previews', { status: 500 })
+  }
+
+  let user
+
+  try {
+    user = await payload.auth({
+      req: req as unknown as PayloadRequest,
+      headers: req.headers,
+    })
+  } catch (error) {
+    payload.logger.error({ err: error }, 'Error verifying token for live preview')
+    return new Response('You are not allowed to preview this page', { status: 403 })
+  }
+
+  const draft = await draftMode()
+
+  if (!user) {
+    draft.disable()
+    return new Response('You are not allowed to preview this page', { status: 403 })
+  }
+
+  // You can add additional checks here to see if the user is allowed to preview this page
+
+  draft.enable()
+
+  redirect(path)
 }

--- a/templates/website/src/utilities/generatePreviewPath.ts
+++ b/templates/website/src/utilities/generatePreviewPath.ts
@@ -12,22 +12,16 @@ type Props = {
 }
 
 export const generatePreviewPath = ({ collection, slug, req }: Props) => {
-  const path = `${collectionPrefixMap[collection]}/${slug}`
-
-  const params = {
+  const encodedParams = new URLSearchParams({
     slug,
     collection,
-    path,
-  }
-
-  const encodedParams = new URLSearchParams()
-
-  Object.entries(params).forEach(([key, value]) => {
-    encodedParams.append(key, value)
+    path: `${collectionPrefixMap[collection]}/${slug}`,
+    previewSecret: process.env.PREVIEW_SECRET || '',
   })
 
   const isProduction =
     process.env.NODE_ENV === 'production' || Boolean(process.env.VERCEL_PROJECT_PRODUCTION_URL)
+
   const protocol = isProduction ? 'https:' : req.protocol
 
   const url = `${protocol}//${req.host}/next/preview?${encodedParams.toString()}`

--- a/templates/with-vercel-website/.env.example
+++ b/templates/with-vercel-website/.env.example
@@ -1,8 +1,14 @@
 # Database connection string
 POSTGRES_URL=postgresql://127.0.0.1:5432/your-database-name
+
 # Used to encrypt JWT tokens
 PAYLOAD_SECRET=YOUR_SECRET_HERE
+
 # Used to configure CORS, format links and more. No trailing slash
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
+
 # Secret used to authenticate cron jobs
 CRON_SECRET=YOUR_CRON_SECRET_HERE
+
+# Used to validate preview requests
+PREVIEW_SECRET=YOUR_SECRET_HERE

--- a/templates/with-vercel-website/README.md
+++ b/templates/with-vercel-website/README.md
@@ -4,7 +4,7 @@ This is the official [Payload Website Template](https://github.com/payloadcms/pa
 
 You can deploy to Vercel, using Neon and Vercel Blob Storage with one click:
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/payloadcms/payload/tree/main/templates/with-vercel-website&project-name=payload-project&env=PAYLOAD_SECRET%2CCRON_SECRET&build-command=pnpm%20run%20ci&stores=%5B%7B%22type%22:%22postgres%22%7D,%7B%22type%22:%22blob%22%7D%5D)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/payloadcms/payload/tree/main/templates/with-vercel-website&project-name=payload-project&env=PAYLOAD_SECRET%2CCRON_SECRET%2CPREVIEW_SECRET&build-command=pnpm%20run%20ci&stores=%5B%7B%22type%22:%22postgres%22%7D,%7B%22type%22:%22blob%22%7D%5D)
 
 This template is right for you if you are working on:
 

--- a/templates/with-vercel-website/src/app/(frontend)/next/exit-preview/GET.ts
+++ b/templates/with-vercel-website/src/app/(frontend)/next/exit-preview/GET.ts
@@ -1,7 +1,0 @@
-import { draftMode } from 'next/headers'
-
-export async function GET(): Promise<Response> {
-  const draft = await draftMode()
-  draft.disable()
-  return new Response('Draft mode is disabled')
-}

--- a/templates/with-vercel-website/src/app/(frontend)/next/preview/route.ts
+++ b/templates/with-vercel-website/src/app/(frontend)/next/preview/route.ts
@@ -1,91 +1,63 @@
+import type { CollectionSlug, PayloadRequest } from 'payload'
+import { getPayload } from 'payload'
+
 import { draftMode } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { getPayload, type PayloadRequest } from 'payload'
+
 import configPromise from '@payload-config'
-import { CollectionSlug } from 'payload'
 
 export async function GET(
-  req: Request & {
+  req: {
     cookies: {
       get: (name: string) => {
         value: string
       }
     }
-  },
+  } & Request,
 ): Promise<Response> {
   const payload = await getPayload({ config: configPromise })
+
   const { searchParams } = new URL(req.url)
+
   const path = searchParams.get('path')
   const collection = searchParams.get('collection') as CollectionSlug
   const slug = searchParams.get('slug')
-
   const previewSecret = searchParams.get('previewSecret')
 
-  if (previewSecret) {
+  if (previewSecret !== process.env.PREVIEW_SECRET) {
     return new Response('You are not allowed to preview this page', { status: 403 })
-  } else {
-    if (!path) {
-      return new Response('No path provided', { status: 404 })
-    }
-
-    if (!collection) {
-      return new Response('No path provided', { status: 404 })
-    }
-
-    if (!slug) {
-      return new Response('No path provided', { status: 404 })
-    }
-
-    if (!path.startsWith('/')) {
-      return new Response('This endpoint can only be used for internal previews', { status: 500 })
-    }
-
-    let user
-
-    try {
-      user = await payload.auth({
-        req: req as unknown as PayloadRequest,
-        headers: req.headers,
-      })
-    } catch (error) {
-      payload.logger.error({ err: error }, 'Error verifying token for live preview')
-      return new Response('You are not allowed to preview this page', { status: 403 })
-    }
-
-    const draft = await draftMode()
-
-    // You can add additional checks here to see if the user is allowed to preview this page
-    if (!user) {
-      draft.disable()
-      return new Response('You are not allowed to preview this page', { status: 403 })
-    }
-
-    // Verify the given slug exists
-    try {
-      const docs = await payload.find({
-        collection,
-        draft: true,
-        limit: 1,
-        // pagination: false reduces overhead if you don't need totalDocs
-        pagination: false,
-        depth: 0,
-        select: {},
-        where: {
-          slug: {
-            equals: slug,
-          },
-        },
-      })
-
-      if (!docs.docs.length) {
-        return new Response('Document not found', { status: 404 })
-      }
-    } catch (error) {
-      payload.logger.error({ err: error }, 'Error verifying token for live preview')
-    }
-
-    draft.enable()
-
-    redirect(path)
   }
+
+  if (!path || !collection || !slug) {
+    return new Response('Insufficient search params', { status: 404 })
+  }
+
+  if (!path.startsWith('/')) {
+    return new Response('This endpoint can only be used for relative previews', { status: 500 })
+  }
+
+  let user
+
+  try {
+    user = await payload.auth({
+      req: req as unknown as PayloadRequest,
+      headers: req.headers,
+    })
+  } catch (error) {
+    payload.logger.error({ err: error }, 'Error verifying token for live preview')
+    return new Response('You are not allowed to preview this page', { status: 403 })
+  }
+
+  const draft = await draftMode()
+
+  if (!user) {
+    draft.disable()
+    return new Response('You are not allowed to preview this page', { status: 403 })
+  }
+
+  // You can add additional checks here to see if the user is allowed to preview this page
+
+  draft.enable()
+
+  redirect(path)
 }

--- a/templates/with-vercel-website/src/utilities/generatePreviewPath.ts
+++ b/templates/with-vercel-website/src/utilities/generatePreviewPath.ts
@@ -12,22 +12,16 @@ type Props = {
 }
 
 export const generatePreviewPath = ({ collection, slug, req }: Props) => {
-  const path = `${collectionPrefixMap[collection]}/${slug}`
-
-  const params = {
+  const encodedParams = new URLSearchParams({
     slug,
     collection,
-    path,
-  }
-
-  const encodedParams = new URLSearchParams()
-
-  Object.entries(params).forEach(([key, value]) => {
-    encodedParams.append(key, value)
+    path: `${collectionPrefixMap[collection]}/${slug}`,
+    previewSecret: process.env.PREVIEW_SECRET || '',
   })
 
   const isProduction =
     process.env.NODE_ENV === 'production' || Boolean(process.env.VERCEL_PROJECT_PRODUCTION_URL)
+
   const protocol = isProduction ? 'https:' : req.protocol
 
   const url = `${protocol}//${req.host}/next/preview?${encodedParams.toString()}`


### PR DESCRIPTION
Similar to #10876. There were a number of things wrong or in need of improvement with the Draft Preview implementation of the Website Template, namely:
- The preview secret was missing entirely, with pointless logic was written to throw an error if it missing in the search params as opposed to not matching the environment secret. This will ensure that only admin users, not _any_ user, can enter into preview mode.
- The preview endpoint was unnecessarily querying the database for a matching document as opposed to letting the underlying page itself 404 as needed, and it was also throwing an inaccurate error message. The preview route already checks that the path is relative, so there is no security risk of redirecting to another domain.
- The `/next/exit-preview` route was duplicated twice.
- The logic to format search params in the preview URL was unnecessarily complex.