### PR TITLE
fix(ui): locale selector in versions view should remove filtered locales

### DIFF
--- a/packages/next/src/views/Version/index.tsx
+++ b/packages/next/src/views/Version/index.tsx
@@ -145,17 +145,17 @@ export async function VersionView(props: DocumentViewServerProps) {
 
   let selectedLocales: OptionObject[] = []
   if (localization) {
-    let locales: Locale[] = localization.locales
-
+    let locales: Locale[] = []
     if (localeCodesFromParams) {
       for (const code of localeCodesFromParams) {
         const locale = localization.locales.find((locale) => locale.code === code)
         if (!locale) {
           continue
         }
-
         locales.push(locale)
       }
+    } else {
+      locales = localization.locales
     }
 
     if (localization.filterAvailableLocales) {

--- a/packages/next/src/views/Version/index.tsx
+++ b/packages/next/src/views/Version/index.tsx
@@ -1,6 +1,7 @@
 import type {
   Document,
   DocumentViewServerProps,
+  Locale,
   OptionObject,
   SanitizedCollectionPermission,
   SanitizedGlobalPermission,
@@ -142,24 +143,29 @@ export async function VersionView(props: DocumentViewServerProps) {
     }
   }
 
-  const selectedLocales: OptionObject[] = []
+  let selectedLocales: OptionObject[] = []
   if (localization) {
-    const localeCodes = localeCodesFromParams || localization.locales.map(({ code }) => code)
+    let locales: Locale[] = localization.locales
 
-    for (const code of localeCodes) {
-      const locale = localization.locales.find((locale) => locale.code === code)
-      if (!locale) {
-        continue
+    if (localeCodesFromParams) {
+      for (const code of localeCodesFromParams) {
+        const locale = localization.locales.find((locale) => locale.code === code)
+        if (!locale) {
+          continue
+        }
+
+        locales.push(locale)
       }
-
-      let filteredLocales = [locale]
-      if (localization.filterAvailableLocales) {
-        filteredLocales =
-          (await localization.filterAvailableLocales({ locales: [locale], req })) || []
-      }
-
-      selectedLocales.push(...filteredLocales.map(({ code, label }) => ({ label, value: code })))
     }
+
+    if (localization.filterAvailableLocales) {
+      locales = (await localization.filterAvailableLocales({ locales, req })) || []
+    }
+
+    selectedLocales = locales.map((locale) => ({
+      label: locale.label,
+      value: locale.code,
+    }))
   }
 
   const latestVersion =

--- a/packages/next/src/views/Version/index.tsx
+++ b/packages/next/src/views/Version/index.tsx
@@ -144,23 +144,21 @@ export async function VersionView(props: DocumentViewServerProps) {
 
   const selectedLocales: OptionObject[] = []
   if (localization) {
-    if (localeCodesFromParams) {
-      for (const code of localeCodesFromParams) {
-        const locale = localization.locales.find((locale) => locale.code === code)
-        if (locale) {
-          selectedLocales.push({
-            label: locale.label,
-            value: locale.code,
-          })
-        }
+    const localeCodes = localeCodesFromParams || localization.locales.map(({ code }) => code)
+
+    for (const code of localeCodes) {
+      const locale = localization.locales.find((locale) => locale.code === code)
+      if (!locale) {
+        continue
       }
-    } else {
-      for (const { code, label } of localization.locales) {
-        selectedLocales.push({
-          label,
-          value: code,
-        })
+
+      let filteredLocales = [locale]
+      if (localization.filterAvailableLocales) {
+        filteredLocales =
+          (await localization.filterAvailableLocales({ locales: [locale], req })) || []
       }
+
+      selectedLocales.push(...filteredLocales.map(({ code, label }) => ({ label, value: code })))
     }
   }
 

--- a/test/localization/collections/LocalizedDrafts/index.ts
+++ b/test/localization/collections/LocalizedDrafts/index.ts
@@ -1,0 +1,17 @@
+import type { CollectionConfig } from 'payload'
+
+import { localizedDraftsSlug } from '../../shared.js'
+
+export const LocalizedDrafts: CollectionConfig = {
+  slug: localizedDraftsSlug,
+  versions: {
+    drafts: true,
+  },
+  fields: [
+    {
+      type: 'text',
+      name: 'title',
+      localized: true,
+    },
+  ],
+}

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -11,6 +11,7 @@ import { devUser } from '../credentials.js'
 import { ArrayCollection } from './collections/Array/index.js'
 import { BlocksCollection } from './collections/Blocks/index.js'
 import { Group } from './collections/Group/index.js'
+import { LocalizedDrafts } from './collections/LocalizedDrafts/index.js'
 import { LocalizedWithinLocalized } from './collections/LocalizedWithinLocalized/index.js'
 import { NestedArray } from './collections/NestedArray/index.js'
 import { NestedFields } from './collections/NestedFields/index.js'
@@ -37,7 +38,6 @@ import {
   withLocalizedRelSlug,
   withRequiredLocalizedFields,
 } from './shared.js'
-
 export type LocalizedPostAllLocale = {
   title: {
     en?: string
@@ -63,6 +63,7 @@ export default buildConfigWithDefaults({
     BlocksCollection,
     NestedArray,
     NestedFields,
+    LocalizedDrafts,
     {
       admin: {
         listSearchableFields: 'name',

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -17,6 +17,7 @@ import {
   changeLocale,
   closeLocaleSelector,
   ensureCompilationIsDone,
+  findTableRow,
   initPageConsoleErrorCatch,
   openLocaleSelector,
   saveDocAndAssert,
@@ -30,6 +31,7 @@ import { richTextSlug } from './collections/RichText/index.js'
 import {
   defaultLocale,
   englishTitle,
+  localizedDraftsSlug,
   localizedPostsSlug,
   relationshipLocalizedSlug,
   spanishLocale,
@@ -53,6 +55,7 @@ let url: AdminUrlUtil
 let urlWithRequiredLocalizedFields: AdminUrlUtil
 let urlRelationshipLocalized: AdminUrlUtil
 let urlCannotCreateDefaultLocale: AdminUrlUtil
+let urlPostsWithDrafts: AdminUrlUtil
 
 const title = 'english title'
 const spanishTitle = 'spanish title'
@@ -76,6 +79,7 @@ describe('Localization', () => {
     richTextURL = new AdminUrlUtil(serverURL, richTextSlug)
     urlWithRequiredLocalizedFields = new AdminUrlUtil(serverURL, withRequiredLocalizedFields)
     urlCannotCreateDefaultLocale = new AdminUrlUtil(serverURL, 'cannot-create-default-locale')
+    urlPostsWithDrafts = new AdminUrlUtil(serverURL, localizedDraftsSlug)
 
     context = await browser.newContext()
     page = await context.newPage()
@@ -109,6 +113,21 @@ describe('Localization', () => {
       await expect(page.locator('.localizer.app-header__localizer')).toBeVisible()
       await page.locator('.localizer >> button').first().click()
       await expect(page.locator('.localizer .popup.popup--active')).not.toContainText('FILTERED')
+    })
+
+    test('should filter version locale selector with filterAvailableLocales', async () => {
+      await page.goto(urlPostsWithDrafts.create)
+      await page.locator('#field-title').fill('title')
+      await page.locator('#action-save').click()
+
+      await page.locator('text=Versions').click()
+      const firstVersion = findTableRow(page, 'Current Published Version')
+      await firstVersion.locator('a').click()
+
+      await expect(page.locator('.select-version-locales__label')).toBeVisible()
+      await expect(page.locator('.select-version-locales .react-select')).not.toContainText(
+        'FILTERED',
+      )
     })
 
     test('should disable control for active locale', async () => {

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -70,6 +70,7 @@ export interface Config {
     'blocks-fields': BlocksField;
     'nested-arrays': NestedArray;
     'nested-field-tables': NestedFieldTable;
+    'localized-drafts': LocalizedDraft;
     users: User;
     'localized-posts': LocalizedPost;
     'no-localized-fields': NoLocalizedField;
@@ -94,6 +95,7 @@ export interface Config {
     'blocks-fields': BlocksFieldsSelect<false> | BlocksFieldsSelect<true>;
     'nested-arrays': NestedArraysSelect<false> | NestedArraysSelect<true>;
     'nested-field-tables': NestedFieldTablesSelect<false> | NestedFieldTablesSelect<true>;
+    'localized-drafts': LocalizedDraftsSelect<false> | LocalizedDraftsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'localized-posts': LocalizedPostsSelect<false> | LocalizedPostsSelect<true>;
     'no-localized-fields': NoLocalizedFieldsSelect<false> | NoLocalizedFieldsSelect<true>;
@@ -315,6 +317,17 @@ export interface NestedFieldTable {
     | null;
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-drafts".
+ */
+export interface LocalizedDraft {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -696,6 +709,10 @@ export interface PayloadLockedDocument {
         value: string | NestedFieldTable;
       } | null)
     | ({
+        relationTo: 'localized-drafts';
+        value: string | LocalizedDraft;
+      } | null)
+    | ({
         relationTo: 'users';
         value: string | User;
       } | null)
@@ -923,6 +940,16 @@ export interface NestedFieldTablesSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-drafts_select".
+ */
+export interface LocalizedDraftsSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/localization/shared.ts
+++ b/test/localization/shared.ts
@@ -16,6 +16,8 @@ export const withLocalizedRelSlug = 'with-localized-relationship'
 export const relationshipLocalizedSlug = 'relationship-localized'
 export const withRequiredLocalizedFields = 'localized-required'
 export const localizedSortSlug = 'localized-sort'
+
+export const localizedDraftsSlug = 'localized-drafts'
 export const usersSlug = 'users'
 export const blocksWithLocalizedSameName = 'blocks-same-name'
 export const cannotCreateDefaultLocale = 'cannot-create-default-locale'


### PR DESCRIPTION
### What?
The `locale selector` in the version comparison view shows all locales on first load. It does not accomodate the `filterAvailableLocales` option and shows locales which should be filtered.

### How?
Pass the initial locales through the `filterAvailableLocales` function.

Closes #11408

#### Testing
Use test suite `localization` and the `localized-drafts` collection. Test added to `test/localization/e2e`.