### PR TITLE
feat: threads path through field validate function

### DIFF
--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -286,15 +286,15 @@ export const MyField: Field = {
 
 The following additional properties are provided in the `ctx` object:
 
-|    Property         |    Description                                                                                                                              |
+|    Property         |    Description                                                                                                                                                  |
 | --- | --- |
-|    `data`           |    An object containing the full collection or global document currently being edited.                                                      |
-|    `siblingData`    |    An object containing document data that is scoped to only fields within the same parent of this field.                                   |
-|    `operation`      |    Will be `create` or `update` depending on the UI action or API call.                                                                     |
-|    `path`           |    The full path to the field in the schema, including array indexes. Useful for dynamic lookups.                                           |
-|    `id`             |    The `id` of the current document being edited. `id` is `undefined` during the `create` operation.                                        |
-|    `req`            |    The current HTTP request object. Contains `payload`, `user`, etc.                                                                        |
-|    `event`          |    Either `onChange` or `submit` depending on the current action. Used as a performance opt-in. [More details](#async-field-validations).   |
+|    `data`           |    An object containing the full collection or global document currently being edited.                                                                          |
+|    `siblingData`    |    An object containing document data that is scoped to only fields within the same parent of this field.                                                       |
+|    `operation`      |    Will be `create` or `update` depending on the UI action or API call.                                                                                         |
+|    `path`           |    The full path to the field in the schema, represented as an array of string segments, including array indexes. I.e `['group', 'myArray', '1', 'textField']`. |
+|    `id`             |    The `id` of the current document being edited. `id` is `undefined` during the `create` operation.                                                            |
+|    `req`            |    The current HTTP request object. Contains `payload`, `user`, etc.                                                                                            |
+|    `event`          |    Either `onChange` or `submit` depending on the current action. Used as a performance opt-in. [More details](#async-field-validations).                       |
 
 #### Reusing Default Field Validations
 
@@ -523,11 +523,11 @@ You can show and hide fields based on what other fields are doing by utilizing c
 
 The `ctx` object:
 
-|    Property           |    Description                                                                                    |
+|    Property           |    Description                                                                                                                                                  |
 | --- | --- |
-|    **`blockData`**    |    The nearest parent block's data. If the field is not inside a block, this will be `undefined`. |
-|    **`path`**         |    The full path to the field in the schema, including array indexes. Useful for dynamic lookups. |
-|    **`user`**         |    The currently authenticated user object.                                                       |
+|    **`blockData`**    |    The nearest parent block's data. If the field is not inside a block, this will be `undefined`.                                                               |
+|    **`path`**         |    The full path to the field in the schema, represented as an array of string segments, including array indexes. I.e `['group', 'myArray', '1', 'textField']`. |
+|    **`user`**         |    The currently authenticated user object.                                                                                                                     |
 
 The `condition` function should return a boolean that will control if the field should be displayed or not.
 

--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -291,9 +291,10 @@ The following additional properties are provided in the `ctx` object:
 |    `data`           |    An object containing the full collection or global document currently being edited.                                                      |
 |    `siblingData`    |    An object containing document data that is scoped to only fields within the same parent of this field.                                   |
 |    `operation`      |    Will be `create` or `update` depending on the UI action or API call.                                                                     |
+|    `path`           |    The full path to the field in the schema, including array indexes. Useful for dynamic lookups.                                           |
 |    `id`             |    The `id` of the current document being edited. `id` is `undefined` during the `create` operation.                                        |
 |    `req`            |    The current HTTP request object. Contains `payload`, `user`, etc.                                                                        |
-|    `event`          |    Either `onChange` or `submit` depending on the current action. Used as a performance opt-in. [More details](#async-field-validations).    |
+|    `event`          |    Either `onChange` or `submit` depending on the current action. Used as a performance opt-in. [More details](#async-field-validations).   |
 
 #### Reusing Default Field Validations
 

--- a/packages/next/src/views/ForgotPassword/ForgotPasswordForm/index.tsx
+++ b/packages/next/src/views/ForgotPassword/ForgotPasswordForm/index.tsx
@@ -94,6 +94,7 @@ export const ForgotPasswordForm: React.FC = () => {
               blockData: {},
               data: {},
               event: 'onChange',
+              path: ['username'],
               preferences: { fields: {} },
               req: {
                 payload: {
@@ -124,6 +125,7 @@ export const ForgotPasswordForm: React.FC = () => {
               blockData: {},
               data: {},
               event: 'onChange',
+              path: ['email'],
               preferences: { fields: {} },
               req: { payload: { config }, t } as unknown as PayloadRequest,
               required: true,

--- a/packages/payload/src/auth/strategies/local/generatePasswordSaltHash.ts
+++ b/packages/payload/src/auth/strategies/local/generatePasswordSaltHash.ts
@@ -37,6 +37,7 @@ export const generatePasswordSaltHash = async ({
     blockData: {},
     data: {},
     event: 'submit',
+    path: ['password'],
     preferences: { fields: {} },
     req,
     required: true,

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -404,6 +404,10 @@ export type BaseValidateOptions<TData, TSiblingData, TValue> = {
   event?: 'onChange' | 'submit'
   id?: number | string
   operation?: Operation
+  /**
+   * The path of the field, e.g. ["group", "myArray", 1, "textField"]. The path is the schemaPath but with indexes and would be used in the context of field data, not field schemas.
+   */
+  path: (number | string)[]
   preferences: DocumentPreferences
   previousValue?: TValue
   req: PayloadRequest

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -181,6 +181,7 @@ export const promise = async ({
         // @ts-expect-error
         jsonError,
         operation,
+        path: pathSegments,
         preferences: { fields: {} },
         previousValue: siblingDoc[field.name],
         req,

--- a/packages/ui/src/fields/Password/index.tsx
+++ b/packages/ui/src/fields/Password/index.tsx
@@ -42,6 +42,8 @@ const PasswordFieldComponent: React.FC<PasswordFieldProps> = (props) => {
 
   const memoizedValidate: PasswordFieldValidation = useCallback(
     (value, options) => {
+      const pathSegments = path ? path.split('.') : []
+
       if (typeof validate === 'function') {
         return validate(value, { ...options, required })
       }
@@ -52,6 +54,7 @@ const PasswordFieldComponent: React.FC<PasswordFieldProps> = (props) => {
         blockData: {},
         data: {},
         event: 'onChange',
+        path: pathSegments,
         preferences: { fields: {} },
         req: {
           payload: {
@@ -63,7 +66,7 @@ const PasswordFieldComponent: React.FC<PasswordFieldProps> = (props) => {
         siblingData: {},
       })
     },
-    [validate, config, t, required],
+    [validate, config, t, required, path],
   )
 
   const {

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -134,6 +134,7 @@ export const Form: React.FC<FormProps> = (props) => {
     const validationPromises = Object.entries(contextRef.current.fields).map(
       async ([path, field]) => {
         const validatedField = field
+        const pathSegments = path ? path.split('.') : []
 
         if (field.passesCondition !== false) {
           let validationResult: boolean | string = validatedField.valid
@@ -154,6 +155,7 @@ export const Form: React.FC<FormProps> = (props) => {
               data: documentForm?.getData ? documentForm.getData() : data,
               event: 'submit',
               operation,
+              path: pathSegments,
               preferences: {} as any,
               req: {
                 payload: {

--- a/packages/ui/src/forms/useField/index.tsx
+++ b/packages/ui/src/forms/useField/index.tsx
@@ -58,6 +58,8 @@ export const useField = <TValue,>(options: Options): FieldType<TValue> => {
   const prevValid = useRef(valid)
   const prevErrorMessage = useRef(field?.errorMessage)
 
+  const pathSegments = path ? path.split('.') : []
+
   // Method to return from `useField`, used to
   // update field values from field component(s)
   const setValue = useCallback(
@@ -154,6 +156,7 @@ export const useField = <TValue,>(options: Options): FieldType<TValue> => {
                 data: documentForm?.getData ? documentForm.getData() : data,
                 event: 'onChange',
                 operation,
+                path: pathSegments,
                 preferences: {} as any,
                 req: {
                   payload: {

--- a/packages/ui/src/views/Edit/Auth/APIKey.tsx
+++ b/packages/ui/src/views/Edit/Auth/APIKey.tsx
@@ -43,6 +43,7 @@ export const APIKey: React.FC<{ readonly enabled: boolean; readonly readOnly?: b
       event: 'onChange',
       maxLength: 48,
       minLength: 24,
+      path: ['apiKey'],
       preferences: { fields: {} },
       req: {
         payload: {


### PR DESCRIPTION
This PR updates the field `validate` function property to include a new `path` argument. 

The `path` arg provides the schema path of the field, including array indices where applicable.

#### Changes:

- Added `path: (number | string)[]` in the ValidateOptions type.

