### PR TITLE
chore(deps): moves ts-essentials to devDependencies

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -54,14 +54,14 @@
   "dependencies": {
     "graphql-scalars": "1.22.2",
     "pluralize": "8.0.0",
-    "ts-essentials": "10.0.3",
     "tsx": "4.19.2"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "workspace:*",
     "@types/pluralize": "^0.0.33",
     "graphql-http": "^1.22.0",
-    "payload": "workspace:*"
+    "payload": "workspace:*",
+    "ts-essentials": "10.0.3"
   },
   "peerDependencies": {
     "graphql": "^16.8.1",

--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -110,7 +110,6 @@
     "qs-esm": "7.0.2",
     "sanitize-filename": "1.6.3",
     "scmp": "2.1.0",
-    "ts-essentials": "10.0.3",
     "tsx": "4.19.2",
     "uuid": "10.0.0",
     "ws": "^8.16.0"
@@ -130,7 +129,8 @@
     "graphql-http": "^1.22.0",
     "react-datepicker": "7.6.0",
     "rimraf": "6.0.1",
-    "sharp": "0.32.6"
+    "sharp": "0.32.6",
+    "ts-essentials": "10.0.3"
   },
   "peerDependencies": {
     "graphql": "^16.8.1"

--- a/packages/richtext-lexical/package.json
+++ b/packages/richtext-lexical/package.json
@@ -354,8 +354,8 @@
     "@lexical/react": "0.21.0",
     "@lexical/rich-text": "0.21.0",
     "@lexical/selection": "0.21.0",
-    "@lexical/utils": "0.21.0",
     "@lexical/table": "0.21.0",
+    "@lexical/utils": "0.21.0",
     "@payloadcms/translations": "workspace:*",
     "@payloadcms/ui": "workspace:*",
     "@types/uuid": "10.0.0",
@@ -369,7 +369,6 @@
     "mdast-util-mdx-jsx": "3.1.3",
     "micromark-extension-mdx-jsx": "3.0.1",
     "react-error-boundary": "4.1.2",
-    "ts-essentials": "10.0.3",
     "uuid": "10.0.0"
   },
   "devDependencies": {
@@ -391,7 +390,8 @@
     "esbuild-sass-plugin": "3.3.1",
     "eslint-plugin-react-compiler": "19.0.0-beta-714736e-20250131",
     "payload": "workspace:*",
-    "swc-plugin-transform-remove-imports": "3.1.0"
+    "swc-plugin-transform-remove-imports": "3.1.0",
+    "ts-essentials": "10.0.3"
   },
   "peerDependencies": {
     "@faceless-ui/modal": "3.0.0-beta.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -135,7 +135,6 @@
     "react-select": "5.9.0",
     "scheduler": "0.25.0",
     "sonner": "^1.7.2",
-    "ts-essentials": "10.0.3",
     "use-context-selector": "2.0.0",
     "uuid": "10.0.0"
   },
@@ -154,7 +153,8 @@
     "esbuild": "0.24.2",
     "esbuild-sass-plugin": "3.3.1",
     "eslint-plugin-react-compiler": "19.0.0-beta-714736e-20250131",
-    "payload": "workspace:*"
+    "payload": "workspace:*",
+    "ts-essentials": "10.0.3"
   },
   "peerDependencies": {
     "next": "^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,9 +596,6 @@ importers:
       pluralize:
         specifier: 8.0.0
         version: 8.0.0
-      ts-essentials:
-        specifier: 10.0.3
-        version: 10.0.3(typescript@5.7.3)
       tsx:
         specifier: 4.19.2
         version: 4.19.2
@@ -615,6 +612,9 @@ importers:
       payload:
         specifier: workspace:*
         version: link:../payload
+      ts-essentials:
+        specifier: 10.0.3
+        version: 10.0.3(typescript@5.7.3)
 
   packages/live-preview:
     devDependencies:
@@ -858,9 +858,6 @@ importers:
       scmp:
         specifier: 2.1.0
         version: 2.1.0
-      ts-essentials:
-        specifier: 10.0.3
-        version: 10.0.3(typescript@5.7.3)
       tsx:
         specifier: 4.19.2
         version: 4.19.2
@@ -916,6 +913,9 @@ importers:
       sharp:
         specifier: 0.32.6
         version: 0.32.6
+      ts-essentials:
+        specifier: 10.0.3
+        version: 10.0.3(typescript@5.7.3)
 
   packages/payload-cloud:
     dependencies:
@@ -1251,9 +1251,6 @@ importers:
       react-error-boundary:
         specifier: 4.1.2
         version: 4.1.2(react@19.0.0)
-      ts-essentials:
-        specifier: 10.0.3
-        version: 10.0.3(typescript@5.7.3)
       uuid:
         specifier: 10.0.0
         version: 10.0.0
@@ -1315,6 +1312,9 @@ importers:
       swc-plugin-transform-remove-imports:
         specifier: 3.1.0
         version: 3.1.0
+      ts-essentials:
+        specifier: 10.0.3
+        version: 10.0.3(typescript@5.7.3)
 
   packages/richtext-slate:
     dependencies:
@@ -1535,9 +1535,6 @@ importers:
       sonner:
         specifier: ^1.7.2
         version: 1.7.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      ts-essentials:
-        specifier: 10.0.3
-        version: 10.0.3(typescript@5.7.3)
       use-context-selector:
         specifier: 2.0.0
         version: 2.0.0(react@19.0.0)(scheduler@0.25.0)
@@ -1590,6 +1587,9 @@ importers:
       payload:
         specifier: workspace:*
         version: link:../payload
+      ts-essentials:
+        specifier: 10.0.3
+        version: 10.0.3(typescript@5.7.3)
 
   test:
     devDependencies:


### PR DESCRIPTION
The `ts-essentials` package is only used help define types and does not need to be listed as a dependency. This should be installed as a `devDependency` instead.