### PR TITLE
docs: global upload lean

### DIFF
--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -115,7 +115,7 @@ _An asterisk denotes that an option is required._
 
 Upload options are specifiable on a Collection by Collection basis, you can also control app wide options by passing your base Payload Config an `upload` property containing an object supportive of all `Busboy` configuration options. [Click here](https://github.com/mscdex/busboy#api) for more documentation about what you can control.
 
-A common example of what you might want to customize within Payload-wide Upload options would be to increase the allowed `fileSize` of uploads sent to Payload:
+A common example of what you might want to customize within Payload-wide Upload options would be to increase the allowed `fileSize` of uploads sent to Payload in `payload.config.ts`:
 
 ```ts
 import { buildConfig } from 'payload'


### PR DESCRIPTION
Referencing the payload config file in an line code formatted block is a visual nudge to recognise this is a global option when reading a page about not global options.