### PR TITLE
fix: fallback to previous value, or default, if field access is denied

### DIFF
--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -328,7 +328,24 @@ export const promise = async <T>({
         : await field.access[operation]({ id, blockData, data, doc, req, siblingData })
 
       if (!result) {
-        delete siblingData[field.name]
+        // No access, but existing document data is found, merge it in
+        if (typeof siblingDoc[field.name] !== 'undefined') {
+          siblingData[field.name] = cloneDataFromOriginalDoc(siblingDoc[field.name])
+  
+        // Fallback to the default value
+        } else if (typeof field.defaultValue !== 'undefined') {
+          siblingData[field.name] = await getDefaultValue({
+            defaultValue: field.defaultValue,
+            locale: req.locale,
+            req,
+            user: req.user,
+            value: siblingData[field.name],
+          })
+        
+        // If there is no previous value, and no default value, remove the field
+        } else {
+          delete siblingData[field.name]
+        }
       }
     }
   }


### PR DESCRIPTION
### What?
https://github.com/payloadcms/payload/issues/11543
Data is lost or validation fails when the user is not allowed to update the field, as the order in traverse fields was changed in https://github.com/payloadcms/payload/pull/11433

### How?
Fallback to previous data, then to default value and finally delete the field, to restore previous behavior while avoiding regression of the previous bug.

Closes #11543
