### PR TITLE
fix(plugin-multi-tenant): correctly set doc default value on load

### DIFF
--- a/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantField/index.client.tsx
@@ -24,15 +24,21 @@ export const TenantField = (args: Props) => {
   const hasSetValueRef = React.useRef(false)
 
   React.useEffect(() => {
-    if (!hasSetValueRef.current && value) {
+    if (!hasSetValueRef.current) {
       // set value on load
-      setTenant({ id: value, refresh: unique })
+      if (value && value !== selectedTenantID) {
+        setTenant({ id: value, refresh: unique })
+      } else {
+        // in the document view, the tenant field should always have a value
+        const defaultValue =
+          !selectedTenantID || selectedTenantID === SELECT_ALL
+            ? options[0]?.value
+            : selectedTenantID
+        setTenant({ id: defaultValue, refresh: unique })
+      }
       hasSetValueRef.current = true
-    } else if (selectedTenantID && selectedTenantID === SELECT_ALL && options?.[0]?.value) {
-      // in the document view, the tenant field should always have a value
-      setTenant({ id: options[0].value, refresh: unique })
-    } else if ((!value || value !== selectedTenantID) && selectedTenantID) {
-      // Update the field value when the tenant is changed
+    } else if ((!value || value !== selectedTenantID) && selectedTenantID !== SELECT_ALL) {
+      // Update the field on the document value when the tenant is changed
       setValue(selectedTenantID)
     }
   }, [value, selectedTenantID, setTenant, setValue, options, unique])


### PR DESCRIPTION
When navigating from the list view, with no tenant selected, the document would load and set the hidden tenant field to the first tenant option.

This was caused by incorrect logic inside the TenantField useEffect that sets the value on the field upon load.
