### PR TITLE
perf: 50% faster compilation speed by skipping bundling of server-only packages during dev

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,54 +12,57 @@ const withBundleAnalyzer = bundleAnalyzer({
 })
 
 const config = withBundleAnalyzer(
-  withPayload({
-    eslint: {
-      ignoreDuringBuilds: true,
-    },
-    typescript: {
-      ignoreBuildErrors: true,
-    },
-    experimental: {
-      fullySpecified: true,
-      serverActions: {
-        bodySizeLimit: '5mb',
+  withPayload(
+    {
+      eslint: {
+        ignoreDuringBuilds: true,
+      },
+      typescript: {
+        ignoreBuildErrors: true,
+      },
+      experimental: {
+        fullySpecified: true,
+        serverActions: {
+          bodySizeLimit: '5mb',
+        },
+      },
+      env: {
+        PAYLOAD_CORE_DEV: 'true',
+        ROOT_DIR: path.resolve(dirname),
+        // @todo remove in 4.0 - will behave like this by default in 4.0
+        PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY: 'true',
+      },
+      async redirects() {
+        return [
+          {
+            destination: '/admin',
+            permanent: false,
+            source: '/',
+          },
+        ]
+      },
+      images: {
+        domains: ['localhost'],
+      },
+      webpack: (webpackConfig) => {
+        webpackConfig.resolve.extensionAlias = {
+          '.cjs': ['.cts', '.cjs'],
+          '.js': ['.ts', '.tsx', '.js', '.jsx'],
+          '.mjs': ['.mts', '.mjs'],
+        }
+
+        // Ignore sentry warnings when not wrapped with withSentryConfig
+        webpackConfig.ignoreWarnings = [
+          ...(webpackConfig.ignoreWarnings ?? []),
+          { file: /esm\/platform\/node\/instrumentation.js/ },
+          { module: /esm\/platform\/node\/instrumentation.js/ },
+        ]
+
+        return webpackConfig
       },
     },
-    env: {
-      PAYLOAD_CORE_DEV: 'true',
-      ROOT_DIR: path.resolve(dirname),
-      // @todo remove in 4.0 - will behave like this by default in 4.0
-      PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY: 'true',
-    },
-    async redirects() {
-      return [
-        {
-          destination: '/admin',
-          permanent: false,
-          source: '/',
-        },
-      ]
-    },
-    images: {
-      domains: ['localhost'],
-    },
-    webpack: (webpackConfig) => {
-      webpackConfig.resolve.extensionAlias = {
-        '.cjs': ['.cts', '.cjs'],
-        '.js': ['.ts', '.tsx', '.js', '.jsx'],
-        '.mjs': ['.mts', '.mjs'],
-      }
-
-      // Ignore sentry warnings when not wrapped with withSentryConfig
-      webpackConfig.ignoreWarnings = [
-        ...(webpackConfig.ignoreWarnings ?? []),
-        { file: /esm\/platform\/node\/instrumentation.js/ },
-        { module: /esm\/platform\/node\/instrumentation.js/ },
-      ]
-
-      return webpackConfig
-    },
-  }),
+    { devBundleServerPackages: false },
+  ),
 )
 
 export default process.env.NEXT_PUBLIC_SENTRY_DSN

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -117,12 +117,11 @@ export const withPayload = (nextConfig = {}) => {
             '@payloadcms/plugin-redirects',
             '@payloadcms/plugin-sentry',
             '@payloadcms/plugin-stripe',
-            '@payloadcms/storage-azure',
-            '@payloadcms/storage-gcs',
-            '@payloadcms/storage-s3',
-            '@payloadcms/storage-uploadthing',
-            '@payloadcms/storage-vercel-blob',
-            '@payloadcms/translations',
+            //'@payloadcms/storage-azure', //has /client export
+            //'@payloadcms/storage-gcs', //has /client export
+            //'@payloadcms/storage-s3', //has /client export
+            //'@payloadcms/storage-uploadthing', //has /client export
+            //'@payloadcms/storage-vercel-blob', //has /client export
           ]
         : []),
     ],

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -1,9 +1,11 @@
 /**
  * @param {import('next').NextConfig} nextConfig
+ * @param {Object} [options] - Optional configuration options
+ * @param {boolean} [options.devBundleServerPackages] - Whether to bundle server packages in development mode. @default true
  *
  * @returns {import('next').NextConfig}
  * */
-export const withPayload = (nextConfig = {}) => {
+export const withPayload = (nextConfig = {}, options = {}) => {
   const env = nextConfig?.env || {}
 
   if (nextConfig.experimental?.staleTimes?.dynamic) {
@@ -100,7 +102,7 @@ export const withPayload = (nextConfig = {}) => {
       'pino-pretty',
       'graphql',
       // Do not bundle server-only packages during dev to improve compile speed
-      ...(process.env.npm_lifecycle_event === 'dev'
+      ...(process.env.npm_lifecycle_event === 'dev' && options.devBundleServerPackages === false
         ? [
             'payload',
             '@payloadcms/db-mongodb',
@@ -109,7 +111,6 @@ export const withPayload = (nextConfig = {}) => {
             '@payloadcms/db-vercel-postgres',
             '@payloadcms/drizzle',
             '@payloadcms/email-nodemailer',
-            // TODO: Can I add @payloadcms/richtext-lexical without @payloadcms/richtext-lexical/client ?
             '@payloadcms/email-resend',
             '@payloadcms/graphql',
             '@payloadcms/payload-cloud',
@@ -117,11 +118,13 @@ export const withPayload = (nextConfig = {}) => {
             '@payloadcms/plugin-redirects',
             '@payloadcms/plugin-sentry',
             '@payloadcms/plugin-stripe',
-            //'@payloadcms/storage-azure', //has /client export
-            //'@payloadcms/storage-gcs', //has /client export
-            //'@payloadcms/storage-s3', //has /client export
-            //'@payloadcms/storage-uploadthing', //has /client export
-            //'@payloadcms/storage-vercel-blob', //has /client export
+            // TODO: Add the following packages, excluding their /client subpath exports, once Next.js supports it
+            // @payloadcms/richtext-lexical
+            //'@payloadcms/storage-azure',
+            //'@payloadcms/storage-gcs',
+            //'@payloadcms/storage-s3',
+            //'@payloadcms/storage-uploadthing',
+            //'@payloadcms/storage-vercel-blob',
           ]
         : []),
     ],

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -99,6 +99,32 @@ export const withPayload = (nextConfig = {}) => {
       'libsql',
       'pino-pretty',
       'graphql',
+      // Do not bundle server-only packages during dev to improve compile speed
+      ...(process.env.npm_lifecycle_event === 'dev'
+        ? [
+            'payload',
+            '@payloadcms/db-mongodb',
+            '@payloadcms/db-postgres',
+            '@payloadcms/db-sqlite',
+            '@payloadcms/db-vercel-postgres',
+            '@payloadcms/drizzle',
+            '@payloadcms/email-nodemailer',
+            // TODO: Can I add @payloadcms/richtext-lexical without @payloadcms/richtext-lexical/client ?
+            '@payloadcms/email-resend',
+            '@payloadcms/graphql',
+            '@payloadcms/payload-cloud',
+            '@payloadcms/plugin-cloud-storage',
+            '@payloadcms/plugin-redirects',
+            '@payloadcms/plugin-sentry',
+            '@payloadcms/plugin-stripe',
+            '@payloadcms/storage-azure',
+            '@payloadcms/storage-gcs',
+            '@payloadcms/storage-s3',
+            '@payloadcms/storage-uploadthing',
+            '@payloadcms/storage-vercel-blob',
+            '@payloadcms/translations',
+          ]
+        : []),
     ],
     webpack: (webpackConfig, webpackOptions) => {
       const incomingWebpackConfig =

--- a/packages/payload-cloud/src/utilities/refreshSession.ts
+++ b/packages/payload-cloud/src/utilities/refreshSession.ts
@@ -1,12 +1,12 @@
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity'
-import * as AWS from '@aws-sdk/client-s3'
+import { S3 } from '@aws-sdk/client-s3'
 import { fromCognitoIdentityPool } from '@aws-sdk/credential-providers'
 
 import { authAsCognitoUser } from './authAsCognitoUser.js'
 
 export type GetStorageClient = () => Promise<{
   identityID: string
-  storageClient: AWS.S3
+  storageClient: S3
 }>
 
 export const refreshSession = async () => {
@@ -33,7 +33,7 @@ export const refreshSession = async () => {
   // @ts-expect-error - Incorrect AWS types
   const identityID = credentials.identityId
 
-  const storageClient = new AWS.S3({
+  const storageClient = new S3({
     credentials,
     region: process.env.PAYLOAD_CLOUD_BUCKET_REGION,
   })

--- a/templates/_template/next.config.mjs
+++ b/templates/_template/next.config.mjs
@@ -5,4 +5,4 @@ const nextConfig = {
   // Your Next.js config here
 }
 
-export default withPayload(nextConfig)
+export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/templates/blank/next.config.mjs
+++ b/templates/blank/next.config.mjs
@@ -5,4 +5,4 @@ const nextConfig = {
   // Your Next.js config here
 }
 
-export default withPayload(nextConfig)
+export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/templates/plugin/dev/next.config.mjs
+++ b/templates/plugin/dev/next.config.mjs
@@ -18,4 +18,4 @@ const nextConfig = {
   // transpilePackages: ['../src'],
 }
 
-export default withPayload(nextConfig)
+export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/templates/website/next.config.js
+++ b/templates/website/next.config.js
@@ -24,4 +24,4 @@ const nextConfig = {
   redirects,
 }
 
-export default withPayload(nextConfig)
+export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/templates/with-payload-cloud/next.config.mjs
+++ b/templates/with-payload-cloud/next.config.mjs
@@ -5,4 +5,4 @@ const nextConfig = {
   // Your Next.js config here
 }
 
-export default withPayload(nextConfig)
+export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/templates/with-postgres/next.config.mjs
+++ b/templates/with-postgres/next.config.mjs
@@ -5,4 +5,4 @@ const nextConfig = {
   // Your Next.js config here
 }
 
-export default withPayload(nextConfig)
+export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/templates/with-vercel-mongodb/next.config.mjs
+++ b/templates/with-vercel-mongodb/next.config.mjs
@@ -5,4 +5,4 @@ const nextConfig = {
   // Your Next.js config here
 }
 
-export default withPayload(nextConfig)
+export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/templates/with-vercel-postgres/next.config.mjs
+++ b/templates/with-vercel-postgres/next.config.mjs
@@ -5,4 +5,4 @@ const nextConfig = {
   // Your Next.js config here
 }
 
-export default withPayload(nextConfig)
+export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/templates/with-vercel-website/next.config.js
+++ b/templates/with-vercel-website/next.config.js
@@ -24,4 +24,4 @@ const nextConfig = {
   redirects,
 }
 
-export default withPayload(nextConfig)
+export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/test/next.config.mjs
+++ b/test/next.config.mjs
@@ -12,45 +12,48 @@ const withBundleAnalyzer = bundleAnalyzer({
 })
 
 export default withBundleAnalyzer(
-  withPayload({
-    eslint: {
-      ignoreDuringBuilds: true,
-    },
-    typescript: {
-      ignoreBuildErrors: true,
-    },
-    experimental: {
-      fullySpecified: true,
-      serverActions: {
-        bodySizeLimit: '5mb',
+  withPayload(
+    {
+      eslint: {
+        ignoreDuringBuilds: true,
+      },
+      typescript: {
+        ignoreBuildErrors: true,
+      },
+      experimental: {
+        fullySpecified: true,
+        serverActions: {
+          bodySizeLimit: '5mb',
+        },
+      },
+      env: {
+        PAYLOAD_CORE_DEV: 'true',
+        ROOT_DIR: path.resolve(dirname),
+        // @todo remove in 4.0 - will behave like this by default in 4.0
+        PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY: 'true',
+      },
+      async redirects() {
+        return [
+          {
+            destination: '/admin',
+            permanent: true,
+            source: '/',
+          },
+        ]
+      },
+      images: {
+        domains: ['localhost'],
+      },
+      webpack: (webpackConfig) => {
+        webpackConfig.resolve.extensionAlias = {
+          '.cjs': ['.cts', '.cjs'],
+          '.js': ['.ts', '.tsx', '.js', '.jsx'],
+          '.mjs': ['.mts', '.mjs'],
+        }
+
+        return webpackConfig
       },
     },
-    env: {
-      PAYLOAD_CORE_DEV: 'true',
-      ROOT_DIR: path.resolve(dirname),
-      // @todo remove in 4.0 - will behave like this by default in 4.0
-      PAYLOAD_DO_NOT_SANITIZE_LOCALIZED_PROPERTY: 'true',
-    },
-    async redirects() {
-      return [
-        {
-          destination: '/admin',
-          permanent: true,
-          source: '/',
-        },
-      ]
-    },
-    images: {
-      domains: ['localhost'],
-    },
-    webpack: (webpackConfig) => {
-      webpackConfig.resolve.extensionAlias = {
-        '.cjs': ['.cts', '.cjs'],
-        '.js': ['.ts', '.tsx', '.js', '.jsx'],
-        '.mjs': ['.mts', '.mjs'],
-      }
-
-      return webpackConfig
-    },
-  }),
+    { devBundleServerPackages: false },
+  ),
 )


### PR DESCRIPTION
This PR skips bundling server-only payload packages during development, which results in 50% faster compilation speeds using turbo.

Test results using our blank template (both /api and /admin):

Webpack before: 11.5
Webpack now: 7.1s
=> 38% faster compilation speed

Turbopack before: 4.1s
Turbopack after: 2.1s
=> 50% faster compilation speed