### PR TITLE
feat: add `forceSelect` collection / global config property

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -79,6 +79,7 @@ The following options are available:
 | `versions`         | Set to true to enable default options, or configure with object properties. [More details](../versions/overview#collection-config).                                                                                  |
 | `defaultPopulate`  | Specify which fields to select when this Collection is populated from another document. [More Details](../queries/select#defaultpopulate-collection-config-property).                                                |
 | `indexes`          | Define compound indexes for this collection. This can be used to either speed up querying/sorting by 2 or more fields at the same time or to ensure uniqueness between several fields.                               |
+| `forceSelect`      | Specify which fields should be selected always, regardless of the `select` query which can be useful that the field exists for access control / hooks                                                                |
 
 _* An asterisk denotes that a property is required._
 

--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -65,22 +65,23 @@ export const Nav: GlobalConfig = {
 
 The following options are available:
 
-| Option              | Description                                                                                                                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Option          | Description                                                                                                                                                                                    |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `access`        | Provide Access Control functions to define exactly who should be able to do what with this Global. [More details](../access-control/globals).                                                  |
-| `admin`         | The configuration options for the Admin Panel. [More details](#admin-options).                                                                                                               |
+| `admin`         | The configuration options for the Admin Panel. [More details](#admin-options).                                                                                                                 |
 | `custom`        | Extension point for adding custom data (e.g. for plugins)                                                                                                                                      |
 | `dbName`        | Custom table or collection name for this Global depending on the Database Adapter. Auto-generated from slug if not defined.                                                                    |
 | `description`   | Text or React component to display below the Global header to give editors more information.                                                                                                   |
 | `endpoints`     | Add custom routes to the REST API. [More details](../rest-api/overview#custom-endpoints).                                                                                                      |
-| `fields` *     | Array of field types that will determine the structure and functionality of the data stored within this Global. [More details](../fields/overview).                                            |
+| `fields` *      | Array of field types that will determine the structure and functionality of the data stored within this Global. [More details](../fields/overview).                                            |
 | `graphQL`       | Manage GraphQL-related properties related to this global. [More details](#graphql)                                                                                                             |
 | `hooks`         | Entry point for Hooks. [More details](../hooks/overview#global-hooks).                                                                                                                         |
 | `label`         | Text for the name in the Admin Panel or an object with keys for each language. Auto-generated from slug if not defined.                                                                        |
 | `lockDocuments` | Enables or disables document locking. By default, document locking is enabled. Set to an object to configure, or set to `false` to disable locking. [More details](../admin/locked-documents). |
-| `slug` *       | Unique, URL-friendly string that will act as an identifier for this Global.                                                                                                                    |
+| `slug` *        | Unique, URL-friendly string that will act as an identifier for this Global.                                                                                                                    |
 | `typescript`    | An object with property `interface` as the text used in schema generation. Auto-generated from slug if not defined.                                                                            |
-| `versions`      | Set to true to enable default options, or configure with object properties. [More details](../versions/overview#global-config).                                                               |
+| `versions`      | Set to true to enable default options, or configure with object properties. [More details](../versions/overview#global-config).                                                                |
+| `forceSelect`   | Specify which fields should be selected always, regardless of the `select` query which can be useful that the field exists for access control / hooks                                          |
 
 _* An asterisk denotes that a property is required._
 

--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -56,6 +56,7 @@ const getPosts = async (payload: Payload) => {
 <Banner type="warning">
   **Important:**
   To perform querying with `select` efficiently, Payload implements your `select` query on the database level. Because of that, your `beforeRead` and `afterRead` hooks may not receive the full `doc`.
+  To ensure that some fields are always selected for your hooks / access control, regardless of the `select` query you can use `forceSelect` collection config property.
 </Banner>
 
 

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -43,6 +43,7 @@ import type {
 } from '../../index.js'
 import type {
   PayloadRequest,
+  SelectIncludeType,
   SelectType,
   Sort,
   TransformCollectionWithSelect,
@@ -424,8 +425,11 @@ export type CollectionConfig<TSlug extends CollectionSlug = any> = {
    */
   endpoints?: false | Omit<Endpoint, 'root'>[]
   fields: Field[]
+  /**
+   * Specify which fields should be selected always, regardless of the `select` query which can be useful that the field exists for access control / hooks
+   */
   forceSelect?: IsAny<SelectFromCollectionSlug<TSlug>> extends true
-    ? SelectType
+    ? SelectIncludeType
     : SelectFromCollectionSlug<TSlug>
   /**
    * GraphQL configuration

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -424,6 +424,9 @@ export type CollectionConfig<TSlug extends CollectionSlug = any> = {
    */
   endpoints?: false | Omit<Endpoint, 'root'>[]
   fields: Field[]
+  forceSelect?: IsAny<SelectFromCollectionSlug<TSlug>> extends true
+    ? SelectType
+    : SelectFromCollectionSlug<TSlug>
   /**
    * GraphQL configuration
    */

--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -35,6 +35,7 @@ import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { saveVersion } from '../../versions/saveVersion.js'
 import { buildAfterOperation } from './utils.js'
 
@@ -109,7 +110,7 @@ export const createOperation = async <
         payload: { config },
       },
       req,
-      select,
+      select: incomingSelect,
       showHiddenFields,
     } = args
 
@@ -244,6 +245,11 @@ export const createOperation = async <
     // /////////////////////////////////////
 
     let doc
+
+    const select = sanitizeSelect({
+      forceSelect: collectionConfig.forceSelect,
+      select: incomingSelect,
+    })
 
     if (collectionConfig.auth && !collectionConfig.auth.disableLocalStrategy) {
       if (collectionConfig.auth.verify) {

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -23,6 +23,7 @@ import { checkDocumentLockStatus } from '../../utilities/checkDocumentLockStatus
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { deleteCollectionVersions } from '../../versions/deleteCollectionVersions.js'
 import { deleteScheduledPublishJobs } from '../../versions/deleteScheduledPublishJobs.js'
 import { buildAfterOperation } from './utils.js'
@@ -80,7 +81,7 @@ export const deleteOperation = async <
         payload,
       },
       req,
-      select,
+      select: incomingSelect,
       showHiddenFields,
       where,
     } = args
@@ -107,6 +108,11 @@ export const deleteOperation = async <
     })
 
     const fullWhere = combineQueries(where, accessResult)
+
+    const select = sanitizeSelect({
+      forceSelect: collectionConfig.forceSelect,
+      select: incomingSelect,
+    })
 
     // /////////////////////////////////////
     // Retrieve documents

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -19,6 +19,7 @@ import { checkDocumentLockStatus } from '../../utilities/checkDocumentLockStatus
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { deleteCollectionVersions } from '../../versions/deleteCollectionVersions.js'
 import { deleteScheduledPublishJobs } from '../../versions/deleteScheduledPublishJobs.js'
 import { buildAfterOperation } from './utils.js'
@@ -75,7 +76,7 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
         payload,
       },
       req,
-      select,
+      select: incomingSelect,
       showHiddenFields,
     } = args
 
@@ -165,6 +166,11 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
         req,
       })
     }
+
+    const select = sanitizeSelect({
+      forceSelect: collectionConfig.forceSelect,
+      select: incomingSelect,
+    })
 
     // /////////////////////////////////////
     // Delete document

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -23,6 +23,7 @@ import { sanitizeJoinQuery } from '../../database/sanitizeJoinQuery.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { lockedDocumentsCollectionSlug } from '../../locked-documents/config.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
 import { appendVersionToQueryKey } from '../../versions/drafts/appendVersionToQueryKey.js'
 import { getQueryDraftsSelect } from '../../versions/drafts/getQueryDraftsSelect.js'
@@ -93,11 +94,16 @@ export const findOperation = async <
       populate,
       req: { fallbackLocale, locale, payload },
       req,
-      select,
+      select: incomingSelect,
       showHiddenFields,
       sort,
       where,
     } = args
+
+    const select = sanitizeSelect({
+      forceSelect: collectionConfig.forceSelect,
+      select: incomingSelect,
+    })
 
     // /////////////////////////////////////
     // Access

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -22,6 +22,7 @@ import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { validateQueryPaths } from '../../index.js'
 import { lockedDocumentsCollectionSlug } from '../../locked-documents/config.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import replaceWithDraftIfAvailable from '../../versions/drafts/replaceWithDraftIfAvailable.js'
 import { buildAfterOperation } from './utils.js'
 
@@ -81,9 +82,14 @@ export const findByIDOperation = async <
       populate,
       req: { fallbackLocale, locale, t },
       req,
-      select,
+      select: incomingSelect,
       showHiddenFields,
     } = args
+
+    const select = sanitizeSelect({
+      forceSelect: collectionConfig.forceSelect,
+      select: incomingSelect,
+    })
 
     // /////////////////////////////////////
     // Access

--- a/packages/payload/src/collections/operations/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/findVersionByID.ts
@@ -10,6 +10,8 @@ import { combineQueries } from '../../database/combineQueries.js'
 import { APIError, Forbidden, NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
+import { getQueryDraftsSelect } from '../../versions/drafts/getQueryDraftsSelect.js'
 
 export type Arguments = {
   collection: Collection
@@ -37,7 +39,7 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
     populate,
     req: { fallbackLocale, locale, payload },
     req,
-    select,
+    select: incomingSelect,
     showHiddenFields,
   } = args
 
@@ -66,6 +68,11 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
     // /////////////////////////////////////
     // Find by ID
     // /////////////////////////////////////
+
+    const select = sanitizeSelect({
+      forceSelect: getQueryDraftsSelect({ select: collectionConfig.forceSelect }),
+      select: incomingSelect,
+    })
 
     const versionsQuery = await payload.db.findVersions<TData>({
       collection: collectionConfig.slug,

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -10,7 +10,9 @@ import { validateQueryPaths } from '../../database/queryValidation/validateQuery
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
+import { getQueryDraftsSelect } from '../../versions/drafts/getQueryDraftsSelect.js'
 
 export type Arguments = {
   collection: Collection
@@ -40,7 +42,7 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
     populate,
     req: { fallbackLocale, locale, payload },
     req,
-    select,
+    select: incomingSelect,
     showHiddenFields,
     sort,
     where,
@@ -68,6 +70,11 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
     })
 
     const fullWhere = combineQueries(where, accessResults)
+
+    const select = sanitizeSelect({
+      forceSelect: getQueryDraftsSelect({ select: collectionConfig.forceSelect }),
+      select: incomingSelect,
+    })
 
     // /////////////////////////////////////
     // Find

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -12,6 +12,7 @@ import { APIError, Forbidden, NotFound } from '../../errors/index.js'
 import { afterChange } from '../../fields/hooks/afterChange/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { getLatestCollectionVersion } from '../../versions/getLatestCollectionVersion.js'
 
 export type Arguments = {
@@ -40,7 +41,7 @@ export const restoreVersionOperation = async <TData extends TypeWithID = any>(
     populate,
     req,
     req: { fallbackLocale, locale, payload },
-    select,
+    select: incomingSelect,
     showHiddenFields,
   } = args
 
@@ -114,6 +115,11 @@ export const restoreVersionOperation = async <TData extends TypeWithID = any>(
     // /////////////////////////////////////
     // Update
     // /////////////////////////////////////
+
+    const select = sanitizeSelect({
+      forceSelect: collectionConfig.forceSelect,
+      select: incomingSelect,
+    })
 
     let result = await req.payload.db.updateOne({
       id: parentDocID,

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -23,6 +23,7 @@ import { unlinkTempFiles } from '../../uploads/unlinkTempFiles.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
 import { appendVersionToQueryKey } from '../../versions/drafts/appendVersionToQueryKey.js'
 import { updateDocument } from './utilities/update.js'
@@ -93,7 +94,7 @@ export const updateOperation = async <
         payload,
       },
       req,
-      select,
+      select: incomingSelect,
       showHiddenFields,
       where,
     } = args
@@ -183,6 +184,11 @@ export const updateOperation = async <
       const { id } = docWithLocales
 
       try {
+        const select = sanitizeSelect({
+          forceSelect: collectionConfig.forceSelect,
+          select: incomingSelect,
+        })
+
         // ///////////////////////////////////////////////
         // Update document, runs all document level hooks
         // ///////////////////////////////////////////////

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -26,6 +26,7 @@ import { unlinkTempFiles } from '../../uploads/unlinkTempFiles.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { getLatestCollectionVersion } from '../../versions/getLatestCollectionVersion.js'
 import { updateDocument } from './utilities/update.js'
 import { buildAfterOperation } from './utils.js'
@@ -100,7 +101,7 @@ export const updateByIDOperation = async <
         payload,
       },
       req,
-      select,
+      select: incomingSelect,
       showHiddenFields,
     } = args
 
@@ -157,6 +158,11 @@ export const updateByIDOperation = async <
       overwriteExistingFiles,
       req,
       throwOnMissingFile: false,
+    })
+
+    const select = sanitizeSelect({
+      forceSelect: collectionConfig.forceSelect,
+      select: incomingSelect,
     })
 
     // ///////////////////////////////////////////////

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -1,5 +1,5 @@
 import type { GraphQLNonNull, GraphQLObjectType } from 'graphql'
-import type { DeepRequired } from 'ts-essentials'
+import type { DeepRequired, IsAny } from 'ts-essentials'
 
 import type {
   CustomPreviewButton,
@@ -22,7 +22,7 @@ import type {
 import type { DBIdentifierName } from '../../database/types.js'
 import type { Field, FlattenedField } from '../../fields/config/types.js'
 import type { GlobalSlug, RequestContext, TypedGlobal, TypedGlobalSelect } from '../../index.js'
-import type { PayloadRequest, Where } from '../../types/index.js'
+import type { PayloadRequest, SelectType, Where } from '../../types/index.js'
 import type { IncomingGlobalVersions, SanitizedGlobalVersions } from '../../versions/types.js'
 
 export type DataFromGlobalSlug<TSlug extends GlobalSlug> = TypedGlobal[TSlug]
@@ -142,7 +142,7 @@ export type GlobalAdminOptions = {
   preview?: GeneratePreviewURL
 }
 
-export type GlobalConfig = {
+export type GlobalConfig<TSlug extends GlobalSlug = any> = {
   /**
    * Do not set this property manually. This is set to true during sanitization, to avoid
    * sanitizing the same global multiple times.
@@ -163,6 +163,9 @@ export type GlobalConfig = {
   dbName?: DBIdentifierName
   endpoints?: false | Omit<Endpoint, 'root'>[]
   fields: Field[]
+  forceSelect?: IsAny<SelectFromGlobalSlug<TSlug>> extends true
+    ? SelectType
+    : SelectFromGlobalSlug<TSlug>
   graphQL?:
     | {
         disableMutations?: true

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -22,7 +22,7 @@ import type {
 import type { DBIdentifierName } from '../../database/types.js'
 import type { Field, FlattenedField } from '../../fields/config/types.js'
 import type { GlobalSlug, RequestContext, TypedGlobal, TypedGlobalSelect } from '../../index.js'
-import type { PayloadRequest, SelectType, Where } from '../../types/index.js'
+import type { PayloadRequest, SelectIncludeType, Where } from '../../types/index.js'
 import type { IncomingGlobalVersions, SanitizedGlobalVersions } from '../../versions/types.js'
 
 export type DataFromGlobalSlug<TSlug extends GlobalSlug> = TypedGlobal[TSlug]
@@ -163,8 +163,11 @@ export type GlobalConfig<TSlug extends GlobalSlug = any> = {
   dbName?: DBIdentifierName
   endpoints?: false | Omit<Endpoint, 'root'>[]
   fields: Field[]
+  /**
+   * Specify which fields should be selected always, regardless of the `select` query which can be useful that the field exists for access control / hooks
+   */
   forceSelect?: IsAny<SelectFromGlobalSlug<TSlug>> extends true
-    ? SelectType
+    ? SelectIncludeType
     : SelectFromGlobalSlug<TSlug>
   graphQL?:
     | {

--- a/packages/payload/src/globals/operations/findOne.ts
+++ b/packages/payload/src/globals/operations/findOne.ts
@@ -8,6 +8,7 @@ import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { lockedDocumentsCollectionSlug } from '../../locked-documents/config.js'
 import { getSelectMode } from '../../utilities/getSelectMode.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import replaceWithDraftIfAvailable from '../../versions/drafts/replaceWithDraftIfAvailable.js'
 
 type Args = {
@@ -36,7 +37,7 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
     populate,
     req: { fallbackLocale, locale },
     req,
-    select,
+    select: incomingSelect,
     showHiddenFields,
   } = args
 
@@ -50,6 +51,11 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
     if (!overrideAccess) {
       accessResult = await executeAccess({ req }, globalConfig.access.read)
     }
+
+    const select = sanitizeSelect({
+      forceSelect: globalConfig.forceSelect,
+      select: incomingSelect,
+    })
 
     // /////////////////////////////////////
     // Perform database operation

--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -10,6 +10,8 @@ import { Forbidden, NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { deepCopyObjectSimple } from '../../utilities/deepCopyObject.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
+import { getQueryDraftsSelect } from '../../versions/drafts/getQueryDraftsSelect.js'
 
 export type Arguments = {
   currentDepth?: number
@@ -37,7 +39,7 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
     populate,
     req: { fallbackLocale, locale, payload },
     req,
-    select,
+    select: incomingSelect,
     showHiddenFields,
   } = args
 
@@ -56,6 +58,11 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
     }
 
     const hasWhereAccess = typeof accessResults === 'object'
+
+    const select = sanitizeSelect({
+      forceSelect: getQueryDraftsSelect({ select: globalConfig.forceSelect }),
+      select: incomingSelect,
+    })
 
     const findGlobalVersionsArgs: FindGlobalVersionsArgs = {
       global: globalConfig.slug,

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -10,7 +10,9 @@ import { validateQueryPaths } from '../../database/queryValidation/validateQuery
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import sanitizeInternalFields from '../../utilities/sanitizeInternalFields.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { buildVersionGlobalFields } from '../../versions/buildGlobalFields.js'
+import { getQueryDraftsSelect } from '../../versions/drafts/getQueryDraftsSelect.js'
 
 export type Arguments = {
   depth?: number
@@ -40,7 +42,7 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
     populate,
     req: { fallbackLocale, locale, payload },
     req,
-    select,
+    select: incomingSelect,
     showHiddenFields,
     sort,
     where,
@@ -66,6 +68,11 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
     })
 
     const fullWhere = combineQueries(where, accessResults)
+
+    const select = sanitizeSelect({
+      forceSelect: getQueryDraftsSelect({ select: globalConfig.forceSelect }),
+      select: incomingSelect,
+    })
 
     // /////////////////////////////////////
     // Find

--- a/packages/payload/src/globals/operations/update.ts
+++ b/packages/payload/src/globals/operations/update.ts
@@ -27,6 +27,7 @@ import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { getSelectMode } from '../../utilities/getSelectMode.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
+import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
 import { getLatestGlobalVersion } from '../../versions/getLatestGlobalVersion.js'
 import { saveVersion } from '../../versions/saveVersion.js'
 
@@ -70,7 +71,7 @@ export const updateOperation = async <
     publishSpecificLocale,
     req: { fallbackLocale, locale, payload },
     req,
-    select,
+    select: incomingSelect,
     showHiddenFields,
   } = args
 
@@ -243,6 +244,11 @@ export const updateOperation = async <
     // /////////////////////////////////////
     // Update
     // /////////////////////////////////////
+
+    const select = sanitizeSelect({
+      forceSelect: globalConfig.forceSelect,
+      select: incomingSelect,
+    })
 
     if (!shouldSaveDraft) {
       // Ensure global has createdAt

--- a/packages/payload/src/utilities/sanitizeSelect.ts
+++ b/packages/payload/src/utilities/sanitizeSelect.ts
@@ -1,0 +1,25 @@
+import { deepMergeSimple } from '@payloadcms/translations/utilities'
+
+import type { SelectType } from '../types/index.js'
+
+import { getSelectMode } from './getSelectMode.js'
+
+export const sanitizeSelect = ({
+  forceSelect,
+  select,
+}: {
+  forceSelect?: SelectType
+  select?: SelectType
+}): SelectType | undefined => {
+  if (!forceSelect || !select) {
+    return select
+  }
+
+  const selectMode = getSelectMode(select)
+
+  if (selectMode === 'exclude') {
+    return select
+  }
+
+  return deepMergeSimple(select, forceSelect)
+}

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -83,7 +83,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   globals: {
     menu: Menu;
@@ -123,7 +123,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: string;
+  id: number;
   title?: string | null;
   content?: {
     root: {
@@ -148,7 +148,7 @@ export interface Post {
  * via the `definition` "media".
  */
 export interface Media {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -192,7 +192,7 @@ export interface Media {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -209,24 +209,24 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'posts';
-        value: string | Post;
+        value: number | Post;
       } | null)
     | ({
         relationTo: 'media';
-        value: string | Media;
+        value: number | Media;
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -236,10 +236,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -259,7 +259,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -378,7 +378,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "menu".
  */
 export interface Menu {
-  id: string;
+  id: number;
   globalText?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;

--- a/test/select/collections/ForceSelect/index.tsx
+++ b/test/select/collections/ForceSelect/index.tsx
@@ -1,0 +1,26 @@
+import type { CollectionConfig } from 'payload'
+
+export const ForceSelect: CollectionConfig<'force-select'> = {
+  slug: 'force-select',
+  fields: [
+    {
+      name: 'text',
+      type: 'text',
+    },
+    {
+      name: 'forceSelected',
+      type: 'text',
+    },
+    {
+      name: 'array',
+      type: 'array',
+      fields: [
+        {
+          name: 'forceSelected',
+          type: 'text',
+        },
+      ],
+    },
+  ],
+  forceSelect: { array: { forceSelected: true }, forceSelected: true },
+}

--- a/test/select/config.ts
+++ b/test/select/config.ts
@@ -1,11 +1,16 @@
+import type { GlobalConfig } from 'payload'
+
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
+
+import type { Post } from './payload-types.js'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { CustomID } from './collections/CustomID/index.js'
 import { DeepPostsCollection } from './collections/DeepPosts/index.js'
+import { ForceSelect } from './collections/ForceSelect/index.js'
 import { LocalizedPostsCollection } from './collections/LocalizedPosts/index.js'
 import { Pages } from './collections/Pages/index.js'
 import { Points } from './collections/Points/index.js'
@@ -24,6 +29,7 @@ export default buildConfigWithDefaults({
     DeepPostsCollection,
     Pages,
     Points,
+    ForceSelect,
     {
       slug: 'upload',
       fields: [],
@@ -51,6 +57,30 @@ export default buildConfigWithDefaults({
         },
       ],
     },
+    {
+      slug: 'force-select-global',
+      fields: [
+        {
+          name: 'text',
+          type: 'text',
+        },
+        {
+          name: 'forceSelected',
+          type: 'text',
+        },
+        {
+          name: 'array',
+          type: 'array',
+          fields: [
+            {
+              name: 'forceSelected',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+      forceSelect: { array: { forceSelected: true }, forceSelected: true },
+    } satisfies GlobalConfig<'force-select-global'>,
   ],
   admin: {
     importMap: {

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -2336,6 +2336,53 @@ describe('Select', () => {
       })
     })
   })
+
+  it('should force collection select fields with forceSelect', async () => {
+    const { id, text, array, forceSelected } = await payload.create({
+      collection: 'force-select',
+      data: {
+        array: [{ forceSelected: 'text' }],
+        text: 'some-text',
+        forceSelected: 'force-selected',
+      },
+    })
+
+    const response = await payload.findByID({
+      collection: 'force-select',
+      id,
+      select: { text: true },
+    })
+
+    expect(response).toStrictEqual({
+      id,
+      forceSelected,
+      text,
+      array,
+    })
+  })
+
+  it('should force global select fields with forceSelect', async () => {
+    const { forceSelected, id, array, text } = await payload.updateGlobal({
+      slug: 'force-select-global',
+      data: {
+        array: [{ forceSelected: 'text' }],
+        text: 'some-text',
+        forceSelected: 'force-selected',
+      },
+    })
+
+    const response = await payload.findGlobal({
+      slug: 'force-select-global',
+      select: { text: true },
+    })
+
+    expect(response).toStrictEqual({
+      id,
+      forceSelected,
+      text,
+      array,
+    })
+  })
 })
 
 async function createPost() {

--- a/test/select/payload-types.ts
+++ b/test/select/payload-types.ts
@@ -72,6 +72,7 @@ export interface Config {
     'deep-posts': DeepPost;
     pages: Page;
     points: Point;
+    'force-select': ForceSelect;
     upload: Upload;
     rels: Rel;
     'custom-ids': CustomId;
@@ -88,6 +89,7 @@ export interface Config {
     'deep-posts': DeepPostsSelect<false> | DeepPostsSelect<true>;
     pages: PagesSelect<false> | PagesSelect<true>;
     points: PointsSelect<false> | PointsSelect<true>;
+    'force-select': ForceSelectSelect<false> | ForceSelectSelect<true>;
     upload: UploadSelect<false> | UploadSelect<true>;
     rels: RelsSelect<false> | RelsSelect<true>;
     'custom-ids': CustomIdsSelect<false> | CustomIdsSelect<true>;
@@ -101,9 +103,11 @@ export interface Config {
   };
   globals: {
     'global-post': GlobalPost;
+    'force-select-global': ForceSelectGlobal;
   };
   globalsSelect: {
     'global-post': GlobalPostSelect<false> | GlobalPostSelect<true>;
+    'force-select-global': ForceSelectGlobalSelect<false> | ForceSelectGlobalSelect<true>;
   };
   locale: 'en' | 'de';
   user: User & {
@@ -447,6 +451,23 @@ export interface Point {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "force-select".
+ */
+export interface ForceSelect {
+  id: string;
+  text?: string | null;
+  forceSelected?: string | null;
+  array?:
+    | {
+        forceSelected?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "custom-ids".
  */
 export interface CustomId {
@@ -502,6 +523,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'points';
         value: string | Point;
+      } | null)
+    | ({
+        relationTo: 'force-select';
+        value: string | ForceSelect;
       } | null)
     | ({
         relationTo: 'upload';
@@ -837,6 +862,22 @@ export interface PointsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "force-select_select".
+ */
+export interface ForceSelectSelect<T extends boolean = true> {
+  text?: T;
+  forceSelected?: T;
+  array?:
+    | T
+    | {
+        forceSelected?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "upload_select".
  */
 export interface UploadSelect<T extends boolean = true> {
@@ -930,11 +971,45 @@ export interface GlobalPost {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "force-select-global".
+ */
+export interface ForceSelectGlobal {
+  id: string;
+  text?: string | null;
+  forceSelected?: string | null;
+  array?:
+    | {
+        forceSelected?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "global-post_select".
  */
 export interface GlobalPostSelect<T extends boolean = true> {
   text?: T;
   number?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "force-select-global_select".
+ */
+export interface ForceSelectGlobalSelect<T extends boolean = true> {
+  text?: T;
+  forceSelected?: T;
+  array?:
+    | T
+    | {
+        forceSelected?: T;
+        id?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;


### PR DESCRIPTION
### What?
Adds a new property to collection / global config `forceSelect` which can be used to ensure that some fields are always selected, regardless of the `select` query.

### Why?
This can be beneficial for hooks and access control, for example imagine you need the value of `data.slug` in your hook.
With the following query it would be `undefined`:
`?select[title]=true`
Now, to solve this you can specify
```
forceSelect: {
  slug: true
}
```

### How?
Every operation now merges the incoming `select` with `collectionConfig.forceSelect`.