### PR TITLE
fix(next): properly instantiates req.url on localhost

### DIFF
--- a/packages/next/src/utilities/initPage/index.ts
+++ b/packages/next/src/utilities/initPage/index.ts
@@ -1,8 +1,7 @@
 import type { InitPageResult, VisibleEntities } from 'payload'
 
-import { headers as getHeaders } from 'next/headers.js'
 import { notFound } from 'next/navigation.js'
-import { getPayload, isEntityHidden, parseCookies } from 'payload'
+import { isEntityHidden } from 'payload'
 import * as qs from 'qs-esm'
 
 import type { Args } from './types.js'
@@ -40,8 +39,8 @@ export const initPage = async ({
           ignoreQueryPrefix: true,
         }),
       },
+      urlSuffix: `${route}${searchParams ? queryString : ''}`,
     },
-    urlSuffix: `${route}${searchParams ? queryString : ''}`,
   })
 
   const {

--- a/packages/next/src/utilities/initReq.ts
+++ b/packages/next/src/utilities/initReq.ts
@@ -96,6 +96,7 @@ export const initReq = async function ({
     const { i18n, languageCode, payload, responseHeaders, user } = partialResult
 
     const { req: reqOverrides, ...optionsOverrides } = overrides || {}
+
     const req = await createLocalReq(
       {
         req: {
@@ -103,7 +104,6 @@ export const initReq = async function ({
           host: headers.get('host'),
           i18n: i18n as I18n,
           responseHeaders,
-          url: `${payload.config.serverURL}${urlSuffix || ''}`,
           user,
           ...(reqOverrides || {}),
         },
@@ -115,6 +115,7 @@ export const initReq = async function ({
     const locale = await getRequestLocale({
       req,
     })
+
     req.locale = locale?.code
 
     const permissions = await getAccessResults({

--- a/packages/next/src/utilities/initReq.ts
+++ b/packages/next/src/utilities/initReq.ts
@@ -53,13 +53,11 @@ export const initReq = async function ({
   importMap,
   key,
   overrides,
-  urlSuffix,
 }: {
   configPromise: Promise<SanitizedConfig> | SanitizedConfig
   importMap: ImportMap
   key: string
   overrides?: Parameters<typeof createLocalReq>[0]
-  urlSuffix?: string
 }): Promise<Result> {
   const headers = await getHeaders()
   const cookies = parseCookies(headers)


### PR DESCRIPTION
The `req.url` property at the page level was not reflective of the actual URL on localhost. This was because we were passing an incompatible `url` override into `createLocalReq` (lacking protocol). This would silently fail to construct the URL object, ultimately losing the top-level domain on `req.url` as well as the port on `req.origin` (see #11454).

Closes #11448.