### PR TITLE
docs: remove file extension from import statement in useLexicalComposerContext

### DIFF
--- a/docs/rich-text/custom-features.mdx
+++ b/docs/rich-text/custom-features.mdx
@@ -614,7 +614,7 @@ import {
   COMMAND_PRIORITY_EDITOR
 } from '@payloadcms/richtext-lexical/lexical'
 
-import { useLexicalComposerContext } from '@payloadcms/richtext-lexical/lexical/react/LexicalComposerContext.js'
+import { useLexicalComposerContext } from '@payloadcms/richtext-lexical/lexical/react/LexicalComposerContext'
 import { $insertNodeToNearestRoot } from '@payloadcms/richtext-lexical/lexical/utils'
 import { useEffect } from 'react'
 


### PR DESCRIPTION
that import does not exist, it is a typo

reported in [Discord](https://discord.com/channels/967097582721572934/1328768805450809415)