### PR TITLE
feat(richtext-lexical): adds createdBlock in EditorConfigContext to allow custom admin Block components to open drawer on block create

### DIFF
--- a/packages/richtext-lexical/src/features/blocks/client/plugin/index.tsx
+++ b/packages/richtext-lexical/src/features/blocks/client/plugin/index.tsx
@@ -32,7 +32,7 @@ export const BlocksPlugin: PluginComponent = () => {
 
   const [targetNodeKey, setTargetNodeKey] = useState<null | string>(null)
 
-  const { setCreatedInlineBlock, uuid } = useEditorConfigContext()
+  const { setCreatedInlineBlock, setCreatedBlock, uuid } = useEditorConfigContext()
   const editDepth = useEditDepth()
 
   const drawerSlug = formatDrawerSlug({
@@ -56,6 +56,7 @@ export const BlocksPlugin: PluginComponent = () => {
 
             if ($isRangeSelection(selection)) {
               const blockNode = $createBlockNode(payload)
+              setCreatedBlock(blockNode)
               // Insert blocks node BEFORE potentially removing focusNode, as $insertNodeToNearestRoot errors if the focusNode doesn't exist
               $insertNodeToNearestRoot(blockNode)
 
@@ -109,7 +110,7 @@ export const BlocksPlugin: PluginComponent = () => {
         COMMAND_PRIORITY_EDITOR,
       ),
     )
-  }, [editor, setCreatedInlineBlock, targetNodeKey, toggleDrawer])
+  }, [editor, setCreatedInlineBlock, setCreatedBlock, targetNodeKey, toggleDrawer])
 
   return null
 }

--- a/packages/richtext-lexical/src/lexical/config/client/EditorConfigProvider.tsx
+++ b/packages/richtext-lexical/src/lexical/config/client/EditorConfigProvider.tsx
@@ -9,6 +9,7 @@ import * as React from 'react'
 import { createContext, useContext, useMemo, useRef, useState } from 'react'
 
 import type { InlineBlockNode } from '../../../features/blocks/client/nodes/InlineBlocksNode.js'
+import type { BlockNode } from '../../../features/blocks/client/nodes/BlocksNode.js'
 import type { LexicalRichTextFieldProps } from '../../../types.js'
 import type { SanitizedClientEditorConfig } from '../types.js'
 
@@ -22,6 +23,7 @@ export interface EditorConfigContextType {
   blurEditor: (editorContext: EditorConfigContextType) => void
   childrenEditors: React.RefObject<Map<string, EditorConfigContextType>>
   createdInlineBlock?: InlineBlockNode
+  createdBlock?: BlockNode
   editDepth: number
   editor: LexicalEditor
   editorConfig: SanitizedClientEditorConfig
@@ -33,6 +35,7 @@ export interface EditorConfigContextType {
   parentEditor: EditorConfigContextType
   registerChild: (uuid: string, editorContext: EditorConfigContextType) => void
   setCreatedInlineBlock?: React.Dispatch<React.SetStateAction<InlineBlockNode | undefined>>
+  setCreatedBlock?: React.Dispatch<React.SetStateAction<BlockNode | undefined>>
   unregisterChild?: (uuid: string) => void
   uuid: string
 }
@@ -66,6 +69,7 @@ export const EditorConfigProvider = ({
   const [focusedEditor, setFocusedEditor] = useState<EditorConfigContextType | null>(null)
   const focusHistory = useRef<Set<string>>(new Set())
   const [createdInlineBlock, setCreatedInlineBlock] = useState<InlineBlockNode>()
+  const [createdBlock, setCreatedBlock] = useState<BlockNode>()
 
   const editDepth = useEditDepth()
 
@@ -78,6 +82,7 @@ export const EditorConfigProvider = ({
         },
         childrenEditors,
         createdInlineBlock,
+        createdBlock,
         editDepth,
         editor,
         editorConfig,
@@ -115,6 +120,7 @@ export const EditorConfigProvider = ({
           }
         },
         setCreatedInlineBlock,
+        setCreatedBlock,
         unregisterChild: (childUUID) => {
           if (childrenEditors.current.has(childUUID)) {
             const newMap = new Map(childrenEditors.current)
@@ -128,6 +134,8 @@ export const EditorConfigProvider = ({
     [
       createdInlineBlock,
       setCreatedInlineBlock,
+      createdBlock,
+      setCreatedBlock,
       editor,
       childrenEditors,
       editorConfig,


### PR DESCRIPTION
### What?  
Enable custom admin Block components to open the field drawer when inserted into the editor.  

### Why?  
Currently, there is no straightforward way to determine which Block component was inserted, making it impossible to trigger the field drawer automatically. However, the `InlineBlock` component already supports this behavior. To achieve the same functionality for Block components, it is necessary to identify the inserted `BlockNode`.  

### How?  
This PR ensures that the inserted `BlockNode` is accessible, allowing custom Block components to use this information to open the field drawer upon insertion.  
