### PR TITLE
fix(ui): object type field labels not displaying in search filter

### DIFF
--- a/packages/ui/src/elements/ListControls/index.tsx
+++ b/packages/ui/src/elements/ListControls/index.tsx
@@ -73,7 +73,8 @@ export const ListControls: React.FC<ListControlsProps> = (props) => {
   const searchLabel =
     (titleField &&
       getTranslation(
-        'label' in titleField && typeof titleField.label === 'string'
+        'label' in titleField &&
+          (typeof titleField.label === 'string' || typeof titleField.label === 'object')
           ? titleField.label
           : 'name' in titleField
             ? titleField.name

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -64,8 +64,16 @@ export default buildConfigWithDefaults({
     NestedArray,
     NestedFields,
     {
+      admin: {
+        listSearchableFields: 'name',
+      },
       auth: true,
       fields: [
+        {
+          name: 'name',
+          label: { en: 'Full name' },
+          type: 'text',
+        },
         {
           name: 'relation',
           relationTo: localizedPostsSlug,
@@ -83,6 +91,7 @@ export default buildConfigWithDefaults({
       fields: [
         {
           name: 'title',
+          label: { en: 'Full title' },
           index: true,
           localized: true,
           type: 'text',

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -64,7 +64,6 @@ export interface Config {
   auth: {
     users: UserAuthOperations;
   };
-  blocks: {};
   collections: {
     richText: RichText;
     'blocks-fields': BlocksField;
@@ -322,6 +321,7 @@ export interface NestedFieldTable {
  */
 export interface User {
   id: string;
+  name?: string | null;
   relation?: (string | null) | LocalizedPost;
   updatedAt: string;
   createdAt: string;
@@ -928,6 +928,7 @@ export interface NestedFieldTablesSelect<T extends boolean = true> {
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
+  name?: T;
   relation?: T;
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
This PR ensures that when `titleField.label` is provided as an object, it is correctly translated and displayed in the search filter's placeholder.

Previously, the implementation only supported string values, which could lead to issues with object type labels. With these changes, object type labels will now properly show as intended in the search filter.

Fixes #11348 
