### PR TITLE
fix(ui): bulk editing users throws client-side exception

### DIFF
--- a/packages/ui/src/elements/FieldSelect/index.tsx
+++ b/packages/ui/src/elements/FieldSelect/index.tsx
@@ -67,7 +67,7 @@ const reduceFields = ({
     // escape for a variety of reasons, include ui fields as they have `name`.
     if (
       (fieldAffectsData(field) || field.type === 'ui') &&
-      (field.admin.disableBulkEdit ||
+      (field.admin?.disableBulkEdit ||
         field.unique ||
         fieldIsHiddenOrDisabled(field) ||
         ('readOnly' in field && field.readOnly))


### PR DESCRIPTION
When bulk editing an auth-enabled collection such as users, a client-side exception is thrown. This is because we're trying to access the `disableBulkEdit` property on `undefined`. This is due to hidden, auth-specific fields like `salt` and `hash` lacking an admin config.

No test is explicitly needed for this as `"strictNullChecks": true` will throw an error at compile time, once enabled.