### PR TITLE
chore(richtext-lexical): fix unchecked indexed access, make richtext-lexical full ts strict  (part 5/5)

### DIFF
--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -15,6 +15,7 @@ export type FileSize = {
 /**
  * FileSize_P4 is a more precise type, and will replace FileSize in Payload v4.
  * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ * @internal
  */
 export type FileSize_P4 = {
   url: null | string

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -9,9 +9,16 @@ export type FileSize = {
   filesize: null | number
   height: null | number
   mimeType: null | string
-  url: null | string
   width: null | number
 }
+
+/**
+ * FileSize_P4 is a more precise type, and will replace FileSize in Payload v4.
+ * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ */
+export type FileSize_P4 = {
+  url: null | string
+} & FileSize
 
 export type FileSizes = {
   [size: string]: FileSize

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -9,6 +9,7 @@ export type FileSize = {
   filesize: null | number
   height: null | number
   mimeType: null | string
+  url: null | string
   width: null | number
 }
 

--- a/packages/payload/src/uploads/types.ts
+++ b/packages/payload/src/uploads/types.ts
@@ -12,12 +12,13 @@ export type FileSize = {
   width: null | number
 }
 
+// TODO: deprecate in Payload v4.
 /**
- * FileSize_P4 is a more precise type, and will replace FileSize in Payload v4.
- * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ * FileSizeImproved is a more precise type, and will replace FileSize in Payload v4.
+ * This type is for internal use only as it will be deprecated in the future.
  * @internal
  */
-export type FileSize_P4 = {
+export type FileSizeImproved = {
   url: null | string
 } & FileSize
 

--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
@@ -1,3 +1,5 @@
+import type { FileSize_P4 } from 'payload'
+
 import type { UploadData_P4 } from '../../../../../../features/upload/server/nodes/UploadNode.js'
 import type { SerializedUploadNode } from '../../../../../../nodeTypes.js'
 import type { JSXConverters } from '../types.js'
@@ -43,7 +45,7 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
 
     // Iterate through each size in the data.sizes object
     for (const size in uploadDocument.value.sizes) {
-      const imageSize = uploadDocument.value.sizes[size]
+      const imageSize = uploadDocument.value.sizes[size] as FileSize_P4
 
       // Skip if any property of the size object is null
       if (

--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
@@ -1,13 +1,13 @@
-import type { FileSize_P4 } from 'payload'
+import type { FileSizeImproved } from 'payload'
 
-import type { UploadData_P4 } from '../../../../../../features/upload/server/nodes/UploadNode.js'
+import type { UploadDataImproved } from '../../../../../../features/upload/server/nodes/UploadNode.js'
 import type { SerializedUploadNode } from '../../../../../../nodeTypes.js'
 import type { JSXConverters } from '../types.js'
 
 export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
   upload: ({ node }) => {
     // TO-DO (v4): SerializedUploadNode should use UploadData_P4
-    const uploadDocument = node as UploadData_P4
+    const uploadDocument = node as UploadDataImproved
     if (typeof uploadDocument.value !== 'object') {
       return null
     }
@@ -45,7 +45,7 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
 
     // Iterate through each size in the data.sizes object
     for (const size in uploadDocument.value.sizes) {
-      const imageSize = uploadDocument.value.sizes[size] as FileSize_P4
+      const imageSize = uploadDocument.value.sizes[size] as FileSizeImproved
 
       // Skip if any property of the size object is null
       if (

--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
@@ -1,23 +1,23 @@
-import type { FileData, FileSize, TypeWithID } from 'payload'
-
+import type { UploadData_P4 } from '../../../../../../features/upload/server/nodes/UploadNode.js'
 import type { SerializedUploadNode } from '../../../../../../nodeTypes.js'
 import type { JSXConverters } from '../types.js'
 
 export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
   upload: ({ node }) => {
-    const uploadDocument: {
-      value?: FileData & TypeWithID
-    } = node as any
-
-    const url = uploadDocument?.value?.url
+    // TO-DO (v4): SerializedUploadNode should use UploadData_P4
+    const uploadDocument = node as UploadData_P4
+    if (typeof uploadDocument.value !== 'object') {
+      return null
+    }
+    const url = uploadDocument.value.url
 
     /**
      * If the upload is not an image, return a link to the upload
      */
-    if (!uploadDocument?.value?.mimeType?.startsWith('image')) {
+    if (!uploadDocument.value.mimeType.startsWith('image')) {
       return (
         <a href={url} rel="noopener noreferrer">
-          {uploadDocument.value?.filename}
+          {uploadDocument.value.filename}
         </a>
       )
     }
@@ -25,13 +25,13 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
     /**
      * If the upload is a simple image with no different sizes, return a simple img tag
      */
-    if (!uploadDocument?.value?.sizes || !Object.keys(uploadDocument?.value?.sizes).length) {
+    if (!Object.keys(uploadDocument.value.sizes).length) {
       return (
         <img
-          alt={uploadDocument?.value?.filename}
-          height={uploadDocument?.value?.height}
+          alt={uploadDocument.value.filename}
+          height={uploadDocument.value.height}
           src={url}
-          width={uploadDocument?.value?.width}
+          width={uploadDocument.value.width}
         />
       )
     }
@@ -42,13 +42,12 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
     const pictureJSX: React.ReactNode[] = []
 
     // Iterate through each size in the data.sizes object
-    for (const size in uploadDocument.value?.sizes) {
-      const imageSize: {
-        url?: string
-      } & FileSize = uploadDocument.value?.sizes[size]
+    for (const size in uploadDocument.value.sizes) {
+      const imageSize = uploadDocument.value.sizes[size]
 
       // Skip if any property of the size object is null
       if (
+        !imageSize ||
         !imageSize.width ||
         !imageSize.height ||
         !imageSize.mimeType ||

--- a/packages/richtext-lexical/src/features/blocks/server/validate.ts
+++ b/packages/richtext-lexical/src/features/blocks/server/validate.ts
@@ -46,8 +46,9 @@ export const blockValidationHOC = (
 
     const errorPathsSet = new Set<string>()
     for (const fieldKey in result) {
-      if (result[fieldKey].errorPaths?.length) {
-        for (const errorPath of result[fieldKey].errorPaths) {
+      const fieldState = result[fieldKey]
+      if (fieldState?.errorPaths?.length) {
+        for (const errorPath of fieldState.errorPaths) {
           errorPathsSet.add(errorPath)
         }
       }

--- a/packages/richtext-lexical/src/features/link/server/validate.ts
+++ b/packages/richtext-lexical/src/features/link/server/validate.ts
@@ -38,8 +38,9 @@ export const linkValidation = (
 
     const errorPathsSet = new Set<string>()
     for (const fieldKey in result) {
-      if (result[fieldKey].errorPaths?.length) {
-        for (const errorPath of result[fieldKey].errorPaths) {
+      const fieldState = result[fieldKey]
+      if (fieldState?.errorPaths?.length) {
+        for (const errorPath of fieldState.errorPaths) {
           errorPathsSet.add(errorPath)
         }
       }

--- a/packages/richtext-lexical/src/features/upload/server/feature.server.ts
+++ b/packages/richtext-lexical/src/features/upload/server/feature.server.ts
@@ -4,7 +4,7 @@ import type {
   Field,
   FieldSchemaMap,
   FileData,
-  FileSize,
+  FileSizeImproved,
   Payload,
   TypeWithID,
 } from 'payload'
@@ -172,9 +172,7 @@ export const UploadFeature = createServerFeature<
 
                   // Iterate through each size in the data.sizes object
                   for (const size in uploadDocument.value?.sizes) {
-                    const imageSize: {
-                      url?: string
-                    } & FileSize = uploadDocument.value?.sizes[size]
+                    const imageSize = uploadDocument.value.sizes[size] as FileSizeImproved
 
                     // Skip if any property of the size object is null
                     if (
@@ -207,7 +205,8 @@ export const UploadFeature = createServerFeature<
             if (!node) {
               let allSubFields: Field[] = []
               for (const collection in props?.collections) {
-                allSubFields = allSubFields.concat(props?.collections?.[collection]?.fields)
+                const collectionFields = props.collections[collection]!.fields
+                allSubFields = allSubFields.concat(collectionFields)
               }
               return allSubFields
             }
@@ -250,7 +249,7 @@ export const UploadFeature = createServerFeature<
                 if (!collection) {
                   return node
                 }
-                // @ts-expect-error
+                // @ts-expect-error - Fix in Payload v4
                 const id = node?.value?.id || node?.value // for backwards-compatibility
 
                 const populateDepth =

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -25,12 +25,13 @@ export type UploadData<TUploadExtraFieldsData extends JsonObject = JsonObject> =
   value: number | string | TypedCollection
 }
 
+// TODO: deprecate in Payload v4.
 /**
- * UploadData_P4 is a more precise type, and will replace UploadData in Payload v4.
- * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ * UploadDataImproved is a more precise type, and will replace UploadData in Payload v4.
+ * This type is for internal use only as it will be deprecated in the future.
  * @internal
  */
-export type UploadData_P4<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
+export type UploadDataImproved<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
   fields: TUploadExtraFieldsData
   // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
   id: string

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -18,16 +18,17 @@ import * as React from 'react'
 
 export type UploadData<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
   fields: TUploadExtraFieldsData
-  // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
+  /** Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document */
   id: string
   relationTo: string
-  // Value can be just the document ID, or the full, populated document
+  /** Value can be just the document ID, or the full, populated document */
   value: number | string | TypedCollection
 }
 
 /**
  * UploadData_P4 is a more precise type, and will replace UploadData in Payload v4.
  * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ * @internal
  */
 export type UploadData_P4<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
   fields: TUploadExtraFieldsData

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -8,7 +8,7 @@ import type {
   NodeKey,
   Spread,
 } from 'lexical'
-import type { CollectionSlug, DataFromCollectionSlug, JsonObject } from 'payload'
+import type { FileData, JsonObject, TypedCollection, TypeWithID } from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
@@ -17,15 +17,26 @@ import { $applyNodeReplacement } from 'lexical'
 import * as React from 'react'
 
 export type UploadData<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
-  [TCollectionSlug in CollectionSlug]: {
-    fields: TUploadExtraFieldsData
-    // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
-    id: string
-    relationTo: TCollectionSlug
-    // Value can be just the document ID, or the full, populated document
-    value: DataFromCollectionSlug<TCollectionSlug> | number | string
-  }
-}[CollectionSlug]
+  fields: TUploadExtraFieldsData
+  // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
+  id: string
+  relationTo: string
+  // Value can be just the document ID, or the full, populated document
+  value: number | string | TypedCollection
+}
+
+/**
+ * UploadData_P4 is a more precise type, and will replace UploadData in Payload v4.
+ * I am not encouraging users to use this type via tsdoc yet, in case we find more breaking changes to do prior to v4.
+ */
+export type UploadData_P4<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
+  fields: TUploadExtraFieldsData
+  // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
+  id: string
+  relationTo: string
+  // Value can be just the document ID, or the full, populated document
+  value: (FileData & TypeWithID) | number | string
+}
 
 export function isGoogleDocCheckboxImg(img: HTMLImageElement): boolean {
   return (

--- a/packages/richtext-lexical/src/features/upload/server/validate.ts
+++ b/packages/richtext-lexical/src/features/upload/server/validate.ts
@@ -21,8 +21,8 @@ export const uploadValidation = (
       },
     },
   }) => {
-    const idType = payload.collections[node.relationTo].customIDType || payload.db.defaultIDType
-    // @ts-expect-error
+    const idType = payload.collections[node.relationTo]?.customIDType || payload.db.defaultIDType
+    // @ts-expect-error - Fix in Payload v4
     const nodeID = node?.value?.id || node?.value // for backwards-compatibility
 
     if (!isValidID(nodeID, idType)) {
@@ -62,8 +62,9 @@ export const uploadValidation = (
 
     const errorPathsSet = new Set<string>()
     for (const fieldKey in result) {
-      if (result[fieldKey].errorPaths?.length) {
-        for (const errorPath of result[fieldKey].errorPaths) {
+      const fieldState = result[fieldKey]
+      if (fieldState?.errorPaths?.length) {
+        for (const errorPath of fieldState.errorPaths) {
           errorPathsSet.add(errorPath)
         }
       }

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownExport.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownExport.ts
@@ -49,11 +49,10 @@ export function createMarkdownExport(
     })
 
   return (node) => {
-    const output = []
+    const output: string[] = []
     const children = (node || $getRoot()).getChildren()
 
-    for (let i = 0; i < children.length; i++) {
-      const child = children[i]
+    children.forEach((child, i) => {
       const result = exportTopLevelElements(
         child,
         elementTransformers,
@@ -67,12 +66,12 @@ export function createMarkdownExport(
           isNewlineDelimited &&
             i > 0 &&
             !isEmptyParagraph(child) &&
-            !isEmptyParagraph(children[i - 1])
+            !isEmptyParagraph(children[i - 1]!)
             ? '\n'.concat(result)
             : result,
         )
       }
-    }
+    })
     // Ensure consecutive groups of texts are at least \n\n apart while each empty paragraph render as a newline.
     // Eg. ["hello", "", "", "hi", "\nworld"] -> "hello\n\n\nhi\n\nworld"
     return output.join('\n')
@@ -218,7 +217,7 @@ function exportTextFormat(
   const applied = new Set()
 
   for (const transformer of textTransformers) {
-    const format = transformer.format[0]
+    const format = transformer.format[0]!
     const tag = transformer.tag
 
     // dedup applied formats
@@ -237,8 +236,9 @@ function exportTextFormat(
 
   // close any tags in the same order they were applied, if necessary
   for (let i = 0; i < unclosedTags.length; i++) {
-    const nodeHasFormat = hasFormat(node, unclosedTags[i].format)
-    const nextNodeHasFormat = hasFormat(nextNode, unclosedTags[i].format)
+    const unclosedTag = unclosedTags[i]!
+    const nodeHasFormat = hasFormat(node, unclosedTag.format)
+    const nextNodeHasFormat = hasFormat(nextNode, unclosedTag.format)
 
     // prevent adding closing tag if next sibling will do it
     if (nodeHasFormat && nextNodeHasFormat) {

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownImport.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownImport.ts
@@ -56,7 +56,7 @@ export function createMarkdownImport(
     root.clear()
 
     for (let i = 0; i < linesLength; i++) {
-      const lineText = lines[i]
+      const lineText = lines[i]!
 
       const [imported, shiftedIndex] = $importMultiline(lines, i, byType.multilineElement, root)
 
@@ -101,7 +101,7 @@ function $importMultiline(
   for (const transformer of multilineElementTransformers) {
     const { handleImportAfterStartMatch, regExpEnd, regExpStart, replace } = transformer
 
-    const startMatch = lines[startLineIndex].match(regExpStart)
+    const startMatch = lines[startLineIndex]?.match(regExpStart)
     if (!startMatch) {
       continue // Try next transformer
     }
@@ -134,7 +134,7 @@ function $importMultiline(
 
     // check every single line for the closing match. It could also be on the same line as the opening match.
     while (endLineIndex < linesLength) {
-      const endMatch = regexpEndRegex ? lines[endLineIndex].match(regexpEndRegex) : null
+      const endMatch = regexpEndRegex ? lines[endLineIndex]?.match(regexpEndRegex) : null
       if (!endMatch) {
         if (
           !isEndOptional ||
@@ -157,22 +157,23 @@ function $importMultiline(
       const linesInBetween: string[] = []
 
       if (endMatch && startLineIndex === endLineIndex) {
-        linesInBetween.push(lines[startLineIndex].slice(startMatch[0].length, -endMatch[0].length))
+        linesInBetween.push(lines[startLineIndex]!.slice(startMatch[0].length, -endMatch[0].length))
       } else {
         for (let i = startLineIndex; i <= endLineIndex; i++) {
+          const line = lines[i]!
           if (i === startLineIndex) {
-            const text = lines[i].slice(startMatch[0].length)
+            const text = line.slice(startMatch[0].length)
             linesInBetween.push(text) // Also include empty text
           } else if (i === endLineIndex && endMatch) {
-            const text = lines[i].slice(0, -endMatch[0].length)
+            const text = line.slice(0, -endMatch[0].length)
             linesInBetween.push(text) // Also include empty text
           } else {
-            linesInBetween.push(lines[i])
+            linesInBetween.push(line)
           }
         }
       }
 
-      if (replace(rootNode, null, startMatch, endMatch, linesInBetween, true) !== false) {
+      if (replace(rootNode, null, startMatch, endMatch!, linesInBetween, true) !== false) {
         // Return here. This $importMultiline function is run line by line and should only process a single multiline element at a time.
         return [true, endLineIndex]
       }

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownShortcuts.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownShortcuts.ts
@@ -59,7 +59,7 @@ function runElementTransformers(
     if (match && match[0].length === (match[0].endsWith(' ') ? anchorOffset : anchorOffset - 1)) {
       const nextSiblings = anchorNode.getNextSiblings()
       const [leadingNode, remainderNode] = anchorNode.splitText(anchorOffset)
-      leadingNode.remove()
+      leadingNode?.remove()
       const siblings = remainderNode ? [remainderNode, ...nextSiblings] : nextSiblings
       if (replace(parentNode, siblings, match, false) !== false) {
         return true
@@ -107,7 +107,7 @@ function runMultilineElementTransformers(
     if (match && match[0].length === (match[0].endsWith(' ') ? anchorOffset : anchorOffset - 1)) {
       const nextSiblings = anchorNode.getNextSiblings()
       const [leadingNode, remainderNode] = anchorNode.splitText(anchorOffset)
-      leadingNode.remove()
+      leadingNode?.remove()
       const siblings = remainderNode ? [remainderNode, ...nextSiblings] : nextSiblings
 
       if (replace(parentNode, siblings, match, null, null, false) !== false) {
@@ -125,7 +125,7 @@ function runTextMatchTransformers(
   transformersByTrigger: Readonly<Record<string, Array<TextMatchTransformer>>>,
 ): boolean {
   let textContent = anchorNode.getTextContent()
-  const lastChar = textContent[anchorOffset - 1]
+  const lastChar = textContent[anchorOffset - 1]!
   const transformers = transformersByTrigger[lastChar]
 
   if (transformers == null) {
@@ -157,9 +157,10 @@ function runTextMatchTransformers(
     } else {
       ;[, replaceNode] = anchorNode.splitText(startIndex, endIndex)
     }
-
-    replaceNode.selectNext(0, 0)
-    transformer.replace(replaceNode, match)
+    if (replaceNode) {
+      replaceNode.selectNext(0, 0)
+      transformer.replace(replaceNode, match)
+    }
     return true
   }
 
@@ -173,7 +174,7 @@ function $runTextFormatTransformers(
 ): boolean {
   const textContent = anchorNode.getTextContent()
   const closeTagEndIndex = anchorOffset - 1
-  const closeChar = textContent[closeTagEndIndex]
+  const closeChar = textContent[closeTagEndIndex]!
   // Quick check if we're possibly at the end of inline markdown style
   const matchers = textFormatTransformers[closeChar]
 

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownTransformers.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownTransformers.ts
@@ -255,7 +255,7 @@ const listReplace = (listType: ListType): ElementTransformer['replace'] => {
     }
     listItem.append(...children)
     listItem.select(0, 0)
-    const indent = getIndent(match[1])
+    const indent = getIndent(match[1]!)
     if (indent) {
       listItem.setIndent(indent)
     }
@@ -307,7 +307,7 @@ export const HEADING: ElementTransformer = {
   },
   regExp: HEADING_REGEX,
   replace: createBlockNode((match) => {
-    const tag = ('h' + match[1].length) as HeadingTagType
+    const tag = ('h' + match[1]!.length) as HeadingTagType
     return $createHeadingNode(tag)
   }),
 }
@@ -443,7 +443,7 @@ export function normalizeMarkdown(input: string, shouldMergeAdjacentLines: boole
   let nestedDeepCodeBlock = 0
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
+    const line = lines[i]!
     const lastLine = sanitizedLines[sanitizedLines.length - 1]
 
     // Code blocks of ```single line``` don't toggle the inCodeBlock flag
@@ -484,7 +484,7 @@ export function normalizeMarkdown(input: string, shouldMergeAdjacentLines: boole
     // Blocks must be separated by an empty line. Non-empty adjacent lines must be merged.
     if (
       EMPTY_OR_WHITESPACE_ONLY.test(line) ||
-      EMPTY_OR_WHITESPACE_ONLY.test(lastLine) ||
+      EMPTY_OR_WHITESPACE_ONLY.test(lastLine!) ||
       !lastLine ||
       HEADING_REGEX.test(lastLine) ||
       HEADING_REGEX.test(line) ||

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/importTextFormatTransformer.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/importTextFormatTransformer.ts
@@ -32,6 +32,7 @@ export function findOutermostTextFormatTransformer(
   const textFormatMatchStart: number = match.index || 0
   const textFormatMatchEnd = textFormatMatchStart + match[0].length
 
+  // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
   const transformer: TextFormatTransformer = textFormatTransformersIndex.transformersByTag[match[1]]
 
   return {
@@ -101,7 +102,9 @@ export function importTextFormatTransformer(
   const textContent = textNode.getTextContent()
 
   // No text matches - we can safely process the text format match
-  let nodeAfter, nodeBefore, transformedNode
+  let nodeAfter: TextNode | undefined
+  let nodeBefore: TextNode | undefined
+  let transformedNode: TextNode
 
   // If matching full content there's no need to run splitText and can reuse existing textNode
   // to update its content and apply format. E.g. for **_Hello_** string after applying bold
@@ -110,14 +113,20 @@ export function importTextFormatTransformer(
     transformedNode = textNode
   } else {
     if (startIndex === 0) {
-      ;[transformedNode, nodeAfter] = textNode.splitText(endIndex)
+      ;[transformedNode, nodeAfter] = textNode.splitText(endIndex) as [
+        TextNode,
+        TextNode | undefined,
+      ]
     } else {
-      ;[nodeBefore, transformedNode, nodeAfter] = textNode.splitText(startIndex, endIndex)
+      ;[nodeBefore, transformedNode, nodeAfter] = textNode.splitText(startIndex, endIndex) as [
+        TextNode,
+        TextNode,
+        TextNode | undefined,
+      ]
     }
   }
 
-  transformedNode.setTextContent(match[2])
-
+  transformedNode.setTextContent(match[2]!)
   if (transformer) {
     for (const format of transformer.format) {
       if (!transformedNode.hasFormat(format)) {

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/importTextMatchTransformer.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/importTextMatchTransformer.ts
@@ -95,7 +95,9 @@ export function importFoundTextMatchTransformer(
   if (!transformer.replace) {
     return null
   }
-  const potentialTransformedNode = transformer.replace(transformedNode, match)
+  const potentialTransformedNode = transformedNode
+    ? transformer.replace(transformedNode, match)
+    : undefined
 
   return {
     nodeAfter,

--- a/packages/richtext-lexical/src/utilities/jsx/collectTopLevelJSXInLines.ts
+++ b/packages/richtext-lexical/src/utilities/jsx/collectTopLevelJSXInLines.ts
@@ -64,7 +64,8 @@ export function collectTopLevelJSXInLines(
   const linesLength = lines.length
 
   for (let i = 0; i < linesLength; i++) {
-    const startMatch = lines[i].match(regex.regExpStart)
+    const line = lines[i]!
+    const startMatch = line.match(regex.regExpStart)
     if (!startMatch) {
       continue // Try next transformer
     }

--- a/packages/richtext-lexical/src/utilities/migrateSlateToLexical/migrateDocumentFieldsRecursively.ts
+++ b/packages/richtext-lexical/src/utilities/migrateSlateToLexical/migrateDocumentFieldsRecursively.ts
@@ -47,11 +47,11 @@ export const migrateDocumentFieldsRecursively = ({
       })
     } else if (Array.isArray(data[field.name])) {
       if (field.type === 'blocks') {
-        ;(data[field.name] as Array<Record<string, unknown>>).forEach((row, i) => {
+        ;(data[field.name] as Array<Record<string, unknown>>).forEach((row) => {
           const block = field.blocks.find(({ slug }) => slug === row?.blockType)
           if (block) {
             found += migrateDocumentFieldsRecursively({
-              data: (data[field.name] as Array<Record<string, unknown>>)[i],
+              data: row,
               fields: block.fields,
               found,
             })
@@ -60,9 +60,9 @@ export const migrateDocumentFieldsRecursively = ({
       }
 
       if (field.type === 'array') {
-        ;(data[field.name] as Array<Record<string, unknown>>).forEach((_, i) => {
+        ;(data[field.name] as Array<Record<string, unknown>>).forEach((row) => {
           found += migrateDocumentFieldsRecursively({
-            data: (data[field.name] as Array<Record<string, unknown>>)[i],
+            data: row,
             fields: field.fields,
             found,
           })

--- a/packages/richtext-lexical/src/utilities/upgradeLexicalData/upgradeDocumentFieldsRecursively.ts
+++ b/packages/richtext-lexical/src/utilities/upgradeLexicalData/upgradeDocumentFieldsRecursively.ts
@@ -45,11 +45,11 @@ export const upgradeDocumentFieldsRecursively = ({
       })
     } else if (Array.isArray(data[field.name])) {
       if (field.type === 'blocks') {
-        ;(data[field.name] as Record<string, unknown>[]).forEach((row, i) => {
+        ;(data[field.name] as Record<string, unknown>[]).forEach((row) => {
           const block = field.blocks.find(({ slug }) => slug === row?.blockType)
           if (block) {
             found += upgradeDocumentFieldsRecursively({
-              data: (data[field.name] as Record<string, unknown>[])[i],
+              data: row,
               fields: block.fields,
               found,
             })
@@ -58,9 +58,9 @@ export const upgradeDocumentFieldsRecursively = ({
       }
 
       if (field.type === 'array') {
-        ;(data[field.name] as Record<string, unknown>[]).forEach((_, i) => {
+        ;(data[field.name] as Record<string, unknown>[]).forEach((row) => {
           found += upgradeDocumentFieldsRecursively({
-            data: (data[field.name] as Record<string, unknown>[])[i],
+            data: row,
             fields: field.fields,
             found,
           })

--- a/packages/richtext-lexical/src/validate/hasText.ts
+++ b/packages/richtext-lexical/src/validate/hasText.ts
@@ -19,7 +19,7 @@ export function hasText(
         hasOnlyEmptyParagraph = true
       } else if (paragraphNode?.children?.length === 1) {
         const paragraphNodeChild = paragraphNode?.children[0]
-        if (paragraphNodeChild.type === 'text') {
+        if (paragraphNodeChild?.type === 'text') {
           if (!(paragraphNodeChild as SerializedTextNode | undefined)?.['text']?.length) {
             hasOnlyEmptyParagraph = true
           }

--- a/packages/richtext-lexical/tsconfig.json
+++ b/packages/richtext-lexical/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    /* TODO: remove the following lines */
-    "noUncheckedIndexedAccess": false
-  },
   "references": [
     { "path": "../payload" },
     { "path": "../translations" },


### PR DESCRIPTION
This PR concludes the series to make `richtext-lexical` full strict in TypeScript 🥳