### PR TITLE
fix(ui): copyToLocale should not pass id in data, throws error in postgres

### DIFF
--- a/packages/ui/src/utilities/copyDataFromLocale.ts
+++ b/packages/ui/src/utilities/copyDataFromLocale.ts
@@ -288,11 +288,13 @@ export const copyDataFromLocale = async (args: CopyDataFromLocaleArgs) => {
     throw new Error(`Error fetching data from locale "${toLocale}"`)
   }
 
+  const { id, ...fromLocaleDataWithoutID } = fromLocaleData.value
+
   return globalSlug
     ? await payload.updateGlobal({
         slug: globalSlug,
         data: overrideData
-          ? fromLocaleData.value
+          ? fromLocaleDataWithoutID
           : mergeData(
               fromLocaleData.value,
               toLocaleData.value,
@@ -309,7 +311,7 @@ export const copyDataFromLocale = async (args: CopyDataFromLocaleArgs) => {
         id: docID,
         collection: collectionSlug,
         data: overrideData
-          ? fromLocaleData.value
+          ? fromLocaleDataWithoutID
           : mergeData(
               fromLocaleData.value,
               toLocaleData.value,


### PR DESCRIPTION
### What?
Using the `Copy To Locale` function with Postgres throws an error related to the `id` field:

```ts
[15:15:41] ERROR: There was an error copying data from "en" to "de"
    err: {
      "type": "ValidationError",
      "message": "error:followingFieldsInvalid id",
      "stack":
          ValidationError: error:followingFieldsInvalid id
```

### Why?
In `packages/ui/src/utilities/copyDataFromLocale.ts` we are passing `fromLocaleData` to `updateByID` on Line 314. 

This data contains an `id` and causes an error to be thrown during the update process - only when using Postgres.

### How?
To resolve we needed to remove `id` from the `fromLocaleData` before updating the document. 

Closes #11309