### PR TITLE
fix: exclude plugin-cloud-storage, plugin-sentry and plugin-stripe from bundling optimization

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -102,7 +102,7 @@ export const withPayload = (nextConfig = {}, options = {}) => {
       'pino-pretty',
       'graphql',
       // Do not bundle server-only packages during dev to improve compile speed
-      ...(process.env.npm_lifecycle_event === 'dev' && options.devBundleServerPackages === false
+      ...(process.env.NODE_ENV === 'development' && options.devBundleServerPackages === false
         ? [
             'payload',
             '@payloadcms/db-mongodb',

--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -114,11 +114,11 @@ export const withPayload = (nextConfig = {}, options = {}) => {
             '@payloadcms/email-resend',
             '@payloadcms/graphql',
             '@payloadcms/payload-cloud',
-            '@payloadcms/plugin-cloud-storage',
             '@payloadcms/plugin-redirects',
-            '@payloadcms/plugin-sentry',
-            '@payloadcms/plugin-stripe',
             // TODO: Add the following packages, excluding their /client subpath exports, once Next.js supports it
+            //'@payloadcms/plugin-cloud-storage',
+            //'@payloadcms/plugin-sentry',
+            //'@payloadcms/plugin-stripe',
             // @payloadcms/richtext-lexical
             //'@payloadcms/storage-azure',
             //'@payloadcms/storage-gcs',


### PR DESCRIPTION
Since those packages have `/client` exports, we cannot exclude them from the bundler until https://github.com/vercel/next.js/discussions/76991 is implemented.

Fixes https://github.com/payloadcms/payload/pull/11594#issuecomment-2717309220

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210495300843784