### PR TITLE
templates: allow to pass `resource={null}` to `Media` component

### DIFF
--- a/examples/localization/src/components/Media/types.ts
+++ b/examples/localization/src/components/Media/types.ts
@@ -13,7 +13,7 @@ export interface Props {
   onLoad?: () => void
   priority?: boolean // for NextImage only
   ref?: Ref<HTMLImageElement | HTMLVideoElement | null>
-  resource?: MediaType | string | number // for Payload media
+  resource?: MediaType | string | number | null // for Payload media
   size?: string // for NextImage only
   src?: StaticImageData // for static media
   videoClassName?: string

--- a/templates/website/src/components/Media/types.ts
+++ b/templates/website/src/components/Media/types.ts
@@ -14,7 +14,7 @@ export interface Props {
   loading?: 'lazy' | 'eager' // for NextImage only
   priority?: boolean // for NextImage only
   ref?: Ref<HTMLImageElement | HTMLVideoElement | null>
-  resource?: MediaType | string | number // for Payload media
+  resource?: MediaType | string | number | null // for Payload media
   size?: string // for NextImage only
   src?: StaticImageData // for static media
   videoClassName?: string

--- a/templates/with-vercel-website/src/components/Media/types.ts
+++ b/templates/with-vercel-website/src/components/Media/types.ts
@@ -14,7 +14,7 @@ export interface Props {
   loading?: 'lazy' | 'eager' // for NextImage only
   priority?: boolean // for NextImage only
   ref?: Ref<HTMLImageElement | HTMLVideoElement | null>
-  resource?: MediaType | string | number // for Payload media
+  resource?: MediaType | string | number | null // for Payload media
   size?: string // for NextImage only
   src?: StaticImageData // for static media
   videoClassName?: string


### PR DESCRIPTION
The `Media` component has an optional property `resource` so we can skip that property. As in payload `required: false` types are generated like `media?: Media | string | null`, it also makes sense to allow `null` as a `resource` value.

Fixes https://github.com/payloadcms/payload/issues/11200
