### PR TITLE
fix(db-mongodb): remove duplicative indexing of timestamps

### DIFF
--- a/packages/db-mongodb/src/models/buildCollectionSchema.ts
+++ b/packages/db-mongodb/src/models/buildCollectionSchema.ts
@@ -34,11 +34,6 @@ export const buildCollectionSchema = (
     schema.index(indexDefinition, { unique: true })
   }
 
-  if (payload.config.indexSortableFields && collection.timestamps !== false) {
-    schema.index({ updatedAt: 1 })
-    schema.index({ createdAt: 1 })
-  }
-
   schema
     .plugin<any, PaginateOptions>(paginate, { useEstimatedCount: true })
     .plugin(getBuildQueryPlugin({ collectionSlug: collection.slug }))


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR removes a pair unnecessary calls to `schema.index` against the timestamp fields. The issue is when a user sets `indexSortableFields` as this is what will ultimately pass the predicate which then creates duplicate indexes.

### Why?
These calls are redundant as `index` is [already passed](https://github.com/payloadcms/payload/blob/main/packages/db-mongodb/src/models/buildSchema.ts#L69) to the underlying fields base schema options in the process of formatting and will already be indexed.

These warnings were surfaced after the bump to mongoose to version 8.9.5 as [in 8.9.3 mongoose began throwing these warnings to indicate duplicative indexes](https://github.com/Automattic/mongoose/releases/tag/8.9.3).

### How?
By removing these calls and, as a result, silencing the warnings thrown by mongoose.