### PR TITLE
chore(ui): code/json field full height should include any padding added

### DIFF
--- a/packages/ui/src/elements/CodeEditor/CodeEditor.tsx
+++ b/packages/ui/src/elements/CodeEditor/CodeEditor.tsx
@@ -15,6 +15,9 @@ const baseClass = 'code-editor'
 const CodeEditor: React.FC<Props> = (props) => {
   const { className, maxHeight, minHeight, options, readOnly, ...rest } = props
   const MIN_HEIGHT = minHeight ?? 56 // equivalent to 3 lines
+  const paddingFromProps = options?.padding
+    ? (options.padding.top || 0) + (options.padding?.bottom || 0)
+    : 0
 
   const [dynamicHeight, setDynamicHeight] = useState(MIN_HEIGHT)
   const { theme } = useTheme()
@@ -57,11 +60,13 @@ const CodeEditor: React.FC<Props> = (props) => {
       height={maxHeight ? Math.min(dynamicHeight, maxHeight) : dynamicHeight}
       onChange={(value, ev) => {
         rest.onChange?.(value, ev)
-        setDynamicHeight(Math.max(MIN_HEIGHT, value.split('\n').length * 18 + 2))
+        setDynamicHeight(Math.max(MIN_HEIGHT, value.split('\n').length * 18 + 2 + paddingFromProps))
       }}
       onMount={(editor, monaco) => {
         rest.onMount?.(editor, monaco)
-        setDynamicHeight(Math.max(MIN_HEIGHT, editor.getValue().split('\n').length * 18 + 2))
+        setDynamicHeight(
+          Math.max(MIN_HEIGHT, editor.getValue().split('\n').length * 18 + 2 + paddingFromProps),
+        )
       }}
     />
   )

--- a/test/fields/collections/Code/index.tsx
+++ b/test/fields/collections/Code/index.tsx
@@ -40,6 +40,13 @@ const Code: CollectionConfig = {
         language: 'css',
       },
     },
+    {
+      name: 'codeWithPadding',
+      type: 'code',
+      admin: {
+        editorOptions: { padding: { bottom: 25, top: 25 } },
+      },
+    },
   ],
 }
 


### PR DESCRIPTION
### What?
We setup the `code` and `json` field to have dynamic height based on the field value. However, when a user adds additional padding, the dynamic height doesn't account for this and the scrollbar gets displayed.

### Why?
Currently, the dynamic height based is calculated based on number of code lines. We have to do a weird workaround because the Monaco editor also tries to enforce a height.

### How?
Adds any potential padding into the dynamic height being calculated.

#### Testing
Use the `fields` test suite and `code` collection. There is a new field added called `codeWithPadding` at the bottom.

Closes #11602

Before:
<img width="758" alt="Screenshot 2025-03-10 at 11 11 16 AM" src="https://github.com/user-attachments/assets/b97907eb-cb03-4d45-ac8b-48bdbe5d355b" />

After:
<img width="762" alt="Screenshot 2025-03-10 at 11 12 26 AM" src="https://github.com/user-attachments/assets/a4c18dd8-3637-4dfd-9f19-e45e699bb4d8" />