### PR TITLE
fix: incorrect types for field Label, Description and Error server components

### DIFF
--- a/packages/payload/src/admin/forms/Description.ts
+++ b/packages/payload/src/admin/forms/Description.ts
@@ -32,7 +32,7 @@ export type FieldDescriptionServerProps<
   clientField: TFieldClient
   readonly field: TFieldServer
 } & GenericDescriptionProps &
-  Partial<ServerComponentProps>
+  ServerComponentProps
 
 export type FieldDescriptionClientProps<
   TFieldClient extends ClientFieldWithOptionalType = ClientFieldWithOptionalType,

--- a/packages/payload/src/admin/forms/Description.ts
+++ b/packages/payload/src/admin/forms/Description.ts
@@ -1,8 +1,7 @@
 import type { TFunction } from '@payloadcms/translations'
 
-import type { ServerProps } from '../../config/types.js'
 import type { Field } from '../../fields/config/types.js'
-import type { ClientFieldWithOptionalType } from './Field.js'
+import type { ClientFieldWithOptionalType, ServerComponentProps } from './Field.js'
 
 export type DescriptionFunction = ({ t }: { t: TFunction }) => string
 
@@ -33,7 +32,7 @@ export type FieldDescriptionServerProps<
   clientField: TFieldClient
   readonly field: TFieldServer
 } & GenericDescriptionProps &
-  Partial<ServerProps>
+  Partial<ServerComponentProps>
 
 export type FieldDescriptionClientProps<
   TFieldClient extends ClientFieldWithOptionalType = ClientFieldWithOptionalType,

--- a/packages/payload/src/admin/forms/Error.ts
+++ b/packages/payload/src/admin/forms/Error.ts
@@ -21,7 +21,7 @@ export type FieldErrorServerProps<
   clientField: TFieldClient
   readonly field: TFieldServer
 } & GenericErrorProps &
-  Partial<ServerComponentProps>
+  ServerComponentProps
 
 export type FieldErrorClientComponent<
   TFieldClient extends ClientFieldWithOptionalType = ClientFieldWithOptionalType,

--- a/packages/payload/src/admin/forms/Error.ts
+++ b/packages/payload/src/admin/forms/Error.ts
@@ -1,6 +1,5 @@
-import type { ServerProps } from '../../config/types.js'
 import type { Field } from '../../fields/config/types.js'
-import type { ClientFieldWithOptionalType } from './Field.js'
+import type { ClientFieldWithOptionalType, ServerComponentProps } from './Field.js'
 
 export type GenericErrorProps = {
   readonly alignCaret?: 'center' | 'left' | 'right'
@@ -22,7 +21,7 @@ export type FieldErrorServerProps<
   clientField: TFieldClient
   readonly field: TFieldServer
 } & GenericErrorProps &
-  Partial<ServerProps>
+  Partial<ServerComponentProps>
 
 export type FieldErrorClientComponent<
   TFieldClient extends ClientFieldWithOptionalType = ClientFieldWithOptionalType,

--- a/packages/payload/src/admin/forms/Label.ts
+++ b/packages/payload/src/admin/forms/Label.ts
@@ -1,6 +1,6 @@
-import type { ServerProps, StaticLabel } from '../../config/types.js'
+import type { StaticLabel } from '../../config/types.js'
 import type { Field } from '../../fields/config/types.js'
-import type { ClientFieldWithOptionalType } from './Field.js'
+import type { ClientFieldWithOptionalType, ServerComponentProps } from './Field.js'
 
 export type GenericLabelProps = {
   readonly as?: 'label' | 'span'
@@ -26,7 +26,7 @@ export type FieldLabelServerProps<
   clientField: TFieldClient
   readonly field: TFieldServer
 } & GenericLabelProps &
-  Partial<ServerProps>
+  Partial<ServerComponentProps>
 
 export type SanitizedLabelProps<TFieldClient extends ClientFieldWithOptionalType> = Omit<
   FieldLabelClientProps<TFieldClient>,

--- a/packages/payload/src/admin/forms/Label.ts
+++ b/packages/payload/src/admin/forms/Label.ts
@@ -26,7 +26,7 @@ export type FieldLabelServerProps<
   clientField: TFieldClient
   readonly field: TFieldServer
 } & GenericLabelProps &
-  Partial<ServerComponentProps>
+  ServerComponentProps
 
 export type SanitizedLabelProps<TFieldClient extends ClientFieldWithOptionalType> = Omit<
   FieldLabelClientProps<TFieldClient>,


### PR DESCRIPTION
Our previous types for Label, Description and Error server components were incorrectly typed. We were using the `ServerProps` type, which was wrong.

In our renderFields function, you can see that `ServerComponentProps` are passed as server props, not `ServerProps`: https://github.com/payloadcms/payload/blob/fix/incorrect-component-types/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx

Additionally, we no longer have to wrap that type in `Partial<>`, as all server props in that type are required.