### PR TITLE
examples: added missing sharp dependency to the remix website package

### DIFF
--- a/examples/remix/website/package.json
+++ b/examples/remix/website/package.json
@@ -18,7 +18,8 @@
     "payload": "latest",
     "payload-app": "workspace:*",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "sharp": "0.32.6"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.15.2",


### PR DESCRIPTION
When the sharp module is not added to the website package, you get a reference error when trying to start a production build. This is solved by just installing the sharp module.

Solves #10929 