### PR TITLE
fix: ensure custom IDs are returned to the result when `select` query exists

### DIFF
--- a/packages/payload/src/fields/hooks/afterRead/promise.ts
+++ b/packages/payload/src/fields/hooks/afterRead/promise.ts
@@ -123,7 +123,7 @@ export const promise = async ({
   }
 
   // Strip unselected fields
-  if (fieldAffectsData(field) && select && selectMode) {
+  if (fieldAffectsData(field) && select && selectMode && path !== 'id') {
     if (selectMode === 'include') {
       if (!select[field.name]) {
         delete siblingDoc[field.name]

--- a/test/select/collections/CustomID/index.ts
+++ b/test/select/collections/CustomID/index.ts
@@ -1,0 +1,15 @@
+import type { CollectionConfig } from 'payload'
+
+export const CustomID: CollectionConfig = {
+  slug: 'custom-ids',
+  fields: [
+    {
+      name: 'id',
+      type: 'number',
+    },
+    {
+      name: 'text',
+      type: 'text',
+    },
+  ],
+}

--- a/test/select/config.ts
+++ b/test/select/config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
+import { CustomID } from './collections/CustomID/index.js'
 import { DeepPostsCollection } from './collections/DeepPosts/index.js'
 import { LocalizedPostsCollection } from './collections/LocalizedPosts/index.js'
 import { Pages } from './collections/Pages/index.js'
@@ -34,6 +35,7 @@ export default buildConfigWithDefaults({
       slug: 'rels',
       fields: [],
     },
+    CustomID,
   ],
   globals: [
     {

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import path from 'path'
 import { deepCopyObject, type Payload } from 'payload'
 import { assert } from 'ts-essentials'
@@ -75,6 +76,21 @@ describe('Select', () => {
         })
       })
 
+      it('customID - should select only id as default', async () => {
+        const { id } = await createCustomID()
+
+        const res = await payload.findByID({
+          collection: 'custom-ids',
+          id,
+          select: {},
+          depth: 0,
+        })
+
+        expect(res).toStrictEqual({
+          id,
+        })
+      })
+
       it('should select only number', async () => {
         const res = await payload.findByID({
           collection: 'posts',
@@ -88,6 +104,24 @@ describe('Select', () => {
         expect(res).toStrictEqual({
           id: postId,
           number: post.number,
+        })
+      })
+
+      it('customID - should select only text', async () => {
+        const { id, text } = await createCustomID()
+
+        const res = await payload.findByID({
+          collection: 'custom-ids',
+          id,
+          select: {
+            text: true,
+          },
+          depth: 0,
+        })
+
+        expect(res).toStrictEqual({
+          id,
+          text,
         })
       })
 
@@ -444,6 +478,25 @@ describe('Select', () => {
         delete expected['text']
 
         expect(res).toStrictEqual(expected)
+      })
+
+      it('customID - should exclude text', async () => {
+        const { id, createdAt, updatedAt } = await createCustomID()
+
+        const res = await payload.findByID({
+          collection: 'custom-ids',
+          id,
+          select: {
+            text: false,
+          },
+          depth: 0,
+        })
+
+        expect(res).toStrictEqual({
+          id,
+          createdAt,
+          updatedAt,
+        })
       })
 
       it('should exclude number', async () => {
@@ -2427,4 +2480,10 @@ function createVersionedPost() {
 
 function createPoint() {
   return payload.create({ collection: 'points', data: { text: 'some', point: [10, 20] } })
+}
+
+let id = 1
+
+function createCustomID() {
+  return payload.create({ collection: 'custom-ids', data: { id: id++, text: randomUUID() } })
 }

--- a/test/select/payload-types.ts
+++ b/test/select/payload-types.ts
@@ -74,6 +74,7 @@ export interface Config {
     points: Point;
     upload: Upload;
     rels: Rel;
+    'custom-ids': CustomId;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -89,6 +90,7 @@ export interface Config {
     points: PointsSelect<false> | PointsSelect<true>;
     upload: UploadSelect<false> | UploadSelect<true>;
     rels: RelsSelect<false> | RelsSelect<true>;
+    'custom-ids': CustomIdsSelect<false> | CustomIdsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -445,6 +447,16 @@ export interface Point {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "custom-ids".
+ */
+export interface CustomId {
+  id: number;
+  text?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -498,6 +510,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'rels';
         value: string | Rel;
+      } | null)
+    | ({
+        relationTo: 'custom-ids';
+        value: number | CustomId;
       } | null)
     | ({
         relationTo: 'users';
@@ -841,6 +857,16 @@ export interface UploadSelect<T extends boolean = true> {
  * via the `definition` "rels_select".
  */
 export interface RelsSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "custom-ids_select".
+ */
+export interface CustomIdsSelect<T extends boolean = true> {
+  id?: T;
+  text?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
Previously, behavior with custom IDs and `select` query was incorrect. By default, the `id` field is guaranteed to be selected, even if it doesn't exist in the `select` query, this wasn't true for custom IDs.