### PR TITLE
chore: fix eslint wasn't running in test dir

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,7 @@ export const defaultESLintIgnores = [
   '**/build/',
   '**/node_modules/',
   '**/temp/',
-  '**/*.spec.ts',
+  '**/packages/*.spec.ts',
   'next-env.d.ts',
   '**/app',
 ]

--- a/test/eslint.config.js
+++ b/test/eslint.config.js
@@ -58,7 +58,7 @@ export const testEslintConfig = [
       'jest/require-top-level-describe': 'off',
       'jest-dom/prefer-to-have-attribute': 'off',
       'playwright/prefer-web-first-assertions': 'error',
-      'payload/no-flaky-assertions': 'error',
+      'payload/no-flaky-assertions': 'warn',
       'payload/no-wait-function': 'warn',
       // Enable the no-non-retryable-assertions rule ONLY for hunting for flakes
       // 'payload/no-non-retryable-assertions': 'error',

--- a/test/eslint.config.js
+++ b/test/eslint.config.js
@@ -17,9 +17,6 @@ export const testEslintConfig = [
         tsconfigRootDir: import.meta.dirname,
       },
     },
-    plugins: {
-      payload: payloadPlugin,
-    },
     rules: {
       'payload/no-relative-monorepo-imports': 'error',
     },
@@ -61,7 +58,7 @@ export const testEslintConfig = [
       'jest/require-top-level-describe': 'off',
       'jest-dom/prefer-to-have-attribute': 'off',
       'playwright/prefer-web-first-assertions': 'error',
-      'payload/no-flaky-assertions': 'warn',
+      'payload/no-flaky-assertions': 'error',
       'payload/no-wait-function': 'warn',
       // Enable the no-non-retryable-assertions rule ONLY for hunting for flakes
       // 'payload/no-non-retryable-assertions': 'error',


### PR DESCRIPTION
This PR fixes 2 eslint config issues that prevented it from running in our test dir

- spec files were ignored by the root eslint config. This should have only ignored spec files within our packages, as they are ignored by the respective package tsconfigs
- defining the payload plugin crashed eslint in our test dir, as it was already defined in the root eslint config it was inheriting