### PR TITLE
fix(ui): safe call within useEffect teardown

### DIFF
--- a/packages/ui/src/elements/Nav/context.tsx
+++ b/packages/ui/src/elements/Nav/context.tsx
@@ -96,7 +96,9 @@ export const NavProvider: React.FC<{
   // when the component unmounts, clear all body scroll locks
   useEffect(() => {
     return () => {
-      navRef.current.style.overscrollBehavior = 'auto'
+      if (navRef.current) {
+        navRef.current.style.overscrollBehavior = 'auto'
+      }
     }
   }, [])
 


### PR DESCRIPTION
`NavProvider` useEffects teardown is trying to set `style` on an element that may not exist. The original code produces the following error:

![image](https://github.com/user-attachments/assets/11a83fbe-67eb-42a9-bd78-749ea98b67c5)
![image](https://github.com/user-attachments/assets/28ed2534-2387-416b-8191-d68b478161aa)

Therefore, a condition has been added to check if `navRef.current` is truthy.