### PR TITLE
chore: cleanup generated configs

### DIFF
--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -21,6 +21,7 @@ import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
 import { sanitizeJoinQuery } from '../../database/sanitizeJoinQuery.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
+import { lockedDocumentsCollectionSlug } from '../../locked-documents/config.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
 import { appendVersionToQueryKey } from '../../versions/drafts/appendVersionToQueryKey.js'
@@ -199,7 +200,7 @@ export const findOperation = async <
         const now = new Date().getTime()
 
         const lockedDocuments = await payload.find({
-          collection: 'payload-locked-documents',
+          collection: lockedDocumentsCollectionSlug,
           depth: 1,
           limit: sanitizedLimit,
           overrideAccess: false,

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -20,6 +20,7 @@ import { sanitizeJoinQuery } from '../../database/sanitizeJoinQuery.js'
 import { NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { validateQueryPaths } from '../../index.js'
+import { lockedDocumentsCollectionSlug } from '../../locked-documents/config.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import replaceWithDraftIfAvailable from '../../versions/drafts/replaceWithDraftIfAvailable.js'
 import { buildAfterOperation } from './utils.js'
@@ -162,7 +163,7 @@ export const findByIDOperation = async <
         const lockDurationInMilliseconds = lockDuration * 1000
 
         const lockedDocument = await req.payload.find({
-          collection: 'payload-locked-documents',
+          collection: lockedDocumentsCollectionSlug,
           depth: 1,
           limit: 1,
           overrideAccess: false,

--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -26,9 +26,12 @@ import {
   type GlobalSlug,
   sanitizeFields,
 } from '../index.js'
-import { getLockedDocumentsCollection } from '../lockedDocuments/lockedDocumentsCollection.js'
-import getPreferencesCollection from '../preferences/preferencesCollection.js'
-import { getDefaultJobsCollection } from '../queues/config/jobsCollection.js'
+import {
+  getLockedDocumentsCollection,
+  lockedDocumentsCollectionSlug,
+} from '../locked-documents/config.js'
+import { getPreferencesCollection, preferencesCollectionSlug } from '../preferences/config.js'
+import { getDefaultJobsCollection, jobsCollectionSlug } from '../queues/config/index.js'
 import { flattenBlock } from '../utilities/flattenAllFields.js'
 import { getSchedulePublishTask } from '../versions/schedule/job.js'
 import { addDefaultsToConfig } from './defaults.js'
@@ -179,9 +182,9 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
 
   const validRelationships = [
     ...(config.collections.map((c) => c.slug) ?? []),
-    'payload-jobs',
-    'payload-locked-documents',
-    'payload-preferences',
+    jobsCollectionSlug,
+    lockedDocumentsCollectionSlug,
+    preferencesCollectionSlug,
   ]
 
   /**

--- a/packages/payload/src/globals/operations/findOne.ts
+++ b/packages/payload/src/globals/operations/findOne.ts
@@ -5,6 +5,7 @@ import type { SanitizedGlobalConfig } from '../config/types.js'
 
 import executeAccess from '../../auth/executeAccess.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
+import { lockedDocumentsCollectionSlug } from '../../locked-documents/config.js'
 import { getSelectMode } from '../../utilities/getSelectMode.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import replaceWithDraftIfAvailable from '../../versions/drafts/replaceWithDraftIfAvailable.js'
@@ -80,7 +81,7 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
         const lockDurationInMilliseconds = lockDuration * 1000
 
         const lockedDocument = await req.payload.find({
-          collection: 'payload-locked-documents',
+          collection: lockedDocumentsCollectionSlug,
           depth: 1,
           limit: 1,
           overrideAccess: false,

--- a/packages/payload/src/locked-documents/config.ts
+++ b/packages/payload/src/locked-documents/config.ts
@@ -2,8 +2,10 @@
 import type { CollectionConfig } from '../collections/config/types.js'
 import type { Config } from '../config/types.js'
 
+export const lockedDocumentsCollectionSlug = 'payload-locked-documents'
+
 export const getLockedDocumentsCollection = (config: Config): CollectionConfig => ({
-  slug: 'payload-locked-documents',
+  slug: lockedDocumentsCollectionSlug,
   admin: {
     hidden: true,
   },

--- a/packages/payload/src/preferences/config.ts
+++ b/packages/payload/src/preferences/config.ts
@@ -18,8 +18,10 @@ const preferenceAccess: Access = ({ req }) => {
   }
 }
 
-const getPreferencesCollection = (config: Config): CollectionConfig => ({
-  slug: 'payload-preferences',
+export const preferencesCollectionSlug = 'payload-preferences'
+
+export const getPreferencesCollection = (config: Config): CollectionConfig => ({
+  slug: preferencesCollectionSlug,
   access: {
     delete: preferenceAccess,
     read: preferenceAccess,
@@ -91,5 +93,3 @@ const getPreferencesCollection = (config: Config): CollectionConfig => ({
   ],
   lockDocuments: false,
 })
-
-export default getPreferencesCollection

--- a/packages/payload/src/preferences/deleteUserPreferences.ts
+++ b/packages/payload/src/preferences/deleteUserPreferences.ts
@@ -2,6 +2,8 @@ import type { SanitizedCollectionConfig } from '../collections/config/types.js'
 import type { Payload } from '../index.js'
 import type { PayloadRequest } from '../types/index.js'
 
+import { preferencesCollectionSlug } from './config.js'
+
 type Args = {
   collectionConfig: SanitizedCollectionConfig
   /**
@@ -14,7 +16,7 @@ type Args = {
 export const deleteUserPreferences = async ({ collectionConfig, ids, payload, req }: Args) => {
   if (collectionConfig.auth) {
     await payload.db.deleteMany({
-      collection: 'payload-preferences',
+      collection: preferencesCollectionSlug,
       req,
       where: {
         or: [
@@ -36,7 +38,7 @@ export const deleteUserPreferences = async ({ collectionConfig, ids, payload, re
     })
   } else {
     await payload.db.deleteMany({
-      collection: 'payload-preferences',
+      collection: preferencesCollectionSlug,
       req,
       where: {
         key: { in: ids.map((id) => `collection-${collectionConfig.slug}-${id}`) },

--- a/packages/payload/src/preferences/operations/delete.ts
+++ b/packages/payload/src/preferences/operations/delete.ts
@@ -3,6 +3,7 @@ import type { PreferenceRequest } from '../types.js'
 
 import { NotFound } from '../../errors/NotFound.js'
 import { UnauthorizedError } from '../../errors/UnauthorizedError.js'
+import { preferencesCollectionSlug } from '../config.js'
 
 export async function deleteOperation(args: PreferenceRequest): Promise<Document> {
   const {
@@ -25,7 +26,7 @@ export async function deleteOperation(args: PreferenceRequest): Promise<Document
   }
 
   const result = await payload.db.deleteOne({
-    collection: 'payload-preferences',
+    collection: preferencesCollectionSlug,
     req,
     where,
   })

--- a/packages/payload/src/preferences/operations/findOne.ts
+++ b/packages/payload/src/preferences/operations/findOne.ts
@@ -3,6 +3,8 @@ import type { TypedCollection } from '../../index.js'
 import type { Where } from '../../types/index.js'
 import type { PreferenceRequest } from '../types.js'
 
+import { preferencesCollectionSlug } from '../config.js'
+
 export async function findOne(args: PreferenceRequest): Promise<TypedCollection['_preference']> {
   const {
     key,
@@ -24,7 +26,7 @@ export async function findOne(args: PreferenceRequest): Promise<TypedCollection[
   }
 
   const { docs } = await payload.db.find({
-    collection: 'payload-preferences',
+    collection: preferencesCollectionSlug,
     limit: 1,
     pagination: false,
     req,

--- a/packages/payload/src/preferences/operations/update.ts
+++ b/packages/payload/src/preferences/operations/update.ts
@@ -2,6 +2,7 @@ import type { Where } from '../../types/index.js'
 import type { PreferenceUpdateRequest } from '../types.js'
 
 import { UnauthorizedError } from '../../errors/UnauthorizedError.js'
+import { preferencesCollectionSlug } from '../config.js'
 
 export async function update(args: PreferenceUpdateRequest) {
   const {
@@ -15,8 +16,6 @@ export async function update(args: PreferenceUpdateRequest) {
   if (!user) {
     throw new UnauthorizedError(req.t)
   }
-
-  const collection = 'payload-preferences'
 
   const where: Where = {
     and: [
@@ -36,7 +35,7 @@ export async function update(args: PreferenceUpdateRequest) {
   }
 
   return await payload.db.upsert({
-    collection,
+    collection: preferencesCollectionSlug,
     data: preference,
     req,
     where,

--- a/packages/payload/src/queues/config/index.ts
+++ b/packages/payload/src/queues/config/index.ts
@@ -5,6 +5,8 @@ import type { Field } from '../../fields/config/types.js'
 import { runJobsEndpoint } from '../restEndpointRun.js'
 import { getJobTaskStatus } from '../utilities/getJobTaskStatus.js'
 
+export const jobsCollectionSlug = 'payload-jobs'
+
 export const getDefaultJobsCollection: (config: Config) => CollectionConfig | null = (config) => {
   const workflowSlugs: Set<string> = new Set()
   const taskSlugs: Set<string> = new Set(['inline'])
@@ -91,7 +93,7 @@ export const getDefaultJobsCollection: (config: Config) => CollectionConfig | nu
   }
 
   const jobsCollection: CollectionConfig = {
-    slug: 'payload-jobs',
+    slug: jobsCollectionSlug,
     admin: {
       group: 'System',
       hidden: true,

--- a/packages/payload/src/queues/localAPI.ts
+++ b/packages/payload/src/queues/localAPI.ts
@@ -8,6 +8,7 @@ import {
   type TypedJobs,
   type Where,
 } from '../index.js'
+import { jobsCollectionSlug } from './config/index.js'
 import { runJobs } from './operations/runJobs/index.js'
 
 export const getJobsLocalAPI = (payload: Payload) => ({
@@ -72,7 +73,7 @@ export const getJobsLocalAPI = (payload: Payload) => ({
     }
 
     return (await payload.create({
-      collection: 'payload-jobs',
+      collection: jobsCollectionSlug,
       data,
       req: args.req,
     })) as TTaskOrWorkflowSlug extends keyof TypedJobs['workflows']
@@ -143,7 +144,7 @@ export const getJobsLocalAPI = (payload: Payload) => ({
     }
 
     await payload.db.updateMany({
-      collection: 'payload-jobs',
+      collection: jobsCollectionSlug,
       data: {
         completedAt: null,
         error: {
@@ -172,7 +173,7 @@ export const getJobsLocalAPI = (payload: Payload) => ({
 
     await payload.db.updateOne({
       id: args.id,
-      collection: 'payload-jobs',
+      collection: jobsCollectionSlug,
       data: {
         completedAt: null,
         error: {

--- a/packages/payload/src/queues/operations/runJobs/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/index.ts
@@ -12,6 +12,7 @@ import type { RunJobResult } from './runJob/index.js'
 
 import { Forbidden } from '../../../errors/Forbidden.js'
 import isolateObjectProperty from '../../../utilities/isolateObjectProperty.js'
+import { jobsCollectionSlug } from '../../config/index.js'
 import { getUpdateJobFunction } from './runJob/getUpdateJobFunction.js'
 import { importHandlerPath } from './runJob/importHandlerPath.js'
 import { runJob } from './runJob/index.js'
@@ -110,7 +111,7 @@ export const runJobs = async ({
         docs: [
           (await req.payload.update({
             id,
-            collection: 'payload-jobs',
+            collection: jobsCollectionSlug,
             data: {
               processing: true,
               seenByWorker: true,
@@ -122,7 +123,7 @@ export const runJobs = async ({
         ],
       }
     : ((await req.payload.update({
-        collection: 'payload-jobs',
+        collection: jobsCollectionSlug,
         data: {
           processing: true,
           seenByWorker: true,
@@ -253,7 +254,7 @@ export const runJobs = async ({
   if (jobsToDelete && jobsToDelete.length > 0) {
     try {
       await req.payload.delete({
-        collection: 'payload-jobs',
+        collection: jobsCollectionSlug,
         req,
         where: { id: { in: jobsToDelete } },
       })

--- a/packages/payload/src/queues/operations/runJobs/runJob/getUpdateJobFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getUpdateJobFunction.ts
@@ -2,13 +2,15 @@
 import type { PayloadRequest } from '../../../../types/index.js'
 import type { BaseJob } from '../../../config/types/workflowTypes.js'
 
+import { jobsCollectionSlug } from '../../../config/index.js'
+
 export type UpdateJobFunction = (jobData: Partial<BaseJob>) => Promise<BaseJob>
 
 export function getUpdateJobFunction(job: BaseJob, req: PayloadRequest): UpdateJobFunction {
   return async (jobData) => {
     const updatedJob = (await req.payload.update({
       id: job.id,
-      collection: 'payload-jobs',
+      collection: jobsCollectionSlug,
       data: jobData,
       depth: 0,
       disableTransaction: true,

--- a/packages/payload/src/utilities/checkDocumentLockStatus.ts
+++ b/packages/payload/src/utilities/checkDocumentLockStatus.ts
@@ -3,6 +3,7 @@ import type { PaginatedDocs } from '../database/types.js'
 import type { JsonObject, PayloadRequest } from '../types/index.js'
 
 import { Locked } from '../errors/index.js'
+import { lockedDocumentsCollectionSlug } from '../locked-documents/config.js'
 
 type CheckDocumentLockStatusArgs = {
   collectionSlug?: string
@@ -60,7 +61,7 @@ export const checkDocumentLockStatus = async ({
     const finalLockErrorMessage = lockErrorMessage || defaultLockErrorMessage
 
     const lockedDocumentResult: PaginatedDocs<JsonObject & TypeWithID> = await payload.db.find({
-      collection: 'payload-locked-documents',
+      collection: lockedDocumentsCollectionSlug,
       limit: 1,
       pagination: false,
       sort: '-updatedAt',
@@ -91,7 +92,7 @@ export const checkDocumentLockStatus = async ({
 
   // Perform the delete operation regardless of overrideLock status
   await payload.db.deleteMany({
-    collection: 'payload-locked-documents',
+    collection: lockedDocumentsCollectionSlug,
     // Not passing req fails on postgres
     req: payload.db.name === 'mongoose' ? undefined : req,
     where: lockedDocumentQuery,

--- a/packages/payload/src/utilities/sanitizePermissions.spec.ts
+++ b/packages/payload/src/utilities/sanitizePermissions.spec.ts
@@ -1,4 +1,5 @@
 import type { CollectionPermission, Permissions } from '../auth/types.js'
+import { preferencesCollectionSlug } from '../preferences/config.js'
 
 import { sanitizePermissions } from './sanitizePermissions.js'
 
@@ -1561,7 +1562,7 @@ describe('sanitizePermissions', () => {
     const permissions: Permissions = {
       canAccessAdmin: false,
       collections: {
-        'payload-preferences': {
+        preferencesCollectionSlug: {
           fields: {
             user: {
               create: {

--- a/packages/payload/src/versions/deleteScheduledPublishJobs.ts
+++ b/packages/payload/src/versions/deleteScheduledPublishJobs.ts
@@ -1,6 +1,7 @@
 import type { PayloadRequest } from '../types/index.js'
 
 import { type Payload } from '../index.js'
+import { jobsCollectionSlug } from '../queues/config/index.js'
 
 type Args = {
   id?: number | string
@@ -17,7 +18,7 @@ export const deleteScheduledPublishJobs = async ({
 }: Args): Promise<void> => {
   try {
     await payload.db.deleteMany({
-      collection: 'payload-jobs',
+      collection: jobsCollectionSlug,
       req,
       where: {
         and: [


### PR DESCRIPTION
Cleans up various Payload-generated configs, namely:
- Renames config entry files from `preferencesCollection.ts`, `lockedDocumentsCollection.ts`, and `jobsCollection.ts` to `config.ts`
- Standardizes collection slugs for `payload-preferences`, `payload-locked-documents`, and `payload-jobs` and reuses everywhere
- Renames camel-cased `payloadPreferences` directory to kebab case, i.e. `payload-preferences`