### PR TITLE
fix(richtext-lexical): add container div to table element to allow horizontal scroll in HTML and JSX converters

### DIFF
--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/table.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/table.tsx
@@ -13,9 +13,11 @@ export const TableJSXConverter: JSXConverters<
       nodes: node.children,
     })
     return (
-      <table className="lexical-table" style={{ borderCollapse: 'collapse' }}>
-        <tbody>{children}</tbody>
-      </table>
+      <div className="lexical-table-container">
+        <table className="lexical-table" style={{ borderCollapse: 'collapse' }}>
+          <tbody>{children}</tbody>
+        </table>
+      </div>
     )
   },
   tablecell: ({ node, nodesToJSX }) => {

--- a/packages/richtext-lexical/src/features/experimental_table/server/index.ts
+++ b/packages/richtext-lexical/src/features/experimental_table/server/index.ts
@@ -101,7 +101,7 @@ export const EXPERIMENTAL_TableFeature = createServerFeature({
                   req,
                   showHiddenFields,
                 })
-                return `<table class="lexical-table" style="border-collapse: collapse;">${childrenText}</table>`
+                return `<div class="lexical-table-container"><table class="lexical-table" style="border-collapse: collapse;">${childrenText}</table></div>`
               },
               nodeTypes: [TableNode.getType()],
             },


### PR DESCRIPTION
### What?
Add a `div` wrapper to `table` tag in `TableFeature`

### Why?
This allows for adding horizontal scrolling to the table. We use table in our blog, however, on mobile, the content is wider than the screen width, and causes a horizontal scroll of all the content. I attached a video to show. You can see it by visiting the page on mobile https://magichour.ai/blog/10-best-ai-video-generators

https://github.com/user-attachments/assets/55778765-697e-426d-ac8a-1b0913adac13


Adding this container div allow me to target the div with a style
```css
.lexical-table-container {
  overflow-x: scroll;
}
```

### How?
![Screenshot 2025-02-11 at 11 26 18 AM](https://github.com/user-attachments/assets/873050b3-79b9-49ec-85ed-297286813577)

I tested this change by manually editing the HTML in our blog to include the `div` with the overflow style, and it fixes the issue. 

Also, verified just adding the `div` did not change anything related to the rendered output. 

