### PR TITLE
fix(ui): show auth fields when `disabledLocalStrategy.enableFields` is true

### DIFF
--- a/packages/ui/src/views/Edit/Auth/index.tsx
+++ b/packages/ui/src/views/Edit/Auth/index.tsx
@@ -136,9 +136,13 @@ export const Auth: React.FC<Props> = (props) => {
 
   const disabled = readOnly || isInitializing
 
+  const showFields =
+    !disableLocalStrategy ||
+    (typeof disableLocalStrategy === 'object' && disableLocalStrategy.enableFields === true)
+
   return (
     <div className={[baseClass, className].filter(Boolean).join(' ')}>
-      {!disableLocalStrategy && (
+      {showFields && (
         <React.Fragment>
           <EmailAndUsernameFields
             loginWithUsername={loginWithUsername}


### PR DESCRIPTION
When using `disabledLocalStrategy.enableFields`, it was impossible to create a user from the admin panel because the username and password fields were not visible.