### PR TITLE
feat(richtext-lexical): add editorConfigFactory helper to streamline getting the editor config

### DIFF
--- a/docs/rich-text/converters.mdx
+++ b/docs/rich-text/converters.mdx
@@ -392,9 +392,8 @@ const yourEditorConfig3 = await editorConfigFactory.fromFeatures({
 // Version 4 - if you have instantiated a lexical editor and are accessing it outside a field (=> this is the unsanitized editor),
 // you can extract the editor config from it.
 // This is common if you define the editor in a re-usable module scope variable and pass it to the richText field.
-// This is the least efficient way to get the editor config, and not recommended. It tis recommended to xtract the `features` arg
+// This is the least efficient way to get the editor config, and not recommended. It is recommended to extract the `features` arg
 // into a separate variable and use `fromFeatures` instead.
-
 const editor = lexicalEditor({
   features: ({ defaultFeatures }) => [...defaultFeatures, FixedToolbarFeature()],
 })

--- a/docs/rich-text/converters.mdx
+++ b/docs/rich-text/converters.mdx
@@ -346,48 +346,74 @@ A headless editor can perform such conversions outside of the main editor instan
 
 ```ts
 import { createHeadlessEditor } from '@payloadcms/richtext-lexical/lexical/headless'
-import { getEnabledNodes, sanitizeServerEditorConfig } from '@payloadcms/richtext-lexical'
+import { getEnabledNodes, editorConfigFactory } from '@payloadcms/richtext-lexical'
 
-const yourEditorConfig // <= your editor config here
 const payloadConfig // <= your Payload Config here
 
 const headlessEditor = createHeadlessEditor({
   nodes: getEnabledNodes({
-    editorConfig: sanitizeServerEditorConfig(yourEditorConfig, payloadConfig),
+    editorConfig: await editorConfigFactory.default({config: payloadConfig})
   }),
 })
 ```
 
 ### Getting the editor config
 
-As you can see, you need to provide an editor config in order to create a headless editor. This is because the editor config is used to determine which nodes & features are enabled, and which converters are used.
+You need to provide an editor config in order to create a headless editor. This is because the editor config is used to determine which nodes & features are enabled, and which converters are used.
 
-To get the editor config, simply import the default editor config and adjust it - just like you did inside of the `editor: lexicalEditor({})` property:
+To get the editor config, import the `editorConfigFactory` factory - this factory provides a variety of ways to get the editor config, depending on your use case.
 
 ```ts
-import { defaultEditorConfig, defaultEditorFeatures } from '@payloadcms/richtext-lexical' // <= make sure this package is installed
+import type { SanitizedConfig } from 'payload'
 
-const yourEditorConfig = defaultEditorConfig
+import {
+  editorConfigFactory,
+  FixedToolbarFeature,
+  lexicalEditor,
+} from '@payloadcms/richtext-lexical'
 
-// If you made changes to the features of the field's editor config, you should also make those changes here:
-yourEditorConfig.features = [
-  ...defaultEditorFeatures,
-  // Add your custom features here
-]
+// Your config needs to be available in order to retrieve the default editor config
+const config: SanitizedConfig = {} as SanitizedConfig
+
+// Version 1 - use the default editor config
+const yourEditorConfig = await editorConfigFactory.default({ config })
+
+// Version 2 - if you have access to a lexical fields, you can extract the editor config from it
+const yourEditorConfig2 = editorConfigFactory.fromField({
+  field: collectionConfig.fields[1],
+})
+
+// Version 3 - create a new editor config - behaves just like instantiating a new `lexicalEditor`
+const yourEditorConfig3 = await editorConfigFactory.fromFeatures({
+  config,
+  features: ({ defaultFeatures }) => [...defaultFeatures, FixedToolbarFeature()],
+})
+
+// Version 4 - if you have instantiated a lexical editor and are accessing it outside a field (=> this is the unsanitized editor),
+// you can extract the editor config from it.
+// This is common if you define the editor in a re-usable module scope variable and pass it to the richText field.
+// This is the least efficient way to get the editor config, and not recommended. It tis recommended to xtract the `features` arg
+// into a separate variable and use `fromFeatures` instead.
+
+const editor = lexicalEditor({
+  features: ({ defaultFeatures }) => [...defaultFeatures, FixedToolbarFeature()],
+})
+
+const yourEditorConfig4 = await editorConfigFactory.fromEditor({
+  config,
+  editor,
+})
 ```
 
-### Getting the editor config from an existing field
+### Example - Getting the editor config from an existing field
 
 If you have access to the sanitized collection config, you can get access to the lexical sanitized editor config & features, as every lexical richText field returns it. Here is an example how you can get it from another field's afterRead hook:
 
 ```ts
 import type { CollectionConfig, RichTextField } from 'payload'
+
+import { editorConfigFactory, getEnabledNodes, lexicalEditor } from '@payloadcms/richtext-lexical'
 import { createHeadlessEditor } from '@payloadcms/richtext-lexical/lexical/headless'
-import type { LexicalRichTextAdapter, SanitizedServerEditorConfig } from '@payloadcms/richtext-lexical'
-import {
-  getEnabledNodes,
-  lexicalEditor
-} from '@payloadcms/richtext-lexical'
 
 export const MyCollection: CollectionConfig = {
   slug: 'slug',
@@ -397,20 +423,18 @@ export const MyCollection: CollectionConfig = {
       type: 'text',
       hooks: {
         afterRead: [
-          ({ value, collection }) => {
-            const otherRichTextField: RichTextField = collection.fields.find(
+          ({ siblingFields, value }) => {
+            const field: RichTextField = siblingFields.find(
               (field) => 'name' in field && field.name === 'richText',
             ) as RichTextField
 
-            const lexicalAdapter: LexicalRichTextAdapter =
-              otherRichTextField.editor as LexicalRichTextAdapter
-
-            const sanitizedServerEditorConfig: SanitizedServerEditorConfig =
-              lexicalAdapter.editorConfig
+            const editorConfig = editorConfigFactory.fromField({
+              field,
+            })
 
             const headlessEditor = createHeadlessEditor({
               nodes: getEnabledNodes({
-                editorConfig: sanitizedServerEditorConfig,
+                editorConfig,
               }),
             })
 
@@ -424,11 +448,9 @@ export const MyCollection: CollectionConfig = {
     {
       name: 'richText',
       type: 'richText',
-      editor: lexicalEditor({
-        features,
-      }),
-    }
-  ]
+      editor: lexicalEditor(),
+    },
+  ],
 }
 ```
 
@@ -479,14 +501,14 @@ This has been taken from the [lexical serialization & deserialization docs](http
 Convert markdown content to the Lexical editor format with the following:
 
 ```ts
-import { sanitizeServerEditorConfig, $convertFromMarkdownString } from '@payloadcms/richtext-lexical'
+import { $convertFromMarkdownString, editorConfigFactory } from '@payloadcms/richtext-lexical'
 
-const yourSanitizedEditorConfig = sanitizeServerEditorConfig(yourEditorConfig, payloadConfig) // <= your editor config & Payload Config here
+const yourEditorConfig = await editorConfigFactory.default({ config })
 const markdown = `# Hello World`
 
 headlessEditor.update(
   () => {
-    $convertFromMarkdownString(markdown, yourSanitizedEditorConfig.features.markdownTransformers)
+    $convertFromMarkdownString(markdown, yourEditorConfig.features.markdownTransformers)
   },
   { discrete: true },
 )
@@ -505,11 +527,12 @@ Export content from the Lexical editor into Markdown format using these steps:
 Here's the code for it:
 
 ```ts
-import { $convertToMarkdownString } from '@payloadcms/richtext-lexical/lexical/markdown'
-import { sanitizeServerEditorConfig } from '@payloadcms/richtext-lexical'
 import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
 
-const yourSanitizedEditorConfig = sanitizeServerEditorConfig(yourEditorConfig, payloadConfig) // <= your editor config & Payload Config here
+import { editorConfigFactory } from '@payloadcms/richtext-lexical'
+import { $convertToMarkdownString } from '@payloadcms/richtext-lexical/lexical/markdown'
+
+const yourEditorConfig = await editorConfigFactory.default({ config })
 const yourEditorState: SerializedEditorState // <= your current editor state here
 
 // Import editor state into your headless editor
@@ -518,7 +541,7 @@ try {
     () => {
       headlessEditor.setEditorState(headlessEditor.parseEditorState(yourEditorState))
     },
-    { discrete: true },  // This should commit the editor state immediately
+    { discrete: true }, // This should commit the editor state immediately
   )
 } catch (e) {
   logger.error({ err: e }, 'ERROR parsing editor state')
@@ -527,7 +550,7 @@ try {
 // Export to markdown
 let markdown: string
 headlessEditor.getEditorState().read(() => {
-  markdown = $convertToMarkdownString(yourSanitizedEditorConfig?.features?.markdownTransformers)
+  markdown = $convertToMarkdownString(yourEditorConfig?.features?.markdownTransformers)
 })
 ```
 
@@ -542,19 +565,20 @@ Here's the code for it:
 
 ```ts
 import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
+
 import { $getRoot } from '@payloadcms/richtext-lexical/lexical'
 
 const yourEditorState: SerializedEditorState // <= your current editor state here
 
 // Import editor state into your headless editor
 try {
-    headlessEditor.update(
+  headlessEditor.update(
     () => {
       headlessEditor.setEditorState(headlessEditor.parseEditorState(yourEditorState))
     },
-    { discrete: true },  // This should commit the editor state immediately
+    { discrete: true }, // This should commit the editor state immediately
   )
-  } catch (e) {
+} catch (e) {
   logger.error({ err: e }, 'ERROR parsing editor state')
 }
 

--- a/packages/richtext-lexical/src/types.ts
+++ b/packages/richtext-lexical/src/types.ts
@@ -38,40 +38,42 @@ export type LexicalFieldAdminClientProps = {
   placeholder?: string
 } & Omit<LexicalFieldAdminProps, 'placeholder'>
 
+export type FeaturesInput =
+  | (({
+      defaultFeatures,
+      rootFeatures,
+    }: {
+      /**
+       * This opinionated array contains all "recommended" default features.
+       *
+       * @Example
+       *
+       * ```ts
+       *  editor: lexicalEditor({
+       *    features: ({ defaultFeatures }) => [...defaultFeatures, FixedToolbarFeature()],
+       *  })
+       *  ```
+       */
+      defaultFeatures: FeatureProviderServer<any, any, any>[]
+      /**
+       * This array contains all features that are enabled in the root richText editor (the one defined in the payload.config.ts).
+       * If this field is the root richText editor, or if the root richText editor is not a lexical editor, this array will be empty.
+       *
+       * @Example
+       *
+       * ```ts
+       *  editor: lexicalEditor({
+       *    features: ({ rootFeatures }) => [...rootFeatures, FixedToolbarFeature()],
+       *  })
+       *  ```
+       */
+      rootFeatures: FeatureProviderServer<any, any, any>[]
+    }) => FeatureProviderServer<any, any, any>[])
+  | FeatureProviderServer<any, any, any>[]
+
 export type LexicalEditorProps = {
   admin?: LexicalFieldAdminProps
-  features?:
-    | (({
-        defaultFeatures,
-        rootFeatures,
-      }: {
-        /**
-         * This opinionated array contains all "recommended" default features.
-         *
-         * @Example
-         *
-         * ```ts
-         *  editor: lexicalEditor({
-         *    features: ({ defaultFeatures }) => [...defaultFeatures, FixedToolbarFeature()],
-         *  })
-         *  ```
-         */
-        defaultFeatures: FeatureProviderServer<any, any, any>[]
-        /**
-         * This array contains all features that are enabled in the root richText editor (the one defined in the payload.config.ts).
-         * If this field is the root richText editor, or if the root richText editor is not a lexical editor, this array will be empty.
-         *
-         * @Example
-         *
-         * ```ts
-         *  editor: lexicalEditor({
-         *    features: ({ rootFeatures }) => [...rootFeatures, FixedToolbarFeature()],
-         *  })
-         *  ```
-         */
-        rootFeatures: FeatureProviderServer<any, any, any>[]
-      }) => FeatureProviderServer<any, any, any>[])
-    | FeatureProviderServer<any, any, any>[]
+  features?: FeaturesInput
   lexical?: LexicalEditorConfig
 }
 

--- a/packages/richtext-lexical/src/utilities/editorConfigFactory.ts
+++ b/packages/richtext-lexical/src/utilities/editorConfigFactory.ts
@@ -1,0 +1,129 @@
+import type { EditorConfig as LexicalEditorConfig } from 'lexical'
+import type { RichTextAdapterProvider, RichTextField, SanitizedConfig } from 'payload'
+
+import type { FeatureProviderServer, ResolvedServerFeatureMap } from '../features/typesServer.js'
+import type { SanitizedServerEditorConfig } from '../lexical/config/types.js'
+import type {
+  FeaturesInput,
+  LexicalRichTextAdapter,
+  LexicalRichTextAdapterProvider,
+} from '../types.js'
+
+import { getDefaultSanitizedEditorConfig } from '../getDefaultSanitizedEditorConfig.js'
+import { defaultEditorConfig, defaultEditorFeatures } from '../lexical/config/server/default.js'
+import { loadFeatures } from '../lexical/config/server/loader.js'
+import { sanitizeServerFeatures } from '../lexical/config/server/sanitize.js'
+
+export const editorConfigFactory = {
+  default: async (args: {
+    config: SanitizedConfig
+    parentIsLocalized?: boolean
+  }): Promise<SanitizedServerEditorConfig> => {
+    return getDefaultSanitizedEditorConfig({
+      config: args.config,
+      parentIsLocalized: args.parentIsLocalized ?? false,
+    })
+  },
+  fromEditor: async (args: {
+    config: SanitizedConfig
+    editor: LexicalRichTextAdapterProvider
+    isRoot?: boolean
+    lexical?: LexicalEditorConfig
+    parentIsLocalized?: boolean
+  }): Promise<SanitizedServerEditorConfig> => {
+    const lexicalAdapter: LexicalRichTextAdapter = await args.editor({
+      config: args.config,
+      isRoot: args.isRoot ?? false,
+      parentIsLocalized: args.parentIsLocalized ?? false,
+    })
+
+    const sanitizedServerEditorConfig: SanitizedServerEditorConfig = lexicalAdapter.editorConfig
+    return sanitizedServerEditorConfig
+  },
+  fromFeatures: async (args: {
+    config: SanitizedConfig
+    features?: FeaturesInput
+    isRoot?: boolean
+    lexical?: LexicalEditorConfig
+    parentIsLocalized?: boolean
+  }): Promise<SanitizedServerEditorConfig> => {
+    return (await featuresInputToEditorConfig(args)).sanitizedConfig
+  },
+  fromField: (args: { field: RichTextField }): SanitizedServerEditorConfig => {
+    const lexicalAdapter: LexicalRichTextAdapter = args.field.editor as LexicalRichTextAdapter
+
+    const sanitizedServerEditorConfig: SanitizedServerEditorConfig = lexicalAdapter.editorConfig
+    return sanitizedServerEditorConfig
+  },
+  fromUnsanitizedField: async (args: {
+    config: SanitizedConfig
+    field: RichTextField
+    isRoot?: boolean
+    parentIsLocalized?: boolean
+  }): Promise<SanitizedServerEditorConfig> => {
+    const lexicalAdapterProvider: RichTextAdapterProvider = args.field
+      .editor as RichTextAdapterProvider
+
+    const lexicalAdapter: LexicalRichTextAdapter = (await lexicalAdapterProvider({
+      config: args.config,
+      isRoot: args.isRoot ?? false,
+      parentIsLocalized: args.parentIsLocalized ?? false,
+    })) as LexicalRichTextAdapter
+
+    const sanitizedServerEditorConfig: SanitizedServerEditorConfig = lexicalAdapter.editorConfig
+    return sanitizedServerEditorConfig
+  },
+}
+
+export const featuresInputToEditorConfig = async (args: {
+  config: SanitizedConfig
+  features?: FeaturesInput
+  isRoot?: boolean
+  lexical?: LexicalEditorConfig
+  parentIsLocalized?: boolean
+}): Promise<{
+  features: FeatureProviderServer<unknown, unknown, unknown>[]
+  resolvedFeatureMap: ResolvedServerFeatureMap
+  sanitizedConfig: SanitizedServerEditorConfig
+}> => {
+  let features: FeatureProviderServer<unknown, unknown, unknown>[] = []
+  if (args.features && typeof args.features === 'function') {
+    const rootEditor = args.config.editor
+    let rootEditorFeatures: FeatureProviderServer<unknown, unknown, unknown>[] = []
+    if (typeof rootEditor === 'object' && 'features' in rootEditor) {
+      rootEditorFeatures = (rootEditor as LexicalRichTextAdapter).features
+    }
+    features = args.features({
+      defaultFeatures: defaultEditorFeatures,
+      rootFeatures: rootEditorFeatures,
+    })
+  } else {
+    features = args.features as FeatureProviderServer<unknown, unknown, unknown>[]
+  }
+
+  if (!features) {
+    features = defaultEditorFeatures
+  }
+
+  const lexical = args.lexical ?? defaultEditorConfig.lexical
+
+  const resolvedFeatureMap = await loadFeatures({
+    config: args.config,
+    isRoot: args.isRoot ?? false,
+    parentIsLocalized: args.parentIsLocalized ?? false,
+    unSanitizedEditorConfig: {
+      features,
+      lexical,
+    },
+  })
+
+  return {
+    features,
+    resolvedFeatureMap,
+    sanitizedConfig: {
+      features: sanitizeServerFeatures(resolvedFeatureMap),
+      lexical: args.lexical,
+      resolvedFeatureMap,
+    },
+  }
+}

--- a/packages/richtext-lexical/src/utilities/editorConfigFactory.ts
+++ b/packages/richtext-lexical/src/utilities/editorConfigFactory.ts
@@ -24,6 +24,14 @@ export const editorConfigFactory = {
       parentIsLocalized: args.parentIsLocalized ?? false,
     })
   },
+  /**
+   * If you have instantiated a lexical editor and are accessing it outside a field (=> this is the unsanitized editor),
+   * you can extract the editor config from it.
+   * This is common if you define the editor in a re-usable module scope variable and pass it to the richText field.
+   *
+   * This is the least efficient way to get the editor config, and not recommended. It is recommended to extract the `features` arg
+   * into a separate variable and use `fromFeatures` instead.
+   */
   fromEditor: async (args: {
     config: SanitizedConfig
     editor: LexicalRichTextAdapterProvider
@@ -40,6 +48,9 @@ export const editorConfigFactory = {
     const sanitizedServerEditorConfig: SanitizedServerEditorConfig = lexicalAdapter.editorConfig
     return sanitizedServerEditorConfig
   },
+  /**
+   * Create a new editor config - behaves just like instantiating a new `lexicalEditor`
+   */
   fromFeatures: async (args: {
     config: SanitizedConfig
     features?: FeaturesInput


### PR DESCRIPTION
This PR exports a new `editorConfigFactory` that provides multiple standardized ways to retrieve the editor configuration needed for the Lexical editor.

## Why this is needed

Getting the editor config is required for converting the lexical editor state into/from different formats, as it's needed to create a headless editor. While we're moving away from requiring headless editor instantiation for common format conversions, some conversion types and other use cases still require it.

Currently, retrieving the editor config is cumbersome - you either need an existing field to extract it from or the payload config to create it from scratch, with multiple approaches for each method.

## What this PR does

The `editorConfigFactory` consolidates all possible ways to retrieve the editor config into a single factory with clear methods:

```ts
editorConfigFactory.default()
editorConfigFactory.fromField()
editorConfigFactory.fromUnsanitizedField()
editorConfigFactory.fromFeatures()
editorConfigFactory.fromEditor()
```

This results in less code, simpler implementation, and improved developer experience. The PR also adds documentation for all retrieval methods.