### PR TITLE
docs: correct grammar and improve clarity on preventing-abuse.mdx

### DIFF
--- a/docs/production/preventing-abuse.mdx
+++ b/docs/production/preventing-abuse.mdx
@@ -28,7 +28,7 @@ To securely allow headless operation you will need to configure the allowed orig
 
 ## Limiting GraphQL Complexity
 
-Because GraphQL gives the power of query writing outside a server's control, someone with bad intentions might write a maliciously complex query and bog down your server. To prevent resource-intensive GraphQL requests, Payload provides a way specify complexity limits which are based on a complexity score that is calculated for each request.
+Because GraphQL gives the power of query writing outside a server's control, someone with bad intentions might write a maliciously complex query and bog down your server. To prevent resource-intensive GraphQL requests, Payload provides a way to specify complexity limits. These limits are based on a complexity score calculated for each request.
 
 Any GraphQL request that is calculated to be too expensive is rejected. On the Payload Config, in `graphQL` you can set the `maxComplexity` value as an integer. For reference, the default complexity value for each added field is 1, and all `relationship` and `upload` fields are assigned a value of 10.
 


### PR DESCRIPTION
## What
Refactored the explanation of complexity limits in the ⁠preventing-abuse.mdx documentation to correct grammar and improve clarity.

## Why
- Grammar fix: The original sentence omitted the preposition "to" ("way specify" → "way to specify").
- Readability: The long, compound sentence was difficult to parse at a glance.
- Concept separation: Merging two ideas (defining limits and explaining scoring) confused the workflow.

## How
- Added the missing "to" to ensure grammatical correctness.
- Split the sentence into two parts:
  1. Introduces the purpose of complexity limits.
  2. Explains how complexity scores enforce these limits.
- Preserved technical accuracy while simplifying the flow.