### PR TITLE
fix(storage-*): ensure client handler is always added to the import map, even if the plugin is disabled

### DIFF
--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -64,21 +64,19 @@ type AzureStoragePlugin = (azureStorageArgs: AzureStorageOptions) => Plugin
 export const azureStorage: AzureStoragePlugin =
   (azureStorageOptions: AzureStorageOptions) =>
   (incomingConfig: Config): Config => {
-    if (azureStorageOptions.enabled === false) {
-      return incomingConfig
-    }
-
     const getStorageClient = () =>
       getStorageClientFunc({
         connectionString: azureStorageOptions.connectionString,
         containerName: azureStorageOptions.containerName,
       })
 
+    const isPluginDisabled = azureStorageOptions.enabled === false
+
     initClientUploads({
       clientHandler: '@payloadcms/storage-azure/client#AzureClientUploadHandler',
       collections: azureStorageOptions.collections,
       config: incomingConfig,
-      enabled: !!azureStorageOptions.clientUploads,
+      enabled: !isPluginDisabled && Boolean(azureStorageOptions.clientUploads),
       serverHandler: getGenerateSignedURLHandler({
         access:
           typeof azureStorageOptions.clientUploads === 'object'
@@ -90,6 +88,10 @@ export const azureStorage: AzureStoragePlugin =
       }),
       serverHandlerPath: '/storage-azure-generate-signed-url',
     })
+
+    if (isPluginDisabled) {
+      return incomingConfig
+    }
 
     const adapter = azureStorageInternal(getStorageClient, azureStorageOptions)
 

--- a/packages/storage-uploadthing/src/index.ts
+++ b/packages/storage-uploadthing/src/index.ts
@@ -56,22 +56,13 @@ export type ACL = 'private' | 'public-read'
 export const uploadthingStorage: UploadthingPlugin =
   (uploadthingStorageOptions: UploadthingStorageOptions) =>
   (incomingConfig: Config): Config => {
-    if (uploadthingStorageOptions.enabled === false) {
-      return incomingConfig
-    }
-
-    // Default ACL to public-read
-    if (!uploadthingStorageOptions.options.acl) {
-      uploadthingStorageOptions.options.acl = 'public-read'
-    }
-
-    const adapter = uploadthingInternal(uploadthingStorageOptions)
+    const isPluginDisabled = uploadthingStorageOptions.enabled === false
 
     initClientUploads({
       clientHandler: '@payloadcms/storage-uploadthing/client#UploadthingClientUploadHandler',
       collections: uploadthingStorageOptions.collections,
       config: incomingConfig,
-      enabled: !!uploadthingStorageOptions.clientUploads,
+      enabled: !isPluginDisabled && Boolean(uploadthingStorageOptions.clientUploads),
       serverHandler: getClientUploadRoute({
         access:
           typeof uploadthingStorageOptions.clientUploads === 'object'
@@ -82,6 +73,17 @@ export const uploadthingStorage: UploadthingPlugin =
       }),
       serverHandlerPath: '/storage-uploadthing-client-upload-route',
     })
+
+    if (isPluginDisabled) {
+      return incomingConfig
+    }
+
+    // Default ACL to public-read
+    if (!uploadthingStorageOptions.options.acl) {
+      uploadthingStorageOptions.options.acl = 'public-read'
+    }
+
+    const adapter = uploadthingInternal(uploadthingStorageOptions)
 
     // Add adapter to each collection option object
     const collectionsWithAdapter: CloudStoragePluginOptions['collections'] = Object.entries(


### PR DESCRIPTION
Ensures that even if you pass `enabled: false` to the storage adapter options, e.g:
```ts
s3Storage({
  enabled: false,
  collections: {
    [mediaSlug]: true,
  },
  bucket: process.env.S3_BUCKET,
  config: {
    credentials: {
      accessKeyId: process.env.S3_ACCESS_KEY_ID,
      secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
    },
  },
})
```
the client handler component is added to the import map. This prevents errors when you use the adapter only on production, but you don't regenerate the import map before running the build
