### PR TITLE
fix(db-postgres): incorrect pagination results when querying hasMany relationships multiple times

### DIFF
--- a/packages/drizzle/src/queries/addJoinTable.ts
+++ b/packages/drizzle/src/queries/addJoinTable.ts
@@ -1,5 +1,5 @@
-import type { SQL } from 'drizzle-orm'
-import type { PgTableWithColumns } from 'drizzle-orm/pg-core'
+import { type SQL } from 'drizzle-orm'
+import { type PgTableWithColumns } from 'drizzle-orm/pg-core'
 
 import type { GenericTable } from '../types.js'
 import type { BuildQueryJoinAliases } from './buildQuery.js'
@@ -10,16 +10,18 @@ export const addJoinTable = ({
   type,
   condition,
   joins,
+  queryPath,
   table,
 }: {
   condition: SQL
   joins: BuildQueryJoinAliases
+  queryPath?: string
   table: GenericTable | PgTableWithColumns<any>
   type?: 'innerJoin' | 'leftJoin' | 'rightJoin'
 }) => {
   const name = getNameFromDrizzleTable(table)
 
   if (!joins.some((eachJoin) => getNameFromDrizzleTable(eachJoin.table) === name)) {
-    joins.push({ type, condition, table })
+    joins.push({ type, condition, queryPath, table })
   }
 }

--- a/packages/drizzle/src/queries/buildQuery.ts
+++ b/packages/drizzle/src/queries/buildQuery.ts
@@ -9,6 +9,7 @@ import { parseParams } from './parseParams.js'
 
 export type BuildQueryJoinAliases = {
   condition: SQL
+  queryPath?: string
   table: GenericTable | PgTableWithColumns<any>
   type?: 'innerJoin' | 'leftJoin' | 'rightJoin'
 }[]

--- a/packages/drizzle/src/queries/getTableColumnFromPath.ts
+++ b/packages/drizzle/src/queries/getTableColumnFromPath.ts
@@ -363,7 +363,10 @@ export const getTableColumnFromPath = ({
           const {
             newAliasTable: aliasRelationshipTable,
             newAliasTableName: aliasRelationshipTableName,
-          } = getTableAlias({ adapter, tableName: relationTableName })
+          } = getTableAlias({
+            adapter,
+            tableName: relationTableName,
+          })
 
           if (selectLocale && field.localized && adapter.payload.config.localization) {
             selectFields._locale = aliasRelationshipTable.locale
@@ -380,17 +383,21 @@ export const getTableColumnFromPath = ({
               conditions.push(eq(aliasRelationshipTable.locale, locale))
             }
 
-            joins.push({
+            addJoinTable({
               condition: and(...conditions),
+              joins,
+              queryPath: `${constraintPath}.${field.name}`,
               table: aliasRelationshipTable,
             })
           } else {
             // Join in the relationships table
-            joins.push({
+            addJoinTable({
               condition: and(
                 eq((aliasTable || adapter.tables[rootTableName]).id, aliasRelationshipTable.parent),
                 like(aliasRelationshipTable.path, `${constraintPath}${field.name}`),
               ),
+              joins,
+              queryPath: `${constraintPath}.${field.name}`,
               table: aliasRelationshipTable,
             })
           }

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -543,6 +543,7 @@ describe('Relationships', () => {
             },
           })
 
+          // eslint-disable-next-line jest/no-standalone-expect
           expect(query1.totalDocs).toStrictEqual(1)
         })
 
@@ -1469,6 +1470,7 @@ describe('Relationships', () => {
         })
         .then((res) => res.json())
 
+      // eslint-disable-next-line jest/no-standalone-expect
       expect(queryOne.docs).toHaveLength(1)
     })
 

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -412,6 +412,51 @@ describe('Relationships', () => {
           expect(customIdNumberRelation).toMatchObject({ id: generatedCustomIdNumber })
         })
 
+        it('should retrieve totalDocs correctly with hasMany,', async () => {
+          const movie1 = await payload.create({
+            collection: 'movies',
+            data: {},
+          })
+          const movie2 = await payload.create({
+            collection: 'movies',
+            data: {},
+          })
+
+          await payload.create({
+            collection: 'directors',
+            data: {
+              name: 'Quentin Tarantino',
+              movies: [movie2.id, movie1.id],
+            },
+          })
+
+          const res = await payload.find({
+            collection: 'directors',
+            limit: 10,
+            where: {
+              or: [
+                {
+                  movies: {
+                    equals: movie2.id,
+                  },
+                },
+                {
+                  movies: {
+                    equals: movie1.id,
+                  },
+                },
+                {
+                  movies: {
+                    equals: movie1.id,
+                  },
+                },
+              ],
+            },
+          })
+
+          expect(res.totalDocs).toBe(1)
+        })
+
         it('should query using "contains" by hasMany relationship field', async () => {
           const movie1 = await payload.create({
             collection: 'movies',


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/10810

This was caused by using `COUNT(*)` aggregation instead of `COUNT(DISTINCT table.id)`. However, we want to use `COUNT(*)` because `COUNT(DISTINCT table.id)` is slow on large tables. Now we fallback to `COUNT(DISTINCT table.id)` only when `COUNT(*)` cannot work properly.

Example of a query that leads to incorrect `totalDocs`:
```ts
const res = await payload.find({
  collection: 'directors',
  limit: 10,
  where: {
    or: [
      {
        movies: {
          equals: movie2.id,
        },
      },
      {
        movies: {
          equals: movie1.id,
        },
      },
      {
        movies: {
          equals: movie1.id,
        },
      },
    ],
  },
})
```