### PR TITLE
fix(db-mongodb): properly sanitize `updateVersion` read result

### DIFF
--- a/packages/db-mongodb/src/updateVersion.ts
+++ b/packages/db-mongodb/src/updateVersion.ts
@@ -67,7 +67,7 @@ export const updateVersion: UpdateVersion = async function updateVersion(
     return null
   }
 
-  transform({ adapter: this, data: doc, fields, operation: 'write' })
+  transform({ adapter: this, data: doc, fields, operation: 'read' })
 
   return doc
 }

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -743,7 +743,7 @@ describe('Versions', () => {
         expect(updated1.title).toBe('new-title')
 
         expect(updated2.id).toBe(id)
-        expect(updated2.title).toBe('new-title')
+        expect(updated2.title).toBe('new-title-2')
       })
     })
 

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -1,8 +1,8 @@
-import type { Payload } from 'payload';
+import type { Payload } from 'payload'
 
 import { schedulePublishHandler } from '@payloadcms/ui/utilities/schedulePublishHandler'
 import path from 'path'
-import { createLocalReq , ValidationError } from 'payload'
+import { createLocalReq, ValidationError } from 'payload'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
 
@@ -688,6 +688,62 @@ describe('Versions', () => {
         expect(updateManyResult.errors).toStrictEqual([
           { id: doc.id, message: 'The following field is invalid: Title' },
         ])
+      })
+
+      it('should update with autosave: true', async () => {
+        // Save a draft
+        const { id } = await payload.create({
+          collection: autosaveCollectionSlug,
+          draft: true,
+          data: { title: 'my-title', description: 'some-description', _status: 'draft' },
+        })
+
+        // Autosave the same draft, calls db.updateVersion
+        const updated1 = await payload.update({
+          collection: autosaveCollectionSlug,
+          id,
+          data: {
+            title: 'new-title',
+          },
+          autosave: true,
+          draft: true,
+        })
+
+        const versionsCount = await payload.countVersions({
+          collection: autosaveCollectionSlug,
+          where: {
+            parent: {
+              equals: id,
+            },
+          },
+        })
+
+        // This should not create a new version
+        const updated2 = await payload.update({
+          collection: autosaveCollectionSlug,
+          id,
+          data: {
+            title: 'new-title-2',
+          },
+          autosave: true,
+          draft: true,
+        })
+
+        const versionsCountAfter = await payload.countVersions({
+          collection: autosaveCollectionSlug,
+          where: {
+            parent: {
+              equals: id,
+            },
+          },
+        })
+
+        expect(versionsCount.totalDocs).toBe(versionsCountAfter.totalDocs)
+        expect(updated1.id).toBe(id)
+        expect(updated1.title).toBe('new-title')
+
+        expect(updated2.id).toBe(id)
+        expect(updated2.title).toBe('new-title')
       })
     })
 


### PR DESCRIPTION
Previously, `db.updateVersion` had a mistake with using `transform({ operation: 'write' })` instead of  `transform({ operation: 'read' })` which led to improper DB data sanitization (like ObjectID -> string, Date -> string) when calling `payload.update` with `autosave: true` when some other autosave draft already exists. This fixes https://github.com/payloadcms/payload/issues/11542 additionally for this case.