### PR TITLE
chore: ensure jest respects PAYLOAD_DATABASE env variable

### DIFF
--- a/test/helpers/startMemoryDB.ts
+++ b/test/helpers/startMemoryDB.ts
@@ -1,9 +1,10 @@
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import dotenv from 'dotenv'
+dotenv.config()
+
 
 // eslint-disable-next-line no-restricted-exports
 export default async () => {
-  console.log('Starting memory db...')
-
   // @ts-expect-error
   process.env.NODE_ENV = 'test'
   process.env.PAYLOAD_DROP_DATABASE = 'true'
@@ -14,6 +15,7 @@ export default async () => {
     (!process.env.PAYLOAD_DATABASE || process.env.PAYLOAD_DATABASE === 'mongodb') &&
     !global._mongoMemoryServer
   ) {
+    console.log('Starting memory db...')
     const db = await MongoMemoryReplSet.create({
       replSet: {
         count: 3,

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -2,6 +2,9 @@ import { jest } from '@jest/globals'
 import console from 'console'
 global.console = console
 
+import dotenv from 'dotenv'
+dotenv.config()
+
 import nodemailer from 'nodemailer'
 
 import { generateDatabaseAdapter } from './generateDatabaseAdapter.js'


### PR DESCRIPTION
Previously, if the `PAYLOAD_DATABASE` env variable was set to `postgres`, it would still start up the mongo memory db and write the mongo db adapter.