### PR TITLE
fix(ui): incorrectly incrementing version counts if maxPerDoc is set to 0

### DIFF
--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -257,10 +257,19 @@ const DocumentInfo: React.FC<
   )
 
   const incrementVersionCount = useCallback(() => {
+    const newCount = versionCount + 1
     if (collectionConfig && collectionConfig.versions) {
-      setVersionCount(Math.min(versionCount + 1, collectionConfig.versions.maxPerDoc))
+      if (collectionConfig.versions.maxPerDoc > 0) {
+        setVersionCount(Math.min(newCount, collectionConfig.versions.maxPerDoc))
+      } else {
+        setVersionCount(newCount)
+      }
     } else if (globalConfig && globalConfig.versions) {
-      setVersionCount(Math.min(versionCount + 1, globalConfig.versions.max))
+      if (globalConfig.versions.max > 0) {
+        setVersionCount(Math.min(newCount, globalConfig.versions.max))
+      } else {
+        setVersionCount(newCount)
+      }
     }
   }, [collectionConfig, globalConfig, versionCount])
 

--- a/test/versions/collections/Drafts.ts
+++ b/test/versions/collections/Drafts.ts
@@ -127,7 +127,7 @@ const DraftPosts: CollectionConfig = {
     drafts: {
       schedulePublish: true,
     },
-    maxPerDoc: 35,
+    maxPerDoc: 0,
   },
 }
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/9891

We were incorrectly setting max version count to 0 if it was configured as maxPerDoc `0` due to `Math.min`