### PR TITLE
fix(storage-s3): attempts to solve open socket issue

### DIFF
--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -64,11 +64,11 @@ export type S3StorageOptions = {
 
 type S3StoragePlugin = (storageS3Args: S3StorageOptions) => Plugin
 
+let storageClient: AWS.S3 | null = null
+
 export const s3Storage: S3StoragePlugin =
   (s3StorageOptions: S3StorageOptions) =>
   (incomingConfig: Config): Config => {
-    let storageClient: AWS.S3 | null = null
-
     const getStorageClient: () => AWS.S3 = () => {
       if (storageClient) {
         return storageClient

--- a/packages/storage-s3/src/staticHandler.ts
+++ b/packages/storage-s3/src/staticHandler.ts
@@ -28,10 +28,17 @@ const isNodeReadableStream = (body: unknown): body is Readable => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const streamToBuffer = async (readableStream: any) => {
   const chunks = []
-  for await (const chunk of readableStream) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+  try {
+    for await (const chunk of readableStream) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+    }
+    return Buffer.concat(chunks)
+  } finally {
+    // Ensure the stream is always closed
+    if (typeof readableStream.destroy === 'function') {
+      readableStream.destroy()
+    }
   }
-  return Buffer.concat(chunks)
 }
 
 export const getHandler = ({ bucket, collection, getStorageClient }: Args): StaticHandler => {


### PR DESCRIPTION
WIP - attempts to solve open S3 sockets via caching the `storageClient` in module scope as well as destroying sockets in a more thorough way after converting the stream to a buffer.

Possibly fixes #6382

Released as `3.28.0-internal.b3cf0a3` if anyone wants to try it out

Todo:

- [ ] Ensure that multiple instances of S3 adapter can be cached globally. Do we need to create a hash key based on the info passed to the adapter? Maybe the collection slugs that the adapter is installed on? Or, some other approach? Is it supported / desired to add multiple S3 adapters to a single collection?