### PR TITLE
fix(ui): hide array field "add" button if `admin.readOnly: true` is set

### DIFF
--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -336,11 +336,10 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
           )}
         </DraggableSortable>
       )}
-      {!hasMaxRows && (
+      {!hasMaxRows && !readOnly && (
         <Button
           buttonStyle="icon-label"
           className={`${baseClass}__add-row`}
-          disabled={readOnly}
           icon="plus"
           iconPosition="left"
           iconStyle="with-border"

--- a/test/fields/collections/Array/e2e.spec.ts
+++ b/test/fields/collections/Array/e2e.spec.ts
@@ -71,6 +71,7 @@ describe('Array', () => {
     await page.goto(url.create)
     const field = page.locator('#field-readOnly__0__text')
     await expect(field).toBeDisabled()
+    await expect(page.locator('#field-readOnly .array-field__add-row')).toBeHidden()
   })
 
   test('should have defaultValue', async () => {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11178