### PR TITLE
feat(richtext-lexical): allow disabling TabNode

### DIFF
--- a/packages/richtext-lexical/src/features/indent/server/index.ts
+++ b/packages/richtext-lexical/src/features/indent/server/index.ts
@@ -7,6 +7,13 @@ export type IndentFeatureProps = {
    * These can be: "paragraph", "heading", "listitem", "quote" or other indentable nodes if they exist.
    */
   disabledNodes?: string[]
+  /**
+   * If false, pressing Tab in the middle of a block such as a paragraph or heading will insert a tabNode.
+   * This property does not change the behavior of block-level indents.
+   *
+   * @default false
+   */
+  disableTabNode?: boolean
 }
 
 export const IndentFeature = createServerFeature<

--- a/packages/richtext-lexical/src/features/indent/server/index.ts
+++ b/packages/richtext-lexical/src/features/indent/server/index.ts
@@ -8,8 +8,8 @@ export type IndentFeatureProps = {
    */
   disabledNodes?: string[]
   /**
-   * If false, pressing Tab in the middle of a block such as a paragraph or heading will insert a tabNode.
-   * This property does not change the behavior of block-level indents.
+   * If true, pressing Tab in the middle of a block such as a paragraph or heading will not insert a tabNode.
+   * Instead, Tab will only be used for block-level indentation.
    *
    * @default false
    */


### PR DESCRIPTION
Similar to https://github.com/payloadcms/payload/pull/11631.

IndentFeature causes pressing Tab in the middle of a block such as a paragraph or heading to insert a TabNode. This property allows you to disable this behavior, and indentation will occur instead if the block allows it.

Usage: 
```ts
editor: lexicalEditor({
  features: ({ defaultFeatures }) => [
    ...defaultFeatures,
    IndentFeature({
      disableTabNode: true,
    }),
  ],
}),
```