### PR TITLE
docs: updates docs for `useDocumentInfo`

### DIFF
--- a/docs/admin/react-hooks.mdx
+++ b/docs/admin/react-hooks.mdx
@@ -711,23 +711,41 @@ const CustomComponent: React.FC = () => {
 
 The `useDocumentInfo` hook provides information about the current document being edited, including the following:
 
-| Property                  | Description                                                                                                        |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| **`currentEditor`**       | The user currently editing the document.                                                                             |
-| **`docConfig`**              | Either the Collection or Global config of the document, depending on what is being edited.                         |
-| **`documentIsLocked`**    | Whether the document is currently locked by another user.                                                          |
-| **`id`**                  | If the doc is a collection, its ID will be returned                                                                |
-| **`getDocPermissions`**   | Method to retrieve document-level user preferences.                                                 |
-| **`getDocPreferences`**   | Method to retrieve document-level user preferences.                                                 |
-| **`hasPublishedDoc`**     | Whether the document has a published version.                                                                      |
-| **`incrementVersionCount`** | Method to increment the version count of the document.                                                           |
-| **`preferencesKey`**      | The `preferences` key to use when interacting with document-level user preferences.                                 |
-| **`versions`**            | Versions of the current doc.                                                                                        |
-| **`unpublishedVersions`** | Unpublished versions of the current doc.                                                                            |
-| **`publishedDoc`**        | The currently published version of the doc being edited.                                                            |
-| **`getVersions`**         | Method to retrieve document versions.                                                               |
-| **`docPermissions`**      | The current documents permissions. Collection document permissions fallback when no id is present (i.e. on create). |
-| **`versionCount`**        | The current version count of the document.                                                                          |
+| Property                            | Description                                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **`action`**                        | The current action being performed on the document (create, edit, etc.).                                |
+| **`apiURL`**                        | The API URL for the current document.                                                                   |
+| **`collectionSlug`**                | The slug of the collection if editing a collection document.                                            |
+| **`currentEditor`**                 | The user currently editing the document.                                                                |
+| **`docConfig`**                     | Either the Collection or Global config of the document, depending on what is being edited.              |
+| **`docPermissions`**                | The current document's permissions. Fallback to collection permissions when no id is present.           |
+| **`documentIsLocked`**              | Whether the document is currently locked by another user.                                               |
+| **`getDocPermissions`**             | Method to retrieve document-level permissions.                                                          |
+| **`getDocPreferences`**             | Method to retrieve document-level user preferences.                                                     |
+| **`globalSlug`**                    | The slug of the global if editing a global document.                                                    |
+| **`hasPublishedDoc`**               | Whether the document has a published version.                                                           |
+| **`hasPublishPermission`**          | Whether the current user has permission to publish the document.                                        |
+| **`hasSavePermission`**             | Whether the current user has permission to save the document.                                           |
+| **`id`**                            | If the doc is a collection, its ID will be returned.                                                    |
+| **`incrementVersionCount`**         | Method to increment the version count of the document.                                                  |
+| **`initialData`**                   | The initial data of the document.                                                                       |
+| **`isEditing`**                     | Whether the document is being edited (as opposed to created).                                           |
+| **`isInitializing`**                | Whether the document info is still initializing.                                                        |
+| **`isLocked`**                      | Whether the document is locked.                                                                         |
+| **`lastUpdateTime`**                | Timestamp of the last update to the document.                                                           |
+| **`mostRecentVersionIsAutosaved`**  | Whether the most recent version is an autosaved version.                                                |
+| **`preferencesKey`**                | The `preferences` key to use when interacting with document-level user preferences.                     |
+| **`savedDocumentData`**             | The saved data of the document.                                                                         |
+| **`setDocFieldPreferences`**        | Method to set preferences for a specific field.                                                         |
+| **`setDocumentTitle`**              | Method to set the document title.                                                                       |
+| **`setHasPublishedDoc`**            | Method to update whether the document has been published.                                               |
+| **`title`**                         | The title of the document.                                                                              |
+| **`unlockDocument`**                | Method to unlock a document.                                                                            |
+| **`unpublishedVersionCount`**       | The number of unpublished versions of the document.                                                     |
+| **`updateDocumentEditor`**          | Method to update who is currently editing the document.                                                 |
+| **`updateSavedDocumentData`**       | Method to update the saved document data.                                                               |
+| **`uploadStatus`**                  | Status of any uploads in progress ('idle', 'uploading', or 'failed').                                   |
+| **`versionCount`**                  | The current version count of the document.                                                              |
 
 **Example:**
 

--- a/docs/admin/react-hooks.mdx
+++ b/docs/admin/react-hooks.mdx
@@ -719,7 +719,7 @@ The `useDocumentInfo` hook provides information about the current document being
 | **`currentEditor`**                 | The user currently editing the document.                                                                |
 | **`docConfig`**                     | Either the Collection or Global config of the document, depending on what is being edited.              |
 | **`docPermissions`**                | The current document's permissions. Fallback to collection permissions when no id is present.           |
-| **`documentIsLocked`**              | Whether the document is currently locked by another user.                                               |
+| **`documentIsLocked`**              | Whether the document is currently locked by another user. More details](./locked-documents).                                               |
 | **`getDocPermissions`**             | Method to retrieve document-level permissions.                                                          |
 | **`getDocPreferences`**             | Method to retrieve document-level user preferences.                                                     |
 | **`globalSlug`**                    | The slug of the global if editing a global document.                                                    |
@@ -731,7 +731,7 @@ The `useDocumentInfo` hook provides information about the current document being
 | **`initialData`**                   | The initial data of the document.                                                                       |
 | **`isEditing`**                     | Whether the document is being edited (as opposed to created).                                           |
 | **`isInitializing`**                | Whether the document info is still initializing.                                                        |
-| **`isLocked`**                      | Whether the document is locked.                                                                         |
+| **`isLocked`**                      | Whether the document is locked. More details](./locked-documents).                                                                        |
 | **`lastUpdateTime`**                | Timestamp of the last update to the document.                                                           |
 | **`mostRecentVersionIsAutosaved`**  | Whether the most recent version is an autosaved version.                                                |
 | **`preferencesKey`**                | The `preferences` key to use when interacting with document-level user preferences.                     |
@@ -740,9 +740,9 @@ The `useDocumentInfo` hook provides information about the current document being
 | **`setDocumentTitle`**              | Method to set the document title.                                                                       |
 | **`setHasPublishedDoc`**            | Method to update whether the document has been published.                                               |
 | **`title`**                         | The title of the document.                                                                              |
-| **`unlockDocument`**                | Method to unlock a document.                                                                            |
+| **`unlockDocument`**                | Method to unlock a document. More details](./locked-documents).                                                                            |
 | **`unpublishedVersionCount`**       | The number of unpublished versions of the document.                                                     |
-| **`updateDocumentEditor`**          | Method to update who is currently editing the document.                                                 |
+| **`updateDocumentEditor`**          | Method to update who is currently editing the document. More details](./locked-documents).                                                |
 | **`updateSavedDocumentData`**       | Method to update the saved document data.                                                               |
 | **`uploadStatus`**                  | Status of any uploads in progress ('idle', 'uploading', or 'failed').                                   |
 | **`versionCount`**                  | The current version count of the document.                                                              |

--- a/docs/admin/react-hooks.mdx
+++ b/docs/admin/react-hooks.mdx
@@ -713,7 +713,7 @@ The `useDocumentInfo` hook provides information about the current document being
 
 | Property                            | Description                                                                                             |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| **`action`**                        | The current action being performed on the document (create, edit, etc.).                                |
+| **`action`**                        | The URL attached to the action attribute on the underlying form element, which specifies where to send the form data when the form is submitted.                              |
 | **`apiURL`**                        | The API URL for the current document.                                                                   |
 | **`collectionSlug`**                | The slug of the collection if editing a collection document.                                            |
 | **`currentEditor`**                 | The user currently editing the document.                                                                |

--- a/docs/admin/react-hooks.mdx
+++ b/docs/admin/react-hooks.mdx
@@ -721,7 +721,7 @@ The `useDocumentInfo` hook provides information about the current document being
 | **`docPermissions`**                | The current document's permissions. Fallback to collection permissions when no id is present.           |
 | **`documentIsLocked`**              | Whether the document is currently locked by another user. More details](./locked-documents).                                               |
 | **`getDocPermissions`**             | Method to retrieve document-level permissions.                                                          |
-| **`getDocPreferences`**             | Method to retrieve document-level user preferences.                                                     |
+| **`getDocPreferences`**             | Method to retrieve document-level user preferences. [More details](./preferences).                                                    |
 | **`globalSlug`**                    | The slug of the global if editing a global document.                                                    |
 | **`hasPublishedDoc`**               | Whether the document has a published version.                                                           |
 | **`hasPublishPermission`**          | Whether the current user has permission to publish the document.                                        |
@@ -734,9 +734,9 @@ The `useDocumentInfo` hook provides information about the current document being
 | **`isLocked`**                      | Whether the document is locked. More details](./locked-documents).                                                                        |
 | **`lastUpdateTime`**                | Timestamp of the last update to the document.                                                           |
 | **`mostRecentVersionIsAutosaved`**  | Whether the most recent version is an autosaved version.                                                |
-| **`preferencesKey`**                | The `preferences` key to use when interacting with document-level user preferences.                     |
+| **`preferencesKey`**                | The `preferences` key to use when interacting with document-level user preferences. [More details](./preferences).                     |
 | **`savedDocumentData`**             | The saved data of the document.                                                                         |
-| **`setDocFieldPreferences`**        | Method to set preferences for a specific field.                                                         |
+| **`setDocFieldPreferences`**        | Method to set preferences for a specific field. [More details](./preferences).                                                         |
 | **`setDocumentTitle`**              | Method to set the document title.                                                                       |
 | **`setHasPublishedDoc`**            | Method to update whether the document has been published.                                               |
 | **`title`**                         | The title of the document.                                                                              |


### PR DESCRIPTION
Based on the current `packages/ui/src/providers/DocumentInfo/types.ts`.

- Removes properties like `versions`, `unpublishedVersions`, `publishedDoc`, `getVersions` from the docs, which were listed in the docs, but not in the type definition.
- Adds properties like `savedDocumentData`, `setCurrentEditor`, `setDocFieldPreferences`, etc., which  are in the type definition, but which were missing in the docs.
- Fixes that the description for `getDocPermissions` said it retrieves "user preferences", but should be about permissions.
