### PR TITLE
refactor: simplify running field hooks

### DIFF
--- a/packages/payload/src/admin/RichText.ts
+++ b/packages/payload/src/admin/RichText.ts
@@ -88,7 +88,7 @@ export type BeforeChangeRichTextHookArgs<
 
   errors?: ValidationFieldError[]
   /** Only available in `beforeChange` field hooks */
-  mergeLocaleActions?: (() => Promise<void>)[]
+  mergeLocaleActions?: (() => Promise<void> | void)[]
   /** A string relating to which operation the field type is currently executing within. */
   operation?: 'create' | 'delete' | 'read' | 'update'
   /** The sibling data of the document before changes being applied. */

--- a/packages/payload/src/fields/hooks/afterChange/promise.ts
+++ b/packages/payload/src/fields/hooks/afterChange/promise.ts
@@ -75,10 +75,8 @@ export const promise = async ({
   if (fieldAffectsData(field)) {
     // Execute hooks
     if (field.hooks?.afterChange) {
-      await field.hooks.afterChange.reduce(async (priorHook, currentHook) => {
-        await priorHook
-
-        const hookedValue = await currentHook({
+      for (const hook of field.hooks.afterChange) {
+        const hookedValue = await hook({
           blockData,
           collection,
           context,
@@ -102,7 +100,7 @@ export const promise = async ({
         if (hookedValue !== undefined) {
           siblingDoc[field.name] = hookedValue
         }
-      }, Promise.resolve())
+      }
     }
   }
 
@@ -242,17 +240,15 @@ export const promise = async ({
         throw new MissingEditorProp(field) // while we allow disabling editor functionality, you should not have any richText fields defined if you do not have an editor
       }
 
-      if (typeof field?.editor === 'function') {
+      if (typeof field.editor === 'function') {
         throw new Error('Attempted to access unsanitized rich text editor.')
       }
 
-      const editor: RichTextAdapter = field?.editor
+      const editor: RichTextAdapter = field.editor
 
       if (editor?.hooks?.afterChange?.length) {
-        await editor.hooks.afterChange.reduce(async (priorHook, currentHook) => {
-          await priorHook
-
-          const hookedValue = await currentHook({
+        for (const hook of editor.hooks.afterChange) {
+          const hookedValue = await hook({
             collection,
             context,
             data,
@@ -275,7 +271,7 @@ export const promise = async ({
           if (hookedValue !== undefined) {
             siblingDoc[field.name] = hookedValue
           }
-        }, Promise.resolve())
+        }
       }
       break
     }

--- a/packages/payload/src/fields/hooks/beforeChange/index.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/index.ts
@@ -81,10 +81,9 @@ export const beforeChange = async <T extends JsonObject>({
     )
   }
 
-  await mergeLocaleActions.reduce(async (priorAction, action) => {
-    await priorAction
+  for (const action of mergeLocaleActions) {
     await action()
-  }, Promise.resolve())
+  }
 
   return data
 }

--- a/packages/payload/src/fields/hooks/beforeChange/traverseFields.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/traverseFields.ts
@@ -28,7 +28,7 @@ type Args = {
   fields: (Field | TabAsField)[]
   global: null | SanitizedGlobalConfig
   id?: number | string
-  mergeLocaleActions: (() => Promise<void>)[]
+  mergeLocaleActions: (() => Promise<void> | void)[]
   operation: Operation
   parentIndexPath: string
   /**

--- a/packages/payload/src/fields/hooks/beforeDuplicate/runHook.ts
+++ b/packages/payload/src/fields/hooks/beforeDuplicate/runHook.ts
@@ -1,8 +1,0 @@
-// @ts-strict-ignore
-import type { FieldHookArgs } from '../../config/types.js'
-
-export const runBeforeDuplicateHooks = async (args: FieldHookArgs) =>
-  await args.field.hooks.beforeDuplicate.reduce(async (priorHook, currentHook) => {
-    await priorHook
-    return await currentHook(args)
-  }, Promise.resolve())

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -276,10 +276,8 @@ export const promise = async <T>({
 
     // Execute hooks
     if (field.hooks?.beforeValidate) {
-      await field.hooks.beforeValidate.reduce(async (priorHook, currentHook) => {
-        await priorHook
-
-        const hookedValue = await currentHook({
+      for (const hook of field.hooks.beforeValidate) {
+        const hookedValue = await hook({
           blockData,
           collection,
           context,
@@ -303,7 +301,7 @@ export const promise = async <T>({
         if (hookedValue !== undefined) {
           siblingData[field.name] = hookedValue
         }
-      }, Promise.resolve())
+      }
     }
 
     // Execute access control
@@ -493,10 +491,8 @@ export const promise = async <T>({
       const editor: RichTextAdapter = field?.editor
 
       if (editor?.hooks?.beforeValidate?.length) {
-        await editor.hooks.beforeValidate.reduce(async (priorHook, currentHook) => {
-          await priorHook
-
-          const hookedValue = await currentHook({
+        for (const hook of editor.hooks.beforeValidate) {
+          const hookedValue = await hook({
             collection,
             context,
             data,
@@ -519,7 +515,7 @@ export const promise = async <T>({
           if (hookedValue !== undefined) {
             siblingData[field.name] = hookedValue
           }
-        }, Promise.resolve())
+        }
       }
       break
     }

--- a/packages/richtext-lexical/src/features/typesServer.ts
+++ b/packages/richtext-lexical/src/features/typesServer.ts
@@ -176,7 +176,7 @@ export type BeforeChangeNodeHookArgs<T extends SerializedLexicalNode> = {
    * Only available in `beforeChange` hooks.
    */
   errors: ValidationFieldError[]
-  mergeLocaleActions: (() => Promise<void>)[]
+  mergeLocaleActions: (() => Promise<void> | void)[]
   /** A string relating to which operation the field type is currently executing within. Useful within beforeValidate, beforeChange, and afterChange hooks to differentiate between create and update operations. */
   operation: 'create' | 'delete' | 'read' | 'update'
   /** The value of the node before any changes. Not available in afterRead hooks */


### PR DESCRIPTION
Previously, we were quite frequently using `.reduce()` to sequentially run field hooks. This PR replaces them with simple `for` loops, which is less overhead, less code, less confusing and simpler to understand.

Additionally, it refactors `mergeLocaleActions` which previously was unnecessarily complex. They no longer entail async code, thus we no longer have to juggle with promises