### PR TITLE
chore(plugin-search): improves types

### DIFF
--- a/packages/plugin-search/src/Search/index.ts
+++ b/packages/plugin-search/src/Search/index.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig, Field } from 'payload'
 
 import type { SearchPluginConfigWithLocales } from '../types.js'
+import type { ReindexButtonServerProps } from './ui/ReindexButton/types.js'
 
 import { generateReindexHandler } from '../utilities/generateReindexHandler.js'
 
@@ -73,7 +74,7 @@ export const generateSearchCollection = (
                   collectionLabels,
                   searchCollections,
                   searchSlug,
-                },
+                } satisfies ReindexButtonServerProps,
               },
             ],
           },

--- a/packages/plugin-search/src/Search/ui/ReindexButton/index.client.tsx
+++ b/packages/plugin-search/src/Search/ui/ReindexButton/index.client.tsx
@@ -65,7 +65,7 @@ export const ReindexButtonClient: React.FC<ReindexButtonProps> = ({
         toast.success(message)
         router.refresh()
       }
-    } catch (err: unknown) {
+    } catch (_err: unknown) {
       // swallow error, toast shown above
     } finally {
       setReindexCollections([])

--- a/packages/plugin-search/src/Search/ui/ReindexButton/index.tsx
+++ b/packages/plugin-search/src/Search/ui/ReindexButton/index.tsx
@@ -1,3 +1,4 @@
+import type { ResolvedCollectionLabels } from '../../../types.js'
 import type { SearchReindexButtonServerComponent } from './types.js'
 
 import { ReindexButtonClient } from './index.client.js'
@@ -5,28 +6,26 @@ import { ReindexButtonClient } from './index.client.js'
 export const ReindexButton: SearchReindexButtonServerComponent = (props) => {
   const { collectionLabels, i18n, searchCollections, searchSlug } = props
 
-  const getStaticLocalizedPluralLabels = () => {
-    return Object.fromEntries(
-      searchCollections.map((collection) => {
-        const labels = collectionLabels[collection]
-        const pluralLabel = labels?.plural
+  const resolvedCollectionLabels: ResolvedCollectionLabels = Object.fromEntries(
+    searchCollections.map((collection) => {
+      const labels = collectionLabels[collection]
+      const pluralLabel = labels?.plural
 
-        if (typeof pluralLabel === 'function') {
-          return [collection, pluralLabel({ t: i18n.t })]
-        }
+      if (typeof pluralLabel === 'function') {
+        return [collection, pluralLabel({ t: i18n.t })]
+      }
 
-        if (pluralLabel) {
-          return [collection, pluralLabel]
-        }
+      if (pluralLabel) {
+        return [collection, pluralLabel]
+      }
 
-        return [collection, collection]
-      }),
-    )
-  }
+      return [collection, collection]
+    }),
+  )
 
   return (
     <ReindexButtonClient
-      collectionLabels={getStaticLocalizedPluralLabels()}
+      collectionLabels={resolvedCollectionLabels}
       searchCollections={searchCollections}
       searchSlug={searchSlug}
     />

--- a/packages/plugin-search/src/Search/ui/ReindexButton/types.ts
+++ b/packages/plugin-search/src/Search/ui/ReindexButton/types.ts
@@ -1,18 +1,19 @@
-import type { CustomComponent, PayloadServerReactComponent, StaticLabel } from 'payload'
+import type { CustomComponent, PayloadServerReactComponent } from 'payload'
 
-import type { CollectionLabels } from '../../../types.js'
+import type { CollectionLabels, ResolvedCollectionLabels } from '../../../types.js'
 
 export type ReindexButtonProps = {
-  collectionLabels: Record<string, StaticLabel>
+  collectionLabels: ResolvedCollectionLabels
   searchCollections: string[]
   searchSlug: string
 }
 
-type ReindexButtonServerProps = {
+export type ReindexButtonServerProps = {
   collectionLabels: CollectionLabels
-} & ReindexButtonProps
+} & Omit<ReindexButtonProps, 'collectionLabels'>
 
 export type SearchReindexButtonClientComponent = ReindexButtonProps
+
 export type SearchReindexButtonServerComponent = PayloadServerReactComponent<
   CustomComponent<ReindexButtonServerProps>
 >

--- a/packages/plugin-search/src/types.ts
+++ b/packages/plugin-search/src/types.ts
@@ -3,7 +3,6 @@ import type {
   CollectionAfterDeleteHook,
   CollectionConfig,
   Field,
-  LabelFunction,
   Locale,
   Payload,
   PayloadRequest,
@@ -45,10 +44,11 @@ export type SearchPluginConfig = {
 }
 
 export type CollectionLabels = {
-  [collection: string]: {
-    plural?: LabelFunction | StaticLabel
-    singular?: LabelFunction | StaticLabel
-  }
+  [collection: string]: CollectionConfig['labels']
+}
+
+export type ResolvedCollectionLabels = {
+  [collection: string]: StaticLabel
 }
 
 export type SearchPluginConfigWithLocales = {
@@ -62,7 +62,7 @@ export type SyncWithSearchArgs = {
 } & Omit<Parameters<CollectionAfterChangeHook>[0], 'collection'>
 
 export type SyncDocArgs = {
-  locale?: string
+  locale?: Locale['code']
   onSyncError?: () => void
 } & Omit<SyncWithSearchArgs, 'context' | 'previousDoc'>
 


### PR DESCRIPTION
There were a number of areas within the Search Plugin where typings could have been improved, namely:
- The `customProps` sent to the `ReindexButton`. This now uses the `satisfies` keyword to ensure type strictness.
- The `collectionLabels` prop sent to the `ReindexButtonClient` component. This is now standardized behind a new `ResolvedCollectionLabels` type to closely reflect `CollectionLabels`. This was also converted from unnecessarily invoking a function to being a basic object.
- The `locale` type sent through `SyncDocArgs`. This now uses `Locale['code']` from Payload.