### PR TITLE
chore: add JSDoc for collection Local API operations properties

### DIFF
--- a/packages/payload/src/collections/operations/local/count.ts
+++ b/packages/payload/src/collections/operations/local/count.ts
@@ -7,17 +7,47 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { countOperation } from '../count.js'
 
 export type Options<TSlug extends CollectionSlug> = {
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * When set to `true`, errors will not be thrown.
+   */
   disableErrors?: boolean
+  /**
+   *  Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
+  /**
+   * A filter [query](https://payloadcms.com/docs/queries/overview)
+   */
   where?: Where
 }
 

--- a/packages/payload/src/collections/operations/local/countVersions.ts
+++ b/packages/payload/src/collections/operations/local/countVersions.ts
@@ -7,17 +7,47 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { countVersionsOperation } from '../countVersions.js'
 
 export type Options<TSlug extends CollectionSlug> = {
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * When set to `true`, errors will not be thrown.
+   */
   disableErrors?: boolean
+  /**
+   * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
+  /**
+   * A filter [query](https://payloadcms.com/docs/queries/overview)
+   */
   where?: Where
 }
 

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -26,27 +26,92 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { createOperation } from '../create.js'
 
 export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = {
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * The data for the document to create.
+   */
   data: RequiredDataFromCollectionSlug<TSlug>
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * When set to `true`, a [database transactions](https://payloadcms.com/docs/database/transactions) will not be initialized.
+   * @default false
+   */
   disableTransaction?: boolean
+  /**
+   * If creating verification-enabled auth doc,
+   * you can disable the email that is auto-sent
+   */
   disableVerificationEmail?: boolean
+  /**
+   * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+   */
   draft?: boolean
+  /**
+   * If you want to create a document that is a duplicate of another document
+   */
   duplicateFromID?: DataFromCollectionSlug<TSlug>['id']
+  /**
+   * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
+   */
   fallbackLocale?: false | TypedLocale
+  /**
+   * A `File` object when creating a collection with `upload: true`.
+   */
   file?: File
+  /**
+   * A file path when creating a collection with `upload: true`.
+   */
   filePath?: string
+  /**
+   * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * If you are uploading a file and would like to replace
+   * the existing file instead of generating a new filename,
+   * you can set the following property to `true`
+   */
   overwriteExistingFiles?: boolean
+  /**
+   * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
+   */
   populate?: PopulateType
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
+   */
   select?: TSelect
+  /**
+   * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
+   * @default false
+   */
   showHiddenFields?: boolean
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
 }
 

--- a/packages/payload/src/collections/operations/local/delete.ts
+++ b/packages/payload/src/collections/operations/local/delete.ts
@@ -16,21 +16,66 @@ import { deleteOperation } from '../delete.js'
 import { deleteByIDOperation } from '../deleteByID.js'
 
 export type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * When set to `true`, a [database transactions](https://payloadcms.com/docs/database/transactions) will not be initialized.
+   * @default false
+   */
   disableTransaction?: boolean
+  /**
+   * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
+   */
   fallbackLocale?: false | TypedLocale
+  /**
+   * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * By default, document locks are ignored (`true`). Set to `false` to enforce locks and prevent operations when a document is locked by another user. [More details](https://payloadcms.com/docs/admin/locked-documents).
+   * @default true
+   */
   overrideLock?: boolean
+  /**
+   * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
+   */
   populate?: PopulateType
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
+   */
   select?: TSelect
+  /**
+   * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
+   * @default false
+   */
   showHiddenFields?: boolean
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
 }
 
@@ -38,7 +83,13 @@ export type ByIDOptions<
   TSlug extends CollectionSlug,
   TSelect extends SelectFromCollectionSlug<TSlug>,
 > = {
+  /**
+   * The ID of the document to delete.
+   */
   id: number | string
+  /**
+   * A filter [query](https://payloadcms.com/docs/queries/overview)
+   */
   where?: never
 } & BaseOptions<TSlug, TSelect>
 
@@ -46,7 +97,13 @@ export type ManyOptions<
   TSlug extends CollectionSlug,
   TSelect extends SelectFromCollectionSlug<TSlug>,
 > = {
+  /**
+   * The ID of the document to delete.
+   */
   id?: never
+  /**
+   * A filter [query](https://payloadcms.com/docs/queries/overview)
+   */
   where: Where
 } & BaseOptions<TSlug, TSelect>
 

--- a/packages/payload/src/collections/operations/local/duplicate.ts
+++ b/packages/payload/src/collections/operations/local/duplicate.ts
@@ -20,23 +20,73 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { duplicateOperation } from '../duplicate.js'
 
 export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = {
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * Override the data for the document to duplicate.
+   */
   data?: DeepPartial<RequiredDataFromCollectionSlug<TSlug>>
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * When set to `true`, a [database transactions](https://payloadcms.com/docs/database/transactions) will not be initialized.
+   * @default false
+   */
   disableTransaction?: boolean
+  /**
+   * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+   */
   draft?: boolean
+  /**
+   * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
+   */
   fallbackLocale?: false | TypedLocale
+  /**
+   * The ID of the document to duplicate from.
+   */
   id: number | string
+  /**
+   * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
+   */
   populate?: PopulateType
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
+   */
   select?: TSelect
+  /**
+   * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
+   * @default false
+   */
   showHiddenFields?: boolean
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
 }
 

--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -23,29 +23,104 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findOperation } from '../find.js'
 
 export type Options<TSlug extends CollectionSlug, TSelect extends SelectType> = {
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * The current population depth, used internally for relationships population.
+   * @internal
+   */
   currentDepth?: number
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * When set to `true`, errors will not be thrown.
+   */
   disableErrors?: boolean
+  /**
+   * Whether the documents should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+   */
   draft?: boolean
+  /**
+   * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
+   */
   fallbackLocale?: false | TypedLocale
+  /**
+   * Include info about the lock status to the result into all documents with fields: `_isLocked` and `_userEditing`
+   */
   includeLockStatus?: boolean
+  /**
+   * The [Join Field Query](https://payloadcms.com/docs/fields/join#query-options).
+   * Pass `false` to disable all join fields from the result.
+   */
   joins?: JoinQuery<TSlug>
+  /**
+   * The maximum related documents to be returned.
+   * Defaults unless `defaultLimit` is specified for the collection config
+   * @default 10
+   */
   limit?: number
+  /**
+   * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: 'all' | TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * Get a specific page number
+   * @default 1
+   */
   page?: number
+  /**
+   * Set to `false` to return all documents and avoid querying for document counts which introduces some overhead.
+   * You can also combine that property with a specified `limit` to limit documents but avoid the count query.
+   */
   pagination?: boolean
+  /**
+   * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
+   */
   populate?: PopulateType
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
+   */
   select?: TSelect
+  /**
+   * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
+   * @default false
+   */
   showHiddenFields?: boolean
+  /**
+   * Sort the documents, can be a string or an array of strings
+   * @example '-createdAt' // Sort DESC by createdAt
+   * @example ['group', '-createdAt'] // sort by 2 fields, ASC group and DESC createdAt
+   */
   sort?: Sort
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
+  /**
+   * A filter [query](https://payloadcms.com/docs/queries/overview)
+   */
   where?: Where
 }
 

--- a/packages/payload/src/collections/operations/local/findByID.ts
+++ b/packages/payload/src/collections/operations/local/findByID.ts
@@ -26,25 +26,83 @@ export type Options<
   TDisableErrors extends boolean,
   TSelect extends SelectType,
 > = {
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * The current population depth, used internally for relationships population.
+   * @internal
+   */
   currentDepth?: number
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * When set to `true`, errors will not be thrown.
+   * `null` will be returned instead, if the document on this ID was not found.
+   */
   disableErrors?: TDisableErrors
+  /**
+   * Whether the document should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+   */
   draft?: boolean
+  /**
+   * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
+   */
   fallbackLocale?: false | TypedLocale
+  /**
+   * The ID of the document to find.
+   */
   id: number | string
+  /**
+   * Include info about the lock status to the result with fields: `_isLocked` and `_userEditing`
+   */
   includeLockStatus?: boolean
+  /**
+   * The [Join Field Query](https://payloadcms.com/docs/fields/join#query-options).
+   * Pass `false` to disable all join fields from the result.
+   */
   joins?: JoinQuery<TSlug>
+  /**
+   * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: 'all' | TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
+   */
   populate?: PopulateType
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
+   */
   select?: TSelect
+  /**
+   * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
+   * @default false
+   */
   showHiddenFields?: boolean
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
 }
 

--- a/packages/payload/src/collections/operations/local/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/local/findVersionByID.ts
@@ -9,22 +9,69 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findVersionByIDOperation } from '../findVersionByID.js'
 
 export type Options<TSlug extends CollectionSlug> = {
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * When set to `true`, errors will not be thrown.
+   * `null` will be returned instead, if the document on this ID was not found.
+   */
   disableErrors?: boolean
+  /**
+   * Whether the document should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+   */
   draft?: boolean
+  /**
+   * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
+   */
   fallbackLocale?: false | TypedLocale
+  /**
+   * The ID of the version to find.
+   */
   id: string
+  /**
+   * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: 'all' | TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
+   */
   populate?: PopulateType
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
+   */
   select?: SelectType
+  /**
+   * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
+   * @default false
+   */
   showHiddenFields?: boolean
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
 }
 

--- a/packages/payload/src/collections/operations/local/findVersions.ts
+++ b/packages/payload/src/collections/operations/local/findVersions.ts
@@ -17,24 +17,81 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { findVersionsOperation } from '../findVersions.js'
 
 export type Options<TSlug extends CollectionSlug> = {
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * Whether the documents should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+   */
   draft?: boolean
+  /**
+   * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
+   */
   fallbackLocale?: false | TypedLocale
+  /**
+   * The maximum related documents to be returned.
+   * Defaults unless `defaultLimit` is specified for the collection config
+   * @default 10
+   */
   limit?: number
+  /**
+   * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: 'all' | TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * Get a specific page number
+   * @default 1
+   */
   page?: number
+  /**
+   * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
+   */
   populate?: PopulateType
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
+   */
   select?: SelectType
+  /**
+   * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
+   * @default false
+   */
   showHiddenFields?: boolean
+  /**
+   * Sort the documents, can be a string or an array of strings
+   * @example '-version.createdAt' // Sort DESC by createdAt
+   * @example ['version.group', '-version.createdAt'] // sort by 2 fields, ASC group and DESC createdAt
+   */
   sort?: Sort
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
+  /**
+   * A filter [query](https://payloadcms.com/docs/queries/overview)
+   */
   where?: Where
 }
 

--- a/packages/payload/src/collections/operations/local/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/local/restoreVersion.ts
@@ -8,21 +8,64 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { restoreVersionOperation } from '../restoreVersion.js'
 
 export type Options<TSlug extends CollectionSlug> = {
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * Whether the document should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+   */
   draft?: boolean
+  /**
+   * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
+   */
   fallbackLocale?: false | TypedLocale
+  /**
+   * The ID of the version to restore.
+   */
   id: string
+  /**
+   * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
+   */
   populate?: PopulateType
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
+   */
   select?: SelectType
+  /**
+   * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
+   * @default false
+   */
   showHiddenFields?: boolean
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
 }
 

--- a/packages/payload/src/collections/operations/local/update.ts
+++ b/packages/payload/src/collections/operations/local/update.ts
@@ -24,28 +24,97 @@ import { updateOperation } from '../update.js'
 import { updateByIDOperation } from '../updateByID.js'
 
 export type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
+  /**
+   * Whether the current update should be marked as from autosave.
+   * `versions.drafts.autosave` should be specified.
+   */
   autosave?: boolean
+  /**
+   * the Collection slug to operate against.
+   */
   collection: TSlug
   /**
-   * context, which will then be passed to req.context, which can be read by hooks
+   * [Context](https://payloadcms.com/docs/hooks/context), which will then be passed to `context` and `req.context`,
+   * which can be read by hooks. Useful if you want to pass additional information to the hooks which
+   * shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook
+   * to determine if it should run or not.
    */
   context?: RequestContext
+  /**
+   * The document / documents data to update.
+   */
   data: DeepPartial<RequiredDataFromCollectionSlug<TSlug>>
+  /**
+   * [Control auto-population](https://payloadcms.com/docs/queries/depth) of nested relationship and upload fields.
+   */
   depth?: number
+  /**
+   * When set to `true`, a [database transactions](https://payloadcms.com/docs/database/transactions) will not be initialized.
+   * @default false
+   */
   disableTransaction?: boolean
+  /**
+   * Update documents to a draft.
+   */
   draft?: boolean
+  /**
+   * Specify a [fallback locale](https://payloadcms.com/docs/configuration/localization) to use for any returned documents.
+   */
   fallbackLocale?: false | TypedLocale
+  /**
+   * A `File` object when updating a collection with `upload: true`.
+   */
   file?: File
+  /**
+   * A file path when creating a collection with `upload: true`.
+   */
   filePath?: string
+  /**
+   * Specify [locale](https://payloadcms.com/docs/configuration/localization) for any returned documents.
+   */
   locale?: TypedLocale
+  /**
+   * Skip access control.
+   * Set to `false` if you want to respect Access Control for the operation, for example when fetching data for the fron-end.
+   * @default true
+   */
   overrideAccess?: boolean
+  /**
+   * By default, document locks are ignored (`true`). Set to `false` to enforce locks and prevent operations when a document is locked by another user. [More details](https://payloadcms.com/docs/admin/locked-documents).
+   * @default true
+   */
   overrideLock?: boolean
+  /**
+   * If you are uploading a file and would like to replace
+   * the existing file instead of generating a new filename,
+   * you can set the following property to `true`
+   */
   overwriteExistingFiles?: boolean
+  /**
+   * Specify [populate](https://payloadcms.com/docs/queries/select#populate) to control which fields to include to the result from populated documents.
+   */
   populate?: PopulateType
+  /**
+   * Publish the document / documents with a specific locale.
+   */
   publishSpecificLocale?: string
+  /**
+   * The `PayloadRequest` object. You can pass it to thread the current [transaction](https://payloadcms.com/docs/database/transactions), user and locale to the operation.
+   * Recommended to pass when using the Local API from hooks, as usually you want to execute the operation within the current transaction.
+   */
   req?: Partial<PayloadRequest>
+  /**
+   * Specify [select](https://payloadcms.com/docs/queries/select) to control which fields to include to the result.
+   */
   select?: TSelect
+  /**
+   * Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.
+   * @default false
+   */
   showHiddenFields?: boolean
+  /**
+   * If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.
+   */
   user?: Document
 }
 
@@ -53,8 +122,17 @@ export type ByIDOptions<
   TSlug extends CollectionSlug,
   TSelect extends SelectFromCollectionSlug<TSlug>,
 > = {
+  /**
+   * The ID of the document to update.
+   */
   id: number | string
+  /**
+   * Limit documents to update
+   */
   limit?: never
+  /**
+   * A filter [query](https://payloadcms.com/docs/queries/overview)
+   */
   where?: never
 } & BaseOptions<TSlug, TSelect>
 
@@ -62,8 +140,17 @@ export type ManyOptions<
   TSlug extends CollectionSlug,
   TSelect extends SelectFromCollectionSlug<TSlug>,
 > = {
+  /**
+   * The ID of the document to update.
+   */
   id?: never
+  /**
+   * Limit documents to update
+   */
   limit?: number
+  /**
+   * A filter [query](https://payloadcms.com/docs/queries/overview)
+   */
   where: Where
 } & BaseOptions<TSlug, TSelect>
 


### PR DESCRIPTION
### What?
Adds JSDoc for options of all collection Local API operations
_Every_ property now is documented there, even those that aren't on our website docs.

### Why?
This is useful to have, now you can hover over any property to see what it does in your editor.
Some properties also link to the documentation website directly for more info.

### How?
Updates every collection operation arguments definition with JSDoc.

For globals will be a separate PR.