### PR TITLE
fix(ui): allow schedule publish to be accessed without changes

### DIFF
--- a/packages/ui/src/elements/Button/index.tsx
+++ b/packages/ui/src/elements/Button/index.tsx
@@ -57,7 +57,7 @@ export const Button: React.FC<Props> = (props) => {
     className,
     disabled,
     el = 'button',
-    enableSubmenu,
+    enableSubMenu,
     icon,
     iconPosition = 'right',
     iconStyle = 'without-border',
@@ -184,8 +184,8 @@ export const Button: React.FC<Props> = (props) => {
         <Popup
           button={<ChevronIcon />}
           buttonSize={size}
-          className={disabled && !enableSubmenu ? `${baseClass}--popup-disabled` : ''}
-          disabled={disabled && !enableSubmenu}
+          className={disabled && !enableSubMenu ? `${baseClass}--popup-disabled` : ''}
+          disabled={disabled && !enableSubMenu}
           horizontalAlign="right"
           noBackground
           render={({ close }) => SubMenuPopupContent({ close: () => close() })}

--- a/packages/ui/src/elements/Button/index.tsx
+++ b/packages/ui/src/elements/Button/index.tsx
@@ -67,6 +67,7 @@ export const Button: React.FC<Props> = (props) => {
     ref,
     round,
     size = 'medium',
+    subMenuOverrideDisabled,
     SubMenuPopupContent,
     to,
     tooltip,
@@ -183,8 +184,8 @@ export const Button: React.FC<Props> = (props) => {
         <Popup
           button={<ChevronIcon />}
           buttonSize={size}
-          className={disabled ? `${baseClass}--popup-disabled` : ''}
-          disabled={disabled}
+          className={disabled && !subMenuOverrideDisabled ? `${baseClass}--popup-disabled` : ''}
+          disabled={disabled && !subMenuOverrideDisabled}
           horizontalAlign="right"
           noBackground
           render={({ close }) => SubMenuPopupContent({ close: () => close() })}

--- a/packages/ui/src/elements/Button/index.tsx
+++ b/packages/ui/src/elements/Button/index.tsx
@@ -57,6 +57,7 @@ export const Button: React.FC<Props> = (props) => {
     className,
     disabled,
     el = 'button',
+    enableSubmenu,
     icon,
     iconPosition = 'right',
     iconStyle = 'without-border',
@@ -67,7 +68,6 @@ export const Button: React.FC<Props> = (props) => {
     ref,
     round,
     size = 'medium',
-    subMenuOverrideDisabled,
     SubMenuPopupContent,
     to,
     tooltip,
@@ -184,8 +184,8 @@ export const Button: React.FC<Props> = (props) => {
         <Popup
           button={<ChevronIcon />}
           buttonSize={size}
-          className={disabled && !subMenuOverrideDisabled ? `${baseClass}--popup-disabled` : ''}
-          disabled={disabled && !subMenuOverrideDisabled}
+          className={disabled && !enableSubmenu ? `${baseClass}--popup-disabled` : ''}
+          disabled={disabled && !enableSubmenu}
           horizontalAlign="right"
           noBackground
           render={({ close }) => SubMenuPopupContent({ close: () => close() })}

--- a/packages/ui/src/elements/Button/types.ts
+++ b/packages/ui/src/elements/Button/types.ts
@@ -34,6 +34,10 @@ export type Props = {
   round?: boolean
   secondaryActions?: secondaryAction | secondaryAction[]
   size?: 'large' | 'medium' | 'small'
+  /**
+   * Allow the submenu to be opened when the button is disabled
+   */
+  subMenuOverrideDisabled?: boolean
   SubMenuPopupContent?: (props: { close: () => void }) => React.ReactNode
   to?: string
   tooltip?: string

--- a/packages/ui/src/elements/Button/types.ts
+++ b/packages/ui/src/elements/Button/types.ts
@@ -17,7 +17,7 @@ export type Props = {
   /**
    * Setting to `true` will allow the submenu to be opened when the button is disabled
    */
-  enableSubmenu?: boolean
+  enableSubMenu?: boolean
   icon?: ['chevron' | 'edit' | 'plus' | 'x'] | React.ReactNode
   iconPosition?: 'left' | 'right'
   iconStyle?: 'none' | 'with-border' | 'without-border'

--- a/packages/ui/src/elements/Button/types.ts
+++ b/packages/ui/src/elements/Button/types.ts
@@ -14,6 +14,10 @@ export type Props = {
   className?: string
   disabled?: boolean
   el?: 'anchor' | 'link' | ElementType
+  /**
+   * Setting to `true` will allow the submenu to be opened when the button is disabled
+   */
+  enableSubmenu?: boolean
   icon?: ['chevron' | 'edit' | 'plus' | 'x'] | React.ReactNode
   iconPosition?: 'left' | 'right'
   iconStyle?: 'none' | 'with-border' | 'without-border'
@@ -34,10 +38,6 @@ export type Props = {
   round?: boolean
   secondaryActions?: secondaryAction | secondaryAction[]
   size?: 'large' | 'medium' | 'small'
-  /**
-   * Allow the submenu to be opened when the button is disabled
-   */
-  subMenuOverrideDisabled?: boolean
   SubMenuPopupContent?: (props: { close: () => void }) => React.ReactNode
   to?: string
   tooltip?: string

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -197,7 +197,7 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
       <FormSubmit
         buttonId="action-save"
         disabled={!canPublish}
-        enableSubmenu={canSchedulePublish}
+        enableSubMenu={canSchedulePublish}
         onClick={defaultPublish}
         size="medium"
         SubMenuPopupContent={

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -199,6 +199,7 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
         disabled={!canPublish}
         onClick={defaultPublish}
         size="medium"
+        subMenuOverrideDisabled={canSchedulePublish}
         SubMenuPopupContent={
           localization || canSchedulePublish
             ? ({ close }) => {
@@ -211,7 +212,7 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
                         </PopupList.Button>
                       </PopupList.ButtonGroup>
                     )}
-                    {localization && (
+                    {localization && canPublish && (
                       <PopupList.ButtonGroup>
                         <PopupList.Button onClick={secondaryPublish}>
                           {secondaryLabel}

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -197,9 +197,9 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
       <FormSubmit
         buttonId="action-save"
         disabled={!canPublish}
+        enableSubmenu={canSchedulePublish}
         onClick={defaultPublish}
         size="medium"
-        subMenuOverrideDisabled={canSchedulePublish}
         SubMenuPopupContent={
           localization || canSchedulePublish
             ? ({ close }) => {


### PR DESCRIPTION
### What?
Using the versions drafts feature and scheduling publish jobs, the UI does not allow you to open the schedule publish drawer when the document has been published already.

### Why?
Because of this you cannot schedule unpublish, unless as a user you modify a form field as a workaround before clicking the publish submenu.

### How?
This change extends the Button props to include subMenuDisableOverride allowing the schedule publish submenu to still be used on even when the form is not modified.

Before: 
![image](https://github.com/user-attachments/assets/a69f2e39-d74e-476c-9744-2b8523e2b831)


With changes:
![Animation](https://github.com/user-attachments/assets/0a13fe33-974c-402b-8464-6ef2cb397d86)
