### PR TITLE
docs: add info about changes in localized fields to v2 -> v3 migration guide

### DIFF
--- a/docs/migration-guide/overview.mdx
+++ b/docs/migration-guide/overview.mdx
@@ -414,6 +414,15 @@ For more details, see the [Documentation](https://payloadcms.com/docs/getting-st
     ```
 1. The `./src/public` directory is now located directly at root level `./public` [see Next.js docs for details](https://nextjs.org/docs/pages/building-your-application/optimizing/static-assets)
 
+1.  Data structure changes for all fields with `localized: true`. All nested locale has a new, simplified data structure. You need to create your own migrations that work with your payload collections and fields.
+Mongodb example for a link in a page layout.
+
+    ```diff
+    - layout.columns.en.link.en.type.en
+    + layout.en.columns.link.type
+    ```
+
+
 ## Custom Components
 
 1. All Payload React components have been moved from the `payload` package to `@payloadcms/ui`. If you were previously importing components into your app from the `payload` package, for example to create Custom Components, you will need to change your import paths:

--- a/docs/migration-guide/overview.mdx
+++ b/docs/migration-guide/overview.mdx
@@ -414,7 +414,7 @@ For more details, see the [Documentation](https://payloadcms.com/docs/getting-st
     ```
 1. The `./src/public` directory is now located directly at root level `./public` [see Next.js docs for details](https://nextjs.org/docs/pages/building-your-application/optimizing/static-assets)
 
-1.  Data structure changes for all fields with `localized: true`. All nested locale has a new, simplified data structure. You need to create your own migrations that work with your payload collections and fields.
+1.  Data structure changes for all fields with `localized: true`. All nested locale has a new, simplified data structure. If you want to retain v2 data structure, you need to enable `allowLocalizedWithinLocalized` flag in your payload.config [read more in documentation](https://payloadcms.com/docs/configuration/overview#compatibility-flags). If you want to align with v3 structure you have to create your own migrations that work for your payload collections and fields.
 Mongodb example for a link in a page layout.
 
     ```diff

--- a/docs/migration-guide/overview.mdx
+++ b/docs/migration-guide/overview.mdx
@@ -414,12 +414,12 @@ For more details, see the [Documentation](https://payloadcms.com/docs/getting-st
     ```
 1. The `./src/public` directory is now located directly at root level `./public` [see Next.js docs for details](https://nextjs.org/docs/pages/building-your-application/optimizing/static-assets)
 
-1.  Data structure changes for all fields with `localized: true`. All nested locale has a new, simplified data structure. If you want to retain v2 data structure, you need to enable `allowLocalizedWithinLocalized` flag in your payload.config [read more in documentation](https://payloadcms.com/docs/configuration/overview#compatibility-flags). If you want to align with v3 structure you have to create your own migrations that work for your payload collections and fields.
+1.  Payload now automatically removes `localized: true` property from sub-fields if a parent is localized, as it's redunant and unnecessary. If you have some existing data in this structure and you want to disable that behavior, you need to enable `allowLocalizedWithinLocalized` flag in your payload.config [read more in documentation](https://payloadcms.com/docs/configuration/overview#compatibility-flags), or create a migration script that aligns your data.
 Mongodb example for a link in a page layout.
 
     ```diff
     - layout.columns.en.link.en.type.en
-    + layout.en.columns.link.type
+    + layout.columns.en.link.type
     ```
 
 


### PR DESCRIPTION
### What?
Information that locale fields in database are changing to a simpler data structure in v3. 

### Why?
Simple data migration is not enough to get it working, I had to spend quite some time to figure out migration files and still it required some manual input. Maybe others will find it useful when starting a v3 migration.

### How?
I had to do some custom migration scripts on my own to get v3 to work with existing pages data. 
