### PR TITLE
fix(ui): logic for showing copyToLocale button and adds test

### DIFF
--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -137,7 +137,7 @@ export const DocumentControls: React.FC<{
     (collectionConfig?.versions?.drafts && collectionConfig?.versions?.drafts?.autosave) ||
     (globalConfig?.versions?.drafts && globalConfig?.versions?.drafts?.autosave)
 
-  const disableCopyToLocale = localization && collectionConfig?.admin?.disableCopyToLocale
+  const showCopyToLocale = localization && !collectionConfig?.admin?.disableCopyToLocale
 
   return (
     <Gutter className={baseClass}>
@@ -265,7 +265,7 @@ export const DocumentControls: React.FC<{
               verticalAlign="bottom"
             >
               <PopupList.ButtonGroup>
-                {!disableCopyToLocale && <CopyLocaleData />}
+                {showCopyToLocale && <CopyLocaleData />}
                 {hasCreatePermission && (
                   <React.Fragment>
                     {!disableCreate && (

--- a/test/admin-root/e2e.spec.ts
+++ b/test/admin-root/e2e.spec.ts
@@ -80,6 +80,15 @@ test.describe('Admin Panel (Root)', () => {
     await expect(firstRow).toBeVisible()
   })
 
+  test('collection - should hide Copy To Locale button when localization is false', async () => {
+    await page.goto(url.create)
+    const textField = page.locator('#field-text')
+    await textField.fill('test')
+    await saveDocAndAssert(page)
+    await page.locator('.doc-controls__popup >> .popup-button').click()
+    await expect(page.locator('#copy-locale-data__button')).toBeHidden()
+  })
+
   test('global — navigates to edit view', async () => {
     await page.goto(url.global('menu'))
     const pageURL = page.url()


### PR DESCRIPTION
### What?
This [PR](https://github.com/payloadcms/payload/pull/11546) introduced a bug where the `CopyToLocale` button can show up when localization is false.

### Why?
`const disableCopyToLocale = localization && collectionConfig?.admin?.disableCopyToLocale` this line was faulty

### How?
Fixed the logic and added test to confirm button doesn't show when localization is false.