### PR TITLE
fix(db-mongodb): properly handle document notfound cases for update and delete operations

### DIFF
--- a/packages/db-mongodb/src/deleteOne.ts
+++ b/packages/db-mongodb/src/deleteOne.ts
@@ -29,7 +29,11 @@ export const deleteOne: DeleteOne = async function deleteOne(
     where,
   })
 
-  const doc = await Model.findOneAndDelete(query, options).lean()
+  const doc = await Model.findOneAndDelete(query, options)?.lean()
+
+  if (!doc) {
+    return null
+  }
 
   let result: Document = JSON.parse(JSON.stringify(doc))
 

--- a/packages/db-mongodb/src/updateGlobal.ts
+++ b/packages/db-mongodb/src/updateGlobal.ts
@@ -37,6 +37,10 @@ export const updateGlobal: UpdateGlobal = async function updateGlobal(
 
   result = await Model.findOneAndUpdate({ globalType: slug }, sanitizedData, options)
 
+  if (!result) {
+    return null
+  }
+
   result = JSON.parse(JSON.stringify(result))
 
   // custom id type reset

--- a/packages/db-mongodb/src/updateGlobalVersion.ts
+++ b/packages/db-mongodb/src/updateGlobalVersion.ts
@@ -55,6 +55,10 @@ export async function updateGlobalVersion<T extends TypeWithID>(
 
   const doc = await VersionModel.findOneAndUpdate(query, sanitizedData, options)
 
+  if (!doc) {
+    return null
+  }
+
   const result = JSON.parse(JSON.stringify(doc))
 
   const verificationToken = doc._verificationToken

--- a/packages/db-mongodb/src/updateOne.ts
+++ b/packages/db-mongodb/src/updateOne.ts
@@ -51,6 +51,10 @@ export const updateOne: UpdateOne = async function updateOne(
     handleError({ collection, error, req })
   }
 
+  if (!result) {
+    return null
+  }
+
   result = JSON.parse(JSON.stringify(result))
   result.id = result._id
   result = sanitizeInternalFields(result)

--- a/packages/db-mongodb/src/updateVersion.ts
+++ b/packages/db-mongodb/src/updateVersion.ts
@@ -53,6 +53,10 @@ export const updateVersion: UpdateVersion = async function updateVersion(
 
   const doc = await VersionModel.findOneAndUpdate(query, sanitizedData, options)
 
+  if (!doc) {
+    return null
+  }
+
   const result = JSON.parse(JSON.stringify(doc))
 
   const verificationToken = doc._verificationToken

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -305,6 +305,9 @@ export type UpdateGlobalVersionArgs<T = TypeWithID> = {
     }
 )
 
+/**
+ * @todo type as Promise<TypeWithVersion<T> | null> in 4.0
+ */
 export type UpdateGlobalVersion = <T extends TypeWithID = TypeWithID>(
   args: UpdateGlobalVersionArgs<T>,
 ) => Promise<TypeWithVersion<T>>
@@ -332,6 +335,9 @@ export type UpdateGlobalArgs<T extends Record<string, unknown> = any> = {
   select?: SelectType
   slug: string
 }
+/**
+ * @todo type as Promise<T | null> in 4.0
+ */
 export type UpdateGlobal = <T extends Record<string, unknown> = any>(
   args: UpdateGlobalArgs<T>,
 ) => Promise<T>
@@ -410,6 +416,9 @@ export type UpdateVersionArgs<T = TypeWithID> = {
     }
 )
 
+/**
+ * @todo type as Promise<TypeWithVersion<T> | null> in 4.0
+ */
 export type UpdateVersion = <T extends TypeWithID = TypeWithID>(
   args: UpdateVersionArgs<T>,
 ) => Promise<TypeWithVersion<T>>
@@ -448,6 +457,9 @@ export type UpdateOneArgs = {
     }
 )
 
+/**
+ * @todo type as Promise<Document | null> in 4.0
+ */
 export type UpdateOne = (args: UpdateOneArgs) => Promise<Document>
 
 export type UpsertArgs = {
@@ -470,6 +482,9 @@ export type DeleteOneArgs = {
   where: Where
 }
 
+/**
+ * @todo type as Promise<Document | null> in 4.0
+ */
 export type DeleteOne = (args: DeleteOneArgs) => Promise<Document>
 
 export type DeleteManyArgs = {


### PR DESCRIPTION
In the `findOne` db operation, we return `null` if the document was not found.

For single-document delete and update operations, if the document you wanted to update is not found, the following runtime error is thrown instead: `Cannot read properties of null (reading '_id')`.

This PR correctly handles these cases and returns `null` from the db method, just like the `findOne` operation.