### PR TITLE
ci: cache mongodb image to avoid rate limiting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -457,8 +457,9 @@ jobs:
         if: matrix.database == 'postgres'
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.11.0
+        uses: supercharge/mongodb-github-action@1.12.0
         with:
+          mongodb-image: 'public.ecr.aws/docker/library/mongo'
           mongodb-version: 6.0
         if: matrix.database == 'mongodb'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -417,6 +417,7 @@ jobs:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: payloadtests
+      MONGODB_VERSION: 6.0
 
     steps:
       - uses: actions/checkout@v4
@@ -456,10 +457,15 @@ jobs:
           echo "POSTGRES_URL=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/$POSTGRES_DB" >> $GITHUB_ENV
         if: matrix.database == 'postgres'
 
+      # Avoid dockerhub rate-limiting
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ runner.os }}-mongo-${{ env.MONGODB_VERSION }}
+
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.0
         with:
-          mongodb-image: 'public.ecr.aws/docker/library/mongo'
           mongodb-version: 6.0
         if: matrix.database == 'mongodb'
 


### PR DESCRIPTION
Adding usage of `ScribeMD/docker-cache` to cache the mongodb image.

We utilize the [supercharge/mongodb-github-action](https://github.com/supercharge/mongodb-github-action) for pulling and starting our mongo image. This would at times cause `You have reached your unauthenticated pull rate limit` errors because of how many jobs our CI spins up at one time.