### PR TITLE
ci: repro guide to use `create-payload-app@latest` instead of `@beta`

### DIFF
--- a/.github/comments/invalid-reproduction.md
+++ b/.github/comments/invalid-reproduction.md
@@ -4,7 +4,7 @@ Depending on the quality of reproduction steps, this issue may be closed if no r
 
 ### Why was this issue marked with the `invalid-reproduction` label?
 
-To be able to investigate, we need access to a reproduction to identify what triggered the issue. We prefer a link to a public GitHub repository created with `create-payload-app@beta -t blank` or a forked/branched version of this repository with tests added (more info in the [reproduction-guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md)).
+To be able to investigate, we need access to a reproduction to identify what triggered the issue. We prefer a link to a public GitHub repository created with `create-payload-app@latest -t blank` or a forked/branched version of this repository with tests added (more info in the [reproduction-guide](https://github.com/payloadcms/payload/blob/main/.github/reproduction-guide.md)).
 
 To make sure the issue is resolved as quickly as possible, please make sure that the reproduction is as **minimal** as possible. This means that you should **remove unnecessary code, files, and dependencies** that do not contribute to the issue. Ensure your reproduction does not depend on secrets, 3rd party registries, private dependencies, or any other data that cannot be made public. Avoid a reproduction including a whole monorepo (unless relevant to the issue). The easier it is to reproduce the issue, the quicker we can help.
 


### PR DESCRIPTION
This PR updates the reproduction guide to reference `create-payload-app@latest -t blank` instead of `@beta`, ensuring users follow the latest stable release when setting up a minimal reproduction.
