### PR TITLE
fix(richtext-lexical): incorrect UploadData types

### DIFF
--- a/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
+++ b/packages/richtext-lexical/src/exports/react/components/RichText/converter/converters/upload.tsx
@@ -8,18 +8,20 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
   upload: ({ node }) => {
     // TO-DO (v4): SerializedUploadNode should use UploadData_P4
     const uploadDocument = node as UploadDataImproved
-    if (typeof uploadDocument.value !== 'object') {
+    if (typeof uploadDocument?.value !== 'object') {
       return null
     }
-    const url = uploadDocument.value.url
+
+    const value = uploadDocument.value
+    const url = value.url
 
     /**
      * If the upload is not an image, return a link to the upload
      */
-    if (!uploadDocument.value.mimeType.startsWith('image')) {
+    if (!value.mimeType.startsWith('image')) {
       return (
         <a href={url} rel="noopener noreferrer">
-          {uploadDocument.value.filename}
+          {value.filename}
         </a>
       )
     }
@@ -27,15 +29,8 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
     /**
      * If the upload is a simple image with no different sizes, return a simple img tag
      */
-    if (!Object.keys(uploadDocument.value.sizes).length) {
-      return (
-        <img
-          alt={uploadDocument.value.filename}
-          height={uploadDocument.value.height}
-          src={url}
-          width={uploadDocument.value.width}
-        />
-      )
+    if (!Object.keys(value.sizes).length) {
+      return <img alt={value.filename} height={value.height} src={url} width={value.width} />
     }
 
     /**
@@ -44,8 +39,8 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
     const pictureJSX: React.ReactNode[] = []
 
     // Iterate through each size in the data.sizes object
-    for (const size in uploadDocument.value.sizes) {
-      const imageSize = uploadDocument.value.sizes[size] as FileSizeImproved
+    for (const size in value.sizes) {
+      const imageSize = value.sizes[size] as FileSizeImproved
 
       // Skip if any property of the size object is null
       if (
@@ -74,11 +69,11 @@ export const UploadJSXConverter: JSXConverters<SerializedUploadNode> = {
     // Add the default img tag
     pictureJSX.push(
       <img
-        alt={uploadDocument.value?.filename}
-        height={uploadDocument.value?.height}
+        alt={value?.filename}
+        height={value?.height}
         key={'image'}
         src={url}
-        width={uploadDocument.value?.width}
+        width={value?.width}
       />,
     )
     return <picture>{pictureJSX}</picture>

--- a/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
+++ b/packages/richtext-lexical/src/features/upload/server/nodes/UploadNode.tsx
@@ -8,7 +8,13 @@ import type {
   NodeKey,
   Spread,
 } from 'lexical'
-import type { FileData, JsonObject, TypedCollection, TypeWithID } from 'payload'
+import type {
+  CollectionSlug,
+  DataFromCollectionSlug,
+  JsonObject,
+  TypedUploadCollection,
+  UploadCollectionSlug,
+} from 'payload'
 import type { JSX } from 'react'
 
 import { DecoratorBlockNode } from '@lexical/react/LexicalDecoratorBlockNode.js'
@@ -17,28 +23,29 @@ import { $applyNodeReplacement } from 'lexical'
 import * as React from 'react'
 
 export type UploadData<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
-  fields: TUploadExtraFieldsData
-  /** Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document */
-  id: string
-  relationTo: string
-  /** Value can be just the document ID, or the full, populated document */
-  value: number | string | TypedCollection
-}
+  [TCollectionSlug in CollectionSlug]: {
+    fields: TUploadExtraFieldsData
+    // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
+    id: string
+    relationTo: TCollectionSlug
+    // Value can be just the document ID, or the full, populated document
+    value: DataFromCollectionSlug<TCollectionSlug> | number | string
+  }
+}[CollectionSlug]
 
-// TODO: deprecate in Payload v4.
 /**
- * UploadDataImproved is a more precise type, and will replace UploadData in Payload v4.
- * This type is for internal use only as it will be deprecated in the future.
- * @internal
+ * @todo Replace UploadData with UploadDataImproved
  */
 export type UploadDataImproved<TUploadExtraFieldsData extends JsonObject = JsonObject> = {
-  fields: TUploadExtraFieldsData
-  // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
-  id: string
-  relationTo: string
-  // Value can be just the document ID, or the full, populated document
-  value: (FileData & TypeWithID) | number | string
-}
+  [TCollectionSlug in UploadCollectionSlug]: {
+    fields: TUploadExtraFieldsData
+    // Every lexical node that has sub-fields needs to have a unique ID. This is the ID of this upload node, not the ID of the linked upload document
+    id: string
+    relationTo: TCollectionSlug
+    // Value can be just the document ID, or the full, populated document
+    value: number | string | TypedUploadCollection[TCollectionSlug]
+  }
+}[UploadCollectionSlug]
 
 export function isGoogleDocCheckboxImg(img: HTMLImageElement): boolean {
   return (


### PR DESCRIPTION
This PR fixes the `UploadData` type that was weakened in a previous PR, causing a breaking change. It also improves the newly added `UploadDataImproved` type by bringing back its support for generated types and using the `UploadCollectionSlug` type helper to restrict collection slugs to upload-enabled collections.