### PR TITLE
fix(ui): confirmation modal should build off of drawerDepth, instead …

### DIFF
--- a/packages/ui/src/elements/ConfirmationModal/index.tsx
+++ b/packages/ui/src/elements/ConfirmationModal/index.tsx
@@ -2,10 +2,9 @@
 import { Modal, useModal } from '@faceless-ui/modal'
 import React, { useCallback } from 'react'
 
-import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { Button } from '../Button/index.js'
-import { drawerZBase } from '../Drawer/index.js'
+import { drawerZBase, useDrawerDepth } from '../Drawer/index.js'
 import './index.scss'
 
 const baseClass = 'confirmation-modal'
@@ -37,7 +36,7 @@ export function ConfirmationModal(props: ConfirmationModalProps) {
     onConfirm: onConfirmFromProps,
   } = props
 
-  const editDepth = useEditDepth()
+  const editDepth = useDrawerDepth()
 
   const [confirming, setConfirming] = React.useState(false)
 


### PR DESCRIPTION
When the new ConfirmationModal is used outside of the context of an EditDepthProvider, it stacks behind currently open modals. This is apparent when using it in custom views.

The fix is to build the confirm modal's depth off of drawerDepth instead of editDepth.
