### PR TITLE
feat: exposes helpful args to ts schema gen

### DIFF
--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1,6 +1,7 @@
 import type {
   DefaultTranslationKeys,
   DefaultTranslationsObject,
+  I18n,
   I18nClient,
   I18nOptions,
   TFunction,
@@ -1122,7 +1123,16 @@ export type Config = {
      * Allows you to modify the base JSON schema that is generated during generate:types. This JSON schema will be used
      * to generate the TypeScript interfaces.
      */
-    schema?: Array<(args: { jsonSchema: JSONSchema4 }) => JSONSchema4>
+    schema?: Array<
+      (args: {
+        collectionIDFieldTypes: {
+          [key: string]: 'number' | 'string'
+        }
+        config: SanitizedConfig
+        i18n: I18n
+        jsonSchema: JSONSchema4
+      }) => JSONSchema4
+    >
   }
   /**
    * Customize the handling of incoming file uploads for collections that have uploads enabled.

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -1102,7 +1102,7 @@ export function configToJSONSchema(
 
   if (config?.typescript?.schema?.length) {
     for (const schema of config.typescript.schema) {
-      jsonSchema = schema({ jsonSchema })
+      jsonSchema = schema({ collectionIDFieldTypes, config, i18n, jsonSchema })
     }
   }
 


### PR DESCRIPTION
You can currently extend Payload's type generation if you provide additional JSON schema definitions yourself.

But, Payload has helpful functions like `fieldsToJSONSchema` which would be nice to easily re-use.

The only issue is that the `fieldsToJSONSchema` requires arguments which are difficult to access from the context of plugins, etc. They should really be provided at runtime to the `config.typescript.schema` functions.

This PR does exactly that. Adds more args to the `schema` extension point to make utility functions easier to re-use. 