### PR TITLE
fix: ensure generated types for config.blocks are not undefined if no blocks defined

### DIFF
--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -1156,14 +1156,13 @@ export function configToJSONSchema(
       )
     : {}
 
-  let blocksDefinition: JSONSchema4 | undefined = undefined
+  const blocksDefinition: JSONSchema4 | undefined = {
+    type: 'object',
+    additionalProperties: false,
+    properties: {},
+    required: [],
+  }
   if (config?.blocks?.length) {
-    blocksDefinition = {
-      type: 'object',
-      additionalProperties: false,
-      properties: {},
-      required: [],
-    }
     for (const block of config.blocks) {
       const blockFieldSchemas = fieldsToJSONSchema(
         collectionIDFieldTypes,


### PR DESCRIPTION
Previously, if no `config.blocks` were defined, `blocks: undefined` would incorrectly be added to the generated types.