### PR TITLE
fix: beforeValidate deleting value when access returns false

### DIFF
--- a/packages/payload/src/fields/hooks/beforeValidate/getFallbackValue.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/getFallbackValue.ts
@@ -17,11 +17,10 @@ export async function getFallbackValue({
   if ('name' in field) {
     if (typeof siblingDoc[field.name] !== 'undefined') {
       fallbackValue = cloneDataFromOriginalDoc(siblingDoc[field.name])
-    }
-    if ('defaultValue' in field && typeof field.defaultValue !== 'undefined') {
+    } else if ('defaultValue' in field && typeof field.defaultValue !== 'undefined') {
       fallbackValue = await getDefaultValue({
         defaultValue: field.defaultValue,
-        locale: req.locale,
+        locale: req.locale || '',
         req,
         user: req.user,
       })

--- a/packages/payload/src/fields/hooks/beforeValidate/getFallbackValue.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/getFallbackValue.ts
@@ -1,0 +1,32 @@
+import type { JsonObject, JsonValue, PayloadRequest } from '../../../types/index.js'
+import type { FieldAffectingData } from '../../config/types.js'
+
+import { getDefaultValue } from '../../getDefaultValue.js'
+import { cloneDataFromOriginalDoc } from '../beforeChange/cloneDataFromOriginalDoc.js'
+
+export async function getFallbackValue({
+  field,
+  req,
+  siblingDoc,
+}: {
+  field: FieldAffectingData
+  req: PayloadRequest
+  siblingDoc: JsonObject
+}): Promise<JsonValue> {
+  let fallbackValue = undefined
+  if ('name' in field) {
+    if (typeof siblingDoc[field.name] !== 'undefined') {
+      fallbackValue = cloneDataFromOriginalDoc(siblingDoc[field.name])
+    }
+    if ('defaultValue' in field && typeof field.defaultValue !== 'undefined') {
+      fallbackValue = await getDefaultValue({
+        defaultValue: field.defaultValue,
+        locale: req.locale,
+        req,
+        user: req.user,
+      })
+    }
+  }
+
+  return fallbackValue
+}

--- a/packages/payload/src/fields/hooks/beforeValidate/getFallbackValue.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/getFallbackValue.ts
@@ -14,7 +14,7 @@ export async function getFallbackValue({
   siblingDoc: JsonObject
 }): Promise<JsonValue> {
   let fallbackValue = undefined
-  if ('name' in field) {
+  if ('name' in field && field.name) {
     if (typeof siblingDoc[field.name] !== 'undefined') {
       fallbackValue = cloneDataFromOriginalDoc(siblingDoc[field.name])
     } else if ('defaultValue' in field && typeof field.defaultValue !== 'undefined') {

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -282,6 +282,7 @@ export const promise = async <T>({
     if (typeof siblingData[field.name] === 'undefined') {
       fallbackResult.value = await getFallbackValue({ field, req, siblingDoc })
       fallbackResult.executed = true
+      siblingData[field.name] = fallbackResult.value
     }
 
     // Execute hooks
@@ -305,10 +306,7 @@ export const promise = async <T>({
           schemaPath: schemaPathSegments,
           siblingData,
           siblingFields,
-          value:
-            typeof siblingData[field.name] === 'undefined'
-              ? fallbackResult.value
-              : siblingData[field.name],
+          value: siblingData[field.name],
         })
 
         if (hookedValue !== undefined) {

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -282,7 +282,6 @@ export const promise = async <T>({
     if (typeof siblingData[field.name] === 'undefined') {
       fallbackResult.value = await getFallbackValue({ field, req, siblingDoc })
       fallbackResult.executed = true
-      siblingData[field.name] = fallbackResult.value
     }
 
     // Execute hooks
@@ -306,7 +305,10 @@ export const promise = async <T>({
           schemaPath: schemaPathSegments,
           siblingData,
           siblingFields,
-          value: siblingData[field.name],
+          value:
+            typeof siblingData[field.name] === 'undefined'
+              ? fallbackResult.value
+              : siblingData[field.name],
         })
 
         if (hookedValue !== undefined) {

--- a/packages/payload/src/fields/hooks/beforeValidate/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeValidate/promise.ts
@@ -322,10 +322,14 @@ export const promise = async <T>({
         : await field.access[operation]({ id, blockData, data, doc, req, siblingData })
 
       if (!result) {
-        siblingData[field.name] = !fallbackResult.executed
-          ? await getFallbackValue({ field, req, siblingDoc })
-          : fallbackResult.value
+        delete siblingData[field.name]
       }
+    }
+
+    if (typeof siblingData[field.name] === 'undefined') {
+      siblingData[field.name] = !fallbackResult.executed
+        ? await getFallbackValue({ field, req, siblingDoc })
+        : fallbackResult.value
     }
   }
 

--- a/test/access-control/collections/hooks/index.ts
+++ b/test/access-control/collections/hooks/index.ts
@@ -1,0 +1,44 @@
+import type { CollectionConfig } from 'payload'
+
+import { hooksSlug } from '../../shared.js'
+
+export const Hooks: CollectionConfig = {
+  slug: hooksSlug,
+  access: {
+    update: () => true,
+  },
+  fields: [
+    {
+      name: 'cannotMutateRequired',
+      type: 'text',
+      access: {
+        update: () => false,
+      },
+      required: true,
+    },
+    {
+      name: 'cannotMutateNotRequired',
+      type: 'text',
+      access: {
+        update: () => false,
+      },
+      hooks: {
+        beforeChange: [
+          ({ value }) => {
+            if (!value) {
+              return 'no value found'
+            }
+            return value
+          },
+        ],
+      },
+    },
+    {
+      name: 'canMutate',
+      type: 'text',
+      access: {
+        update: () => true,
+      },
+    },
+  ],
+}

--- a/test/access-control/config.ts
+++ b/test/access-control/config.ts
@@ -10,6 +10,7 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { textToLexicalJSON } from '../fields/collections/LexicalLocalized/textToLexicalJSON.js'
 import { Disabled } from './collections/Disabled/index.js'
+import { Hooks } from './collections/hooks/index.js'
 import { Regression1 } from './collections/Regression-1/index.js'
 import { Regression2 } from './collections/Regression-2/index.js'
 import { RichText } from './collections/RichText/index.js'
@@ -567,6 +568,7 @@ export default buildConfigWithDefaults(
       RichText,
       Regression1,
       Regression2,
+      Hooks,
     ],
     globals: [
       {

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -8,7 +8,7 @@ import type {
 } from 'payload'
 
 import path from 'path'
-import { Forbidden } from 'payload'
+import { Forbidden, ValidationError } from 'payload'
 import { fileURLToPath } from 'url'
 
 import type { FullyRestricted, Post } from './payload-types.js'
@@ -21,6 +21,7 @@ import {
   hiddenAccessCountSlug,
   hiddenAccessSlug,
   hiddenFieldsSlug,
+  hooksSlug,
   relyOnRequestHeadersSlug,
   restrictedVersionsSlug,
   secondArrayText,
@@ -58,115 +59,186 @@ describe('Access Control', () => {
     }
   })
 
-  it('should not affect hidden fields when patching data', async () => {
-    const doc = await payload.create({
-      collection: hiddenFieldsSlug,
-      data: {
-        partiallyHiddenArray: [
-          {
+  describe('Fields', () => {
+    it('should not affect hidden fields when patching data', async () => {
+      const doc = await payload.create({
+        collection: hiddenFieldsSlug,
+        data: {
+          partiallyHiddenArray: [
+            {
+              name: 'public_name',
+              value: 'private_value',
+            },
+          ],
+          partiallyHiddenGroup: {
             name: 'public_name',
             value: 'private_value',
           },
-        ],
-        partiallyHiddenGroup: {
-          name: 'public_name',
-          value: 'private_value',
         },
-      },
+      })
+
+      await payload.update({
+        id: doc.id,
+        collection: hiddenFieldsSlug,
+        data: {
+          title: 'Doc Title',
+        },
+      })
+
+      const updatedDoc = await payload.findByID({
+        id: doc.id,
+        collection: hiddenFieldsSlug,
+        showHiddenFields: true,
+      })
+
+      expect(updatedDoc.partiallyHiddenGroup.value).toStrictEqual('private_value')
+      expect(updatedDoc.partiallyHiddenArray[0].value).toStrictEqual('private_value')
     })
 
-    await payload.update({
-      id: doc.id,
-      collection: hiddenFieldsSlug,
-      data: {
-        title: 'Doc Title',
-      },
-    })
-
-    const updatedDoc = await payload.findByID({
-      id: doc.id,
-      collection: hiddenFieldsSlug,
-      showHiddenFields: true,
-    })
-
-    expect(updatedDoc.partiallyHiddenGroup.value).toStrictEqual('private_value')
-    expect(updatedDoc.partiallyHiddenArray[0].value).toStrictEqual('private_value')
-  })
-
-  it('should not affect hidden fields when patching data - update many', async () => {
-    const docsMany = await payload.create({
-      collection: hiddenFieldsSlug,
-      data: {
-        partiallyHiddenArray: [
-          {
+    it('should not affect hidden fields when patching data - update many', async () => {
+      const docsMany = await payload.create({
+        collection: hiddenFieldsSlug,
+        data: {
+          partiallyHiddenArray: [
+            {
+              name: 'public_name',
+              value: 'private_value',
+            },
+          ],
+          partiallyHiddenGroup: {
             name: 'public_name',
             value: 'private_value',
           },
-        ],
-        partiallyHiddenGroup: {
-          name: 'public_name',
-          value: 'private_value',
         },
-      },
+      })
+
+      await payload.update({
+        collection: hiddenFieldsSlug,
+        data: {
+          title: 'Doc Title',
+        },
+        where: {
+          id: { equals: docsMany.id },
+        },
+      })
+
+      const updatedMany = await payload.findByID({
+        id: docsMany.id,
+        collection: hiddenFieldsSlug,
+        showHiddenFields: true,
+      })
+
+      expect(updatedMany.partiallyHiddenGroup.value).toStrictEqual('private_value')
+      expect(updatedMany.partiallyHiddenArray[0].value).toStrictEqual('private_value')
     })
 
-    await payload.update({
-      collection: hiddenFieldsSlug,
-      data: {
-        title: 'Doc Title',
-      },
-      where: {
-        id: { equals: docsMany.id },
-      },
+    it('should be able to restrict access based upon siblingData', async () => {
+      const { id } = await payload.create({
+        collection: siblingDataSlug,
+        data: {
+          array: [
+            {
+              allowPublicReadability: true,
+              text: firstArrayText,
+            },
+            {
+              allowPublicReadability: false,
+              text: secondArrayText,
+            },
+          ],
+        },
+      })
+
+      const doc = await payload.findByID({
+        id,
+        collection: siblingDataSlug,
+        overrideAccess: false,
+      })
+
+      expect(doc.array?.[0].text).toBe(firstArrayText)
+      // Should respect PublicReadabilityAccess function and not be sent
+      expect(doc.array?.[1].text).toBeUndefined()
+
+      // Retrieve with default of overriding access
+      const docOverride = await payload.findByID({
+        id,
+        collection: siblingDataSlug,
+      })
+
+      expect(docOverride.array?.[0].text).toBe(firstArrayText)
+      expect(docOverride.array?.[1].text).toBe(secondArrayText)
     })
 
-    const updatedMany = await payload.findByID({
-      id: docsMany.id,
-      collection: hiddenFieldsSlug,
-      showHiddenFields: true,
-    })
+    it('should throw validation error when trying to update a field without permission', async () => {
+      const doc = await payload.create({
+        collection: hooksSlug,
+        data: {
+          cannotMutateRequired: 'original',
+        },
+      })
 
-    expect(updatedMany.partiallyHiddenGroup.value).toStrictEqual('private_value')
-    expect(updatedMany.partiallyHiddenArray[0].value).toStrictEqual('private_value')
-  })
-
-  it('should be able to restrict access based upon siblingData', async () => {
-    const { id } = await payload.create({
-      collection: siblingDataSlug,
-      data: {
-        array: [
-          {
-            allowPublicReadability: true,
-            text: firstArrayText,
+      let error
+      try {
+        await payload.update({
+          id: doc.id,
+          collection: hooksSlug,
+          overrideAccess: false,
+          data: {
+            cannotMutateRequired: 'new',
+            canMutate: 'canMutate',
           },
-          {
-            allowPublicReadability: false,
-            text: secondArrayText,
-          },
-        ],
-      },
+        })
+      } catch (e) {
+        error = e
+      }
+
+      expect(error).toBeInstanceOf(ValidationError)
     })
 
-    const doc = await payload.findByID({
-      id,
-      collection: siblingDataSlug,
-      overrideAccess: false,
+    it('should use fallback data and NOT throw validation error when required data is missing', async () => {
+      const doc = await payload.create({
+        collection: hooksSlug,
+        data: {
+          cannotMutateRequired: 'original',
+        },
+      })
+
+      const updatedDoc = await payload.update({
+        id: doc.id,
+        collection: hooksSlug,
+        overrideAccess: false,
+        data: {
+          canMutate: 'canMutate',
+        },
+      })
+
+      // should fallback to original data and not throw validation error
+      expect(updatedDoc.cannotMutateRequired).toBe('original')
     })
 
-    expect(doc.array?.[0].text).toBe(firstArrayText)
-    // Should respect PublicReadabilityAccess function and not be sent
-    expect(doc.array?.[1].text).toBeUndefined()
+    it('should pass fallback value through to beforeChange hook when access returns false', async () => {
+      const doc = await payload.create({
+        collection: hooksSlug,
+        data: {
+          cannotMutateRequired: 'cannotMutateRequired',
+          cannotMutateNotRequired: 'cannotMutateNotRequired',
+        },
+      })
 
-    // Retrieve with default of overriding access
-    const docOverride = await payload.findByID({
-      id,
-      collection: siblingDataSlug,
+      const updatedDoc = await payload.update({
+        id: doc.id,
+        collection: hooksSlug,
+        overrideAccess: false,
+        data: {
+          cannotMutateNotRequired: 'updated',
+        },
+      })
+
+      // should fallback to original data and not throw validation error
+      expect(updatedDoc.cannotMutateRequired).toBe('cannotMutateRequired')
+      expect(updatedDoc.cannotMutateNotRequired).toBe('cannotMutateNotRequired')
     })
-
-    expect(docOverride.array?.[0].text).toBe(firstArrayText)
-    expect(docOverride.array?.[1].text).toBe(secondArrayText)
   })
-
   describe('Collections', () => {
     describe('restricted collection', () => {
       it('field without read access should not show', async () => {

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -169,7 +169,7 @@ describe('Access Control', () => {
       expect(docOverride.array?.[1].text).toBe(secondArrayText)
     })
 
-    it('should throw validation error when trying to update a field without permission', async () => {
+    it('should use fallback value when trying to update a field without permission', async () => {
       const doc = await payload.create({
         collection: hooksSlug,
         data: {
@@ -177,25 +177,20 @@ describe('Access Control', () => {
         },
       })
 
-      let error
-      try {
-        await payload.update({
-          id: doc.id,
-          collection: hooksSlug,
-          overrideAccess: false,
-          data: {
-            cannotMutateRequired: 'new',
-            canMutate: 'canMutate',
-          },
-        })
-      } catch (e) {
-        error = e
-      }
+      const updatedDoc = await payload.update({
+        id: doc.id,
+        collection: hooksSlug,
+        overrideAccess: false,
+        data: {
+          cannotMutateRequired: 'new',
+          canMutate: 'canMutate',
+        },
+      })
 
-      expect(error).toBeInstanceOf(ValidationError)
+      expect(updatedDoc.cannotMutateRequired).toBe('original')
     })
 
-    it('should use fallback data and NOT throw validation error when required data is missing', async () => {
+    it('should use fallback value when required data is missing', async () => {
       const doc = await payload.create({
         collection: hooksSlug,
         data: {

--- a/test/access-control/payload-types.ts
+++ b/test/access-control/payload-types.ts
@@ -89,6 +89,7 @@ export interface Config {
     'rich-text': RichText;
     regression1: Regression1;
     regression2: Regression2;
+    hooks: Hook;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -117,6 +118,7 @@ export interface Config {
     'rich-text': RichTextSelect<false> | RichTextSelect<true>;
     regression1: Regression1Select<false> | Regression1Select<true>;
     regression2: Regression2Select<false> | Regression2Select<true>;
+    hooks: HooksSelect<false> | HooksSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -682,6 +684,18 @@ export interface Regression2 {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "hooks".
+ */
+export interface Hook {
+  id: string;
+  cannotMutateRequired: string;
+  cannotMutateNotRequired?: string | null;
+  canMutate?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -774,6 +788,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'regression2';
         value: string | Regression2;
+      } | null)
+    | ({
+        relationTo: 'hooks';
+        value: string | Hook;
       } | null);
   globalSlug?: string | null;
   user:
@@ -1165,6 +1183,17 @@ export interface Regression2Select<T extends boolean = true> {
         richText2?: T;
         id?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "hooks_select".
+ */
+export interface HooksSelect<T extends boolean = true> {
+  cannotMutateRequired?: T;
+  cannotMutateNotRequired?: T;
+  canMutate?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/test/access-control/shared.ts
+++ b/test/access-control/shared.ts
@@ -5,6 +5,7 @@ export const slug = 'posts'
 export const unrestrictedSlug = 'unrestricted'
 export const readOnlySlug = 'read-only-collection'
 export const readOnlyGlobalSlug = 'read-only-global'
+export const hooksSlug = 'hooks'
 
 export const userRestrictedCollectionSlug = 'user-restricted-collection'
 export const fullyRestrictedSlug = 'fully-restricted'

--- a/test/hooks/payload-types.ts
+++ b/test/hooks/payload-types.ts
@@ -156,6 +156,8 @@ export interface BeforeValidate {
   id: string;
   title?: string | null;
   selection?: ('a' | 'b') | null;
+  cannotMutate?: string | null;
+  canMutate?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -741,6 +743,8 @@ export interface BeforeChangeHooksSelect<T extends boolean = true> {
 export interface BeforeValidateSelect<T extends boolean = true> {
   title?: T;
   selection?: T;
+  cannotMutate?: T;
+  canMutate?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
### What?
Regression caused by https://github.com/payloadcms/payload/pull/11433 

If a beforeChange hook was checking for a missing or undefined `value` in order to change the value before inserting into the database, data could be lost.

### Why?
In #11433 the logic for setting the fallback field value was moved above the logic that cleared the value when access control returned false. 

### How?
This change ensures that the fallback value is passed into the beforeValidate function _and_ still available with the fallback value on siblingData if access control returns false.

Fixes https://github.com/payloadcms/payload/issues/11543