### PR TITLE
fix(ui): adds fallback locale when defaultLocale is unavailable

### DIFF
--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -69,7 +69,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
 
   const editingDefaultLocale = (() => {
     if (localization && localization.fallback) {
-      const defaultLocale = localization.defaultLocale || 'en'
+      const defaultLocale = localization.defaultLocale
       return locale === defaultLocale
     }
 

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -76,7 +76,7 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
 
   const editingDefaultLocale = (() => {
     if (localization && localization.fallback) {
-      const defaultLocale = localization.defaultLocale || 'en'
+      const defaultLocale = localization.defaultLocale
       return locale === defaultLocale
     }
 

--- a/packages/ui/src/forms/NullifyField/index.tsx
+++ b/packages/ui/src/forms/NullifyField/index.tsx
@@ -24,12 +24,15 @@ export const NullifyLocaleField: React.FC<NullifyLocaleFieldProps> = ({
     config: { localization },
   } = useConfig()
   const [checked, setChecked] = React.useState<boolean>(typeof fieldValue !== 'number')
-  const defaultLocale =
-    localization && localization.defaultLocale ? localization.defaultLocale : 'en'
   const { t } = useTranslation()
 
-  if (!localized || currentLocale === defaultLocale || (localization && !localization.fallback)) {
-    // hide when field is not localized or editing default locale or when fallback is disabled
+  if (!localized || !localization) {
+    // hide when field is not localized or localization is not enabled
+    return null
+  }
+
+  if (localization.defaultLocale === currentLocale || !localization.fallback) {
+    // if editing default locale or when fallback is disabled
     return null
   }
 

--- a/packages/ui/src/providers/Locale/index.tsx
+++ b/packages/ui/src/providers/Locale/index.tsx
@@ -48,14 +48,13 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode; locale?: Loc
 
   const { user } = useAuth()
 
-  const defaultLocale =
-    localization && localization.defaultLocale ? localization.defaultLocale : 'en'
+  const defaultLocale = localization ? localization.defaultLocale : 'en'
 
   const { getPreference, setPreference } = usePreferences()
   const localeFromParams = useSearchParams().get('locale')
 
   const [locale, setLocale] = React.useState<Locale>(() => {
-    if (!localization) {
+    if (!localization || (localization && !localization.locales.length)) {
       // TODO: return null V4
       return {} as Locale
     }
@@ -98,15 +97,16 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode; locale?: Loc
       if (localization && user?.id) {
         const localeToUse =
           localeFromParams ||
-          (await fetchPreferences<Locale['code']>('locale', fetchURL)?.then((res) => res.value)) ||
-          defaultLocale
+          (await fetchPreferences<Locale['code']>('locale', fetchURL)?.then((res) => res.value))
 
         const newLocale =
           findLocaleFromCode(localization, localeToUse) ||
           findLocaleFromCode(localization, defaultLocale) ||
-          findLocaleFromCode(localization, localization.locales[0].code)
+          findLocaleFromCode(localization, localization?.locales?.[0]?.code)
 
-        setLocale(newLocale)
+        if (newLocale) {
+          setLocale(newLocale)
+        }
       }
     }
 

--- a/packages/ui/src/providers/Locale/index.tsx
+++ b/packages/ui/src/providers/Locale/index.tsx
@@ -63,7 +63,8 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode; locale?: Loc
     return (
       findLocaleFromCode(localization, localeFromParams) ||
       findLocaleFromCode(localization, initialLocaleFromPrefs) ||
-      findLocaleFromCode(localization, defaultLocale)
+      findLocaleFromCode(localization, defaultLocale) ||
+      findLocaleFromCode(localization, localization.locales[0].code)
     )
   })
 
@@ -102,7 +103,8 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode; locale?: Loc
 
         const newLocale =
           findLocaleFromCode(localization, localeToUse) ||
-          findLocaleFromCode(localization, defaultLocale)
+          findLocaleFromCode(localization, defaultLocale) ||
+          findLocaleFromCode(localization, localization.locales[0].code)
 
         setLocale(newLocale)
       }


### PR DESCRIPTION
### What?
Since we introduced the localization option `filterAvailableLocales`, it is possible for the `defaultLocale` to not exist within the list of available locales. This causes an error in the Locale Selector and crashes the admin panel.

### Why?
The `defaultLocale` is our final locale fallback in the `LocaleProvider`.

### How?
To consider scenarios where the `defaultLocale` might be undefined, there should be a new final fallback which uses the first locale from the list of available locales.

#### Misc
This PR also cleans up some hard-coded `defaultLocales` and adds a couple safety catches to the `localeProvider`.

Closes #11598