### PR TITLE
fix(payload): change migrations:fresh to migrate:fresh

### DIFF
--- a/packages/payload/src/bin/migrate.ts
+++ b/packages/payload/src/bin/migrate.ts
@@ -21,7 +21,7 @@ export const availableCommands = [
   'migrate:refresh',
   'migrate:reset',
   'migrate:status',
-  'migration:fresh',
+  'migrate:fresh',
 ]
 
 const availableCommandsMsg = `Available commands: ${availableCommands.join(', ')}`


### PR DESCRIPTION
### What?
Changed the command name from **migrations:fresh** to **migrate:fresh** in the CLI. No technical functionality was altered; this is purely a naming correction for consistency with other CLI commands.
### Why?
The command name **migrations:fresh** was incorrect and inconsistent with the rest of the command naming conventions. This change ensures consistency and clarity without altering any functionality.
### How?
Updated the command name in the CLI code from migrations:fresh to migrate:fresh.


