### PR TITLE
feat(ui): don't trigger preventLeave when opening a new tab

### DIFF
--- a/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
+++ b/packages/ui/src/elements/LeaveWithoutSaving/usePreventLeave.tsx
@@ -117,8 +117,9 @@ export const usePreventLeave = ({
           const newUrl = anchor.href
           const isAnchor = isAnchorOfCurrentUrl(currentUrl, newUrl)
           const isDownloadLink = anchor.download !== ''
+          const isNewTab = anchor.target === '_blank' || event.metaKey || event.ctrlKey
 
-          const isPageLeaving = !(newUrl === currentUrl || isAnchor || isDownloadLink)
+          const isPageLeaving = !(newUrl === currentUrl || isAnchor || isDownloadLink || isNewTab)
 
           if (isPageLeaving && prevent && (!onPrevent ? !window.confirm(message) : true)) {
             // Keep a reference of the href

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1008,7 +1008,7 @@ describe('General', () => {
       const newTitle = 'new title'
       await page.locator('#field-title').fill(newTitle)
 
-      await page.locator(`header.app-header a[href="${postsUrl.list}"]`).click()
+      await page.locator(`header.app-header a[href="/admin/collections/posts"]`).click()
 
       // Locate the modal container
       const modalContainer = page.locator('.payload__modal-container')
@@ -1036,17 +1036,21 @@ describe('General', () => {
     // Open link in a new tab by holding down the Meta key
     const [newPage] = await Promise.all([
       page.context().waitForEvent('page'),
-      page.locator(`header.app-header a[href="${postsUrl.list}"]`).click({ modifiers: ['Meta'] }),
+      page
+        .locator(`header.app-header a[href="/admin/collections/posts"]`)
+        .click({ modifiers: ['Meta'] }),
     ])
 
-    await newPage.waitForLoadState('domcontentloaded')
+    // Wait for navigation to complete in the new tab
+    await newPage.waitForLoadState('load')
 
     // Locate the modal container and ensure it is not visible
     const modalContainer = page.locator('.payload__modal-container')
     await expect(modalContainer).toBeHidden()
 
     // Ensure the new page is the correct URL
-    expect(newPage.url()).toBe(postsUrl.list)
+    // using contain here, because after load the lists view will add query params like "?limit=10"
+    expect(newPage.url()).toContain(postsUrl.list)
 
     // Ensure the original page is the correct URL
     expect(page.url()).toBe(postsUrl.create)

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1042,16 +1042,14 @@ describe('General', () => {
         .click({ modifiers: [modifier] }),
     ])
 
-    // Wait for navigation to complete in the new tab
-    await newPage.waitForLoadState('load')
+    // Wait for navigation to complete in the new tab and ensure correct URL
+    await expect(newPage.locator('.list-header')).toBeVisible()
+    // using contain here, because after load the lists view will add query params like "?limit=10"
+    expect(newPage.url()).toContain(postsUrl.list)
 
     // Locate the modal container and ensure it is not visible
     const modalContainer = page.locator('.payload__modal-container')
     await expect(modalContainer).toBeHidden()
-
-    // Ensure the new page is the correct URL
-    // using contain here, because after load the lists view will add query params like "?limit=10"
-    expect(newPage.url()).toContain(postsUrl.list)
 
     // Ensure the original page is the correct URL
     expect(page.url()).toBe(postsUrl.create)

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1033,12 +1033,13 @@ describe('General', () => {
     const newTitle = 'new title'
     await page.locator('#field-title').fill(newTitle)
 
-    // Open link in a new tab by holding down the Meta key
+    // Open link in a new tab by holding down the Meta or Control key
+    const modifier = process.platform === 'win32' ? 'Control' : 'Meta'
     const [newPage] = await Promise.all([
       page.context().waitForEvent('page'),
       page
         .locator(`header.app-header a[href="/admin/collections/posts"]`)
-        .click({ modifiers: ['Meta'] }),
+        .click({ modifiers: [modifier] }),
     ])
 
     // Wait for navigation to complete in the new tab

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1024,6 +1024,27 @@ describe('General', () => {
     })
   })
 
+  test('should not open leave-without-saving modal if opening a new tab', async () => {
+    const { id } = await createPost()
+    await page.goto(postsUrl.edit(id))
+    const title = 'title'
+    await page.locator('#field-title').fill(title)
+    await saveDocHotkeyAndAssert(page)
+    await expect(page.locator('#field-title')).toHaveValue(title)
+
+    const newTitle = 'new title'
+    await page.locator('#field-title').fill(newTitle)
+
+    // Open link in a new tab by holding down the Meta key
+    await page
+      .locator('header.app-header a[href="/admin/collections/posts"]')
+      .click({ modifiers: ['Meta'] })
+
+    // Locate the modal container
+    const modalContainer = page.locator('.payload__modal-container')
+    await expect(modalContainer).toBeHidden()
+  })
+
   describe('preferences', () => {
     test('should successfully reset prefs after clicking reset button', async () => {
       await page.goto(`${serverURL}/admin/account`)

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1036,16 +1036,23 @@ describe('General', () => {
     await page.locator('#field-title').fill(newTitle)
 
     // Open link in a new tab by holding down the Meta key
-    await page
-      .locator('header.app-header a[href="/admin/collections/posts"]')
-      .click({ modifiers: ['Meta'] })
+    const [newPage] = await Promise.all([
+      page.context().waitForEvent('page'),
+      page
+        .locator('header.app-header a[href="/admin/collections/posts"]')
+        .click({ modifiers: ['Meta'] }),
+    ])
 
-    // Locate the modal container
+    await newPage.waitForLoadState('domcontentloaded')
+
+    // Locate the modal container and ensure it is not visible
     const modalContainer = page.locator('.payload__modal-container')
     await expect(modalContainer).toBeHidden()
 
-    // Playwright doesn't open a new tab in headless mode, so we cannot check if the new tab is actually opened
-    // We can only check if the page URL stays the same as expected
+    // Ensure the new page is the correct URL
+    expect(newPage.url()).toContain('/admin/collections/posts')
+
+    // Ensure the original page is the correct URL
     expect(page.url()).toBe(postsUrl.edit(id))
   })
 

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1034,12 +1034,11 @@ describe('General', () => {
     await page.locator('#field-title').fill(newTitle)
 
     // Open link in a new tab by holding down the Meta or Control key
-    const modifier = process.platform === 'win32' ? 'Control' : 'Meta'
     const [newPage] = await Promise.all([
       page.context().waitForEvent('page'),
       page
         .locator(`header.app-header a[href="/admin/collections/posts"]`)
-        .click({ modifiers: [modifier] }),
+        .click({ modifiers: ['ControlOrMeta'] }),
     ])
 
     // Wait for navigation to complete in the new tab and ensure correct URL

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1043,6 +1043,10 @@ describe('General', () => {
     // Locate the modal container
     const modalContainer = page.locator('.payload__modal-container')
     await expect(modalContainer).toBeHidden()
+
+    // Playwright doesn't open a new tab in headless mode, so we cannot check if the new tab is actually opened
+    // We can only check if the page URL stays the same as expected
+    expect(page.url()).toBe(postsUrl.edit(id))
   })
 
   describe('preferences', () => {

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1008,7 +1008,7 @@ describe('General', () => {
       const newTitle = 'new title'
       await page.locator('#field-title').fill(newTitle)
 
-      await page.locator('header.app-header a[href="/admin/collections/posts"]').click()
+      await page.locator(`header.app-header a[href="${postsUrl.list}"]`).click()
 
       // Locate the modal container
       const modalContainer = page.locator('.payload__modal-container')
@@ -1025,11 +1025,9 @@ describe('General', () => {
   })
 
   test('should not open leave-without-saving modal if opening a new tab', async () => {
-    const { id } = await createPost()
-    await page.goto(postsUrl.edit(id))
     const title = 'title'
+    await page.goto(postsUrl.create)
     await page.locator('#field-title').fill(title)
-    await saveDocHotkeyAndAssert(page)
     await expect(page.locator('#field-title')).toHaveValue(title)
 
     const newTitle = 'new title'
@@ -1038,9 +1036,7 @@ describe('General', () => {
     // Open link in a new tab by holding down the Meta key
     const [newPage] = await Promise.all([
       page.context().waitForEvent('page'),
-      page
-        .locator('header.app-header a[href="/admin/collections/posts"]')
-        .click({ modifiers: ['Meta'] }),
+      page.locator(`header.app-header a[href="${postsUrl.list}"]`).click({ modifiers: ['Meta'] }),
     ])
 
     await newPage.waitForLoadState('domcontentloaded')
@@ -1050,10 +1046,10 @@ describe('General', () => {
     await expect(modalContainer).toBeHidden()
 
     // Ensure the new page is the correct URL
-    expect(newPage.url()).toContain('/admin/collections/posts')
+    expect(newPage.url()).toBe(postsUrl.list)
 
     // Ensure the original page is the correct URL
-    expect(page.url()).toBe(postsUrl.edit(id))
+    expect(page.url()).toBe(postsUrl.create)
   })
 
   describe('preferences', () => {


### PR DESCRIPTION
### What?
Prevents the preventLeave dialog from showing if a clicked link is about to open in a new tab.

### Why?
Currently, no external link can be clicked on the edit page if it was modified, even if the link would not navigate the user away from that page but open in a new tab instead.

### How?
We don't trigger the preventLeave dialog if
- the target of a clicked anchor is `_blank`
- the user pressed the command or ctrl key while clicking on a link (which opens link in a new tab)