### PR TITLE
fix(ui): do not pass req in handleFormStateLocking

### DIFF
--- a/packages/ui/src/utilities/handleFormStateLocking.ts
+++ b/packages/ui/src/utilities/handleFormStateLocking.ts
@@ -64,7 +64,6 @@ export const handleFormStateLocking = async ({
         limit: 1,
         overrideAccess: false,
         pagination: false,
-        req,
         where: lockedDocumentQuery,
       })
 
@@ -85,7 +84,6 @@ export const handleFormStateLocking = async ({
             id: lockedDocument.docs[0].id,
             collection: 'payload-locked-documents',
             data: {},
-            req,
           })
         }
       } else {
@@ -119,7 +117,6 @@ export const handleFormStateLocking = async ({
 
         await req.payload.db.deleteMany({
           collection: 'payload-locked-documents',
-          req,
           where: deleteExpiredLocksQuery,
         })
 
@@ -138,7 +135,6 @@ export const handleFormStateLocking = async ({
               value: req.user.id,
             },
           },
-          req,
         })
 
         result = {

--- a/packages/ui/src/utilities/handleFormStateLocking.ts
+++ b/packages/ui/src/utilities/handleFormStateLocking.ts
@@ -64,6 +64,7 @@ export const handleFormStateLocking = async ({
         limit: 1,
         overrideAccess: false,
         pagination: false,
+        user: req.user,
         where: lockedDocumentQuery,
       })
 


### PR DESCRIPTION
Not passing through `req` ensures that the db operations in `handleFormStateLocking` run independently, preventing them from being part of the same transaction. Since locked document operations aren't critical enough to require transactional consistency, this change helps avoid unnecessary transaction errors that have previously occurred here.







