### PR TITLE
feat(richtext-lexical): allow disabling indentation for specific nodes

### DIFF
--- a/packages/richtext-lexical/src/features/indent/client/IndentPlugin.tsx
+++ b/packages/richtext-lexical/src/features/indent/client/IndentPlugin.tsx
@@ -1,0 +1,73 @@
+import type { ElementNode } from 'lexical'
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin'
+import { $findMatchingParent, mergeRegister } from '@lexical/utils'
+import {
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  COMMAND_PRIORITY_LOW,
+  INDENT_CONTENT_COMMAND,
+} from 'lexical'
+import { useEffect } from 'react'
+
+import type { PluginComponent } from '../../typesClient.js'
+import type { IndentFeatureProps } from '../server/index.js'
+
+export const IndentPlugin: PluginComponent<IndentFeatureProps> = (props) => {
+  const [editor] = useLexicalComposerContext()
+  const { disabledNodes } = props.clientProps
+
+  useEffect(() => {
+    if (!editor) {
+      return
+    }
+    return mergeRegister(
+      editor.registerCommand(
+        INDENT_CONTENT_COMMAND,
+        () => {
+          return $handleIndentAndOutdent((block) => {
+            if (!disabledNodes || !disabledNodes.includes(block.getType())) {
+              const indent = block.getIndent()
+              block.setIndent(indent + 1)
+            }
+          })
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+    )
+  }, [editor, disabledNodes])
+
+  return <TabIndentationPlugin />
+}
+
+function $handleIndentAndOutdent(indentOrOutdent: (block: ElementNode) => void): boolean {
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection)) {
+    return false
+  }
+  const alreadyHandled = new Set()
+  const nodes = selection.getNodes()
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!
+    const key = node.getKey()
+    if (alreadyHandled.has(key)) {
+      continue
+    }
+    const parentBlock = $findMatchingParent(
+      node,
+      (parentNode): parentNode is ElementNode =>
+        $isElementNode(parentNode) && !parentNode.isInline(),
+    )
+    if (parentBlock === null) {
+      continue
+    }
+    const parentKey = parentBlock.getKey()
+    if (parentBlock.canIndent() && !alreadyHandled.has(parentKey)) {
+      alreadyHandled.add(parentKey)
+      indentOrOutdent(parentBlock)
+    }
+  }
+  return alreadyHandled.size > 0
+}

--- a/packages/richtext-lexical/src/features/indent/client/IndentPlugin.tsx
+++ b/packages/richtext-lexical/src/features/indent/client/IndentPlugin.tsx
@@ -20,7 +20,7 @@ export const IndentPlugin: PluginComponent<IndentFeatureProps> = (props) => {
   const { disabledNodes } = props.clientProps
 
   useEffect(() => {
-    if (!editor) {
+    if (!editor || !disabledNodes?.length) {
       return
     }
     return mergeRegister(
@@ -28,7 +28,7 @@ export const IndentPlugin: PluginComponent<IndentFeatureProps> = (props) => {
         INDENT_CONTENT_COMMAND,
         () => {
           return $handleIndentAndOutdent((block) => {
-            if (!disabledNodes || !disabledNodes.includes(block.getType())) {
+            if (!disabledNodes.includes(block.getType())) {
               const indent = block.getIndent()
               block.setIndent(indent + 1)
             }

--- a/packages/richtext-lexical/src/features/indent/client/index.tsx
+++ b/packages/richtext-lexical/src/features/indent/client/index.tsx
@@ -2,26 +2,20 @@
 
 import type { ElementNode, LexicalNode } from 'lexical'
 
-import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
-import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin'
-import { $findMatchingParent, mergeRegister } from '@lexical/utils'
+import { $findMatchingParent } from '@lexical/utils'
 import {
-  $getSelection,
   $isElementNode,
   $isRangeSelection,
-  COMMAND_PRIORITY_LOW,
   INDENT_CONTENT_COMMAND,
   OUTDENT_CONTENT_COMMAND,
 } from 'lexical'
-import { useEffect } from 'react'
 
 import type { ToolbarGroup } from '../../toolbars/types.js'
-import type { PluginComponent } from '../../typesClient.js'
-import type { IndentFeatureProps } from '../server/index.js'
 
 import { IndentDecreaseIcon } from '../../../lexical/ui/icons/IndentDecrease/index.js'
 import { IndentIncreaseIcon } from '../../../lexical/ui/icons/IndentIncrease/index.js'
 import { createClientFeature } from '../../../utilities/createClientFeature.js'
+import { IndentPlugin } from './IndentPlugin.js'
 import { toolbarIndentGroupWithItems } from './toolbarIndentGroup.js'
 
 const toolbarGroups: ToolbarGroup[] = [
@@ -86,45 +80,6 @@ const toolbarGroups: ToolbarGroup[] = [
   ]),
 ]
 
-const IndentPlugin: PluginComponent<IndentFeatureProps> = (props) => {
-  const [editor] = useLexicalComposerContext()
-  const { disabledNodes } = props.clientProps
-
-  useEffect(() => {
-    if (!editor) {
-      return
-    }
-    return mergeRegister(
-      editor.registerCommand(
-        INDENT_CONTENT_COMMAND,
-        () => {
-          return $handleIndentAndOutdent((block) => {
-            if (!disabledNodes || !disabledNodes.includes(block.getType())) {
-              const indent = block.getIndent()
-              block.setIndent(indent + 1)
-            }
-          })
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
-      editor.registerCommand(
-        OUTDENT_CONTENT_COMMAND,
-        () => {
-          return $handleIndentAndOutdent((block) => {
-            const indent = block.getIndent()
-            if (indent > 0) {
-              block.setIndent(indent - 1)
-            }
-          })
-        },
-        COMMAND_PRIORITY_LOW,
-      ),
-    )
-  }, [editor, disabledNodes])
-
-  return <TabIndentationPlugin />
-}
-
 export const IndentFeatureClient = createClientFeature({
   plugins: [
     {
@@ -139,33 +94,3 @@ export const IndentFeatureClient = createClientFeature({
     groups: toolbarGroups,
   },
 })
-
-function $handleIndentAndOutdent(indentOrOutdent: (block: ElementNode) => void): boolean {
-  const selection = $getSelection()
-  if (!$isRangeSelection(selection)) {
-    return false
-  }
-  const alreadyHandled = new Set()
-  const nodes = selection.getNodes()
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i]!
-    const key = node.getKey()
-    if (alreadyHandled.has(key)) {
-      continue
-    }
-    const parentBlock = $findMatchingParent(
-      node,
-      (parentNode): parentNode is ElementNode =>
-        $isElementNode(parentNode) && !parentNode.isInline(),
-    )
-    if (parentBlock === null) {
-      continue
-    }
-    const parentKey = parentBlock.getKey()
-    if (parentBlock.canIndent() && !alreadyHandled.has(parentKey)) {
-      alreadyHandled.add(parentKey)
-      indentOrOutdent(parentBlock)
-    }
-  }
-  return alreadyHandled.size > 0
-}

--- a/packages/richtext-lexical/src/features/indent/client/index.tsx
+++ b/packages/richtext-lexical/src/features/indent/client/index.tsx
@@ -2,17 +2,22 @@
 
 import type { ElementNode, LexicalNode } from 'lexical'
 
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin'
-import { $findMatchingParent } from '@lexical/utils'
+import { $findMatchingParent, mergeRegister } from '@lexical/utils'
 import {
+  $getSelection,
   $isElementNode,
   $isRangeSelection,
+  COMMAND_PRIORITY_LOW,
   INDENT_CONTENT_COMMAND,
   OUTDENT_CONTENT_COMMAND,
 } from 'lexical'
+import { useEffect } from 'react'
 
 import type { ToolbarGroup } from '../../toolbars/types.js'
 import type { PluginComponent } from '../../typesClient.js'
+import type { IndentFeatureProps } from '../server/index.js'
 
 import { IndentDecreaseIcon } from '../../../lexical/ui/icons/IndentDecrease/index.js'
 import { IndentIncreaseIcon } from '../../../lexical/ui/icons/IndentIncrease/index.js'
@@ -81,10 +86,49 @@ const toolbarGroups: ToolbarGroup[] = [
   ]),
 ]
 
+const IndentPlugin: PluginComponent<IndentFeatureProps> = (props) => {
+  const [editor] = useLexicalComposerContext()
+  const { disabledNodes } = props.clientProps
+
+  useEffect(() => {
+    if (!editor) {
+      return
+    }
+    return mergeRegister(
+      editor.registerCommand(
+        INDENT_CONTENT_COMMAND,
+        () => {
+          return $handleIndentAndOutdent((block) => {
+            if (!disabledNodes || !disabledNodes.includes(block.getType())) {
+              const indent = block.getIndent()
+              block.setIndent(indent + 1)
+            }
+          })
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        OUTDENT_CONTENT_COMMAND,
+        () => {
+          return $handleIndentAndOutdent((block) => {
+            const indent = block.getIndent()
+            if (indent > 0) {
+              block.setIndent(indent - 1)
+            }
+          })
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+    )
+  }, [editor, disabledNodes])
+
+  return <TabIndentationPlugin />
+}
+
 export const IndentFeatureClient = createClientFeature({
   plugins: [
     {
-      Component: TabIndentationPlugin as PluginComponent,
+      Component: IndentPlugin,
       position: 'normal',
     },
   ],
@@ -95,3 +139,33 @@ export const IndentFeatureClient = createClientFeature({
     groups: toolbarGroups,
   },
 })
+
+function $handleIndentAndOutdent(indentOrOutdent: (block: ElementNode) => void): boolean {
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection)) {
+    return false
+  }
+  const alreadyHandled = new Set()
+  const nodes = selection.getNodes()
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!
+    const key = node.getKey()
+    if (alreadyHandled.has(key)) {
+      continue
+    }
+    const parentBlock = $findMatchingParent(
+      node,
+      (parentNode): parentNode is ElementNode =>
+        $isElementNode(parentNode) && !parentNode.isInline(),
+    )
+    if (parentBlock === null) {
+      continue
+    }
+    const parentKey = parentBlock.getKey()
+    if (parentBlock.canIndent() && !alreadyHandled.has(parentKey)) {
+      alreadyHandled.add(parentKey)
+      indentOrOutdent(parentBlock)
+    }
+  }
+  return alreadyHandled.size > 0
+}

--- a/packages/richtext-lexical/src/features/indent/server/index.ts
+++ b/packages/richtext-lexical/src/features/indent/server/index.ts
@@ -1,10 +1,31 @@
 import { createServerFeature } from '../../../utilities/createServerFeature.js'
 import { i18n } from './i18n.js'
 
-export const IndentFeature = createServerFeature({
-  feature: {
-    ClientFeature: '@payloadcms/richtext-lexical/client#IndentFeatureClient',
-    i18n,
+export type IndentFeatureProps = {
+  /**
+   * The nodes that should not be indented. "type" property of the nodes you don't want to be indented.
+   * These can be: "paragraph", "heading", "listitem", "quote" or other indentable nodes if they exist.
+   */
+  disabledNodes?: string[]
+}
+
+/**
+ * This feature is used to indent and outdent the text in the editor.
+ *
+ * @param props - The props for the feature.
+ * @param props.disabledNodes - The nodes that should not be indented. "type" property of the nodes you don't want to be indented. These can be: "paragraph", "heading", "listitem", "quote" or other indentable nodes if they exist.
+ */
+export const IndentFeature = createServerFeature<
+  IndentFeatureProps,
+  IndentFeatureProps,
+  IndentFeatureProps
+>({
+  feature: ({ props }) => {
+    return {
+      ClientFeature: '@payloadcms/richtext-lexical/client#IndentFeatureClient',
+      clientFeatureProps: props,
+      i18n,
+    }
   },
   key: 'indent',
 })

--- a/packages/richtext-lexical/src/features/indent/server/index.ts
+++ b/packages/richtext-lexical/src/features/indent/server/index.ts
@@ -9,12 +9,6 @@ export type IndentFeatureProps = {
   disabledNodes?: string[]
 }
 
-/**
- * This feature is used to indent and outdent the text in the editor.
- *
- * @param props - The props for the feature.
- * @param props.disabledNodes - The nodes that should not be indented. "type" property of the nodes you don't want to be indented. These can be: "paragraph", "heading", "listitem", "quote" or other indentable nodes if they exist.
- */
 export const IndentFeature = createServerFeature<
   IndentFeatureProps,
   IndentFeatureProps,


### PR DESCRIPTION
allow disabling indentation for specific nodes via IndentFeature

Usage: 

```ts
editor: lexicalEditor({
  features: ({ defaultFeatures }) => [
    ...defaultFeatures,
    IndentFeature({
      // the array must contain the "type" property of registered indentable nodes
      disabledNodes: ['paragraph', 'listitem'],
    }),
  ],
}),
```

The nodes "paragraph", "heading", "listitem", "quote" remain indentable by default, even without `IndentFeature` registered.

In a future PR we will probably add the option to disable TabNode.


