### PR TITLE
docs: add inlineBlock converter example to the converters configuration in Converters.mdx

### DIFF
--- a/docs/rich-text/converters.mdx
+++ b/docs/rich-text/converters.mdx
@@ -51,6 +51,10 @@ const jsxConverters: JSXConvertersFunction = ({ defaultConverters }) => ({
     // myTextBlock is the slug of the block
     myTextBlock: ({ node }) => <div style={{ backgroundColor: 'red' }}>{node.fields.text}</div>,
   },
+  inlineBlocks: {
+    // myInlineBlock is the slug of the block
+    myInlineBlock: ({ node }) => <span>{node.fields.text}</span>,
+  },
 })
 
 export const MyComponent = ({ lexicalData }) => {


### PR DESCRIPTION
### What?
Added a quick example to showcase how to add a converter for inlineBlocks.

### Why?
This is not easy to figure out in the current version. As per [Discord discussion](https://discord.com/channels/967097582721572934/1338624577990823997)

### How?
Added a very basic 3 lines example to keep the file simple.

