### PR TITLE
chore: deflake joins e2e tests

### DIFF
--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -175,7 +175,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
 
       void renderTable(withNewOrUpdatedDoc)
     },
-    [data.docs, renderTable],
+    [data?.docs, renderTable],
   )
 
   const onDrawerCreate = useCallback<DocumentDrawerProps['onSave']>(
@@ -191,7 +191,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
       const newDocs = data.docs.filter((doc) => doc.id !== args.id)
       void renderTable(newDocs)
     },
-    [data.docs, renderTable],
+    [data?.docs, renderTable],
   )
 
   const preferenceKey = `${relationTo}-list`
@@ -227,7 +227,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
         <p>{t('general:loading')}</p>
       ) : (
         <Fragment>
-          {data.docs && data.docs.length === 0 && (
+          {data?.docs && data.docs.length === 0 && (
             <div className={`${baseClass}__no-results`}>
               <p>
                 {i18n.t('general:noResults', {
@@ -243,7 +243,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
               )}
             </div>
           )}
-          {data.docs && data.docs.length > 0 && (
+          {data?.docs && data.docs.length > 0 && (
             <RelationshipProvider>
               <ListQueryProvider
                 data={data}
@@ -256,7 +256,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
                 <TableColumnsProvider
                   collectionSlug={relationTo}
                   columnState={columnState}
-                  docs={data.docs}
+                  docs={data?.docs}
                   LinkedCellOverride={
                     <DrawerLink onDrawerDelete={onDrawerDelete} onDrawerSave={onDrawerSave} />
                   }

--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -175,7 +175,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
 
       void renderTable(withNewOrUpdatedDoc)
     },
-    [data?.docs, renderTable],
+    [data.docs, renderTable],
   )
 
   const onDrawerCreate = useCallback<DocumentDrawerProps['onSave']>(
@@ -191,7 +191,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
       const newDocs = data.docs.filter((doc) => doc.id !== args.id)
       void renderTable(newDocs)
     },
-    [data?.docs, renderTable],
+    [data.docs, renderTable],
   )
 
   const preferenceKey = `${relationTo}-list`
@@ -227,7 +227,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
         <p>{t('general:loading')}</p>
       ) : (
         <Fragment>
-          {data?.docs && data.docs.length === 0 && (
+          {data.docs && data.docs.length === 0 && (
             <div className={`${baseClass}__no-results`}>
               <p>
                 {i18n.t('general:noResults', {
@@ -243,7 +243,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
               )}
             </div>
           )}
-          {data?.docs && data.docs.length > 0 && (
+          {data.docs && data.docs.length > 0 && (
             <RelationshipProvider>
               <ListQueryProvider
                 data={data}
@@ -256,7 +256,7 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
                 <TableColumnsProvider
                   collectionSlug={relationTo}
                   columnState={columnState}
-                  docs={data?.docs}
+                  docs={data.docs}
                   LinkedCellOverride={
                     <DrawerLink onDrawerDelete={onDrawerDelete} onDrawerSave={onDrawerSave} />
                   }

--- a/test/fields/collections/Array/e2e.spec.ts
+++ b/test/fields/collections/Array/e2e.spec.ts
@@ -56,7 +56,7 @@ describe('Array', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -51,7 +51,7 @@ describe('Block fields', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/Checkbox/e2e.spec.ts
+++ b/test/fields/collections/Checkbox/e2e.spec.ts
@@ -53,7 +53,7 @@ describe('Checkboxes', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/Collapsible/e2e.spec.ts
+++ b/test/fields/collections/Collapsible/e2e.spec.ts
@@ -55,7 +55,7 @@ describe('Collapsibles', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/ConditionalLogic/e2e.spec.ts
+++ b/test/fields/collections/ConditionalLogic/e2e.spec.ts
@@ -68,7 +68,7 @@ describe('Conditional Logic', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/CustomID/e2e.spec.ts
+++ b/test/fields/collections/CustomID/e2e.spec.ts
@@ -60,7 +60,7 @@ describe('Custom IDs', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/Date/e2e.spec.ts
+++ b/test/fields/collections/Date/e2e.spec.ts
@@ -58,7 +58,7 @@ describe('Date', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/Email/e2e.spec.ts
+++ b/test/fields/collections/Email/e2e.spec.ts
@@ -58,7 +58,7 @@ describe('Email', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/Indexed/e2e.spec.ts
+++ b/test/fields/collections/Indexed/e2e.spec.ts
@@ -55,7 +55,7 @@ describe('Radio', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/JSON/e2e.spec.ts
+++ b/test/fields/collections/JSON/e2e.spec.ts
@@ -59,7 +59,7 @@ describe('JSON', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/Lexical/e2e/blocks/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e/blocks/e2e.spec.ts
@@ -223,7 +223,7 @@ describe('lexicalBlocks', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'rich-text-fields', serverURL })
+    client = new RESTClient({ defaultSlug: 'rich-text-fields', serverURL })
     await client.login()
   })
 

--- a/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
@@ -94,7 +94,7 @@ describe('lexicalMain', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'rich-text-fields', serverURL })
+    client = new RESTClient({ defaultSlug: 'rich-text-fields', serverURL })
     await client.login()
   })
 

--- a/test/fields/collections/Number/e2e.spec.ts
+++ b/test/fields/collections/Number/e2e.spec.ts
@@ -61,7 +61,7 @@ describe('Number', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/Point/e2e.spec.ts
+++ b/test/fields/collections/Point/e2e.spec.ts
@@ -59,7 +59,7 @@ describe('Point', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/Radio/e2e.spec.ts
+++ b/test/fields/collections/Radio/e2e.spec.ts
@@ -54,7 +54,7 @@ describe('Radio', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -63,7 +63,7 @@ describe('relationship', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/RichText/e2e.spec.ts
+++ b/test/fields/collections/RichText/e2e.spec.ts
@@ -51,7 +51,7 @@ describe('Rich Text', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/Row/e2e.spec.ts
+++ b/test/fields/collections/Row/e2e.spec.ts
@@ -55,7 +55,7 @@ describe('Row', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/Select/e2e.spec.ts
+++ b/test/fields/collections/Select/e2e.spec.ts
@@ -58,7 +58,7 @@ describe('Radio', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/Tabs/e2e.spec.ts
+++ b/test/fields/collections/Tabs/e2e.spec.ts
@@ -61,7 +61,7 @@ describe('Tabs', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/Tabs2/e2e.spec.ts
+++ b/test/fields/collections/Tabs2/e2e.spec.ts
@@ -58,7 +58,7 @@ describe('Tabs', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/Text/e2e.spec.ts
+++ b/test/fields/collections/Text/e2e.spec.ts
@@ -65,7 +65,7 @@ describe('Text', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/UI/e2e.spec.ts
+++ b/test/fields/collections/UI/e2e.spec.ts
@@ -54,7 +54,7 @@ describe('Radio', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
     await ensureCompilationIsDone({ page, serverURL })
   })

--- a/test/fields/collections/Upload/e2e.spec.ts
+++ b/test/fields/collections/Upload/e2e.spec.ts
@@ -60,7 +60,7 @@ describe('Upload', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/UploadRestricted/e2e.spec.ts
+++ b/test/fields/collections/UploadRestricted/e2e.spec.ts
@@ -55,7 +55,7 @@ describe('Upload with restrictions', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/helpers/rest.ts
+++ b/test/helpers/rest.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { Config, PaginatedDocs, TypedUser, Where } from 'payload'
+import type { PaginatedDocs, TypedUser, Where } from 'payload'
 
 import * as qs from 'qs-esm'
 
@@ -110,8 +110,6 @@ type QueryResponse<T> = {
 }
 
 export class RESTClient {
-  private readonly config: Config
-
   private defaultSlug: string
 
   private token: string
@@ -120,8 +118,7 @@ export class RESTClient {
 
   public user: TypedUser
 
-  constructor(config: Config, args: Args) {
-    this.config = config
+  constructor(args: Args) {
     this.serverURL = args.serverURL
     this.defaultSlug = args.defaultSlug
   }

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -18,7 +18,7 @@ import {
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { navigateToDoc } from '../helpers/e2e/navigateToDoc.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
-import { TEST_TIMEOUT_LONG } from '../playwright.config.js'
+import { EXPECT_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import { categoriesJoinRestrictedSlug, categoriesSlug, postsSlug, uploadsSlug } from './shared.js'
 import { reInitializeDB } from '../helpers/reInitializeDB.js'
 import { RESTClient } from '../helpers/rest.js'
@@ -55,11 +55,10 @@ describe('Join Field', () => {
     initPageConsoleErrorCatch(page)
     await ensureCompilationIsDone({ page, serverURL })
 
-    await throttleTest({ context, delay: 'Slow 4G', page })
+    //await throttleTest({ context, delay: 'Slow 4G', page })
   })
 
   beforeEach(async () => {
-    console.log('reInitializeDB')
     await reInitializeDB({
       serverURL,
       snapshotKey: 'joinsTest',
@@ -291,8 +290,9 @@ describe('Join Field', () => {
     await addButton.click()
     const drawer = page.locator('[id^=doc-drawer_posts_1_]')
     await expect(drawer).toBeVisible()
+
     const categoryField = drawer.locator('#field-category')
-    await expect(categoryField).toBeVisible()
+    await expect(categoryField).toBeVisible({ timeout: EXPECT_TIMEOUT * 80 })
     const categoryValue = categoryField.locator('.relationship--single-value__text')
     await expect(categoryValue).toHaveText('example')
     const titleField = drawer.locator('#field-title')

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -292,7 +292,7 @@ describe('Join Field', () => {
     await expect(drawer).toBeVisible()
 
     const categoryField = drawer.locator('#field-category')
-    await expect(categoryField).toBeVisible({ timeout: EXPECT_TIMEOUT * 80 })
+    await expect(categoryField).toBeVisible({ timeout: EXPECT_TIMEOUT * 5 })
     const categoryValue = categoryField.locator('.relationship--single-value__text')
     await expect(categoryValue).toHaveText('example')
     const titleField = drawer.locator('#field-title')

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -13,34 +13,65 @@ import {
   exactText,
   initPageConsoleErrorCatch,
   saveDocAndAssert,
+  throttleTest,
 } from '../helpers.js'
 import { AdminUrlUtil } from '../helpers/adminUrlUtil.js'
 import { navigateToDoc } from '../helpers/e2e/navigateToDoc.js'
 import { initPayloadE2ENoConfig } from '../helpers/initPayloadE2ENoConfig.js'
 import { TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import { categoriesJoinRestrictedSlug, categoriesSlug, postsSlug, uploadsSlug } from './shared.js'
+import { reInitializeDB } from '../helpers/reInitializeDB.js'
+import { RESTClient } from '../helpers/rest.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 let payload: PayloadTestSDK<Config>
 let serverURL: string
+let client: RESTClient
 
-test.describe('Join Field', () => {
+const { beforeAll, beforeEach, describe } = test
+
+describe('Join Field', () => {
   let page: Page
   let categoriesURL: AdminUrlUtil
   let uploadsURL: AdminUrlUtil
   let categoriesJoinRestrictedURL: AdminUrlUtil
   let categoryID: string | number
 
-  test.beforeAll(async ({ browser }, testInfo) => {
+  beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
+    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
     }))
+
     categoriesURL = new AdminUrlUtil(serverURL, categoriesSlug)
     uploadsURL = new AdminUrlUtil(serverURL, uploadsSlug)
     categoriesJoinRestrictedURL = new AdminUrlUtil(serverURL, categoriesJoinRestrictedSlug)
+
+    const context = await browser.newContext()
+    page = await context.newPage()
+    initPageConsoleErrorCatch(page)
+    await ensureCompilationIsDone({ page, serverURL })
+
+    await throttleTest({ context, delay: 'Slow 4G', page })
+  })
+
+  beforeEach(async () => {
+    console.log('reInitializeDB')
+    await reInitializeDB({
+      serverURL,
+      snapshotKey: 'joinsTest',
+      uploadsDir: [],
+    })
+
+    if (client) {
+      await client.logout()
+    }
+    client = new RESTClient({ defaultSlug: postsSlug, serverURL })
+    await client.login()
+
     const { docs } = await payload.find({
       collection: categoriesSlug,
       where: {
@@ -55,11 +86,6 @@ test.describe('Join Field', () => {
     }
 
     ;({ id: categoryID } = docs[0])
-
-    const context = await browser.newContext()
-    page = await context.newPage()
-    initPageConsoleErrorCatch(page)
-    await ensureCompilationIsDone({ page, serverURL })
   })
 
   test('should populate joined relationships in table cells of list view', async () => {
@@ -253,6 +279,8 @@ test.describe('Join Field', () => {
     await page.goto(categoriesURL.edit(categoryID))
     const joinField = page.locator('#field-relatedPosts.field-type.join')
     await expect(joinField).toBeVisible()
+
+    await expect(joinField.locator('tbody tr')).toHaveCount(3)
 
     const addButton = joinField.locator('.relationship-table__actions button.doc-drawer__toggler', {
       hasText: exactText('Add new'),

--- a/test/joins/seed.ts
+++ b/test/joins/seed.ts
@@ -19,7 +19,7 @@ import {
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-export const seed = async (_payload) => {
+export const seed = async (_payload: Payload) => {
   await _payload.create({
     collection: 'users',
     data: {
@@ -90,7 +90,7 @@ export const seed = async (_payload) => {
   await _payload.create({
     collection: postsSlug,
     data: {
-      upload: uploadedImage.id,
+      upload: uploadedImage,
     },
   })
 
@@ -123,6 +123,6 @@ export async function clearAndSeedEverything(_payload: Payload) {
     _payload,
     collectionSlugs,
     seedFunction: seed,
-    snapshotKey: 'adminTest',
+    snapshotKey: 'joinsTest',
   })
 }

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -83,7 +83,7 @@ describe('Localization', () => {
 
     initPageConsoleErrorCatch(page)
 
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -8,8 +8,8 @@ const dirname = path.dirname(filename)
 
 dotenv.config({ path: path.resolve(dirname, 'test.env') })
 
-let multiplier = process.env.CI ? 3 : 1
-let smallMultiplier = process.env.CI ? 2 : 1
+let multiplier = process.env.CI ? 15 : 1
+let smallMultiplier = process.env.CI ? 10 : 1
 
 export const TEST_TIMEOUT_LONG = 640000 * multiplier // 8*3 minutes - used as timeOut for the beforeAll
 export const TEST_TIMEOUT = 40000 * multiplier

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -8,8 +8,8 @@ const dirname = path.dirname(filename)
 
 dotenv.config({ path: path.resolve(dirname, 'test.env') })
 
-let multiplier = process.env.CI ? 15 : 1
-let smallMultiplier = process.env.CI ? 10 : 1
+let multiplier = process.env.CI ? 5 : 1
+let smallMultiplier = process.env.CI ? 4 : 1
 
 export const TEST_TIMEOUT_LONG = 640000 * multiplier // 8*3 minutes - used as timeOut for the beforeAll
 export const TEST_TIMEOUT = 40000 * multiplier

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -109,7 +109,7 @@ describe('Uploads', () => {
     if (client) {
       await client.logout()
     }
-    client = new RESTClient(null, { defaultSlug: 'users', serverURL })
+    client = new RESTClient({ defaultSlug: 'users', serverURL })
     await client.login()
 
     await ensureCompilationIsDone({ page, serverURL })


### PR DESCRIPTION
Previously, data created by other tests was also leaking into unrelated tests, causing them to fail. The new reset-db-between-tests logic added by this PR fixes this. 

Additionally, this increases playwright timeouts for CI, and adds a specific timeout override for opening a drawer, as it was incredibly slow in CI

