### PR TITLE
fix: do not set updatedAt to default value when it is provided

### DIFF
--- a/packages/drizzle/src/transform/write/traverseFields.ts
+++ b/packages/drizzle/src/transform/write/traverseFields.ts
@@ -506,8 +506,8 @@ export const traverseFields = ({
       }
 
       if (field.type === 'date' && fieldName === 'updatedAt') {
-        // let the db handle this
-        formattedValue = new Date().toISOString()
+        // let the db handle this if not provided
+        formattedValue = value || new Date().toISOString()
       }
 
       if (typeof formattedValue !== 'undefined') {


### PR DESCRIPTION
### What?  
Allow `updatedAt` to be included in the create or update data payload, rather than always being overridden by `traverseFields.ts`.  

### Why?  
Currently, `updatedAt` is always set to `new Date().toISOString()` by `traverseFields.ts`, making it impossible to provide a custom value. While this is fine for most cases, it becomes problematic when performing a database migration to Payload. In such cases, it's important to retain the original `updatedAt` values from the source database instead of setting them to the migration date.  

### How?  
This PR modifies `traverseFields.ts` to allow `updatedAt` to be explicitly set when provided in the create or update payload. If no value is provided, it will still default to `new Date().toISOString()`, ensuring existing behavior remains unchanged unless explicitly overridden.  
