### PR TITLE
templates: fix docker build "cannot find matching keyid" by setting node.js image to `node:22.14.0-alpine`

### DIFF
--- a/templates/website/Dockerfile
+++ b/templates/website/Dockerfile
@@ -1,7 +1,7 @@
 # To use this Dockerfile, you have to set `output: 'standalone'` in your next.config.js file.
 # From https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
-FROM node:22.12.0-alpine AS base
+FROM node:22.14.0-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/templates/with-vercel-website/Dockerfile
+++ b/templates/with-vercel-website/Dockerfile
@@ -1,7 +1,7 @@
 # To use this Dockerfile, you have to set `output: 'standalone'` in your next.config.js file.
 # From https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
-FROM node:22.12.0-alpine AS base
+FROM node:22.14.0-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
Before, docker build was failing with this error:
<img width="963" alt="image" src="https://github.com/user-attachments/assets/bfce003b-53cd-417a-af77-7817ce3f94f5" />

Now it works correctly.
