### PR TITLE
docs: explains i18n installation

### DIFF
--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -10,7 +10,7 @@ The [Admin Panel](../admin/overview) is translated in over [30 languages and cou
 
 By default, Payload comes preinstalled with English, but you can easily load other languages into your own application. Languages are automatically detected based on the request. If no language is detected, or if the user's language is not yet supported by your application, English will be chosen.
 
-To configure I18n, use the `i18n` key in your [Payload Config](./overview):
+To configure I18n, install the `@payloadcms/translations` package and use the `i18n` key in your [Payload Config](./overview):
 
 ```ts
 import { buildConfig } from 'payload'

--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -10,7 +10,13 @@ The [Admin Panel](../admin/overview) is translated in over [30 languages and cou
 
 By default, Payload comes preinstalled with English, but you can easily load other languages into your own application. Languages are automatically detected based on the request. If no language is detected, or if the user's language is not yet supported by your application, English will be chosen.
 
-To configure I18n, install the `@payloadcms/translations` package and use the `i18n` key in your [Payload Config](./overview):
+To add I18n to your project, you first need to install the `@payloadcms/translations` package:
+
+```bash
+pnpm install @payloadcms/translations
+```
+
+Once installed, it can be configured using the `i18n` key in your [Payload Config](./overview):
 
 ```ts
 import { buildConfig } from 'payload'


### PR DESCRIPTION
Make it clearer that you need to install `@payloadcms/translations`. I think it would help for new people, especially new programmers.