### PR TITLE
feat: add support for custom list controls beforeActions

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -156,15 +156,16 @@ The following options are available:
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | **`beforeList`**           | An array of components to inject _before_ the built-in List View                                                                           |
 | **`beforeListTable`**      | An array of components to inject _before_ the built-in List View's table                                                                   |
+| **`beforeActions`**        | An array of components to inject _before_ the built-in List Control's actions                                                              |
 | **`afterList`**            | An array of components to inject _after_ the built-in List View                                                                            |
 | **`afterListTable`**       | An array of components to inject _after_ the built-in List View's table                                                                    |
 | **`Description`**          | A component to render below the Collection label in the List View. An alternative to the `admin.description` property.                     |
 | **`edit.SaveButton`**      | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled.                                    |
 | **`edit.SaveDraftButton`** | Replace the default Save Draft Button with a Custom Component. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. |
 | **`edit.PublishButton`**   | Replace the default Publish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled.                                  |
-| **`edit.PreviewButton`**   | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled.                                           |
+| **`edit.PreviewButton`**   | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled.                                   |
 | **`edit.Upload`**          | Replace the default Upload component with a Custom Component. [Upload](../upload/overview) must be enabled.                                |
-| **`views`**                | Override or create new views within the Admin Panel. [More details](../admin/views).                                                              |
+| **`views`**                | Override or create new views within the Admin Panel. [More details](../admin/views).                                                       |
 
 <Banner type="success">
   **Note:**

--- a/packages/next/src/views/List/renderListViewSlots.tsx
+++ b/packages/next/src/views/List/renderListViewSlots.tsx
@@ -42,6 +42,15 @@ export const renderListViewSlots = ({
     })
   }
 
+  if (collectionConfig.admin.components?.beforeActions) {
+    result.BeforeActions = RenderServerComponent({
+      clientProps,
+      Component: collectionConfig.admin.components.beforeActions,
+      importMap: payload.importMap,
+      serverProps,
+    })
+  }
+
   if (collectionConfig.admin.components?.beforeList) {
     result.BeforeList = RenderServerComponent({
       clientProps,

--- a/packages/payload/src/bin/generateImportMap/iterateCollections.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateCollections.ts
@@ -31,6 +31,7 @@ export function iterateCollections({
 
     addToImportMap(collection.admin?.components?.afterList)
     addToImportMap(collection.admin?.components?.afterListTable)
+    addToImportMap(collection.admin?.components?.beforeActions)
     addToImportMap(collection.admin?.components?.beforeList)
     addToImportMap(collection.admin?.components?.beforeListTable)
     addToImportMap(collection.admin?.components?.Description)

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -277,6 +277,7 @@ export type CollectionAdminOptions = {
   components?: {
     afterList?: CustomComponent[]
     afterListTable?: CustomComponent[]
+    beforeActions?: CustomComponent[]
     beforeList?: CustomComponent[]
     beforeListTable?: CustomComponent[]
     Description?: EntityDescriptionComponent

--- a/packages/ui/src/views/List/index.scss
+++ b/packages/ui/src/views/List/index.scss
@@ -174,6 +174,10 @@
 
     @include small-break {
       margin-bottom: base(2.4);
+
+      &__list-selection-actions {
+        flex-wrap: wrap;
+      }
     }
   }
 }

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -45,6 +45,7 @@ const Link = (LinkImport.default || LinkImport) as unknown as typeof LinkImport.
 export type ListViewSlots = {
   AfterList?: React.ReactNode
   AfterListTable?: React.ReactNode
+  BeforeActions?: React.ReactNode
   BeforeList?: React.ReactNode
   BeforeListTable?: React.ReactNode
   Description?: React.ReactNode
@@ -69,7 +70,8 @@ export const DefaultListView: React.FC<ListViewClientProps> = (props) => {
   const {
     AfterList,
     AfterListTable,
-    beforeActions,
+    BeforeActions,
+    beforeActions: beforeActionsFromProps,
     BeforeList,
     BeforeListTable,
     collectionSlug,
@@ -171,6 +173,15 @@ export const DefaultListView: React.FC<ListViewClientProps> = (props) => {
     }
   }, [setStepNav, labels, drawerDepth])
 
+  const beforeActions = [
+    ...(BeforeActions ? (Array.isArray(BeforeActions) ? BeforeActions : [BeforeActions]) : []),
+    ...(beforeActionsFromProps ?? []),
+  ]
+  const beforeActionsWithSelection =
+    enableRowSelections && typeof onBulkSelect === 'function'
+      ? [...beforeActions, <SelectMany key="select-many" onClick={onBulkSelect} />]
+      : beforeActions
+
   return (
     <Fragment>
       <TableColumnsProvider
@@ -207,13 +218,7 @@ export const DefaultListView: React.FC<ListViewClientProps> = (props) => {
                 t={t}
               />
               <ListControls
-                beforeActions={
-                  enableRowSelections && typeof onBulkSelect === 'function'
-                    ? beforeActions
-                      ? [...beforeActions, <SelectMany key="select-many" onClick={onBulkSelect} />]
-                      : [<SelectMany key="select-many" onClick={onBulkSelect} />]
-                    : beforeActions
-                }
+                beforeActions={beforeActionsWithSelection}
                 collectionConfig={collectionConfig}
                 collectionSlug={collectionSlug}
                 disableBulkDelete={disableBulkDelete}
@@ -281,14 +286,7 @@ export const DefaultListView: React.FC<ListViewClientProps> = (props) => {
                             label={getTranslation(collectionConfig.labels.plural, i18n)}
                           />
                           <div className={`${baseClass}__list-selection-actions`}>
-                            {enableRowSelections && typeof onBulkSelect === 'function'
-                              ? beforeActions
-                                ? [
-                                    ...beforeActions,
-                                    <SelectMany key="select-many" onClick={onBulkSelect} />,
-                                  ]
-                                : [<SelectMany key="select-many" onClick={onBulkSelect} />]
-                              : beforeActions}
+                            {beforeActionsWithSelection}
                             {!disableBulkEdit && (
                               <Fragment>
                                 <EditMany collection={collectionConfig} />

--- a/test/admin/collections/Posts.ts
+++ b/test/admin/collections/Posts.ts
@@ -13,6 +13,7 @@ export const Posts: CollectionConfig = {
     group: 'One',
     listSearchableFields: ['id', 'title', 'description', 'number'],
     components: {
+      beforeActions: ['/components/ResetColumns/index.js#ResetDefaultColumnsButton'],
       beforeListTable: [
         '/components/ResetColumns/index.js#ResetDefaultColumnsButton',
         {

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -156,6 +156,18 @@ describe('List View', () => {
     })
   })
 
+  describe('list view custom components', () => {
+    test('should render custom beforeAction component', async () => {
+      await page.goto(postsUrl.list)
+      const beforeActionButton = page.locator('.list-controls__buttons-wrap button').first()
+      await expect(
+        beforeActionButton.locator('span', {
+          hasText: exactText('Reset to default columns'),
+        }),
+      ).toBeVisible()
+    })
+  })
+
   describe('search', () => {
     test('should prefill search input from query param', async () => {
       await createPost({ title: 'dennis' })


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR adds support for custom `beforeActions` components in list view `ListControls`. This PR also adds a test to ensure that these components get rendered, as well as docs changes.

### Why?
To allow users to add custom List Controls `beforeActions` to their list views.

### How?
By enabling discoverability of these components through the `importMap`, and threading these components down through the default list view where there was already existing support n place for `beforeActions`.

Demo:
[Dashboard-List-BeforeAction--Payload.webm](https://github.com/user-attachments/assets/aeb173a5-b566-4237-984c-aff24bc9d45c)
