### PR TITLE
templates: allow displaying dynamic error message on forms created via Form Builder plugin

### DIFF
--- a/templates/website/src/blocks/Form/Checkbox/index.tsx
+++ b/templates/website/src/blocks/Form/Checkbox/index.tsx
@@ -39,7 +39,7 @@ export const Checkbox: React.FC<
           {label}
         </Label>
       </div>
-      {errors[name] && <Error />}
+      {errors[name] && <Error name={name} />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Country/index.tsx
+++ b/templates/website/src/blocks/Form/Country/index.tsx
@@ -59,7 +59,7 @@ export const Country: React.FC<
         }}
         rules={{ required }}
       />
-      {errors[name] && <Error />}
+      {errors[name] && <Error name={name} />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Email/index.tsx
+++ b/templates/website/src/blocks/Form/Email/index.tsx
@@ -32,7 +32,7 @@ export const Email: React.FC<
         {...register(name, { pattern: /^\S[^\s@]*@\S+$/, required })}
       />
 
-      {errors[name] && <Error />}
+      {errors[name] && <Error name={name} />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Error/index.tsx
+++ b/templates/website/src/blocks/Form/Error/index.tsx
@@ -1,5 +1,15 @@
-import * as React from 'react'
+'use client'
 
-export const Error: React.FC = () => {
-  return <div className="mt-2 text-red-500 text-sm">This field is required</div>
+import * as React from 'react'
+import { useFormContext } from 'react-hook-form'
+
+export const Error = ({ name }: { name: string }) => {
+  const {
+    formState: { errors },
+  } = useFormContext()
+  return (
+    <div className="mt-2 text-red-500 text-sm">
+      {(errors[name]?.message as string) || 'This field is required'}
+    </div>
+  )
 }

--- a/templates/website/src/blocks/Form/Number/index.tsx
+++ b/templates/website/src/blocks/Form/Number/index.tsx
@@ -30,7 +30,7 @@ export const Number: React.FC<
         type="number"
         {...register(name, { required })}
       />
-      {errors[name] && <Error />}
+      {errors[name] && <Error name={name} />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Select/index.tsx
+++ b/templates/website/src/blocks/Form/Select/index.tsx
@@ -57,7 +57,7 @@ export const Select: React.FC<
         }}
         rules={{ required }}
       />
-      {errors[name] && <Error />}
+      {errors[name] && <Error name={name} />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/State/index.tsx
+++ b/templates/website/src/blocks/Form/State/index.tsx
@@ -58,7 +58,7 @@ export const State: React.FC<
         }}
         rules={{ required }}
       />
-      {errors[name] && <Error />}
+      {errors[name] && <Error name={name} />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Text/index.tsx
+++ b/templates/website/src/blocks/Form/Text/index.tsx
@@ -26,7 +26,7 @@ export const Text: React.FC<
         )}
       </Label>
       <Input defaultValue={defaultValue} id={name} type="text" {...register(name, { required })} />
-      {errors[name] && <Error />}
+      {errors[name] && <Error name={name} />}
     </Width>
   )
 }

--- a/templates/website/src/blocks/Form/Textarea/index.tsx
+++ b/templates/website/src/blocks/Form/Textarea/index.tsx
@@ -34,7 +34,7 @@ export const Textarea: React.FC<
         {...register(name, { required: required })}
       />
 
-      {errors[name] && <Error />}
+      {errors[name] && <Error name={name} />}
     </Width>
   )
 }


### PR DESCRIPTION
Close #11274

### Why this PR?
I've created a custom phone number input block for my form builder, including validation. However, the component on the frontend only displays the generic message "This field is required," even when formState.errors contains specific error messages. This is not the expected behavior. I need the component to display the error messages from formState.errors.

### Description
This pull request includes changes to improve error handling in various form components by passing the `name` prop to the `Error` component and updating the `Error` component to display specific error messages.

#### Error handling improvements:

* [`templates/website/src/blocks/Form/Error/index.tsx`](diffhunk://#diff-a97a4b2b87ff1a02431d11ab00f4e0ead5d11819f45dac120b9502ace520196fR1-R14): Updated the `Error` component to accept a `name` prop and use `useFormContext` to display specific error messages.

#### Form component updates:

* [`templates/website/src/blocks/Form/Checkbox/index.tsx`](diffhunk://#diff-4f0ad9596965f1e3b2f6356943d1d34009a742502bc8ab8d438ce98593fdef4aL42-R42): Modified to pass the `name` prop to the `Error` component.
* [`templates/website/src/blocks/Form/Country/index.tsx`](diffhunk://#diff-3abd97c2bfe7ce2a1809e6eaac68e6c02078514308f964b1792f7a1af2df92a7L62-R62): Modified to pass the `name` prop to the `Error` component.
* [`templates/website/src/blocks/Form/Email/index.tsx`](diffhunk://#diff-f1be3cf1e7c1fa9b543ed8f56a3655e601fdb399d31ede1d099a37004a1861bfL35-R35): Modified to pass the `name` prop to the `Error` component.
* [`templates/website/src/blocks/Form/Number/index.tsx`](diffhunk://#diff-72e5bd63eda769bce077e87bc614cb338211600580ad38ba86a7f066a35212a5L33-R33): Modified to pass the `name` prop to the `Error` component.
* [`templates/website/src/blocks/Form/Select/index.tsx`](diffhunk://#diff-69d52ba3bb01fc0ce4428f5b76ab48a86c448dceaf36390edbcf345f0b15c34eL60-R60): Modified to pass the `name` prop to the `Error` component.
* [`templates/website/src/blocks/Form/State/index.tsx`](diffhunk://#diff-c0eb5a8c64b6384a44e19556556921bff4c89ed3a8d5a1d2e46ce493178587caL61-R61): Modified to pass the `name` prop to the `Error` component.
* [`templates/website/src/blocks/Form/Text/index.tsx`](diffhunk://#diff-9d32d5b3132729534809280d97d8a0952e96270f434b5d57a32a2d4981a36384L29-R29): Modified to pass the `name` prop to the `Error` component.
* [`templates/website/src/blocks/Form/Textarea/index.tsx`](diffhunk://#diff-d25c7cb831ee04c195983c1a88718bdcec8f1dc34c3e5237875678eb8194994dL37-R37): Modified to pass the `name` prop to the `Error` component.