### PR TITLE
feat: add `page` query parameter for `joins`

### DIFF
--- a/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
+++ b/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
@@ -68,6 +68,7 @@ export const buildJoinAggregation = async ({
 
       const {
         limit: limitJoin = join.field.defaultLimit ?? 10,
+        page,
         sort: sortJoin = join.field.defaultSort || collectionConfig.defaultSort,
         where: whereJoin,
       } = joins?.[join.joinPath] || {}
@@ -94,6 +95,12 @@ export const buildJoinAggregation = async ({
           $sort: { [sortProperty]: sortDirection },
         },
       ]
+
+      if (page) {
+        pipeline.push({
+          $skip: (page - 1) * limitJoin,
+        })
+      }
 
       if (limitJoin > 0) {
         pipeline.push({

--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -342,6 +342,7 @@ export const traverseFields = ({
 
         const {
           limit: limitArg = field.defaultLimit ?? 10,
+          page,
           sort = field.defaultSort,
           where,
         } = joinQuery[joinSchemaPath] || {}
@@ -426,6 +427,16 @@ export const traverseFields = ({
             args: [limit],
             method: 'limit',
           })
+        }
+
+        if (page && limit !== 0) {
+          const offset = (page - 1) * limit - 1
+          if (offset > 0) {
+            chainedMethods.push({
+              args: [offset],
+              method: 'offset',
+            })
+          }
         }
 
         const db = adapter.drizzle as LibSQLDatabase

--- a/packages/graphql/src/schema/buildObjectType.ts
+++ b/packages/graphql/src/schema/buildObjectType.ts
@@ -238,6 +238,9 @@ export function buildObjectType({
           limit: {
             type: GraphQLInt,
           },
+          page: {
+            type: GraphQLInt,
+          },
           sort: {
             type: GraphQLString,
           },
@@ -251,7 +254,7 @@ export function buildObjectType({
         },
         async resolve(parent, args, context: Context) {
           const { collection } = field
-          const { limit, sort, where } = args
+          const { limit, page, sort, where } = args
           const { req } = context
 
           const fullWhere = combineQueries(where, {
@@ -265,6 +268,7 @@ export function buildObjectType({
             limit,
             locale: req.locale,
             overrideAccess: false,
+            page,
             req,
             sort,
             where: fullWhere,

--- a/packages/payload/src/database/sanitizeJoinQuery.ts
+++ b/packages/payload/src/database/sanitizeJoinQuery.ts
@@ -3,7 +3,6 @@ import type { JoinQuery, PayloadRequest } from '../types/index.js'
 
 import executeAccess from '../auth/executeAccess.js'
 import { QueryError } from '../errors/QueryError.js'
-import { deepCopyObjectSimple } from '../utilities/deepCopyObject.js'
 import { combineQueries } from './combineQueries.js'
 import { validateQueryPaths } from './queryValidation/validateQueryPaths.js'
 

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -145,6 +145,7 @@ export type JoinQuery<TSlug extends CollectionSlug = string> =
             [K in keyof TypedCollectionJoins[TSlug]]:
               | {
                   limit?: number
+                  page?: number
                   sort?: string
                   where?: Where
                 }

--- a/packages/payload/src/utilities/sanitizeJoinParams.ts
+++ b/packages/payload/src/utilities/sanitizeJoinParams.ts
@@ -27,6 +27,7 @@ export const sanitizeJoinParams = (
     } else {
       joinQuery[schemaPath] = {
         limit: isNumber(joins[schemaPath]?.limit) ? Number(joins[schemaPath].limit) : undefined,
+        page: isNumber(joins[schemaPath]?.page) ? Number(joins[schemaPath].page) : undefined,
         sort: joins[schemaPath]?.sort ? joins[schemaPath].sort : undefined,
         where: joins[schemaPath]?.where ? joins[schemaPath].where : undefined,
       }

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -617,6 +617,46 @@ describe('Joins Field', () => {
       expect(unlimited.docs[0].relatedPosts.hasNextPage).toStrictEqual(false)
     })
 
+    it('should have simple paginate with page for joins', async () => {
+      const query = {
+        depth: 1,
+        where: {
+          name: { equals: 'paginate example' },
+        },
+        joins: {
+          relatedPosts: {
+            sort: 'createdAt',
+            limit: 2,
+            page: 1,
+          },
+        },
+      }
+      let pageWithLimit = await restClient.GET(`/categories`, { query }).then((res) => res.json())
+
+      query.joins.relatedPosts.limit = 0
+      const unlimited = await restClient.GET(`/categories`, { query }).then((res) => res.json())
+
+      expect(pageWithLimit.docs[0].relatedPosts.docs).toHaveLength(2)
+      expect(pageWithLimit.docs[0].relatedPosts.docs[0].id).toBe(
+        unlimited.docs[0].relatedPosts.docs[0].id,
+      )
+      expect(pageWithLimit.docs[0].relatedPosts.docs[1].id).toBe(
+        unlimited.docs[0].relatedPosts.docs[1].id,
+      )
+      query.joins.relatedPosts.limit = 2
+      query.joins.relatedPosts.page = 2
+
+      pageWithLimit = await restClient.GET(`/categories`, { query }).then((res) => res.json())
+
+      expect(pageWithLimit.docs[0].relatedPosts.docs).toHaveLength(2)
+      expect(pageWithLimit.docs[0].relatedPosts.docs[0].id).toBe(
+        unlimited.docs[0].relatedPosts.docs[2].id,
+      )
+      expect(pageWithLimit.docs[0].relatedPosts.docs[1].id).toBe(
+        unlimited.docs[0].relatedPosts.docs[3].id,
+      )
+    })
+
     it('should respect access control for join collections', async () => {
       const { docs } = await payload.find({
         collection: categoriesJoinRestrictedSlug,
@@ -747,6 +787,94 @@ describe('Joins Field', () => {
       expect(unlimited.data.Categories.docs[0].relatedPosts.docs).toHaveLength(15)
       expect(unlimited.data.Categories.docs[0].relatedPosts.docs[0].title).toStrictEqual('test 0')
       expect(unlimited.data.Categories.docs[0].relatedPosts.hasNextPage).toStrictEqual(false)
+    })
+
+    it('should have simple paginate with page for joins', async () => {
+      let queryWithLimit = `query {
+    Categories(where: {
+            name: { equals: "paginate example" }
+          }) {
+          docs {
+            relatedPosts(
+              sort: "createdAt",
+              limit: 2
+            ) {
+              docs {
+                title
+              }
+              hasNextPage
+            }
+          }
+        }
+      }`
+      let pageWithLimit = await restClient
+        .GRAPHQL_POST({ body: JSON.stringify({ query: queryWithLimit }) })
+        .then((res) => res.json())
+
+      const queryUnlimited = `query {
+        Categories(
+          where: {
+            name: { equals: "paginate example" }
+          }
+        ) {
+          docs {
+            relatedPosts(
+              sort: "createdAt",
+              limit: 0
+            ) {
+              docs {
+                title
+                createdAt
+              }
+              hasNextPage
+            }
+          }
+        }
+      }`
+
+      const unlimited = await restClient
+        .GRAPHQL_POST({ body: JSON.stringify({ query: queryUnlimited }) })
+        .then((res) => res.json())
+
+      expect(pageWithLimit.data.Categories.docs[0].relatedPosts.docs).toHaveLength(2)
+      expect(pageWithLimit.data.Categories.docs[0].relatedPosts.docs[0].id).toStrictEqual(
+        unlimited.data.Categories.docs[0].relatedPosts.docs[0].id,
+      )
+      expect(pageWithLimit.data.Categories.docs[0].relatedPosts.docs[1].id).toStrictEqual(
+        unlimited.data.Categories.docs[0].relatedPosts.docs[1].id,
+      )
+
+      expect(pageWithLimit.data.Categories.docs[0].relatedPosts.hasNextPage).toStrictEqual(true)
+
+      queryWithLimit = `query {
+        Categories(where: {
+                name: { equals: "paginate example" }
+              }) {
+              docs {
+                relatedPosts(
+                  sort: "createdAt",
+                  limit: 2,
+                  page: 2,
+                ) {
+                  docs {
+                    title
+                  }
+                  hasNextPage
+                }
+              }
+            }
+          }`
+
+      pageWithLimit = await restClient
+        .GRAPHQL_POST({ body: JSON.stringify({ query: queryWithLimit }) })
+        .then((res) => res.json())
+
+      expect(pageWithLimit.data.Categories.docs[0].relatedPosts.docs[0].id).toStrictEqual(
+        unlimited.data.Categories.docs[0].relatedPosts.docs[2].id,
+      )
+      expect(pageWithLimit.data.Categories.docs[0].relatedPosts.docs[1].id).toStrictEqual(
+        unlimited.data.Categories.docs[0].relatedPosts.docs[3].id,
+      )
     })
 
     it('should have simple paginate for joins inside groups', async () => {


### PR DESCRIPTION
Currently, the join field outputs to its result `hasNextPage: boolean` and have the `limit` query parameter but lacks `page` which can be useful. This PR adds it.