### PR TITLE
fix(richtext-lexical): reliably install exact lexical version by removing it from peerDeps

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,7 @@ export const defaultESLintIgnores = [
   'packages/**/*.spec.ts',
   'next-env.d.ts',
   '**/app',
+  'src/**/*.spec.ts',
 ]
 
 /** @typedef {import('eslint').Linter.Config} Config */
@@ -29,10 +30,7 @@ export const defaultESLintIgnores = [
 export const rootParserOptions = {
   sourceType: 'module',
   ecmaVersion: 'latest',
-  projectService: {
-    maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 40,
-    allowDefaultProject: ['scripts/*.ts', '*.js', '*.mjs', '*.d.ts'],
-  },
+  projectService: true,
 }
 
 /** @type {Config[]} */

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,7 @@ export const defaultESLintIgnores = [
   '**/build/',
   '**/node_modules/',
   '**/temp/',
-  '**/packages/*.spec.ts',
+  'packages/**/*.spec.ts',
   'next-env.d.ts',
   '**/app',
 ]

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -355,6 +355,7 @@
     "@lexical/rich-text": "0.21.0",
     "@lexical/selection": "0.21.0",
     "@lexical/utils": "0.21.0",
+    "@lexical/table": "0.21.0",
     "@payloadcms/translations": "workspace:*",
     "@payloadcms/ui": "workspace:*",
     "@types/uuid": "10.0.0",

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -395,18 +395,7 @@
   "peerDependencies": {
     "@faceless-ui/modal": "3.0.0-beta.2",
     "@faceless-ui/scroll-info": "2.0.0",
-    "@lexical/headless": "0.21.0",
-    "@lexical/html": "0.21.0",
-    "@lexical/link": "0.21.0",
-    "@lexical/list": "0.21.0",
-    "@lexical/mark": "0.21.0",
-    "@lexical/react": "0.21.0",
-    "@lexical/rich-text": "0.21.0",
-    "@lexical/selection": "0.21.0",
-    "@lexical/table": "0.21.0",
-    "@lexical/utils": "0.21.0",
     "@payloadcms/next": "workspace:*",
-    "lexical": "0.21.0",
     "payload": "workspace:*",
     "react": "^19.0.0 || ^19.0.0-rc-65a56d0e-20241020",
     "react-dom": "^19.0.0 || ^19.0.0-rc-65a56d0e-20241020"

--- a/packages/richtext-lexical/src/dependencyChecker.spec.ts
+++ b/packages/richtext-lexical/src/dependencyChecker.spec.ts
@@ -14,8 +14,5 @@ describe('Lexical dependency checker', () => {
     const packageJsonLexicalVersion = packageJson.dependencies['lexical']
 
     expect(packageJsonLexicalVersion).toBe(lexicalTargetVersion)
-
-    const packageJsonLexicalPeerDepVersion = packageJson.peerDependencies['lexical']
-    expect(packageJsonLexicalPeerDepVersion).toBe(lexicalTargetVersion)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1197,6 +1197,9 @@ importers:
       '@lexical/selection':
         specifier: 0.21.0
         version: 0.21.0
+      '@lexical/table':
+        specifier: 0.21.0
+        version: 0.21.0
       '@lexical/utils':
         specifier: 0.21.0
         version: 0.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1197,9 +1197,6 @@ importers:
       '@lexical/selection':
         specifier: 0.21.0
         version: 0.21.0
-      '@lexical/table':
-        specifier: 0.21.0
-        version: 0.21.0
       '@lexical/utils':
         specifier: 0.21.0
         version: 0.21.0


### PR DESCRIPTION
This will allow pnpm to reliably install the correct lexical version, as lexical is now solely part of our `dependencies`. Currently, pnpm completely disregards lexical version bumps until the user deletes both the lockfile and their `node_modules` folder.

The downside of this is that pnpm will no longer throw a warning if payload is installed in a project with a mismatching lexical version. However, noone read that warning anyways, and our runtime dependency checker is more reliable.