### PR TITLE
fix: kill transaction only if operation created transaction

### DIFF
--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -62,9 +62,10 @@ export const createOperation = async <
   incomingArgs: Arguments<TSlug>,
 ): Promise<TransformCollectionWithSelect<TSlug, TSelect>> => {
   let args = incomingArgs
+  let shouldCommit = false
 
   try {
-    const shouldCommit = !args.disableTransaction && (await initTransaction(args.req))
+    shouldCommit = !args.disableTransaction && (await initTransaction(args.req))
 
     ensureUsernameOrEmail<TSlug>({
       authOptions: args.collection.config.auth,
@@ -394,7 +395,9 @@ export const createOperation = async <
 
     return result
   } catch (error: unknown) {
-    await killTransaction(args.req)
+    if (shouldCommit) {
+      await killTransaction(args.req)
+    }
     throw error
   }
 }


### PR DESCRIPTION
### What?

Only kill the transaction if the transaction originated in this operation

### Why?

I'm running a migration that uses the the `createOperation` function, but exceptions are handled in the calling code.  Killing the transaction in the is corrupting the rest of the migration.

I've only updated `createOperation` for now to ask if this is the correct pattern to apply to the rest of the operations.  Let me know and I'll update the rest
