### PR TITLE
feat(richtext-lexical): support single-quoted jsx property values in mdx converter

### DIFF
--- a/packages/richtext-lexical/src/utilities/jsx/extractPropsFromJSXPropsString.ts
+++ b/packages/richtext-lexical/src/utilities/jsx/extractPropsFromJSXPropsString.ts
@@ -54,6 +54,8 @@ function handleValue(propsString: string, startIndex: number): { newIndex: numbe
 
   if (char === '"') {
     return handleQuotedString(propsString, startIndex)
+  } else if (char === "'") {
+    return handleQuotedString(propsString, startIndex, true)
   } else if (char === '{') {
     return handleObject(propsString, startIndex)
   } else if (char === '[') {
@@ -86,10 +88,14 @@ function handleArray(propsString: string, startIndex: number): { newIndex: numbe
 function handleQuotedString(
   propsString: string,
   startIndex: number,
+  isSingleQuoted = false,
 ): { newIndex: number; value: string } {
   let value = ''
   let i = startIndex + 1
-  while (i < propsString.length && (propsString[i] !== '"' || propsString[i - 1] === '\\')) {
+  while (
+    i < propsString.length &&
+    (propsString[i] !== (isSingleQuoted ? "'" : '"') || propsString[i - 1] === '\\')
+  ) {
     value += propsString[i]
     i++
   }

--- a/packages/richtext-lexical/src/utilities/jsx/jsx.spec.ts
+++ b/packages/richtext-lexical/src/utilities/jsx/jsx.spec.ts
@@ -15,6 +15,13 @@ describe('jsx', () => {
         },
       },
       {
+        input: "key='value'",
+        output: {
+          key: 'value',
+        },
+        inputFromOutput: 'key="value"',
+      },
+      {
         input: 'key={[1, 2, 3]}',
         output: {
           key: [1, 2, 3],

--- a/test/lexical-mdx/tests/default.test.ts
+++ b/test/lexical-mdx/tests/default.test.ts
@@ -21,6 +21,23 @@ export const defaultTests: Test[] = [
     },
   },
   {
+    // Same test but with single quote property values
+    inputAfterConvertFromEditorJSON: `<PackageInstallOptions packageId="444" uniqueId="xxx" update/>`,
+    input: `
+<PackageInstallOptions
+  packageId='444'
+  uniqueId='xxx' update/>
+      `,
+    blockNode: {
+      fields: {
+        blockType: 'PackageInstallOptions',
+        packageId: '444',
+        update: true,
+        uniqueId: 'xxx',
+      },
+    },
+  },
+  {
     input: `
 <PackageInstallOptions packageId="444">
   ignored


### PR DESCRIPTION
The following MDX:

```tsx
<Banner type='info'>
  Hello
</Banner>
```

was not able to be parsed by the lexical mdx converter, as the jsx props string extractor did not support the single quotes around the `info` string.