### PR TITLE
feat: use IDs in arrays for more semantic version diff

### DIFF
--- a/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
@@ -21,6 +21,7 @@ import { fieldIsID, fieldShouldBeLocalized, getUniqueListBy, tabHasName } from '
 
 import { diffMethods } from './fields/diffMethods.js'
 import { diffComponents } from './fields/index.js'
+import { getArrayElementIdsInComparisonOrder } from './utilities/getArrayElementIdsInComparisonOrder.js'
 import { getFieldPathsModified } from './utilities/getFieldPathsModified.js'
 
 export type BuildVersionFieldsArgs = {
@@ -292,29 +293,66 @@ const buildVersionField = ({
   } // At this point, we are dealing with a `row`, etc
   else if ('fields' in field) {
     if (field.type === 'array' && versionValue) {
-      const arrayValue = Array.isArray(versionValue) ? versionValue : []
+      const versionArray = Array.isArray(versionValue) ? versionValue : []
+      const comparisonArray = Array.isArray(comparisonValue) ? comparisonValue : []
       baseVersionField.rows = []
 
-      for (let i = 0; i < arrayValue.length; i++) {
-        const comparisonRow = comparisonValue?.[i] || {}
-        const versionRow = arrayValue?.[i] || {}
-        baseVersionField.rows[i] = buildVersionFields({
-          clientSchemaMap,
-          comparisonSiblingData: comparisonRow,
-          customDiffComponents,
-          entitySlug,
-          fieldPermissions,
-          fields: field.fields,
-          i18n,
-          modifiedOnly,
-          parentIndexPath: 'name' in field ? '' : indexPath,
-          parentIsLocalized: parentIsLocalized || field.localized,
-          parentPath: path + '.' + i,
-          parentSchemaPath: schemaPath,
-          req,
-          selectedLocales,
-          versionSiblingData: versionRow,
-        }).versionFields
+      // If all values in the version and comparison array have an `id` property,
+      // the diff can compare the matching entries, so that e.g. a removed entry in the middle
+      // doesn't cause the diff view to show all following entries as being entirely changed.
+      // This improves readability of the diff for humans.
+      const doAllArrayValuesHaveId = [...versionArray, ...comparisonArray].every((value) =>
+        Object.keys(value).includes('id'),
+      )
+      if (doAllArrayValuesHaveId) {
+        const arrayElementIdsInComparisonOrder = getArrayElementIdsInComparisonOrder(
+          versionArray,
+          comparisonArray,
+        )
+        for (let i = 0; i < arrayElementIdsInComparisonOrder.length; i++) {
+          const arrayEntryId = arrayElementIdsInComparisonOrder[i]
+          const comparisonRow = comparisonArray.find((entry) => entry.id === arrayEntryId) || {}
+          const versionRow = versionArray.find((entry) => entry.id === arrayEntryId) || {}
+          baseVersionField.rows[i] = buildVersionFields({
+            clientSchemaMap,
+            comparisonSiblingData: comparisonRow,
+            customDiffComponents,
+            entitySlug,
+            fieldPermissions,
+            fields: field.fields,
+            i18n,
+            modifiedOnly,
+            parentIndexPath: 'name' in field ? '' : indexPath,
+            parentIsLocalized: parentIsLocalized || field.localized,
+            parentPath: path + '.' + i,
+            parentSchemaPath: schemaPath,
+            req,
+            selectedLocales,
+            versionSiblingData: versionRow,
+          }).versionFields
+        }
+      } else {
+        for (let i = 0; i < versionArray.length; i++) {
+          const comparisonRow = comparisonValue?.[i] || {}
+          const versionRow = versionArray?.[i] || {}
+          baseVersionField.rows[i] = buildVersionFields({
+            clientSchemaMap,
+            comparisonSiblingData: comparisonRow,
+            customDiffComponents,
+            entitySlug,
+            fieldPermissions,
+            fields: field.fields,
+            i18n,
+            modifiedOnly,
+            parentIndexPath: 'name' in field ? '' : indexPath,
+            parentIsLocalized: parentIsLocalized || field.localized,
+            parentPath: path + '.' + i,
+            parentSchemaPath: schemaPath,
+            req,
+            selectedLocales,
+            versionSiblingData: versionRow,
+          }).versionFields
+        }
       }
     } else {
       baseVersionField.fields = buildVersionFields({

--- a/packages/next/src/views/Version/RenderFieldsToDiff/utilities/getArrayElementIdsInComparisonOrder.spec.ts
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/utilities/getArrayElementIdsInComparisonOrder.spec.ts
@@ -1,0 +1,141 @@
+import { getArrayElementIdsInComparisonOrder } from './getArrayElementIdsInComparisonOrder.ts'
+
+describe('getArrayElementIdsInComparisonOrder', () => {
+  it('handles new value at the end', () => {
+    const newArray = [{ id: 1 }, { id: 2 }, { id: 3 }]
+    const oldArray = [{ id: 1 }, { id: 2 }]
+
+    const result = getArrayElementIdsInComparisonOrder(newArray, oldArray)
+
+    expect(result).toEqual([1, 2, 3])
+  })
+
+  it('handles new value in the middle', () => {
+    const newArray = [{ id: 3 }, { id: 15 }, { id: 1 }]
+    const oldArray = [{ id: 3 }, { id: 1 }]
+
+    const result = getArrayElementIdsInComparisonOrder(newArray, oldArray)
+
+    expect(result).toEqual([3, 15, 1])
+  })
+
+  it('handles moved value', () => {
+    const newArray = [{ id: 'a' }, { id: 'c' }, { id: 'b' }]
+    const oldArray = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+
+    const result = getArrayElementIdsInComparisonOrder(newArray, oldArray)
+
+    expect(result).toEqual(['a', 'c', 'b'])
+  })
+
+  it('handles removed values at the beginning', () => {
+    const newArray = [{ id: 2 }, { id: 3 }, { id: 4 }]
+    const oldArray = [{ id: 1 }, { id: 2 }]
+
+    const result = getArrayElementIdsInComparisonOrder(newArray, oldArray)
+
+    expect(result).toEqual([1, 2, 3, 4])
+  })
+
+  it('handles removed value in the middle', () => {
+    const newArray = [{ id: 'b2' }, { id: 'b5' }]
+    const oldArray = [{ id: 'b2' }, { id: 'b3' }, { id: 'b4' }, { id: 'b5' }]
+
+    const result = getArrayElementIdsInComparisonOrder(newArray, oldArray)
+
+    expect(result).toEqual(['b2', 'b3', 'b4', 'b5'])
+  })
+
+  it('handles removed values at the end', () => {
+    const newArray = [{ id: 'a20' }]
+    const oldArray = [{ id: 'a20' }, { id: 'a21' }, { id: 'a22' }, { id: 'a66' }]
+
+    const result = getArrayElementIdsInComparisonOrder(newArray, oldArray)
+
+    expect(result).toEqual(['a20', 'a21', 'a22', 'a66'])
+  })
+
+  it('handles cases with new values and removed values in the same spot in the middle', () => {
+    let result = getArrayElementIdsInComparisonOrder([{ id: 1 }, { id: 2 }], [{ id: 1 }, { id: 3 }])
+    expect(result).toEqual([1, 2, 3])
+
+    result = getArrayElementIdsInComparisonOrder(
+      [{ id: 1 }, { id: 2 }, { id: 4 }],
+      [{ id: 1 }, { id: 3 }, { id: 4 }],
+    )
+    expect(result).toEqual([1, 2, 3, 4])
+  })
+
+  it('handles complex scenario with multiple changes', () => {
+    const newArray = [
+      { id: 1 },
+      { id: 3 },
+      { id: 2 },
+      { id: 7 },
+      { id: 8 },
+      { id: 4 },
+      { id: 9 },
+      { id: 10 },
+    ]
+    const oldArray = [
+      { id: 1 },
+      { id: 2 },
+      { id: 3 },
+      { id: 4 },
+      { id: 5 },
+      { id: 6 },
+      { id: 8 },
+      { id: 9 },
+    ]
+
+    const result = getArrayElementIdsInComparisonOrder(newArray, oldArray)
+
+    expect(result).toEqual([1, 3, 2, 7, 8, 4, 5, 6, 9, 10])
+  })
+
+  it('handles empty arrays', () => {
+    // Empty newArray, non-empty oldArray
+    let result = getArrayElementIdsInComparisonOrder([], [{ id: 1 }, { id: 2 }])
+    expect(result).toEqual([1, 2])
+
+    // Non-empty newArray, empty oldArray
+    result = getArrayElementIdsInComparisonOrder([{ id: 1 }, { id: 2 }], [])
+    expect(result).toEqual([1, 2])
+
+    // Both arrays empty
+    result = getArrayElementIdsInComparisonOrder([], [])
+    expect(result).toEqual([])
+  })
+
+  it('handles arrays with different ID types', () => {
+    // Numeric IDs
+    let result = getArrayElementIdsInComparisonOrder([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }])
+    expect(result).toEqual([1, 2, 3])
+
+    // String IDs
+    result = getArrayElementIdsInComparisonOrder(
+      [{ id: 'a' }, { id: 'b' }],
+      [{ id: 'b' }, { id: 'c' }],
+    )
+    expect(result).toEqual(['a', 'b', 'c'])
+
+    // Mixed ID types
+    result = getArrayElementIdsInComparisonOrder([{ id: 1 }, { id: 'b' }], [{ id: 'b' }, { id: 2 }])
+    expect(result).toEqual([1, 'b', 2])
+  })
+
+  it('handles objects with additional properties', () => {
+    const newArray = [
+      { id: 1, name: 'First', value: 100 },
+      { id: 2, name: 'Second', active: true },
+    ]
+    const oldArray = [
+      { id: 1, name: 'First', value: 50 },
+      { id: 3, name: 'Third', status: 'pending' },
+    ]
+
+    const result = getArrayElementIdsInComparisonOrder(newArray, oldArray)
+
+    expect(result).toEqual([1, 2, 3])
+  })
+})

--- a/packages/next/src/views/Version/RenderFieldsToDiff/utilities/getArrayElementIdsInComparisonOrder.ts
+++ b/packages/next/src/views/Version/RenderFieldsToDiff/utilities/getArrayElementIdsInComparisonOrder.ts
@@ -1,0 +1,72 @@
+type ArrayElementWithID = {
+  [key: string]: any
+  id: any
+}
+
+/**
+ * Creates a sorted array of IDs from two arrays to enable side-by-side diff view
+ *
+ * @param newArray - The array representing the new state
+ * @param oldArray - The array representing the old state
+ * @returns An array of IDs representing the union of both arrays in a specific order
+ */
+export const getArrayElementIdsInComparisonOrder = (
+  newArray: ArrayElementWithID[],
+  oldArray: ArrayElementWithID[],
+): any[] => {
+  // Start with the new array IDs
+  const result = newArray.map((item) => item.id)
+
+  // Find IDs that are in oldArray but not in newArray
+  const oldIds = oldArray.map((item) => item.id)
+  const removedIds = oldIds.filter((id) => !result.includes(id))
+
+  // For each removed ID, find where to insert it for a logical row position in the version diff
+  for (const removedId of removedIds) {
+    const oldIndex = oldIds.indexOf(removedId)
+
+    // Find the closest previous ID in oldArray that is in newArray (that is not followed by a new entry)
+    let closestPreviousIndex = -1
+    for (let i = oldIndex - 1; i >= 0; i--) {
+      const id = oldIds[i]
+      const resultIndex = result.indexOf(id)
+      // When the predecessing ID's index is found, and the following entry's ID is not new,
+      // use the index in between as insertion point.
+      if (resultIndex !== -1 && (!result[i + 1] || oldIds.includes(result[i + 1]))) {
+        closestPreviousIndex = resultIndex
+        break
+      }
+      // When the predecessing ID's index is found, and the following entry's ID is new,
+      // use the first non-new entry as insertion point.
+      // When there's no (non-new) entry, insert at the end.
+      // This is so that the new array's entry order is preserved as much as possible.
+      else if (resultIndex !== -1) {
+        for (let i2 = i + 1; i2 <= result.length; i2++) {
+          if (oldIds.includes(result[i2])) {
+            closestPreviousIndex = i2 - 1
+            break
+          }
+          closestPreviousIndex = newArray.length
+        }
+      }
+    }
+
+    // Find the closest following ID in oldArray that is in result
+
+    // Insert the removed ID in the appropriate position
+    let insersionIndex: number
+
+    if (closestPreviousIndex !== -1) {
+      // If there's a previous ID, insert after it
+      insersionIndex = closestPreviousIndex + 1
+    } else {
+      // If neither, insert at the beginning
+      insersionIndex = 0
+    }
+
+    // Insert the removedId
+    result.splice(insersionIndex, 0, removedId)
+  }
+
+  return result
+}


### PR DESCRIPTION
### What?

For arrays, where every entry has an `id`, use the `id` to track the movement of elements when computing the version diff. This means that e.g. deleting an entry in the middle, or adding an entry in the middle no longer causes all following array elements to be shown as fully changed, making the version diff easier to read for humans (see screenshots below for how diffs would render now).

Arrays where (some) entries lack the `id` are compared as before, by index.

#### Version diff in array where elements have `id` when a new entry is created in 1st place:

<img width="936" alt="image" src="https://github.com/user-attachments/assets/a689f9ab-0366-40dd-ba84-59e811df23b2" />

<details>
  <summary>status quo</summary>
  
  <img width="906" alt="image" src="https://github.com/user-attachments/assets/855e6794-0fb3-40d6-9181-61ea91b92428" />
</details>

#### Version diff in array where elements have `id` when the first entry is deleted:

<img width="946" alt="image" src="https://github.com/user-attachments/assets/a30a57d4-2e3c-4311-82c6-3a9b5c327697" />

<details>
  <summary>status quo</summary>
  
  <img width="941" alt="image" src="https://github.com/user-attachments/assets/2036d5a0-b05f-494c-a700-12172ca1aa29" />
</details>


#### Version diff in array where elements have `id` when a new entry is created in the middle:

<img width="943" alt="image" src="https://github.com/user-attachments/assets/f2aa3d26-014f-4058-842c-3bfb91066a5a" />

<details>
  <summary>status quo</summary>

  <img width="921" alt="image" src="https://github.com/user-attachments/assets/76d6d5e7-5c01-4ebc-b75e-5899e9ea5935" />  
</details>


#### Version diff in array where elements have `id` when an entry is deleted in the middle:

<img width="912" alt="image" src="https://github.com/user-attachments/assets/497c1bb5-6ccf-4fae-9cea-18315f5db4c8" />

<details>
  <summary>status quo</summary>

  <img width="914" alt="image" src="https://github.com/user-attachments/assets/1ff7e59a-22b4-4fe1-8832-80105c839c7a" />
</details>


#### Version diff in array where elements have `id` when an an entry is added at the end:

<img width="913" alt="image" src="https://github.com/user-attachments/assets/e16d7e00-6f12-47b7-a896-f190f1c34b4e" />


#### Version diff in array where elements have `id` when an entry is deleted at the end:

<img width="907" alt="image" src="https://github.com/user-attachments/assets/f929524f-6f3f-411b-bcab-0d451b32438e" />


### Why?

Makes version diff easier to parse for humans, because only changed parts are highlighted.


### Possible Follow-Ups

This change is an improvement, but the diff could be even more human readable: Right now, when an array element is removed, the version diff only shows properties that were set as removed, not the whole element. Likewise, when an element is moved to a different place in the array, there's no indicator that the element was merely moved, not 1 element removed, and 1 element added. So the "labelling" of rows in the version diff could still be more semantic.


### How?

`packages/next/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx` checks whether all elements of an array field, both in the comparison and the new version contain an `id` property. If that's not the case, the current, index-based code path is used. But if it is the case, the new utility `packages/next/src/views/Version/RenderFieldsToDiff/utilities/getArrayElementIdsInComparisonOrder.ts` is called to get the union of all array element IDs in a reasonable order, which is used to iteratively call `buildVersionFields` with the  `comparisonSiblingData` of the array element with the matching `id` property (if existing).