### PR TITLE
fix(plugin-multi-tenant): scope access constraint to admin collection

### DIFF
--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -80,9 +80,13 @@ export const multiTenantPlugin =
         if (!incomingConfig.i18n.translations) {
           incomingConfig.i18n.translations = {}
         }
-        if (!incomingConfig.i18n.translations[locale]) {
+        if (!(locale in incomingConfig.i18n.translations)) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
           incomingConfig.i18n.translations[locale] = {}
         }
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
         if (!('multiTenant' in incomingConfig.i18n.translations[locale])) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
@@ -125,6 +129,7 @@ export const multiTenantPlugin =
     }
 
     addCollectionAccess({
+      adminUsersSlug: adminUsersCollection.slug,
       collection: adminUsersCollection,
       fieldName: `${tenantsArrayFieldName}.${tenantsArrayTenantFieldName}`,
       tenantsArrayFieldName,
@@ -182,6 +187,7 @@ export const multiTenantPlugin =
            * - constrains access a users assigned tenants
            */
           addCollectionAccess({
+            adminUsersSlug: adminUsersCollection.slug,
             collection,
             fieldName: 'id',
             tenantsArrayFieldName,
@@ -284,6 +290,7 @@ export const multiTenantPlugin =
            * Add access control constraint to tenant enabled collection
            */
           addCollectionAccess({
+            adminUsersSlug: adminUsersCollection.slug,
             collection,
             fieldName: tenantFieldName,
             tenantsArrayFieldName,

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -81,8 +81,6 @@ export const multiTenantPlugin =
           incomingConfig.i18n.translations = {}
         }
         if (!(locale in incomingConfig.i18n.translations)) {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-expect-error
           incomingConfig.i18n.translations[locale] = {}
         }
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -152,7 +152,9 @@ export type Tenant<IDType = number | string> = {
 }
 
 export type UserWithTenantsField = {
-  tenants: {
-    tenant: number | string | Tenant
-  }[]
+  tenants?:
+    | {
+        tenant: number | string | Tenant
+      }[]
+    | null
 } & User

--- a/packages/plugin-multi-tenant/src/utilities/addCollectionAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/addCollectionAccess.ts
@@ -18,6 +18,7 @@ const collectionAccessKeys: AllAccessKeys<
 > = ['create', 'read', 'update', 'delete', 'readVersions', 'unlock'] as const
 
 type Args<ConfigType> = {
+  adminUsersSlug: string
   collection: CollectionConfig
   fieldName: string
   tenantsArrayFieldName?: string
@@ -32,6 +33,7 @@ type Args<ConfigType> = {
  * - constrains access a users assigned tenants
  */
 export const addCollectionAccess = <ConfigType>({
+  adminUsersSlug,
   collection,
   fieldName,
   tenantsArrayFieldName,
@@ -44,6 +46,7 @@ export const addCollectionAccess = <ConfigType>({
     }
     collection.access[key] = withTenantAccess<ConfigType>({
       accessFunction: collection.access?.[key],
+      adminUsersSlug,
       collection,
       fieldName: key === 'readVersions' ? `version.${fieldName}` : fieldName,
       operation: key,

--- a/packages/plugin-multi-tenant/src/utilities/withTenantAccess.ts
+++ b/packages/plugin-multi-tenant/src/utilities/withTenantAccess.ts
@@ -15,6 +15,7 @@ import { getTenantAccess } from './getTenantAccess.js'
 
 type Args<ConfigType> = {
   accessFunction?: Access
+  adminUsersSlug: string
   collection: CollectionConfig
   fieldName: string
   operation: AllOperations
@@ -27,6 +28,7 @@ type Args<ConfigType> = {
 export const withTenantAccess =
   <ConfigType>({
     accessFunction,
+    adminUsersSlug,
     collection,
     fieldName,
     tenantsArrayFieldName,
@@ -49,6 +51,7 @@ export const withTenantAccess =
 
     if (
       args.req.user &&
+      args.req.user.collection === adminUsersSlug &&
       !userHasAccessToAllTenants(
         args.req.user as ConfigType extends { user: unknown } ? ConfigType['user'] : User,
       )

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -45,7 +45,6 @@ describe('@payloadcms/plugin-multi-tenant', () => {
         data: {
           name: 'tenant1',
           domain: 'tenant1.com',
-          slug: 'tenant1',
         },
       })
 


### PR DESCRIPTION
### What?
The idea of this plugin is to only add constraints when a user is present on a request. This change makes it so access control only applies to admin panel users as they are the ones assigned to tenants.

This change allows you to more freely write access functions on tenant enabled collections. Say you have 2 auth enabled collections, the plugin would incorrectly assume since there is a user on the req that it needs to apply tenant constraints. When really, you should be able to just add in your own access check for `req.user.collection` and return true/false if you want to prevent/allow other auth enabled collections for certain operations.

```ts
import { Access } from 'payload'

const readByTenant: Access = ({ req }) => {
  const { user } = req
  if (!user || user.collection === 'auth2') return false
  return true
}
```

When you have a function like this  that returns `true` and the collection is multi-tenant enabled - the plugin injects constraints ensuring the user on the request is assigned to the tenant on the doc being accessed.

Before this change, you would need to opt out of access control with `useTenantAccess` and then wire up your own access function:

```ts
import type { Access } from 'payload'
import { getTenantAccess } from '@payloadcms/plugin-multi-tenant/utilities'

export const tenantAccess: Access = async ({ req: { user } }) => {
  if (user) {
    if (user.collection === 'auth2') {
      return true
    }

    // Before, you would need to re-implement
    // internal multi-tenant access constraints
    if (user.roles?.includes('super-admin')) return true

    return getTenantAccess({
      fieldName: 'tenant',
      user,
    })
  }

  return false
}
```

After this change you would not need to opt out of `useTenantAccess` and can just write:

```ts
import type { Access } from 'payload'
import { getTenantAccess } from '@payloadcms/plugin-multi-tenant/utilities'

export const tenantAccess: Access = async ({ req: { user } }) => {
  return Boolean(user)
}
```

This is because internally the plugin will only add the tenant constraint when the access function returns true/Where _AND_ the user belongs to the admin panel users collection.