### PR TITLE
feat(db-postgres): dependency inject pg to allow Sentry instrumentation

### DIFF
--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -3,7 +3,6 @@ import type { Connect, Payload } from 'payload'
 
 import { pushDevSchema } from '@payloadcms/drizzle'
 import { drizzle } from 'drizzle-orm/node-postgres'
-import pg from 'pg'
 
 import type { PostgresAdapter } from './types.js'
 
@@ -61,7 +60,7 @@ export const connect: Connect = async function connect(
 
   try {
     if (!this.pool) {
-      this.pool = new pg.Pool(this.poolOptions)
+      this.pool = new this.pg.Pool(this.poolOptions)
       await connectWithReconnect({ adapter: this, payload: this.payload })
     }
 

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -53,6 +53,7 @@ import {
 } from '@payloadcms/drizzle/postgres'
 import { pgEnum, pgSchema, pgTable } from 'drizzle-orm/pg-core'
 import { createDatabaseAdapter, defaultBeginTransaction } from 'payload'
+import pgDependency from 'pg'
 import { fileURLToPath } from 'url'
 
 import type { Args, PostgresAdapter } from './types.js'
@@ -122,6 +123,7 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       localesSuffix: args.localesSuffix || '_locales',
       logger: args.logger,
       operators: operatorMap,
+      pg: args.pg || pgDependency,
       pgSchema: adapterSchema,
       pool: undefined,
       poolOptions: args.pool,

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -12,6 +12,8 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
 import type { PgSchema, PgTableFn, PgTransactionConfig } from 'drizzle-orm/pg-core'
 import type { Pool, PoolConfig } from 'pg'
 
+type PgDependency = typeof import('pg')
+
 export type Args = {
   /**
    * Transform the schema after it's built.
@@ -37,6 +39,7 @@ export type Args = {
   localesSuffix?: string
   logger?: DrizzleConfig['logger']
   migrationDir?: string
+  pg?: PgDependency
   pool: PoolConfig
   prodMigrations?: {
     down: (args: MigrateDownArgs) => Promise<void>
@@ -66,6 +69,7 @@ type ResolveSchemaType<T> = 'schema' extends keyof T
 type Drizzle = NodePgDatabase<ResolveSchemaType<GeneratedDatabaseSchema>>
 export type PostgresAdapter = {
   drizzle: Drizzle
+  pg: PgDependency
   pool: Pool
   poolOptions: PoolConfig
 } & BasePostgresAdapter
@@ -90,6 +94,8 @@ declare module 'payload' {
     initializing: Promise<void>
     localesSuffix?: string
     logger: DrizzleConfig['logger']
+    /** Optionally inject your own node-postgres. This is required if you wish to instrument the driver with @payloadcms/plugin-sentry. */
+    pg?: PgDependency
     pgSchema?: { table: PgTableFn } | PgSchema
     pool: Pool
     poolOptions: Args['pool']


### PR DESCRIPTION
### What?

I changed the interface of `@payloadcms/db-postgres` to allow a user to (optionally) inject their own `pg` module.

### Why?

I noticed that `@payloadcms/sentry-plugin` wasn't instrumenting Payload's database queries through the [local payload API](https://payloadcms.com/docs/local-api/overview):

![image](https://github.com/user-attachments/assets/425691f5-cf7e-4625-89e0-6d07dda9cbc0)

This is because Sentry applies a patch to the `pg` driver on import. For whatever reason, it doesn't patch `pg` when imported by dependencies (e.g. `@payloadcms/db-postgres`). After applying this fix, I can see the underlying query traces!

![image](https://github.com/user-attachments/assets/fb6f9aef-13d9-41b1-b4cc-36c565d15930)
