### PR TITLE
docs: fix access control overview links

### DIFF
--- a/docs/access-control/overview.mdx
+++ b/docs/access-control/overview.mdx
@@ -23,9 +23,9 @@ There are many use cases for Access Control, including:
 
 There are three main types of Access Control in Payload:
 
-- [Collection Access Control](./collections)
-- [Global Access Control](./globals)
-- [Field Access Control](./fields)
+- [Collection Access Control](../access-control/collections)
+- [Global Access Control](../access-control/globals)
+- [Field Access Control](../access-control/fields)
 
 ## Default Access Control
 


### PR DESCRIPTION
### What?
Fixes the access control links in the docs overview

### Why?
They currently direct to a 404 page

### How?
Similar to other docs the path goes back one path, then into the folder.

Fixes #10908 