### PR TITLE
fix(ui): unsaved changes allows for scheduled publish missing changes

### DIFF
--- a/packages/ui/src/elements/Button/index.tsx
+++ b/packages/ui/src/elements/Button/index.tsx
@@ -187,6 +187,7 @@ export const Button: React.FC<Props> = (props) => {
           className={disabled && !enableSubMenu ? `${baseClass}--popup-disabled` : ''}
           disabled={disabled && !enableSubMenu}
           horizontalAlign="right"
+          id={`${id}-popup`}
           noBackground
           render={({ close }) => SubMenuPopupContent({ close: () => close() })}
           size="large"

--- a/packages/ui/src/elements/Button/types.ts
+++ b/packages/ui/src/elements/Button/types.ts
@@ -38,10 +38,6 @@ export type Props = {
   round?: boolean
   secondaryActions?: secondaryAction | secondaryAction[]
   size?: 'large' | 'medium' | 'small'
-  /**
-   * Allow the submenu to be opened when the button is disabled
-   */
-  subMenuOverrideDisabled?: boolean
   SubMenuPopupContent?: (props: { close: () => void }) => React.ReactNode
   to?: string
   tooltip?: string

--- a/packages/ui/src/elements/Button/types.ts
+++ b/packages/ui/src/elements/Button/types.ts
@@ -38,6 +38,10 @@ export type Props = {
   round?: boolean
   secondaryActions?: secondaryAction | secondaryAction[]
   size?: 'large' | 'medium' | 'small'
+  /**
+   * Allow the submenu to be opened when the button is disabled
+   */
+  subMenuOverrideDisabled?: boolean
   SubMenuPopupContent?: (props: { close: () => void }) => React.ReactNode
   to?: string
   tooltip?: string

--- a/packages/ui/src/elements/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/elements/DatePicker/DatePicker.tsx
@@ -19,6 +19,7 @@ const baseClass = 'date-time-picker'
 
 const DatePicker: React.FC<Props> = (props) => {
   const {
+    id,
     displayFormat: customDisplayFormat,
     maxDate,
     maxTime,
@@ -113,7 +114,7 @@ const DatePicker: React.FC<Props> = (props) => {
   }, [i18n.language, i18n.dateFNS])
 
   return (
-    <div className={classes}>
+    <div className={classes} id={id}>
       <div className={`${baseClass}__icon-wrap`}>
         {dateTimePickerProps.selected && (
           <button

--- a/packages/ui/src/elements/DatePicker/types.ts
+++ b/packages/ui/src/elements/DatePicker/types.ts
@@ -1,6 +1,7 @@
 import type { DayPickerProps, SharedProps, TimePickerProps } from 'payload'
 
 export type Props = {
+  id?: string
   onChange?: (val: Date) => void
   placeholder?: string
   readOnly?: boolean

--- a/packages/ui/src/elements/Popup/index.tsx
+++ b/packages/ui/src/elements/Popup/index.tsx
@@ -25,6 +25,7 @@ export type PopupProps = {
   disabled?: boolean
   forceOpen?: boolean
   horizontalAlign?: 'center' | 'left' | 'right'
+  id?: string
   initActive?: boolean
   noBackground?: boolean
   onToggleOpen?: (active: boolean) => void
@@ -37,6 +38,7 @@ export type PopupProps = {
 
 export const Popup: React.FC<PopupProps> = (props) => {
   const {
+    id,
     boundingRef,
     button,
     buttonClassName,
@@ -168,7 +170,7 @@ export const Popup: React.FC<PopupProps> = (props) => {
     .join(' ')
 
   return (
-    <div className={classes}>
+    <div className={classes} id={id}>
       <div className={`${baseClass}__trigger-wrap`}>
         {showOnHover ? (
           <div

--- a/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
+++ b/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
@@ -34,6 +34,7 @@ import './index.scss'
 const baseClass = 'schedule-publish'
 
 type Props = {
+  defaultType?: PublishType
   slug: string
 }
 
@@ -42,7 +43,7 @@ const defaultLocaleOption = {
   value: 'all',
 }
 
-export const ScheduleDrawer: React.FC<Props> = ({ slug }) => {
+export const ScheduleDrawer: React.FC<Props> = ({ slug, defaultType }) => {
   const { toggleModal } = useModal()
   const {
     config: {
@@ -55,7 +56,7 @@ export const ScheduleDrawer: React.FC<Props> = ({ slug }) => {
   const { id, collectionSlug, globalSlug, title } = useDocumentInfo()
   const { i18n, t } = useTranslation()
   const { schedulePublish } = useServerFunctions()
-  const [type, setType] = React.useState<PublishType>('publish')
+  const [type, setType] = React.useState<PublishType>(defaultType || 'publish')
   const [date, setDate] = React.useState<Date>()
   const [locale, setLocale] = React.useState<{ label: string; value: string }>(defaultLocaleOption)
   const [processing, setProcessing] = React.useState(false)

--- a/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
+++ b/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
@@ -250,8 +250,9 @@ export const ScheduleDrawer: React.FC<Props> = ({ slug, defaultType }) => {
           </li>
         </ul>
         <br />
-        <FieldLabel label={t('general:time')} required />
+        <FieldLabel label={t('general:time')} path={'time'} required />
         <DatePickerField
+          id="time"
           minDate={new Date()}
           onChange={(e) => setDate(e)}
           pickerAppearance="dayAndTime"
@@ -272,7 +273,13 @@ export const ScheduleDrawer: React.FC<Props> = ({ slug, defaultType }) => {
           </React.Fragment>
         )}
         <div className={`${baseClass}__actions`}>
-          <Button buttonStyle="primary" disabled={processing} onClick={handleSave} type="button">
+          <Button
+            buttonStyle="primary"
+            disabled={processing}
+            id="scheduled-publish-save"
+            onClick={handleSave}
+            type="button"
+          >
             {t('general:save')}
           </Button>
           {processing ? <span>{t('general:saving')}</span> : null}

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -210,7 +210,10 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
                   <React.Fragment>
                     {canSchedulePublish && (
                       <PopupList.ButtonGroup key="schedule-publish">
-                        <PopupList.Button onClick={() => [toggleModal(drawerSlug), close()]}>
+                        <PopupList.Button
+                          id="schedule-publish"
+                          onClick={() => [toggleModal(drawerSlug), close()]}
+                        >
                           {t('version:schedulePublish')}
                         </PopupList.Button>
                       </PopupList.ButtonGroup>

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -71,7 +71,10 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
     entityConfig?.versions?.drafts.schedulePublish
 
   const canSchedulePublish = Boolean(
-    scheduledPublishEnabled && hasPublishPermission && (globalSlug || (collectionSlug && id)),
+    scheduledPublishEnabled &&
+      hasPublishPermission &&
+      (globalSlug || (collectionSlug && id)) &&
+      !modified,
   )
 
   const operation = useOperation()

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -232,7 +232,12 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
       >
         {localization ? defaultLabel : label}
       </FormSubmit>
-      {canSchedulePublish && isModalOpen(drawerSlug) && <ScheduleDrawer slug={drawerSlug} />}
+      {canSchedulePublish && isModalOpen(drawerSlug) && (
+        <ScheduleDrawer
+          defaultType={!hasNewerVersions ? 'unpublish' : 'publish'}
+          slug={drawerSlug}
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -200,6 +200,7 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
         enableSubMenu={canSchedulePublish}
         onClick={defaultPublish}
         size="medium"
+        subMenuOverrideDisabled={canSchedulePublish}
         SubMenuPopupContent={
           localization || canSchedulePublish
             ? ({ close }) => {

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -203,7 +203,6 @@ export const PublishButton: React.FC<{ label?: string }> = ({ label: labelProp }
         enableSubMenu={canSchedulePublish}
         onClick={defaultPublish}
         size="medium"
-        subMenuOverrideDisabled={canSchedulePublish}
         SubMenuPopupContent={
           localization || canSchedulePublish
             ? ({ close }) => {

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -686,6 +686,49 @@ describe('Versions', () => {
       expect(versionsTabUpdated).toBeTruthy()
     })
   })
+
+  describe('Scheduled publish', () => {
+    beforeAll(() => {
+      url = new AdminUrlUtil(serverURL, draftCollectionSlug)
+    })
+
+    test('should schedule publish', async () => {
+      await page.goto(url.create)
+      await page.waitForURL(url.create)
+      await page.locator('#field-title').fill('scheduled publish')
+      await page.locator('#field-description').fill('scheduled publish description')
+
+      // schedule publish should not be available before document has been saved
+      await page.locator('#action-save-popup').click()
+      await expect(page.locator('#schedule-publish')).not.toBeVisible()
+
+      // save draft then try to schedule publish
+      await saveDocAndAssert(page)
+      await page.locator('#action-save-popup').click()
+      await page.locator('#schedule-publish').click()
+
+      // drawer should open
+      await expect(page.locator('.schedule-publish__drawer-header')).toBeVisible()
+      // nothing in scheduled
+      await expect(page.locator('.drawer__content')).toContainText('No upcoming events scheduled.')
+
+      // set date and time
+      await page.locator('.date-time-picker input').fill('Feb 21, 2050 12:00 AM')
+      await page.keyboard.press('Enter')
+
+      // save the scheduled publish
+      await page.locator('#scheduled-publish-save').click()
+
+      // delete the scheduled event after it was made
+      await page.locator('.cell-delete').locator('.btn').click()
+
+      // see toast deleted successfully
+      await expect(
+        page.locator('.payload-toast-item:has-text("Deleted successfully.")'),
+      ).toBeVisible()
+    })
+  })
+
   describe('Collections - publish specific locale', () => {
     beforeAll(() => {
       url = new AdminUrlUtil(serverURL, localizedCollectionSlug)


### PR DESCRIPTION
### What?
When you first edit a document and then open the Schedule publish drawer, you can schedule publish changes but the current changes made to the form won't be included.

### Why?
The UX does not make it clear that the changes you have in the form are not actually going to be published.

### How?
Instead of allowing that we just disable the Schedule Publish drawer toggler so that users are forced to save a draft first.

In addition to the above, this change also passes a defaultType so that an already published document will default the radio type have "Unpublish" selected.