### PR TITLE
fix(plugin-multi-tenant): user access, thread field names through

### DIFF
--- a/packages/plugin-multi-tenant/src/hooks/afterTenantDelete.ts
+++ b/packages/plugin-multi-tenant/src/hooks/afterTenantDelete.ts
@@ -115,7 +115,13 @@ export const afterTenantDelete =
             id: user.id,
             collection: usersSlug,
             data: {
-              tenants: (user.tenants || []).filter(({ tenant: tenantID }) => tenantID !== id),
+              [usersTenantsArrayFieldName]: (user[usersTenantsArrayFieldName] || []).filter(
+                (row: Record<string, string>) => {
+                  if (row[usersTenantsArrayTenantFieldName]) {
+                    return row[usersTenantsArrayTenantFieldName] !== id
+                  }
+                },
+              ),
             },
           }),
         )

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -92,6 +92,8 @@ export const multiTenantPlugin =
     addCollectionAccess({
       collection: adminUsersCollection,
       fieldName: `${tenantsArrayFieldName}.${tenantsArrayTenantFieldName}`,
+      tenantsArrayFieldName,
+      tenantsArrayTenantFieldName,
       userHasAccessToAllTenants,
     })
 
@@ -130,6 +132,8 @@ export const multiTenantPlugin =
           addCollectionAccess({
             collection,
             fieldName: 'id',
+            tenantsArrayFieldName,
+            tenantsArrayTenantFieldName,
             userHasAccessToAllTenants,
           })
         }
@@ -205,6 +209,8 @@ export const multiTenantPlugin =
           addCollectionAccess({
             collection,
             fieldName: tenantFieldName,
+            tenantsArrayFieldName,
+            tenantsArrayTenantFieldName,
             userHasAccessToAllTenants,
           })
         }

--- a/packages/plugin-multi-tenant/src/utilities/addCollectionAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/addCollectionAccess.ts
@@ -20,6 +20,8 @@ const collectionAccessKeys: AllAccessKeys<
 type Args<ConfigType> = {
   collection: CollectionConfig
   fieldName: string
+  tenantsArrayFieldName?: string
+  tenantsArrayTenantFieldName?: string
   userHasAccessToAllTenants: Required<
     MultiTenantPluginConfig<ConfigType>
   >['userHasAccessToAllTenants']
@@ -32,6 +34,8 @@ type Args<ConfigType> = {
 export const addCollectionAccess = <ConfigType>({
   collection,
   fieldName,
+  tenantsArrayFieldName,
+  tenantsArrayTenantFieldName,
   userHasAccessToAllTenants,
 }: Args<ConfigType>): void => {
   collectionAccessKeys.forEach((key) => {
@@ -40,7 +44,11 @@ export const addCollectionAccess = <ConfigType>({
     }
     collection.access[key] = withTenantAccess<ConfigType>({
       accessFunction: collection.access?.[key],
+      collection,
       fieldName: key === 'readVersions' ? `version.${fieldName}` : fieldName,
+      operation: key,
+      tenantsArrayFieldName,
+      tenantsArrayTenantFieldName,
       userHasAccessToAllTenants,
     })
   })

--- a/packages/plugin-multi-tenant/src/utilities/getTenantAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getTenantAccess.ts
@@ -2,14 +2,25 @@ import type { Where } from 'payload'
 
 import type { UserWithTenantsField } from '../types.js'
 
+import { defaults } from '../defaults.js'
 import { getUserTenantIDs } from './getUserTenantIDs.js'
 
 type Args = {
   fieldName: string
+  tenantsArrayFieldName?: string
+  tenantsArrayTenantFieldName?: string
   user: UserWithTenantsField
 }
-export function getTenantAccess({ fieldName, user }: Args): Where {
-  const userAssignedTenantIDs = getUserTenantIDs(user)
+export function getTenantAccess({
+  fieldName,
+  tenantsArrayFieldName = defaults.tenantsArrayFieldName,
+  tenantsArrayTenantFieldName = defaults.tenantsArrayTenantFieldName,
+  user,
+}: Args): Where {
+  const userAssignedTenantIDs = getUserTenantIDs(user, {
+    tenantsArrayFieldName,
+    tenantsArrayTenantFieldName,
+  })
 
   return {
     [fieldName]: {

--- a/packages/plugin-multi-tenant/src/utilities/getUserTenantIDs.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getUserTenantIDs.ts
@@ -1,5 +1,6 @@
 import type { Tenant, UserWithTenantsField } from '../types.js'
 
+import { defaults } from '../defaults.js'
 import { extractID } from './extractID.js'
 
 /**
@@ -9,15 +10,26 @@ import { extractID } from './extractID.js'
  */
 export const getUserTenantIDs = <IDType extends number | string>(
   user: null | UserWithTenantsField,
+  options?: {
+    tenantsArrayFieldName?: string
+    tenantsArrayTenantFieldName?: string
+  },
 ): IDType[] => {
   if (!user) {
     return []
   }
 
+  const {
+    tenantsArrayFieldName = defaults.tenantsArrayFieldName,
+    tenantsArrayTenantFieldName = defaults.tenantsArrayTenantFieldName,
+  } = options || {}
+
   return (
-    user?.tenants?.reduce<IDType[]>((acc, { tenant }) => {
-      if (tenant) {
-        acc.push(extractID<IDType>(tenant as Tenant<IDType>))
+    (Array.isArray(user[tenantsArrayFieldName]) ? user[tenantsArrayFieldName] : [])?.reduce<
+      IDType[]
+    >((acc, row) => {
+      if (row[tenantsArrayTenantFieldName]) {
+        acc.push(extractID<IDType>(row[tenantsArrayTenantFieldName] as Tenant<IDType>))
       }
 
       return acc

--- a/packages/plugin-multi-tenant/src/utilities/withTenantAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/withTenantAccess.ts
@@ -1,4 +1,12 @@
-import type { Access, AccessArgs, AccessResult, User } from 'payload'
+import type {
+  Access,
+  AccessArgs,
+  AccessResult,
+  AllOperations,
+  CollectionConfig,
+  User,
+  Where,
+} from 'payload'
 
 import type { MultiTenantPluginConfig, UserWithTenantsField } from '../types.js'
 
@@ -7,15 +15,26 @@ import { getTenantAccess } from './getTenantAccess.js'
 
 type Args<ConfigType> = {
   accessFunction?: Access
+  collection: CollectionConfig
   fieldName: string
+  operation: AllOperations
+  tenantsArrayFieldName?: string
+  tenantsArrayTenantFieldName?: string
   userHasAccessToAllTenants: Required<
     MultiTenantPluginConfig<ConfigType>
   >['userHasAccessToAllTenants']
 }
 export const withTenantAccess =
-  <ConfigType>({ accessFunction, fieldName, userHasAccessToAllTenants }: Args<ConfigType>) =>
+  <ConfigType>({
+    accessFunction,
+    collection,
+    fieldName,
+    tenantsArrayFieldName,
+    tenantsArrayTenantFieldName,
+    userHasAccessToAllTenants,
+  }: Args<ConfigType>) =>
   async (args: AccessArgs): Promise<AccessResult> => {
-    const constraints = []
+    const constraints: Where[] = []
     const accessFn =
       typeof accessFunction === 'function'
         ? accessFunction
@@ -34,12 +53,26 @@ export const withTenantAccess =
         args.req.user as ConfigType extends { user: unknown } ? ConfigType['user'] : User,
       )
     ) {
-      constraints.push(
-        getTenantAccess({
-          fieldName,
-          user: args.req.user as UserWithTenantsField,
-        }),
-      )
+      const tenantConstraint = getTenantAccess({
+        fieldName,
+        tenantsArrayFieldName,
+        tenantsArrayTenantFieldName,
+        user: args.req.user as UserWithTenantsField,
+      })
+      if (collection.slug === args.req.user.collection) {
+        constraints.push({
+          or: [
+            {
+              id: {
+                equals: args.req.user.id,
+              },
+            },
+            tenantConstraint,
+          ],
+        })
+      } else {
+        constraints.push(tenantConstraint)
+      }
       return combineWhereConstraints(constraints)
     }
 

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -7,6 +7,7 @@ import type { NextRESTClient } from '../helpers/NextRESTClient.js'
 
 import { devUser } from '../credentials.js'
 import { initPayloadInt } from '../helpers/initPayloadInt.js'
+import { tenantsSlug } from './shared.js'
 
 let payload: Payload
 let restClient: NextRESTClient
@@ -40,7 +41,7 @@ describe('@payloadcms/plugin-multi-tenant', () => {
   describe('tenants', () => {
     it('should create a tenant', async () => {
       const tenant1 = await payload.create({
-        collection: 'tenants',
+        collection: tenantsSlug,
         data: {
           name: 'tenant1',
           domain: 'tenant1.com',

--- a/test/plugin-multi-tenant/seed/index.ts
+++ b/test/plugin-multi-tenant/seed/index.ts
@@ -1,19 +1,19 @@
 import type { Config } from 'payload'
 
 import { devUser } from '../../credentials.js'
-import { menuItemsSlug, menuSlug, usersSlug } from '../shared.js'
+import { menuItemsSlug, menuSlug, tenantsSlug, usersSlug } from '../shared.js'
 
 export const seed: Config['onInit'] = async (payload) => {
   // create tenants
   const blueDogTenant = await payload.create({
-    collection: 'tenants',
+    collection: tenantsSlug,
     data: {
       name: 'Blue Dog',
       domain: 'bluedog.com',
     },
   })
   const steelCatTenant = await payload.create({
-    collection: 'tenants',
+    collection: tenantsSlug,
     data: {
       name: 'Steel Cat',
       domain: 'steelcat.com',


### PR DESCRIPTION
### What?
Two things:
1. Users unassigned to a tenant could not access their own account
2. Custom `tenantsArrayFieldName` and `tenantsArrayTenantFieldName` configurations were not being used in all cases

### Why?
1. The access constraint provided by the plugin would not allow them to make changes to their own account
2. `getUserTenantIDs` and `afterTenantDelete` were not using the custom field names properly

### How?
1. Adds constraint for users allowing them to manage their own account by default. Externally nothing has changed. If you need to lock your users access control down you should do that just as you would without this plugin.
2. Threads the field names through for usage.

Fixes https://github.com/payloadcms/payload/issues/11317

