### PR TITLE
fix(plugin-multi-tenant): corrects default value for tenantsArrayTenantFieldName

### DIFF
--- a/examples/multi-tenant/src/collections/Users/index.ts
+++ b/examples/multi-tenant/src/collections/Users/index.ts
@@ -10,6 +10,9 @@ import { setCookieBasedOnDomain } from './hooks/setCookieBasedOnDomain'
 import { tenantsArrayField } from '@payloadcms/plugin-multi-tenant/fields'
 
 const defaultTenantArrayField = tenantsArrayField({
+  tenantsArrayFieldName: 'tenants',
+  tenantsArrayTenantFieldName: 'tenant',
+  tenantsCollectionSlug: 'tenants',
   arrayFieldAccess: {},
   tenantFieldAccess: {},
   rowFields: [

--- a/packages/plugin-multi-tenant/src/fields/tenantsArrayField/index.ts
+++ b/packages/plugin-multi-tenant/src/fields/tenantsArrayField/index.ts
@@ -3,12 +3,36 @@ import type { ArrayField, RelationshipField } from 'payload'
 import { defaults } from '../../defaults.js'
 
 type Args = {
+  /**
+   * Access configuration for the array field
+   */
   arrayFieldAccess?: ArrayField['access']
+  /**
+   * Additional fields to include on the tenant array rows
+   */
   rowFields?: ArrayField['fields']
+  /**
+   * Access configuration for the tenant field
+   */
   tenantFieldAccess?: RelationshipField['access']
-  tenantsArrayFieldName: ArrayField['name']
-  tenantsArrayTenantFieldName: RelationshipField['name']
-  tenantsCollectionSlug: string
+  /**
+   * The name of the array field that holds the tenants
+   *
+   * @default 'tenants'
+   */
+  tenantsArrayFieldName?: ArrayField['name']
+  /**
+   * The name of the field that will be used to store the tenant relationship in the array
+   *
+   * @default 'tenant'
+   */
+  tenantsArrayTenantFieldName?: RelationshipField['name']
+  /**
+   * The slug for the tenant collection
+   *
+   * @default 'tenants'
+   */
+  tenantsCollectionSlug?: string
 }
 export const tenantsArrayField = ({
   arrayFieldAccess,

--- a/packages/plugin-multi-tenant/src/fields/tenantsArrayField/index.ts
+++ b/packages/plugin-multi-tenant/src/fields/tenantsArrayField/index.ts
@@ -15,7 +15,7 @@ export const tenantsArrayField = ({
   rowFields,
   tenantFieldAccess,
   tenantsArrayFieldName = defaults.tenantsArrayFieldName,
-  tenantsArrayTenantFieldName = defaults.tenantsArrayFieldName,
+  tenantsArrayTenantFieldName = defaults.tenantsArrayTenantFieldName,
   tenantsCollectionSlug = defaults.tenantCollectionSlug,
 }: Args): ArrayField => ({
   name: tenantsArrayFieldName,


### PR DESCRIPTION
Incorrect default value on exported `tenantsArrayField` field. Should have been `tenant` but was using `tenants`. This affected the multi-tenant example which uses a custom tenants array field.

You would not notice this issue unless you were using:
```ts
tenantsArrayField: {
  includeDefaultField: false,
}
```

Fixes https://github.com/payloadcms/payload/issues/11125