### PR TITLE
fix: support node subpath imports in importmap

### DIFF
--- a/packages/payload/src/bin/generateImportMap/utilities/parsePayloadComponent.ts
+++ b/packages/payload/src/bin/generateImportMap/utilities/parsePayloadComponent.ts
@@ -1,5 +1,7 @@
 import type { PayloadComponent } from '../../../config/types.js'
 
+import { extractPathAndExportName } from '../../../utilities/extractPathAndExportName.js'
+
 export function parsePayloadComponent(PayloadComponent: PayloadComponent): {
   exportName: string
   path: string
@@ -11,16 +13,12 @@ export function parsePayloadComponent(PayloadComponent: PayloadComponent): {
   const pathAndMaybeExport =
     typeof PayloadComponent === 'string' ? PayloadComponent : PayloadComponent.path
 
-  let path: string | undefined = pathAndMaybeExport
-  let exportName: string | undefined = 'default'
+  const { exportName: possibleExport, path } = extractPathAndExportName(
+    pathAndMaybeExport,
+    'default',
+  )
 
-  const lastHashIndex = pathAndMaybeExport?.lastIndexOf('#') ?? -1
-
-  if (lastHashIndex > 0) {
-    exportName = pathAndMaybeExport.substring(lastHashIndex + 1)
-    path = pathAndMaybeExport.substring(0, lastHashIndex)
-  }
-
+  let exportName = possibleExport
   if (typeof PayloadComponent === 'object' && PayloadComponent.exportName) {
     exportName = PayloadComponent.exportName
   }

--- a/packages/payload/src/bin/generateImportMap/utilities/parsePayloadComponent.ts
+++ b/packages/payload/src/bin/generateImportMap/utilities/parsePayloadComponent.ts
@@ -11,14 +11,14 @@ export function parsePayloadComponent(PayloadComponent: PayloadComponent): {
   const pathAndMaybeExport =
     typeof PayloadComponent === 'string' ? PayloadComponent : PayloadComponent.path
 
-  let path: string
-  let exportName: string
+  let path: string | undefined = pathAndMaybeExport
+  let exportName: string | undefined = 'default'
 
-  if (pathAndMaybeExport.includes('#')) {
-    ;[path, exportName] = pathAndMaybeExport.split('#', 2) as [string, string]
-  } else {
-    path = pathAndMaybeExport
-    exportName = 'default'
+  const lastHashIndex = pathAndMaybeExport?.lastIndexOf('#') ?? -1
+
+  if (lastHashIndex > 0) {
+    exportName = pathAndMaybeExport.substring(lastHashIndex + 1)
+    path = pathAndMaybeExport.substring(0, lastHashIndex)
   }
 
   if (typeof PayloadComponent === 'object' && PayloadComponent.exportName) {

--- a/packages/payload/src/queues/operations/runJobs/runJob/importHandlerPath.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/importHandlerPath.ts
@@ -1,17 +1,28 @@
+import { pathToFileURL } from 'node:url'
+
 import type { TaskConfig, TaskHandler, TaskType } from '../../../config/types/taskTypes.js'
 
 import { dynamicImport } from '../../../../utilities/dynamicImport.js'
+import { extractPathAndExportName } from '../../../../utilities/extractPathAndExportName.js'
 
 /**
  * Imports a handler function from a given path.
  */
 export async function importHandlerPath<T>(path: string): Promise<T> {
   let runner!: T
-  const [runnerPath, runnerImportName] = path.split('#')
+  const { exportName: runnerImportName, path: runnerPath } = extractPathAndExportName(path)
 
   let runnerModule: Record<string, unknown>
   try {
     runnerModule = await dynamicImport<Record<string, unknown>>(runnerPath!)
+
+    // We need to check for `require` for compatibility with outdated frameworks that do not
+    // properly support ESM, like Jest. This is not done to support projects without "type": "module" set
+    runnerModule =
+      typeof require === 'function'
+        ? await eval(`require('${runnerPath.replaceAll('\\', '/')}')`)
+        : await eval(`import('${pathToFileURL(runnerPath).href}')`)
+
   } catch (e) {
     throw new Error(
       `Error importing job queue handler module for path ${path}. This is an advanced feature that may require a sophisticated build pipeline, especially when using it in production or within Next.js, e.g. by calling opening the /api/payload-jobs/run endpoint. You will have to transpile the handler files separately and ensure they are available in the same location when the job is run. If you're using an endpoint to execute your jobs, it's recommended to define your handlers as functions directly in your Payload Config, or use import paths handlers outside of Next.js. Import Error: \n${e instanceof Error ? e.message : 'Unknown error'}`,

--- a/packages/payload/src/utilities/extractPathAndExportName.ts
+++ b/packages/payload/src/utilities/extractPathAndExportName.ts
@@ -6,7 +6,7 @@ export const extractPathAndExportName = (
   let exportName = defaultExport
 
   // `#` is a valid import path prefix.
-  // We have check if alias is not the only occurence.
+  // We have to check if alias is not the only occurrence.
   const lastDelimiterIndex = pathAndMaybeExport?.lastIndexOf('#') ?? -1
   if (lastDelimiterIndex > 0) {
     exportName = pathAndMaybeExport.substring(lastDelimiterIndex + 1)

--- a/packages/payload/src/utilities/extractPathAndExportName.ts
+++ b/packages/payload/src/utilities/extractPathAndExportName.ts
@@ -1,6 +1,6 @@
 export const extractPathAndExportName = (
   pathAndMaybeExport: string,
-  defaultExport: string,
+  defaultExport: string = 'default',
 ): { exportName: string; path: string } => {
   let path = pathAndMaybeExport
   let exportName = defaultExport

--- a/packages/payload/src/utilities/extractPathAndExportName.ts
+++ b/packages/payload/src/utilities/extractPathAndExportName.ts
@@ -1,0 +1,17 @@
+export const extractPathAndExportName = (
+  pathAndMaybeExport: string,
+  defaultExport: string,
+): { exportName: string; path: string } => {
+  let path = pathAndMaybeExport
+  let exportName = defaultExport
+
+  // `#` is a valid import path prefix.
+  // We have check if alias is not the only occurence.
+  const lastDelimiterIndex = pathAndMaybeExport?.lastIndexOf('#') ?? -1
+  if (lastDelimiterIndex > 0) {
+    exportName = pathAndMaybeExport.substring(lastDelimiterIndex + 1)
+    path = pathAndMaybeExport.substring(0, lastDelimiterIndex)
+  }
+
+  return { exportName, path }
+}


### PR DESCRIPTION
### What?

Support path aliases that start with `#`, when generating import map.

### Why?

Nodejs allows to define "imports" field in package.json to create mappings - just like "paths" in tsconfig.json. Each import has to start with a `#`. This breaks existing implementation of `parsePayloadComponent` and leads to invalid `importMap.js` contents.

Payload splits path and export name using `#`. As. a result, the full import path might have 2 `#` characters.

### How?

1. By default, use payload component as path and "default" as export name. 
2. Check if there is `#` character in path and it's not at the beginning.
  1. If true, use part after last `#` as export name and rest of the string as path