### PR TITLE
fix(db-mongodb): `hasNextPage` with polymorphic joins

### DIFF
--- a/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
+++ b/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
@@ -195,17 +195,17 @@ export const buildJoinAggregation = async ({
     const sliceValue = page ? [(page - 1) * limitJoin, limitJoin] : [limitJoin]
 
     aggregate.push({
-      $set: {
-        [`${as}.docs`]: {
-          $slice: [`$${as}.docs`, ...sliceValue],
+      $addFields: {
+        [`${as}.hasNextPage`]: {
+          $gt: [{ $size: `$${as}.docs` }, limitJoin || Number.MAX_VALUE],
         },
       },
     })
 
     aggregate.push({
-      $addFields: {
-        [`${as}.hasNextPage`]: {
-          $gt: [{ $size: `$${as}.docs` }, limitJoin || Number.MAX_VALUE],
+      $set: {
+        [`${as}.docs`]: {
+          $slice: [`$${as}.docs`, ...sliceValue],
         },
       },
     })

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -1205,6 +1205,22 @@ describe('Joins Field', () => {
       expect(parent.children.docs[1]?.value.id).toBe(child_1.id)
       expect(parent.children.docs[1]?.relationTo).toBe('multiple-collections-1')
 
+      // Pagination across collections
+      parent = await payload.findByID({
+        collection: 'multiple-collections-parents',
+        id: parent.id,
+        depth: 1,
+        joins: {
+          children: {
+            limit: 1,
+            sort: 'title',
+          },
+        },
+      })
+
+      expect(parent.children.docs).toHaveLength(1)
+      expect(parent.children?.hasNextPage).toBe(true)
+
       // Sorting across collections
       parent = await payload.findByID({
         collection: 'multiple-collections-parents',

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -1221,6 +1221,21 @@ describe('Joins Field', () => {
       expect(parent.children.docs).toHaveLength(1)
       expect(parent.children?.hasNextPage).toBe(true)
 
+      parent = await payload.findByID({
+        collection: 'multiple-collections-parents',
+        id: parent.id,
+        depth: 1,
+        joins: {
+          children: {
+            limit: 2,
+            sort: 'title',
+          },
+        },
+      })
+
+      expect(parent.children.docs).toHaveLength(2)
+      expect(parent.children?.hasNextPage).toBe(false)
+
       // Sorting across collections
       parent = await payload.findByID({
         collection: 'multiple-collections-parents',


### PR DESCRIPTION
Previously, `hasNextPage` was working incorrectly with polymorphic joins (that have an array of `collection`) in MongoDB. 

This PR fixes it and adds extra assertions to the polymorphic joins test.