### PR TITLE
docs: fix formatting in field hooks table

### DIFF
--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -71,8 +71,7 @@ The following arguments are provided to all Field Hooks:
 | **`schemaPath`**         | The path of the [Field](../fields/overview) in the schema.                                                                                                                                                                                  |
 | **`siblingData`**        | The data of sibling fields adjacent to the field that the Hook is running against.        |
 | **`siblingDocWithLocales`**      | The sibling data of the Document with all [Locales](../configuration/localization).        |
-| **`siblingFields`**      | The sibling fields of the field which the hook is running against.
-       |
+| **`siblingFields`**      | The sibling fields of the field which the hook is running against.        |
 | **`value`**              | The value of the [Field](../fields/overview).                                                                                                                                                                                               |
 
 <Banner type="success">


### PR DESCRIPTION
The line for `siblingFields` has an extra newline and space that's breaking the table formatting.

https://payloadcms.com/docs/hooks/fields