### PR TITLE
style(eslint): add no-unused-imports autofix

### DIFF
--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -2,6 +2,7 @@ import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import perfectionist from 'eslint-plugin-perfectionist'
 import { configs as regexpPluginConfigs } from 'eslint-plugin-regexp'
+import unusedImports from 'eslint-plugin-unused-imports'
 import eslintConfigPrettier from 'eslint-config-prettier'
 import payloadPlugin from '@payloadcms/eslint-plugin'
 import reactExtends from './configs/react/index.mjs'
@@ -51,6 +52,18 @@ const baseRules = {
     },
   ],*/
   'payload/no-jsx-import-statements': 'error',
+
+  '@typescript-eslint/no-unused-vars': 'off',
+  'unused-imports/no-unused-imports': 'warn',
+  'unused-imports/no-unused-vars': [
+    'warn',
+    {
+      vars: 'all',
+      varsIgnorePattern: '^_',
+      args: 'after-used',
+      argsIgnorePattern: '^_',
+    },
+  ],
 }
 
 const reactA11yRules = {
@@ -135,6 +148,7 @@ export const rootEslintConfig = [
     },
     plugins: {
       'import-x': importX,
+      'unused-imports': unusedImports,
     },
   },
   {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-perfectionist": "3.9.1",
     "eslint-plugin-react-hooks": "0.0.0-experimental-a4b2d0d5-20250203",
     "eslint-plugin-regexp": "2.6.0",
+    "eslint-plugin-unused-imports": "4.1.4",
     "globals": "15.12.0",
     "typescript": "5.7.3",
     "typescript-eslint": "8.14.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,9 @@ importers:
       eslint-plugin-regexp:
         specifier: 2.6.0
         version: 2.6.0(eslint@9.14.0(jiti@1.21.6))
+      eslint-plugin-unused-imports:
+        specifier: 4.1.4
+        version: 4.1.4(@typescript-eslint/eslint-plugin@8.14.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.7.3))(eslint@9.14.0(jiti@1.21.6))(typescript@5.7.3))(eslint@9.14.0(jiti@1.21.6))
       globals:
         specifier: 15.12.0
         version: 15.12.0
@@ -6685,6 +6688,15 @@ packages:
     engines: {node: ^18 || >=20}
     peerDependencies:
       eslint: '>=8.44.0'
+
+  eslint-plugin-unused-imports@4.1.4:
+    resolution: {integrity: sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+      eslint: ^9.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
 
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
@@ -16226,6 +16238,12 @@ snapshots:
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
+
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.14.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.7.3))(eslint@9.14.0(jiti@1.21.6))(typescript@5.7.3))(eslint@9.14.0(jiti@1.21.6)):
+    dependencies:
+      eslint: 9.14.0(jiti@1.21.6)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.14.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.7.3))(eslint@9.14.0(jiti@1.21.6))(typescript@5.7.3)
 
   eslint-scope@5.1.1:
     dependencies:


### PR DESCRIPTION
We have many unused imports throughout the codebase. At times, I've gone through and done a lint of the full codebase to clean them up, but it seems like the general feedback is that this would be a good addition to our default config.

A plugin is necessary to be able to differentiate between unused imports and unused vars. If we want to autofix both, we can use another rule that might be lighter weight.

Note: this does appear to slow down the save a bit.