### PR TITLE
chore: fix flaky lexical test

### DIFF
--- a/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
@@ -1337,7 +1337,6 @@ describe('lexicalMain', () => {
   })
 
   test('select decoratorNodes', async () => {
-    await navigateToLexicalFields()
     // utils
     const decoratorLocator = page.locator('.decorator-selected') // [data-lexical-decorator="true"]
     const expectInsideSelectedDecorator = async (innerLocator: Locator) => {

--- a/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/fields/collections/Lexical/e2e/main/e2e.spec.ts
@@ -61,6 +61,14 @@ async function navigateToLexicalFields(
   await linkToDoc.click()
 
   await page.waitForURL(`**${linkDocHref}`)
+
+  if (collectionSlug === 'lexical-fields') {
+    const richTextField = page.locator('.rich-text-lexical').nth(2) // second
+    await richTextField.scrollIntoViewIfNeeded()
+    await expect(richTextField).toBeVisible()
+    // Wait until there at least 10 blocks visible in that richtext field - thus wait for it to be fully loaded
+    await expect(richTextField.locator('.lexical-block')).toHaveCount(10)
+  }
 }
 
 describe('lexicalMain', () => {
@@ -1329,6 +1337,7 @@ describe('lexicalMain', () => {
   })
 
   test('select decoratorNodes', async () => {
+    await navigateToLexicalFields()
     // utils
     const decoratorLocator = page.locator('.decorator-selected') // [data-lexical-decorator="true"]
     const expectInsideSelectedDecorator = async (innerLocator: Locator) => {
@@ -1339,7 +1348,7 @@ describe('lexicalMain', () => {
     // test
     await navigateToLexicalFields()
     const bottomOfUploadNode = page
-      .locator('div')
+      .locator('.lexical-upload div')
       .filter({ hasText: /^payload\.jpg$/ })
       .first()
     await bottomOfUploadNode.click()

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -881,6 +881,7 @@ export interface TextField {
   fieldWithDefaultValue?: string | null;
   dependentOnFieldWithDefaultValue?: string | null;
   hasMany?: string[] | null;
+  readOnlyHasMany?: string[] | null;
   validatesHasMany?: string[] | null;
   localizedHasMany?: string[] | null;
   withMinRows?: string[] | null;
@@ -3243,6 +3244,7 @@ export interface TextFieldsSelect<T extends boolean = true> {
   fieldWithDefaultValue?: T;
   dependentOnFieldWithDefaultValue?: T;
   hasMany?: T;
+  readOnlyHasMany?: T;
   validatesHasMany?: T;
   localizedHasMany?: T;
   withMinRows?: T;

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -8,8 +8,8 @@ const dirname = path.dirname(filename)
 
 dotenv.config({ path: path.resolve(dirname, 'test.env') })
 
-let multiplier = process.env.CI ? 5 : 1
-let smallMultiplier = process.env.CI ? 4 : 1
+let multiplier = process.env.CI ? 4 : 1
+let smallMultiplier = process.env.CI ? 3 : 1
 
 export const TEST_TIMEOUT_LONG = 640000 * multiplier // 8*3 minutes - used as timeOut for the beforeAll
 export const TEST_TIMEOUT = 40000 * multiplier


### PR DESCRIPTION
The "select decoratorNodes" test was flaky, as it often selected the relationship block node with a relationship to "payload.jpg", instead of the upload node for "payload.jpg", depending on which node loaded first.

This PR ensures it waits for all blocks to be loaded, and updates the selector to specifically target the upload node