### PR TITLE
feat(richtext-lexical): export INSERT_BLOCK_COMMAND and INSERT_INLINE_BLOCK_COMMAND

### DIFF
--- a/packages/richtext-lexical/src/exports/client/index.ts
+++ b/packages/richtext-lexical/src/exports/client/index.ts
@@ -6,6 +6,11 @@ export { slashMenuBasicGroupWithItems } from '../../features/shared/slashMenu/ba
 export { AlignFeatureClient } from '../../features/align/client/index.js'
 export { BlockquoteFeatureClient } from '../../features/blockquote/client/index.js'
 export { BlocksFeatureClient } from '../../features/blocks/client/index.js'
+export {
+  INSERT_BLOCK_COMMAND,
+  INSERT_INLINE_BLOCK_COMMAND,
+} from '../../features/blocks/client/plugin/commands.js'
+
 export { TestRecorderFeatureClient } from '../../features/debug/testRecorder/client/index.js'
 export { TreeViewFeatureClient } from '../../features/debug/treeView/client/index.js'
 export { BoldFeatureClient } from '../../features/format/bold/feature.client.js'


### PR DESCRIPTION
Lexical checks commands by reference equality. This means that even if you re-define those commands in your own codebase using the same command `type` string, they will be treated as different commands.

If you wanted to dispatch the block creation command in your own codebase (e.g. from a different lexical feature, or any component within the editor), this will not be possible right now. See https://discord.com/channels/967097582721572934/1339557113898340352/1339557113898340352

This PR exports them from `@payloadcms/richtext-lexical/client`