### PR TITLE
chore: add typescript-strict-plugin to the payload package for incremental file-by-file migration [skip lint]

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -74,7 +74,7 @@
     "build": "rimraf .dist && rimraf tsconfig.tsbuildinfo && pnpm copyfiles && pnpm build:types && pnpm build:swc && pnpm build:esbuild",
     "build:esbuild": "echo skipping esbuild",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
-    "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "build:types": "concurrently --group \"tsc --emitDeclarationOnly --outDir dist\" \"tsc-strict\"",
     "clean": "rimraf -g {dist,*.tsbuildinfo}",
     "clean:cache": "rimraf node_modules/.cache",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
@@ -124,13 +124,15 @@
     "@types/pluralize": "0.0.33",
     "@types/uuid": "10.0.0",
     "@types/ws": "^8.5.10",
+    "concurrently": "9.1.2",
     "copyfiles": "2.4.1",
     "cross-env": "7.0.3",
     "esbuild": "0.24.2",
     "graphql-http": "^1.22.0",
     "react-datepicker": "7.6.0",
     "rimraf": "6.0.1",
-    "sharp": "0.32.6"
+    "sharp": "0.32.6",
+    "typescript-strict-plugin": "2.4.4"
   },
   "peerDependencies": {
     "graphql": "^16.8.1"

--- a/packages/payload/src/admin/RichText.ts
+++ b/packages/payload/src/admin/RichText.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { GenericLanguages, I18n } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
 

--- a/packages/payload/src/admin/forms/Diff.ts
+++ b/packages/payload/src/admin/forms/Diff.ts
@@ -1,3 +1,5 @@
+// @ts-strict-ignore
+
 import type { I18nClient } from '@payloadcms/translations'
 
 import type { ClientField, Field, FieldTypes, Tab } from '../../fields/config/types.js'

--- a/packages/payload/src/auth/cookies.ts
+++ b/packages/payload/src/auth/cookies.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from './../collections/config/types.js'
 
 type CookieOptions = {

--- a/packages/payload/src/auth/crypto.ts
+++ b/packages/payload/src/auth/crypto.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import crypto from 'crypto'
 
 const algorithm = 'aes-256-ctr'

--- a/packages/payload/src/auth/endpoints/forgotPassword.ts
+++ b/packages/payload/src/auth/endpoints/forgotPassword.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/auth/endpoints/login.ts
+++ b/packages/payload/src/auth/endpoints/login.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/auth/endpoints/me.ts
+++ b/packages/payload/src/auth/endpoints/me.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/auth/endpoints/refresh.ts
+++ b/packages/payload/src/auth/endpoints/refresh.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/auth/endpoints/registerFirstUser.ts
+++ b/packages/payload/src/auth/endpoints/registerFirstUser.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/auth/endpoints/resetPassword.ts
+++ b/packages/payload/src/auth/endpoints/resetPassword.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/auth/executeAuthStrategies.ts
+++ b/packages/payload/src/auth/executeAuthStrategies.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { AuthStrategyFunctionArgs, AuthStrategyResult } from './index.js'
 
 export const executeAuthStrategies = async (

--- a/packages/payload/src/auth/getAccessResults.ts
+++ b/packages/payload/src/auth/getAccessResults.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { AllOperations, PayloadRequest } from '../types/index.js'
 import type { Permissions, SanitizedPermissions } from './types.js'
 

--- a/packages/payload/src/auth/getFieldsToSign.ts
+++ b/packages/payload/src/auth/getFieldsToSign.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionConfig } from '../collections/config/types.js'
 import type { Field, TabAsField } from '../fields/config/types.js'
 import type { PayloadRequest } from '../types/index.js'

--- a/packages/payload/src/auth/getLoginOptions.ts
+++ b/packages/payload/src/auth/getLoginOptions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Auth } from './types.js'
 
 export const getLoginOptions = (

--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import crypto from 'crypto'
 import { status as httpStatus } from 'http-status'
 import { URL } from 'url'

--- a/packages/payload/src/auth/operations/local/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/local/forgotPassword.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionSlug, Payload, RequestContext } from '../../../index.js'
 import type { PayloadRequest } from '../../../types/index.js'
 import type { Result } from '../forgotPassword.js'

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type {
   AuthOperationsFromCollectionSlug,
   Collection,

--- a/packages/payload/src/auth/operations/me.ts
+++ b/packages/payload/src/auth/operations/me.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { decodeJwt } from 'jose'
 
 import type { Collection } from '../../collections/config/types.js'

--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import url from 'url'
 
 import type { BeforeOperationHook, Collection } from '../../collections/config/types.js'

--- a/packages/payload/src/auth/operations/unlock.ts
+++ b/packages/payload/src/auth/operations/unlock.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type {

--- a/packages/payload/src/auth/sendVerificationEmail.ts
+++ b/packages/payload/src/auth/sendVerificationEmail.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { URL } from 'url'
 
 import type { Collection } from '../collections/config/types.js'

--- a/packages/payload/src/auth/strategies/apiKey.ts
+++ b/packages/payload/src/auth/strategies/apiKey.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import crypto from 'crypto'
 
 import type { SanitizedCollectionConfig } from '../../collections/config/types.js'

--- a/packages/payload/src/auth/strategies/jwt.ts
+++ b/packages/payload/src/auth/strategies/jwt.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { jwtVerify } from 'jose'
 
 import type { Payload, Where } from '../../types/index.js'

--- a/packages/payload/src/auth/strategies/local/authenticate.ts
+++ b/packages/payload/src/auth/strategies/local/authenticate.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import crypto from 'crypto'
 import scmp from 'scmp'
 

--- a/packages/payload/src/bin/generateImportMap/iterateConfig.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateConfig.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import type { AdminViewConfig } from '../../admin/views/types.js'
 import type { SanitizedConfig } from '../../config/types.js'

--- a/packages/payload/src/bin/generateImportMap/iterateFields.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import type { PayloadComponent, SanitizedConfig } from '../../config/types.js'
 import type { Block, Field, Tab } from '../../fields/config/types.js'

--- a/packages/payload/src/bin/generateImportMap/parsePayloadComponent.ts
+++ b/packages/payload/src/bin/generateImportMap/parsePayloadComponent.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadComponent } from '../../config/types.js'
 
 export function parsePayloadComponent(PayloadComponent: PayloadComponent): {

--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /* eslint-disable no-console */
 import { Cron } from 'croner'
 import minimist from 'minimist'

--- a/packages/payload/src/bin/loadEnv.ts
+++ b/packages/payload/src/bin/loadEnv.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import nextEnvImport from '@next/env'
 
 import { findUpSync } from '../utilities/findUp.js'

--- a/packages/payload/src/bin/migrate.ts
+++ b/packages/payload/src/bin/migrate.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { ParsedArgs } from 'minimist'
 
 import type { SanitizedConfig } from '../config/types.js'

--- a/packages/payload/src/collections/config/client.ts
+++ b/packages/payload/src/collections/config/client.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { I18nClient } from '@payloadcms/translations'
 
 import type { StaticDescription } from '../../admin/types.js'

--- a/packages/payload/src/collections/config/reservedFieldNames.ts
+++ b/packages/payload/src/collections/config/reservedFieldNames.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Field } from '../../fields/config/types.js'
 import type { CollectionConfig } from '../../index.js'
 

--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { LoginWithUsernameOptions } from '../../auth/types.js'
 import type { Config, SanitizedConfig } from '../../config/types.js'
 import type { CollectionConfig, SanitizedCollectionConfig, SanitizedJoins } from './types.js'

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { BatchLoadFn } from 'dataloader'
 
 import DataLoader from 'dataloader'

--- a/packages/payload/src/collections/endpoints/create.ts
+++ b/packages/payload/src/collections/endpoints/create.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { getTranslation } from '@payloadcms/translations'
 import { status as httpStatus } from 'http-status'
 

--- a/packages/payload/src/collections/endpoints/delete.ts
+++ b/packages/payload/src/collections/endpoints/delete.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { getTranslation } from '@payloadcms/translations'
 import { status as httpStatus } from 'http-status'
 

--- a/packages/payload/src/collections/endpoints/find.ts
+++ b/packages/payload/src/collections/endpoints/find.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/collections/endpoints/findByID.ts
+++ b/packages/payload/src/collections/endpoints/findByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/collections/endpoints/getFile.ts
+++ b/packages/payload/src/collections/endpoints/getFile.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { fileTypeFromFile } from 'file-type'
 import fsPromises from 'fs/promises'
 import { status as httpStatus } from 'http-status'

--- a/packages/payload/src/collections/endpoints/getFileFromURL.ts
+++ b/packages/payload/src/collections/endpoints/getFileFromURL.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadHandler } from '../../config/types.js'
 
 import executeAccess from '../../auth/executeAccess.js'

--- a/packages/payload/src/collections/endpoints/preview.ts
+++ b/packages/payload/src/collections/endpoints/preview.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/collections/endpoints/update.ts
+++ b/packages/payload/src/collections/endpoints/update.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { getTranslation } from '@payloadcms/translations'
 import { status as httpStatus } from 'http-status'
 

--- a/packages/payload/src/collections/endpoints/updateByID.ts
+++ b/packages/payload/src/collections/endpoints/updateByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/collections/operations/count.ts
+++ b/packages/payload/src/collections/operations/count.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { AccessResult } from '../../config/types.js'
 import type { CollectionSlug } from '../../index.js'
 import type { PayloadRequest, Where } from '../../types/index.js'

--- a/packages/payload/src/collections/operations/countVersions.ts
+++ b/packages/payload/src/collections/operations/countVersions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { AccessResult } from '../../config/types.js'
 import type { PayloadRequest, Where } from '../../types/index.js'
 import type { Collection } from '../config/types.js'

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import crypto from 'crypto'
 
 import type {

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { AccessResult } from '../../config/types.js'

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionSlug } from '../../index.js'
 import type {
   PayloadRequest,

--- a/packages/payload/src/collections/operations/docAccess.ts
+++ b/packages/payload/src/collections/operations/docAccess.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionPermission } from '../../auth/index.js'
 import type { AllOperations, PayloadRequest } from '../../types/index.js'
 import type { Collection } from '../config/types.js'

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { AccessResult } from '../../config/types.js'
 import type { PaginatedDocs } from '../../database/types.js'
 import type { CollectionSlug, JoinQuery } from '../../index.js'

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { FindOneArgs } from '../../database/types.js'
 import type { CollectionSlug, JoinQuery } from '../../index.js'
 import type {

--- a/packages/payload/src/collections/operations/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/findVersionByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadRequest, PopulateType, SelectType } from '../../types/index.js'

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PaginatedDocs } from '../../database/types.js'
 import type { PayloadRequest, PopulateType, SelectType, Sort, Where } from '../../types/index.js'
 import type { TypeWithVersion } from '../../versions/types.js'

--- a/packages/payload/src/collections/operations/local/count.ts
+++ b/packages/payload/src/collections/operations/local/count.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type { Document, PayloadRequest, Where } from '../../../types/index.js'
 

--- a/packages/payload/src/collections/operations/local/countVersions.ts
+++ b/packages/payload/src/collections/operations/local/countVersions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type { Document, PayloadRequest, Where } from '../../../types/index.js'
 

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type {
   Document,
   PayloadRequest,

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type {
   Document,

--- a/packages/payload/src/collections/operations/local/duplicate.ts
+++ b/packages/payload/src/collections/operations/local/duplicate.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { DeepPartial } from 'ts-essentials'
 
 import type { CollectionSlug, TypedLocale } from '../../..//index.js'

--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PaginatedDocs } from '../../../database/types.js'
 import type {
   CollectionSlug,

--- a/packages/payload/src/collections/operations/local/findByID.ts
+++ b/packages/payload/src/collections/operations/local/findByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /* eslint-disable no-restricted-exports */
 import type {
   CollectionSlug,

--- a/packages/payload/src/collections/operations/local/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/local/findVersionByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type { Document, PayloadRequest, PopulateType, SelectType } from '../../../types/index.js'
 import type { TypeWithVersion } from '../../../versions/types.js'

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PaginatedDocs } from '../../../database/types.js'
 import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type {

--- a/packages/payload/src/collections/operations/local/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/local/restoreVersion.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type { Document, PayloadRequest, PopulateType, SelectType } from '../../../types/index.js'
 import type { DataFromCollectionSlug } from '../../config/types.js'

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { DeepPartial } from 'ts-essentials'
 
 import type { CollectionSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { FindOneArgs } from '../../database/types.js'

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { DeepPartial } from 'ts-essentials'
 
 import { status as httpStatus } from 'http-status'

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { DeepPartial } from 'ts-essentials'
 
 import { status as httpStatus } from 'http-status'

--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { DeepPartial } from 'ts-essentials'
 
 import type { Args } from '../../../fields/hooks/beforeChange/index.js'

--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { I18nClient } from '@payloadcms/translations'
 import type { DeepPartial } from 'ts-essentials'
 

--- a/packages/payload/src/config/find.ts
+++ b/packages/payload/src/config/find.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { getTsconfig } from 'get-tsconfig'
 import path from 'path'
 

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { AcceptedLanguages } from '@payloadcms/translations'
 
 import { en } from '@payloadcms/translations/languages/en'

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type {
   DefaultTranslationKeys,
   DefaultTranslationsObject,

--- a/packages/payload/src/database/combineQueries.ts
+++ b/packages/payload/src/database/combineQueries.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Where } from '../types/index.js'
 
 import { hasWhereAccessResult } from '../auth/index.js'

--- a/packages/payload/src/database/createDatabaseAdapter.ts
+++ b/packages/payload/src/database/createDatabaseAdapter.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { MarkOptional } from 'ts-essentials'
 
 import type {

--- a/packages/payload/src/database/getLocalizedPaths.ts
+++ b/packages/payload/src/database/getLocalizedPaths.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Field, FlattenedField } from '../fields/config/types.js'
 import type { Payload } from '../index.js'
 import type { PathToQuery } from './queryValidation/types.js'

--- a/packages/payload/src/database/migrations/createMigration.ts
+++ b/packages/payload/src/database/migrations/createMigration.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import fs from 'fs'
 
 import type { CreateMigration } from '../types.js'

--- a/packages/payload/src/database/migrations/migrate.ts
+++ b/packages/payload/src/database/migrations/migrate.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { BaseDatabaseAdapter } from '../types.js'
 
 import { commitTransaction } from '../../utilities/commitTransaction.js'

--- a/packages/payload/src/database/migrations/migrateDown.ts
+++ b/packages/payload/src/database/migrations/migrateDown.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { BaseDatabaseAdapter } from '../types.js'
 
 import { commitTransaction } from '../../utilities/commitTransaction.js'

--- a/packages/payload/src/database/migrations/migrateRefresh.ts
+++ b/packages/payload/src/database/migrations/migrateRefresh.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { BaseDatabaseAdapter } from '../types.js'
 
 import { commitTransaction } from '../../utilities/commitTransaction.js'

--- a/packages/payload/src/database/migrations/migrateReset.ts
+++ b/packages/payload/src/database/migrations/migrateReset.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { BaseDatabaseAdapter } from '../types.js'
 
 import { commitTransaction } from '../../utilities/commitTransaction.js'

--- a/packages/payload/src/database/migrations/readMigrationFiles.ts
+++ b/packages/payload/src/database/migrations/readMigrationFiles.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import fs from 'fs'
 import { pathToFileURL } from 'node:url'
 import path from 'path'

--- a/packages/payload/src/database/queryValidation/validateQueryPaths.ts
+++ b/packages/payload/src/database/queryValidation/validateQueryPaths.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../collections/config/types.js'
 import type { FlattenedField } from '../../fields/config/types.js'
 import type { SanitizedGlobalConfig } from '../../globals/config/types.js'

--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../collections/config/types.js'
 import type { FlattenedField } from '../../fields/config/types.js'
 import type { SanitizedGlobalConfig } from '../../globals/config/types.js'

--- a/packages/payload/src/database/sanitizeJoinQuery.ts
+++ b/packages/payload/src/database/sanitizeJoinQuery.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../collections/config/types.js'
 import type { JoinQuery, PayloadRequest } from '../types/index.js'
 

--- a/packages/payload/src/duplicateDocument/index.ts
+++ b/packages/payload/src/duplicateDocument/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../collections/config/types.js'
 import type { FindOneArgs } from '../database/types.js'
 import type { JsonObject, PayloadRequest } from '../types/index.js'

--- a/packages/payload/src/email/getStringifiedToAddress.ts
+++ b/packages/payload/src/email/getStringifiedToAddress.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SendEmailOptions } from './types.js'
 
 export const getStringifiedToAddress = (message: SendEmailOptions): string | undefined => {

--- a/packages/payload/src/errors/APIError.ts
+++ b/packages/payload/src/errors/APIError.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 // This gets dynamically reassigned during compilation

--- a/packages/payload/src/fields/baseFields/timezone/baseField.ts
+++ b/packages/payload/src/fields/baseFields/timezone/baseField.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SelectField } from '../../config/types.js'
 
 export const baseTimezoneField: (args: Partial<SelectField>) => SelectField = ({

--- a/packages/payload/src/fields/config/client.ts
+++ b/packages/payload/src/fields/config/client.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /* eslint-disable perfectionist/sort-switch-case */
 // Keep perfectionist/sort-switch-case disabled - it incorrectly messes up the ordering of the switch cases, causing it to break
 import type { I18nClient } from '@payloadcms/translations'

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { deepMergeSimple } from '@payloadcms/translations/utilities'
 
 import type { CollectionConfig, SanitizedJoins } from '../../collections/config/types.js'

--- a/packages/payload/src/fields/config/sanitizeJoinField.ts
+++ b/packages/payload/src/fields/config/sanitizeJoinField.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedJoin, SanitizedJoins } from '../../collections/config/types.js'
 import type { Config } from '../../config/types.js'
 import type { FlattenedJoinField, JoinField, RelationshipField, UploadField } from './types.js'

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { EditorProps } from '@monaco-editor/react'

--- a/packages/payload/src/fields/getFieldPaths.ts
+++ b/packages/payload/src/fields/getFieldPaths.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { ClientField, Field, Tab, TabAsFieldClient } from './config/types.js'
 
 type Args = {

--- a/packages/payload/src/fields/hooks/afterChange/index.ts
+++ b/packages/payload/src/fields/hooks/afterChange/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
 import type { RequestContext } from '../../../index.js'

--- a/packages/payload/src/fields/hooks/afterChange/promise.ts
+++ b/packages/payload/src/fields/hooks/afterChange/promise.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { RichTextAdapter } from '../../../admin/RichText.js'
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'

--- a/packages/payload/src/fields/hooks/afterChange/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/afterChange/traverseFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
 import type { RequestContext } from '../../../index.js'

--- a/packages/payload/src/fields/hooks/afterRead/index.ts
+++ b/packages/payload/src/fields/hooks/afterRead/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
 import type { RequestContext } from '../../../index.js'

--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { RichTextAdapter } from '../../../admin/RichText.js'
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'

--- a/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/relationshipPopulationPromise.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadRequest, PopulateType } from '../../../types/index.js'
 import type { JoinField, RelationshipField, UploadField } from '../../config/types.js'
 

--- a/packages/payload/src/fields/hooks/beforeChange/index.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { ValidationFieldError } from '../../../errors/index.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { RichTextAdapter } from '../../../admin/RichText.js'
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { ValidationFieldError } from '../../../errors/index.js'

--- a/packages/payload/src/fields/hooks/beforeChange/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/traverseFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { ValidationFieldError } from '../../../errors/index.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'

--- a/packages/payload/src/fields/hooks/beforeDuplicate/index.ts
+++ b/packages/payload/src/fields/hooks/beforeDuplicate/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { RequestContext } from '../../../index.js'
 import type { JsonObject, PayloadRequest } from '../../../types/index.js'

--- a/packages/payload/src/fields/hooks/beforeDuplicate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeDuplicate/promise.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { RequestContext } from '../../../index.js'
 import type { JsonObject, PayloadRequest } from '../../../types/index.js'

--- a/packages/payload/src/fields/hooks/beforeDuplicate/runHook.ts
+++ b/packages/payload/src/fields/hooks/beforeDuplicate/runHook.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { FieldHookArgs } from '../../config/types.js'
 
 export const runBeforeDuplicateHooks = async (args: FieldHookArgs) =>

--- a/packages/payload/src/fields/hooks/beforeDuplicate/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/beforeDuplicate/traverseFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { RequestContext } from '../../../index.js'
 import type { JsonObject, PayloadRequest } from '../../../types/index.js'

--- a/packages/payload/src/fields/hooks/beforeValidate/index.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
 import type { JsonObject, PayloadRequest } from '../../../types/index.js'

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { RichTextAdapter } from '../../../admin/RichText.js'
 import type { SanitizedCollectionConfig, TypeWithID } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'

--- a/packages/payload/src/fields/hooks/beforeValidate/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/traverseFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../../../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../../../globals/config/types.js'
 import type { RequestContext } from '../../../index.js'

--- a/packages/payload/src/fields/mergeBaseFields.ts
+++ b/packages/payload/src/fields/mergeBaseFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Field, FieldWithSubFields } from './config/types.js'
 
 import { deepMergeWithReactComponents } from '../utilities/deepMerge.js'

--- a/packages/payload/src/fields/setDefaultBeforeDuplicate.ts
+++ b/packages/payload/src/fields/setDefaultBeforeDuplicate.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 // default beforeDuplicate hook for required and unique fields
 import type { FieldAffectingData, FieldHook } from './config/types.js'
 

--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Ajv from 'ajv'
 import ObjectIdImport from 'bson-objectid'
 

--- a/packages/payload/src/globals/config/client.ts
+++ b/packages/payload/src/globals/config/client.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { I18nClient } from '@payloadcms/translations'
 
 import type { ImportMap } from '../../bin/generateImportMap/index.js'

--- a/packages/payload/src/globals/config/sanitize.ts
+++ b/packages/payload/src/globals/config/sanitize.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Config, SanitizedConfig } from '../../config/types.js'
 import type { GlobalConfig, SanitizedGlobalConfig } from './types.js'
 

--- a/packages/payload/src/globals/endpoints/findVersionByID.ts
+++ b/packages/payload/src/globals/endpoints/findVersionByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/globals/endpoints/preview.ts
+++ b/packages/payload/src/globals/endpoints/preview.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/globals/endpoints/restoreVersion.ts
+++ b/packages/payload/src/globals/endpoints/restoreVersion.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/globals/endpoints/update.ts
+++ b/packages/payload/src/globals/endpoints/update.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/globals/operations/countGlobalVersions.ts
+++ b/packages/payload/src/globals/operations/countGlobalVersions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { AccessResult } from '../../config/types.js'
 import type { PayloadRequest, Where } from '../../types/index.js'
 

--- a/packages/payload/src/globals/operations/docAccess.ts
+++ b/packages/payload/src/globals/operations/docAccess.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedGlobalPermission } from '../../auth/index.js'
 import type { AllOperations, PayloadRequest } from '../../types/index.js'
 import type { SanitizedGlobalConfig } from '../config/types.js'

--- a/packages/payload/src/globals/operations/findOne.ts
+++ b/packages/payload/src/globals/operations/findOne.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { AccessResult } from '../../config/types.js'
 import type { PayloadRequest, PopulateType, SelectType, Where } from '../../types/index.js'
 import type { SanitizedGlobalConfig } from '../config/types.js'

--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { FindGlobalVersionsArgs } from '../../database/types.js'
 import type { PayloadRequest, PopulateType, SelectType } from '../../types/index.js'
 import type { TypeWithVersion } from '../../versions/types.js'

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PaginatedDocs } from '../../database/types.js'
 import type { PayloadRequest, PopulateType, SelectType, Sort, Where } from '../../types/index.js'
 import type { TypeWithVersion } from '../../versions/types.js'

--- a/packages/payload/src/globals/operations/local/countGlobalVersions.ts
+++ b/packages/payload/src/globals/operations/local/countGlobalVersions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { GlobalSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type { Document, PayloadRequest, Where } from '../../../types/index.js'
 

--- a/packages/payload/src/globals/operations/local/findOne.ts
+++ b/packages/payload/src/globals/operations/local/findOne.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { GlobalSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type {
   Document,

--- a/packages/payload/src/globals/operations/local/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/local/findVersionByID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { GlobalSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type { Document, PayloadRequest, PopulateType, SelectType } from '../../../types/index.js'
 import type { TypeWithVersion } from '../../../versions/types.js'

--- a/packages/payload/src/globals/operations/local/findVersions.ts
+++ b/packages/payload/src/globals/operations/local/findVersions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /* eslint-disable no-restricted-exports */
 import type { PaginatedDocs } from '../../../database/types.js'
 import type { GlobalSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'

--- a/packages/payload/src/globals/operations/local/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/local/restoreVersion.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /* eslint-disable no-restricted-exports */
 import type { GlobalSlug, Payload, RequestContext, TypedLocale } from '../../../index.js'
 import type { Document, PayloadRequest, PopulateType } from '../../../types/index.js'

--- a/packages/payload/src/globals/operations/local/update.ts
+++ b/packages/payload/src/globals/operations/local/update.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { DeepPartial } from 'ts-essentials'
 
 import type {

--- a/packages/payload/src/globals/operations/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/restoreVersion.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadRequest, PopulateType } from '../../types/index.js'
 import type { TypeWithVersion } from '../../versions/types.js'
 import type { SanitizedGlobalConfig } from '../config/types.js'

--- a/packages/payload/src/globals/operations/update.ts
+++ b/packages/payload/src/globals/operations/update.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { DeepPartial } from 'ts-essentials'
 
 import type { GlobalSlug, JsonObject } from '../../index.js'

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { ExecutionResult, GraphQLSchema, ValidationRule } from 'graphql'
 import type { Request as graphQLRequest, OperationArgs } from 'graphql-http'
 import type { Logger } from 'pino'

--- a/packages/payload/src/lockedDocuments/lockedDocumentsCollection.ts
+++ b/packages/payload/src/lockedDocuments/lockedDocumentsCollection.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionConfig } from '../collections/config/types.js'
 import type { Config } from '../config/types.js'
 

--- a/packages/payload/src/preferences/operations/findOne.ts
+++ b/packages/payload/src/preferences/operations/findOne.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { TypedCollection } from '../../index.js'
 import type { Where } from '../../types/index.js'
 import type { PreferenceRequest } from '../types.js'

--- a/packages/payload/src/preferences/preferencesCollection.ts
+++ b/packages/payload/src/preferences/preferencesCollection.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionConfig } from '../collections/config/types.js'
 import type { Access, Config } from '../config/types.js'
 

--- a/packages/payload/src/preferences/requestHandlers/delete.ts
+++ b/packages/payload/src/preferences/requestHandlers/delete.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/preferences/requestHandlers/findOne.ts
+++ b/packages/payload/src/preferences/requestHandlers/findOne.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/preferences/requestHandlers/update.ts
+++ b/packages/payload/src/preferences/requestHandlers/update.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 
 import type { PayloadHandler } from '../../config/types.js'

--- a/packages/payload/src/queues/config/generateJobsJSONSchemas.ts
+++ b/packages/payload/src/queues/config/generateJobsJSONSchemas.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { I18n } from '@payloadcms/translations'
 import type { JSONSchema4 } from 'json-schema'
 

--- a/packages/payload/src/queues/localAPI.ts
+++ b/packages/payload/src/queues/localAPI.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { BaseJob, RunningJobFromTask } from './config/types/workflowTypes.js'
 
 import {

--- a/packages/payload/src/queues/operations/runJobs/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PaginatedDocs } from '../../../database/types.js'
 import type { PayloadRequest, Where } from '../../../types/index.js'
 import type { WorkflowJSON } from '../../config/types/workflowJSONTypes.js'

--- a/packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadRequest } from '../../../../types/index.js'
 import type { WorkflowJSON, WorkflowStep } from '../../../config/types/workflowJSONTypes.js'
 import type {

--- a/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadRequest } from '../../../../types/index.js'
 import type {
   RetryConfig,

--- a/packages/payload/src/queues/operations/runJobs/runJob/getUpdateJobFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getUpdateJobFunction.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadRequest } from '../../../../types/index.js'
 import type { BaseJob } from '../../../config/types/workflowTypes.js'
 

--- a/packages/payload/src/queues/operations/runJobs/runJob/handleWorkflowError.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/handleWorkflowError.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadRequest } from '../../../../types/index.js'
 import type { BaseJob, WorkflowConfig, WorkflowTypes } from '../../../config/types/workflowTypes.js'
 import type { RunTaskFunctionState } from './getRunTaskFunction.js'

--- a/packages/payload/src/queues/operations/runJobs/runJob/importHandlerPath.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/importHandlerPath.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { pathToFileURL } from 'url'
 
 export async function importHandlerPath<T>(path: string): Promise<T> {

--- a/packages/payload/src/queues/operations/runJobs/runJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadRequest } from '../../../../types/index.js'
 import type {
   BaseJob,

--- a/packages/payload/src/queues/restEndpointRun.ts
+++ b/packages/payload/src/queues/restEndpointRun.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Endpoint, SanitizedConfig } from '../config/types.js'
 
 import { runJobs, type RunJobsArgs } from './operations/runJobs/index.js'

--- a/packages/payload/src/queues/utilities/getJobTaskStatus.ts
+++ b/packages/payload/src/queues/utilities/getJobTaskStatus.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { TaskConfig, TaskType } from '../config/types/taskTypes.js'
 import type { BaseJob, JobTaskStatus } from '../config/types/workflowTypes.js'
 

--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { I18n, TFunction } from '@payloadcms/translations'
 import type DataLoader from 'dataloader'
 import type { URL } from 'url'

--- a/packages/payload/src/uploads/checkFileAccess.ts
+++ b/packages/payload/src/uploads/checkFileAccess.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Collection, TypeWithID } from '../collections/config/types.js'
 import type { PayloadRequest, Where } from '../types/index.js'
 

--- a/packages/payload/src/uploads/cropImage.ts
+++ b/packages/payload/src/uploads/cropImage.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SharpOptions } from 'sharp'
 
 import type { SanitizedConfig } from '../config/types.js'

--- a/packages/payload/src/uploads/fetchAPI-multipart/handlers.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/handlers.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import crypto from 'crypto'
 import fs, { WriteStream } from 'fs'
 import path from 'path'

--- a/packages/payload/src/uploads/fetchAPI-multipart/index.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import path from 'path'
 
 import type { FetchAPIFileUploadOptions } from '../../config/types.js'

--- a/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 // eslint-disable-next-line regexp/no-super-linear-backtracking, regexp/no-obscure-range
 const ACCEPTABLE_CONTENT_TYPE = /multipart\/['"()+-_]+(?:; ?['"()+-_]*)+$/i
 const UNACCEPTABLE_METHODS = new Set(['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'TRACE'])

--- a/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Readable } from 'stream'
 
 import Busboy from 'busboy'

--- a/packages/payload/src/uploads/fetchAPI-multipart/processNested.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processNested.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { isSafeFromPollution } from './utilities.js'
 
 export const processNested = function (data) {

--- a/packages/payload/src/uploads/fetchAPI-multipart/uploadTimer.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/uploadTimer.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 type CreateUploadTimer = (
   timeout?: number,
   callback?: () => void,

--- a/packages/payload/src/uploads/fetchAPI-multipart/utilities.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/utilities.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import fs from 'fs'
 import path from 'path'
 import { Readable } from 'stream'

--- a/packages/payload/src/uploads/fetchAPI-stream-file/index.ts
+++ b/packages/payload/src/uploads/fetchAPI-stream-file/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import fs from 'fs'
 
 export function iteratorToStream(iterator) {

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { OutputInfo, Sharp, SharpOptions } from 'sharp'
 
 import { fileTypeFromBuffer } from 'file-type'

--- a/packages/payload/src/uploads/getBaseFields.ts
+++ b/packages/payload/src/uploads/getBaseFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionConfig } from '../collections/config/types.js'
 import type { Config } from '../config/types.js'
 import type { Field } from '../fields/config/types.js'

--- a/packages/payload/src/uploads/getExternalFile.ts
+++ b/packages/payload/src/uploads/getExternalFile.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadRequest } from '../types/index.js'
 import type { File, FileData, UploadConfig } from './types.js'
 

--- a/packages/payload/src/uploads/getFileByPath.ts
+++ b/packages/payload/src/uploads/getFileByPath.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { fileTypeFromFile } from 'file-type'
 import fs from 'fs'
 import path from 'path'

--- a/packages/payload/src/uploads/getImageSize.ts
+++ b/packages/payload/src/uploads/getImageSize.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import fs from 'fs'
 import sizeOfImport from 'image-size'
 import { promisify } from 'util'

--- a/packages/payload/src/uploads/imageResizer.ts
+++ b/packages/payload/src/uploads/imageResizer.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Sharp, Metadata as SharpMetadata, SharpOptions } from 'sharp'
 
 import { fileTypeFromBuffer } from 'file-type'

--- a/packages/payload/src/uploads/saveBufferToFile.ts
+++ b/packages/payload/src/uploads/saveBufferToFile.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import fs from 'fs'
 import { Readable } from 'stream'
 

--- a/packages/payload/src/uploads/tempFile.ts
+++ b/packages/payload/src/uploads/tempFile.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { promises as fsPromises } from 'fs'
 import os from 'node:os'
 import path from 'node:path'

--- a/packages/payload/src/utilities/addDataAndFileToRequest.ts
+++ b/packages/payload/src/utilities/addDataAndFileToRequest.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadRequest } from '../types/index.js'
 
 import { APIError } from '../errors/APIError.js'

--- a/packages/payload/src/utilities/addLocalesToRequest.ts
+++ b/packages/payload/src/utilities/addLocalesToRequest.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedConfig } from '../config/types.js'
 import type { PayloadRequest } from '../types/index.js'
 

--- a/packages/payload/src/utilities/commitTransaction.ts
+++ b/packages/payload/src/utilities/commitTransaction.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { MarkRequired } from 'ts-essentials'
 
 import type { PayloadRequest } from '../types/index.js'

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { JSONSchema4, JSONSchema4TypeName } from 'json-schema'
 
 import pluralize from 'pluralize'

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { User } from '../auth/types.js'
 import type { Payload, RequestContext, TypedLocale } from '../index.js'
 import type { PayloadRequest } from '../types/index.js'

--- a/packages/payload/src/utilities/createPayloadRequest.ts
+++ b/packages/payload/src/utilities/createPayloadRequest.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { initI18n } from '@payloadcms/translations'
 import * as qs from 'qs-esm'
 

--- a/packages/payload/src/utilities/deepCopyObject.ts
+++ b/packages/payload/src/utilities/deepCopyObject.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { JsonValue } from '../types/index.js'
 
 /*

--- a/packages/payload/src/utilities/deepMerge.ts
+++ b/packages/payload/src/utilities/deepMerge.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import deepMerge from 'deepmerge'
 
 import { isPlainObject } from './isPlainObject.js'

--- a/packages/payload/src/utilities/dependencies/dependencyChecker.ts
+++ b/packages/payload/src/utilities/dependencies/dependencyChecker.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import path from 'path'
 import { fileURLToPath } from 'url'
 

--- a/packages/payload/src/utilities/dependencies/versionUtils.ts
+++ b/packages/payload/src/utilities/dependencies/versionUtils.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CustomVersionParser } from './dependencyChecker.js'
 
 export function parseVersion(version: string): { parts: number[]; preReleases: string[] } {

--- a/packages/payload/src/utilities/fieldSchemaToJSON.ts
+++ b/packages/payload/src/utilities/fieldSchemaToJSON.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { ClientField } from '../fields/config/client.js'
 import type { FieldTypes } from '../fields/config/types.js'
 

--- a/packages/payload/src/utilities/findUp.ts
+++ b/packages/payload/src/utilities/findUp.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import fs from 'fs'
 import path from 'path'
 

--- a/packages/payload/src/utilities/flattenTopLevelFields.ts
+++ b/packages/payload/src/utilities/flattenTopLevelFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { ClientTab } from '../admin/fields/Tabs.js'
 import type { ClientField } from '../fields/config/client.js'
 import type {

--- a/packages/payload/src/utilities/formatErrors.ts
+++ b/packages/payload/src/utilities/formatErrors.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { ErrorResult } from '../config/types.js'
 import type { APIError } from '../errors/APIError.js'
 

--- a/packages/payload/src/utilities/formatLabels.ts
+++ b/packages/payload/src/utilities/formatLabels.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import pluralize from 'pluralize'
 const { isPlural, singular } = pluralize
 

--- a/packages/payload/src/utilities/getCollectionIDFieldTypes.ts
+++ b/packages/payload/src/utilities/getCollectionIDFieldTypes.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedConfig } from '../config/types.js'
 
 /**

--- a/packages/payload/src/utilities/getDataByPath.ts
+++ b/packages/payload/src/utilities/getDataByPath.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { FormState } from '../admin/types.js'
 
 import { unflatten } from './unflatten.js'

--- a/packages/payload/src/utilities/getEntityPolicies.ts
+++ b/packages/payload/src/utilities/getEntityPolicies.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CollectionPermission, GlobalPermission } from '../auth/types.js'
 import type { SanitizedCollectionConfig, TypeWithID } from '../collections/config/types.js'
 import type { Access } from '../config/types.js'

--- a/packages/payload/src/utilities/getObjectDotNotation.ts
+++ b/packages/payload/src/utilities/getObjectDotNotation.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export const getObjectDotNotation = <T>(
   obj: Record<string, unknown>,
   path: string,

--- a/packages/payload/src/utilities/getRequestEntity.ts
+++ b/packages/payload/src/utilities/getRequestEntity.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Collection } from '../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'
 import type { PayloadRequest } from '../types/index.js'

--- a/packages/payload/src/utilities/getRequestLanguage.ts
+++ b/packages/payload/src/utilities/getRequestLanguage.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { AcceptedLanguages } from '@payloadcms/translations'
 import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies.js'
 

--- a/packages/payload/src/utilities/getSiblingData.ts
+++ b/packages/payload/src/utilities/getSiblingData.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Data, FormState } from '../admin/types.js'
 
 import { reduceFieldsToValues } from './reduceFieldsToValues.js'

--- a/packages/payload/src/utilities/getTranslatedLabel.ts
+++ b/packages/payload/src/utilities/getTranslatedLabel.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { getTranslation, type I18n } from '@payloadcms/translations'
 
 import type { LabelFunction, StaticLabel } from '../config/types.js'

--- a/packages/payload/src/utilities/getUniqueListBy.ts
+++ b/packages/payload/src/utilities/getUniqueListBy.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export function getUniqueListBy<T>(arr: T[], key: string): T[] {
   return [...new Map(arr.map((item) => [item[key], item])).values()]
 }

--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { status as httpStatus } from 'http-status'
 import { match } from 'path-to-regexp'
 

--- a/packages/payload/src/utilities/headersWithCors.ts
+++ b/packages/payload/src/utilities/headersWithCors.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PayloadRequest } from '../types/index.js'
 
 type CorsArgs = {

--- a/packages/payload/src/utilities/initTransaction.ts
+++ b/packages/payload/src/utilities/initTransaction.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { MarkRequired } from 'ts-essentials'
 
 import type { PayloadRequest } from '../types/index.js'

--- a/packages/payload/src/utilities/isEntityHidden.ts
+++ b/packages/payload/src/utilities/isEntityHidden.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'
 import type { PayloadRequest } from '../types/index.js'

--- a/packages/payload/src/utilities/isValidID.ts
+++ b/packages/payload/src/utilities/isValidID.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import ObjectIdImport from 'bson-objectid'
 
 const ObjectId = (ObjectIdImport.default ||

--- a/packages/payload/src/utilities/killTransaction.ts
+++ b/packages/payload/src/utilities/killTransaction.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { MarkRequired } from 'ts-essentials'
 
 import type { PayloadRequest } from '../types/index.js'

--- a/packages/payload/src/utilities/logError.ts
+++ b/packages/payload/src/utilities/logError.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type pino from 'pino'
 
 import type { Payload } from '../types/index.js'

--- a/packages/payload/src/utilities/parseCookies.ts
+++ b/packages/payload/src/utilities/parseCookies.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { APIError } from '../errors/APIError.js'
 
 export const parseCookies = (headers: Request['headers']): Map<string, string> => {

--- a/packages/payload/src/utilities/reduceFieldsToValues.ts
+++ b/packages/payload/src/utilities/reduceFieldsToValues.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Data, FormState } from '../admin/types.js'
 
 import { unflatten as flatleyUnflatten } from './unflatten.js'

--- a/packages/payload/src/utilities/sanitizeJoinParams.ts
+++ b/packages/payload/src/utilities/sanitizeJoinParams.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { JoinQuery } from '../types/index.js'
 
 import { isNumber } from './isNumber.js'

--- a/packages/payload/src/utilities/sanitizePermissions.ts
+++ b/packages/payload/src/utilities/sanitizePermissions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { MarkOptional } from 'ts-essentials'
 
 import type {

--- a/packages/payload/src/utilities/sanitizePopulateParam.ts
+++ b/packages/payload/src/utilities/sanitizePopulateParam.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { PopulateType } from '../types/index.js'
 
 import { sanitizeSelectParam } from './sanitizeSelectParam.js'

--- a/packages/payload/src/utilities/sanitizeSelectParam.ts
+++ b/packages/payload/src/utilities/sanitizeSelectParam.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SelectType } from '../types/index.js'
 
 /**

--- a/packages/payload/src/utilities/telemetry/conf/envPaths.ts
+++ b/packages/payload/src/utilities/telemetry/conf/envPaths.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /**
  * Taken from https://github.com/sindresorhus/env-paths/blob/main/index.js
  *

--- a/packages/payload/src/utilities/telemetry/events/adminInit.ts
+++ b/packages/payload/src/utilities/telemetry/events/adminInit.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Payload } from '../../../index.js'
 import type { PayloadRequest } from '../../../types/index.js'
 

--- a/packages/payload/src/utilities/telemetry/index.ts
+++ b/packages/payload/src/utilities/telemetry/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { execSync } from 'child_process'
 import ciInfo from 'ci-info'
 import { randomBytes } from 'crypto'

--- a/packages/payload/src/utilities/timestamp.ts
+++ b/packages/payload/src/utilities/timestamp.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export const timestamp = (label) => {
   if (!process.env.PAYLOAD_TIME) {
     process.env.PAYLOAD_TIME = String(new Date().getTime())

--- a/packages/payload/src/utilities/toKebabCase.ts
+++ b/packages/payload/src/utilities/toKebabCase.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 const toKebabCase = (string) =>
   string
     .replace(/([a-z])([A-Z])/g, '$1-$2')

--- a/packages/payload/src/utilities/traverseFields.ts
+++ b/packages/payload/src/utilities/traverseFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { ArrayField, BlocksField, Field, TabAsField } from '../fields/config/types.js'
 
 import { fieldHasSubFields } from '../fields/config/types.js'

--- a/packages/payload/src/utilities/unflatten.ts
+++ b/packages/payload/src/utilities/unflatten.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /*
  * Copyright (c) 2014, Hugh Kennedy
  * All rights reserved.

--- a/packages/payload/src/utilities/wait.ts
+++ b/packages/payload/src/utilities/wait.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export async function wait(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms)

--- a/packages/payload/src/versions/baseFields.ts
+++ b/packages/payload/src/versions/baseFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CheckboxField, Field } from '../fields/config/types.js'
 
 export const statuses = [

--- a/packages/payload/src/versions/buildCollectionFields.ts
+++ b/packages/payload/src/versions/buildCollectionFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../collections/config/types.js'
 import type { SanitizedConfig } from '../config/types.js'
 import type { Field, FlattenedField } from '../fields/config/types.js'

--- a/packages/payload/src/versions/buildGlobalFields.ts
+++ b/packages/payload/src/versions/buildGlobalFields.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedConfig } from '../config/types.js'
 import type { Field, FlattenedField } from '../fields/config/types.js'
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'

--- a/packages/payload/src/versions/drafts/replaceWithDraftIfAvailable.ts
+++ b/packages/payload/src/versions/drafts/replaceWithDraftIfAvailable.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig, TypeWithID } from '../../collections/config/types.js'
 import type { AccessResult } from '../../config/types.js'
 import type { FindGlobalVersionsArgs, FindVersionsArgs } from '../../database/types.js'

--- a/packages/payload/src/versions/enforceMaxVersions.ts
+++ b/packages/payload/src/versions/enforceMaxVersions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig } from '../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'
 import type { Payload, PayloadRequest, Where } from '../types/index.js'

--- a/packages/payload/src/versions/getLatestCollectionVersion.ts
+++ b/packages/payload/src/versions/getLatestCollectionVersion.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig, TypeWithID } from '../collections/config/types.js'
 import type { FindOneArgs } from '../database/types.js'
 import type { Payload, PayloadRequest } from '../types/index.js'

--- a/packages/payload/src/versions/getLatestGlobalVersion.ts
+++ b/packages/payload/src/versions/getLatestGlobalVersion.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'
 import type { Document, Payload, PayloadRequest, Where } from '../types/index.js'
 

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { SanitizedCollectionConfig, TypeWithID } from '../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'
 import type { Payload } from '../index.js'

--- a/packages/payload/src/versions/schedule/job.ts
+++ b/packages/payload/src/versions/schedule/job.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { User } from '../../auth/types.js'
 import type { TaskConfig } from '../../queues/config/types/taskTypes.js'
 import type { SchedulePublishTaskInput } from './types.js'

--- a/packages/payload/tsconfig.json
+++ b/packages/payload/tsconfig.json
@@ -4,6 +4,14 @@
     /* TODO: remove the following lines */
     "strict": false,
     "noUncheckedIndexedAccess": false,
+    "plugins": [
+      {
+        "name": "typescript-strict-plugin"
+      },
+      {
+        "name": "tsc-strict"
+      }
+    ],
   },
   "references": [{ "path": "../translations" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 1.50.0
       '@sentry/nextjs':
         specifier: ^8.33.1
-        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12))
       '@sentry/node':
         specifier: ^8.33.1
         version: 8.37.1
@@ -135,7 +135,7 @@ importers:
         version: 10.1.3(@aws-sdk/credential-providers@3.687.0(@aws-sdk/client-sso-oidc@3.687.0(@aws-sdk/client-sts@3.687.0)))(socks@2.8.3)
       next:
         specifier: 15.1.5
-        version: 15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+        version: 15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
       open:
         specifier: ^10.1.0
         version: 10.1.0
@@ -895,6 +895,9 @@ importers:
       '@types/ws':
         specifier: ^8.5.10
         version: 8.5.13
+      concurrently:
+        specifier: 9.1.2
+        version: 9.1.2
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1
@@ -916,6 +919,9 @@ importers:
       sharp:
         specifier: 0.32.6
         version: 0.32.6
+      typescript-strict-plugin:
+        specifier: 2.4.4
+        version: 2.4.4
 
   packages/payload-cloud:
     dependencies:
@@ -1008,7 +1014,7 @@ importers:
     dependencies:
       next:
         specifier: ^15.0.3
-        version: 15.1.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+        version: 15.1.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*
@@ -1070,7 +1076,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ^8.33.1
-        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12))
       '@sentry/types':
         specifier: ^8.33.1
         version: 8.37.1
@@ -1420,7 +1426,7 @@ importers:
         version: link:../plugin-cloud-storage
       uploadthing:
         specifier: 7.3.0
-        version: 7.3.0(next@15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))
+        version: 7.3.0(next@15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))
     devDependencies:
       payload:
         specifier: workspace:*
@@ -1700,7 +1706,7 @@ importers:
         version: link:../packages/ui
       '@sentry/nextjs':
         specifier: ^8.33.1
-        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12))
       '@sentry/react':
         specifier: ^7.77.0
         version: 7.119.2(react@19.0.0)
@@ -1751,7 +1757,7 @@ importers:
         version: 8.9.5(@aws-sdk/credential-providers@3.687.0(@aws-sdk/client-sso-oidc@3.687.0(@aws-sdk/client-sts@3.687.0)))(socks@2.8.3)
       next:
         specifier: 15.1.5
-        version: 15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+        version: 15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
       nodemailer:
         specifier: 6.9.16
         version: 6.9.16
@@ -5958,9 +5964,17 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
 
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
@@ -5975,6 +5989,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -6046,6 +6064,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.1.2:
+    resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -6199,6 +6222,9 @@ packages:
   default-browser@5.2.1:
     resolution: {integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==}
     engines: {node: '>=18'}
+
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
   defaults@3.0.0:
     resolution: {integrity: sha512-RsqXDEAALjfRTro+IFNKpcPCt0/Cy2FqHSIlnomiJp9YGadpQnrtbRpSgN2+np21qHcIKiva4fiOQGjS9/qR/A==}
@@ -6740,6 +6766,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  execa@4.1.0:
+    resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
+    engines: {node: '>=10'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -7009,6 +7039,10 @@ packages:
     resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
     engines: {node: '>=12'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -7221,6 +7255,10 @@ packages:
     resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
     engines: {node: '>= 14'}
 
+  human-signals@1.1.1:
+    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
+    engines: {node: '>=8.12.0'}
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -7402,6 +7440,10 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-interactive@1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
@@ -7464,6 +7506,10 @@ packages:
   is-typed-array@1.1.13:
     resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
 
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
@@ -7794,6 +7840,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lie@3.1.1:
@@ -7845,6 +7892,10 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -8392,6 +8443,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  ora@5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
+
   oxc-resolver@1.12.0:
     resolution: {integrity: sha512-YlaCIArvWNKCWZFRrMjhh2l5jK80eXnpYP+bhRc1J/7cW3TiyEY0ngJo73o/5n8hA3+4yLdTmXLNTQ3Ncz50LQ==}
 
@@ -8907,6 +8962,10 @@ packages:
     resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
     engines: {node: '>=14.16'}
 
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -9186,6 +9245,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.2:
+    resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
+    engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
     resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
@@ -9636,6 +9699,10 @@ packages:
     resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
     engines: {node: '>=14'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
@@ -9767,6 +9834,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  typescript-strict-plugin@2.4.4:
+    resolution: {integrity: sha512-OXcWHQk+pW9gqEL/Mb1eTgj/Yiqk1oHBERr9v4VInPOYN++p+cXejmQK/h/VlUPGD++FXQ8pgiqVMyEtxU4T6A==}
+    hasBin: true
 
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
@@ -9937,6 +10008,9 @@ packages:
   watchpack@2.4.2:
     resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
     engines: {node: '>=10.13.0'}
+
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -13607,7 +13681,7 @@ snapshots:
       '@sentry/utils': 7.119.2
       localforage: 1.10.0
 
-  '@sentry/nextjs@8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))':
+  '@sentry/nextjs@8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation-http': 0.53.0(@opentelemetry/api@1.9.0)
@@ -13621,9 +13695,9 @@ snapshots:
       '@sentry/types': 8.37.1
       '@sentry/utils': 8.37.1
       '@sentry/vercel-edge': 8.37.1
-      '@sentry/webpack-plugin': 2.22.6(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+      '@sentry/webpack-plugin': 2.22.6(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12))
       chalk: 3.0.0
-      next: 15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+      next: 15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.10
@@ -13731,12 +13805,12 @@ snapshots:
       '@sentry/types': 8.37.1
       '@sentry/utils': 8.37.1
 
-  '@sentry/webpack-plugin@2.22.6(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))':
+  '@sentry/webpack-plugin@2.22.6(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12))':
     dependencies:
       '@sentry/bundler-plugin-core': 2.22.6
       unplugin: 1.0.1
       uuid: 9.0.0
-      webpack: 5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))
+      webpack: 5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -15325,9 +15399,15 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
 
   cli-truncate@4.0.0:
     dependencies:
@@ -15347,6 +15427,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clone@1.0.4: {}
 
   clsx@2.1.1: {}
 
@@ -15403,6 +15485,16 @@ snapshots:
   compute-scroll-into-view@1.0.20: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@9.1.2:
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.1
+      shell-quote: 1.8.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   confbox@0.1.8: {}
 
@@ -15545,6 +15637,10 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.0
+
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
 
   defaults@3.0.0: {}
 
@@ -16226,6 +16322,18 @@ snapshots:
 
   events@3.3.0: {}
 
+  execa@4.1.0:
+    dependencies:
+      cross-spawn: 7.0.5
+      get-stream: 5.2.0
+      human-signals: 1.1.1
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.5
@@ -16520,6 +16628,10 @@ snapshots:
 
   get-stdin@9.0.0: {}
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.2
+
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
@@ -16780,6 +16892,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@1.1.1: {}
+
   human-signals@2.1.0: {}
 
   human-signals@5.0.0: {}
@@ -16935,6 +17049,8 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-interactive@1.0.0: {}
+
   is-negative-zero@2.0.3: {}
 
   is-number-object@1.0.7:
@@ -16981,6 +17097,8 @@ snapshots:
   is-typed-array@1.1.13:
     dependencies:
       which-typed-array: 1.1.15
+
+  is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@2.1.0: {}
 
@@ -17560,6 +17678,11 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.0.0
@@ -18066,7 +18189,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.1.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4):
+  next@15.1.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4):
     dependencies:
       '@next/env': 15.1.3
       '@swc/counter': 0.1.3
@@ -18094,7 +18217,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4):
+  next@15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4):
     dependencies:
       '@next/env': 15.1.5
       '@swc/counter': 0.1.3
@@ -18250,6 +18373,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@5.4.1:
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.9.2
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
 
   oxc-resolver@1.12.0:
     optionalDependencies:
@@ -18796,6 +18931,11 @@ snapshots:
     dependencies:
       lowercase-keys: 3.0.0
 
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -19070,6 +19210,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.2: {}
 
   shelljs@0.8.5:
     dependencies:
@@ -19481,16 +19623,17 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.10.12(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))):
+  terser-webpack-plugin@5.3.10(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.36.0
-      webpack: 5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))
+      webpack: 5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12)
     optionalDependencies:
       '@swc/core': 1.10.12(@swc/helpers@0.5.15)
+      esbuild: 0.19.12
 
   terser@5.36.0:
     dependencies:
@@ -19557,6 +19700,8 @@ snapshots:
   tr46@4.1.1:
     dependencies:
       punycode: 2.3.1
+
+  tree-kill@1.2.2: {}
 
   truncate-utf8-bytes@1.0.2:
     dependencies:
@@ -19680,6 +19825,14 @@ snapshots:
       - eslint
       - supports-color
 
+  typescript-strict-plugin@2.4.4:
+    dependencies:
+      chalk: 3.0.0
+      execa: 4.1.0
+      minimatch: 9.0.5
+      ora: 5.4.1
+      yargs: 16.2.0
+
   typescript@5.7.3: {}
 
   ufo@1.5.4: {}
@@ -19761,14 +19914,14 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  uploadthing@7.3.0(next@15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)):
+  uploadthing@7.3.0(next@15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)):
     dependencies:
       '@effect/platform': 0.69.8(effect@3.10.3)
       '@uploadthing/mime-types': 0.3.2
       '@uploadthing/shared': 7.1.1
       effect: 3.10.3
     optionalDependencies:
-      next: 15.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+      next: 15.1.5(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
 
   uri-js@4.4.1:
     dependencies:
@@ -19833,6 +19986,10 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
@@ -19862,7 +20019,7 @@ snapshots:
 
   webpack-virtual-modules@0.5.0: {}
 
-  webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)):
+  webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -19884,7 +20041,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.10.12(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15))(esbuild@0.19.12))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
### What?

Implement the [typescript-strict-plugin](https://github.com/allegro/typescript-strict-plugin) plugin in the payload (core) package.

### Why?

1. One strategy for incremental migration is to enable strictness rules in tsconfig, fix some errors, and push them without committing the changes to tsconfig.json. However, this is not feasible for a package as large as Payload that has over 1000 typescript errors. Until the work is done, new contributions would undo the work being done.
2. Even if no migration work is done after this PR, this change already improves the strictness of the package. 89 of the 311 files within the package already satisfy strict mode. This PR only adds a comment `@ts-strict-ignore` to files that had at least one compilation error. This way, the propagation of errors in those files is stopped.
3. New files created in the package are strict by default (this was the main improvement in version 2 of `typescript-strict-plugin`).

I recommend starting the migration with this package because it is the one that almost all the others depend on. Once we finish this package, we can repeat the same strategy on another one, or use the strategy I mentioned in point 1 if the package is small.

### Note

If you don't see errors in the IDE when you uncomment `// @ts-strict-ignore`, try restarting the typescript server or VSCode


### How to contribute to the migration ❤️

1. Remove `// @ts-strict-ignore` comments from 1 or more files
2. Fix the pending errors (they should appear in your IDE's intellisense or when running `cd packages/payload` + `pnpm build:types` 
3. Submit your PR!

Important: You don't need to fix everything at once! Furthermore, I recommend breaking this down into very small PRs to trace potential issues later if there are any. So if you have 5 minutes, tackle a small file—every bit counts! 🤗


