### PR TITLE
test: admin list view custom components

### DIFF
--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -156,6 +156,56 @@ describe('List View', () => {
     })
   })
 
+  describe('list view custom components', () => {
+    test('should render custom beforeList component', async () => {
+      await page.goto(postsUrl.list)
+      await expect(
+        page.locator('.collection-list--posts').locator('div', {
+          hasText: exactText('BeforeList custom component'),
+        }),
+      ).toBeVisible()
+    })
+
+    test('should render custom beforeListTable component', async () => {
+      await page.goto(postsUrl.list)
+      await expect(
+        page.locator('.collection-list__wrap').locator('div', {
+          hasText: exactText('BeforeListTable custom component'),
+        }),
+      ).toBeVisible()
+    })
+
+    test('should render custom Cell component in table', async () => {
+      await page.goto(postsUrl.list)
+      await expect(
+        page
+          .locator(`${tableRowLocator} td.cell-demoUIField`)
+          .first()
+          .locator('p', {
+            hasText: exactText('Demo UI Field Cell'),
+          }),
+      ).toBeVisible()
+    })
+
+    test('should render custom afterList component', async () => {
+      await page.goto(postsUrl.list)
+      await expect(
+        page.locator('.collection-list__wrap').locator('div', {
+          hasText: exactText('AfterListTable custom component'),
+        }),
+      ).toBeVisible()
+    })
+
+    test('should render custom afterListTable component', async () => {
+      await page.goto(postsUrl.list)
+      await expect(
+        page.locator('.collection-list--posts').locator('div', {
+          hasText: exactText('AfterList custom component'),
+        }),
+      ).toBeVisible()
+    })
+  })
+
   describe('search', () => {
     test('should prefill search input from query param', async () => {
       await createPost({ title: 'dennis' })


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR adds tests for custom list view components to the existing suite in `admin/e2e/list-view/`. Custom components are already tested in the document-level counterpart, and should be tested here as well.

### Why?
Previously, there were no tests for these list view components. Refactors, features, or changes that impact the importMap, default list view, etc., could affect how these components get rendered. It's safer to have tests in place to catch this as custom list view components, in general, are used quite often.

### How?
This PR adds 5 simple tests that check for the rendering of the following list view components:
- `BeforeList`
- `BeforeListTable`
- `UI Field Cell`
- `AfterList`
- `AfterListTable`