### PR TITLE
fix: collection config deep merge during sanitization causing unpredictable behavior

### DIFF
--- a/packages/payload/src/collections/config/defaults.ts
+++ b/packages/payload/src/collections/config/defaults.ts
@@ -62,7 +62,7 @@ export const mergeCollectionConfigWithDefaults = (
     read: defaultAccess,
     unlock: defaultAccess,
     update: defaultAccess,
-    ...collection.access,
+    ...(collection.access || {}),
   }
 
   collection.admin = {
@@ -70,13 +70,13 @@ export const mergeCollectionConfigWithDefaults = (
     custom: {},
     enableRichTextLink: true,
     enableRichTextRelationship: true,
+    useAsTitle: 'id',
+    ...(collection.admin || {}),
     pagination: {
       defaultLimit: 10,
       limits: [5, 10, 25, 50, 100],
-      ...collection.admin?.pagination,
+      ...(collection.admin?.pagination || {}),
     },
-    useAsTitle: 'id',
-    ...collection.admin,
   }
 
   collection.auth = collection.auth ?? false
@@ -102,7 +102,7 @@ export const mergeCollectionConfigWithDefaults = (
     beforeValidate: [],
     me: [],
     refresh: [],
-    ...collection.hooks,
+    ...(collection.hooks || {}),
   }
 
   collection.timestamps = collection.timestamps ?? true
@@ -132,7 +132,7 @@ export const mergeAuthConfigWithDefaults = (auth: IncomingAuthType): IncomingAut
   auth.cookies = {
     sameSite: 'Lax',
     secure: false,
-    ...auth.cookies,
+    ...(auth.cookies || {}),
   }
 
   auth.forgotPassword = auth.forgotPassword ?? {}
@@ -161,5 +161,5 @@ export const mergeLoginWithUsernameConfigWithDefaults = (
     allowEmailLogin: false,
     requireEmail: false,
     requireUsername: true,
-    ...loginWithUsername,
+    ...(loginWithUsername || {}),
   }) as LoginWithUsernameOptions

--- a/packages/payload/src/collections/config/defaults.ts
+++ b/packages/payload/src/collections/config/defaults.ts
@@ -53,9 +53,7 @@ export const defaults: Partial<CollectionConfig> = {
   versions: false,
 }
 
-export const mergeCollectionConfigWithDefaults = (
-  collection: CollectionConfig,
-): CollectionConfig => {
+export const addDefaultsToCollectionConfig = (collection: CollectionConfig): CollectionConfig => {
   collection.access = {
     create: defaultAccess,
     delete: defaultAccess,
@@ -128,7 +126,7 @@ export const authDefaults: IncomingAuthType = {
   verify: false,
 }
 
-export const mergeAuthConfigWithDefaults = (auth: IncomingAuthType): IncomingAuthType => {
+export const addDefaultsToAuthConfig = (auth: IncomingAuthType): IncomingAuthType => {
   auth.cookies = {
     sameSite: 'Lax',
     secure: false,
@@ -141,6 +139,11 @@ export const mergeAuthConfigWithDefaults = (auth: IncomingAuthType): IncomingAut
   auth.maxLoginAttempts = auth.maxLoginAttempts ?? 5
   auth.tokenExpiration = auth.tokenExpiration ?? 7200
   auth.verify = auth.verify ?? false
+  auth.strategies = auth.strategies ?? []
+
+  if (!auth.disableLocalStrategy && auth.verify === true) {
+    auth.verify = {}
+  }
 
   return auth
 }
@@ -154,7 +157,7 @@ export const loginWithUsernameDefaults: LoginWithUsernameOptions = {
   requireUsername: true,
 }
 
-export const mergeLoginWithUsernameConfigWithDefaults = (
+export const addDefaultsToLoginWithUsernameConfig = (
   loginWithUsername: LoginWithUsernameOptions,
 ): LoginWithUsernameOptions =>
   ({

--- a/packages/payload/src/collections/config/defaults.ts
+++ b/packages/payload/src/collections/config/defaults.ts
@@ -3,6 +3,9 @@ import type { CollectionConfig } from './types.js'
 
 import defaultAccess from '../../auth/defaultAccess.js'
 
+/**
+ * @deprecated - remove in 4.0. This is error-prone, as mutating this object will affect any objects that use the defaults as a base.
+ */
 export const defaults: Partial<CollectionConfig> = {
   access: {
     create: defaultAccess,
@@ -50,6 +53,68 @@ export const defaults: Partial<CollectionConfig> = {
   versions: false,
 }
 
+export const mergeCollectionConfigWithDefaults = (
+  collection: CollectionConfig,
+): CollectionConfig => {
+  collection.access = {
+    create: defaultAccess,
+    delete: defaultAccess,
+    read: defaultAccess,
+    unlock: defaultAccess,
+    update: defaultAccess,
+    ...collection.access,
+  }
+
+  collection.admin = {
+    components: {},
+    custom: {},
+    enableRichTextLink: true,
+    enableRichTextRelationship: true,
+    pagination: {
+      defaultLimit: 10,
+      limits: [5, 10, 25, 50, 100],
+      ...collection.admin?.pagination,
+    },
+    useAsTitle: 'id',
+    ...collection.admin,
+  }
+
+  collection.auth = collection.auth ?? false
+  collection.custom = collection.custom ?? {}
+  collection.endpoints = collection.endpoints ?? []
+  collection.fields = collection.fields ?? []
+
+  collection.hooks = {
+    afterChange: [],
+    afterDelete: [],
+    afterForgotPassword: [],
+    afterLogin: [],
+    afterLogout: [],
+    afterMe: [],
+    afterOperation: [],
+    afterRead: [],
+    afterRefresh: [],
+    beforeChange: [],
+    beforeDelete: [],
+    beforeLogin: [],
+    beforeOperation: [],
+    beforeRead: [],
+    beforeValidate: [],
+    me: [],
+    refresh: [],
+    ...collection.hooks,
+  }
+
+  collection.timestamps = collection.timestamps ?? true
+  collection.upload = collection.upload ?? false
+  collection.versions = collection.versions ?? false
+
+  return collection
+}
+
+/**
+ * @deprecated - remove in 4.0. This is error-prone, as mutating this object will affect any objects that use the defaults as a base.
+ */
 export const authDefaults: IncomingAuthType = {
   cookies: {
     sameSite: 'Lax',
@@ -63,8 +128,38 @@ export const authDefaults: IncomingAuthType = {
   verify: false,
 }
 
+export const mergeAuthConfigWithDefaults = (auth: IncomingAuthType): IncomingAuthType => {
+  auth.cookies = {
+    sameSite: 'Lax',
+    secure: false,
+    ...auth.cookies,
+  }
+
+  auth.forgotPassword = auth.forgotPassword ?? {}
+  auth.lockTime = auth.lockTime ?? 600000 // 10 minutes
+  auth.loginWithUsername = auth.loginWithUsername ?? false
+  auth.maxLoginAttempts = auth.maxLoginAttempts ?? 5
+  auth.tokenExpiration = auth.tokenExpiration ?? 7200
+  auth.verify = auth.verify ?? false
+
+  return auth
+}
+
+/**
+ * @deprecated - remove in 4.0. This is error-prone, as mutating this object will affect any objects that use the defaults as a base.
+ */
 export const loginWithUsernameDefaults: LoginWithUsernameOptions = {
   allowEmailLogin: false,
   requireEmail: false,
   requireUsername: true,
 }
+
+export const mergeLoginWithUsernameConfigWithDefaults = (
+  loginWithUsername: LoginWithUsernameOptions,
+): LoginWithUsernameOptions =>
+  ({
+    allowEmailLogin: false,
+    requireEmail: false,
+    requireUsername: true,
+    ...loginWithUsername,
+  }) as LoginWithUsernameOptions

--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -21,9 +21,9 @@ import baseVersionFields from '../../versions/baseFields.js'
 import { versionDefaults } from '../../versions/defaults.js'
 import { defaultCollectionEndpoints } from '../endpoints/index.js'
 import {
-  mergeAuthConfigWithDefaults,
-  mergeCollectionConfigWithDefaults,
-  mergeLoginWithUsernameConfigWithDefaults,
+  addDefaultsToAuthConfig,
+  addDefaultsToCollectionConfig,
+  addDefaultsToLoginWithUsernameConfig,
 } from './defaults.js'
 import { sanitizeAuthFields, sanitizeUploadFields } from './reservedFieldNames.js'
 import { validateUseAsTitle } from './useAsTitle.js'
@@ -42,7 +42,7 @@ export const sanitizeCollection = async (
   // Make copy of collection config
   // /////////////////////////////////
 
-  const sanitized: CollectionConfig = mergeCollectionConfigWithDefaults(collection)
+  const sanitized: CollectionConfig = addDefaultsToCollectionConfig(collection)
 
   // /////////////////////////////////
   // Sanitize fields
@@ -192,26 +192,18 @@ export const sanitizeCollection = async (
     // sanitize fields for reserved names
     sanitizeAuthFields(sanitized.fields, sanitized)
 
-    sanitized.auth = mergeAuthConfigWithDefaults(
+    sanitized.auth = addDefaultsToAuthConfig(
       typeof sanitized.auth === 'boolean' ? {} : sanitized.auth,
     )
-
-    if (!sanitized.auth.disableLocalStrategy && sanitized.auth.verify === true) {
-      sanitized.auth.verify = {}
-    }
 
     // disable duplicate for auth enabled collections by default
     sanitized.disableDuplicate = sanitized.disableDuplicate ?? true
 
-    if (!sanitized.auth.strategies) {
-      sanitized.auth.strategies = []
-    }
-
     if (sanitized.auth.loginWithUsername) {
       if (sanitized.auth.loginWithUsername === true) {
-        sanitized.auth.loginWithUsername = mergeLoginWithUsernameConfigWithDefaults({})
+        sanitized.auth.loginWithUsername = addDefaultsToLoginWithUsernameConfig({})
       } else {
-        const loginWithUsernameWithDefaults = mergeLoginWithUsernameConfigWithDefaults(
+        const loginWithUsernameWithDefaults = addDefaultsToLoginWithUsernameConfig(
           sanitized.auth.loginWithUsername,
         )
 

--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -38,6 +38,10 @@ export const sanitizeCollection = async (
   richTextSanitizationPromises?: Array<(config: SanitizedConfig) => Promise<void>>,
   _validRelationships?: string[],
 ): Promise<SanitizedCollectionConfig> => {
+  if (collection._sanitized) {
+    return collection as SanitizedCollectionConfig
+  }
+  collection._sanitized = true
   // /////////////////////////////////
   // Make copy of collection config
   // /////////////////////////////////

--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -16,7 +16,6 @@ import { fieldAffectsData } from '../../fields/config/types.js'
 import mergeBaseFields from '../../fields/mergeBaseFields.js'
 import { uploadCollectionEndpoints } from '../../uploads/endpoints/index.js'
 import { getBaseUploadFields } from '../../uploads/getBaseFields.js'
-import { deepMergeWithReactComponents } from '../../utilities/deepMerge.js'
 import { flattenAllFields } from '../../utilities/flattenAllFields.js'
 import { formatLabels } from '../../utilities/formatLabels.js'
 import baseVersionFields from '../../versions/baseFields.js'
@@ -40,7 +39,26 @@ export const sanitizeCollection = async (
   // Make copy of collection config
   // /////////////////////////////////
 
-  const sanitized: CollectionConfig = deepMergeWithReactComponents(defaults, collection)
+  const sanitized: CollectionConfig = {
+    ...defaults,
+    ...collection,
+    access: {
+      ...defaults.access,
+      ...collection?.access,
+    },
+    admin: {
+      ...defaults?.admin,
+      ...collection?.admin,
+      pagination: {
+        ...defaults?.admin?.pagination,
+        ...collection?.admin?.pagination,
+      },
+    },
+    hooks: {
+      ...defaults.hooks,
+      ...collection?.hooks,
+    },
+  }
 
   // /////////////////////////////////
   // Sanitize fields
@@ -190,10 +208,16 @@ export const sanitizeCollection = async (
     // sanitize fields for reserved names
     sanitizeAuthFields(sanitized.fields, sanitized)
 
-    sanitized.auth = deepMergeWithReactComponents(
-      authDefaults,
-      typeof sanitized.auth === 'object' ? sanitized.auth : {},
-    )
+    sanitized.auth = {
+      ...authDefaults,
+      ...(typeof sanitized.auth === 'object' ? sanitized.auth : {}),
+      cookies: {
+        ...authDefaults.cookies,
+        ...(typeof sanitized.auth === 'object' && typeof sanitized.auth?.cookies === 'object'
+          ? sanitized.auth.cookies
+          : {}),
+      },
+    }
 
     if (!sanitized.auth.disableLocalStrategy && sanitized.auth.verify === true) {
       sanitized.auth.verify = {}

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -370,6 +370,11 @@ export type CollectionAdminOptions = {
 /** Manage all aspects of a data collection */
 export type CollectionConfig<TSlug extends CollectionSlug = any> = {
   /**
+   * Do not set this property manually. This is set to true during sanitization, to avoid
+   * sanitizing the same collection multiple times.
+   */
+  _sanitized?: boolean
+  /**
    * Access control
    */
   access?: {

--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -73,7 +73,7 @@ export const defaults: Omit<Config, 'db' | 'editor' | 'secret'> = {
   upload: {},
 }
 
-export const mergeConfigWithDefaults = (config: Config): Config => {
+export const addDefaultsToConfig = (config: Config): Config => {
   config.admin = {
     avatar: 'gravatar',
     components: {},

--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -3,6 +3,9 @@ import type { Config } from './types.js'
 
 import defaultAccess from '../auth/defaultAccess.js'
 
+/**
+ * @deprecated - remove in 4.0. This is error-prone, as mutating this object will affect any objects that use the defaults as a base.
+ */
 export const defaults: Omit<Config, 'db' | 'editor' | 'secret'> = {
   admin: {
     avatar: 'gravatar',
@@ -68,4 +71,83 @@ export const defaults: Omit<Config, 'db' | 'editor' | 'secret'> = {
     outputFile: `${typeof process?.cwd === 'function' ? process.cwd() : ''}/payload-types.ts`,
   },
   upload: {},
+}
+
+export const mergeConfigWithDefaults = (config: Config): Config => {
+  config.admin = {
+    avatar: 'gravatar',
+    components: {},
+    custom: {},
+    dateFormat: 'MMMM do yyyy, h:mm a',
+    dependencies: {},
+    theme: 'all',
+    ...(config.admin || {}),
+    importMap: {
+      baseDir: `${typeof process?.cwd === 'function' ? process.cwd() : ''}`,
+      ...(config?.admin?.importMap || {}),
+    },
+    meta: {
+      defaultOGImageType: 'dynamic',
+      titleSuffix: '- Payload',
+      ...(config?.admin?.meta || {}),
+    },
+    routes: {
+      account: '/account',
+      createFirstUser: '/create-first-user',
+      forgot: '/forgot',
+      inactivity: '/logout-inactivity',
+      login: '/login',
+      logout: '/logout',
+      reset: '/reset',
+      unauthorized: '/unauthorized',
+      ...(config?.admin?.routes || {}),
+    },
+  }
+
+  config.bin = config.bin ?? []
+  config.collections = config.collections ?? []
+  config.cookiePrefix = config.cookiePrefix ?? 'payload'
+  config.cors = config.cors ?? []
+  config.csrf = config.csrf ?? []
+  config.custom = config.custom ?? {}
+  config.defaultDepth = config.defaultDepth ?? 2
+  config.defaultMaxTextLength = config.defaultMaxTextLength ?? 40000
+  config.endpoints = config.endpoints ?? []
+  config.globals = config.globals ?? []
+  config.graphQL = {
+    disablePlaygroundInProduction: true,
+    maxComplexity: 1000,
+    schemaOutputFile: `${typeof process?.cwd === 'function' ? process.cwd() : ''}/schema.graphql`,
+    ...(config.graphQL || {}),
+  }
+  config.hooks = config.hooks ?? {}
+  config.i18n = config.i18n ?? {}
+  config.jobs = {
+    deleteJobOnComplete: true,
+    depth: 0,
+    ...(config.jobs || {}),
+    access: {
+      run: defaultAccess,
+      ...(config.jobs?.access || {}),
+    },
+  } as JobsConfig
+  config.localization = config.localization ?? false
+  config.maxDepth = config.maxDepth ?? 10
+  config.routes = {
+    admin: '/admin',
+    api: (process.env.NEXT_BASE_PATH ?? '') + '/api',
+    graphQL: '/graphql',
+    graphQLPlayground: '/graphql-playground',
+    ...(config.routes || {}),
+  }
+  config.serverURL = config.serverURL ?? ''
+  config.telemetry = config.telemetry ?? true
+  config.typescript = {
+    autoGenerate: true,
+    outputFile: `${typeof process?.cwd === 'function' ? process.cwd() : ''}/payload-types.ts`,
+    ...(config.typescript || {}),
+  }
+  config.upload = config.upload ?? {}
+
+  return config
 }

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -31,7 +31,7 @@ import getPreferencesCollection from '../preferences/preferencesCollection.js'
 import { getDefaultJobsCollection } from '../queues/config/jobsCollection.js'
 import { flattenBlock } from '../utilities/flattenAllFields.js'
 import { getSchedulePublishTask } from '../versions/schedule/job.js'
-import { mergeConfigWithDefaults } from './defaults.js'
+import { addDefaultsToConfig } from './defaults.js'
 
 const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig> => {
   const sanitizedConfig = { ...configToSanitize }
@@ -100,7 +100,7 @@ const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig>
 }
 
 export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedConfig> => {
-  const configWithDefaults = mergeConfigWithDefaults(incomingConfig)
+  const configWithDefaults = addDefaultsToConfig(incomingConfig)
 
   const config: Partial<SanitizedConfig> = sanitizeAdminConfig(configWithDefaults)
 

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -278,46 +278,57 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
   ) {
     let defaultJobsCollection = getDefaultJobsCollection(config as unknown as Config)
 
-    if (typeof configWithDefaults.jobs.jobsCollectionOverrides === 'function') {
-      defaultJobsCollection = configWithDefaults.jobs.jobsCollectionOverrides({
+    if (defaultJobsCollection) {
+      if (typeof configWithDefaults.jobs.jobsCollectionOverrides === 'function') {
+        defaultJobsCollection = configWithDefaults.jobs.jobsCollectionOverrides({
+          defaultJobsCollection,
+        })
+      }
+      const sanitizedJobsCollection = await sanitizeCollection(
+        config as unknown as Config,
         defaultJobsCollection,
-      })
+        richTextSanitizationPromises,
+        validRelationships,
+      )
+
+      configWithDefaults.collections.push(sanitizedJobsCollection)
     }
-
-    const sanitizedJobsCollection = await sanitizeCollection(
-      config as unknown as Config,
-      defaultJobsCollection,
-      richTextSanitizationPromises,
-      validRelationships,
-    )
-
-    configWithDefaults.collections.push(sanitizedJobsCollection)
   }
 
-  configWithDefaults.collections.push(
-    await sanitizeCollection(
-      config as unknown as Config,
-      getLockedDocumentsCollection(config as unknown as Config),
-      richTextSanitizationPromises,
-      validRelationships,
-    ),
-  )
-  configWithDefaults.collections.push(
-    await sanitizeCollection(
-      config as unknown as Config,
-      getPreferencesCollection(config as unknown as Config),
-      richTextSanitizationPromises,
-      validRelationships,
-    ),
-  )
-  configWithDefaults.collections.push(
-    await sanitizeCollection(
-      config as unknown as Config,
-      migrationsCollection,
-      richTextSanitizationPromises,
-      validRelationships,
-    ),
-  )
+  const lockedDocumentsCollection = getLockedDocumentsCollection(config as unknown as Config)
+  if (lockedDocumentsCollection) {
+    configWithDefaults.collections.push(
+      await sanitizeCollection(
+        config as unknown as Config,
+        getLockedDocumentsCollection(config as unknown as Config),
+        richTextSanitizationPromises,
+        validRelationships,
+      ),
+    )
+  }
+
+  const preferencesCollection = getPreferencesCollection(config as unknown as Config)
+  if (preferencesCollection) {
+    configWithDefaults.collections.push(
+      await sanitizeCollection(
+        config as unknown as Config,
+        getPreferencesCollection(config as unknown as Config),
+        richTextSanitizationPromises,
+        validRelationships,
+      ),
+    )
+  }
+
+  if (migrationsCollection) {
+    configWithDefaults.collections.push(
+      await sanitizeCollection(
+        config as unknown as Config,
+        migrationsCollection,
+        richTextSanitizationPromises,
+        validRelationships,
+      ),
+    )
+  }
 
   if (config.serverURL !== '') {
     config.csrf.push(config.serverURL)

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -31,7 +31,7 @@ import getPreferencesCollection from '../preferences/preferencesCollection.js'
 import { getDefaultJobsCollection } from '../queues/config/jobsCollection.js'
 import { flattenBlock } from '../utilities/flattenAllFields.js'
 import { getSchedulePublishTask } from '../versions/schedule/job.js'
-import { defaults } from './defaults.js'
+import { mergeConfigWithDefaults } from './defaults.js'
 
 const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig> => {
   const sanitizedConfig = { ...configToSanitize }
@@ -100,55 +100,7 @@ const sanitizeAdminConfig = (configToSanitize: Config): Partial<SanitizedConfig>
 }
 
 export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedConfig> => {
-  const configWithDefaults = {
-    ...defaults,
-    ...incomingConfig,
-    admin: {
-      ...defaults.admin,
-      ...incomingConfig?.admin,
-      meta: {
-        ...defaults.admin.meta,
-        ...incomingConfig?.admin?.meta,
-      },
-      routes: {
-        ...defaults.admin.routes,
-        ...incomingConfig?.admin?.routes,
-      },
-    },
-    graphQL: {
-      ...defaults.graphQL,
-      ...incomingConfig?.graphQL,
-    },
-    jobs: {
-      ...defaults.jobs,
-      ...incomingConfig?.jobs,
-      access: {
-        ...defaults.jobs.access,
-        ...incomingConfig?.jobs?.access,
-      },
-      tasks: incomingConfig?.jobs?.tasks || [],
-      workflows: incomingConfig?.jobs?.workflows || [],
-    },
-    routes: {
-      ...defaults.routes,
-      ...incomingConfig?.routes,
-    },
-    typescript: {
-      ...defaults.typescript,
-      ...incomingConfig?.typescript,
-    },
-  }
-
-  if (!configWithDefaults?.serverURL) {
-    configWithDefaults.serverURL = ''
-  }
-
-  if (process.env.NEXT_BASE_PATH) {
-    if (!incomingConfig?.routes?.api) {
-      // check for incomingConfig, as configWithDefaults will always have a default value for routes.api
-      configWithDefaults.routes.api = process.env.NEXT_BASE_PATH + '/api'
-    }
-  }
+  const configWithDefaults = mergeConfigWithDefaults(incomingConfig)
 
   const config: Partial<SanitizedConfig> = sanitizeAdminConfig(configWithDefaults)
 

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -79,6 +79,9 @@ export const sanitizeFields = async ({
     if ('_sanitized' in field && field._sanitized === true) {
       continue
     }
+    if ('_sanitized' in field) {
+      field._sanitized = true
+    }
 
     if (!field.type) {
       throw new MissingFieldType(field)
@@ -303,10 +306,6 @@ export const sanitizeFields = async ({
 
     if (field.type === 'ui' && typeof field.admin.disableBulkEdit === 'undefined') {
       field.admin.disableBulkEdit = true
-    }
-
-    if ('_sanitized' in field) {
-      field._sanitized = true
     }
 
     fields[i] = field

--- a/packages/payload/src/globals/config/sanitize.ts
+++ b/packages/payload/src/globals/config/sanitize.ts
@@ -22,6 +22,11 @@ export const sanitizeGlobal = async (
   richTextSanitizationPromises?: Array<(config: SanitizedConfig) => Promise<void>>,
   _validRelationships?: string[],
 ): Promise<SanitizedGlobalConfig> => {
+  if (global._sanitized) {
+    return global as SanitizedGlobalConfig
+  }
+  global._sanitized = true
+
   global.label = global.label || toWords(global.slug)
 
   // /////////////////////////////////

--- a/packages/payload/src/globals/config/sanitize.ts
+++ b/packages/payload/src/globals/config/sanitize.ts
@@ -22,8 +22,6 @@ export const sanitizeGlobal = async (
   richTextSanitizationPromises?: Array<(config: SanitizedConfig) => Promise<void>>,
   _validRelationships?: string[],
 ): Promise<SanitizedGlobalConfig> => {
-  const { collections } = config
-
   global.label = global.label || toWords(global.slug)
 
   // /////////////////////////////////

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -143,6 +143,11 @@ export type GlobalAdminOptions = {
 }
 
 export type GlobalConfig = {
+  /**
+   * Do not set this property manually. This is set to true during sanitization, to avoid
+   * sanitizing the same global multiple times.
+   */
+  _sanitized?: boolean
   access?: {
     read?: Access
     readDrafts?: Access

--- a/packages/payload/src/queues/config/jobsCollection.ts
+++ b/packages/payload/src/queues/config/jobsCollection.ts
@@ -6,20 +6,16 @@ import { runJobsEndpoint } from '../restEndpointRun.js'
 import { getJobTaskStatus } from '../utilities/getJobTaskStatus.js'
 
 export const getDefaultJobsCollection: (config: Config) => CollectionConfig | null = (config) => {
-  if (!Array.isArray(config?.jobs?.workflows)) {
-    return null
-  }
-
   const workflowSlugs: Set<string> = new Set()
   const taskSlugs: Set<string> = new Set(['inline'])
 
-  if (config.jobs?.workflows.length) {
+  if (config.jobs?.workflows?.length) {
     config.jobs?.workflows.forEach((workflow) => {
       workflowSlugs.add(workflow.slug)
     })
   }
 
-  if (config.jobs?.tasks.length) {
+  if (config.jobs?.tasks?.length) {
     config.jobs.tasks.forEach((task) => {
       if (workflowSlugs.has(task.slug)) {
         throw new Error(

--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -4,6 +4,7 @@ import type { Config } from '../config/types.js'
 
 import { sanitizeConfig } from '../config/sanitize.js'
 import { configToJSONSchema } from './configToJSONSchema.js'
+import type { Block, BlocksField, RichTextField } from '../fields/config/types.js'
 
 describe('configToJSONSchema', () => {
   it('should handle optional arrays with required fields', async () => {
@@ -332,5 +333,82 @@ describe('configToJSONSchema', () => {
       required: ['id'],
       title: 'Test',
     })
+  })
+
+  it('should handle same block object being referenced in both collection and config.blocks', async () => {
+    const sharedBlock: Block = {
+      slug: 'sharedBlock',
+      interfaceName: 'SharedBlock',
+      fields: [
+        {
+          name: 'richText',
+          type: 'richText',
+          editor: () => {
+            // stub rich text editor
+            return {
+              CellComponent: '',
+              FieldComponent: '',
+              validate: () => true,
+            }
+          },
+        },
+      ],
+    }
+
+    // @ts-expect-error
+    const config: Config = {
+      blocks: [sharedBlock],
+      collections: [
+        {
+          slug: 'test',
+          fields: [
+            {
+              name: 'someBlockField',
+              type: 'blocks',
+              blocks: [sharedBlock],
+            },
+          ],
+          timestamps: false,
+        },
+      ],
+    }
+
+    // Ensure both rich text editor are sanitized
+    const sanitizedConfig = await sanitizeConfig(config)
+    expect(typeof (sanitizedConfig?.blocks?.[0]?.fields?.[0] as RichTextField)?.editor).toBe(
+      'object',
+    )
+    expect(
+      typeof (
+        (sanitizedConfig.collections[0].fields[0] as BlocksField)?.blocks?.[0]
+          ?.fields?.[0] as RichTextField
+      )?.editor,
+    ).toBe('object')
+
+    const schema = configToJSONSchema(sanitizedConfig, 'text')
+
+    expect(schema?.definitions?.test).toStrictEqual({
+      type: 'object',
+      additionalProperties: false,
+      title: 'Test',
+      properties: {
+        id: {
+          type: 'string',
+        },
+        someBlockField: {
+          type: ['array', 'null'],
+          items: {
+            oneOf: [
+              {
+                $ref: '#/definitions/SharedBlock',
+              },
+            ],
+          },
+        },
+      },
+      required: ['id'],
+    })
+
+    expect(schema?.definitions?.SharedBlock).toBeDefined()
   })
 })


### PR DESCRIPTION
Deep‐merging the collection config defaults during sanitization causes all collection fields to end up with different object references. This is not only slow, but can also lead to unpredictable behavior: mutations made before collection sanitization are reflected in the field config, while mutations made afterward, using the same object reference, are not reflected in the collection’s field config.

Specifically, the following happened:

1. A Block was defined in the module scope.
2. It was then added to both a collection’s blocks field and the config.blocks property.
3. Rich text sanitization promises for config.blocks were collected.
4. The collection config was sanitized.
5. The config.blocks sanitization promises were awaited.
6. Rich text fields were sanitized in config.blocks, but ended up not being sanitized in the collection config referencing the same block, because the object reference held by the promise callback no longer matched the collection config’s object reference. The collection config block did not create its own rich text sanitization promise, as `_sanitized: true` was set on the block during the earlier config.blocks sanitization, which skipped it.

Our config defaults pattern was brittle in general. It’s easy to misuse object spreading or to mutate the config defaults later when you intended only to mutate the payload or collection config. Our current approach was vulnerable to this because it retained some object references from the config defaults.

This PR introduces reliable merge functions that are faster and ensure no object references are shared with defaults that reside in the module scope.