### PR TITLE
fix(next): email verification not working due to incorrect token url parsing

### DIFF
--- a/packages/next/src/views/Verify/index.tsx
+++ b/packages/next/src/views/Verify/index.tsx
@@ -14,7 +14,7 @@ export { generateVerifyMetadata } from './meta.js'
 export async function Verify({ initPageResult, params, searchParams }: AdminViewServerProps) {
   // /:collectionSlug/verify/:token
 
-  const [collectionSlug, token] = params.segments
+  const [collectionSlug, verify, token] = params.segments
   const { locale, permissions, req } = initPageResult
 
   const {


### PR DESCRIPTION
### What?
This PR reverts a presumably accidental change made in [b80010b1a1b77fa041fc46d7277830420c72d97c](https://github.com/payloadcms/payload/commit/b80010b1a1b77fa041fc46d7277830420c72d97c), that broke the email verification feature in v3.24.0 and onwards.
### Why?
Through  the missing verify in `const [collectionSlug, verify, token] = params.segments`, the token value was always the string `verify`