### PR TITLE
fix(db-postgres): querying with `in: []` returns empty result

### DIFF
--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -89,7 +89,7 @@ export const sanitizeQueryValue = ({
       }
     }
 
-    if (!Array.isArray(formattedValue) || formattedValue.length === 0) {
+    if (!Array.isArray(formattedValue)) {
       return null
     }
   }

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -2984,6 +2984,7 @@ describe('Fields', () => {
       })
 
       expect(query.docs).toBeDefined()
+      expect(query.docs).toEqual([])
     })
   })
 

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -1164,19 +1164,23 @@ describe('Versions', () => {
           and: [
             {
               id: {
-                not_in: allDocs.docs[0].id,
+                not_in: [allDocs.docs[0].id],
               },
             },
             {
-              title: {
-                like: 'Published',
+              radio: {
+                exists: true,
               },
             },
           ],
         },
       })
 
-      expect(results.docs).toHaveLength(1)
+      const manuallyFiltered = allDocs.docs
+        .filter((doc) => doc.id !== allDocs.docs[0].id)
+        .filter((doc) => Boolean(doc.radio))
+
+      expect(results.docs).toEqual(manuallyFiltered)
     })
   })
 


### PR DESCRIPTION
There was an issue with relational databases where, when an empty array was used as a value for the IN operator, the constraint was being ignored. Fixes #10788

I investigated this issue and found that, in the past, Drizzle's inArray operator would throw an error when it received an empty array. Because of this behavior, the Payload server would crash when handling queries with in: []. To address this, the following commit was made: https://github.com/payloadcms/payload/commit/c4ac341d75b6c057f66b60934b4b642b94298efc.

However, this approach resulted in the constraint being ignored, which is not the ideal behavior. The Drizzle community discussed the expected behavior of the inArray operator (see: https://github.com/drizzle-team/drizzle-orm/issues/1295), and the team decided to modify it to accept empty arrays instead of throwing an error.

With this change, simply removing the unnecessary check resolves the issue.

After making this fix, one of the tests failed because it was using the not_in operator. I also updated the test to reflect the new behavior.
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
