### PR TITLE
feat(richtext-lexical): expose client config to client features

### DIFF
--- a/packages/richtext-lexical/src/features/typesClient.ts
+++ b/packages/richtext-lexical/src/features/typesClient.ts
@@ -5,7 +5,7 @@ import type {
   LexicalNodeReplacement,
   TextFormatType,
 } from 'lexical'
-import type { RichTextFieldClient } from 'payload'
+import type { ClientConfig, RichTextFieldClient } from 'payload'
 import type React from 'react'
 import type { JSX } from 'react'
 
@@ -33,6 +33,7 @@ export type FeatureProviderClient<
   clientFeatureProps: BaseClientFeatureProps<UnSanitizedClientFeatureProps>
   feature:
     | ((props: {
+        config: ClientConfig
         featureClientSchemaMap: FeatureClientSchemaMap
         /** unSanitizedEditorConfig.features, but mapped */
         featureProviderMap: ClientFeatureProviderMap

--- a/packages/richtext-lexical/src/field/index.tsx
+++ b/packages/richtext-lexical/src/field/index.tsx
@@ -2,7 +2,7 @@
 
 import type { RichTextFieldClient } from 'payload'
 
-import { ShimmerEffect } from '@payloadcms/ui'
+import { ShimmerEffect, useConfig } from '@payloadcms/ui'
 import React, { lazy, Suspense, useEffect, useState } from 'react'
 
 import type { FeatureProviderClient } from '../features/typesClient.js'
@@ -27,6 +27,8 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
     schemaPath,
   } = props
 
+  const { config } = useConfig()
+
   const [finalSanitizedEditorConfig, setFinalSanitizedEditorConfig] =
     useState<null | SanitizedClientEditorConfig>(null)
 
@@ -50,6 +52,7 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
       : defaultEditorLexicalConfig
 
     const resolvedClientFeatures = loadClientFeatures({
+      config,
       featureClientSchemaMap,
       field: field as RichTextFieldClient,
       schemaPath: schemaPath ?? field.name,
@@ -69,6 +72,7 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
     clientFeatures,
     featureClientSchemaMap,
     field,
+    config,
     schemaPath,
   ]) // TODO: Optimize this and use useMemo for this in the future. This might break sub-richtext-blocks from the blocks feature. Need to investigate
 

--- a/packages/richtext-lexical/src/lexical/config/client/loader.ts
+++ b/packages/richtext-lexical/src/lexical/config/client/loader.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import type { RichTextFieldClient } from 'payload'
+import type { ClientConfig, RichTextFieldClient } from 'payload'
 
 import type {
   ClientFeatureProviderMap,
@@ -15,11 +15,13 @@ import type { ClientEditorConfig } from '../types.js'
  * @param unSanitizedEditorConfig
  */
 export function loadClientFeatures({
+  config,
   featureClientSchemaMap,
   field,
   schemaPath,
   unSanitizedEditorConfig,
 }: {
+  config: ClientConfig
   featureClientSchemaMap: FeatureClientSchemaMap
   field?: RichTextFieldClient
   schemaPath: string
@@ -55,6 +57,7 @@ export function loadClientFeatures({
     const feature: Partial<ResolvedClientFeature<any>> =
       typeof featureProvider.feature === 'function'
         ? featureProvider.feature({
+            config,
             featureClientSchemaMap,
             featureProviderMap,
             field,

--- a/packages/richtext-lexical/src/utilities/createClientFeature.ts
+++ b/packages/richtext-lexical/src/utilities/createClientFeature.ts
@@ -1,4 +1,4 @@
-import type { RichTextFieldClient } from 'payload'
+import type { ClientConfig, RichTextFieldClient } from 'payload'
 
 import type {
   BaseClientFeatureProps,
@@ -13,6 +13,7 @@ import type { FeatureClientSchemaMap } from '../types.js'
 
 export type CreateClientFeatureArgs<UnSanitizedClientProps, ClientProps> =
   | ((props: {
+      config: ClientConfig
       featureClientSchemaMap: FeatureClientSchemaMap
       /** unSanitizedEditorConfig.features, but mapped */
       featureProviderMap: ClientFeatureProviderMap
@@ -39,6 +40,7 @@ export const createClientFeature: <
 
     if (typeof feature === 'function') {
       featureProviderClient.feature = ({
+        config,
         featureClientSchemaMap,
         featureProviderMap,
         field,
@@ -47,6 +49,7 @@ export const createClientFeature: <
         unSanitizedEditorConfig,
       }) => {
         const toReturn = feature({
+          config,
           featureClientSchemaMap,
           featureProviderMap,
           field,


### PR DESCRIPTION
This PR exposes the `ClientConfig` as an argument to the lexical `ClientFeature`. This is a requirement for https://github.com/payloadcms/payload/pull/10905, as we need to get the ClientBlocks from the `clientConfig.blocksMap` if they are strings.

## Example

```tsx
export const BlocksFeatureClient = createClientFeature(
  ({ config, featureClientSchemaMap, props, schemaPath }) => { // <= config is the new argument
  	
  	// Return ClientFeature
})
```