### PR TITLE
docs: explains i18n language changing

### DIFF
--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -166,7 +166,11 @@ export const Articles: CollectionConfig = {
 }
 ```
 
-## Node
+## Changing Languages
+
+Users can change their preferred language in their account settings.
+
+## Node.js#node
 
 Payload's backend sets the language on incoming requests before they are handled. This allows backend validation to return error messages in the user's own language or system generated emails to be sent using the correct translation. You can make HTTP requests with the `accept-language` header and Payload will use that language.
 
@@ -174,7 +178,7 @@ Anywhere in your Payload app that you have access to the `req` object, you can a
 
 ## TypeScript
 
-In order to use custom translations in your project, you need to provide the types for the translations.
+In order to use [Custom Translations](#custom-translations) in your project, you need to provide the types for the translations.
 
 Here we create a shareable translations object. We will import this in both our custom components and in our Payload config.
 
@@ -253,8 +257,3 @@ const field: Field = {
   ) => t('fields:addLabel'),
 }
 ```
-
-## Changing the Language
-
-Users can change their preferred language in their account settings.
-

--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -168,7 +168,7 @@ export const Articles: CollectionConfig = {
 
 ## Changing Languages
 
-Users can change their preferred language in their account settings.
+Users can change their preferred language in their account settings or by otherwise manipulating their [User Preferences](../admin/preferences).
 
 ## Node.js#node
 

--- a/docs/configuration/i18n.mdx
+++ b/docs/configuration/i18n.mdx
@@ -254,3 +254,7 @@ const field: Field = {
 }
 ```
 
+## Changing the Language
+
+Users can change their preferred language in their account settings.
+


### PR DESCRIPTION
Elaborate how one is supposed to change the admin panel's language because it is not initially clear or trivial to someone new and going through the docs from the start.