### PR TITLE
fix(ui): prevent removeThumbnail from desyncing thumbnail array in bulkUpload

### DIFF
--- a/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
@@ -265,7 +265,23 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
   )
 
   const removeThumbnails = React.useCallback((indexes: number[]) => {
-    thumbnailUrlsRef.current = thumbnailUrlsRef.current.filter((_, i) => !indexes.includes(i))
+    const indexSet = new Set(indexes)
+    const newArr: (string | undefined)[] = new Array(
+      Math.max(thumbnailUrlsRef.current.length - indexes.length, 0),
+    )
+
+    let shiftIndex = 0
+
+    for (let i = 0; i < thumbnailUrlsRef.current.length; i++) {
+      if (!indexSet.has(i)) {
+        if (thumbnailUrlsRef.current[i]) {
+          newArr[shiftIndex] = thumbnailUrlsRef.current[i]
+        }
+        shiftIndex++
+      }
+    }
+
+    thumbnailUrlsRef.current = newArr
     setRenderedThumbnails([...thumbnailUrlsRef.current])
   }, [])
 

--- a/packages/ui/src/elements/BulkUpload/FormsManager/reducer.ts
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/reducer.ts
@@ -58,10 +58,12 @@ export function formsManagementReducer(state: State, action: Action): State {
         }
       }
 
+      const activeIndex = newForms.length ? state.forms.length : state.activeIndex
+
       return {
         ...state,
-        activeIndex: 0,
-        forms: [...newForms, ...state.forms],
+        activeIndex,
+        forms: [...state.forms, ...newForms],
       }
     }
     case 'REMOVE_FORM': {

--- a/packages/ui/src/elements/Thumbnail/index.tsx
+++ b/packages/ui/src/elements/Thumbnail/index.tsx
@@ -56,8 +56,7 @@ export const Thumbnail: React.FC<ThumbnailProps> = (props) => {
   return (
     <div className={classNames}>
       {fileExists === undefined && <ShimmerEffect height="100%" />}
-      {fileExists && <img alt={filename as string} src={src} />}
-      {fileExists === false && <File />}
+      {fileExists && src ? <img alt={filename as string} src={src} /> : <File />}
     </div>
   )
 }
@@ -106,8 +105,7 @@ export function ThumbnailComponent(props: ThumbnailComponentProps) {
   return (
     <div className={classNames}>
       {fileExists === undefined && <ShimmerEffect height="100%" />}
-      {fileExists && <img alt={alt || filename} src={src} />}
-      {fileExists === false && <File />}
+      {fileExists && src ? <img alt={alt || filename} src={src} /> : <File />}
     </div>
   )
 }


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes a pair of issues around thumbnails and their removal in the `BulkUpload` component. Namely:

1. Adding non-image files followed by an image files simultaneously in the `BulkUpload` drawer causes a runtime error due to the `Thumbnail` component potentially rendering an `img` element with an empty string, which, as the error points out, could cause Next to redownload the whole page supposedly.

2. Adding non-image files with images simultaneously in the `BulkUpload` drawer and then removing them via the `XIcon` button causes the thumbnails array to desync, showing incorrect thumbnails for subsequent forms. This is because the `thumbnailUrlsRef` array is **sparse** and using `.filter` on a sparse array omits empty holes in the array, causing it to desync. 

### Why?
To properly preserve the thumbnail order and show the correct thumbnails for existing forms in the `BulkUpload` drawer, and to prevent a runtime error.

### How?
1. Solved by checking if `src` is truthy.

2. Solved by preserving the sparseness of the array containing the thumbnail urls instead of using `.filter`. This PR also changes how the `reducer` adds new forms to the `BulkUpload` component as the existing way added new forms in the _beginning_ of the array. This is problematic as thumbnails are generated and added sequentially to the array potentially causing another area of desynchronization between these two arrays.

Before

[Before](https://github.com/user-attachments/assets/da3ee7ca-6b88-4a88-be3f-b9182340b364)

After

[After](https://github.com/user-attachments/assets/a6822543-072a-4c42-a565-73de5b5b793e)

Notes:
- In general, I try to avoid sparse arrays. I think one was used here to minimize memory usage in a component that might need to generate _many_ thumbnails, which makes sense to me. However, synchronizing sparse and dense arrays come with a few gotchas. It might be worth exploring swapping out the thumbnail array for a `Map<string, string>` to map filenames to their urls, or permitting the thumbnail array to be dense.

If this array was dense, then the fix for desynchronizing thumbnails becomes _very simple_. You would populate non-image indexes with `undefined` in the `thumbnailUrlsRef` array instead of skipping them.
- Initially, when implementing `removeThumbnails`, I didn't realize that `thumbnailUrlsRef` was indeed sparse. My mistake.
- Test coverage here should be considered, I can add this if necessary.