### PR TITLE
fix(next): uses assetPrefix from next config in webpack-hmr URL

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -147,6 +147,10 @@ export const withPayload = (nextConfig = {}) => {
     toReturn.env.NEXT_BASE_PATH = nextConfig.basePath
   }
 
+  if (nextConfig.assetPrefix) {
+    toReturn.env.NEXT_ASSET_PREFIX = nextConfig.assetPrefix
+  }
+
   return toReturn
 }
 

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -917,9 +917,11 @@ export const getPayload = async (
     ) {
       try {
         const port = process.env.PORT || '3000'
+        const basePath = process.env.NEXT_BASE_PATH || ''
+        const assetPrefix = process.env.NEXT_ASSET_PREFIX || ''
 
         cached.ws = new WebSocket(
-          `ws://localhost:${port}${process.env.NEXT_BASE_PATH ?? ''}/_next/webpack-hmr`,
+          `ws://localhost:${port}${basePath}${assetPrefix}/_next/webpack-hmr`,
         )
 
         cached.ws.onmessage = (event) => {


### PR DESCRIPTION
### What?
Adding `assetPrefix` to the `next.config` prevents the hot module reloading functionality.

### Why & How?
Need to incorporate `assetPrefix` into the URL generated for webpack HMR.

Fixes #11150

#### Testing
1. Add `assetPrefix: '/test'` to the `next.config.mjs` in the root folder
2. Run `pnpm test _community`
3. Go to the `_community/collections/posts` config and change a field
4. Open post collection in browser and see no change (if this PR is checked out then you _**will**_ see the change)