### PR TITLE
fix: auto generate types faster and more reliably to avoid issues when spawning processes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,10 +18,10 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   // Load .git-blame-ignore-revs file
   "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"],
-  "jestrunner.jestCommand": "pnpm exec cross-env NODE_OPTIONS=\"--no-deprecation\" node 'node_modules/jest/bin/jest.js'",
+  "jestrunner.jestCommand": "pnpm exec cross-env NODE_OPTIONS=\"--no-deprecation --experimental-vm-modules\" node 'node_modules/jest/bin/jest.js'",
   "jestrunner.changeDirectoryToWorkspaceRoot": false,
   "jestrunner.debugOptions": {
-    "runtimeArgs": ["--no-deprecation"]
+    "runtimeArgs": ["--no-deprecation", "--experimental-vm-modules"]
   },
   // Essentially disables bun test buttons
   "bun.test.filePattern": "bun.test.ts"

--- a/package.json
+++ b/package.json
@@ -96,11 +96,11 @@
     "test:e2e:headed": "cross-env NODE_OPTIONS=--no-deprecation NODE_NO_WARNINGS=1 DISABLE_LOGGING=true playwright test --headed",
     "test:e2e:prod": "pnpm prepare-run-test-against-prod && pnpm runts ./test/runE2E.ts --prod",
     "test:e2e:prod:ci": "pnpm prepare-run-test-against-prod:ci && pnpm runts ./test/runE2E.ts --prod",
-    "test:int": "cross-env NODE_OPTIONS=\"--no-deprecation\" NODE_NO_WARNINGS=1 DISABLE_LOGGING=true jest --forceExit --detectOpenHandles --config=test/jest.config.js --runInBand",
-    "test:int:postgres": "cross-env NODE_OPTIONS=\"--no-deprecation\" NODE_NO_WARNINGS=1 PAYLOAD_DATABASE=postgres DISABLE_LOGGING=true jest --forceExit --detectOpenHandles --config=test/jest.config.js --runInBand",
-    "test:int:sqlite": "cross-env NODE_OPTIONS=\"--no-deprecation\" NODE_NO_WARNINGS=1 PAYLOAD_DATABASE=sqlite DISABLE_LOGGING=true jest --forceExit --detectOpenHandles --config=test/jest.config.js --runInBand",
+    "test:int": "cross-env NODE_OPTIONS=\"--no-deprecation --experimental-vm-modules\" NODE_NO_WARNINGS=1 DISABLE_LOGGING=true jest --forceExit --detectOpenHandles --config=test/jest.config.js --runInBand",
+    "test:int:postgres": "cross-env NODE_OPTIONS=\"--no-deprecation --experimental-vm-modules\" NODE_NO_WARNINGS=1 PAYLOAD_DATABASE=postgres DISABLE_LOGGING=true jest --forceExit --detectOpenHandles --config=test/jest.config.js --runInBand",
+    "test:int:sqlite": "cross-env NODE_OPTIONS=\"--no-deprecation --experimental-vm-modules\" NODE_NO_WARNINGS=1 PAYLOAD_DATABASE=sqlite DISABLE_LOGGING=true jest --forceExit --detectOpenHandles --config=test/jest.config.js --runInBand",
     "test:types": "tstyche",
-    "test:unit": "cross-env NODE_OPTIONS=\"--no-deprecation\" NODE_NO_WARNINGS=1 DISABLE_LOGGING=true jest --forceExit --detectOpenHandles  --config=jest.config.js --runInBand",
+    "test:unit": "cross-env NODE_OPTIONS=\"--no-deprecation --experimental-vm-modules\" NODE_NO_WARNINGS=1 DISABLE_LOGGING=true jest --forceExit --detectOpenHandles  --config=jest.config.js --runInBand",
     "translateNewKeys": "pnpm --filter translations run translateNewKeys"
   },
   "lint-staged": {

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -72,6 +72,7 @@ import { decrypt, encrypt } from './auth/crypto.js'
 import { APIKeyAuthentication } from './auth/strategies/apiKey.js'
 import { JWTAuthentication } from './auth/strategies/jwt.js'
 import { generateImportMap, type ImportMap } from './bin/generateImportMap/index.js'
+import { generateTypes } from './bin/generateTypes.js'
 import { checkPayloadDependencies } from './checkPayloadDependencies.js'
 import localOperations from './collections/operations/local/index.js'
 import { consoleEmailAdapter } from './email/consoleEmailAdapter.js'
@@ -636,12 +637,7 @@ export class BasePayload {
 
     // Generate types on startup
     if (process.env.NODE_ENV !== 'production' && this.config.typescript.autoGenerate !== false) {
-      // We cannot run it directly here, as generate-types imports json-schema-to-typescript, which breaks on turbopack.
-      // see: https://github.com/vercel/next.js/issues/66723
-      void this.bin({
-        args: ['generate:types'],
-        log: false,
-      })
+      void generateTypes(this.config, { log: false })
     }
 
     this.db = this.config.db.init({ payload: this })
@@ -848,12 +844,7 @@ export const reload = async (
 
   // Generate types
   if (config.typescript.autoGenerate !== false) {
-    // We cannot run it directly here, as generate-types imports json-schema-to-typescript, which breaks on turbopack.
-    // see: https://github.com/vercel/next.js/issues/66723
-    void payload.bin({
-      args: ['generate:types'],
-      log: false,
-    })
+    void generateTypes(config, { log: false })
   }
 
   // Generate component map

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals'
+global.jest = jest
 import console from 'console'
 global.console = console
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11276

Previously, to auto generate types on HMR and startup we spawned a child process with the `payload generate:types` command. 
This, potentially can cause some issues in monorepos (our Astro and Remix examples, as described in https://github.com/payloadcms/payload/issues/11276) and whenever payload config path cannot be determined (as it's necessary for `payload.bin`) It's also faster to execute `generateTypes` directly.

Nevertheless, it was a necessary change because of a turbopack issue https://github.com/payloadcms/payload/pull/6714 https://github.com/vercel/next.js/issues/66723

The issue now looks resolved, I tested against the latest next.js canary with a packed `payload` version from this PR and types auto-generation works correctly using `pnpm dev --turbo`.

Other changes were necessary to pass integration and unit tests Apparently, as `jest` isn't executed in a proper ESM environment, it requires to use `--experimental-vm-modules` to be able to load `json-schema-to-typescript`.