### PR TITLE
chore: typo in migrate:fresh command

### DIFF
--- a/packages/payload/src/bin/migrate.ts
+++ b/packages/payload/src/bin/migrate.ts
@@ -21,7 +21,7 @@ export const availableCommands = [
   'migrate:refresh',
   'migrate:reset',
   'migrate:status',
-  'migration:fresh',
+  'migrate:fresh',
 ]
 
 const availableCommandsMsg = `Available commands: ${availableCommands.join(', ')}`


### PR DESCRIPTION
### What?
The migration CLI help says `migration:fresh` is available to use - this doesn't exist, the command should be `migrate:fresh`. 

Closes #10965 & #10967
