### PR TITLE
fix(next): viewing modified-only diff view containing localized arrays throws error

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
@@ -113,7 +113,7 @@ export const buildVersionFields = ({
       versionField.fieldByLocale = {}
 
       for (const locale of selectedLocales) {
-        versionField.fieldByLocale[locale] = buildVersionField({
+        const localizedVersionField = buildVersionField({
           clientField: clientField as ClientField,
           clientSchemaMap,
           comparisonValue: comparisonValue?.[locale],
@@ -133,12 +133,12 @@ export const buildVersionFields = ({
           selectedLocales,
           versionValue: versionValue?.[locale],
         })
-        if (!versionField.fieldByLocale[locale]) {
-          continue
+        if (localizedVersionField) {
+          versionField.fieldByLocale[locale] = localizedVersionField
         }
       }
     } else {
-      versionField.field = buildVersionField({
+      const baseVersionField = buildVersionField({
         clientField: clientField as ClientField,
         clientSchemaMap,
         comparisonValue,
@@ -158,8 +158,8 @@ export const buildVersionFields = ({
         versionValue,
       })
 
-      if (!versionField.field) {
-        continue
+      if (baseVersionField) {
+        versionField.field = baseVersionField
       }
     }
 

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -960,6 +960,18 @@ describe('Versions', () => {
       )
     })
 
+    test('correctly renders modified-only diff for localized array fields', async () => {
+      await navigateToVersionFieldsDiff()
+
+      const textInArrayES = page.locator('[data-field-path="arrayLocalized"][data-locale="es"]')
+
+      await expect(textInArrayES).toContainText('No Array Localizeds found')
+
+      await page.locator('#modifiedOnly').click()
+
+      await expect(textInArrayES).toBeHidden()
+    })
+
     test('correctly renders diff for block fields', async () => {
       await navigateToVersionFieldsDiff()
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11002

`buildVersionFields` was adding `null` version fields to the version fields array. When RenderVersionFieldsToDiff tried to render those, it threw an error.

This PR ensures no `null` fields are added, as `RenderVersionFieldsToDiff` can't process them. That way, those fields are properly skipped, which is the intent of `modifiedOnly`