### PR TITLE
perf: ensure fetching and updating preferences doesn't cause transaction errors and is done correctly

### DIFF
--- a/packages/next/src/utilities/getPreferences.ts
+++ b/packages/next/src/utilities/getPreferences.ts
@@ -1,40 +1,41 @@
-import type { Payload, User } from 'payload'
+import type { DefaultDocumentIDType, Payload } from 'payload'
 
 import { cache } from 'react'
 
 export const getPreferences = cache(
-  async <T>(key: string, payload: Payload, user: User): Promise<T> => {
-    let result: T = null
-
-    try {
-      result = await payload
-        .find({
-          collection: 'payload-preferences',
-          depth: 0,
-          limit: 1,
-          user,
-          where: {
-            and: [
-              {
-                'user.relationTo': {
-                  equals: payload.config.admin.user,
-                },
+  async <T>(
+    key: string,
+    payload: Payload,
+    userID: DefaultDocumentIDType,
+    userSlug: string,
+  ): Promise<{ id: DefaultDocumentIDType; value: T }> => {
+    const result = (await payload
+      .find({
+        collection: 'payload-preferences',
+        depth: 0,
+        limit: 1,
+        pagination: false,
+        where: {
+          and: [
+            {
+              key: {
+                equals: key,
               },
-              {
-                'user.value': {
-                  equals: user.id,
-                },
+            },
+            {
+              'user.relationTo': {
+                equals: userSlug,
               },
-              {
-                key: {
-                  equals: key,
-                },
+            },
+            {
+              'user.value': {
+                equals: userID,
               },
-            ],
-          },
-        })
-        ?.then((res) => res.docs?.[0]?.value as T)
-    } catch (_err) {} // eslint-disable-line no-empty
+            },
+          ],
+        },
+      })
+      .then((res) => res.docs?.[0])) as { id: DefaultDocumentIDType; value: T }
 
     return result
   },

--- a/packages/next/src/utilities/getRequestLocale.ts
+++ b/packages/next/src/utilities/getRequestLocale.ts
@@ -18,18 +18,19 @@ export async function getRequestLocale({ req }: GetRequestLocalesArgs): Promise<
     }
 
     return (
-      findLocaleFromCode(
-        req.payload.config.localization,
-        localeFromParams ||
-          (
-            await getPreferences<Locale['code']>(
-              'locale',
-              req.payload,
-              req.user.id,
-              req.user.collection,
-            )
-          )?.value,
-      ) ||
+      (req.user &&
+        findLocaleFromCode(
+          req.payload.config.localization,
+          localeFromParams ||
+            (
+              await getPreferences<Locale['code']>(
+                'locale',
+                req.payload,
+                req.user.id,
+                req.user.collection,
+              )
+            )?.value,
+        )) ||
       findLocaleFromCode(
         req.payload.config.localization,
         req.payload.config.localization.defaultLocale || 'en',

--- a/packages/next/src/utilities/getRequestLocale.ts
+++ b/packages/next/src/utilities/getRequestLocale.ts
@@ -28,7 +28,7 @@ export async function getRequestLocale({ req }: GetRequestLocalesArgs): Promise<
               req.user.id,
               req.user.collection,
             )
-          ).value,
+          )?.value,
       ) ||
       findLocaleFromCode(
         req.payload.config.localization,

--- a/packages/next/src/utilities/getRequestLocale.ts
+++ b/packages/next/src/utilities/getRequestLocale.ts
@@ -20,7 +20,15 @@ export async function getRequestLocale({ req }: GetRequestLocalesArgs): Promise<
     return (
       findLocaleFromCode(
         req.payload.config.localization,
-        localeFromParams || (await getPreferences<Locale['code']>('locale', req.payload, req.user)),
+        localeFromParams ||
+          (
+            await getPreferences<Locale['code']>(
+              'locale',
+              req.payload,
+              req.user.id,
+              req.user.collection,
+            )
+          ).value,
       ) ||
       findLocaleFromCode(
         req.payload.config.localization,

--- a/packages/ui/src/utilities/upsertPreferences.ts
+++ b/packages/ui/src/utilities/upsertPreferences.ts
@@ -1,46 +1,48 @@
-import type { DefaultDocumentIDType, PayloadRequest } from 'payload'
+import type { DefaultDocumentIDType, Payload, PayloadRequest } from 'payload'
 
 import { dequal } from 'dequal/lite'
+import { cache } from 'react'
 
 import { removeUndefined } from './removeUndefined.js'
 
-const getPreferences = async <T>({
-  key,
-  req,
-}: {
-  key: string
-  req: PayloadRequest
-}): Promise<{ id: DefaultDocumentIDType; value: T }> => {
-  const result = (await req.payload
-    .find({
-      collection: 'payload-preferences',
-      depth: 0,
-      limit: 1,
-      pagination: false,
-      where: {
-        and: [
-          {
-            key: {
-              equals: key,
+export const getPreferences = cache(
+  async <T>(
+    key: string,
+    payload: Payload,
+    userID: DefaultDocumentIDType,
+    userSlug: string,
+  ): Promise<{ id: DefaultDocumentIDType; value: T }> => {
+    const result = (await payload
+      .find({
+        collection: 'payload-preferences',
+        depth: 0,
+        limit: 1,
+        pagination: false,
+        where: {
+          and: [
+            {
+              key: {
+                equals: key,
+              },
             },
-          },
-          {
-            'user.relationTo': {
-              equals: req.user.collection,
+            {
+              'user.relationTo': {
+                equals: userSlug,
+              },
             },
-          },
-          {
-            'user.value': {
-              equals: req.user.id,
+            {
+              'user.value': {
+                equals: userID,
+              },
             },
-          },
-        ],
-      },
-    })
-    .then((res) => res.docs?.[0])) as { id: DefaultDocumentIDType; value: T }
+          ],
+        },
+      })
+      .then((res) => res.docs?.[0])) as { id: DefaultDocumentIDType; value: T }
 
-  return result
-}
+    return result
+  },
+)
 
 /**
  * Will update the given preferences by key, creating a new record if it doesn't already exist, or merging existing preferences with the new value.
@@ -59,10 +61,7 @@ export const upsertPreferences = async <T extends Record<string, unknown> | stri
   req: PayloadRequest
   value: T
 }): Promise<T> => {
-  const existingPrefs = await getPreferences<T>({
-    key,
-    req,
-  })
+  const existingPrefs = await getPreferences<T>(key, req.payload, req.user.id, req.user.collection)
 
   let newPrefs = existingPrefs?.value
 
@@ -78,7 +77,8 @@ export const upsertPreferences = async <T extends Record<string, unknown> | stri
         value: incomingValue,
       },
       depth: 0,
-      req,
+      disableTransaction: true,
+      user: req.user,
     })
   } else {
     // Strings are valid JSON, i.e. `locale` saved as a string to the locale preferences
@@ -104,7 +104,8 @@ export const upsertPreferences = async <T extends Record<string, unknown> | stri
             value: mergedPrefs,
           },
           depth: 0,
-          req,
+          disableTransaction: true,
+          user: req.user,
         })
         ?.then((res) => res.value)
     }

--- a/packages/ui/src/utilities/upsertPreferences.ts
+++ b/packages/ui/src/utilities/upsertPreferences.ts
@@ -61,7 +61,9 @@ export const upsertPreferences = async <T extends Record<string, unknown> | stri
   req: PayloadRequest
   value: T
 }): Promise<T> => {
-  const existingPrefs = await getPreferences<T>(key, req.payload, req.user.id, req.user.collection)
+  const existingPrefs: { id?: DefaultDocumentIDType; value?: T } = req.user
+    ? await getPreferences<T>(key, req.payload, req.user.id, req.user.collection)
+    : {}
 
   let newPrefs = existingPrefs?.value
 


### PR DESCRIPTION
## getPreferences function caching

Our `getPreferences` function used in the ui package is now wrapped in react cache, to minimize the amount of times it runs on a single request. This mimics the behavior of our other `getPreferences` function in the next package.

## getPreferences  incorrect behavior

The `getPreferences` function in the next package was passing through the incorrect user slug. This would not have been noticeable in projects with just one users collection, but might break in projects with multiple users collections.

## getPreferences performance optimization

This PR adds `pagination: false` to the getPreferences payload.find() call, which will speed up the query.

## upsertPreferences transaction errors

Due to the potential of preference upsert operations running in parallel (e.g. when switching locales), this PR disables transactions in the preferences creation / update calls. This fixes the transaction errors reported in https://github.com/payloadcms/payload/issues/11310