### PR TITLE
fix(ui): link element triggering clicks twice

### DIFF
--- a/packages/ui/src/elements/Link/index.tsx
+++ b/packages/ui/src/elements/Link/index.tsx
@@ -26,15 +26,17 @@ function isModifiedEvent(event: React.MouseEvent): boolean {
 type Props = {
   /**
    * Disable the e.preventDefault() call on click if you want to handle it yourself via onClick
+   *
+   * @default true
    */
-  disablePreventDefault?: boolean
+  preventDefault?: boolean
 } & Parameters<typeof NextLink>[0]
 
 export const Link: React.FC<Props> = ({
   children,
-  disablePreventDefault,
   href,
   onClick,
+  preventDefault = true,
   ref,
   replace,
   scroll,
@@ -57,7 +59,7 @@ export const Link: React.FC<Props> = ({
 
         // We need a preventDefault here so that a clicked link doesn't trigger twice,
         // once for default browser navigation and once for startRouteTransition
-        if (!disablePreventDefault) {
+        if (preventDefault) {
           e.preventDefault()
         }
 

--- a/packages/ui/src/elements/Link/index.tsx
+++ b/packages/ui/src/elements/Link/index.tsx
@@ -23,8 +23,16 @@ function isModifiedEvent(event: React.MouseEvent): boolean {
   )
 }
 
-export const Link: React.FC<Parameters<typeof NextLink>[0]> = ({
+type Props = {
+  /**
+   * Disable the e.preventDefault() call on click if you want to handle it yourself via onClick
+   */
+  disablePreventDefault?: boolean
+} & Parameters<typeof NextLink>[0]
+
+export const Link: React.FC<Props> = ({
   children,
+  disablePreventDefault,
   href,
   onClick,
   ref,
@@ -45,6 +53,12 @@ export const Link: React.FC<Parameters<typeof NextLink>[0]> = ({
 
         if (onClick) {
           onClick(e)
+        }
+
+        // We need a preventDefault here so that a clicked link doesn't trigger twice,
+        // once for default browser navigation and once for startRouteTransition
+        if (!disablePreventDefault) {
+          e.preventDefault()
         }
 
         startRouteTransition(() => {


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11359#issuecomment-2678213414

The link element by using startTransitionRoute and manually calling router.push would technically cause links to be clicked twice, by not preventing default browser behaviour.

This caused a problem on clicking /create links as it hit the route twice. Added a test making sure Create new doesn't lead to abnormally increased document counts

Changes:
- Added `e.preventDefault()` in our Link element
- Added `preventDefault` as an optional prop to this element so that people can handle it on their own if needed via a custom `onClick`