### PR TITLE
fix(richtext-lexical): fix bug in $createAutoLinkNode when the link is preceded by a textnode

### DIFF
--- a/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.tsx
+++ b/packages/richtext-lexical/src/features/link/client/plugins/autoLink/index.tsx
@@ -187,11 +187,13 @@ function $createAutoLinkNode_(
 
   const linkNode = $createAutoLinkNode({ fields })
   if (nodes.length === 1) {
-    const split = (
-      startIndex === 0 ? nodes[0]?.splitText(endIndex) : nodes[0]?.splitText(startIndex, endIndex)
-    )!
-
-    const [linkTextNode, remainingTextNode] = split
+    const remainingTextNode = nodes[0]!
+    let linkTextNode: TextNode | undefined
+    if (startIndex === 0) {
+      ;[linkTextNode] = remainingTextNode.splitText(endIndex)
+    } else {
+      ;[, linkTextNode] = remainingTextNode.splitText(startIndex, endIndex)
+    }
     if (linkTextNode) {
       const textNode = $createTextNode(match.text)
       textNode.setFormat(linkTextNode.getFormat())


### PR DESCRIPTION
If you type "hello www.world.com" the autlink would remove the word "hello".