### PR TITLE
fix: unhelpful "cannot overwrite model once compiled" errors swallowing actual error

### DIFF
--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -905,6 +905,8 @@ export const getPayload = async (
     }
   } catch (e) {
     cached.promise = null
+    // add identifier to error object, so that our error logger in routeError.ts does not attempt to re-initialize getPayload
+    e.payloadInitError = true
     throw e
   }
 

--- a/packages/payload/src/utilities/routeError.ts
+++ b/packages/payload/src/utilities/routeError.ts
@@ -22,6 +22,19 @@ export const routeError = async ({
   err: APIError
   req: PayloadRequest | Request
 }) => {
+  if ('payloadInitError' in err && err.payloadInitError === true) {
+    // do not attempt initializing Payload if the error is due to a failed initialization. Otherwise,
+    // it will cause an infinite loop of initialization attempts and endless error responses, without
+    // actually logging the error, as the error logging code will never be reached.
+    console.error(err)
+    return Response.json(
+      {
+        message: 'There was an error initializing Payload',
+      },
+      { status: httpStatus.INTERNAL_SERVER_ERROR },
+    )
+  }
+
   let payload = incomingReq && 'payload' in incomingReq && incomingReq?.payload
 
   if (!payload) {


### PR DESCRIPTION
If an error is thrown during the payload init process, it gets ignored and an unhelpful, meaningless

` ⨯ OverwriteModelError: Cannot overwrite ___ model once compiled.`
 
error is thrown instead. The actual error that caused this will never be logged. This PR fixes this and ensures the actual error is logged.
 
 ## Why did this happen?
 
If an error is thrown during the init process, it is caught and handled by the `src/utilities/routeError.ts` - this helper properly logs the error using pino.
The problem is that pino did not exist, as payload did not finish initializing - it errored during it. So, it tries to initialize payload again before logging the error... which will fail again. If payload failed initializing the first time, it will fail the second time. => No error is logged.

This PR ensures the error is logged using `console.error()` if the originating error was thrown during the payload init process, instead of attempting to initialize it again and again