### PR TITLE
feat(ui): close the nav when the user navigates away on small screens

### DIFF
--- a/packages/ui/src/elements/Nav/context.tsx
+++ b/packages/ui/src/elements/Nav/context.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useWindowInfo } from '@faceless-ui/window-info'
+import { usePathname } from 'next/navigation.js'
 import React, { useEffect, useRef } from 'react'
 
 import { usePreferences } from '../../providers/Preferences/index.js'
@@ -40,6 +41,8 @@ export const NavProvider: React.FC<{
     breakpoints: { l: largeBreak, m: midBreak, s: smallBreak },
   } = useWindowInfo()
 
+  const pathname = usePathname()
+
   const { getPreference } = usePreferences()
   const navRef = useRef(null)
 
@@ -64,8 +67,13 @@ export const NavProvider: React.FC<{
     }
   }, [largeBreak, getPreference, setNavOpen])
 
-  // TODO: on smaller screens where the nav is a modal
+  // on smaller screens where the nav is a modal
   // close the nav when the user navigates away
+  useEffect(() => {
+    if (smallBreak === true) {
+      setNavOpen(false)
+    }
+  }, [pathname])
 
   // on open and close, lock the body scroll
   // do not do this on desktop, the sidebar is not a modal


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->

### What?
On smaller screens close the nav when the user navigates away.

### Why?
Users on devices with small screens may not realize the page has changed when clicking a navigation link. It is also unintuitive to have to close the nav since it takes up the entire screen.

### How?
It uses "usePathname()" from next/navigation to trigger a "useEffect", closing the nav if "smallBreak === true".

### Before
![BeforeCloseNavChange](https://github.com/user-attachments/assets/204c248e-c44b-420f-a3df-93feeef7509b)
### After
![AfterCloseNavChange](https://github.com/user-attachments/assets/18093c85-2394-4543-a442-9cc488ecb162)

