### PR TITLE
docs: fixing 3 dead internal links

### DIFF
--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -57,7 +57,7 @@ The `admin` directory contains all the _pages_ related to the interface itself, 
 
 <Banner type="warning">
   **Note:**
-  If you don't intend to use the Admin Panel, [REST API](../rest/overview), or [GraphQL API](../graphql/overview), you can opt-out by simply deleting their corresponding directories within your Next.js app. The overhead, however, is completely constrained to these routes, and will not slow down or affect Payload outside when not in use.
+  If you don't intend to use the Admin Panel, [REST API](../rest-api/overview), or [GraphQL API](../graphql/overview), you can opt-out by simply deleting their corresponding directories within your Next.js app. The overhead, however, is completely constrained to these routes, and will not slow down or affect Payload outside when not in use.
 </Banner>
 
 Finally, the `custom.scss` file is where you can add or override globally-oriented styles in the Admin Panel, such as modify the color palette. Customizing the look and feel through CSS alone is a powerful feature of the Admin Panel, [more on that here](./customizing-css).

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -181,7 +181,7 @@ If none was in either location, Payload will finally check the `dist` directory.
 
 ### Customizing the Config Location
 
-In addition to the above automated detection, you can specify your own location for the Payload Config. This can be useful in situations where your config is not in a standard location, or you wish to switch between multiple configurations. To do this, Payload exposes an [Environment Variable](./environment-variables) to bypass all automatic config detection.
+In addition to the above automated detection, you can specify your own location for the Payload Config. This can be useful in situations where your config is not in a standard location, or you wish to switch between multiple configurations. To do this, Payload exposes an [Environment Variable](../configuration/environment-vars) to bypass all automatic config detection.
 
 To use a custom config location, set the `PAYLOAD_CONFIG_PATH` environment variable:
 

--- a/docs/rich-text/overview.mdx
+++ b/docs/rich-text/overview.mdx
@@ -174,7 +174,7 @@ Notice how even the toolbars are features? That's how extensible our lexical edi
 
 ## Creating your own, custom Feature
 
-You can find more information about creating your own feature in our [building custom feature docs](../rich-text/building-custom-features).
+You can find more information about creating your own feature in our [building custom feature docs](../rich-text/custom-features).
 
 ## TypeScript
 


### PR DESCRIPTION
### What?
Dead links located in docs, replaced with functioning links.

### Why?
It broke my [Cursor AI](https://github.com/getcursor/cursor) from crawling and indexing the docs :( 

### How?
Identified broken links by a free online service, https://www.deadlinkchecker.com/, and fixed all links prefixed with `https://payloadcms.com/docs`

[Referenced in Discord.](https://discord.com/channels/967097582721572934/967097582721572937/1338664792717525032)