### PR TITLE
feat(richtext-lexical): allows client features to access components added to the import map by the server feature

### DIFF
--- a/packages/richtext-lexical/src/features/typesClient.ts
+++ b/packages/richtext-lexical/src/features/typesClient.ts
@@ -34,6 +34,7 @@ export type FeatureProviderClient<
   feature:
     | ((props: {
         config: ClientConfig
+        featureClientImportMap: Record<string, any>
         featureClientSchemaMap: FeatureClientSchemaMap
         /** unSanitizedEditorConfig.features, but mapped */
         featureProviderMap: ClientFeatureProviderMap

--- a/packages/richtext-lexical/src/features/typesServer.ts
+++ b/packages/richtext-lexical/src/features/typesServer.ts
@@ -280,8 +280,18 @@ export type ServerFeature<ServerProps, ClientFeatureProps> = {
    * This determines what props will be available on the Client.
    */
   clientFeatureProps?: ClientFeatureProps
-  // @ts-expect-error - TODO: fix this
-  componentImports?: Config['admin']['importMap']['generators'][0] | PayloadComponent[]
+  /**
+   * Adds payload components to the importMap.
+   *
+   * If an object is provided, the imported components will automatically be made available to the client feature, keyed by the object's keys.
+   */
+  componentImports?:
+    | {
+        [key: string]: PayloadComponent
+      }
+    // @ts-expect-error - TODO: fix this
+    | Config['admin']['importMap']['generators'][0]
+    | PayloadComponent[]
   generatedTypes?: {
     modifyOutputSchema: (args: {
       collectionIDFieldTypes: { [key: string]: 'number' | 'string' }

--- a/packages/richtext-lexical/src/field/index.tsx
+++ b/packages/richtext-lexical/src/field/index.tsx
@@ -21,6 +21,7 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
   const {
     admin = {},
     clientFeatures,
+    featureClientImportMap,
     featureClientSchemaMap,
     field,
     lexicalEditorConfig = defaultEditorLexicalConfig,
@@ -53,6 +54,7 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
 
     const resolvedClientFeatures = loadClientFeatures({
       config,
+      featureClientImportMap,
       featureClientSchemaMap,
       field: field as RichTextFieldClient,
       schemaPath: schemaPath ?? field.name,
@@ -70,6 +72,7 @@ export const RichTextField: React.FC<LexicalRichTextFieldProps> = (props) => {
     admin,
     finalSanitizedEditorConfig,
     clientFeatures,
+    featureClientImportMap,
     featureClientSchemaMap,
     field,
     config,

--- a/packages/richtext-lexical/src/field/rscEntry.tsx
+++ b/packages/richtext-lexical/src/field/rscEntry.tsx
@@ -39,7 +39,7 @@ export const RscEntryLexicalField: React.FC<
     throw new Error('Initialized lexical RSC field without a field name')
   }
 
-  const { clientFeatures, featureClientSchemaMap } = initLexicalFeatures({
+  const { clientFeatures, featureClientImportMap, featureClientSchemaMap } = initLexicalFeatures({
     clientFieldSchemaMap: args.clientFieldSchemaMap,
     fieldSchemaMap: args.fieldSchemaMap,
     i18n: args.i18n,
@@ -88,6 +88,7 @@ export const RscEntryLexicalField: React.FC<
 
   const props: LexicalRichTextFieldProps = {
     clientFeatures,
+    featureClientImportMap,
     featureClientSchemaMap, // TODO: Does client need this? Why cant this just live in the server
     field: args.clientField as RichTextFieldClient,
     forceRender: args.forceRender,

--- a/packages/richtext-lexical/src/lexical/config/client/loader.ts
+++ b/packages/richtext-lexical/src/lexical/config/client/loader.ts
@@ -16,12 +16,14 @@ import type { ClientEditorConfig } from '../types.js'
  */
 export function loadClientFeatures({
   config,
+  featureClientImportMap,
   featureClientSchemaMap,
   field,
   schemaPath,
   unSanitizedEditorConfig,
 }: {
   config: ClientConfig
+  featureClientImportMap: Record<string, any>
   featureClientSchemaMap: FeatureClientSchemaMap
   field?: RichTextFieldClient
   schemaPath: string
@@ -58,6 +60,7 @@ export function loadClientFeatures({
       typeof featureProvider.feature === 'function'
         ? featureProvider.feature({
             config,
+            featureClientImportMap,
             featureClientSchemaMap,
             featureProviderMap,
             field,

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -110,6 +110,7 @@ export type LexicalRichTextFieldProps = {
       clientFeatureProvider?: FeatureProviderProviderClient<any, any>
     }
   }
+  featureClientImportMap: Record<string, any>
   featureClientSchemaMap: FeatureClientSchemaMap
   initialLexicalFormState: InitialLexicalFormState
   lexicalEditorConfig: LexicalEditorConfig | undefined // Undefined if default lexical editor config should be used

--- a/packages/richtext-lexical/src/utilities/createClientFeature.ts
+++ b/packages/richtext-lexical/src/utilities/createClientFeature.ts
@@ -14,6 +14,7 @@ import type { FeatureClientSchemaMap } from '../types.js'
 export type CreateClientFeatureArgs<UnSanitizedClientProps, ClientProps> =
   | ((props: {
       config: ClientConfig
+      featureClientImportMap: Record<string, any>
       featureClientSchemaMap: FeatureClientSchemaMap
       /** unSanitizedEditorConfig.features, but mapped */
       featureProviderMap: ClientFeatureProviderMap
@@ -41,6 +42,7 @@ export const createClientFeature: <
     if (typeof feature === 'function') {
       featureProviderClient.feature = ({
         config,
+        featureClientImportMap,
         featureClientSchemaMap,
         featureProviderMap,
         field,
@@ -50,6 +52,7 @@ export const createClientFeature: <
       }) => {
         const toReturn = feature({
           config,
+          featureClientImportMap,
           featureClientSchemaMap,
           featureProviderMap,
           field,

--- a/packages/richtext-lexical/src/utilities/generateImportMap.tsx
+++ b/packages/richtext-lexical/src/utilities/generateImportMap.tsx
@@ -22,11 +22,17 @@ export const getGenerateImportMap =
             importMap,
             imports,
           })
-        } else if (resolvedFeature.componentImports?.length) {
-          // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
+        } else if (
+          Array.isArray(resolvedFeature.componentImports) &&
+          resolvedFeature.componentImports?.length
+        ) {
           resolvedFeature.componentImports.forEach((component) => {
             addToImportMap(component)
           })
+        } else if (typeof resolvedFeature.componentImports === 'object') {
+          for (const component of Object.values(resolvedFeature.componentImports)) {
+            addToImportMap(component)
+          }
         }
       }
 


### PR DESCRIPTION
Lexical server features are able to add components to the import map through the `componentImports` property. As of now, the client feature did not have access to those. This is usually not necessary, as those import map entries are used internally to render custom components server-side, e.g. when a request to the form state endpoint is made.

However, in some cases, these import map entries need to be accessed by the client feature (see "Why" section below).

This PR ensures that keyed `componentImports` entries are made available to the client feature via the new `featureClientImportMap` property.

## Why?

This is a prerequisite of the lexical [wrapper blocks PR](https://github.com/payloadcms/payload/pull/9289), where wrapper block custom components need to be made to the ClientFeature. The ClientFeature is where the wrapper block node is registered - in order to generate the wrapper block node, we need access to the component