### PR TITLE
fix: upload imageSizes forces original file uploads to be compressed

### DIFF
--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -141,7 +141,7 @@ export const generateFileData = async <T>({
     let mime: string
     const fileHasAdjustments =
       fileSupportsResize &&
-      Boolean(resizeOptions || formatOptions || imageSizes || trimOptions || file.tempFilePath)
+      Boolean(resizeOptions || formatOptions || trimOptions || file.tempFilePath)
 
     const sharpOptions: SharpOptions = {}
 


### PR DESCRIPTION
### What?

When the upload config contains imageSizes, we are forcing the image to be resized using sharp. This leads to lossy compression even when the formatOptions and no cropping or focal point selection was made. This change makes it possible to upload the original image, skipping compression while still using the imageSizes feature.

### Why?

It should be possible to upload files without compression.

### How?

Changes the conditions to remove imageSizes to determine if sharp image processing should be applied to the original image or not.
