### PR TITLE
fix: invalidate cache in dataloader after a document was updated or deleted

### DIFF
--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -25,6 +25,7 @@ import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { deleteCollectionVersions } from '../../versions/deleteCollectionVersions.js'
 import { deleteScheduledPublishJobs } from '../../versions/deleteScheduledPublishJobs.js'
+import { invalidateDocumentInDataloader } from '../dataloader.js'
 import { buildAfterOperation } from './utils.js'
 
 export type Arguments = {
@@ -202,6 +203,8 @@ export const deleteOperation = async <
             },
           },
         })
+
+        invalidateDocumentInDataloader({ id, collectionSlug: collectionConfig.slug, req })
 
         // /////////////////////////////////////
         // afterRead - Fields

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -6,7 +6,7 @@ import type {
   SelectType,
   TransformCollectionWithSelect,
 } from '../../types/index.js'
-import type { BeforeOperationHook, Collection, DataFromCollectionSlug } from '../config/types.js'
+import type { Collection, DataFromCollectionSlug } from '../config/types.js'
 
 import executeAccess from '../../auth/executeAccess.js'
 import { hasWhereAccessResult } from '../../auth/types.js'
@@ -21,6 +21,7 @@ import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { deleteCollectionVersions } from '../../versions/deleteCollectionVersions.js'
 import { deleteScheduledPublishJobs } from '../../versions/deleteScheduledPublishJobs.js'
+import { invalidateDocumentInDataloader } from '../dataloader.js'
 import { buildAfterOperation } from './utils.js'
 
 export type Arguments = {
@@ -176,6 +177,8 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
       select,
       where: { id: { equals: id } },
     })
+
+    invalidateDocumentInDataloader({ id, collectionSlug: collectionConfig.slug, req })
 
     // /////////////////////////////////////
     // Delete Preferences

--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -34,6 +34,7 @@ import { uploadFiles } from '../../../uploads/uploadFiles.js'
 import { checkDocumentLockStatus } from '../../../utilities/checkDocumentLockStatus.js'
 import { getLatestCollectionVersion } from '../../../versions/getLatestCollectionVersion.js'
 import { saveVersion } from '../../../versions/saveVersion.js'
+import { invalidateDocumentInDataloader } from '../../dataloader.js'
 
 export type SharedUpdateDocumentArgs<TSlug extends CollectionSlug> = {
   accessResults: AccessResult
@@ -313,6 +314,8 @@ export const updateDocument = async <
       snapshot: versionSnapshotResult,
     })
   }
+
+  invalidateDocumentInDataloader({ id, collectionSlug: collectionConfig.slug, req })
 
   // /////////////////////////////////////
   // afterRead - Fields


### PR DESCRIPTION
### What?
Fixes an issue when:
* Relationship document was populated
* The same relationship document was updated / deleted
* The same relationship document was populated again
* Populated data for this relationship is staled

(Within the same transaction or if transactions are disabled)

### How?
Introduces an internal `id-collectionSlug, cacheKeyInDataLoader` map that can be used to invalidate keys in `payloadDataLoader` in `update` / `delete` operations.
