### PR TITLE
chore: temporarily disables flaky "should execute a custom script" test

### DIFF
--- a/test/config/int.spec.ts
+++ b/test/config/int.spec.ts
@@ -129,7 +129,7 @@ describe('Config', () => {
       }
     }
 
-    it('should execute a custom script', () => {
+    it.skip('should execute a custom script', () => {
       deleteTestFile()
       executeCLI('start-server')
       expect(JSON.parse(readFileSync(testFilePath, 'utf-8')).docs).toHaveLength(1)


### PR DESCRIPTION
The newly added "should execute a custom script" int test is very flaky on mongodb - it was failing most of the time. This PR skips this test until it's fixed

Example failures:
- https://github.com/payloadcms/payload/actions/runs/13618762213/job/38065304540
- https://github.com/payloadcms/payload/actions/runs/13611742446/job/38049886588
- https://github.com/payloadcms/payload/actions/runs/13608918590/job/38043761182
- https://github.com/payloadcms/payload/actions/runs/13599001510/job/38021936623