### PR TITLE
refactor: simplify collection, global and auth operations

### DIFF
--- a/packages/payload/src/auth/executeAuthStrategies.ts
+++ b/packages/payload/src/auth/executeAuthStrategies.ts
@@ -1,20 +1,19 @@
-// @ts-strict-ignore
 import type { AuthStrategyFunctionArgs, AuthStrategyResult } from './index.js'
-
 export const executeAuthStrategies = async (
   args: AuthStrategyFunctionArgs,
 ): Promise<AuthStrategyResult> => {
-  return args.payload.authStrategies.reduce(
-    async (accumulatorPromise, strategy) => {
-      const result: AuthStrategyResult = await accumulatorPromise
-      if (!result.user) {
-        // add the configured AuthStrategy `name` to the strategy function args
-        args.strategyName = strategy.name
+  if (!args.payload.authStrategies?.length) {
+    return { user: null }
+  }
 
-        return strategy.authenticate(args)
-      }
+  for (const strategy of args.payload.authStrategies) {
+    // add the configured AuthStrategy `name` to the strategy function args
+    args.strategyName = strategy.name
+
+    const result = await strategy.authenticate(args)
+    if (result.user) {
       return result
-    },
-    Promise.resolve({ user: null }),
-  )
+    }
+  }
+  return { user: null }
 }

--- a/packages/payload/src/auth/operations/forgotPassword.ts
+++ b/packages/payload/src/auth/operations/forgotPassword.ts
@@ -64,18 +64,18 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      args =
-        (await hook({
-          args,
-          collection: args.collection?.config,
-          context: args.req.context,
-          operation: 'forgotPassword',
-          req: args.req,
-        })) || args
-    }, Promise.resolve())
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
+        args =
+          (await hook({
+            args,
+            collection: args.collection?.config,
+            context: args.req.context,
+            operation: 'forgotPassword',
+            req: args.req,
+          })) || args
+      }
+    }
 
     const {
       collection: { config: collectionConfig },
@@ -190,10 +190,11 @@ export const forgotPasswordOperation = async <TSlug extends CollectionSlug>(
     // afterForgotPassword - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterForgotPassword.reduce(async (priorHook, hook) => {
-      await priorHook
-      await hook({ args, collection: args.collection?.config, context: req.context })
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterForgotPassword?.length) {
+      for (const hook of collectionConfig.hooks.afterForgotPassword) {
+        await hook({ args, collection: args.collection?.config, context: req.context })
+      }
+    }
 
     // /////////////////////////////////////
     // afterOperation - Collection

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -51,18 +51,18 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      args =
-        (await hook({
-          args,
-          collection: args.collection?.config,
-          context: args.req.context,
-          operation: 'login',
-          req: args.req,
-        })) || args
-    }, Promise.resolve())
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
+        args =
+          (await hook({
+            args,
+            collection: args.collection?.config,
+            context: args.req.context,
+            operation: 'login',
+            req: args.req,
+          })) || args
+      }
+    }
 
     const {
       collection: { config: collectionConfig },
@@ -227,17 +227,17 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     // beforeLogin - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.beforeLogin.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      user =
-        (await hook({
-          collection: args.collection?.config,
-          context: args.req.context,
-          req: args.req,
-          user,
-        })) || user
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.beforeLogin?.length) {
+      for (const hook of collectionConfig.hooks.beforeLogin) {
+        user =
+          (await hook({
+            collection: args.collection?.config,
+            context: args.req.context,
+            req: args.req,
+            user,
+          })) || user
+      }
+    }
 
     const { exp, token } = await jwtSign({
       fieldsToSign,
@@ -251,18 +251,18 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     // afterLogin - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterLogin.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      user =
-        (await hook({
-          collection: args.collection?.config,
-          context: args.req.context,
-          req: args.req,
-          token,
-          user,
-        })) || user
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterLogin?.length) {
+      for (const hook of collectionConfig.hooks.afterLogin) {
+        user =
+          (await hook({
+            collection: args.collection?.config,
+            context: args.req.context,
+            req: args.req,
+            token,
+            user,
+          })) || user
+      }
+    }
 
     // /////////////////////////////////////
     // afterRead - Fields
@@ -286,17 +286,17 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     // afterRead - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      user =
-        (await hook({
-          collection: args.collection?.config,
-          context: req.context,
-          doc: user,
-          req,
-        })) || user
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterRead?.length) {
+      for (const hook of collectionConfig.hooks.afterRead) {
+        user =
+          (await hook({
+            collection: args.collection?.config,
+            context: req.context,
+            doc: user,
+            req,
+          })) || user
+      }
+    }
 
     let result: { user: DataFromCollectionSlug<TSlug> } & Result = {
       exp,

--- a/packages/payload/src/auth/operations/logout.ts
+++ b/packages/payload/src/auth/operations/logout.ts
@@ -25,16 +25,16 @@ export const logoutOperation = async (incomingArgs: Arguments): Promise<boolean>
     throw new APIError('Incorrect collection', httpStatus.FORBIDDEN)
   }
 
-  await collectionConfig.hooks.afterLogout.reduce(async (priorHook, hook) => {
-    await priorHook
-
-    args =
-      (await hook({
-        collection: args.collection?.config,
-        context: req.context,
-        req,
-      })) || args
-  }, Promise.resolve())
+  if (collectionConfig.hooks?.afterLogout?.length) {
+    for (const hook of collectionConfig.hooks.afterLogout) {
+      args =
+        (await hook({
+          collection: args.collection?.config,
+          context: req.context,
+          req,
+        })) || args
+    }
+  }
 
   return true
 }

--- a/packages/payload/src/auth/operations/me.ts
+++ b/packages/payload/src/auth/operations/me.ts
@@ -86,17 +86,17 @@ export const meOperation = async (args: Arguments): Promise<MeOperationResult> =
   // After Me - Collection
   // /////////////////////////////////////
 
-  await collection.config.hooks.afterMe.reduce(async (priorHook, hook) => {
-    await priorHook
-
-    result =
-      (await hook({
-        collection: collection?.config,
-        context: req.context,
-        req,
-        response: result,
-      })) || result
-  }, Promise.resolve())
+  if (collection.config.hooks?.afterMe?.length) {
+    for (const hook of collection.config.hooks.afterMe) {
+      result =
+        (await hook({
+          collection: collection?.config,
+          context: req.context,
+          req,
+          response: result,
+        })) || result
+    }
+  }
 
   return result
 }

--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -35,10 +35,8 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(
-      async (priorHook: BeforeOperationHook | Promise<void>, hook: BeforeOperationHook) => {
-        await priorHook
-
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
         args =
           (await hook({
             args,
@@ -47,9 +45,8 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
             operation: 'refresh',
             req: args.req,
           })) || args
-      },
-      Promise.resolve(),
-    )
+      }
+    }
 
     // /////////////////////////////////////
     // Refresh
@@ -122,18 +119,18 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
     // After Refresh - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterRefresh.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          collection: args.collection?.config,
-          context: args.req.context,
-          exp: result.exp,
-          req: args.req,
-          token: result.refreshedToken,
-        })) || result
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterRefresh?.length) {
+      for (const hook of collectionConfig.hooks.afterRefresh) {
+        result =
+          (await hook({
+            collection: args.collection?.config,
+            context: args.req.context,
+            exp: result.exp,
+            req: args.req,
+            token: result.refreshedToken,
+          })) || result
+      }
+    }
 
     // /////////////////////////////////////
     // afterOperation - Collection

--- a/packages/payload/src/auth/operations/resetPassword.ts
+++ b/packages/payload/src/auth/operations/resetPassword.ts
@@ -91,17 +91,17 @@ export const resetPasswordOperation = async (args: Arguments): Promise<Result> =
     // beforeValidate - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.beforeValidate.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      await hook({
-        collection: args.collection?.config,
-        context: req.context,
-        data: user,
-        operation: 'update',
-        req,
-      })
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.beforeValidate?.length) {
+      for (const hook of collectionConfig.hooks.beforeValidate) {
+        await hook({
+          collection: args.collection?.config,
+          context: req.context,
+          data: user,
+          operation: 'update',
+          req,
+        })
+      }
+    }
 
     // /////////////////////////////////////
     // Update new password

--- a/packages/payload/src/collections/dataloader.ts
+++ b/packages/payload/src/collections/dataloader.ts
@@ -44,7 +44,9 @@ const batchAndLoadDocs =
     *
     **/
 
-    const batchByFindArgs = keys.reduce((batches, key) => {
+    const batchByFindArgs = {}
+
+    for (const key of keys) {
       const [
         transactionID,
         collection,
@@ -77,27 +79,16 @@ const batchAndLoadDocs =
       const batchKey = JSON.stringify(batchKeyArray)
 
       const idType = payload.collections?.[collection].customIDType || payload.db.defaultIDType
-
-      let sanitizedID: number | string = id
-
-      if (idType === 'number') {
-        sanitizedID = parseFloat(id)
-      }
+      const sanitizedID = idType === 'number' ? parseFloat(id) : id
 
       if (isValidID(sanitizedID, idType)) {
-        return {
-          ...batches,
-          [batchKey]: [...(batches[batchKey] || []), sanitizedID],
-        }
+        batchByFindArgs[batchKey] = [...(batchByFindArgs[batchKey] || []), sanitizedID]
       }
-      return batches
-    }, {})
+    }
 
     // Run find requests one after another, so as to not hang transactions
 
-    await Object.entries(batchByFindArgs).reduce(async (priorFind, [batchKey, ids]) => {
-      await priorFind
-
+    for (const [batchKey, ids] of Object.entries(batchByFindArgs)) {
       const [
         transactionID,
         collection,
@@ -137,8 +128,7 @@ const batchAndLoadDocs =
 
       // For each returned doc, find index in original keys
       // Inject doc within docs array if index exists
-
-      result.docs.forEach((doc) => {
+      for (const doc of result.docs) {
         const docKey = createDataloaderCacheKey({
           collectionSlug: collection,
           currentDepth,
@@ -158,8 +148,8 @@ const batchAndLoadDocs =
         if (docsIndex > -1) {
           docs[docsIndex] = doc
         }
-      })
-    }, Promise.resolve())
+      }
+    }
 
     // Return docs array,
     // which has now been injected with all fetched docs

--- a/packages/payload/src/collections/operations/count.ts
+++ b/packages/payload/src/collections/operations/count.ts
@@ -28,18 +28,18 @@ export const countOperation = async <TSlug extends CollectionSlug>(
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      args =
-        (await hook({
-          args,
-          collection: args.collection.config,
-          context: args.req.context,
-          operation: 'count',
-          req: args.req,
-        })) || args
-    }, Promise.resolve())
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
+        args =
+          (await hook({
+            args,
+            collection: args.collection.config,
+            context: args.req.context,
+            operation: 'count',
+            req: args.req,
+          })) || args
+      }
+    }
 
     const {
       collection: { config: collectionConfig },

--- a/packages/payload/src/collections/operations/countVersions.ts
+++ b/packages/payload/src/collections/operations/countVersions.ts
@@ -28,18 +28,18 @@ export const countVersionsOperation = async <TSlug extends CollectionSlug>(
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      args =
-        (await hook({
-          args,
-          collection: args.collection.config,
-          context: args.req.context,
-          operation: 'countVersions',
-          req: args.req,
-        })) || args
-    }, Promise.resolve())
+    if (args.collection.config.hooks.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
+        args =
+          (await hook({
+            args,
+            collection: args.collection.config,
+            context: args.req.context,
+            operation: 'countVersions',
+            req: args.req,
+          })) || args
+      }
+    }
 
     const {
       collection: { config: collectionConfig },

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -78,10 +78,8 @@ export const createOperation = async <
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(
-      async (priorHook: BeforeOperationHook | Promise<void>, hook: BeforeOperationHook) => {
-        await priorHook
-
+    if (args.collection.config.hooks.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
         args =
           (await hook({
             args,
@@ -90,9 +88,8 @@ export const createOperation = async <
             operation: 'create',
             req: args.req,
           })) || args
-      },
-      Promise.resolve(),
-    )
+      }
+    }
 
     const {
       autosave = false,
@@ -183,10 +180,8 @@ export const createOperation = async <
     // beforeValidate - Collections
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.beforeValidate.reduce(
-      async (priorHook: BeforeValidateHook | Promise<void>, hook: BeforeValidateHook) => {
-        await priorHook
-
+    if (collectionConfig.hooks.beforeValidate?.length) {
+      for (const hook of collectionConfig.hooks.beforeValidate) {
         data =
           (await hook({
             collection: collectionConfig,
@@ -196,27 +191,26 @@ export const createOperation = async <
             originalDoc: duplicatedFromDoc,
             req,
           })) || data
-      },
-      Promise.resolve(),
-    )
+      }
+    }
 
     // /////////////////////////////////////
     // beforeChange - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.beforeChange.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      data =
-        (await hook({
-          collection: collectionConfig,
-          context: req.context,
-          data,
-          operation: 'create',
-          originalDoc: duplicatedFromDoc,
-          req,
-        })) || data
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.beforeChange?.length) {
+      for (const hook of collectionConfig.hooks.beforeChange) {
+        data =
+          (await hook({
+            collection: collectionConfig,
+            context: req.context,
+            data,
+            operation: 'create',
+            originalDoc: duplicatedFromDoc,
+            req,
+          })) || data
+      }
+    }
 
     // /////////////////////////////////////
     // beforeChange - Fields
@@ -332,17 +326,17 @@ export const createOperation = async <
     // afterRead - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          collection: collectionConfig,
-          context: req.context,
-          doc: result,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterRead?.length) {
+      for (const hook of collectionConfig.hooks.afterRead) {
+        result =
+          (await hook({
+            collection: collectionConfig,
+            context: req.context,
+            doc: result,
+            req,
+          })) || result
+      }
+    }
 
     // /////////////////////////////////////
     // afterChange - Fields
@@ -363,10 +357,8 @@ export const createOperation = async <
     // afterChange - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterChange.reduce(
-      async (priorHook: AfterChangeHook | Promise<void>, hook: AfterChangeHook) => {
-        await priorHook
-
+    if (collectionConfig.hooks?.afterChange?.length) {
+      for (const hook of collectionConfig.hooks.afterChange) {
         result =
           (await hook({
             collection: collectionConfig,
@@ -376,9 +368,8 @@ export const createOperation = async <
             previousDoc: {},
             req: args.req,
           })) || result
-      },
-      Promise.resolve(),
-    )
+      }
+    }
 
     // /////////////////////////////////////
     // afterOperation - Collection

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -54,10 +54,8 @@ export const deleteOperation = async <
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(
-      async (priorHook: BeforeOperationHook | Promise<void>, hook: BeforeOperationHook) => {
-        await priorHook
-
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
         args =
           (await hook({
             args,
@@ -66,9 +64,8 @@ export const deleteOperation = async <
             operation: 'delete',
             req: args.req,
           })) || args
-      },
-      Promise.resolve(),
-    )
+      }
+    }
 
     const {
       collection: { config: collectionConfig },
@@ -147,16 +144,16 @@ export const deleteOperation = async <
         // beforeDelete - Collection
         // /////////////////////////////////////
 
-        await collectionConfig.hooks.beforeDelete.reduce(async (priorHook, hook) => {
-          await priorHook
-
-          return hook({
-            id,
-            collection: collectionConfig,
-            context: req.context,
-            req,
-          })
-        }, Promise.resolve())
+        if (collectionConfig.hooks?.beforeDelete?.length) {
+          for (const hook of collectionConfig.hooks.beforeDelete) {
+            await hook({
+              id,
+              collection: collectionConfig,
+              context: req.context,
+              req,
+            })
+          }
+        }
 
         await deleteAssociatedFiles({
           collectionConfig,
@@ -229,34 +226,34 @@ export const deleteOperation = async <
         // afterRead - Collection
         // /////////////////////////////////////
 
-        await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-          await priorHook
-
-          result =
-            (await hook({
-              collection: collectionConfig,
-              context: req.context,
-              doc: result || doc,
-              req,
-            })) || result
-        }, Promise.resolve())
+        if (collectionConfig.hooks?.afterRead?.length) {
+          for (const hook of collectionConfig.hooks.afterRead) {
+            result =
+              (await hook({
+                collection: collectionConfig,
+                context: req.context,
+                doc: result || doc,
+                req,
+              })) || result
+          }
+        }
 
         // /////////////////////////////////////
         // afterDelete - Collection
         // /////////////////////////////////////
 
-        await collectionConfig.hooks.afterDelete.reduce(async (priorHook, hook) => {
-          await priorHook
-
-          result =
-            (await hook({
-              id,
-              collection: collectionConfig,
-              context: req.context,
-              doc: result,
-              req,
-            })) || result
-        }, Promise.resolve())
+        if (collectionConfig.hooks?.afterDelete?.length) {
+          for (const hook of collectionConfig.hooks.afterDelete) {
+            result =
+              (await hook({
+                id,
+                collection: collectionConfig,
+                context: req.context,
+                doc: result,
+                req,
+              })) || result
+          }
+        }
 
         // /////////////////////////////////////
         // 8. Return results

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -48,10 +48,8 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(
-      async (priorHook: BeforeOperationHook | Promise<void>, hook: BeforeOperationHook) => {
-        await priorHook
-
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
         args =
           (await hook({
             args,
@@ -60,9 +58,8 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
             operation: 'delete',
             req: args.req,
           })) || args
-      },
-      Promise.resolve(),
-    )
+      }
+    }
 
     const {
       id,
@@ -95,16 +92,16 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
     // beforeDelete - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.beforeDelete.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      return hook({
-        id,
-        collection: collectionConfig,
-        context: req.context,
-        req,
-      })
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.beforeDelete?.length) {
+      for (const hook of collectionConfig.hooks.beforeDelete) {
+        await hook({
+          id,
+          collection: collectionConfig,
+          context: req.context,
+          req,
+        })
+      }
+    }
 
     // /////////////////////////////////////
     // Retrieve document
@@ -215,34 +212,34 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
     // afterRead - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          collection: collectionConfig,
-          context: req.context,
-          doc: result,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterRead?.length) {
+      for (const hook of collectionConfig.hooks.afterRead) {
+        result =
+          (await hook({
+            collection: collectionConfig,
+            context: req.context,
+            doc: result,
+            req,
+          })) || result
+      }
+    }
 
     // /////////////////////////////////////
     // afterDelete - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterDelete.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          id,
-          collection: collectionConfig,
-          context: req.context,
-          doc: result,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterDelete?.length) {
+      for (const hook of collectionConfig.hooks.afterDelete) {
+        result =
+          (await hook({
+            id,
+            collection: collectionConfig,
+            context: req.context,
+            doc: result,
+            req,
+          })) || result
+      }
+    }
 
     // /////////////////////////////////////
     // afterOperation - Collection

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -63,18 +63,18 @@ export const findOperation = async <
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      args =
-        (await hook({
-          args,
-          collection: args.collection.config,
-          context: args.req.context,
-          operation: 'read',
-          req: args.req,
-        })) || args
-    }, Promise.resolve())
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
+        args =
+          (await hook({
+            args,
+            collection: args.collection.config,
+            context: args.req.context,
+            operation: 'read',
+            req: args.req,
+          })) || args
+      }
+    }
 
     const {
       collection: { config: collectionConfig },
@@ -257,9 +257,7 @@ export const findOperation = async <
         result.docs.map(async (doc) => {
           let docRef = doc
 
-          await collectionConfig.hooks.beforeRead.reduce(async (priorHook, hook) => {
-            await priorHook
-
+          for (const hook of collectionConfig.hooks.beforeRead) {
             docRef =
               (await hook({
                 collection: collectionConfig,
@@ -268,7 +266,7 @@ export const findOperation = async <
                 query: fullWhere,
                 req,
               })) || docRef
-          }, Promise.resolve())
+          }
 
           return docRef
         }),
@@ -310,9 +308,7 @@ export const findOperation = async <
         result.docs.map(async (doc) => {
           let docRef = doc
 
-          await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-            await priorHook
-
+          for (const hook of collectionConfig.hooks.afterRead) {
             docRef =
               (await hook({
                 collection: collectionConfig,
@@ -322,7 +318,7 @@ export const findOperation = async <
                 query: fullWhere,
                 req,
               })) || doc
-          }, Promise.resolve())
+          }
 
           return docRef
         }),

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -54,18 +54,18 @@ export const findByIDOperation = async <
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      args =
-        (await hook({
-          args,
-          collection: args.collection.config,
-          context: args.req.context,
-          operation: 'read',
-          req: args.req,
-        })) || args
-    }, Promise.resolve())
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
+        args =
+          (await hook({
+            args,
+            collection: args.collection.config,
+            context: args.req.context,
+            operation: 'read',
+            req: args.req,
+          })) || args
+      }
+    }
 
     const {
       id,
@@ -221,18 +221,18 @@ export const findByIDOperation = async <
     // beforeRead - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.beforeRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          collection: collectionConfig,
-          context: req.context,
-          doc: result,
-          query: findOneArgs.where,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.beforeRead?.length) {
+      for (const hook of collectionConfig.hooks.beforeRead) {
+        result =
+          (await hook({
+            collection: collectionConfig,
+            context: req.context,
+            doc: result,
+            query: findOneArgs.where,
+            req,
+          })) || result
+      }
+    }
 
     // /////////////////////////////////////
     // afterRead - Fields
@@ -259,18 +259,18 @@ export const findByIDOperation = async <
     // afterRead - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          collection: collectionConfig,
-          context: req.context,
-          doc: result,
-          query: findOneArgs.where,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterRead?.length) {
+      for (const hook of collectionConfig.hooks.afterRead) {
+        result =
+          (await hook({
+            collection: collectionConfig,
+            context: req.context,
+            doc: result,
+            query: findOneArgs.where,
+            req,
+          })) || result
+      }
+    }
 
     // /////////////////////////////////////
     // afterOperation - Collection

--- a/packages/payload/src/collections/operations/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/findVersionByID.ts
@@ -101,18 +101,18 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
     // beforeRead - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.beforeRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result.version =
-        (await hook({
-          collection: collectionConfig,
-          context: req.context,
-          doc: result.version,
-          query: fullWhere,
-          req,
-        })) || result.version
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.beforeRead?.length) {
+      for (const hook of collectionConfig.hooks.beforeRead) {
+        result.version =
+          (await hook({
+            collection: collectionConfig,
+            context: req.context,
+            doc: result.version,
+            query: fullWhere,
+            req,
+          })) || result.version
+      }
+    }
 
     // /////////////////////////////////////
     // afterRead - Fields
@@ -139,18 +139,18 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
     // afterRead - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result.version =
-        (await hook({
-          collection: collectionConfig,
-          context: req.context,
-          doc: result.version,
-          query: fullWhere,
-          req,
-        })) || result.version
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterRead?.length) {
+      for (const hook of collectionConfig.hooks.afterRead) {
+        result.version =
+          (await hook({
+            collection: collectionConfig,
+            context: req.context,
+            doc: result.version,
+            query: fullWhere,
+            req,
+          })) || result.version
+      }
+    }
 
     // /////////////////////////////////////
     // Return results

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -96,18 +96,19 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
         if (!docRef.version) {
           ;(docRef as any).version = {}
         }
-        await collectionConfig.hooks.beforeRead.reduce(async (priorHook, hook) => {
-          await priorHook
 
-          docRef.version =
-            (await hook({
-              collection: collectionConfig,
-              context: req.context,
-              doc: docRef.version,
-              query: fullWhere,
-              req,
-            })) || docRef.version
-        }, Promise.resolve())
+        if (collectionConfig.hooks?.beforeRead?.length) {
+          for (const hook of collectionConfig.hooks.beforeRead) {
+            docRef.version =
+              (await hook({
+                collection: collectionConfig,
+                context: req.context,
+                doc: docRef.version,
+                query: fullWhere,
+                req,
+              })) || docRef.version
+          }
+        }
 
         return docRef
       }),
@@ -147,9 +148,7 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
         result.docs.map(async (doc) => {
           const docRef = doc
 
-          await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-            await priorHook
-
+          for (const hook of collectionConfig.hooks.afterRead) {
             docRef.version =
               (await hook({
                 collection: collectionConfig,
@@ -159,7 +158,7 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
                 query: fullWhere,
                 req,
               })) || doc.version
-          }, Promise.resolve())
+          }
 
           return docRef
         }),

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -165,17 +165,17 @@ export const restoreVersionOperation = async <TData extends TypeWithID = any>(
     // afterRead - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          collection: collectionConfig,
-          context: req.context,
-          doc: result,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterRead?.length) {
+      for (const hook of collectionConfig.hooks.afterRead) {
+        result =
+          (await hook({
+            collection: collectionConfig,
+            context: req.context,
+            doc: result,
+            req,
+          })) || result
+      }
+    }
 
     // /////////////////////////////////////
     // afterChange - Fields
@@ -196,19 +196,19 @@ export const restoreVersionOperation = async <TData extends TypeWithID = any>(
     // afterChange - Collection
     // /////////////////////////////////////
 
-    await collectionConfig.hooks.afterChange.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          collection: collectionConfig,
-          context: req.context,
-          doc: result,
-          operation: 'update',
-          previousDoc: prevDocWithLocales,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (collectionConfig.hooks?.afterChange?.length) {
+      for (const hook of collectionConfig.hooks.afterChange) {
+        result =
+          (await hook({
+            collection: collectionConfig,
+            context: req.context,
+            doc: result,
+            operation: 'update',
+            previousDoc: prevDocWithLocales,
+            req,
+          })) || result
+      }
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -62,18 +62,18 @@ export const updateOperation = async <
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      args =
-        (await hook({
-          args,
-          collection: args.collection.config,
-          context: args.req.context,
-          operation: 'update',
-          req: args.req,
-        })) || args
-    }, Promise.resolve())
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
+        args =
+          (await hook({
+            args,
+            collection: args.collection.config,
+            context: args.req.context,
+            operation: 'update',
+            req: args.req,
+          })) || args
+      }
+    }
 
     const {
       collection: { config: collectionConfig },

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -64,18 +64,18 @@ export const updateByIDOperation = async <
     // beforeOperation - Collection
     // /////////////////////////////////////
 
-    await args.collection.config.hooks.beforeOperation.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      args =
-        (await hook({
-          args,
-          collection: args.collection.config,
-          context: args.req.context,
-          operation: 'update',
-          req: args.req,
-        })) || args
-    }, Promise.resolve())
+    if (args.collection.config.hooks?.beforeOperation?.length) {
+      for (const hook of args.collection.config.hooks.beforeOperation) {
+        args =
+          (await hook({
+            args,
+            collection: args.collection.config,
+            context: args.req.context,
+            operation: 'update',
+            req: args.req,
+          })) || args
+      }
+    }
 
     if (args.publishSpecificLocale) {
       args.req.locale = args.publishSpecificLocale

--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -171,19 +171,19 @@ export const updateDocument = async <
   // beforeValidate - Collection
   // /////////////////////////////////////
 
-  await collectionConfig.hooks.beforeValidate.reduce(async (priorHook, hook) => {
-    await priorHook
-
-    data =
-      (await hook({
-        collection: collectionConfig,
-        context: req.context,
-        data,
-        operation: 'update',
-        originalDoc,
-        req,
-      })) || data
-  }, Promise.resolve())
+  if (collectionConfig.hooks?.beforeValidate?.length) {
+    for (const hook of collectionConfig.hooks.beforeValidate) {
+      data =
+        (await hook({
+          collection: collectionConfig,
+          context: req.context,
+          data,
+          operation: 'update',
+          originalDoc,
+          req,
+        })) || data
+    }
+  }
 
   // /////////////////////////////////////
   // Write files to local storage
@@ -197,19 +197,19 @@ export const updateDocument = async <
   // beforeChange - Collection
   // /////////////////////////////////////
 
-  await collectionConfig.hooks.beforeChange.reduce(async (priorHook, hook) => {
-    await priorHook
-
-    data =
-      (await hook({
-        collection: collectionConfig,
-        context: req.context,
-        data,
-        operation: 'update',
-        originalDoc,
-        req,
-      })) || data
-  }, Promise.resolve())
+  if (collectionConfig.hooks?.beforeChange?.length) {
+    for (const hook of collectionConfig.hooks.beforeChange) {
+      data =
+        (await hook({
+          collection: collectionConfig,
+          context: req.context,
+          data,
+          operation: 'update',
+          originalDoc,
+          req,
+        })) || data
+    }
+  }
 
   // /////////////////////////////////////
   // beforeChange - Fields
@@ -338,17 +338,17 @@ export const updateDocument = async <
   // afterRead - Collection
   // /////////////////////////////////////
 
-  await collectionConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-    await priorHook
-
-    result =
-      (await hook({
-        collection: collectionConfig,
-        context: req.context,
-        doc: result,
-        req,
-      })) || result
-  }, Promise.resolve())
+  if (collectionConfig.hooks?.afterRead?.length) {
+    for (const hook of collectionConfig.hooks.afterRead) {
+      result =
+        (await hook({
+          collection: collectionConfig,
+          context: req.context,
+          doc: result,
+          req,
+        })) || result
+    }
+  }
 
   // /////////////////////////////////////
   // afterChange - Fields
@@ -369,19 +369,19 @@ export const updateDocument = async <
   // afterChange - Collection
   // /////////////////////////////////////
 
-  await collectionConfig.hooks.afterChange.reduce(async (priorHook, hook) => {
-    await priorHook
-
-    result =
-      (await hook({
-        collection: collectionConfig,
-        context: req.context,
-        doc: result,
-        operation: 'update',
-        previousDoc: originalDoc,
-        req,
-      })) || result
-  }, Promise.resolve())
+  if (collectionConfig.hooks?.afterChange?.length) {
+    for (const hook of collectionConfig.hooks.afterChange) {
+      result =
+        (await hook({
+          collection: collectionConfig,
+          context: req.context,
+          doc: result,
+          operation: 'update',
+          previousDoc: originalDoc,
+          req,
+        })) || result
+    }
+  }
 
   return result as TransformCollectionWithSelect<TSlug, TSelect>
 }

--- a/packages/payload/src/collections/operations/utils.ts
+++ b/packages/payload/src/collections/operations/utils.ts
@@ -125,10 +125,8 @@ export const buildAfterOperation = async <
 
   let newResult = result as OperationResult<TOperationGeneric, O>
 
-  await args.collection.config.hooks.afterOperation.reduce(
-    async (priorHook, hook: AfterOperationHook<TOperationGeneric>) => {
-      await priorHook
-
+  if (args.collection.config.hooks?.afterOperation?.length) {
+    for (const hook of args.collection.config.hooks.afterOperation) {
       const hookResult = await hook({
         args,
         collection,
@@ -140,9 +138,8 @@ export const buildAfterOperation = async <
       if (hookResult !== undefined) {
         newResult = hookResult as OperationResult<TOperationGeneric, O>
       }
-    },
-    Promise.resolve(),
-  )
+    }
+  }
 
   return newResult
 }

--- a/packages/payload/src/config/build.ts
+++ b/packages/payload/src/config/build.ts
@@ -9,11 +9,10 @@ import { sanitizeConfig } from './sanitize.js'
  */
 export async function buildConfig(config: Config): Promise<SanitizedConfig> {
   if (Array.isArray(config.plugins)) {
-    const configAfterPlugins = await config.plugins.reduce(async (acc, plugin) => {
-      const configAfterPlugin = await acc
-      return plugin(configAfterPlugin)
-    }, Promise.resolve(config))
-
+    let configAfterPlugins = config
+    for (const plugin of config.plugins) {
+      configAfterPlugins = await plugin(configAfterPlugins)
+    }
     return await sanitizeConfig(configAfterPlugins)
   }
 

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -179,10 +179,7 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
       }))
     } else {
       // is Locale[], so convert to string[] for localeCodes
-      config.localization.localeCodes = config.localization.locales.reduce((locales, locale) => {
-        locales.push(locale.code)
-        return locales
-      }, [] as string[])
+      config.localization.localeCodes = config.localization.locales.map((locale) => locale.code)
 
       config.localization.locales = (
         config.localization as LocalizationConfigWithLabels

--- a/packages/payload/src/globals/operations/findOne.ts
+++ b/packages/payload/src/globals/operations/findOne.ts
@@ -133,17 +133,17 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
     // Execute before global hook
     // /////////////////////////////////////
 
-    await globalConfig.hooks.beforeRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      doc =
-        (await hook({
-          context: req.context,
-          doc,
-          global: globalConfig,
-          req,
-        })) || doc
-    }, Promise.resolve())
+    if (globalConfig.hooks?.beforeRead?.length) {
+      for (const hook of globalConfig.hooks.beforeRead) {
+        doc =
+          (await hook({
+            context: req.context,
+            doc,
+            global: globalConfig,
+            req,
+          })) || doc
+      }
+    }
 
     // /////////////////////////////////////
     // Execute globalType field if not selected
@@ -182,17 +182,17 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
     // Execute after global hook
     // /////////////////////////////////////
 
-    await globalConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      doc =
-        (await hook({
-          context: req.context,
-          doc,
-          global: globalConfig,
-          req,
-        })) || doc
-    }, Promise.resolve())
+    if (globalConfig.hooks?.afterRead?.length) {
+      for (const hook of globalConfig.hooks.afterRead) {
+        doc =
+          (await hook({
+            context: req.context,
+            doc,
+            global: globalConfig,
+            req,
+          })) || doc
+      }
+    }
 
     // /////////////////////////////////////
     // Return results

--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -102,17 +102,17 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
     // beforeRead - Collection
     // /////////////////////////////////////
 
-    await globalConfig.hooks.beforeRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          context: req.context,
-          doc: result.version,
-          global: globalConfig,
-          req,
-        })) || result.version
-    }, Promise.resolve())
+    if (globalConfig.hooks?.beforeRead?.length) {
+      for (const hook of globalConfig.hooks.beforeRead) {
+        result =
+          (await hook({
+            context: req.context,
+            doc: result.version,
+            global: globalConfig,
+            req,
+          })) || result.version
+      }
+    }
 
     // /////////////////////////////////////
     // afterRead - Fields
@@ -139,18 +139,18 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
     // afterRead - Global
     // /////////////////////////////////////
 
-    await globalConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result.version =
-        (await hook({
-          context: req.context,
-          doc: result.version,
-          global: globalConfig,
-          query: findGlobalVersionsArgs.where,
-          req,
-        })) || result.version
-    }, Promise.resolve())
+    if (globalConfig.hooks?.afterRead?.length) {
+      for (const hook of globalConfig.hooks.afterRead) {
+        result.version =
+          (await hook({
+            context: req.context,
+            doc: result.version,
+            global: globalConfig,
+            query: findGlobalVersionsArgs.where,
+            req,
+          })) || result.version
+      }
+    }
 
     return result
   } catch (error: unknown) {

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -126,15 +126,12 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
     // afterRead - Global
     // /////////////////////////////////////
 
-    result = {
-      ...result,
-      docs: await Promise.all(
+    if (globalConfig.hooks?.afterRead?.length) {
+      result.docs = await Promise.all(
         result.docs.map(async (doc) => {
           const docRef = doc
 
-          await globalConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-            await priorHook
-
+          for (const hook of globalConfig.hooks.afterRead) {
             docRef.version =
               (await hook({
                 context: req.context,
@@ -144,11 +141,11 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
                 query: fullWhere,
                 req,
               })) || doc.version
-          }, Promise.resolve())
+          }
 
           return docRef
         }),
-      ),
+      )
     }
 
     // /////////////////////////////////////

--- a/packages/payload/src/globals/operations/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/restoreVersion.ts
@@ -143,17 +143,17 @@ export const restoreVersionOperation = async <T extends TypeWithVersion<T> = any
     // afterRead - Global
     // /////////////////////////////////////
 
-    await globalConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          context: req.context,
-          doc: result,
-          global: globalConfig,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (globalConfig.hooks?.afterRead?.length) {
+      for (const hook of globalConfig.hooks.afterRead) {
+        result =
+          (await hook({
+            context: req.context,
+            doc: result,
+            global: globalConfig,
+            req,
+          })) || result
+      }
+    }
 
     // /////////////////////////////////////
     // afterChange - Fields
@@ -174,18 +174,18 @@ export const restoreVersionOperation = async <T extends TypeWithVersion<T> = any
     // afterChange - Global
     // /////////////////////////////////////
 
-    await globalConfig.hooks.afterChange.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          context: req.context,
-          doc: result,
-          global: globalConfig,
-          previousDoc,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (globalConfig.hooks?.afterChange?.length) {
+      for (const hook of globalConfig.hooks.afterChange) {
+        result =
+          (await hook({
+            context: req.context,
+            doc: result,
+            global: globalConfig,
+            previousDoc,
+            req,
+          })) || result
+      }
+    }
 
     if (shouldCommit) {
       await commitTransaction(req)

--- a/packages/payload/src/globals/operations/update.ts
+++ b/packages/payload/src/globals/operations/update.ts
@@ -168,35 +168,35 @@ export const updateOperation = async <
     // beforeValidate - Global
     // /////////////////////////////////////
 
-    await globalConfig.hooks.beforeValidate.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      data =
-        (await hook({
-          context: req.context,
-          data,
-          global: globalConfig,
-          originalDoc,
-          req,
-        })) || data
-    }, Promise.resolve())
+    if (globalConfig.hooks?.beforeValidate?.length) {
+      for (const hook of globalConfig.hooks.beforeValidate) {
+        data =
+          (await hook({
+            context: req.context,
+            data,
+            global: globalConfig,
+            originalDoc,
+            req,
+          })) || data
+      }
+    }
 
     // /////////////////////////////////////
     // beforeChange - Global
     // /////////////////////////////////////
 
-    await globalConfig.hooks.beforeChange.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      data =
-        (await hook({
-          context: req.context,
-          data,
-          global: globalConfig,
-          originalDoc,
-          req,
-        })) || data
-    }, Promise.resolve())
+    if (globalConfig.hooks?.beforeChange?.length) {
+      for (const hook of globalConfig.hooks.beforeChange) {
+        data =
+          (await hook({
+            context: req.context,
+            data,
+            global: globalConfig,
+            originalDoc,
+            req,
+          })) || data
+      }
+    }
 
     // /////////////////////////////////////
     // beforeChange - Fields
@@ -326,17 +326,17 @@ export const updateOperation = async <
     // afterRead - Global
     // /////////////////////////////////////
 
-    await globalConfig.hooks.afterRead.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          context: req.context,
-          doc: result,
-          global: globalConfig,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (globalConfig.hooks?.afterRead?.length) {
+      for (const hook of globalConfig.hooks.afterRead) {
+        result =
+          (await hook({
+            context: req.context,
+            doc: result,
+            global: globalConfig,
+            req,
+          })) || result
+      }
+    }
 
     // /////////////////////////////////////
     // afterChange - Fields
@@ -357,18 +357,18 @@ export const updateOperation = async <
     // afterChange - Global
     // /////////////////////////////////////
 
-    await globalConfig.hooks.afterChange.reduce(async (priorHook, hook) => {
-      await priorHook
-
-      result =
-        (await hook({
-          context: req.context,
-          doc: result,
-          global: globalConfig,
-          previousDoc: originalDoc,
-          req,
-        })) || result
-    }, Promise.resolve())
+    if (globalConfig.hooks?.afterChange?.length) {
+      for (const hook of globalConfig.hooks.afterChange) {
+        result =
+          (await hook({
+            context: req.context,
+            doc: result,
+            global: globalConfig,
+            previousDoc: originalDoc,
+            req,
+          })) || result
+      }
+    }
 
     // /////////////////////////////////////
     // Return results


### PR DESCRIPTION
Continuation of https://github.com/payloadcms/payload/pull/11372 but for our collection, global and auth operations

Previously, we were quite frequently using `.reduce()` to run hooks. This PR replaces them with simple `for` loops, which is less overhead, less code, less confusing and simpler to understand.