### PR TITLE
fix(ui): prevent fieldErrorsToast from showing empty errors list

### DIFF
--- a/packages/ui/src/elements/Toasts/fieldErrors.tsx
+++ b/packages/ui/src/elements/Toasts/fieldErrors.tsx
@@ -34,15 +34,14 @@ function createErrorsFromMessage(message: string): {
   message: string
 } {
   const [intro, errorsString] = message.split(':')
-  const errors = (errorsString || '')
-    .split(',')
-    .map((error) => error.replaceAll(' > ', ' → ').trim())
 
-  if (errors.length === 0) {
+  if (!errorsString) {
     return {
       message: intro,
     }
   }
+
+  const errors = errorsString.split(',').map((error) => error.replaceAll(' > ', ' → ').trim())
 
   if (errors.length === 1) {
     return {


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
The error toast shown on field errors was _greatly_ improved recently with much clearer, more easily consumable messages. This PR adjusts a minor issue when the format of the error message is such that there are no subsequent field errors present.

### Why?
To prevent showing an extra `li` when there are no more field errors.

### How?
Previously, the error msg array was being constructed like so:
```ts
const [intro, errorsString] = message.split(':')
const errors = (errorsString || '')
    .split(',')
    .map((error) => error.replaceAll(' > ', ' → ').trim())
    
if (errors.length === 0) {
    return {
      message: intro,
    }
}
...
```

This works fine. However, if the initial message split makes `errorsString` undefined, as is the case where there are no subsequent field errors, the `(errorsString || '').split(',')` will always return an array with a single `""` element in it, making the check for `errors.length === 0` unreachable. This PR checks if `errorsString` is false-y first before doing further processing instead.

Before:
![Login-Payload-03-11-2025_10_36_PM-before](https://github.com/user-attachments/assets/b2695277-7e33-40c8-a369-de4f72654d5f)

After:
![Login-Payload-03-11-2025_10_35_PM-after](https://github.com/user-attachments/assets/efad92b2-d9c2-4efb-bb67-b1dd625855bf)
