### PR TITLE
fix: add missing auth property to new defaults function

### DIFF
--- a/packages/payload/src/config/defaults.ts
+++ b/packages/payload/src/config/defaults.ts
@@ -152,5 +152,10 @@ export const addDefaultsToConfig = (config: Config): Config => {
   }
   config.upload = config.upload ?? {}
 
+  config.auth = {
+    jwtOrder: ['JWT', 'Bearer', 'cookie'],
+    ...(config.auth || {}),
+  }
+
   return config
 }


### PR DESCRIPTION
https://github.com/payloadcms/payload/pull/10794 added new defaults the config - however, these were only added to the deprecated `defaults` object, which caused our CI to fail. This PR adds them to the new `addDefaultsToConfig` function