### PR TITLE
fix(ui): allow json fields to be updated externally

### DIFF
--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -55,7 +55,7 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
     validate: memoizedValidate,
   })
 
-  const [initialStringValue] = useState<string | undefined>(() =>
+  const [initialStringValue, setInitialStringValue] = useState<string | undefined>(() =>
     (value || initialValue) !== undefined
       ? JSON.stringify(value || initialValue, null, 2)
       : undefined,
@@ -108,6 +108,7 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
 
   useEffect(() => {
     if (inputChangeFromRef.current === 'system') {
+      setInitialStringValue(JSON.stringify(value || initialValue, null, 2))
       setEditorKey(new Date().toString())
     }
 
@@ -150,6 +151,9 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
           options={editorOptions}
           readOnly={readOnly}
           value={initialStringValue}
+          wrapperProps={{
+            id: `field-${path?.replace(/\./g, '__')}`,
+          }}
         />
         {AfterInput}
       </div>

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -31,8 +31,6 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
     readOnly,
     validate,
   } = props
-
-  const [stringValue, setStringValue] = useState<string>()
   const [jsonError, setJsonError] = useState<string>()
   const inputChangeFromRef = React.useRef<'system' | 'user'>('system')
   const [editorKey, setEditorKey] = useState<string>('')
@@ -56,6 +54,12 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
     path,
     validate: memoizedValidate,
   })
+
+  const [initialStringValue] = useState<string | undefined>(() =>
+    (value || initialValue) !== undefined
+      ? JSON.stringify(value || initialValue, null, 2)
+      : undefined,
+  )
 
   const handleMount = useCallback<OnMount>(
     (editor, monaco) => {
@@ -90,7 +94,6 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
         return
       }
       inputChangeFromRef.current = 'user'
-      setStringValue(val)
 
       try {
         setValue(val ? JSON.parse(val) : null)
@@ -100,15 +103,11 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
         setJsonError(e)
       }
     },
-    [readOnly, setValue, setStringValue],
+    [readOnly, setValue],
   )
 
   useEffect(() => {
     if (inputChangeFromRef.current === 'system') {
-      setStringValue(
-        value || initialValue ? JSON.stringify(value ? value : initialValue, null, 2) : '',
-      )
-
       setEditorKey(new Date().toString())
     }
 
@@ -150,7 +149,7 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
           onMount={handleMount}
           options={editorOptions}
           readOnly={readOnly}
-          value={stringValue}
+          value={initialStringValue}
         />
         {AfterInput}
       </div>

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -57,7 +57,7 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
 
   const [initialStringValue, setInitialStringValue] = useState<string | undefined>(() =>
     (value || initialValue) !== undefined
-      ? JSON.stringify(value || initialValue, null, 2)
+      ? JSON.stringify(value ?? initialValue, null, 2)
       : undefined,
   )
 
@@ -108,7 +108,11 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
 
   useEffect(() => {
     if (inputChangeFromRef.current === 'system') {
-      setInitialStringValue(JSON.stringify(value || initialValue, null, 2))
+      setInitialStringValue(
+        (value || initialValue) !== undefined
+          ? JSON.stringify(value ?? initialValue, null, 2)
+          : undefined,
+      )
       setEditorKey(new Date().toString())
     }
 

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -10,10 +10,10 @@ import { useField } from '../../forms/useField/index.js'
 import { withCondition } from '../../forms/withCondition/index.js'
 import { FieldDescription } from '../FieldDescription/index.js'
 import { FieldError } from '../FieldError/index.js'
-import './index.scss'
 import { FieldLabel } from '../FieldLabel/index.js'
 import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import { fieldBaseClass } from '../shared/index.js'
+import './index.scss'
 
 const baseClass = 'json-field'
 
@@ -34,7 +34,8 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
 
   const [stringValue, setStringValue] = useState<string>()
   const [jsonError, setJsonError] = useState<string>()
-  const [hasLoadedValue, setHasLoadedValue] = useState(false)
+  const inputChangeFromRef = React.useRef<'system' | 'user'>('system')
+  const [editorKey, setEditorKey] = useState<string>('')
 
   const memoizedValidate = useCallback(
     (value, options) => {
@@ -88,6 +89,7 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
       if (readOnly) {
         return
       }
+      inputChangeFromRef.current = 'user'
       setStringValue(val)
 
       try {
@@ -102,16 +104,16 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
   )
 
   useEffect(() => {
-    if (hasLoadedValue || value === undefined) {
-      return
+    if (inputChangeFromRef.current === 'system') {
+      setStringValue(
+        value || initialValue ? JSON.stringify(value ? value : initialValue, null, 2) : '',
+      )
+
+      setEditorKey(new Date().toString())
     }
 
-    setStringValue(
-      value || initialValue ? JSON.stringify(value ? value : initialValue, null, 2) : '',
-    )
-
-    setHasLoadedValue(true)
-  }, [initialValue, value, hasLoadedValue])
+    inputChangeFromRef.current = 'system'
+  }, [initialValue, value])
 
   const styles = useMemo(() => mergeFieldStyles(field), [field])
 
@@ -142,6 +144,7 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
         {BeforeInput}
         <CodeEditor
           defaultLanguage="json"
+          key={editorKey}
           maxHeight={maxHeight}
           onChange={handleChange}
           onMount={handleMount}

--- a/test/fields/collections/JSON/AfterField.tsx
+++ b/test/fields/collections/JSON/AfterField.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useField } from '@payloadcms/ui'
+
+export function AfterField() {
+  const { setValue } = useField({ path: 'customJSON' })
+
+  return (
+    <button
+      onClick={(e) => {
+        e.preventDefault()
+        setValue({
+          users: [
+            {
+              id: 1,
+              name: 'John Doe',
+              email: 'john.doe@example.com',
+              isActive: true,
+              roles: ['admin', 'editor'],
+            },
+            {
+              id: 2,
+              name: 'Jane Smith',
+              email: 'jane.smith@example.com',
+              isActive: false,
+              roles: ['viewer'],
+            },
+          ],
+        })
+      }}
+      style={{ marginTop: '5px', padding: '5px 10px' }}
+      type="button"
+    >
+      Set Users Data
+    </button>
+  )
+}

--- a/test/fields/collections/JSON/AfterField.tsx
+++ b/test/fields/collections/JSON/AfterField.tsx
@@ -7,6 +7,7 @@ export function AfterField() {
 
   return (
     <button
+      id="set-custom-json"
       onClick={(e) => {
         e.preventDefault()
         setValue({
@@ -31,7 +32,7 @@ export function AfterField() {
       style={{ marginTop: '5px', padding: '5px 10px' }}
       type="button"
     >
-      Set Users Data
+      Set Custom JSON
     </button>
   )
 }

--- a/test/fields/collections/JSON/e2e.spec.ts
+++ b/test/fields/collections/JSON/e2e.spec.ts
@@ -103,4 +103,24 @@ describe('JSON', () => {
       '"foo.with.periods": "bar"',
     )
   })
+
+  test('should update', async () => {
+    const createdDoc = await payload.create({
+      collection: 'json-fields',
+      data: {
+        customJSON: {
+          default: 'value',
+        },
+      },
+    })
+
+    await page.goto(url.edit(createdDoc.id))
+    const jsonField = page.locator('.json-field #field-customJSON')
+    await expect(jsonField).toContainText('"default": "value"')
+
+    const originalHeight = (await page.locator('#field-customJSON').boundingBox())?.height || 0
+    await page.locator('#set-custom-json').click()
+    const newHeight = (await page.locator('#field-customJSON').boundingBox())?.height || 0
+    expect(newHeight).toBeGreaterThan(originalHeight)
+  })
 })

--- a/test/fields/collections/JSON/index.tsx
+++ b/test/fields/collections/JSON/index.tsx
@@ -67,6 +67,15 @@ const JSON: CollectionConfig = {
         },
       ],
     },
+    {
+      name: 'customJSON',
+      type: 'json',
+      admin: {
+        components: {
+          afterInput: ['./collections/JSON/AfterField#AfterField'],
+        },
+      },
+    },
   ],
   versions: {
     maxPerDoc: 1,

--- a/test/fields/collections/JSON/index.tsx
+++ b/test/fields/collections/JSON/index.tsx
@@ -75,6 +75,7 @@ const JSON: CollectionConfig = {
           afterInput: ['./collections/JSON/AfterField#AfterField'],
         },
       },
+      label: 'Custom Json',
     },
   ],
   versions: {

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -1474,6 +1474,15 @@ export interface JsonField {
       | boolean
       | null;
   };
+  customJSON?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -3165,6 +3174,7 @@ export interface JsonFieldsSelect<T extends boolean = true> {
     | {
         jsonWithinGroup?: T;
       };
+  customJSON?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
### What?
Unable to update json fields externally. For example, calling `setValue` on a json field would not be reflected in the admin panel UI.

### Why?
JSON fields use the monaco editor to manage state internally, so programmatically updating the value in state does not change the internal value.

### How?
Set a ref when the user updates the value and then unset the ref after the change is complete. 

Inside the hook that watches `value`, if the value changed and the change came from the system (i.e. a programmatic change) refresh the editor by adjusting its key prop. If the change was made by the user, there is no need to refresh the editor.

Fixes https://github.com/payloadcms/payload/issues/10819
