### PR TITLE
chore(richtext-lexical): improve types of UploadData

### DIFF
--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -15,6 +15,7 @@ export type FileSize = {
 /**
  * FileSize_P4 is a more precise type, and will replace FileSize in Payload v4.
  * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ * @internal
  */
 export type FileSize_P4 = {
   url: null | string

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -9,9 +9,16 @@ export type FileSize = {
   filesize: null | number
   height: null | number
   mimeType: null | string
-  url: null | string
   width: null | number
 }
+
+/**
+ * FileSize_P4 is a more precise type, and will replace FileSize in Payload v4.
+ * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ */
+export type FileSize_P4 = {
+  url: null | string
+} & FileSize
 
 export type FileSizes = {
   [size: string]: FileSize

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -9,6 +9,7 @@ export type FileSize = {
   filesize: null | number
   height: null | number
   mimeType: null | string
+  url: null | string
   width: null | number
 }
 

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -12,12 +12,13 @@ export type FileSize = {
   width: null | number
 }
 
+// TODO: deprecate in Payload v4.
 /**
- * FileSize_P4 is a more precise type, and will replace FileSize in Payload v4.
- * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ * FileSizeImproved is a more precise type, and will replace FileSize in Payload v4.
+ * This type is for internal use only as it will be deprecated in the future.
  * @internal
  */
-export type FileSize_P4 = {
+export type FileSizeImproved = {
   url: null | string
 } & FileSize
 

--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
@@ -1,3 +1,5 @@
+import type { FileSize_P4 } from 'payload'
+
 import type { UploadData_P4 } from '../../../../../../features/upload/server/nodes/UploadNode.js'
 import type { SerializedUploadNode } from '../../../../../../nodeTypes.js'
 import type { JSXConverters } from '../types.js'
@@ -43,7 +45,7 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
 
     // Iterate through each size in the data.sizes object
     for (const size in uploadDocument.value.sizes) {
-      const imageSize = uploadDocument.value.sizes[size]
+      const imageSize = uploadDocument.value.sizes[size] as FileSize_P4
 
       // Skip if any property of the size object is null
       if (

--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
@@ -1,13 +1,13 @@
-import type { FileSize_P4 } from 'payload'
+import type { FileSizeImproved } from 'payload'
 
-import type { UploadData_P4 } from '../../../../../../features/upload/server/nodes/UploadNode.js'
+import type { UploadDataImproved } from '../../../../../../features/upload/server/nodes/UploadNode.js'
 import type { SerializedUploadNode } from '../../../../../../nodeTypes.js'
 import type { JSXConverters } from '../types.js'
 
 export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
   upload: ({ node }) => {
     // TO-DO (v4): SerializedUploadNode should use UploadData_P4
-    const uploadDocument = node as UploadData_P4
+    const uploadDocument = node as UploadDataImproved
     if (typeof uploadDocument.value !== 'object') {
       return null
     }
@@ -45,7 +45,7 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
 
     // Iterate through each size in the data.sizes object
     for (const size in uploadDocument.value.sizes) {
-      const imageSize = uploadDocument.value.sizes[size] as FileSize_P4
+      const imageSize = uploadDocument.value.sizes[size] as FileSizeImproved
 
       // Skip if any property of the size object is null
       if (

--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
@@ -1,23 +1,23 @@
-import type { FileData, FileSize, TypeWithID } from 'payload'
-
+import type { UploadData_P4 } from '../../../../../../features/upload/server/nodes/UploadNode.js'
 import type { SerializedUploadNode } from '../../../../../../nodeTypes.js'
 import type { JSXConverters } from '../types.js'
 
 export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
   upload: ({ node }) => {
-    const uploadDocument: {
-      value?: FileData & TypeWithID
-    } = node as any
-
-    const url = uploadDocument?.value?.url
+    // TO-DO (v4): SerializedUploadNode should use UploadData_P4
+    const uploadDocument = node as UploadData_P4
+    if (typeof uploadDocument.value !== 'object') {
+      return null
+    }
+    const url = uploadDocument.value.url
 
     /**
      * If the upload is not an image, return a link to the upload
      */
-    if (!uploadDocument?.value?.mimeType?.startsWith('image')) {
+    if (!uploadDocument.value.mimeType.startsWith('image')) {
       return (
         <a href={url} rel="noopener noreferrer">
-          {uploadDocument.value?.filename}
+          {uploadDocument.value.filename}
         </a>
       )
     }
@@ -25,13 +25,13 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
     /**
      * If the upload is a simple image with no different sizes, return a simple img tag
      */
-    if (!uploadDocument?.value?.sizes || !Object.keys(uploadDocument?.value?.sizes).length) {
+    if (!Object.keys(uploadDocument.value.sizes).length) {
       return (
         <img
-          alt={uploadDocument?.value?.filename}
-          height={uploadDocument?.value?.height}
+          alt={uploadDocument.value.filename}
+          height={uploadDocument.value.height}
           src={url}
-          width={uploadDocument?.value?.width}
+          width={uploadDocument.value.width}
         />
       )
     }
@@ -42,13 +42,12 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
     const pictureJSX: React.ReactNode[] = []
 
     // Iterate through each size in the data.sizes object
-    for (const size in uploadDocument.value?.sizes) {
-      const imageSize: {
-        url?: string
-      } & FileSize = uploadDocument.value?.sizes[size]
+    for (const size in uploadDocument.value.sizes) {
+      const imageSize = uploadDocument.value.sizes[size]
 
       // Skip if any property of the size object is null
       if (
+        !imageSize ||
         !imageSize.width ||
         !imageSize.height ||
         !imageSize.mimeType ||

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -25,12 +25,13 @@ export type UploadData<TUploadExtraFieldsData extends JsonObject = JsonObject> =
   value: number | string | TypedCollection
 }
 
+// TODO: deprecate in Payload v4.
 /**
- * UploadData_P4 is a more precise type, and will replace UploadData in Payload v4.
- * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ * UploadDataImproved is a more precise type, and will replace UploadData in Payload v4.
+ * This type is for internal use only as it will be deprecated in the future.
  * @internal
  */
-export type UploadData_P4<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
+export type UploadDataImproved<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
   fields: TUploadExtraFieldsData
   // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
   id: string

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -18,16 +18,17 @@ import * as React from 'react'
 
 export type UploadData<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
   fields: TUploadExtraFieldsData
-  // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
+  /** Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document */
   id: string
   relationTo: string
-  // Value can be just the document ID, or the full, populated document
+  /** Value can be just the document ID, or the full, populated document */
   value: number | string | TypedCollection
 }
 
 /**
  * UploadData_P4 is a more precise type, and will replace UploadData in Payload v4.
  * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ * @internal
  */
 export type UploadData_P4<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
   fields: TUploadExtraFieldsData

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -8,7 +8,7 @@ import type {
   NodeKey,
   Spread,
 } from 'lexical'
-import type { CollectionSlug, DataFromCollectionSlug, JsonObject } from 'payload'
+import type { FileData, JsonObject, TypedCollection, TypeWithID } from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
@@ -17,15 +17,26 @@ import { $applyNodeReplacement } from 'lexical'
 import * as React from 'react'
 
 export type UploadData<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
-  [TCollectionSlug in CollectionSlug]: {
-    fields: TUploadExtraFieldsData
-    // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
-    id: string
-    relationTo: TCollectionSlug
-    // Value can be just the document ID, or the full, populated document
-    value: DataFromCollectionSlug<TCollectionSlug> | number | string
-  }
-}[CollectionSlug]
+  fields: TUploadExtraFieldsData
+  // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
+  id: string
+  relationTo: string
+  // Value can be just the document ID, or the full, populated document
+  value: number | string | TypedCollection
+}
+
+/**
+ * UploadData_P4 is a more precise type, and will replace UploadData in Payload v4.
+ * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ */
+export type UploadData_P4<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
+  fields: TUploadExtraFieldsData
+  // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
+  id: string
+  relationTo: string
+  // Value can be just the document ID, or the full, populated document
+  value: (FileData & TypeWithID) | number | string
+}
 
 export function isGoogleDocCheckboxImg(img: HTMLImageElement): boolean {
   return (


### PR DESCRIPTION
One step closer to being able to remove `noUncheckedIndexedAccess` in `packages/richtext-lexical/tsconfig.json`.

I'm introducing UploadData_P4 which is a more precise version of UploadData. I'm doing it as a different type because there's a chance it'll be a breaking change for some users.

UploadData is used in many places, but I'm currently replacing it only in `packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx`, because in the other files it's too rooted to other types like UploadNode.
