### PR TITLE
perf: automatically add index on a relationship field when used as target for a join field

### DIFF
--- a/packages/payload/src/fields/config/sanitizeJoinField.ts
+++ b/packages/payload/src/fields/config/sanitizeJoinField.ts
@@ -139,6 +139,10 @@ export const sanitizeJoinField = ({
     throw new InvalidFieldJoin(join.field)
   }
 
+  if (!joinRelationship.index && !joinRelationship.unique) {
+    joinRelationship.index = true
+  }
+
   if (validateOnly) {
     return
   }


### PR DESCRIPTION
When the join field is used, Payload now automatically adds an index on the target relationship field.

For example:
```
{
  name: 'relatedPosts',
  type: 'join',
  collection: "posts",
  on: 'category',
},

{
  name: 'category',
  type: 'relationship',
  relationTo: "categories",
},
```

Here, `index: true` implicitly added to the `category` relationship field during sanitization to improve querying performance.