### PR TITLE
fix: return valid s3 Content-Length

### DIFF
--- a/packages/storage-s3/src/staticHandler.ts
+++ b/packages/storage-s3/src/staticHandler.ts
@@ -54,10 +54,12 @@ export const getHandler = ({ bucket, collection, getStorageClient }: Args): Stat
       const objectEtag = object.ETag
 
       if (etagFromHeaders && etagFromHeaders === objectEtag) {
+        const bodyBuffer = await streamToBuffer(object.Body)
+
         const response = new Response(null, {
           headers: new Headers({
             'Accept-Ranges': String(object.AcceptRanges),
-            'Content-Length': String(object.ContentLength),
+            'Content-Length': String(object.ContentLength ?? bodyBuffer.length),
             'Content-Type': String(object.ContentType),
             ETag: String(object.ETag),
           }),
@@ -90,7 +92,7 @@ export const getHandler = ({ bucket, collection, getStorageClient }: Args): Stat
       return new Response(bodyBuffer, {
         headers: new Headers({
           'Accept-Ranges': String(object.AcceptRanges),
-          'Content-Length': String(object.ContentLength),
+          'Content-Length': String(object.ContentLength ?? bodyBuffer.length),
           'Content-Type': String(object.ContentType),
           ETag: String(object.ETag),
         }),


### PR DESCRIPTION
### What?
Files uploaded using `@payloadcms/storage-s3` with MinIO buckets throw errors when the user tries to edit the image or any field related to that image

### Why?
The plugin's static handler gets undefined in the `Content-Length` object details. The request is interpreted as being corrupted from other functions or postman, even if the browser is serving the file.

### How?
Using the `streamToBuffer` function for `Content-Length` I make sure I return a valid attribute.
Any field update works fine now.

Fixes
https://github.com/payloadcms/payload/issues/7037
