### PR TITLE
feat: add locale selectors to localizer component

### DIFF
--- a/packages/ui/src/elements/Localizer/LocalizerLabel/index.tsx
+++ b/packages/ui/src/elements/Localizer/LocalizerLabel/index.tsx
@@ -21,6 +21,7 @@ export const LocalizerLabel: React.FC<{
     <div
       aria-label={ariaLabel || t('general:locale')}
       className={[baseClass, className].filter(Boolean).join(' ')}
+      data-locale={locale ? locale.code : undefined}
     >
       <div className={`${baseClass}__label`}>{`${t('general:locale')}:`}&nbsp;</div>
       <div className={`${baseClass}__current`}>

--- a/packages/ui/src/elements/Localizer/index.tsx
+++ b/packages/ui/src/elements/Localizer/index.tsx
@@ -61,12 +61,17 @@ export const Localizer: React.FC<{
                       <Fragment>
                         {localeOptionLabel}
                         &nbsp;
-                        <span className={`${baseClass}__locale-code`}>
+                        <span
+                          className={`${baseClass}__locale-code`}
+                          data-locale={localeOption.code}
+                        >
                           {`(${localeOption.code})`}
                         </span>
                       </Fragment>
                     ) : (
-                      <span className={`${baseClass}__locale-code`}>{localeOptionLabel}</span>
+                      <span className={`${baseClass}__locale-code`} data-locale={localeOption.code}>
+                        {localeOptionLabel}
+                      </span>
                     )}
                   </PopupList.Button>
                 )


### PR DESCRIPTION
**What?**  
Adds a `locale-${localeOption.code}` class to the localizer component to have locale selectors.

**Why?**  
If someone wants to customize admin visuals of the localizer (for example, adding flags/icons or applying different color schemes), these classes give a straightforward way to write selectors such as `.locale-en` or `.locale-fr` and style each locale item individually. In my case I wanted to add flags to each locale.

**How?**  
Inject the `locale-code` into the element's `className`, enabling unique per-locale styling without altering the code’s logic.