### PR TITLE
fix(richtext-lexical): removes css from jsx converter

### DIFF
--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/list.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/list.tsx
@@ -46,7 +46,11 @@ export const ListJSXConverter: JSXConverters<SerializedListItemNode | Serialized
       )
     } else {
       return (
-        <li className={hasSubLists ? 'nestedListItem' : ''} value={node?.value}>
+        <li
+          className={`${hasSubLists ? 'nestedListItem' : ''}`}
+          style={hasSubLists ? { listStyleType: 'none' } : undefined}
+          value={node?.value}
+        >
           {children}
         </li>
       )

--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/list.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/list.tsx
@@ -29,6 +29,7 @@ export const ListJSXConverter: JSXConverters<SerializedListItemNode | Serialized
           className={`list-item-checkbox${node.checked ? ' list-item-checkbox-checked' : ' list-item-checkbox-unchecked'}${hasSubLists ? ' nestedListItem' : ''}`}
           // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
           role="checkbox"
+          style={{ listStyleType: 'none' }}
           tabIndex={-1}
           value={node?.value}
         >

--- a/packages/richtext-lexical/src/exports/react/components/RichText/index.css
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/index.css
@@ -1,4 +1,0 @@
-.payload-richtext .nestedListItem,
-.payload-richtext .list-check {
-  list-style-type: none;
-}

--- a/packages/richtext-lexical/src/exports/react/components/RichText/index.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/index.tsx
@@ -11,7 +11,6 @@ import type { JSXConverters } from './converter/types.js'
 
 import { defaultJSXConverters } from './converter/defaultConverters.js'
 import { convertLexicalToJSX } from './converter/index.js'
-import './index.css'
 
 export type JSXConvertersFunction<
   T extends { [key: string]: any; type?: string } =


### PR DESCRIPTION
Our new Lexical -> JSX converter is great, but right now it can only be used in environments that support CSS importing / bundling.

It was only that way because of a single import file which can be removed and inlined, therefore, improving the versatility of the JSX converter and making it more usable in a wider variety of runtimes.
