### PR TITLE
docs: clarify that image resizing/cropping require `sharp` to be specified in payload config

### DIFF
--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -185,6 +185,8 @@ The [Admin Panel](../admin/overview) will also automatically display all availab
 
 Behind the scenes, Payload relies on [`sharp`](https://sharp.pixelplumbing.com/api-resize#resize) to perform its image resizing. You can specify additional options for `sharp` to use while resizing your images.
 
+Note that for image resizing to work, `sharp` must be specified in your [Payload Config](../configuration/overview). This is configured by default if you created your Payload project with `create-payload-app`. See `sharp` in [Config Options](../configuration/overview#config-options).
+
 #### Accessing the resized images in hooks
 
 All auto-resized images are exposed to be re-used in hooks and similar via an object that is bound to `req.payloadUploadSizes`.


### PR DESCRIPTION
### What

Clarifies that `sharp` must be specified in payload config for image resizing & cropping to work. Also adds link to the configuration page for further information.

### Why

It is not immediately clear from this single documentation page alone. While it says that the feature relies on sharp, it does not say that it must be added to config. Most people won't probably run into this since they're probably going to use `create-payload-app`, which configures sharp by default. But those who use custom config (like me) may be left wondering why this feature does not work.

See [Crop images and preview sizes not working](https://payloadcms.com/community-help/discord/crop-images-and-preview-sizes-not-working) in community help.
