### PR TITLE
feat(plugin-multi-tenant): export useTenantSelection hook for public usage

### DIFF
--- a/docs/plugins/multi-tenant.mdx
+++ b/docs/plugins/multi-tenant.mdx
@@ -278,6 +278,50 @@ async rewrites() {
 }
 ```
 
+### React Hooks
+
+Below are the hooks exported from the plugin that you can import into your own custom components to consume.
+
+#### useTenantSelection
+
+You can import this like so:
+
+```tsx
+import { useTenantSelection } from '@payloadcms/plugin-multi-tenant/client'
+
+...
+
+const tenantContext = useTenantSelection()
+```
+
+The hook returns the following context:
+
+```ts
+type ContextType = {
+  /**
+   * Array of options to select from
+   */
+  options: OptionObject[]
+  /**
+   * The currently selected tenant ID
+   */
+  selectedTenantID: number | string | undefined
+  /**
+   * Prevents a refresh when the tenant is changed
+   *
+   * If not switching tenants while viewing a "global", set to true
+   */
+  setPreventRefreshOnChange: React.Dispatch<React.SetStateAction<boolean>>
+  /**
+   * Sets the selected tenant ID
+   * 
+   * @param args.id - The ID of the tenant to select
+   * @param args.refresh - Whether to refresh the page after changing the tenant
+   */
+  setTenant: (args: { id: number | string | undefined; refresh?: boolean }) => void
+}
+```
+
 
 ## Examples
 

--- a/packages/plugin-multi-tenant/src/exports/client.ts
+++ b/packages/plugin-multi-tenant/src/exports/client.ts
@@ -1,2 +1,3 @@
 export { TenantField } from '../components/TenantField/index.client.js'
 export { TenantSelector } from '../components/TenantSelector/index.js'
+export { useTenantSelection } from '../providers/TenantSelectionProvider/index.client.js'

--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
@@ -9,9 +9,26 @@ import React, { createContext } from 'react'
 import { SELECT_ALL } from '../../constants.js'
 
 type ContextType = {
+  /**
+   * Array of options to select from
+   */
   options: OptionObject[]
+  /**
+   * The currently selected tenant ID
+   */
   selectedTenantID: number | string | undefined
+  /**
+   * Prevents a refresh when the tenant is changed
+   *
+   * If not switching tenants while viewing a "global", set to true
+   */
   setPreventRefreshOnChange: React.Dispatch<React.SetStateAction<boolean>>
+  /**
+   * Sets the selected tenant ID
+   *
+   * @param args.id - The ID of the tenant to select
+   * @param args.refresh - Whether to refresh the page after changing the tenant
+   */
   setTenant: (args: { id: number | string | undefined; refresh?: boolean }) => void
 }
 


### PR DESCRIPTION
Exports the `useTenantSelection` hook from the multi-tenant plugin, this way other users can import and use the hook along with it's methods.

Can be imported:
```ts
import { useTenantSelection } from '@payloadcms/plugin-multi-tenant/client'
```

The context returned:

```ts
type ContextType = {
  /**
   * Array of options to select from
   */
  options: OptionObject[]
  /**
   * The currently selected tenant ID
   */
  selectedTenantID: number | string | undefined
  /**
   * Prevents a refresh when the tenant is changed
   *
   * If not switching tenants while viewing a "global", set to true
   */
  setPreventRefreshOnChange: React.Dispatch<React.SetStateAction<boolean>>
  /**
   * Sets the selected tenant ID
   * 
   * @param args.id - The ID of the tenant to select
   * @param args.refresh - Whether to refresh the page after changing the tenant
   */
  setTenant: (args: { id: number | string | undefined; refresh?: boolean }) => void
}
```