### PR TITLE
fix(ui): database errors when running autosave and ensure autosave doesn't run unnecessarily

### DIFF
--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -164,9 +164,8 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
 
         if (url) {
           if (modifiedRef.current) {
-            const { data, valid } = {
-              ...reduceFieldsToValuesWithValidation(fieldRef.current, true),
-            }
+            const { data, valid } = reduceFieldsToValuesWithValidation(fieldRef.current, true)
+
             data._status = 'draft'
 
             const skipSubmission =
@@ -293,10 +292,17 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
   const previousDebouncedFields = useRef(debouncedFields)
   // When debounced fields change, autosave
   useEffect(() => {
+    /**
+     * Ensure autosave doesn't run on mount
+     */
     if (!didMount.current) {
       didMount.current = true
       return
     }
+
+    /**
+     * Ensure autosave only runs if the form data changes, not every time the entire form state changes
+     */
     if (
       dequal(
         reduceFieldsToValues(debouncedFields),

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -4,7 +4,7 @@ import type { ClientCollectionConfig, ClientGlobalConfig } from 'payload'
 
 import { dequal } from 'dequal/lite'
 import { reduceFieldsToValues, versionDefaults } from 'payload/shared'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useDeferredValue, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import {
@@ -77,7 +77,8 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
     docConfig?.versions?.drafts && docConfig?.versions?.drafts.validate,
   )
 
-  const [saving, setSaving] = useState(false)
+  const [_saving, setSaving] = useState(false)
+  const saving = useDeferredValue(_saving)
   const debouncedFields = useDebounce(fields, interval)
   const fieldRef = useRef(fields)
   const modifiedRef = useRef(modified)

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -289,7 +289,7 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
   })
 
   const didMount = useRef(false)
-  const previousDebouncedFields = useRef(debouncedFields)
+  const previousDebouncedFieldValues = useRef(reduceFieldsToValues(debouncedFields))
   // When debounced fields change, autosave
   useEffect(() => {
     /**
@@ -303,16 +303,12 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
     /**
      * Ensure autosave only runs if the form data changes, not every time the entire form state changes
      */
-    if (
-      dequal(
-        reduceFieldsToValues(debouncedFields),
-        reduceFieldsToValues(previousDebouncedFields.current),
-      )
-    ) {
+    const debouncedFieldValues = reduceFieldsToValues(debouncedFields)
+    if (dequal(debouncedFieldValues, previousDebouncedFieldValues)) {
       return
     }
 
-    previousDebouncedFields.current = debouncedFields
+    previousDebouncedFieldValues.current = debouncedFieldValues
 
     handleAutosave()
   }, [debouncedFields])

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -87,9 +87,6 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
    * Helps us prevent infinite loops when the queue is processing and the form is invalid
    */
   const isValidRef = useRef(isValid)
-  const debouncedRef = useRef(debouncedFields)
-
-  debouncedRef.current = debouncedFields
 
   // Store fields in ref so the autosave func
   // can always retrieve the most to date copies

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -2,7 +2,8 @@
 // TODO: abstract the `next/navigation` dependency out from this component
 import type { ClientCollectionConfig, ClientGlobalConfig } from 'payload'
 
-import { versionDefaults } from 'payload/shared'
+import { dequal } from 'dequal/lite'
+import { reduceFieldsToValues, versionDefaults } from 'payload/shared'
 import React, { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -18,8 +19,8 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentEvents } from '../../providers/DocumentEvents/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
-import { useTranslation } from '../../providers/Translation/index.js'
 import './index.scss'
+import { useTranslation } from '../../providers/Translation/index.js'
 import { formatTimeToNow } from '../../utilities/formatDate.js'
 import { reduceFieldsToValuesWithValidation } from '../../utilities/reduceFieldsToValuesWithValidation.js'
 import { LeaveWithoutSaving } from '../LeaveWithoutSaving/index.js'
@@ -108,6 +109,7 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
     if (isProcessingRef.current || queueRef.current.length === 0) {
       return
     }
+    isProcessingRef.current = true
 
     if (!isValidRef.current) {
       // Clear queue so we don't end up in an infinite loop
@@ -117,7 +119,6 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
       return
     }
 
-    isProcessingRef.current = true
     const latestAction = queueRef.current[queueRef.current.length - 1]
     queueRef.current = []
 
@@ -131,9 +132,10 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
     }
   }, [])
 
+  const autosaveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
   const handleAutosave = useEffectEvent(() => {
-    const abortController = new AbortController()
-    let autosaveTimeout = undefined
+    autosaveTimeoutRef.current = undefined
     // We need to log the time in order to figure out if we need to trigger the state off later
     let startTimestamp = undefined
     let endTimestamp = undefined
@@ -166,116 +168,117 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
               ...reduceFieldsToValuesWithValidation(fieldRef.current, true),
             }
             data._status = 'draft'
+
             const skipSubmission =
               submitted && !valid && versionsConfig?.drafts && versionsConfig?.drafts?.validate
 
             if (!skipSubmission && isValidRef.current) {
-              await fetch(url, {
-                body: JSON.stringify(data),
-                credentials: 'include',
-                headers: {
-                  'Accept-Language': i18n.language,
-                  'Content-Type': 'application/json',
-                },
-                method,
-                signal: abortController.signal,
-              })
-                .then((res) => {
-                  const newDate = new Date()
-                  // We need to log the time in order to figure out if we need to trigger the state off later
-                  endTimestamp = newDate.getTime()
-
-                  if (res.status === 200) {
-                    setLastUpdateTime(newDate.getTime())
-
-                    reportUpdate({
-                      id,
-                      entitySlug,
-                      updatedAt: newDate.toISOString(),
-                    })
-
-                    if (!mostRecentVersionIsAutosaved) {
-                      incrementVersionCount()
-                      setMostRecentVersionIsAutosaved(true)
-                      setUnpublishedVersionCount((prev) => prev + 1)
-                    }
-                  }
-
-                  return res.json()
+              let res
+              try {
+                res = await fetch(url, {
+                  body: JSON.stringify(data),
+                  credentials: 'include',
+                  headers: {
+                    'Accept-Language': i18n.language,
+                    'Content-Type': 'application/json',
+                  },
+                  method,
                 })
-                .then((json) => {
-                  if (versionsConfig?.drafts && versionsConfig?.drafts?.validate && json?.errors) {
-                    if (Array.isArray(json.errors)) {
-                      const [fieldErrors, nonFieldErrors] = json.errors.reduce(
-                        ([fieldErrs, nonFieldErrs], err) => {
-                          const newFieldErrs = []
-                          const newNonFieldErrs = []
+              } catch (error) {
+                // Swallow Error
+              }
 
-                          if (err?.message) {
-                            newNonFieldErrs.push(err)
-                          }
+              const newDate = new Date()
+              // We need to log the time in order to figure out if we need to trigger the state off later
+              endTimestamp = newDate.getTime()
 
-                          if (Array.isArray(err?.data)) {
-                            err.data.forEach((dataError) => {
-                              if (dataError?.field) {
-                                newFieldErrs.push(dataError)
-                              } else {
-                                newNonFieldErrs.push(dataError)
-                              }
-                            })
-                          }
+              if (res.status === 200) {
+                setLastUpdateTime(newDate.getTime())
 
-                          return [
-                            [...fieldErrs, ...newFieldErrs],
-                            [...nonFieldErrs, ...newNonFieldErrs],
-                          ]
-                        },
-                        [[], []],
-                      )
-
-                      dispatchFields({
-                        type: 'ADD_SERVER_ERRORS',
-                        errors: fieldErrors,
-                      })
-
-                      nonFieldErrors.forEach((err) => {
-                        toast.error(err.message || i18n.t('error:unknown'))
-                      })
-
-                      // Set valid to false internally so the queue doesn't process
-                      isValidRef.current = false
-                      setIsValid(false)
-                      setSubmitted(true)
-
-                      return
-                    }
-                  } else {
-                    // If it's not an error then we can update the document data inside the context
-                    const document = json?.doc || json?.result
-
-                    // Manually update the data since this function doesn't fire the `submit` function from useForm
-                    if (document) {
-                      setIsValid(true)
-
-                      // Reset internal state allowing the queue to process
-                      isValidRef.current = true
-                      updateSavedDocumentData(document)
-                    }
-                  }
+                reportUpdate({
+                  id,
+                  entitySlug,
+                  updatedAt: newDate.toISOString(),
                 })
-                .finally(() => {
-                  // If request was faster than minimum animation time, animate the difference
-                  if (endTimestamp - startTimestamp < minimumAnimationTime) {
-                    autosaveTimeout = setTimeout(
-                      () => {
-                        setSaving(false)
-                      },
-                      minimumAnimationTime - (endTimestamp - startTimestamp),
-                    )
-                  } else {
+
+                if (!mostRecentVersionIsAutosaved) {
+                  incrementVersionCount()
+                  setMostRecentVersionIsAutosaved(true)
+                  setUnpublishedVersionCount((prev) => prev + 1)
+                }
+              }
+              const json = await res.json()
+
+              if (versionsConfig?.drafts && versionsConfig?.drafts?.validate && json?.errors) {
+                if (Array.isArray(json.errors)) {
+                  const [fieldErrors, nonFieldErrors] = json.errors.reduce(
+                    ([fieldErrs, nonFieldErrs], err) => {
+                      const newFieldErrs = []
+                      const newNonFieldErrs = []
+
+                      if (err?.message) {
+                        newNonFieldErrs.push(err)
+                      }
+
+                      if (Array.isArray(err?.data)) {
+                        err.data.forEach((dataError) => {
+                          if (dataError?.field) {
+                            newFieldErrs.push(dataError)
+                          } else {
+                            newNonFieldErrs.push(dataError)
+                          }
+                        })
+                      }
+
+                      return [
+                        [...fieldErrs, ...newFieldErrs],
+                        [...nonFieldErrs, ...newNonFieldErrs],
+                      ]
+                    },
+                    [[], []],
+                  )
+
+                  dispatchFields({
+                    type: 'ADD_SERVER_ERRORS',
+                    errors: fieldErrors,
+                  })
+
+                  nonFieldErrors.forEach((err) => {
+                    toast.error(err.message || i18n.t('error:unknown'))
+                  })
+
+                  // Set valid to false internally so the queue doesn't process
+                  isValidRef.current = false
+                  setIsValid(false)
+                  setSubmitted(true)
+
+                  return
+                }
+              } else {
+                // If it's not an error then we can update the document data inside the context
+                const document = json?.doc || json?.result
+
+                // Manually update the data since this function doesn't fire the `submit` function from useForm
+                if (document) {
+                  setIsValid(true)
+
+                  // Reset internal state allowing the queue to process
+                  isValidRef.current = true
+                  updateSavedDocumentData(document)
+                }
+              }
+
+              // If request was faster than minimum animation time, animate the difference
+              if (endTimestamp - startTimestamp < minimumAnimationTime) {
+                autosaveTimeoutRef.current = setTimeout(
+                  () => {
                     setSaving(false)
-                  }
-                })
+                  },
+                  minimumAnimationTime - (endTimestamp - startTimestamp),
+                )
+              } else {
+                setSaving(false)
+              }
             }
           }
         }
@@ -284,28 +287,46 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
 
     queueRef.current.push(autosave)
     void processQueue()
-
-    return { abortController, autosaveTimeout }
   })
 
+  const didMount = useRef(false)
+  const previousDebouncedFields = useRef(debouncedFields)
   // When debounced fields change, autosave
   useEffect(() => {
-    const { abortController, autosaveTimeout } = handleAutosave()
-
-    return () => {
-      if (autosaveTimeout) {
-        clearTimeout(autosaveTimeout)
-      }
-      if (abortController.signal) {
-        try {
-          abortController.abort('Autosave closed early.')
-        } catch (error) {
-          // swallow error
-        }
-      }
-      setSaving(false)
+    if (!didMount.current) {
+      didMount.current = true
+      return
     }
+    if (
+      dequal(
+        reduceFieldsToValues(debouncedFields),
+        reduceFieldsToValues(previousDebouncedFields.current),
+      )
+    ) {
+      return
+    }
+
+    previousDebouncedFields.current = debouncedFields
+
+    handleAutosave()
   }, [debouncedFields])
+
+  /**
+   * If component unmounts, clear the autosave timeout
+   */
+  useEffect(() => {
+    return () => {
+      stopAutoSaveIndicator()
+    }
+  }, [])
+
+  const stopAutoSaveIndicator = useEffectEvent(() => {
+    if (autosaveTimeoutRef.current) {
+      clearTimeout(autosaveTimeoutRef.current)
+    }
+
+    setSaving(false)
+  })
 
   return (
     <div className={baseClass}>

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -446,6 +446,7 @@ export const Form: React.FC<FormProps> = (props) => {
     },
     [
       beforeSubmit,
+      startRouteTransition,
       action,
       disableSuccessStatus,
       disableValidationOnSubmit,


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11145

## Change 1 - database errors when running autosave

The previous autosave implementation allowed multiple autosave fetch calls (=> save document draft) to run in parallel. While the AbortController aborted previous autosave calls if a new one comes in in order to only process the latest one, this had one flaw:

Using the AbortController to abort the autosave call only aborted the `fetch` call - it did not however abort the database operation that may have started as part of this fetch call. If you then started a new autosave call, this will start yet another database operation on the backend, resulting in two database operations that would be running at the same time.

This has caused a lot of transaction errors that were only noticeable when connected to a slower, remote database. This PR removes the AbortController and ensures that the previous autosave operation is properly awaited before starting a new one, while still discarding outdated autosave requests from the queue **that have not started yet**.

Additionally, it cleans up the AutoSave component to make it more readable.

## Change 2 - ensure autosave doesn't run unnecessarily

If connected to a slower backend or database, one change in a document may trigger two autosave operations instead of just one. This is how it could happen:

1. Type something => formstate changes => autosave is triggered
2. 200ms later: form state request is triggered. Autosave is still processing
3. 100ms later: form state comes back from server => local form state is updated => another autosave is triggered
4. First autosave is aborted - this lead to a browser error. This PR ensures that that error is no longer surfaced to the user
5. Another autosave is started

This PR adds additional checks to ONLY trigger an autosave if the form DATA (not the entire form state itself) changes. Previously, it ran every time the object reference of the form state changes. This includes changes that do not affect the form data, like `field.valid`. => Basically every time form state comes back from the server, we were triggering another, unnecessary autosave