### PR TITLE
fix(ui): views rendered in drawers can update step nav

### DIFF
--- a/packages/ui/src/views/Edit/SetDocumentStepNav/index.tsx
+++ b/packages/ui/src/views/Edit/SetDocumentStepNav/index.tsx
@@ -10,7 +10,6 @@ import type { StepNavItem } from '../../../elements/StepNav/index.js'
 import { useStepNav } from '../../../elements/StepNav/index.js'
 import { useConfig } from '../../../providers/Config/index.js'
 import { useDocumentInfo } from '../../../providers/DocumentInfo/index.js'
-import { useEditDepth } from '../../../providers/EditDepth/index.js'
 import { useEntityVisibility } from '../../../providers/EntityVisibility/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
 
@@ -40,8 +39,6 @@ export const SetDocumentStepNav: React.FC<{
       routes: { admin: adminRoute },
     },
   } = useConfig()
-
-  const drawerDepth = useEditDepth()
 
   useEffect(() => {
     const nav: StepNavItem[] = []
@@ -91,9 +88,7 @@ export const SetDocumentStepNav: React.FC<{
         })
       }
 
-      if (drawerDepth <= 1) {
-        setStepNav(nav)
-      }
+      setStepNav(nav)
     }
   }, [
     setStepNav,
@@ -109,7 +104,6 @@ export const SetDocumentStepNav: React.FC<{
     collectionSlug,
     globalSlug,
     view,
-    drawerDepth,
     isVisible,
   ])
 

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -491,13 +491,15 @@ export function DefaultEditView({
             />
           )}
           {!isReadOnlyForIncomingUser && preventLeaveWithoutSaving && <LeaveWithoutSaving />}
-          <SetDocumentStepNav
-            collectionSlug={collectionConfig?.slug}
-            globalSlug={globalConfig?.slug}
-            id={id}
-            pluralLabel={collectionConfig?.labels?.plural}
-            useAsTitle={collectionConfig?.admin?.useAsTitle}
-          />
+          {!isInDrawer && (
+            <SetDocumentStepNav
+              collectionSlug={collectionConfig?.slug}
+              globalSlug={globalConfig?.slug}
+              id={id}
+              pluralLabel={collectionConfig?.labels?.plural}
+              useAsTitle={collectionConfig?.admin?.useAsTitle}
+            />
+          )}
           <SetDocumentTitle
             collectionConfig={collectionConfig}
             config={config}

--- a/packages/ui/src/views/List/index.tsx
+++ b/packages/ui/src/views/List/index.tsx
@@ -24,7 +24,6 @@ import { TableColumnsProvider } from '../../elements/TableColumns/index.js'
 import { ViewDescription } from '../../elements/ViewDescription/index.js'
 import { useAuth } from '../../providers/Auth/index.js'
 import { useConfig } from '../../providers/Config/index.js'
-import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { useListQuery } from '../../providers/ListQuery/index.js'
 import { SelectionProvider } from '../../providers/Selection/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
@@ -104,8 +103,6 @@ export function DefaultListView(props: ListViewClientProps) {
 
   const { i18n, t } = useTranslation()
 
-  const drawerDepth = useEditDepth()
-
   const { setStepNav } = useStepNav()
 
   const {
@@ -141,14 +138,15 @@ export function DefaultListView(props: ListViewClientProps) {
   ])
 
   useEffect(() => {
-    if (!drawerDepth) {
+    if (!isInDrawer) {
       setStepNav([
         {
           label: labels?.plural,
         },
       ])
     }
-  }, [setStepNav, labels, drawerDepth])
+  }, [setStepNav, labels, isInDrawer])
+
   return (
     <Fragment>
       <TableColumnsProvider collectionSlug={collectionSlug} columnState={columnState}>


### PR DESCRIPTION
When rendering views within a drawer outside of the edit view, i.e. from the list view, it updates the underlying step nav to the collection of the drawer. This is true for both document drawers and list drawers.

This is because the logic controlling this behavior relies on the current edit depth, which is only incremented within the edit view itself. Instead of doing this, we can conditionally run the setter functions based the presence of a drawer slug.

An alternative to this would be to subscribe to the `drawerDepth` context but this would be less efficient, as this requires an unnecessary hook and subsequent rendering cycle.