### PR TITLE
examples: multi-tenant add all params to tenantsArrayField

### DIFF
--- a/examples/multi-tenant/src/collections/Users/index.ts
+++ b/examples/multi-tenant/src/collections/Users/index.ts
@@ -11,6 +11,8 @@ import { tenantsArrayField } from '@payloadcms/plugin-multi-tenant/fields'
 
 const defaultTenantArrayField = tenantsArrayField({
   tenantsCollectionSlug: 'tenants',
+  tenantsArrayFieldName: 'tenants',
+  tenantsArrayTenantFieldName: 'tenant',
   arrayFieldAccess: {},
   tenantFieldAccess: {},
   rowFields: [

--- a/examples/multi-tenant/src/collections/Users/index.ts
+++ b/examples/multi-tenant/src/collections/Users/index.ts
@@ -10,6 +10,7 @@ import { setCookieBasedOnDomain } from './hooks/setCookieBasedOnDomain'
 import { tenantsArrayField } from '@payloadcms/plugin-multi-tenant/fields'
 
 const defaultTenantArrayField = tenantsArrayField({
+  tenantsCollectionSlug: 'tenants',
   arrayFieldAccess: {},
   tenantFieldAccess: {},
   rowFields: [


### PR DESCRIPTION
### What?

After updating to Payload `v3.20.0`, my app derived from the multi-tenant example started throwing an error:

```
InvalidFieldRelationship: Field Tenant has invalid relationship 'undefined'.
```

A quick search revealed a comment by @janbiasi which pointed out the issue – a missing `tenantsCollectionSlug` in `tenantsArrayField` defined in the Users collection.

Fixes #10874

CC @JarrodMFlesch 
