### PR TITLE
fix(storage-s3): sockets not closing

### DIFF
--- a/packages/storage-s3/src/staticHandler.ts
+++ b/packages/storage-s3/src/staticHandler.ts
@@ -1,6 +1,7 @@
 import type * as AWS from '@aws-sdk/client-s3'
 import type { StaticHandler } from '@payloadcms/plugin-cloud-storage/types'
 import type { CollectionConfig } from 'payload'
+import type { Readable } from 'stream'
 
 import { getFilePrefix } from '@payloadcms/plugin-cloud-storage/utilities'
 import path from 'path'
@@ -9,6 +10,18 @@ interface Args {
   bucket: string
   collection: CollectionConfig
   getStorageClient: () => AWS.S3
+}
+
+// Type guard for NodeJS.Readable streams
+const isNodeReadableStream = (body: unknown): body is Readable => {
+  return (
+    typeof body === 'object' &&
+    body !== null &&
+    'pipe' in body &&
+    typeof (body as any).pipe === 'function' &&
+    'destroy' in body &&
+    typeof (body as any).destroy === 'function'
+  )
 }
 
 // Convert a stream into a promise that resolves with a Buffer
@@ -39,7 +52,7 @@ export const getHandler = ({ bucket, collection, getStorageClient }: Args): Stat
       const objectEtag = object.ETag
 
       if (etagFromHeaders && etagFromHeaders === objectEtag) {
-        return new Response(null, {
+        const response = new Response(null, {
           headers: new Headers({
             'Accept-Ranges': String(object.AcceptRanges),
             'Content-Length': String(object.ContentLength),
@@ -47,6 +60,22 @@ export const getHandler = ({ bucket, collection, getStorageClient }: Args): Stat
             ETag: String(object.ETag),
           }),
           status: 304,
+        })
+
+        // Manually destroy stream before returning cached results to close socket
+        if (object.Body && isNodeReadableStream(object.Body)) {
+          object.Body.destroy()
+        }
+
+        return response
+      }
+
+      // On error, manually destroy stream to close socket
+      if (object.Body && isNodeReadableStream(object.Body)) {
+        const stream = object.Body
+        stream.on('error', (err) => {
+          console.error(err)
+          stream.destroy()
         })
       }
 


### PR DESCRIPTION
### What?
Within collections using the `storage-s3` plugins, we eventually start receiving the following warnings:

`@smithy/node-http-handler:WARN socket usage at capacity=50 and 156 additional requests are enqueued. See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler config.`

Also referenced in this issue: #6382

The [solution](https://github.com/payloadcms/payload/issues/6382#issuecomment-2325468104) provided by @denolfe in that issue only delayed the reappearance of the problem somewhat, but did not resolve it.

### Why?
As far as I understand, in the `staticHandler` of the plugin, when getting items from storage, and they are currently cached, the cached results are immediately returned without handling the stream. As per [this](https://github.com/aws/aws-sdk-js-v3/blob/main/supplemental-docs/CLIENTS.md#nodejs-requesthandler) entry in the aws-sdk docs, if the streaming response is not read, or manually destroyed, a socket might not properly close. 

### How?
Before returning the cached items, manually destroy the streaming response to make certain the socket is being properly closed.
Additionally, add an error check to also consume/destroy the streaming response in case an error occurs, to not leave orphaned sockets.

Fixes #6382
