### PR TITLE
perf: add limit: 1 and pagination: false to various payload queries

### DIFF
--- a/packages/payload/src/auth/strategies/jwt.ts
+++ b/packages/payload/src/auth/strategies/jwt.ts
@@ -54,6 +54,8 @@ async function autoLogin({
     await payload.find({
       collection: collection.config.slug,
       depth: isGraphQL ? 0 : collection.config.auth.depth,
+      limit: 1,
+      pagination: false,
       where,
     })
   ).docs[0]

--- a/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
@@ -52,6 +52,7 @@ export async function getGlobalViewRedirect({
       depth: 0,
       limit: 1,
       overrideAccess: false,
+      pagination: false,
       user,
       where: {
         [tenantFieldName]: {

--- a/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
@@ -12,6 +12,8 @@ export const deleteFromSearch: DeleteFromSearch = async ({
     const searchDocQuery = await payload.find({
       collection: searchSlug,
       depth: 0,
+      limit: 1,
+      pagination: false,
       req,
       where: {
         doc: {

--- a/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
+++ b/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
@@ -149,7 +149,9 @@ export const syncDocAsSearchIndex = async ({
             } = await payload.find({
               collection,
               draft: false,
+              limit: 1,
               locale: syncLocale,
+              pagination: false,
               req,
               where: {
                 and: [

--- a/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
+++ b/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
@@ -54,6 +54,8 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
     // First, search for an existing document in Payload
     const payloadQuery = await payload.find({
       collection: collectionSlug,
+      limit: 1,
+      pagination: false,
       where: {
         stripeID: {
           equals: stripeID,
@@ -95,6 +97,8 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
           if (stripeDoc?.email) {
             const authQuery = await payload.find({
               collection: collectionSlug,
+              limit: 1,
+              pagination: false,
               where: {
                 email: {
                   equals: stripeDoc.email,

--- a/packages/plugin-stripe/src/webhooks/handleDeleted.ts
+++ b/packages/plugin-stripe/src/webhooks/handleDeleted.ts
@@ -40,6 +40,8 @@ export const handleDeleted: HandleDeleted = async (args) => {
     try {
       const payloadQuery = await payload.find({
         collection: collectionSlug,
+        limit: 1,
+        pagination: false,
         where: {
           stripeID: {
             equals: stripeID,


### PR DESCRIPTION
`payload.find` queries can be made faster by specifying `limit: 1` and `pagination: false` when only the first document is needed. This PR applies those options to various queries to improve performance.