### PR TITLE
chore(templates): add type detection on getGlobal utility

### DIFF
--- a/examples/form-builder/src/utilities/getGlobals.ts
+++ b/examples/form-builder/src/utilities/getGlobals.ts
@@ -1,13 +1,13 @@
 import type { Config } from 'src/payload-types'
 
 import { unstable_cache } from 'next/cache'
-import { getPayload } from 'payload'
+import { type DataFromGlobalSlug, getPayload } from 'payload'
 
 import configPromise from '../payload.config'
 
 type Global = keyof Config['globals']
 
-async function getGlobal(slug: Global, depth = 0) {
+async function getGlobal<T extends Global>(slug: T, depth = 0): Promise<DataFromGlobalSlug<T>> {
   const payload = await getPayload({ config: configPromise })
 
   const global = await payload.findGlobal({
@@ -21,7 +21,7 @@ async function getGlobal(slug: Global, depth = 0) {
 /**
  * Returns a unstable_cache function mapped with the cache tag for the slug
  */
-export const getCachedGlobal = (slug: Global, depth = 0) =>
-  unstable_cache(async () => getGlobal(slug, depth), [slug], {
+export const getCachedGlobal = <T extends Global>(slug: T, depth = 0) =>
+  unstable_cache(async () => getGlobal<T>(slug, depth), [slug], {
     tags: [`global_${slug}`],
   })

--- a/examples/localization/src/utilities/getGlobals.ts
+++ b/examples/localization/src/utilities/getGlobals.ts
@@ -1,13 +1,13 @@
 import type { Config } from 'src/payload-types'
 
 import configPromise from '@payload-config'
-import { getPayload } from 'payload'
+import { type DataFromGlobalSlug, getPayload } from 'payload'
 import { unstable_cache } from 'next/cache'
 import { TypedLocale } from 'payload'
 
 type Global = keyof Config['globals']
 
-async function getGlobal(slug: Global, depth = 0, locale: TypedLocale) {
+async function getGlobal<T extends Global>(slug: T, depth = 0, locale: TypedLocale): Promise<DataFromGlobalSlug<T>> {
   const payload = await getPayload({ config: configPromise })
 
   const global = await payload.findGlobal({
@@ -22,7 +22,7 @@ async function getGlobal(slug: Global, depth = 0, locale: TypedLocale) {
 /**
  * Returns a unstable_cache function mapped with the cache tag for the slug and locale
  */
-export const getCachedGlobal = (slug: Global, depth = 0, locale: TypedLocale) =>
-  unstable_cache(async () => getGlobal(slug, depth, locale), [slug, locale], {
+export const getCachedGlobal = <T extends Global>(slug: T, depth = 0, locale: TypedLocale) =>
+  unstable_cache(async () => getGlobal<T>(slug, depth, locale), [slug, locale], {
     tags: [`global_${slug}`],
   })

--- a/templates/website/src/utilities/getGlobals.ts
+++ b/templates/website/src/utilities/getGlobals.ts
@@ -1,12 +1,13 @@
 import type { Config } from 'src/payload-types'
 
-import configPromise from '@payload-config'
-import { getPayload } from 'payload'
+import configPromise from '@payload.config'
 import { unstable_cache } from 'next/cache'
+import { type DataFromGlobalSlug, getPayload } from 'payload'
+
 
 type Global = keyof Config['globals']
 
-async function getGlobal(slug: Global, depth = 0) {
+async function getGlobal<T extends Global>(slug: T, depth = 0): Promise<DataFromGlobalSlug<T>> {
   const payload = await getPayload({ config: configPromise })
 
   const global = await payload.findGlobal({
@@ -20,7 +21,7 @@ async function getGlobal(slug: Global, depth = 0) {
 /**
  * Returns a unstable_cache function mapped with the cache tag for the slug
  */
-export const getCachedGlobal = (slug: Global, depth = 0) =>
-  unstable_cache(async () => getGlobal(slug, depth), [slug], {
+export const getCachedGlobal = <T extends Global>(slug: T, depth = 0) =>
+  unstable_cache(async () => getGlobal<T>(slug, depth), [slug], {
     tags: [`global_${slug}`],
   })

--- a/templates/with-vercel-website/src/utilities/getGlobals.ts
+++ b/templates/with-vercel-website/src/utilities/getGlobals.ts
@@ -1,12 +1,13 @@
 import type { Config } from 'src/payload-types'
 
-import configPromise from '@payload-config'
-import { getPayload } from 'payload'
+import configPromise from '@payload.config'
 import { unstable_cache } from 'next/cache'
+import { type DataFromGlobalSlug, getPayload } from 'payload'
+
 
 type Global = keyof Config['globals']
 
-async function getGlobal(slug: Global, depth = 0) {
+async function getGlobal<T extends Global>(slug: T, depth = 0): Promise<DataFromGlobalSlug<T>> {
   const payload = await getPayload({ config: configPromise })
 
   const global = await payload.findGlobal({
@@ -20,7 +21,7 @@ async function getGlobal(slug: Global, depth = 0) {
 /**
  * Returns a unstable_cache function mapped with the cache tag for the slug
  */
-export const getCachedGlobal = (slug: Global, depth = 0) =>
-  unstable_cache(async () => getGlobal(slug, depth), [slug], {
+export const getCachedGlobal = <T extends Global>(slug: T, depth = 0) =>
+  unstable_cache(async () => getGlobal<T>(slug, depth), [slug], {
     tags: [`global_${slug}`],
   })


### PR DESCRIPTION
### What?

Added proper type detection to the global data fetching utilities in the form builder example. Enhanced the getGlobal and getCachedGlobal functions to leverage TypeScript generics for improved type safety.

#### Why?

This change improves developer experience by providing proper TypeScript type inference when working with global data. With these changes:
The returned data from getGlobal is now properly typed as DataFromGlobalSlug<T> based on the slug parameter
TypeScript can now correctly infer the return type of getCachedGlobal based on the global slug
This prevents type errors and provides better IDE autocomplete/IntelliSense when accessing properties on retrieved global data

### How?

Added import for the DataFromGlobalSlug type from Payload
Made getGlobal a generic function that accepts a type parameter T extends Global
Added proper return type annotation (Promise<DataFromGlobalSlug<T>>) to the getGlobal function
Updated getCachedGlobal to use the same generic typing pattern
These changes maintain the same runtime behavior while enhancing type safety
