### PR TITLE
feat: add support for not_like operation

### DIFF
--- a/packages/db-mongodb/src/queries/buildSearchParams.ts
+++ b/packages/db-mongodb/src/queries/buildSearchParams.ts
@@ -255,6 +255,25 @@ export async function buildSearchParam({
         return result
       }
 
+      if (formattedOperator === 'not_like' && typeof formattedValue === 'string') {
+        const words = formattedValue.split(' ')
+
+        const result = {
+          value: {
+            $and: words.map((word) => ({
+              [path]: {
+                $not: {
+                  $options: 'i',
+                  $regex: word.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'),
+                },
+              },
+            })),
+          },
+        }
+
+        return result
+      }
+
       // Some operators like 'near' need to define a full query
       // so if there is no operator key, just return the value
       if (!operatorKey) {

--- a/packages/db-mongodb/src/queries/operatorMap.ts
+++ b/packages/db-mongodb/src/queries/operatorMap.ts
@@ -11,6 +11,5 @@ export const operatorMap = {
   near: '$near',
   not_equals: '$ne',
   not_in: '$nin',
-  not_like: '$not',
   within: '$geoWithin',
 }

--- a/packages/db-mongodb/src/queries/operatorMap.ts
+++ b/packages/db-mongodb/src/queries/operatorMap.ts
@@ -11,5 +11,6 @@ export const operatorMap = {
   near: '$near',
   not_equals: '$ne',
   not_in: '$nin',
+  not_like: '$not',
   within: '$geoWithin',
 }

--- a/packages/db-sqlite/src/createJSONQuery/index.ts
+++ b/packages/db-sqlite/src/createJSONQuery/index.ts
@@ -50,12 +50,11 @@ const createConstraint = ({
   const newAlias = `${pathSegments[0]}_alias_${pathSegments.length - 1}`
   let formattedValue = value
   let formattedOperator = operator
-
   if (['contains', 'like'].includes(operator)) {
     formattedOperator = 'like'
     formattedValue = `%${value}%`
-  } else if (['not_like'].includes(operator)) {
-    formattedOperator = 'notlike'
+  } else if (['not_like', 'notlike'].includes(operator)) {
+    formattedOperator = 'not like'
     formattedValue = `%${value}%`
   } else if (operator === 'equals') {
     formattedOperator = '='
@@ -64,7 +63,7 @@ const createConstraint = ({
   return `EXISTS (
   SELECT 1
   FROM json_each(${alias}.value -> '${pathSegments[0]}') AS ${newAlias}
-  WHERE ${newAlias}.value ->> '${pathSegments[1]}' ${formattedOperator} '${formattedValue}'
+  WHERE COALESCE(${newAlias}.value ->> '${pathSegments[1]}', '') ${formattedOperator} '${formattedValue}'
   )`
 }
 

--- a/packages/db-sqlite/src/createJSONQuery/index.ts
+++ b/packages/db-sqlite/src/createJSONQuery/index.ts
@@ -54,6 +54,9 @@ const createConstraint = ({
   if (['contains', 'like'].includes(operator)) {
     formattedOperator = 'like'
     formattedValue = `%${value}%`
+  } else if (['not_like'].includes(operator)) {
+    formattedOperator = 'notlike'
+    formattedValue = `%${value}%`
   } else if (operator === 'equals') {
     formattedOperator = '='
   }

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -37,7 +37,7 @@ import {
   updateOne,
   updateVersion,
 } from '@payloadcms/drizzle'
-import { like } from 'drizzle-orm'
+import { like, notLike } from 'drizzle-orm'
 import { createDatabaseAdapter, defaultBeginTransaction } from 'payload'
 import { fileURLToPath } from 'url'
 
@@ -81,6 +81,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       ...operatorMap,
       contains: like,
       like,
+      not_like: notLike,
     } as unknown as Operators
 
     return createDatabaseAdapter<SQLiteAdapter>({

--- a/packages/drizzle/src/postgres/createJSONQuery/index.ts
+++ b/packages/drizzle/src/postgres/createJSONQuery/index.ts
@@ -36,12 +36,12 @@ export const createJSONQuery = ({ column, operator, pathSegments, value }: Creat
     })
   } else if (operator === 'exists') {
     sql = `${value === false ? 'NOT ' : ''}jsonb_path_exists(${columnName}, '$.${jsonPaths}')`
-  } else {
+  } else if (['not_like'].includes(operator)) {
     const mappedOperator = operatorMap[operator]
-    const isNegated = mappedOperator.startsWith('!')
-    const cleanOperator = isNegated ? mappedOperator.substring(1) : mappedOperator
 
-    sql = `${isNegated ? 'NOT ' : ''}jsonb_path_exists(${columnName}, '$.${jsonPaths} ? (@ ${cleanOperator} ${sanitizeValue(value, operator)})')`
+    sql = `NOT jsonb_path_exists(${columnName}, '$.${jsonPaths} ? (@ ${mappedOperator.substring(1)} ${sanitizeValue(value, operator)})')`
+  } else {
+    sql = `jsonb_path_exists(${columnName}, '$.${jsonPaths} ? (@ ${operatorMap[operator]} ${sanitizeValue(value, operator)})')`
   }
 
   return sql

--- a/packages/drizzle/src/queries/operatorMap.ts
+++ b/packages/drizzle/src/queries/operatorMap.ts
@@ -11,6 +11,7 @@ import {
   lt,
   lte,
   ne,
+  notIlike,
   notInArray,
   or,
   type SQL,
@@ -31,6 +32,7 @@ type OperatorKeys =
   | 'like'
   | 'not_equals'
   | 'not_in'
+  | 'not_like'
   | 'or'
 
 export type Operators = Record<OperatorKeys, (column: Column, value: SQLWrapper | unknown) => SQL>
@@ -48,6 +50,7 @@ export const operatorMap: Operators = {
   less_than_equal: lte,
   like: ilike,
   not_equals: ne,
+  not_like: notIlike,
   // TODO: support this
   // all: all,
   not_in: notInArray,

--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -161,6 +161,7 @@ export function parseParams({
                     like: { operator: 'like', wildcard: '%' },
                     not_equals: { operator: '<>', wildcard: '' },
                     not_in: { operator: 'not in', wildcard: '' },
+                    not_like: { operator: 'not like', wildcard: '%' },
                   }
 
                   let formattedValue = val

--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -176,11 +176,15 @@ export function parseParams({
                     formattedValue = ''
                   }
 
-                  constraints.push(
-                    sql.raw(
-                      `${table[columnName].name}${jsonQuery} ${operatorKeys[operator].operator} ${formattedValue}`,
-                    ),
-                  )
+                  let jsonQuerySelector = `${table[columnName].name}${jsonQuery}`
+
+                  if (adapter.name === 'sqlite' && operator === 'not_like') {
+                    jsonQuerySelector = `COALESCE(${table[columnName].name}${jsonQuery}, '')`
+                  }
+
+                  const rawSQLQuery = `${jsonQuerySelector} ${operatorKeys[operator].operator} ${formattedValue}`
+
+                  constraints.push(sql.raw(rawSQLQuery))
 
                   break
                 }

--- a/packages/payload/src/types/constants.ts
+++ b/packages/payload/src/types/constants.ts
@@ -11,6 +11,7 @@ export const validOperators = [
   'less_than',
   'less_than_equal',
   'like',
+  'not_like',
   'within',
   'intersects',
   'near',

--- a/packages/translations/src/clientKeys.ts
+++ b/packages/translations/src/clientKeys.ts
@@ -301,6 +301,7 @@ export const clientTranslationKeys = createClientTranslationKeys([
   'operators:isIn',
   'operators:contains',
   'operators:isLike',
+  'operators:isNotLike',
   'operators:isNotEqualTo',
   'operators:near',
   'operators:isGreaterThan',

--- a/packages/translations/src/languages/ar.ts
+++ b/packages/translations/src/languages/ar.ts
@@ -370,6 +370,7 @@ export const arTranslations: DefaultTranslationsObject = {
     isLike: 'هو مثل',
     isNotEqualTo: 'لا يساوي',
     isNotIn: 'غير موجود في',
+    isNotLike: 'ليس مثل',
     near: 'قريب من',
     within: 'في غضون',
   },

--- a/packages/translations/src/languages/az.ts
+++ b/packages/translations/src/languages/az.ts
@@ -375,6 +375,7 @@ export const azTranslations: DefaultTranslationsObject = {
     isLike: 'kimi',
     isNotEqualTo: 'bərabər deyil',
     isNotIn: 'daxil deyil',
+    isNotLike: 'deyil kimi',
     near: 'yaxın',
     within: 'daxilinde',
   },

--- a/packages/translations/src/languages/bg.ts
+++ b/packages/translations/src/languages/bg.ts
@@ -373,6 +373,7 @@ export const bgTranslations: DefaultTranslationsObject = {
     isLike: 'е като',
     isNotEqualTo: 'не е равно на',
     isNotIn: 'не е в',
+    isNotLike: 'не е като',
     near: 'близко',
     within: 'в рамките на',
   },

--- a/packages/translations/src/languages/ca.ts
+++ b/packages/translations/src/languages/ca.ts
@@ -374,6 +374,7 @@ export const caTranslations: DefaultTranslationsObject = {
     isLike: 'és semblant a',
     isNotEqualTo: 'no és igual a',
     isNotIn: 'no està en',
+    isNotLike: 'no és com',
     near: 'a prop de',
     within: 'dins de',
   },

--- a/packages/translations/src/languages/cs.ts
+++ b/packages/translations/src/languages/cs.ts
@@ -371,6 +371,7 @@ export const csTranslations: DefaultTranslationsObject = {
     isLike: 'je jako',
     isNotEqualTo: 'není rovno',
     isNotIn: 'není v',
+    isNotLike: 'není jako',
     near: 'blízko',
     within: 'uvnitř',
   },

--- a/packages/translations/src/languages/da.ts
+++ b/packages/translations/src/languages/da.ts
@@ -372,6 +372,7 @@ export const daTranslations: DefaultTranslationsObject = {
     isLike: 'Ligner',
     isNotEqualTo: 'Er ikke lig med',
     isNotIn: 'Er ikke i',
+    isNotLike: 'er ikke som',
     near: 'Tæt på',
     within: 'Inden for',
   },

--- a/packages/translations/src/languages/de.ts
+++ b/packages/translations/src/languages/de.ts
@@ -379,6 +379,7 @@ export const deTranslations: DefaultTranslationsObject = {
     isLike: 'ist wie',
     isNotEqualTo: 'ist nicht gleich',
     isNotIn: 'ist nicht drin',
+    isNotLike: 'ist nicht wie',
     near: 'in der Nähe',
     within: 'innerhalb',
   },

--- a/packages/translations/src/languages/en.ts
+++ b/packages/translations/src/languages/en.ts
@@ -374,6 +374,7 @@ export const enTranslations = {
     isLike: 'is like',
     isNotEqualTo: 'is not equal to',
     isNotIn: 'is not in',
+    isNotLike: 'is not like',
     near: 'near',
     within: 'within',
   },

--- a/packages/translations/src/languages/es.ts
+++ b/packages/translations/src/languages/es.ts
@@ -378,6 +378,7 @@ export const esTranslations: DefaultTranslationsObject = {
     isLike: 'es como',
     isNotEqualTo: 'no es igual a',
     isNotIn: 'no está en',
+    isNotLike: 'no es como',
     near: 'cerca',
     within: 'dentro de',
   },

--- a/packages/translations/src/languages/et.ts
+++ b/packages/translations/src/languages/et.ts
@@ -370,6 +370,7 @@ export const etTranslations: DefaultTranslationsObject = {
     isLike: 'on sarnane',
     isNotEqualTo: 'ei võrdu',
     isNotIn: 'ei ole hulgas',
+    isNotLike: 'ei ole nagu',
     near: 'lähedal',
     within: 'vahemikus',
   },

--- a/packages/translations/src/languages/fa.ts
+++ b/packages/translations/src/languages/fa.ts
@@ -371,6 +371,7 @@ export const faTranslations: DefaultTranslationsObject = {
     isLike: 'مانند این است',
     isNotEqualTo: 'برابر نیست',
     isNotIn: 'در این نیست',
+    isNotLike: 'مانند نیست',
     near: 'نزدیک',
     within: 'در داخل',
   },

--- a/packages/translations/src/languages/fr.ts
+++ b/packages/translations/src/languages/fr.ts
@@ -383,6 +383,7 @@ export const frTranslations: DefaultTranslationsObject = {
     isLike: 'est comme',
     isNotEqualTo: 'n’est pas égal à',
     isNotIn: 'n’est pas dans',
+    isNotLike: "n'est pas comme",
     near: 'proche',
     within: 'dans',
   },

--- a/packages/translations/src/languages/he.ts
+++ b/packages/translations/src/languages/he.ts
@@ -366,6 +366,7 @@ export const heTranslations: DefaultTranslationsObject = {
     isLike: 'דומה ל',
     isNotEqualTo: 'לא שווה ל',
     isNotIn: 'לא נמצא ב',
+    isNotLike: 'אינו דומה',
     near: 'קרוב ל',
     within: 'בתוך',
   },

--- a/packages/translations/src/languages/hr.ts
+++ b/packages/translations/src/languages/hr.ts
@@ -373,6 +373,7 @@ export const hrTranslations: DefaultTranslationsObject = {
     isLike: 'je kao',
     isNotEqualTo: 'nije jednako',
     isNotIn: 'nije unutra',
+    isNotLike: 'nije kao',
     near: 'blizu',
     within: 'unutar',
   },

--- a/packages/translations/src/languages/hu.ts
+++ b/packages/translations/src/languages/hu.ts
@@ -376,6 +376,7 @@ export const huTranslations: DefaultTranslationsObject = {
     isLike: 'olyan, mint',
     isNotEqualTo: 'nem egyenlő',
     isNotIn: 'nincs benne',
+    isNotLike: 'nem olyan mint',
     near: 'közel',
     within: 'belül',
   },

--- a/packages/translations/src/languages/it.ts
+++ b/packages/translations/src/languages/it.ts
@@ -377,6 +377,7 @@ export const itTranslations: DefaultTranslationsObject = {
     isLike: 'è come',
     isNotEqualTo: 'non è uguale a',
     isNotIn: 'non è in',
+    isNotLike: 'non è come',
     near: 'vicino',
     within: "all'interno",
   },

--- a/packages/translations/src/languages/ja.ts
+++ b/packages/translations/src/languages/ja.ts
@@ -373,6 +373,7 @@ export const jaTranslations: DefaultTranslationsObject = {
     isLike: 'のような',
     isNotEqualTo: '等しくない',
     isNotIn: '入っていません',
+    isNotLike: 'ではない',
     near: '近く',
     within: '内で',
   },

--- a/packages/translations/src/languages/ko.ts
+++ b/packages/translations/src/languages/ko.ts
@@ -371,6 +371,7 @@ export const koTranslations: DefaultTranslationsObject = {
     isLike: '유사',
     isNotEqualTo: '같지 않음',
     isNotIn: '포함되지 않음',
+    isNotLike: '같지 않다',
     near: '근처',
     within: '내에서',
   },

--- a/packages/translations/src/languages/lt.ts
+++ b/packages/translations/src/languages/lt.ts
@@ -375,6 +375,7 @@ export const ltTranslations: DefaultTranslationsObject = {
     isLike: 'yra panašu',
     isNotEqualTo: 'nelygu',
     isNotIn: 'nėra',
+    isNotLike: 'nėra panašus',
     near: 'šalia',
     within: 'viduje',
   },

--- a/packages/translations/src/languages/my.ts
+++ b/packages/translations/src/languages/my.ts
@@ -378,6 +378,7 @@ export const myTranslations: DefaultTranslationsObject = {
     isLike: 'တူသည်',
     isNotEqualTo: 'ညီမျှသည်',
     isNotIn: 'မဝင်ပါ',
+    isNotLike: 'မဟုတ်ကဲ့သို့',
     near: 'နီး',
     within: 'အတွင်း',
   },

--- a/packages/translations/src/languages/nb.ts
+++ b/packages/translations/src/languages/nb.ts
@@ -374,6 +374,7 @@ export const nbTranslations: DefaultTranslationsObject = {
     isLike: 'er som',
     isNotEqualTo: 'er ikke lik',
     isNotIn: 'er ikke med',
+    isNotLike: 'er ikke lik',
     near: 'nær',
     within: 'innen',
   },

--- a/packages/translations/src/languages/nl.ts
+++ b/packages/translations/src/languages/nl.ts
@@ -377,6 +377,7 @@ export const nlTranslations: DefaultTranslationsObject = {
     isLike: 'is als',
     isNotEqualTo: 'is niet gelijk aan',
     isNotIn: 'zit er niet in',
+    isNotLike: 'is niet zoals',
     near: 'nabij',
     within: 'binnen',
   },

--- a/packages/translations/src/languages/pl.ts
+++ b/packages/translations/src/languages/pl.ts
@@ -373,6 +373,7 @@ export const plTranslations: DefaultTranslationsObject = {
     isLike: 'jest jak',
     isNotEqualTo: 'nie jest równe',
     isNotIn: 'nie ma go w',
+    isNotLike: 'nie jest jak',
     near: 'blisko',
     within: 'w ciągu',
   },

--- a/packages/translations/src/languages/pt.ts
+++ b/packages/translations/src/languages/pt.ts
@@ -374,6 +374,7 @@ export const ptTranslations: DefaultTranslationsObject = {
     isLike: 'é como',
     isNotEqualTo: 'não é igual a',
     isNotIn: 'não está em',
+    isNotLike: 'não é como',
     near: 'perto',
     within: 'dentro',
   },

--- a/packages/translations/src/languages/ro.ts
+++ b/packages/translations/src/languages/ro.ts
@@ -377,6 +377,7 @@ export const roTranslations: DefaultTranslationsObject = {
     isLike: 'este ca',
     isNotEqualTo: 'nu este egal cu',
     isNotIn: 'nu este în',
+    isNotLike: 'nu este ca',
     near: 'în apropiere de',
     within: 'înăuntru',
   },

--- a/packages/translations/src/languages/rs.ts
+++ b/packages/translations/src/languages/rs.ts
@@ -373,6 +373,7 @@ export const rsTranslations: DefaultTranslationsObject = {
     isLike: 'је као',
     isNotEqualTo: 'није једнако',
     isNotIn: 'није у',
+    isNotLike: 'nije kao',
     near: 'близу',
     within: 'unutar',
   },

--- a/packages/translations/src/languages/rsLatin.ts
+++ b/packages/translations/src/languages/rsLatin.ts
@@ -374,6 +374,7 @@ export const rsLatinTranslations: DefaultTranslationsObject = {
     isLike: 'je kao',
     isNotEqualTo: 'nije jednako',
     isNotIn: 'nije unutra',
+    isNotLike: 'nije kao',
     near: 'blizu',
     within: 'unutar',
   },

--- a/packages/translations/src/languages/ru.ts
+++ b/packages/translations/src/languages/ru.ts
@@ -377,6 +377,7 @@ export const ruTranslations: DefaultTranslationsObject = {
     isLike: 'похоже',
     isNotEqualTo: 'не равно',
     isNotIn: 'нет в',
+    isNotLike: 'не похож',
     near: 'рядом',
     within: 'в пределах',
   },

--- a/packages/translations/src/languages/sk.ts
+++ b/packages/translations/src/languages/sk.ts
@@ -374,6 +374,7 @@ export const skTranslations: DefaultTranslationsObject = {
     isLike: 'je ako',
     isNotEqualTo: 'nie je rovné',
     isNotIn: 'nie je v',
+    isNotLike: 'nie je ako',
     near: 'blízko',
     within: 'vnútri',
   },

--- a/packages/translations/src/languages/sl.ts
+++ b/packages/translations/src/languages/sl.ts
@@ -372,6 +372,7 @@ export const slTranslations: DefaultTranslationsObject = {
     isLike: 'je podobno',
     isNotEqualTo: 'ni enako',
     isNotIn: 'ni v',
+    isNotLike: 'ni podobno',
     near: 'blizu',
     within: 'znotraj',
   },

--- a/packages/translations/src/languages/sv.ts
+++ b/packages/translations/src/languages/sv.ts
@@ -374,6 +374,7 @@ export const svTranslations: DefaultTranslationsObject = {
     isLike: 'är som',
     isNotEqualTo: 'är inte lika med',
     isNotIn: 'är inte med',
+    isNotLike: 'är inte som',
     near: 'nära',
     within: 'inom',
   },

--- a/packages/translations/src/languages/th.ts
+++ b/packages/translations/src/languages/th.ts
@@ -369,6 +369,7 @@ export const thTranslations: DefaultTranslationsObject = {
     isLike: 'เหมือน',
     isNotEqualTo: 'ไม่เท่ากับ',
     isNotIn: 'ไม่ได้อยู่ใน',
+    isNotLike: 'ไม่เหมือน',
     near: 'ใกล้',
     within: 'ภายใน',
   },

--- a/packages/translations/src/languages/tr.ts
+++ b/packages/translations/src/languages/tr.ts
@@ -378,6 +378,7 @@ export const trTranslations: DefaultTranslationsObject = {
     isLike: 'gibidir',
     isNotEqualTo: 'eşit değildir',
     isNotIn: 'içinde değil',
+    isNotLike: 'gibi değil',
     near: 'yakın',
     within: 'içinde',
   },

--- a/packages/translations/src/languages/uk.ts
+++ b/packages/translations/src/languages/uk.ts
@@ -372,6 +372,7 @@ export const ukTranslations: DefaultTranslationsObject = {
     isLike: 'схоже',
     isNotEqualTo: 'не дорівнює',
     isNotIn: 'не в',
+    isNotLike: 'не такий як',
     near: 'поруч',
     within: 'в межах',
   },

--- a/packages/translations/src/languages/vi.ts
+++ b/packages/translations/src/languages/vi.ts
@@ -372,6 +372,7 @@ export const viTranslations: DefaultTranslationsObject = {
     isLike: 'gần giống',
     isNotEqualTo: 'không bằng',
     isNotIn: 'không có trong',
+    isNotLike: 'không giống như',
     near: 'gần',
     within: 'trong',
   },

--- a/packages/translations/src/languages/zh.ts
+++ b/packages/translations/src/languages/zh.ts
@@ -362,6 +362,7 @@ export const zhTranslations: DefaultTranslationsObject = {
     isLike: '就像',
     isNotEqualTo: '不等于',
     isNotIn: '不在',
+    isNotLike: '不像',
     near: '附近',
     within: '在...之内',
   },

--- a/packages/translations/src/languages/zhTw.ts
+++ b/packages/translations/src/languages/zhTw.ts
@@ -362,6 +362,7 @@ export const zhTwTranslations: DefaultTranslationsObject = {
     isLike: '就像',
     isNotEqualTo: '不等於',
     isNotIn: '不在',
+    isNotLike: '不像',
     near: '附近',
     within: '在...之內',
   },

--- a/packages/ui/src/elements/WhereBuilder/field-types.tsx
+++ b/packages/ui/src/elements/WhereBuilder/field-types.tsx
@@ -73,6 +73,11 @@ const like = {
   value: 'like',
 }
 
+const notLike = {
+  label: 'isNotLike',
+  value: 'not_like',
+}
+
 const contains = {
   label: 'contains',
   value: 'contains',
@@ -90,7 +95,7 @@ const fieldTypeConditions: {
   },
   code: {
     component: 'Text',
-    operators: [...base, like, contains],
+    operators: [...base, like, notLike, contains],
   },
   date: {
     component: 'Date',
@@ -102,7 +107,7 @@ const fieldTypeConditions: {
   },
   json: {
     component: 'Text',
-    operators: [...base, like, contains, within, intersects],
+    operators: [...base, like, contains, notLike, within, intersects],
   },
   number: {
     component: 'Number',
@@ -122,7 +127,7 @@ const fieldTypeConditions: {
   },
   richText: {
     component: 'Text',
-    operators: [...base, like, contains],
+    operators: [...base, like, notLike, contains],
   },
   select: {
     component: 'Select',
@@ -130,11 +135,11 @@ const fieldTypeConditions: {
   },
   text: {
     component: 'Text',
-    operators: [...base, like, contains],
+    operators: [...base, like, notLike, contains],
   },
   textarea: {
     component: 'Text',
-    operators: [...base, like, contains],
+    operators: [...base, like, notLike, contains],
   },
   upload: {
     component: 'Text',

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -2775,6 +2775,20 @@ describe('Fields', () => {
         expect(docIDs).not.toContain(bazBar.id)
       })
 
+      it('should query nested properties - not_like', async () => {
+        const { docs } = await payload.find({
+          collection: 'json-fields',
+          where: {
+            'json.baz': { not_like: 'bar' },
+          },
+        })
+
+        const docIDs = docs.map(({ id }) => id)
+
+        expect(docIDs).toContain(fooBar.id)
+        expect(docIDs).not.toContain(bazBar.id)
+      })
+
       it('should query nested properties - equals', async () => {
         const { docs } = await payload.find({
           collection: 'json-fields',

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -165,6 +165,68 @@ describe('Fields', () => {
       expect(missResult).toBeFalsy()
     })
 
+    it('should query like on value', async () => {
+      const miss = await payload.create({
+        collection: 'text-fields',
+        data: {
+          text: 'dog',
+        },
+      })
+
+      const hit = await payload.create({
+        collection: 'text-fields',
+        data: {
+          text: 'cat',
+        },
+      })
+
+      const { docs } = await payload.find({
+        collection: 'text-fields',
+        where: {
+          text: {
+            like: 'cat',
+          },
+        },
+      })
+
+      const hitResult = docs.find(({ id: findID }) => hit.id === findID)
+      const missResult = docs.find(({ id: findID }) => miss.id === findID)
+
+      expect(hitResult).toBeDefined()
+      expect(missResult).toBeFalsy()
+    })
+
+    it('should query not_like on value', async () => {
+      const hit = await payload.create({
+        collection: 'text-fields',
+        data: {
+          text: 'dog',
+        },
+      })
+
+      const miss = await payload.create({
+        collection: 'text-fields',
+        data: {
+          text: 'cat',
+        },
+      })
+
+      const { docs } = await payload.find({
+        collection: 'text-fields',
+        where: {
+          text: {
+            not_like: 'cat',
+          },
+        },
+      })
+
+      const hitResult = docs.find(({ id: findID }) => hit.id === findID)
+      const missResult = docs.find(({ id: findID }) => miss.id === findID)
+
+      expect(hitResult).toBeDefined()
+      expect(missResult).toBeFalsy()
+    })
+
     it('should query hasMany within an array', async () => {
       const docFirst = await payload.create({
         collection: 'text-fields',


### PR DESCRIPTION
This PR adds support for `not_like` as a query operation. Functions just as a negative to `like`, uses `ilike` in postgres and `like` in sqlite