### PR TITLE
fix(ui): unable to use browser back navigation after visiting list view

### DIFF
--- a/packages/ui/src/providers/ListQuery/index.tsx
+++ b/packages/ui/src/providers/ListQuery/index.tsx
@@ -90,7 +90,7 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
       }
 
       if (modifySearchParams) {
-        // router.replace(`${qs.stringify(newQuery, { addQueryPrefix: true })}`)
+        router.replace(`${qs.stringify(newQuery, { addQueryPrefix: true })}`)
       } else if (
         typeof onQueryChange === 'function' ||
         typeof onQueryChangeFromProps === 'function'

--- a/packages/ui/src/providers/ListQuery/index.tsx
+++ b/packages/ui/src/providers/ListQuery/index.tsx
@@ -90,7 +90,7 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
       }
 
       if (modifySearchParams) {
-        router.replace(`${qs.stringify(newQuery, { addQueryPrefix: true })}`)
+        // router.replace(`${qs.stringify(newQuery, { addQueryPrefix: true })}`)
       } else if (
         typeof onQueryChange === 'function' ||
         typeof onQueryChangeFromProps === 'function'
@@ -153,6 +153,7 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
   )
 
   // If `defaultLimit` or `defaultSort` are updated externally, update the query
+  // I.e. when HMR runs, these properties may be different
   useEffect(() => {
     if (modifySearchParams) {
       let shouldUpdateQueryString = false
@@ -173,7 +174,7 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
       if (shouldUpdateQueryString) {
         setCurrentQuery(newQuery)
         // Do not use router.replace here to avoid re-rendering on initial load
-        window.history.pushState(null, '', `?${qs.stringify(newQuery)}`)
+        window.history.replaceState(null, '', `?${qs.stringify(newQuery)}`)
       }
     }
   }, [defaultSort, defaultLimit, router, modifySearchParams])

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/admin/config.ts"],
+      "@payload-config": ["./test/_community/config.ts"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
       "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/_community/config.ts"],
+      "@payload-config": ["./test/admin/config.ts"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
       "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],


### PR DESCRIPTION
Fixes #11114. After visiting the list view, the browser's back navigation becomes unusable, requiring multiple clicks before any navigation occurs. This was because on mount, the `ListQueryProvider` was _pushing_ new history onto the stack in order to inject the `limit` and `sort` search params, as opposed to _replacing_ the current entry.

Unrelated: a lot of our tests were unnecessarily calling `page.waitForURL()` after calling `page.goto()`. This is duplicative and unneeded as `waitForURL` already waits for the navigation to complete. This is only needed when navigating using other mechanisms such as clicking a link.