### PR TITLE
fix(next): admin panel fails compiling when fullySpecified is set in next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,6 +20,7 @@ const config = withBundleAnalyzer(
       ignoreBuildErrors: true,
     },
     experimental: {
+      fullySpecified: true,
       serverActions: {
         bodySizeLimit: '5mb',
       },

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -94,7 +94,7 @@
     "http-status": "2.1.0",
     "path-to-regexp": "6.3.0",
     "qs-esm": "7.0.2",
-    "react-diff-viewer-continued": "4.0.4",
+    "react-diff-viewer-continued": "4.0.5",
     "sass": "1.77.4",
     "uuid": "10.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,8 +714,8 @@ importers:
         specifier: 7.0.2
         version: 7.0.2
       react-diff-viewer-continued:
-        specifier: 4.0.4
-        version: 4.0.4(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 4.0.5
+        version: 4.0.5(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       sass:
         specifier: 1.77.4
         version: 1.77.4
@@ -8959,8 +8959,8 @@ packages:
       react: 19.0.0
       react-dom: 19.0.0
 
-  react-diff-viewer-continued@4.0.4:
-    resolution: {integrity: sha512-AQ+LST2L9+sjr0h/nkeZyoUzUcajen3qPkymSuFm8KhObK1aincaZFg/auIwOGc0fAGhY4TgDBq0qFH+9WhLsA==}
+  react-diff-viewer-continued@4.0.5:
+    resolution: {integrity: sha512-L43gIPdhHgu1MYdip4vNqAt5s2JLICKe2/RyGUr2ohAxfhYaH1+QZ6vBO0qgo4xGBhE3jmvbOA/swq4/gdS/0g==}
     engines: {node: '>= 16'}
     peerDependencies:
       react: 19.0.0
@@ -19134,7 +19134,7 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  react-diff-viewer-continued@4.0.4(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  react-diff-viewer-continued@4.0.5(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)

--- a/test/fields/collections/ConditionalLogic/index.ts
+++ b/test/fields/collections/ConditionalLogic/index.ts
@@ -29,7 +29,7 @@ const ConditionalLogic: CollectionConfig = {
       type: 'text',
       admin: {
         components: {
-          Field: '/collections/ConditionalLogic/CustomFieldWithField',
+          Field: '/collections/ConditionalLogic/CustomFieldWithField.js',
         },
         condition: ({ toggleField }) => Boolean(toggleField),
       },
@@ -40,7 +40,7 @@ const ConditionalLogic: CollectionConfig = {
       type: 'text',
       admin: {
         components: {
-          Field: '/collections/ConditionalLogic/CustomFieldWithHOC',
+          Field: '/collections/ConditionalLogic/CustomFieldWithHOC.js',
         },
         condition: ({ toggleField }) => Boolean(toggleField),
       },
@@ -50,7 +50,7 @@ const ConditionalLogic: CollectionConfig = {
       type: 'text',
       admin: {
         components: {
-          Field: '/collections/ConditionalLogic/CustomClientField',
+          Field: '/collections/ConditionalLogic/CustomClientField.js',
         },
         condition: ({ toggleField }) => Boolean(toggleField),
       },
@@ -60,7 +60,7 @@ const ConditionalLogic: CollectionConfig = {
       type: 'text',
       admin: {
         components: {
-          Field: '/collections/ConditionalLogic/CustomServerField',
+          Field: '/collections/ConditionalLogic/CustomServerField.js',
         },
         condition: ({ toggleField }) => Boolean(toggleField),
       },

--- a/test/fields/collections/JSON/index.tsx
+++ b/test/fields/collections/JSON/index.tsx
@@ -72,7 +72,7 @@ const JSON: CollectionConfig = {
       type: 'json',
       admin: {
         components: {
-          afterInput: ['./collections/JSON/AfterField#AfterField'],
+          afterInput: ['./collections/JSON/AfterField.js#AfterField'],
         },
       },
       label: 'Custom Json',

--- a/test/next.config.mjs
+++ b/test/next.config.mjs
@@ -20,6 +20,7 @@ export default withBundleAnalyzer(
       ignoreBuildErrors: true,
     },
     experimental: {
+      fullySpecified: true,
       serverActions: {
         bodySizeLimit: '5mb',
       },


### PR DESCRIPTION
If `experimental.fullySpecified` is set to `true` in the next config, the Payload admin panel fails to compile, throwing the following error:

```ts
Failed to compile.

../../node_modules/.pnpm/@payloadcms+next@3.25.0-canary.46647b4_@types+react@18.3.1_graphql@16.10.0_monaco-editor@0.40_w3ro7ziou6gzev7zbe3qqrwaqe/node_modules/@payloadcms/next/dist/views/Version/RenderFieldsToDiff/fields/Select/DiffViewer/index.js
Attempted import error: 'DiffMethod' is not exported from 'react-diff-viewer-continued' (imported as 'DiffMethod').
```

The issue stems from incorrect import statements in `react-diff-viewer-continued` 4.0.4. This was fixed in `react-diff-viewer-continued` 4.0.5.

This PR also enables `fullySpecified` in our test suites, to catch these issues going forward.