### PR TITLE
chore: consistent naming for listControlsMenu

### DIFF
--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -209,7 +209,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'general:loading',
   'general:locale',
   'general:menu',
-  'general:listControlMenu',
+  'general:listControlsMenu',
   'general:moveDown',
   'general:moveUp',
   'general:next',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -261,7 +261,7 @@ export const arTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'المغادرة على أي حال',
     leaveWithoutSaving: 'المغادرة بدون حفظ',
     light: 'فاتح',
-    listControlMenu: 'قائمة التحكم',
+    listControlsMenu: 'قائمة التحكم',
     livePreview: 'معاينة مباشرة',
     loading: 'يتمّ التّحميل',
     locale: 'اللّغة',

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -265,7 +265,7 @@ export const azTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Heç olmasa çıx',
     leaveWithoutSaving: 'Saxlamadan çıx',
     light: 'Açıq',
-    listControlMenu: 'Siyahı nəzarət menyusu',
+    listControlsMenu: 'Siyahı nəzarət menyusu',
     livePreview: 'Öncədən baxış',
     loading: 'Yüklənir',
     locale: 'Lokal',

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -264,7 +264,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Напусни въпреки това',
     leaveWithoutSaving: 'Напусни без да запазиш',
     light: 'Светла',
-    listControlMenu: 'Меню за контрол на списъка',
+    listControlsMenu: 'Меню за контрол на списъка',
     livePreview: 'Предварителен преглед',
     loading: 'Зарежда се',
     locale: 'Локализация',

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -265,7 +265,7 @@ export const caTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Deixa-ho de totes maneres',
     leaveWithoutSaving: 'Deixa sense desar',
     light: 'Clar',
-    listControlMenu: 'Menú de control de llista',
+    listControlsMenu: 'Menú de control de llista',
     livePreview: 'Previsualització en viu',
     loading: 'Carregant',
     locale: 'Idioma',

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -263,7 +263,7 @@ export const csTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Přesto odejít',
     leaveWithoutSaving: 'Odejít bez uložení',
     light: 'Světlé',
-    listControlMenu: 'Nabídka ovládání seznamu',
+    listControlsMenu: 'Nabídka ovládání seznamu',
     livePreview: 'Náhled',
     loading: 'Načítání',
     locale: 'Místní verze',

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -263,7 +263,7 @@ export const daTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Forlad alligevel',
     leaveWithoutSaving: 'Forlad uden at gemme',
     light: 'Lys',
-    listControlMenu: 'Kontrolmenu for liste',
+    listControlsMenu: 'Kontrolmenu for liste',
     livePreview: 'Live-forhåndsvisning',
     loading: 'Loader',
     locale: 'Lokalitet',

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -269,7 +269,7 @@ export const deTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Trotzdem verlassen',
     leaveWithoutSaving: 'Ohne speichern verlassen',
     light: 'Hell',
-    listControlMenu: 'Kontrollmenü auflisten',
+    listControlsMenu: 'Kontrollmenü auflisten',
     livePreview: 'Vorschau',
     loading: 'Lädt',
     locale: 'Sprache',

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -265,7 +265,7 @@ export const enTranslations = {
     leaveAnyway: 'Leave anyway',
     leaveWithoutSaving: 'Leave without saving',
     light: 'Light',
-    listControlMenu: 'List control menu',
+    listControlsMenu: 'List control menu',
     livePreview: 'Live Preview',
     loading: 'Loading',
     locale: 'Locale',

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -269,7 +269,7 @@ export const esTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Salir de todos modos',
     leaveWithoutSaving: 'Salir sin guardar',
     light: 'Claro',
-    listControlMenu: 'Menú de control de lista',
+    listControlsMenu: 'Menú de control de lista',
     livePreview: 'Previsualizar',
     loading: 'Cargando',
     locale: 'Regional',

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -262,7 +262,7 @@ export const etTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Lahku ikkagi',
     leaveWithoutSaving: 'Lahku ilma salvestamata',
     light: 'Hele',
-    listControlMenu: 'Loendikontrolli menüü',
+    listControlsMenu: 'Loendikontrolli menüü',
     livePreview: 'Reaalajas eelvaade',
     loading: 'Laadimine',
     locale: 'Keel',

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -263,7 +263,7 @@ export const faTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'به هر حال ترک کن',
     leaveWithoutSaving: 'ترک کردن بدون ذخیره',
     light: 'روشن',
-    listControlMenu: 'منوی کنترل لیست',
+    listControlsMenu: 'منوی کنترل لیست',
     livePreview: 'پیش‌نمایش',
     loading: 'در حال بارگذاری',
     locale: 'زبان',

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -272,7 +272,7 @@ export const frTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Quitter quand même',
     leaveWithoutSaving: 'Quitter sans sauvegarder',
     light: 'Clair',
-    listControlMenu: 'Menu de contrôle de liste',
+    listControlsMenu: 'Menu de contrôle de liste',
     livePreview: 'Aperçu',
     loading: 'Chargement en cours',
     locale: 'Paramètres régionaux',

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -259,7 +259,7 @@ export const heTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'צא בכל זאת',
     leaveWithoutSaving: 'צא מבלי לשמור',
     light: 'בהיר',
-    listControlMenu: 'תפריט בקרת רשימה',
+    listControlsMenu: 'תפריט בקרת רשימה',
     livePreview: 'תצוגה מקדימה חיה',
     loading: 'טוען',
     locale: 'שפה',

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -265,7 +265,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Svejedno napusti',
     leaveWithoutSaving: 'Napusti bez spremanja',
     light: 'Svijetlo',
-    listControlMenu: 'Izbornik za kontrolu popisa',
+    listControlsMenu: 'Izbornik za kontrolu popisa',
     livePreview: 'Pregled',
     loading: 'Učitavanje',
     locale: 'Jezik',

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -267,7 +267,7 @@ export const huTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Távozás mindenképp',
     leaveWithoutSaving: 'Távozás mentés nélkül',
     light: 'Világos',
-    listControlMenu: 'Lista vezérlő menü',
+    listControlsMenu: 'Lista vezérlő menü',
     livePreview: 'Előnézet',
     loading: 'Betöltés',
     locale: 'Nyelv',

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -268,7 +268,7 @@ export const itTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Esci comunque',
     leaveWithoutSaving: 'Esci senza salvare',
     light: 'Chiaro',
-    listControlMenu: 'Menu di controllo elenco',
+    listControlsMenu: 'Menu di controllo elenco',
     livePreview: 'Anteprima dal vivo',
     loading: 'Caricamento',
     locale: 'Locale',

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -265,7 +265,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'すぐに画面を離れる',
     leaveWithoutSaving: '内容が保存されていません',
     light: 'ライトモード',
-    listControlMenu: 'リスト制御メニュー',
+    listControlsMenu: 'リスト制御メニュー',
     livePreview: 'プレビュー',
     loading: 'ローディング中',
     locale: 'ロケール',

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -263,7 +263,7 @@ export const koTranslations: DefaultTranslationsObject = {
     leaveAnyway: '그래도 나가시겠습니까?',
     leaveWithoutSaving: '저장하지 않고 나가기',
     light: '라이트',
-    listControlMenu: '목록 제어 메뉴',
+    listControlsMenu: '목록 제어 메뉴',
     livePreview: '실시간 미리보기',
     loading: '불러오는 중',
     locale: 'locale',

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -267,7 +267,7 @@ export const myTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'ဘာဖြစ်ဖြစ် ထွက်မည်။',
     leaveWithoutSaving: 'မသိမ်းဘဲ ထွက်မည်။',
     light: 'အလင်း',
-    listControlMenu: 'စာရင်းထိန်းချုပ် မီနူး',
+    listControlsMenu: 'စာရင်းထိန်းချုပ် မီနူး',
     livePreview: 'အစမ်းကြည့်ရန်',
     loading: 'ဖွင့်နေသည်',
     locale: 'ဒေသ',

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -265,7 +265,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Forlat likevel',
     leaveWithoutSaving: 'Forlat uten å lagre',
     light: 'Lys',
-    listControlMenu: 'Kontrollmeny for liste',
+    listControlsMenu: 'Kontrollmeny for liste',
     livePreview: 'Forhåndsvisning',
     loading: 'Laster',
     locale: 'Lokalitet',

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -268,7 +268,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Toch weggaan',
     leaveWithoutSaving: 'Verlaten zonder op te slaan',
     light: 'Licht',
-    listControlMenu: 'Controlelijstmenu',
+    listControlsMenu: 'Controlelijstmenu',
     livePreview: 'Voorbeeld',
     loading: 'Laden',
     locale: 'Taal',

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -265,7 +265,7 @@ export const plTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Wyjdź mimo to',
     leaveWithoutSaving: 'Wyjdź bez zapisywania',
     light: 'Jasny',
-    listControlMenu: 'Menu kontroli listy',
+    listControlsMenu: 'Menu kontroli listy',
     livePreview: 'Podgląd',
     loading: 'Ładowanie',
     locale: 'Ustawienia regionalne',

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -265,7 +265,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Sair mesmo assim',
     leaveWithoutSaving: 'Sair sem salvar',
     light: 'Claro',
-    listControlMenu: 'Menu de controle de lista',
+    listControlsMenu: 'Menu de controle de lista',
     livePreview: 'Pré-visualização',
     loading: 'Carregando',
     locale: 'Local',

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -269,7 +269,7 @@ export const roTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Pleacă oricum',
     leaveWithoutSaving: 'Plecare fără a salva',
     light: 'Light',
-    listControlMenu: 'Meniu de control al listei',
+    listControlsMenu: 'Meniu de control al listei',
     livePreview: 'Previzualizare',
     loading: 'Încărcare',
     locale: 'Localitate',

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -265,7 +265,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Свеједно напусти',
     leaveWithoutSaving: 'Напусти без чувања',
     light: 'Светло',
-    listControlMenu: 'Meni za kontrolu liste',
+    listControlsMenu: 'Meni za kontrolu liste',
     livePreview: 'Преглед',
     loading: 'Учитавање',
     locale: 'Језик',

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -265,7 +265,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Svejedno napusti',
     leaveWithoutSaving: 'Napusti bez čuvanja',
     light: 'Svetlo',
-    listControlMenu: 'Kontrolni meni liste',
+    listControlsMenu: 'Kontrolni meni liste',
     livePreview: 'Pregled',
     loading: 'Učitavanje',
     locale: 'Jezik',

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -267,7 +267,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Все равно уйти',
     leaveWithoutSaving: 'Выход без сохранения',
     light: 'Светлая',
-    listControlMenu: 'Меню управления списком',
+    listControlsMenu: 'Меню управления списком',
     livePreview: 'Предпросмотр',
     loading: 'Загрузка',
     locale: 'Локаль',

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -266,7 +266,7 @@ export const skTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Presto odísť',
     leaveWithoutSaving: 'Odísť bez uloženia',
     light: 'Svetlý',
-    listControlMenu: 'Menu ovládania zoznamu',
+    listControlsMenu: 'Menu ovládania zoznamu',
     livePreview: 'Náhľad',
     loading: 'Načítavanie',
     locale: 'Jazyk',

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -264,7 +264,7 @@ export const slTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Vseeno zapusti',
     leaveWithoutSaving: 'Zapusti brez shranjevanja',
     light: 'Svetlo',
-    listControlMenu: 'Meni za nadzor seznama',
+    listControlsMenu: 'Meni za nadzor seznama',
     livePreview: 'Predogled',
     loading: 'Nalaganje',
     locale: 'Jezik',

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -265,7 +265,7 @@ export const svTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Lämna ändå',
     leaveWithoutSaving: 'Lämna utan att spara',
     light: 'Ljus',
-    listControlMenu: 'Kontrollmeny för lista',
+    listControlsMenu: 'Kontrollmeny för lista',
     livePreview: 'Förhandsvisa',
     loading: 'Läser in',
     locale: 'Lokal',

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -261,7 +261,7 @@ export const thTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'ออกจากหน้านี้',
     leaveWithoutSaving: 'ออกโดยไม่บันทึก',
     light: 'สว่าง',
-    listControlMenu: 'เมนูควบคุมรายการ',
+    listControlsMenu: 'เมนูควบคุมรายการ',
     livePreview: 'แสดงตัวอย่าง',
     loading: 'กำลังโหลด',
     locale: 'ตำแหน่งที่ตั้ง',

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -268,7 +268,7 @@ export const trTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Yine de ayrıl',
     leaveWithoutSaving: 'Kaydetmeden ayrıl',
     light: 'Aydınlık',
-    listControlMenu: 'Liste kontrol menüsü',
+    listControlsMenu: 'Liste kontrol menüsü',
     livePreview: 'Önizleme',
     loading: 'Yükleniyor',
     locale: 'Yerel ayar',

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -264,7 +264,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Все одно вийти',
     leaveWithoutSaving: 'Вийти без збереження',
     light: 'Світла',
-    listControlMenu: 'Меню контролю списку',
+    listControlsMenu: 'Меню контролю списку',
     livePreview: 'Попередній перегляд',
     loading: 'Завантаження',
     locale: 'Локаль',

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -264,7 +264,7 @@ export const viTranslations: DefaultTranslationsObject = {
     leaveAnyway: 'Tiếp tục thoát',
     leaveWithoutSaving: 'Thay đổi chưa được lưu',
     light: 'Nền sáng',
-    listControlMenu: 'Menu điều khiển danh sách',
+    listControlsMenu: 'Menu điều khiển danh sách',
     livePreview: 'Xem trước',
     loading: 'Đang tải',
     locale: 'Ngôn ngữ',

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -255,7 +255,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     leaveAnyway: '无论如何都要离开',
     leaveWithoutSaving: '离开而不保存',
     light: '亮色',
-    listControlMenu: '列表控制菜单',
+    listControlsMenu: '列表控制菜单',
     livePreview: '预览',
     loading: '加载中...',
     locale: '语言环境',

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -255,7 +255,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     leaveAnyway: '無論如何都要離開',
     leaveWithoutSaving: '不儲存直接離開',
     light: '亮色',
-    listControlMenu: '列表控制菜單',
+    listControlsMenu: '列表控制菜單',
     livePreview: '預覽',
     loading: '載入中...',
     locale: '語言環境',

--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -199,7 +199,7 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
             )}
             {listControlsMenu && Array.isArray(listControlsMenu) && (
               <Popup
-                button={<Dots ariaLabel={t('general:listControlMenu')} />}
+                button={<Dots ariaLabel={t('general:listControlsMenu')} />}
                 className={`${baseClass}__popup`}
                 horizontalAlign="right"
                 size="large"


### PR DESCRIPTION
Minor tweak to make naming consistent for listControlsMenu.