### PR TITLE
fix(examples): replace depreciated 'mergeHeaders' import in the MultiTenant example

### DIFF
--- a/examples/multi-tenant/src/collections/Users/hooks/setCookieBasedOnDomain.ts
+++ b/examples/multi-tenant/src/collections/Users/hooks/setCookieBasedOnDomain.ts
@@ -1,7 +1,6 @@
 import type { CollectionAfterLoginHook } from 'payload'
 
-import { mergeHeaders } from '@payloadcms/next/utilities'
-import { generateCookie, getCookieExpiration } from 'payload'
+import { mergeHeaders, generateCookie, getCookieExpiration } from 'payload'
 
 export const setCookieBasedOnDomain: CollectionAfterLoginHook = async ({ req, user }) => {
   const relatedOrg = await req.payload.find({


### PR DESCRIPTION
Simple change to replace the import of the mergeHeaders function, now coming directly from 'payload' and not the next helpers.

Before:
```` typescript
import { mergeHeaders } from '@payloadcms/next/utilities'
import { generateCookie, getCookieExpiration } from 'payload'
````

After
```` typescript
import { mergeHeaders, generateCookie, getCookieExpiration } from 'payload'
````