### PR TITLE
refactor(ui): simplifies confirmation modal callback

### DIFF
--- a/packages/next/src/views/Account/ResetPreferences/index.tsx
+++ b/packages/next/src/views/Account/ResetPreferences/index.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { OnConfirm } from '@payloadcms/ui'
 import type { User } from 'payload'
 
 import { Button, ConfirmationModal, toast, useModal, useTranslation } from '@payloadcms/ui'
@@ -15,54 +14,46 @@ export const ResetPreferences: React.FC<{
   const { openModal } = useModal()
   const { t } = useTranslation()
 
-  const handleResetPreferences: OnConfirm = useCallback(
-    async ({ closeConfirmationModal, setConfirming }) => {
-      if (!user) {
-        setConfirming(false)
-        closeConfirmationModal()
-        return
-      }
+  const handleResetPreferences = useCallback(async () => {
+    if (!user) {
+      return
+    }
 
-      const stringifiedQuery = qs.stringify(
-        {
-          depth: 0,
-          where: {
-            user: {
-              id: {
-                equals: user.id,
-              },
+    const stringifiedQuery = qs.stringify(
+      {
+        depth: 0,
+        where: {
+          user: {
+            id: {
+              equals: user.id,
             },
           },
         },
-        { addQueryPrefix: true },
-      )
+      },
+      { addQueryPrefix: true },
+    )
 
-      try {
-        const res = await fetch(`${apiRoute}/payload-preferences${stringifiedQuery}`, {
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          method: 'DELETE',
-        })
+    try {
+      const res = await fetch(`${apiRoute}/payload-preferences${stringifiedQuery}`, {
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'DELETE',
+      })
 
-        const json = await res.json()
-        const message = json.message
+      const json = await res.json()
+      const message = json.message
 
-        if (res.ok) {
-          toast.success(message)
-        } else {
-          toast.error(message)
-        }
-      } catch (_err) {
-        // swallow error
-      } finally {
-        setConfirming(false)
-        closeConfirmationModal()
+      if (res.ok) {
+        toast.success(message)
+      } else {
+        toast.error(message)
       }
-    },
-    [apiRoute, user],
-  )
+    } catch (_err) {
+      // swallow error
+    }
+  }, [apiRoute, user])
 
   return (
     <Fragment>

--- a/packages/next/src/views/Version/Restore/index.tsx
+++ b/packages/next/src/views/Version/Restore/index.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { OnConfirm } from '@payloadcms/ui'
 
 import { getTranslation } from '@payloadcms/translations'
 import {
@@ -75,27 +74,21 @@ const Restore: React.FC<Props> = ({
     })
   }
 
-  const handleRestore: OnConfirm = useCallback(
-    async ({ closeConfirmationModal, setConfirming }) => {
-      const res = await requests.post(fetchURL, {
-        headers: {
-          'Accept-Language': i18n.language,
-        },
-      })
+  const handleRestore = useCallback(async () => {
+    const res = await requests.post(fetchURL, {
+      headers: {
+        'Accept-Language': i18n.language,
+      },
+    })
 
-      setConfirming(false)
-      closeConfirmationModal()
-
-      if (res.status === 200) {
-        const json = await res.json()
-        toast.success(json.message)
-        startRouteTransition(() => router.push(redirectURL))
-      } else {
-        toast.error(t('version:problemRestoringVersion'))
-      }
-    },
-    [fetchURL, redirectURL, t, i18n, router, startRouteTransition],
-  )
+    if (res.status === 200) {
+      const json = await res.json()
+      toast.success(json.message)
+      return startRouteTransition(() => router.push(redirectURL))
+    } else {
+      toast.error(t('version:problemRestoringVersion'))
+    }
+  }, [fetchURL, redirectURL, t, i18n, router, startRouteTransition])
 
   return (
     <Fragment>

--- a/packages/ui/src/elements/ConfirmationModal/index.tsx
+++ b/packages/ui/src/elements/ConfirmationModal/index.tsx
@@ -10,11 +10,6 @@ import './index.scss'
 
 const baseClass = 'confirmation-modal'
 
-export type OnConfirm = (args: {
-  closeConfirmationModal: () => void
-  setConfirming: (state: boolean) => void
-}) => Promise<void> | void
-
 export type OnCancel = () => void
 
 export type ConfirmationModalProps = {
@@ -25,7 +20,7 @@ export type ConfirmationModalProps = {
   heading: React.ReactNode
   modalSlug: string
   onCancel?: OnCancel
-  onConfirm: OnConfirm
+  onConfirm: () => Promise<void> | void
 }
 
 export function ConfirmationModal(props: ConfirmationModalProps) {
@@ -82,13 +77,12 @@ export function ConfirmationModal(props: ConfirmationModalProps) {
           </Button>
           <Button
             id="confirm-action"
-            onClick={() => {
+            onClick={async () => {
               if (!confirming) {
                 setConfirming(true)
-                void onConfirm({
-                  closeConfirmationModal: () => closeModal(modalSlug),
-                  setConfirming: (state) => setConfirming(state),
-                })
+                await onConfirm()
+                setConfirming(false)
+                closeModal(modalSlug)
               }
             }}
             size="large"

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -8,7 +8,6 @@ import { useRouter } from 'next/navigation.js'
 import React, { useCallback } from 'react'
 import { toast } from 'sonner'
 
-import type { OnConfirm } from '../ConfirmationModal/index.js'
 import type { DocumentDrawerContextType } from '../DocumentDrawer/Provider.js'
 
 import { useForm, useFormModified } from '../../forms/Form/context.js'
@@ -58,91 +57,77 @@ export const DuplicateDocument: React.FC<Props> = ({
 
   const modalSlug = `duplicate-${id}`
 
-  const duplicate = useCallback(
-    async ({ onResponse }: { onResponse?: () => void } = {}) => {
-      setRenderModal(true)
+  const duplicate = useCallback(async () => {
+    setRenderModal(true)
 
-      await requests
-        .post(
-          `${serverURL}${apiRoute}/${slug}/${id}/duplicate${locale?.code ? `?locale=${locale.code}` : ''}`,
-          {
-            body: JSON.stringify({}),
-            headers: {
-              'Accept-Language': i18n.language,
-              'Content-Type': 'application/json',
-              credentials: 'include',
-            },
+    await requests
+      .post(
+        `${serverURL}${apiRoute}/${slug}/${id}/duplicate${locale?.code ? `?locale=${locale.code}` : ''}`,
+        {
+          body: JSON.stringify({}),
+          headers: {
+            'Accept-Language': i18n.language,
+            'Content-Type': 'application/json',
+            credentials: 'include',
           },
-        )
-        .then(async (res) => {
-          const { doc, errors, message } = await res.json()
-          if (typeof onResponse === 'function') {
-            onResponse()
-          }
-
-          if (res.status < 400) {
-            toast.success(
-              message ||
-                t('general:successfullyDuplicated', { label: getTranslation(singularLabel, i18n) }),
-            )
-
-            setModified(false)
-
-            if (redirectAfterDuplicate) {
-              return startRouteTransition(() =>
-                router.push(
-                  formatAdminURL({
-                    adminRoute,
-                    path: `/collections/${slug}/${doc.id}${locale?.code ? `?locale=${locale.code}` : ''}`,
-                  }),
-                ),
-              )
-            }
-
-            if (typeof onDuplicate === 'function') {
-              void onDuplicate({ collectionConfig, doc })
-            }
-          } else {
-            toast.error(
-              errors?.[0].message ||
-                message ||
-                t('error:unspecific', { label: getTranslation(singularLabel, i18n) }),
-            )
-          }
-        })
-    },
-    [
-      locale,
-      serverURL,
-      apiRoute,
-      slug,
-      id,
-      i18n,
-      t,
-      singularLabel,
-      onDuplicate,
-      redirectAfterDuplicate,
-      setModified,
-      router,
-      adminRoute,
-      collectionConfig,
-      startRouteTransition,
-    ],
-  )
-
-  const onConfirm: OnConfirm = useCallback(
-    async ({ closeConfirmationModal, setConfirming }) => {
-      setRenderModal(false)
-
-      await duplicate({
-        onResponse: () => {
-          setConfirming(false)
-          closeConfirmationModal()
         },
+      )
+      .then(async (res) => {
+        const { doc, errors, message } = await res.json()
+
+        if (res.status < 400) {
+          toast.success(
+            message ||
+              t('general:successfullyDuplicated', { label: getTranslation(singularLabel, i18n) }),
+          )
+
+          setModified(false)
+
+          if (redirectAfterDuplicate) {
+            return startRouteTransition(() =>
+              router.push(
+                formatAdminURL({
+                  adminRoute,
+                  path: `/collections/${slug}/${doc.id}${locale?.code ? `?locale=${locale.code}` : ''}`,
+                }),
+              ),
+            )
+          }
+
+          if (typeof onDuplicate === 'function') {
+            void onDuplicate({ collectionConfig, doc })
+          }
+        } else {
+          toast.error(
+            errors?.[0].message ||
+              message ||
+              t('error:unspecific', { label: getTranslation(singularLabel, i18n) }),
+          )
+        }
       })
-    },
-    [duplicate],
-  )
+  }, [
+    locale,
+    serverURL,
+    apiRoute,
+    slug,
+    id,
+    i18n,
+    t,
+    singularLabel,
+    onDuplicate,
+    redirectAfterDuplicate,
+    setModified,
+    router,
+    adminRoute,
+    collectionConfig,
+    startRouteTransition,
+  ])
+
+  const onConfirm = useCallback(async () => {
+    setRenderModal(false)
+
+    await duplicate()
+  }, [duplicate])
 
   return (
     <React.Fragment>

--- a/packages/ui/src/elements/GenerateConfirmation/index.tsx
+++ b/packages/ui/src/elements/GenerateConfirmation/index.tsx
@@ -3,8 +3,6 @@ import { useModal } from '@faceless-ui/modal'
 import React, { useCallback } from 'react'
 import { toast } from 'sonner'
 
-import type { OnConfirm } from '../ConfirmationModal/index.js'
-
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { Button } from '../Button/index.js'
@@ -25,16 +23,11 @@ export function GenerateConfirmation(props: GenerateConfirmationProps) {
 
   const modalSlug = `generate-confirmation-${id}`
 
-  const handleGenerate: OnConfirm = useCallback(
-    ({ closeConfirmationModal, setConfirming }) => {
-      setKey()
-      toast.success(t('authentication:newAPIKeyGenerated'))
-      highlightField(true)
-      setConfirming(false)
-      closeConfirmationModal()
-    },
-    [highlightField, setKey, t],
-  )
+  const handleGenerate = useCallback(() => {
+    setKey()
+    toast.success(t('authentication:newAPIKeyGenerated'))
+    highlightField(true)
+  }, [highlightField, setKey, t])
 
   return (
     <React.Fragment>

--- a/packages/ui/src/elements/LeaveWithoutSaving/index.tsx
+++ b/packages/ui/src/elements/LeaveWithoutSaving/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useCallback } from 'react'
 
-import type { OnCancel, OnConfirm } from '../ConfirmationModal/index.js'
+import type { OnCancel } from '../ConfirmationModal/index.js'
 
 import { useForm, useFormModified } from '../../forms/Form/index.js'
 import { useAuth } from '../../providers/Auth/index.js'
@@ -36,10 +36,8 @@ export const LeaveWithoutSaving: React.FC = () => {
     closeModal(modalSlug)
   }, [closeModal])
 
-  const onConfirm: OnConfirm = useCallback(({ closeConfirmationModal, setConfirming }) => {
+  const onConfirm = useCallback(() => {
     setHasAccepted(true)
-    setConfirming(false)
-    closeConfirmationModal()
   }, [])
 
   return (

--- a/packages/ui/src/elements/PublishMany/index.tsx
+++ b/packages/ui/src/elements/PublishMany/index.tsx
@@ -8,8 +8,6 @@ import * as qs from 'qs-esm'
 import React, { useCallback } from 'react'
 import { toast } from 'sonner'
 
-import type { OnConfirm } from '../ConfirmationModal/index.js'
-
 import { useAuth } from '../../providers/Auth/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useRouteCache } from '../../providers/RouteCache/index.js'
@@ -54,87 +52,80 @@ export const PublishMany: React.FC<PublishManyProps> = (props) => {
     toast.error(t('error:unknown'))
   }, [t])
 
-  const handlePublish: OnConfirm = useCallback(
-    async ({ closeConfirmationModal, setConfirming }) => {
-      await requests
-        .patch(
-          `${serverURL}${api}/${slug}${getQueryParams({ _status: { not_equals: 'published' } })}&draft=true`,
-          {
-            body: JSON.stringify({
-              _status: 'published',
-            }),
-            headers: {
-              'Accept-Language': i18n.language,
-              'Content-Type': 'application/json',
-            },
+  const handlePublish = useCallback(async () => {
+    await requests
+      .patch(
+        `${serverURL}${api}/${slug}${getQueryParams({ _status: { not_equals: 'published' } })}&draft=true`,
+        {
+          body: JSON.stringify({
+            _status: 'published',
+          }),
+          headers: {
+            'Accept-Language': i18n.language,
+            'Content-Type': 'application/json',
           },
-        )
-        .then(async (res) => {
-          try {
-            const json = await res.json()
-            setConfirming(false)
-            closeConfirmationModal()
+        },
+      )
+      .then(async (res) => {
+        try {
+          const json = await res.json()
 
-            const deletedDocs = json?.docs.length || 0
-            const successLabel = deletedDocs > 1 ? plural : singular
+          const deletedDocs = json?.docs.length || 0
+          const successLabel = deletedDocs > 1 ? plural : singular
 
-            if (res.status < 400 || deletedDocs > 0) {
-              toast.success(
-                t('general:updatedCountSuccessfully', {
-                  count: deletedDocs,
-                  label: getTranslation(successLabel, i18n),
-                }),
-              )
+          if (res.status < 400 || deletedDocs > 0) {
+            toast.success(
+              t('general:updatedCountSuccessfully', {
+                count: deletedDocs,
+                label: getTranslation(successLabel, i18n),
+              }),
+            )
 
-              if (json?.errors.length > 0) {
-                toast.error(json.message, {
-                  description: json.errors.map((error) => error.message).join('\n'),
-                })
-              }
-
-              router.replace(
-                qs.stringify(
-                  {
-                    ...parseSearchParams(searchParams),
-                    page: selectAll ? '1' : undefined,
-                  },
-                  { addQueryPrefix: true },
-                ),
-              )
-
-              clearRouteCache() // Use clearRouteCache instead of router.refresh, as we only need to clear the cache if the user has route caching enabled - clearRouteCache checks for this
-              return null
+            if (json?.errors.length > 0) {
+              toast.error(json.message, {
+                description: json.errors.map((error) => error.message).join('\n'),
+              })
             }
 
-            if (json.errors) {
-              json.errors.forEach((error) => toast.error(error.message))
-            } else {
-              addDefaultError()
-            }
-            return false
-          } catch (_err) {
-            setConfirming(false)
-            closeConfirmationModal()
-            return addDefaultError()
+            router.replace(
+              qs.stringify(
+                {
+                  ...parseSearchParams(searchParams),
+                  page: selectAll ? '1' : undefined,
+                },
+                { addQueryPrefix: true },
+              ),
+            )
+
+            clearRouteCache() // Use clearRouteCache instead of router.refresh, as we only need to clear the cache if the user has route caching enabled - clearRouteCache checks for this
+            return null
           }
-        })
-    },
-    [
-      serverURL,
-      api,
-      slug,
-      getQueryParams,
-      i18n,
-      plural,
-      singular,
-      t,
-      router,
-      searchParams,
-      selectAll,
-      clearRouteCache,
-      addDefaultError,
-    ],
-  )
+
+          if (json.errors) {
+            json.errors.forEach((error) => toast.error(error.message))
+          } else {
+            addDefaultError()
+          }
+          return false
+        } catch (_err) {
+          return addDefaultError()
+        }
+      })
+  }, [
+    serverURL,
+    api,
+    slug,
+    getQueryParams,
+    i18n,
+    plural,
+    singular,
+    t,
+    router,
+    searchParams,
+    selectAll,
+    clearRouteCache,
+    addDefaultError,
+  ])
 
   if (!versions?.drafts || selectAll === SelectAllStatus.None || !hasPermission) {
     return null

--- a/packages/ui/src/elements/Status/index.tsx
+++ b/packages/ui/src/elements/Status/index.tsx
@@ -3,8 +3,6 @@ import { useModal } from '@faceless-ui/modal'
 import React, { useCallback } from 'react'
 import { toast } from 'sonner'
 
-import type { OnConfirm } from '../ConfirmationModal/index.js'
-
 import { useForm } from '../../forms/Form/context.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
@@ -55,10 +53,7 @@ export const Status: React.FC = () => {
   }
 
   const performAction = useCallback(
-    async (
-      action: 'revert' | 'unpublish',
-      { closeConfirmationModal, setConfirming }: Parameters<OnConfirm>[0],
-    ) => {
+    async (action: 'revert' | 'unpublish') => {
       let url
       let method
       let body
@@ -99,9 +94,6 @@ export const Status: React.FC = () => {
           'Content-Type': 'application/json',
         },
       })
-
-      setConfirming(false)
-      closeConfirmationModal()
 
       if (res.status === 200) {
         let data
@@ -171,7 +163,7 @@ export const Status: React.FC = () => {
                 confirmingLabel={t('version:unpublishing')}
                 heading={t('version:confirmUnpublish')}
                 modalSlug={unPublishModalSlug}
-                onConfirm={(args) => performAction('unpublish', args)}
+                onConfirm={() => performAction('unpublish')}
               />
             </React.Fragment>
           )}
@@ -191,7 +183,7 @@ export const Status: React.FC = () => {
                 confirmingLabel={t('version:reverting')}
                 heading={t('version:confirmRevertToSaved')}
                 modalSlug={revertModalSlug}
-                onConfirm={(args) => performAction('revert', args)}
+                onConfirm={() => performAction('revert')}
               />
             </React.Fragment>
           )}

--- a/packages/ui/src/elements/StayLoggedIn/index.tsx
+++ b/packages/ui/src/elements/StayLoggedIn/index.tsx
@@ -2,7 +2,7 @@
 import { useRouter } from 'next/navigation.js'
 import React, { useCallback } from 'react'
 
-import type { OnCancel, OnConfirm } from '../ConfirmationModal/index.js'
+import type { OnCancel } from '../ConfirmationModal/index.js'
 
 import { useAuth } from '../../providers/Auth/index.js'
 import { useConfig } from '../../providers/Config/index.js'
@@ -29,22 +29,16 @@ export const StayLoggedInModal: React.FC = () => {
   const { t } = useTranslation()
   const { startRouteTransition } = useRouteTransition()
 
-  const onConfirm: OnConfirm = useCallback(
-    ({ closeConfirmationModal, setConfirming }) => {
-      setConfirming(false)
-      closeConfirmationModal()
-
-      startRouteTransition(() =>
-        router.push(
-          formatAdminURL({
-            adminRoute,
-            path: logoutRoute,
-          }),
-        ),
-      )
-    },
-    [router, startRouteTransition, adminRoute, logoutRoute],
-  )
+  const onConfirm = useCallback(() => {
+    return startRouteTransition(() =>
+      router.push(
+        formatAdminURL({
+          adminRoute,
+          path: logoutRoute,
+        }),
+      ),
+    )
+  }, [router, startRouteTransition, adminRoute, logoutRoute])
 
   const onCancel: OnCancel = useCallback(() => {
     refreshCookie()

--- a/packages/ui/src/elements/UnpublishMany/index.tsx
+++ b/packages/ui/src/elements/UnpublishMany/index.tsx
@@ -8,8 +8,6 @@ import * as qs from 'qs-esm'
 import React, { useCallback } from 'react'
 import { toast } from 'sonner'
 
-import type { OnConfirm } from '../ConfirmationModal/index.js'
-
 import { useAuth } from '../../providers/Auth/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useRouteCache } from '../../providers/RouteCache/index.js'
@@ -53,87 +51,78 @@ export const UnpublishMany: React.FC<UnpublishManyProps> = (props) => {
     toast.error(t('error:unknown'))
   }, [t])
 
-  const handleUnpublish: OnConfirm = useCallback(
-    async ({ closeConfirmationModal, setConfirming }) => {
-      await requests
-        .patch(
-          `${serverURL}${api}/${slug}${getQueryParams({ _status: { not_equals: 'draft' } })}`,
-          {
-            body: JSON.stringify({
-              _status: 'draft',
-            }),
-            headers: {
-              'Accept-Language': i18n.language,
-              'Content-Type': 'application/json',
-            },
-          },
-        )
-        .then(async (res) => {
-          try {
-            const json = await res.json()
-            setConfirming(false)
-            closeConfirmationModal()
+  const handleUnpublish = useCallback(async () => {
+    await requests
+      .patch(`${serverURL}${api}/${slug}${getQueryParams({ _status: { not_equals: 'draft' } })}`, {
+        body: JSON.stringify({
+          _status: 'draft',
+        }),
+        headers: {
+          'Accept-Language': i18n.language,
+          'Content-Type': 'application/json',
+        },
+      })
+      .then(async (res) => {
+        try {
+          const json = await res.json()
 
-            const deletedDocs = json?.docs.length || 0
-            const successLabel = deletedDocs > 1 ? plural : singular
+          const deletedDocs = json?.docs.length || 0
+          const successLabel = deletedDocs > 1 ? plural : singular
 
-            if (res.status < 400 || deletedDocs > 0) {
-              toast.success(
-                t('general:updatedCountSuccessfully', {
-                  count: deletedDocs,
-                  label: getTranslation(successLabel, i18n),
-                }),
-              )
+          if (res.status < 400 || deletedDocs > 0) {
+            toast.success(
+              t('general:updatedCountSuccessfully', {
+                count: deletedDocs,
+                label: getTranslation(successLabel, i18n),
+              }),
+            )
 
-              if (json?.errors.length > 0) {
-                toast.error(json.message, {
-                  description: json.errors.map((error) => error.message).join('\n'),
-                })
-              }
-
-              router.replace(
-                qs.stringify(
-                  {
-                    ...parseSearchParams(searchParams),
-                    page: selectAll ? '1' : undefined,
-                  },
-                  { addQueryPrefix: true },
-                ),
-              )
-
-              clearRouteCache() // Use clearRouteCache instead of router.refresh, as we only need to clear the cache if the user has route caching enabled - clearRouteCache checks for this
-              return null
+            if (json?.errors.length > 0) {
+              toast.error(json.message, {
+                description: json.errors.map((error) => error.message).join('\n'),
+              })
             }
 
-            if (json.errors) {
-              json.errors.forEach((error) => toast.error(error.message))
-            } else {
-              addDefaultError()
-            }
-            return false
-          } catch (_err) {
-            setConfirming(false)
-            closeConfirmationModal()
-            return addDefaultError()
+            router.replace(
+              qs.stringify(
+                {
+                  ...parseSearchParams(searchParams),
+                  page: selectAll ? '1' : undefined,
+                },
+                { addQueryPrefix: true },
+              ),
+            )
+
+            clearRouteCache() // Use clearRouteCache instead of router.refresh, as we only need to clear the cache if the user has route caching enabled - clearRouteCache checks for this
+
+            return null
           }
-        })
-    },
-    [
-      serverURL,
-      api,
-      slug,
-      getQueryParams,
-      i18n,
-      plural,
-      singular,
-      t,
-      router,
-      searchParams,
-      selectAll,
-      clearRouteCache,
-      addDefaultError,
-    ],
-  )
+
+          if (json.errors) {
+            json.errors.forEach((error) => toast.error(error.message))
+          } else {
+            addDefaultError()
+          }
+          return false
+        } catch (_err) {
+          return addDefaultError()
+        }
+      })
+  }, [
+    serverURL,
+    api,
+    slug,
+    getQueryParams,
+    i18n,
+    plural,
+    singular,
+    t,
+    router,
+    searchParams,
+    selectAll,
+    clearRouteCache,
+    addDefaultError,
+  ])
 
   if (!versions?.drafts || selectAll === SelectAllStatus.None || !hasPermission) {
     return null

--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -24,7 +24,7 @@ export { useUseTitleField } from '../../hooks/useUseAsTitle.js'
 
 // elements
 export { ConfirmationModal } from '../../elements/ConfirmationModal/index.js'
-export type { OnCancel, OnConfirm } from '../../elements/ConfirmationModal/index.js'
+export type { OnCancel } from '../../elements/ConfirmationModal/index.js'
 export { Link } from '../../elements/Link/index.js'
 export { LeaveWithoutSaving } from '../../elements/LeaveWithoutSaving/index.js'
 export { DocumentTakeOver } from '../../elements/DocumentTakeOver/index.js'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/plugin-search/config.ts"],
+      "@payload-config": ["./test/versions/config.ts"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
       "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],


### PR DESCRIPTION
Removes unnecessary callback args from the `onConfirm` callback in the new `ConfirmationModal` component introduced in #11271. Now, the component will close and reset `isConfirming` state for itself.