### PR TITLE
fix(ui): exclude disabled and hidden fields from initialColumns

### DIFF
--- a/packages/ui/src/elements/TableColumns/getInitialColumns.ts
+++ b/packages/ui/src/elements/TableColumns/getInitialColumns.ts
@@ -7,6 +7,11 @@ const getRemainingColumns = <T extends ClientField[] | Field[]>(
   useAsTitle: string,
 ): ListPreferences['columns'] =>
   fields?.reduce((remaining, field) => {
+    const { admin } = field
+    if (('hidden' in admin && admin.hidden) || ('disabled' in admin && admin.disabled)) {
+      return remaining
+    }
+
     if (fieldAffectsData(field) && field.name === useAsTitle) {
       return remaining
     }


### PR DESCRIPTION
The jsdoc for `getInitialColumns` says that it will "take useAtTitle, if set, and the next 3 fields that are not hidden or disabled". However, nowhere are fields checked or excluded if they have the values ​​hidden or disabled.
This causes columns to be incorrectly displayed in the table when they shouldn't.