### PR TITLE
fix(ui): turbopack with the latest next.js canary [skip lint]

### DIFF
--- a/packages/ui/bundle.js
+++ b/packages/ui/bundle.js
@@ -36,8 +36,11 @@ const useClientPlugin = {
 
         result.outputFiles.forEach((file) => {
           let contents = file.text
-          contents = contents.replace(directiveRegex, '') // Remove existing use client directives
-          contents = directive + '\n' + contents // Prepend our use client directive
+
+          if (!file.path.endsWith('.map')) {
+            contents = contents.replace(directiveRegex, '') // Remove existing use client directives
+            contents = directive + '\n' + contents // Prepend our use client directive
+          }
 
           if (originalWrite) {
             const filePath = path.join(build.initialOptions.outdir, path.basename(file.path))


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11211

Disables prepending `"use client"` to `.map` files