### PR TITLE
perf: disable returning of db operations that don't need the return value

### DIFF
--- a/packages/payload/src/auth/operations/verifyEmail.ts
+++ b/packages/payload/src/auth/operations/verifyEmail.ts
@@ -48,6 +48,7 @@ export const verifyEmailOperation = async (args: Args): Promise<boolean> => {
         _verified: true,
       },
       req,
+      returning: false,
     })
 
     if (shouldCommit) {

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -195,6 +195,7 @@ export const deleteOperation = async <
         await payload.db.deleteOne({
           collection: collectionConfig.slug,
           req,
+          returning: false,
           where: {
             id: {
               equals: id,

--- a/packages/payload/src/versions/saveVersion.ts
+++ b/packages/payload/src/versions/saveVersion.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import type { SanitizedCollectionConfig, TypeWithID } from '../collections/config/types.js'
 import type { SanitizedGlobalConfig } from '../globals/config/types.js'
-import type { Payload } from '../index.js'
+import type { CreateGlobalVersionArgs, CreateVersionArgs, Payload } from '../index.js'
 import type { PayloadRequest, SelectType } from '../types/index.js'
 
 import { deepCopyObjectSimple } from '../index.js'
@@ -159,10 +159,11 @@ export const saveVersion = async ({
         const updatedArgs = {
           ...createVersionArgs,
           createdAt: snapshotDate,
+          returning: false,
           snapshot: true,
           updatedAt: snapshotDate,
           versionData: snapshotData,
-        } as any
+        } as CreateGlobalVersionArgs & CreateVersionArgs
 
         if (collection) {
           await payload.db.createVersion(updatedArgs)

--- a/packages/ui/src/utilities/handleFormStateLocking.ts
+++ b/packages/ui/src/utilities/handleFormStateLocking.ts
@@ -85,6 +85,7 @@ export const handleFormStateLocking = async ({
             id: lockedDocument.docs[0].id,
             collection: 'payload-locked-documents',
             data: {},
+            returning: false,
           })
         }
       } else {
@@ -136,6 +137,7 @@ export const handleFormStateLocking = async ({
               value: req.user.id,
             },
           },
+          returning: false,
         })
 
         result = {


### PR DESCRIPTION
If the return value of a db operation is not used, we can pass `returning: false` which will result in the query being executed faster.

See https://github.com/payloadcms/payload/pull/11393