### PR TITLE
perf(next): avoid unnecessary upsertPreferences call on page load

### DIFF
--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -105,10 +105,6 @@ export const RootLayout = async ({
     clientConfig.localization.localeCodes = config.localization.locales.map(({ code }) => code)
   }
 
-  const locale = await getRequestLocale({
-    req,
-  })
-
   return (
     <html
       data-theme={theme}
@@ -127,7 +123,7 @@ export const RootLayout = async ({
           isNavOpen={navPrefs?.open ?? true}
           languageCode={languageCode}
           languageOptions={languageOptions}
-          locale={locale?.code}
+          locale={req.locale}
           permissions={permissions}
           serverFunction={serverFunction}
           switchLanguageServerAction={switchLanguageServerAction}

--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -9,7 +9,6 @@ import { getPayload, getRequestLanguage, parseCookies } from 'payload'
 import React from 'react'
 
 import { getNavPrefs } from '../../elements/Nav/getNavPrefs.js'
-import { getRequestLocale } from '../../utilities/getRequestLocale.js'
 import { getRequestTheme } from '../../utilities/getRequestTheme.js'
 import { initReq } from '../../utilities/initReq.js'
 import { checkDependencies } from './checkDependencies.js'


### PR DESCRIPTION
`getRequestLocale` => `upsertPreferences` is already called as part of `initReq`, yet we were still unnecessarily calling `getRequestLocale` afterwards, which potentially resulted in at least one unnecessary `payload.find()` or `payload.update()` call.