### PR TITLE
refactor: do not use description functions for generated types JSDocs

### DIFF
--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -217,7 +217,9 @@ function entityOrFieldToJsDocs({
         description = entity?.admin?.description?.[i18n.language]
       }
     } else if (typeof entity?.admin?.description === 'function' && i18n) {
-      description = entity?.admin?.description(i18n)
+      // do not evaluate description functions for generating JSDocs. The output of
+      // those can differ depending on where and when they are called, creating
+      // inconsistencies in the generated JSDocs.
     }
   }
   return description


### PR DESCRIPTION
In https://github.com/payloadcms/payload/pull/9917 we automatically added `admin.description` as JSDocs to our generated types.

If a function was passed as a description, this could have created unnecessary noise in the generated types, as the output of the description function may differ depending on where and when it's executed.

Example:

```ts
description: () => {
  return `Current date: ${new Date().toString()}`
}
```

This PR disabled evaluating description functions for JSDocs generation