### PR TITLE
fix(storage-*): client uploads with `disablePayloadAccessControl: true`

### DIFF
--- a/packages/plugin-cloud-storage/src/plugin.ts
+++ b/packages/plugin-cloud-storage/src/plugin.ts
@@ -60,6 +60,17 @@ export const cloudStoragePlugin =
 
           if (!options.disablePayloadAccessControl) {
             handlers.push(adapter.staticHandler)
+            // Else if disablePayloadAccessControl: true and clientUploads is used
+            // Build the "proxied" handler that responses only when the file was requested by client upload in addDataAndFileToRequest
+          } else if (adapter.clientUploads) {
+            handlers.push((req, args) => {
+              if ('clientUploadContext' in args.params) {
+                return adapter.staticHandler(req, args)
+              }
+
+              // Otherwise still skip staticHandler
+              return null
+            })
           }
 
           return {

--- a/packages/plugin-cloud-storage/src/types.ts
+++ b/packages/plugin-cloud-storage/src/types.ts
@@ -63,6 +63,7 @@ export type StaticHandler = (
 ) => Promise<Response> | Response
 
 export interface GeneratedAdapter {
+  clientUploads?: ClientUploadsConfig
   /**
    * Additional fields to be injected into the base collection and image sizes
    */

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -134,7 +134,13 @@ export const azureStorage: AzureStoragePlugin =
 
 function azureStorageInternal(
   getStorageClient: () => ContainerClient,
-  { allowContainerCreate, baseURL, connectionString, containerName }: AzureStorageOptions,
+  {
+    allowContainerCreate,
+    baseURL,
+    clientUploads,
+    connectionString,
+    containerName,
+  }: AzureStorageOptions,
 ): Adapter {
   const createContainerIfNotExists = () => {
     void getStorageClientFunc({ connectionString, containerName }).createIfNotExists({
@@ -145,6 +151,7 @@ function azureStorageInternal(
   return ({ collection, prefix }): GeneratedAdapter => {
     return {
       name: 'azure',
+      clientUploads,
       generateURL: getGenerateURL({ baseURL, containerName }),
       handleDelete: getHandleDelete({ collection, getStorageClient }),
       handleUpload: getHandleUpload({

--- a/packages/storage-gcs/src/index.ts
+++ b/packages/storage-gcs/src/index.ts
@@ -128,11 +128,12 @@ export const gcsStorage: GcsStoragePlugin =
 
 function gcsStorageInternal(
   getStorageClient: () => Storage,
-  { acl, bucket }: GcsStorageOptions,
+  { acl, bucket, clientUploads }: GcsStorageOptions,
 ): Adapter {
   return ({ collection, prefix }): GeneratedAdapter => {
     return {
       name: 'gcs',
+      clientUploads,
       generateURL: getGenerateURL({ bucket, getStorageClient }),
       handleDelete: getHandleDelete({ bucket, getStorageClient }),
       handleUpload: getHandleUpload({

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -142,11 +142,12 @@ export const s3Storage: S3StoragePlugin =
 
 function s3StorageInternal(
   getStorageClient: () => AWS.S3,
-  { acl, bucket, config = {} }: S3StorageOptions,
+  { acl, bucket, clientUploads, config = {} }: S3StorageOptions,
 ): Adapter {
   return ({ collection, prefix }): GeneratedAdapter => {
     return {
       name: 's3',
+      clientUploads,
       generateURL: getGenerateURL({ bucket, config }),
       handleDelete: getHandleDelete({ bucket, getStorageClient }),
       handleUpload: getHandleUpload({

--- a/packages/storage-uploadthing/src/index.ts
+++ b/packages/storage-uploadthing/src/index.ts
@@ -141,6 +141,7 @@ function uploadthingInternal(options: UploadthingStorageOptions): Adapter {
 
   return (): GeneratedAdapter => {
     const {
+      clientUploads,
       options: { acl = 'public-read', ...utOptions },
     } = options
 
@@ -148,6 +149,7 @@ function uploadthingInternal(options: UploadthingStorageOptions): Adapter {
 
     return {
       name: 'uploadthing',
+      clientUploads,
       fields,
       generateURL,
       handleDelete: getHandleDelete({ utApi }),

--- a/packages/storage-vercel-blob/src/index.ts
+++ b/packages/storage-vercel-blob/src/index.ts
@@ -172,7 +172,7 @@ function vercelBlobStorageInternal(
   options: { baseUrl: string } & VercelBlobStorageOptions,
 ): Adapter {
   return ({ collection, prefix }): GeneratedAdapter => {
-    const { access, addRandomSuffix, baseUrl, cacheControlMaxAge, token } = options
+    const { access, addRandomSuffix, baseUrl, cacheControlMaxAge, clientUploads, token } = options
 
     if (!token) {
       throw new Error('Vercel Blob storage token is required')
@@ -180,6 +180,7 @@ function vercelBlobStorageInternal(
 
     return {
       name: 'vercel-blob',
+      clientUploads,
       generateURL: getGenerateUrl({ baseUrl, prefix }),
       handleDelete: getHandleDelete({ baseUrl, prefix, token }),
       handleUpload: getHandleUpload({


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11473

Previously, when `disablePayloadAccessControl: true` was defined, client uploads were working improperly. The reason is that `addDataAndFileToRequest` expects `staticHandler` to be defined and we don't add in case if `disablePayloadAccessControl: true`.

This PR makes it so otherwise and if we have `clientUploads`, it pushes the "proxied" handler that responses only when the file was requested in the context of client upload (from `addDataAndFileToRequest`)
