### PR TITLE
feat(storage-s3): added factory to configure response headers

### DIFF
--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -4,7 +4,7 @@ import type {
   CollectionOptions,
   GeneratedAdapter,
 } from '@payloadcms/plugin-cloud-storage/types'
-import type { Config, Plugin, UploadCollectionSlug } from 'payload'
+import type { Config, PayloadRequest, Plugin, UploadCollectionSlug } from 'payload'
 
 import * as AWS from '@aws-sdk/client-s3'
 import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
@@ -46,7 +46,7 @@ export type S3StorageOptions = {
    *
    * @default undefined
    */
-  getResponseHeaders?: (defaultHeaders: HeadersInit) => Headers
+  getResponseHeaders?: (args: { headers: HeadersInit, req: PayloadRequest }) => Headers | Promise<Headers>
 
   /**
    * Whether or not to disable local storage

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -32,12 +32,21 @@ export type S3StorageOptions = {
    * Collection options to apply the S3 adapter to.
    */
   collections: Partial<Record<UploadCollectionSlug, Omit<CollectionOptions, 'adapter'> | true>>
+
   /**
    * AWS S3 client configuration. Highly dependent on your AWS setup.
    *
    * [AWS.S3ClientConfig Docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html)
    */
   config: AWS.S3ClientConfig
+
+  /**
+   * Response headers configuration.
+   * Can be used to replace default or append custom headers to the response.
+   *
+   * @default undefined
+   */
+  getResponseHeaders?: (defaultHeaders: HeadersInit) => Headers
 
   /**
    * Whether or not to disable local storage
@@ -102,7 +111,12 @@ export const s3Storage: S3StoragePlugin =
     })(config)
   }
 
-function s3StorageInternal({ acl, bucket, config = {} }: S3StorageOptions): Adapter {
+function s3StorageInternal({
+  acl,
+  bucket,
+  getResponseHeaders,
+  config = {}
+}: S3StorageOptions): Adapter {
   return ({ collection, prefix }): GeneratedAdapter => {
     let storageClient: AWS.S3 | null = null
     const getStorageClient: () => AWS.S3 = () => {
@@ -124,7 +138,7 @@ function s3StorageInternal({ acl, bucket, config = {} }: S3StorageOptions): Adap
         getStorageClient,
         prefix,
       }),
-      staticHandler: getHandler({ bucket, collection, getStorageClient }),
+      staticHandler: getHandler({ bucket, collection, getStorageClient, getResponseHeaders }),
     }
   }
 }

--- a/packages/storage-s3/src/staticHandler.ts
+++ b/packages/storage-s3/src/staticHandler.ts
@@ -1,6 +1,6 @@
 import type * as AWS from '@aws-sdk/client-s3'
 import type { StaticHandler } from '@payloadcms/plugin-cloud-storage/types'
-import type { CollectionConfig } from 'payload'
+import type { CollectionConfig, PayloadRequest } from 'payload'
 import type { Readable } from 'stream'
 
 import { getFilePrefix } from '@payloadcms/plugin-cloud-storage/utilities'
@@ -10,7 +10,7 @@ interface Args {
   bucket: string
   collection: CollectionConfig
   getStorageClient: () => AWS.S3
-  getResponseHeaders?: (defaultHeaders: HeadersInit) => Headers
+  getResponseHeaders?: (args: { headers: HeadersInit, req: PayloadRequest }) => Headers | Promise<Headers>
 }
 
 // Type guard for NodeJS.Readable streams
@@ -67,7 +67,7 @@ export const getHandler = ({
       }
 
       const headers = getResponseHeaders
-        ? getResponseHeaders(defaultHeaders)
+        ? await getResponseHeaders({ headers: defaultHeaders, req })
         : new Headers(defaultHeaders)
 
       if (etagFromHeaders && etagFromHeaders === objectEtag) {


### PR DESCRIPTION
### What?
This PR allows to set custom response headers to static assets served by the storage-s3-plugin. 

### Why?
There is already a PR open to set Cache-Control headers to these static assets. Due to a response from @r1tsuu I changed the configuration option from the specific `cacheControlMaxAge` prop to a more generic `getResponseHeaders` function to allow the dev to customize all response headers.

### How?

```ts
s3Storage({
      ...
      getResponseHeaders: defaultHeaders => ({
          ...defaultHeaders,
          'Cache-Control': 'public, max-age=36000',
      }),
})
```