### PR TITLE
templates: bump engines pnpm version to support 10

### DIFF
--- a/templates/website/package.json
+++ b/templates/website/package.json
@@ -70,7 +70,7 @@
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
-    "pnpm": "^9"
+    "pnpm": "^9 || ^10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/with-vercel-website/package.json
+++ b/templates/with-vercel-website/package.json
@@ -72,7 +72,7 @@
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
-    "pnpm": "^9"
+    "pnpm": "^9 || ^10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
Bumps to support v10 of pnpm in our website templates so installation doesn't fail on Vercel