### PR TITLE
fix(ui): issues with prevent leave and autosave when the form is submitted but invalid

### DIFF
--- a/packages/ui/src/elements/LeaveWithoutSaving/index.tsx
+++ b/packages/ui/src/elements/LeaveWithoutSaving/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useCallback, useEffect } from 'react'
 
-import { useFormModified } from '../../forms/Form/index.js'
+import { useForm, useFormModified } from '../../forms/Form/index.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { Button } from '../Button/index.js'
@@ -59,11 +59,12 @@ const Component: React.FC<{
 export const LeaveWithoutSaving: React.FC = () => {
   const { closeModal } = useModal()
   const modified = useFormModified()
+  const { isValid } = useForm()
   const { user } = useAuth()
   const [show, setShow] = React.useState(false)
   const [hasAccepted, setHasAccepted] = React.useState(false)
 
-  const prevent = Boolean(modified && user)
+  const prevent = Boolean((modified || !isValid) && user)
 
   const onPrevent = useCallback(() => {
     setShow(true)

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -96,6 +96,11 @@ export const Form: React.FC<FormProps> = (props) => {
   const [disabled, setDisabled] = useState(disabledFromProps || false)
   const [isMounted, setIsMounted] = useState(false)
   const [modified, setModified] = useState(false)
+  /**
+   * Tracks wether the form state passes validation.
+   * For example the state could be submitted but invalid as field errors have been returned.
+   */
+  const [isValid, setIsValid] = useState(true)
   const [initializing, setInitializing] = useState(initializingFromProps)
   const [processing, setProcessing] = useState(false)
   const [submitted, setSubmitted] = useState(false)
@@ -177,6 +182,8 @@ export const Form: React.FC<FormProps> = (props) => {
       dispatchFields({ type: 'REPLACE_STATE', state: validatedFieldState })
     }
 
+    setIsValid(isValid)
+
     return isValid
   }, [collectionSlug, config, dispatchFields, id, operation, t, user, documentForm])
 
@@ -257,6 +264,8 @@ export const Form: React.FC<FormProps> = (props) => {
           ([, field]) => field.valid !== false,
         )
 
+        setIsValid(isValid)
+
         if (!isValid) {
           setProcessing(false)
           setSubmitted(true)
@@ -268,6 +277,7 @@ export const Form: React.FC<FormProps> = (props) => {
       const isValid =
         skipValidation || disableValidationOnSubmit ? true : await contextRef.current.validateForm()
 
+      setIsValid(isValid)
       // If not valid, prevent submission
       if (!isValid) {
         errorToast(t('error:correctInvalidFields'))
@@ -407,6 +417,8 @@ export const Form: React.FC<FormProps> = (props) => {
               },
               [[], []],
             )
+
+            setIsValid(false)
 
             dispatchFields({
               type: 'ADD_SERVER_ERRORS',
@@ -615,6 +627,7 @@ export const Form: React.FC<FormProps> = (props) => {
   contextRef.current.setModified = setModified
   contextRef.current.setProcessing = setProcessing
   contextRef.current.setSubmitted = setSubmitted
+  contextRef.current.setIsValid = setIsValid
   contextRef.current.disabled = disabled
   contextRef.current.setDisabled = setDisabled
   contextRef.current.formRef = formRef
@@ -626,6 +639,7 @@ export const Form: React.FC<FormProps> = (props) => {
   contextRef.current.replaceFieldRow = replaceFieldRow
   contextRef.current.uuid = uuid
   contextRef.current.initializing = initializing
+  contextRef.current.isValid = isValid
 
   useEffect(() => {
     setIsMounted(true)

--- a/packages/ui/src/forms/Form/initContextState.ts
+++ b/packages/ui/src/forms/Form/initContextState.ts
@@ -39,14 +39,17 @@ export const initContextState: Context = {
   getFields: (): FormState => ({}),
   getSiblingData,
   initializing: undefined,
+  isValid: true,
   removeFieldRow: () => undefined,
   replaceFieldRow: () => undefined,
   replaceState: () => undefined,
   reset,
   setDisabled: () => undefined,
+  setIsValid: () => undefined,
   setModified,
   setProcessing,
   setSubmitted,
   submit,
+
   validateForm,
 }

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -227,6 +227,11 @@ export type Context = {
   getFields: GetFields
   getSiblingData: GetSiblingData
   initializing: boolean
+  /**
+   * Tracks wether the form state passes validation.
+   * For example the state could be submitted but invalid as field errors have been returned.
+   */
+  isValid: boolean
   removeFieldRow: ({ path, rowIndex }: { path: string; rowIndex: number }) => void
   replaceFieldRow: ({
     blockType,
@@ -244,6 +249,7 @@ export type Context = {
   replaceState: (state: FormState) => void
   reset: Reset
   setDisabled: (disabled: boolean) => void
+  setIsValid: (processing: boolean) => void
   setModified: SetModified
   setProcessing: SetProcessing
   setSubmitted: SetSubmitted

--- a/test/helpers/waitForAutoSaveToRunAndComplete.ts
+++ b/test/helpers/waitForAutoSaveToRunAndComplete.ts
@@ -4,20 +4,32 @@ import { expect } from '@playwright/test'
 import { wait } from 'payload/shared'
 import { POLL_TOPASS_TIMEOUT } from 'playwright.config.js'
 
-export async function waitForAutoSaveToRunAndComplete(page: Page) {
+export async function waitForAutoSaveToRunAndComplete(
+  page: Page,
+  expectation: 'error' | 'success' = 'success',
+) {
   await expect(async () => {
     await expect(page.locator('.autosave:has-text("Saving...")')).toBeVisible()
   }).toPass({
     timeout: POLL_TOPASS_TIMEOUT,
+    intervals: [50],
   })
 
   await wait(500)
 
-  await expect(async () => {
-    await expect(
-      page.locator('.autosave:has-text("Last saved less than a minute ago")'),
-    ).toBeVisible()
-  }).toPass({
-    timeout: POLL_TOPASS_TIMEOUT,
-  })
+  if (expectation === 'success') {
+    await expect(async () => {
+      await expect(
+        page.locator('.autosave:has-text("Last saved less than a minute ago")'),
+      ).toBeVisible()
+    }).toPass({
+      timeout: POLL_TOPASS_TIMEOUT,
+    })
+  } else {
+    await expect(async () => {
+      await expect(page.locator('.payload-toast-container .toast-error')).toBeVisible()
+    }).toPass({
+      timeout: POLL_TOPASS_TIMEOUT,
+    })
+  }
 }

--- a/test/versions/collections/AutosaveWithValidate.ts
+++ b/test/versions/collections/AutosaveWithValidate.ts
@@ -1,0 +1,33 @@
+import type { CollectionConfig } from 'payload'
+
+import { autosaveWithValidateCollectionSlug } from '../slugs.js'
+
+const AutosaveWithValidatePosts: CollectionConfig = {
+  slug: autosaveWithValidateCollectionSlug,
+  labels: {
+    singular: 'Autosave with Validate Post',
+    plural: 'Autosave with Validate Posts',
+  },
+  admin: {
+    useAsTitle: 'title',
+    defaultColumns: ['title', 'subtitle', 'createdAt', '_status'],
+  },
+  versions: {
+    maxPerDoc: 35,
+    drafts: {
+      validate: true,
+      autosave: {
+        interval: 250,
+      },
+    },
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+  ],
+}
+
+export default AutosaveWithValidatePosts

--- a/test/versions/collections/DraftsWithValidate.ts
+++ b/test/versions/collections/DraftsWithValidate.ts
@@ -1,0 +1,21 @@
+import type { CollectionConfig } from 'payload'
+
+import { draftWithValidateCollectionSlug } from '../slugs.js'
+
+const DraftsWithValidate: CollectionConfig = {
+  slug: draftWithValidateCollectionSlug,
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+  ],
+  versions: {
+    drafts: {
+      validate: true,
+    },
+  },
+}
+
+export default DraftsWithValidate

--- a/test/versions/config.ts
+++ b/test/versions/config.ts
@@ -4,11 +4,13 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import AutosavePosts from './collections/Autosave.js'
+import AutosaveWithValidate from './collections/AutosaveWithValidate.js'
 import CustomIDs from './collections/CustomIDs.js'
 import { Diff } from './collections/Diff.js'
 import DisablePublish from './collections/DisablePublish.js'
 import DraftPosts from './collections/Drafts.js'
 import DraftWithMax from './collections/DraftsWithMax.js'
+import DraftsWithValidate from './collections/DraftsWithValidate.js'
 import LocalizedPosts from './collections/Localized.js'
 import { Media } from './collections/Media.js'
 import Posts from './collections/Posts.js'
@@ -32,8 +34,10 @@ export default buildConfigWithDefaults({
     DisablePublish,
     Posts,
     AutosavePosts,
+    AutosaveWithValidate,
     DraftPosts,
     DraftWithMax,
+    DraftsWithValidate,
     LocalizedPosts,
     VersionPosts,
     CustomIDs,

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -6,16 +6,73 @@
  * and re-run `payload generate:types` to regenerate this file.
  */
 
+/**
+ * Supported timezones in IANA format.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "supportedTimezones".
+ */
+export type SupportedTimezones =
+  | 'Pacific/Midway'
+  | 'Pacific/Niue'
+  | 'Pacific/Honolulu'
+  | 'Pacific/Rarotonga'
+  | 'America/Anchorage'
+  | 'Pacific/Gambier'
+  | 'America/Los_Angeles'
+  | 'America/Tijuana'
+  | 'America/Denver'
+  | 'America/Phoenix'
+  | 'America/Chicago'
+  | 'America/Guatemala'
+  | 'America/New_York'
+  | 'America/Bogota'
+  | 'America/Caracas'
+  | 'America/Santiago'
+  | 'America/Buenos_Aires'
+  | 'America/Sao_Paulo'
+  | 'Atlantic/South_Georgia'
+  | 'Atlantic/Azores'
+  | 'Atlantic/Cape_Verde'
+  | 'Europe/London'
+  | 'Europe/Berlin'
+  | 'Africa/Lagos'
+  | 'Europe/Athens'
+  | 'Africa/Cairo'
+  | 'Europe/Moscow'
+  | 'Asia/Riyadh'
+  | 'Asia/Dubai'
+  | 'Asia/Baku'
+  | 'Asia/Karachi'
+  | 'Asia/Tashkent'
+  | 'Asia/Calcutta'
+  | 'Asia/Dhaka'
+  | 'Asia/Almaty'
+  | 'Asia/Jakarta'
+  | 'Asia/Bangkok'
+  | 'Asia/Shanghai'
+  | 'Asia/Singapore'
+  | 'Asia/Tokyo'
+  | 'Asia/Seoul'
+  | 'Australia/Sydney'
+  | 'Pacific/Guam'
+  | 'Pacific/Noumea'
+  | 'Pacific/Auckland'
+  | 'Pacific/Fiji';
+
 export interface Config {
   auth: {
     users: UserAuthOperations;
   };
+  blocks: {};
   collections: {
     'disable-publish': DisablePublish;
     posts: Post;
     'autosave-posts': AutosavePost;
+    'autosave-with-validate-posts': AutosaveWithValidatePost;
     'draft-posts': DraftPost;
     'draft-with-max-posts': DraftWithMaxPost;
+    'draft-with-validate-posts': DraftWithValidatePost;
     'localized-posts': LocalizedPost;
     'version-posts': VersionPost;
     'custom-ids': CustomId;
@@ -32,8 +89,10 @@ export interface Config {
     'disable-publish': DisablePublishSelect<false> | DisablePublishSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
     'autosave-posts': AutosavePostsSelect<false> | AutosavePostsSelect<true>;
+    'autosave-with-validate-posts': AutosaveWithValidatePostsSelect<false> | AutosaveWithValidatePostsSelect<true>;
     'draft-posts': DraftPostsSelect<false> | DraftPostsSelect<true>;
     'draft-with-max-posts': DraftWithMaxPostsSelect<false> | DraftWithMaxPostsSelect<true>;
+    'draft-with-validate-posts': DraftWithValidatePostsSelect<false> | DraftWithValidatePostsSelect<true>;
     'localized-posts': LocalizedPostsSelect<false> | LocalizedPostsSelect<true>;
     'version-posts': VersionPostsSelect<false> | VersionPostsSelect<true>;
     'custom-ids': CustomIdsSelect<false> | CustomIdsSelect<true>;
@@ -168,6 +227,17 @@ export interface DraftPost {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "autosave-with-validate-posts".
+ */
+export interface AutosaveWithValidatePost {
+  id: string;
+  title: string;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "draft-with-max-posts".
  */
 export interface DraftWithMaxPost {
@@ -186,6 +256,17 @@ export interface DraftWithMaxPost {
       }[]
     | null;
   relation?: (string | null) | DraftWithMaxPost;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "draft-with-validate-posts".
+ */
+export interface DraftWithValidatePost {
+  id: string;
+  title: string;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -443,12 +524,20 @@ export interface PayloadLockedDocument {
         value: string | AutosavePost;
       } | null)
     | ({
+        relationTo: 'autosave-with-validate-posts';
+        value: string | AutosaveWithValidatePost;
+      } | null)
+    | ({
         relationTo: 'draft-posts';
         value: string | DraftPost;
       } | null)
     | ({
         relationTo: 'draft-with-max-posts';
         value: string | DraftWithMaxPost;
+      } | null)
+    | ({
+        relationTo: 'draft-with-validate-posts';
+        value: string | DraftWithValidatePost;
       } | null)
     | ({
         relationTo: 'localized-posts';
@@ -554,6 +643,16 @@ export interface AutosavePostsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "autosave-with-validate-posts_select".
+ */
+export interface AutosaveWithValidatePostsSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "draft-posts_select".
  */
 export interface DraftPostsSelect<T extends boolean = true> {
@@ -601,6 +700,16 @@ export interface DraftWithMaxPostsSelect<T extends boolean = true> {
             };
       };
   relation?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "draft-with-validate-posts_select".
+ */
+export interface DraftWithValidatePostsSelect<T extends boolean = true> {
+  title?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;

--- a/test/versions/seed.ts
+++ b/test/versions/seed.ts
@@ -7,7 +7,12 @@ import type { DraftPost } from './payload-types.js'
 import { devUser } from '../credentials.js'
 import { executePromises } from '../helpers/executePromises.js'
 import { titleToDelete } from './shared.js'
-import { diffCollectionSlug, draftCollectionSlug, mediaCollectionSlug } from './slugs.js'
+import {
+  autosaveWithValidateCollectionSlug,
+  diffCollectionSlug,
+  draftCollectionSlug,
+  mediaCollectionSlug,
+} from './slugs.js'
 import { textToLexicalJSON } from './textToLexicalJSON.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -118,6 +123,13 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     depth: 0,
     overrideAccess: true,
     draft: true,
+  })
+
+  await _payload.create({
+    collection: autosaveWithValidateCollectionSlug,
+    data: {
+      title: 'Initial seeded title',
+    },
   })
 
   const diffDoc = await _payload.create({

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -1,8 +1,12 @@
 export const autosaveCollectionSlug = 'autosave-posts'
 
+export const autosaveWithValidateCollectionSlug = 'autosave-with-validate-posts'
+
 export const customIDSlug = 'custom-ids'
 
 export const draftCollectionSlug = 'draft-posts'
+
+export const draftWithValidateCollectionSlug = 'draft-with-validate-posts'
 export const draftWithMaxCollectionSlug = 'draft-with-max-posts'
 
 export const postCollectionSlug = 'posts'


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11224
Fixes https://github.com/payloadcms/payload/issues/10492

This PR fixes a few weird behaviours when `validate: true` is set on drafts:
- when autosave is on and you submit an invalid form it would get stuck in an infinite loop
- PreventLeave would not trigger for submitted but invalid forms leading to potential data loss

Changes:
- Adds e2e tests for the above scenarios
- Adds a new `isValid` flag on the `Form` context provider to signal globally if the form is in a valid or invalid state
  - Components like Autosave will manage this internally since it manages its own submission flow as well
- Adds PreventLeave to Autosave too for when form is invalid meaning data hasn't been actually saved so we want to prevent the user accidentally losing data by reloading or closing the page


The following tests have been added
![image](https://github.com/user-attachments/assets/db208aa4-6ed6-4287-b200-59575cd3c9d0)
