### PR TITLE
feat: add collection configuration to allow enabling `modifiedOnly=true` as default version comparison view

### DIFF
--- a/docs/versions/overview.mdx
+++ b/docs/versions/overview.mdx
@@ -53,10 +53,11 @@ When you have versions, drafts, _and_ `autosave` enabled, the Admin UI will auto
 
 Configuring Versions is done by adding the `versions` key to your Collection configs. Set it to `true` to enable default Versions settings, or customize versions options by setting the property equal to an object containing the following available options:
 
-| Option      | Description                                                                                                                                                        |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `maxPerDoc` | Use this setting to control how many versions to keep on a document by document basis. Must be an integer. Defaults to 100, use 0 to save all versions.            |
-| `drafts`    | Enable [Drafts](/docs/versions/drafts) mode for this collection. To enable, set to `true` or pass an object with `draft` [options](/docs/versions/drafts#options). |
+| Option                         | Description                                                                                                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `maxPerDoc`                    | Use this setting to control how many versions to keep on a document by document basis. Must be an integer. Defaults to 100, use 0 to save all versions.            |
+| `drafts`                       | Enable [Drafts](/docs/versions/drafts) mode for this collection. To enable, set to `true` or pass an object with `draft` [options](/docs/versions/drafts#options). |
+| `showModifiedOnlyByDefault`    | Controls whether or not only the modified content is shown by default when opening the version view. |
 
 ## Global config
 

--- a/packages/next/src/views/Versions/buildColumns.tsx
+++ b/packages/next/src/views/Versions/buildColumns.tsx
@@ -51,6 +51,7 @@ export const buildVersionColumns = ({
             docID={docID}
             globalSlug={globalConfig?.slug}
             key={i}
+            modifiedOnly={collectionConfig?.versions.showModifiedOnlyByDefault}
             rowData={{
               id: doc.id,
               updatedAt: doc.updatedAt,

--- a/packages/next/src/views/Versions/cells/CreatedAt/index.tsx
+++ b/packages/next/src/views/Versions/cells/CreatedAt/index.tsx
@@ -7,6 +7,7 @@ type CreatedAtCellProps = {
   collectionSlug?: string
   docID?: number | string
   globalSlug?: string
+  modifiedOnly?: boolean
   rowData?: {
     id: number | string
     updatedAt: Date | number | string
@@ -17,6 +18,7 @@ export const CreatedAtCell: React.FC<CreatedAtCellProps> = ({
   collectionSlug,
   docID,
   globalSlug,
+  modifiedOnly,
   rowData: { id, updatedAt } = {},
 }) => {
   const {
@@ -33,7 +35,7 @@ export const CreatedAtCell: React.FC<CreatedAtCellProps> = ({
   if (collectionSlug) {
     to = formatAdminURL({
       adminRoute,
-      path: `/collections/${collectionSlug}/${docID}/versions/${id}`,
+      path: `/collections/${collectionSlug}/${docID}/versions/${id}${modifiedOnly ? '?modifiedOnly=true' : ''}`,
     })
   }
 

--- a/packages/payload/src/versions/types.ts
+++ b/packages/payload/src/versions/types.ts
@@ -57,6 +57,10 @@ export type IncomingCollectionVersions = {
    * @default 100
    */
   maxPerDoc?: number
+  /**
+   * Whether or not to only view the modified content by default when opening the version view.
+   */
+  showModifiedOnlyByDefault?: boolean
 }
 
 export interface SanitizedCollectionVersions extends Omit<IncomingCollectionVersions, 'drafts'> {
@@ -72,6 +76,10 @@ export interface SanitizedCollectionVersions extends Omit<IncomingCollectionVers
    * @default 100
    */
   maxPerDoc: number
+  /**
+   * Whether or not to only view the modified content by default when opening the version view.
+   */
+  showModifiedOnlyByDefault: boolean
 }
 
 export type IncomingGlobalVersions = {

--- a/test/versions/globals/DraftWithOnlyModified.ts
+++ b/test/versions/globals/DraftWithOnlyModified.ts
@@ -1,0 +1,32 @@
+import type { CollectionConfig } from 'payload'
+
+import { draftWithModifiedOnlySlug } from '../slugs.js'
+
+const DraftPostsWithModifiedOnly: CollectionConfig = {
+  slug: draftWithModifiedOnlySlug,
+  admin: {
+    defaultColumns: ['title', 'description', 'createdAt', '_status'],
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      label: 'Title',
+      localized: true,
+      required: true,
+      unique: true,
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      label: 'Description',
+      required: true,
+    },
+  ],
+  versions: {
+    showModifiedOnlyByDefault: true,
+  },
+}
+
+export default DraftPostsWithModifiedOnly

--- a/test/versions/globals/DraftWithOnlyModifiedDisabled.ts
+++ b/test/versions/globals/DraftWithOnlyModifiedDisabled.ts
@@ -1,0 +1,32 @@
+import type { CollectionConfig } from 'payload'
+
+import { draftWithModifiedOnlyDisabledSlug } from '../slugs.js'
+
+const DraftPostsWithModifiedOnlyDisabledSlug: CollectionConfig = {
+  slug: draftWithModifiedOnlyDisabledSlug,
+  admin: {
+    defaultColumns: ['title', 'description', 'createdAt', '_status'],
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      label: 'Title',
+      localized: true,
+      required: true,
+      unique: true,
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      label: 'Description',
+      required: true,
+    },
+  ],
+  versions: {
+    showModifiedOnlyByDefault: false,
+  },
+}
+
+export default DraftPostsWithModifiedOnlyDisabledSlug

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -9,6 +9,9 @@ export const draftCollectionSlug = 'draft-posts'
 export const draftWithValidateCollectionSlug = 'draft-with-validate-posts'
 export const draftWithMaxCollectionSlug = 'draft-with-max-posts'
 
+export const draftWithModifiedOnlySlug = 'draft-with-modified-only'
+export const draftWithModifiedOnlyDisabledSlug = 'draft-with-modified-only-disabled'
+
 export const postCollectionSlug = 'posts'
 
 export const diffCollectionSlug = 'diff'


### PR DESCRIPTION
### What?

Adds new collection configuration option `versions.showModifiedOnlyByDefault: boolean`.

### Why?

For the content management editorial team I work with, it was deemed a better default to only show modified content when accessing version diffs.

![2025-03-04 21 00 11](https://github.com/user-attachments/assets/0dce7fa0-b524-48be-b96f-77f5b0bbb601)

### How?

The new collection option `versions.showModifiedOnlyByDefault: boolean` causes the version list table's links to the version diffs view in `packages/next/src/views/Versions/cells/CreatedAt/index.tsx` to optionally have the existing `?modifiedOnly=true` URL query parameter appended, which causes the `modifiedOnly` state in `packages/next/src/views/Version/index.tsx` to be computed to `true`, causing the UI button "Modified only" to be checked, and the diff to only show modified content.

### Considerations

I considered using the new option in `packages/next/src/views/Version/index.tsx`. Namely, [line 42](https://github.com/payloadcms/payload/blob/6a3d58bb32a23f7092039d44d24c1460f1c6d2ff/packages/next/src/views/Version/index.tsx#L42) could be changed as follows:

```diff
-  const modifiedOnly: boolean = searchParams.modifiedOnly === 'true'
+  const modifiedOnly: boolean =
+    searchParams.modifiedOnly === 'true'
+      ? true
+      : collectionConfig.versions.showModifiedOnlyByDefault
```

This would have allowed to change the default of `modifiedOnly` to true, while being able to force `modifiedOnly` to be `true` from the search params like today. I didn't go for it, because the search params already are existing as interface to transmit the state.

I also want to mention that I'm not sure about the tediously long option name `showModifiedOnlyByDefault`. Maybe `showModifiedOnly` is sufficient? Or `showModifiedOnlyDiff`?

Lastly, this PR is not adding a matching global option. Should that be in scope for consistency?

### Automated Tests

I was not able to get `pnpm test:e2e versions` to work on my machine, so the attached tests were implemented blindly. I'll amend them to actually work once I have that sussed out / CI shows me what I need to change there.

Maybe you can help me get set up with the issue running E2Es?

When running `pnpm test:e2e versions`, (or also all tests without test folder specified), the test seems to "hang" indefinitely after the HTTP 200 call to `GET /admin`. The actual test suites don't appear to start. Is this a known issue?

<img width="810" alt="image" src="https://github.com/user-attachments/assets/3e883394-43a3-48c3-aefa-dcf63b6dbdb5" />
 
Running `pnpm test:e2e:debug` is worse and just fails outright complaining about stuff like `jest` not being defined in `.github/actions/release-commenter/src/index.test.ts` or other stuff that suggests that this command is running code it shouldn’t run.
