### PR TITLE
docs: fix invalid link

### DIFF
--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -101,8 +101,7 @@ unsupported `$facet` aggregation.
 ### CosmosDB
 
 When using Azure Cosmos DB, an index is needed for any field you may want to sort on. To add the sort index for all
-fields that may be sorted in the admin UI use the <a href="/docs/configuration/overview">indexSortableFields</a>
-configuration option.
+fields that may be sorted in the admin UI use the [indexSortableFields](/docs/configuration/overview) option.
 
 ## File storage
 


### PR DESCRIPTION
Links have to be defined in markdown - html a tags won't automatically be converted to links anymore.