### PR TITLE
fix(richtext-lexical): unindent button in toolbar is never active

### DIFF
--- a/packages/richtext-lexical/src/features/indent/client/index.tsx
+++ b/packages/richtext-lexical/src/features/indent/client/index.tsx
@@ -1,7 +1,15 @@
 'use client'
 
+import type { ElementNode, LexicalNode } from 'lexical'
+
 import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin'
-import { INDENT_CONTENT_COMMAND, OUTDENT_CONTENT_COMMAND } from 'lexical'
+import { $findMatchingParent } from '@lexical/utils'
+import {
+  $isElementNode,
+  $isRangeSelection,
+  INDENT_CONTENT_COMMAND,
+  OUTDENT_CONTENT_COMMAND,
+} from 'lexical'
 
 import type { ToolbarGroup } from '../../toolbars/types.js'
 
@@ -16,20 +24,37 @@ const toolbarGroups: ToolbarGroup[] = [
       ChildComponent: IndentDecreaseIcon,
       isActive: () => false,
       isEnabled: ({ selection }) => {
-        if (!selection || !selection?.getNodes()?.length) {
+        const nodes = selection?.getNodes()
+        if (!nodes?.length) {
           return false
         }
-        for (const node of selection.getNodes()) {
-          const parent = node.getParentOrThrow()
-          // If at least one node is indented, this should be active
+        let atLeastOneNodeCanOutdent = false
+        const isIndentable = (node: LexicalNode): node is ElementNode =>
+          $isElementNode(node) && node.canIndent()
+        for (const node of nodes) {
+          if (isIndentable(node)) {
+            if (node.getIndent() <= 0) {
+              return false
+            } else {
+              atLeastOneNodeCanOutdent = true
+            }
+          }
+        }
+        if (!atLeastOneNodeCanOutdent && $isRangeSelection(selection)) {
+          const anchorNode = selection.anchor.getNode()
           if (
-            ('__indent' in node && (node.__indent as number) > 0) ||
-            ('__indent' in parent && parent.__indent > 0)
+            $findMatchingParent(anchorNode, (node) => isIndentable(node) && node.getIndent() > 0)
+          ) {
+            return true
+          }
+          const focusNode = selection.focus.getNode()
+          if (
+            $findMatchingParent(focusNode, (node) => isIndentable(node) && node.getIndent() > 0)
           ) {
             return true
           }
         }
-        return false
+        return atLeastOneNodeCanOutdent
       },
       key: 'indentDecrease',
       label: ({ i18n }) => {


### PR DESCRIPTION
Fixes #11082

In addition to fixing the bug described in that issue, I'm fixing the problem where when outdenting, indent 0 blocks stay the same. The new logic verifies that all selected blocks can be outdented.

It remains to be done the same with the tab and shift + tab commands.