### PR TITLE
fix(ui): prevent omitting fileSize from non-images

### DIFF
--- a/packages/ui/src/fields/Upload/RelationshipContent/index.tsx
+++ b/packages/ui/src/fields/Upload/RelationshipContent/index.tsx
@@ -62,7 +62,7 @@ export function RelationshipContent(props: Props) {
 
   function generateMetaText(mimeType: string, size: number): string {
     const sections: string[] = []
-    if (mimeType?.includes('image')) {
+    if (size) {
       sections.push(formatFilesize(size))
     }
 


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR displays file size in upload cards for all upload mimetypes. The current behavior hides this metric from the user if the file mimetype does not start with `image`.

### Why?
Showing end-users and editors a file size is universally useful - not only for images, but for all types of files that can be uploaded via the upload field.

### How?
By making the predicate that adds this metric less restrictive. Instead of checking if the mimetype is image-like, it checks if the file size is truthy.

Before:
![image](https://github.com/user-attachments/assets/949e3be9-6dca-43c3-b2f8-a7e91307e48e)

After:
![image](https://github.com/user-attachments/assets/cb500390-dc64-48e3-a87c-e4ec4d19d019)
