### PR TITLE
docs: fixes dynamic, fully qualified live preview url args

### DIFF
--- a/docs/live-preview/overview.mdx
+++ b/docs/live-preview/overview.mdx
@@ -112,7 +112,7 @@ The following arguments are provided to the `url` function:
 If your application requires a fully qualified URL, such as within deploying to Vercel Preview Deployments, you can use the `req` property to build this URL:
 
 ```ts
-url: (doc, { req }) => `${req.protocol}//${req.host}/${doc.slug}` // highlight-line
+url: ({ data, req }) => `${req.protocol}//${req.host}/${data.slug}` // highlight-line
 ```
 
 ### Breakpoints


### PR DESCRIPTION
The snippet for generating a dynamic, fully qualified live preview url was wrong. It was indicating there were two arguments passed to that function, when in fact there is only one.