### PR TITLE
chore(eslint): speed up no-imports-from-self rule by ensuring cache is used

### DIFF
--- a/packages/eslint-plugin/customRules/no-imports-from-self.js
+++ b/packages/eslint-plugin/customRules/no-imports-from-self.js
@@ -18,11 +18,11 @@ export const rule = {
     return {
       ImportDeclaration(node) {
         const importPath = node.source.value
-        const pkgName = getPackageName(context, packageName)
-        if (pkgName && importPath.startsWith(pkgName)) {
+        packageName = getPackageName(context, packageName)
+        if (packageName && importPath.startsWith(packageName)) {
           context.report({
             node,
-            message: `Package "${pkgName}" should not import from itself. Use relative instead.`,
+            message: `Package "${packageName}" should not import from itself. Use relative instead.`,
           })
         }
       },
@@ -41,8 +41,7 @@ function getPackageName(context, packageName) {
     return packageName
   }
 
-  const fileName = context.getFilename()
-  const pkg = findNearestPackageJson(path.dirname(fileName))
+  const pkg = findNearestPackageJson(path.dirname(context.filename))
   if (pkg) {
     return pkg.name
   }


### PR DESCRIPTION
Our `no-imports-from-self` eslint rule was supposed to cache the package.json name to ensure it doesn't try to find and read the package.json for every single import statement.

Turns out that cache was never used. Credits to @etrepum for [finding this issue](https://github.com/facebook/lexical/pull/7272#discussion_r1976666227)