### PR TITLE
chore: indexes are not iterable, corrects `indexes` default value sanitization

### DIFF
--- a/packages/payload/src/collections/config/defaults.ts
+++ b/packages/payload/src/collections/config/defaults.ts
@@ -108,6 +108,8 @@ export const addDefaultsToCollectionConfig = (collection: CollectionConfig): Col
   collection.upload = collection.upload ?? false
   collection.versions = collection.versions ?? false
 
+  collection.indexes = collection.indexes ?? []
+
   return collection
 }
 

--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -2,7 +2,6 @@
 import type { Config, SanitizedConfig } from '../../config/types.js'
 import type {
   CollectionConfig,
-  CompoundIndex,
   SanitizedCollectionConfig,
   SanitizedJoin,
   SanitizedJoins,


### PR DESCRIPTION
The PR https://github.com/payloadcms/payload/pull/11512 was merged without changes from this PR https://github.com/payloadcms/payload/pull/11524

Which caused all the tests to fail:
<img width="432" alt="image" src="https://github.com/user-attachments/assets/7c19187e-a9c4-4dad-80c2-bdd6156eeb0b" />

Corrects default value sanitization with the new strategy from #11524
