### PR TITLE
perf(next): page loading fallbacks

### DIFF
--- a/packages/next/src/elements/Nav/Loading.tsx
+++ b/packages/next/src/elements/Nav/Loading.tsx
@@ -1,0 +1,30 @@
+import type { ServerProps } from 'payload'
+
+import React from 'react'
+
+import './index.scss'
+import { NavHamburger } from './NavHamburger/index.js'
+import { NavWrapper } from './NavWrapper/index.js'
+
+const baseClass = 'nav'
+
+import { DefaultNavClient } from './index.client.js'
+
+export type NavProps = ServerProps
+
+export const DefaultNavLoading: React.FC = async () => {
+  return (
+    <NavWrapper baseClass={baseClass}>
+      <nav className={`${baseClass}__wrap`}>
+        <DefaultNavClient groups={[]} navPreferences={undefined} />
+
+        <div className={`${baseClass}__controls`}>{}</div>
+      </nav>
+      <div className={`${baseClass}__header`}>
+        <div className={`${baseClass}__header-content`}>
+          <NavHamburger baseClass={baseClass} />
+        </div>
+      </div>
+    </NavWrapper>
+  )
+}

--- a/packages/next/src/templates/Default/Loading.tsx
+++ b/packages/next/src/templates/Default/Loading.tsx
@@ -1,0 +1,57 @@
+import {
+  ActionsProvider,
+  AppHeader,
+  BulkUploadProvider,
+  EntityVisibilityProvider,
+  NavToggler,
+} from '@payloadcms/ui'
+
+import './index.scss'
+
+import React from 'react'
+
+import { DefaultNavLoading } from '../../elements/Nav/Loading.js'
+import { NavHamburger } from './NavHamburger/index.js'
+import { Wrapper } from './Wrapper/index.js'
+
+const baseClass = 'template-default'
+
+type DefaultTemplateLoaderProps = {
+  children?: React.ReactNode
+  className?: string
+}
+
+export const DefaultTemplateLoading: React.FC<DefaultTemplateLoaderProps> = ({
+  children,
+  className,
+}) => {
+  return (
+    <EntityVisibilityProvider
+      visibleEntities={{
+        collections: [],
+        globals: [],
+      }}
+    >
+      <BulkUploadProvider>
+        <ActionsProvider Actions={{}}>
+          <div style={{ position: 'relative' }}>
+            <div className={`${baseClass}__nav-toggler-wrapper`} id="nav-toggler">
+              <div className={`${baseClass}__nav-toggler-container`} id="nav-toggler">
+                <NavToggler className={`${baseClass}__nav-toggler`}>
+                  <NavHamburger />
+                </NavToggler>
+              </div>
+            </div>
+            <Wrapper baseClass={baseClass} className={className}>
+              <DefaultNavLoading />
+              <div className={`${baseClass}__wrap`}>
+                <AppHeader />
+                {children}
+              </div>
+            </Wrapper>
+          </div>
+        </ActionsProvider>
+      </BulkUploadProvider>
+    </EntityVisibilityProvider>
+  )
+}

--- a/packages/next/src/views/Document/index.tsx
+++ b/packages/next/src/views/Document/index.tsx
@@ -6,7 +6,7 @@ import { formatAdminURL, isEditing as getIsEditing } from '@payloadcms/ui/shared
 import { buildFormState } from '@payloadcms/ui/utilities/buildFormState'
 import { notFound, redirect } from 'next/navigation.js'
 import { logError } from 'payload'
-import React from 'react'
+import React, { Suspense } from 'react'
 
 import type { GenerateEditViewMetadata } from './getMetaBySegment.js'
 import type { ViewFromConfig } from './getViewsFromConfig.js'
@@ -381,10 +381,19 @@ export const renderDocument = async ({
   }
 }
 
-export const Document: React.FC<AdminViewProps> = async (args) => {
+const DocumentWithData: React.FC<AdminViewProps> = async (args) => {
+  const { Document: RenderedDocument } = await renderDocument(args)
+  return RenderedDocument
+}
+export const Document: React.FC<AdminViewProps> = (args) => {
   try {
-    const { Document: RenderedDocument } = await renderDocument(args)
-    return RenderedDocument
+    return (
+      <Suspense
+        key={`document-view-${args?.initPageResult?.collectionConfig?.slug ?? args?.initPageResult?.globalConfig?.slug}`}
+      >
+        <DocumentWithData {...args} />
+      </Suspense>
+    )
   } catch (error) {
     if (error?.message === 'NEXT_REDIRECT') {
       throw error

--- a/packages/next/src/views/List/index.tsx
+++ b/packages/next/src/views/List/index.tsx
@@ -12,7 +12,7 @@ import { renderFilters, renderTable, upsertPreferences } from '@payloadcms/ui/rs
 import { formatAdminURL, mergeListSearchAndWhere } from '@payloadcms/ui/shared'
 import { notFound } from 'next/navigation.js'
 import { isNumber } from 'payload/shared'
-import React, { Fragment } from 'react'
+import React, { Fragment, Suspense } from 'react'
 
 import { renderListViewSlots } from './renderListViewSlots.js'
 import { resolveAllFilterOptions } from './resolveAllFilterOptions.js'
@@ -235,10 +235,20 @@ export const renderListView = async (
   throw new Error('not-found')
 }
 
-export const ListView: React.FC<ListViewArgs> = async (args) => {
+const ListViewWithData: React.FC<ListViewArgs> = async (args) => {
+  const { List: RenderedList } = await renderListView({ ...args, enableRowSelections: true })
+  return RenderedList
+}
+
+export const ListView: React.FC<ListViewArgs> = (args) => {
   try {
-    const { List: RenderedList } = await renderListView({ ...args, enableRowSelections: true })
-    return RenderedList
+    return (
+      <Suspense
+        key={`list-view-${args?.initPageResult?.collectionConfig?.slug ?? args?.initPageResult?.globalConfig?.slug}`}
+      >
+        <ListViewWithData {...args} />
+      </Suspense>
+    )
   } catch (error) {
     if (error.message === 'not-found') {
       notFound()

--- a/packages/next/src/views/Root/getViewFromConfig.ts
+++ b/packages/next/src/views/Root/getViewFromConfig.ts
@@ -67,7 +67,7 @@ type GetViewFromConfigArgs = {
   segments: string[]
 }
 
-type GetViewFromConfigResult = {
+export type GetViewFromConfigResult = {
   DefaultView: ViewFromConfig
   documentSubViewType?: DocumentSubViewTypes
   initPageOptions: Parameters<typeof initPage>[0]


### PR DESCRIPTION
This streams down fallback components for edit and list views while they're loading, using `Suspense`. While this won't speed up loading, it should make the CMS feel more responsive, as you instantly get a response when navigating.

Additionally, data that is available earlier (e.g. Navigation) will show up earlier, as it doesn't have to wait for the list / edit views to load.

## Before

https://github.com/user-attachments/assets/115ff439-3569-408a-9808-bce4c1da767e

## After

https://github.com/user-attachments/assets/977bf3ca-3b30-4240-b10f-b1d420bd84f6

