### PR TITLE
fix(plugin-search): deleting docs even when there's a published version

### DIFF
--- a/packages/plugin-search/src/types.ts
+++ b/packages/plugin-search/src/types.ts
@@ -42,10 +42,25 @@ export type SearchPluginConfig = {
   defaultPriorities?: {
     [collection: string]: ((doc: any) => number | Promise<number>) | number
   }
+  /**
+   * Controls whether drafts are deleted from the search index
+   *
+   * @default true
+   */
   deleteDrafts?: boolean
   localize?: boolean
+  /**
+   * We use batching when re-indexing large collections. You can control the amount of items per batch, lower numbers should help with memory.
+   *
+   * @default 50
+   */
   reindexBatchSize?: number
   searchOverrides?: { fields?: FieldsOverride } & Partial<Omit<CollectionConfig, 'fields'>>
+  /**
+   * Controls whether drafts are synced to the search index
+   *
+   * @default false
+   */
   syncDrafts?: boolean
 }
 

--- a/test/plugin-search/config.ts
+++ b/test/plugin-search/config.ts
@@ -64,7 +64,7 @@ export default buildConfigWithDefaults({
       searchOverrides: {
         access: {
           // Used for int test
-          delete: ({ req: { user } }) => user.email === devUser.email,
+          delete: ({ req: { user } }) => user?.email === devUser.email,
         },
         fields: ({ defaultFields }) => [
           ...defaultFields,


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/9770

If you had a published document but then created a new draft it would delete the search doc, this PR adds an additional find to check if an existing published doc exists before deleting the search doc.

Also adds a few jsdocs to plugin config