### PR TITLE
fix(plugin-multi-tenant): missing key console message

### DIFF
--- a/docs/plugins/multi-tenant.mdx
+++ b/docs/plugins/multi-tenant.mdx
@@ -161,7 +161,7 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   /**
    * Customize tenant selector label
    *
-   * Either a string or an object where the keys are locales and the values are the string labels
+   * Either a string or an object where the keys are i18n codes and the values are the string labels
    */
   tenantSelectorLabel?:
     | Partial<{

--- a/packages/plugin-multi-tenant/README.md
+++ b/packages/plugin-multi-tenant/README.md
@@ -87,6 +87,18 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
          */
         arrayFieldAccess?: ArrayField['access']
         /**
+         * Name of the array field
+         *
+         * @default 'tenants'
+         */
+        arrayFieldName?: string
+        /**
+         * Name of the tenant field
+         *
+         * @default 'tenant'
+         */
+        arrayTenantFieldName?: string
+        /**
          * When `includeDefaultField` is `true`, the field will be added to the users collection automatically
          */
         includeDefaultField?: true
@@ -101,6 +113,8 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
       }
     | {
         arrayFieldAccess?: never
+        arrayFieldName?: string
+        arrayTenantFieldName?: string
         /**
          * When `includeDefaultField` is `false`, you must include the field on your users collection manually
          */
@@ -108,6 +122,16 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
         rowFields?: never
         tenantFieldAccess?: never
       }
+  /**
+   * Customize tenant selector label
+   *
+   * Either a string or an object where the keys are i18n codes and the values are the string labels
+   */
+  tenantSelectorLabel?:
+    | Partial<{
+        [key in AcceptedLanguages]?: string
+      }>
+    | string
   /**
    * The slug for the tenant collection
    *
@@ -120,8 +144,20 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
    * Useful for super-admin type users
    */
   userHasAccessToAllTenants?: (
-    user: ConfigTypes extends { user } ? ConfigTypes['user'] : User,
+    user: ConfigTypes extends { user: unknown } ? ConfigTypes['user'] : User,
   ) => boolean
+  /**
+   * Opt out of adding access constraints to the tenants collection
+   */
+  useTenantsCollectionAccess?: boolean
+  /**
+   * Opt out including the baseListFilter to filter tenants by selected tenant
+   */
+  useTenantsListFilter?: boolean
+  /**
+   * Opt out including the baseListFilter to filter users by selected tenant
+   */
+  useUsersTenantFilter?: boolean
 }
 ```
 
@@ -159,7 +195,7 @@ import { Config as ConfigTypes } from './payload-types'
 // Add the plugin to your payload config
 export default buildConfig({
   plugins: [
-    multiTenantPlugin({
+    multiTenantPlugin<ConfigTypes>({
       collections: {
         media: {
           useTenantAccess: false,

--- a/packages/plugin-multi-tenant/src/components/TenantSelector/index.tsx
+++ b/packages/plugin-multi-tenant/src/components/TenantSelector/index.tsx
@@ -2,16 +2,16 @@
 import type { ReactSelectOption } from '@payloadcms/ui'
 import type { ViewTypes } from 'payload'
 
-import './index.scss'
-
+import { getTranslation } from '@payloadcms/translations'
 import { SelectInput, useTranslation } from '@payloadcms/ui'
 import React from 'react'
 
 import { useTenantSelection } from '../../providers/TenantSelectionProvider/index.client.js'
+import './index.scss'
 
 export const TenantSelector = ({ label, viewType }: { label: string; viewType?: ViewTypes }) => {
   const { options, selectedTenantID, setTenant } = useTenantSelection()
-  const { t } = useTranslation()
+  const { i18n } = useTranslation()
 
   const handleChange = React.useCallback(
     (option: ReactSelectOption | ReactSelectOption[]) => {
@@ -32,7 +32,7 @@ export const TenantSelector = ({ label, viewType }: { label: string; viewType?: 
     <div className="tenant-selector">
       <SelectInput
         isClearable={viewType === 'list'}
-        label={t(label as any)}
+        label={getTranslation(label, i18n)}
         name="setTenant"
         onChange={handleChange}
         options={options}

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -37,7 +37,7 @@ export const multiTenantPlugin =
       pluginConfig?.tenantsArrayField?.arrayFieldName || defaults.tenantsArrayFieldName
     const tenantsArrayTenantFieldName =
       pluginConfig?.tenantsArrayField?.arrayTenantFieldName || defaults.tenantsArrayTenantFieldName
-    let tenantSelectorLabel = pluginConfig.tenantSelectorLabel || defaults.tenantSelectorLabel
+    const tenantSelectorLabel = pluginConfig.tenantSelectorLabel || defaults.tenantSelectorLabel
 
     /**
      * Add defaults for admin properties
@@ -68,11 +68,11 @@ export const multiTenantPlugin =
     /**
      * Add tenant selector localized labels
      */
-    if (pluginConfig.tenantSelectorLabel && typeof pluginConfig.tenantSelectorLabel === 'object') {
+    if (typeof tenantSelectorLabel === 'object') {
       if (!incomingConfig.i18n) {
         incomingConfig.i18n = {}
       }
-      Object.entries(pluginConfig.tenantSelectorLabel).forEach(([_locale, label]) => {
+      Object.entries(tenantSelectorLabel).forEach(([_locale, label]) => {
         const locale = _locale as AcceptedLanguages
         if (!incomingConfig.i18n) {
           incomingConfig.i18n = {}
@@ -93,7 +93,6 @@ export const multiTenantPlugin =
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         incomingConfig.i18n.translations[locale].multiTenant.selectorLabel = label
-        tenantSelectorLabel = 'multiTenant:selectorLabel'
       })
     }
 

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -111,7 +111,7 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   /**
    * Customize tenant selector label
    *
-   * Either a string or an object where the keys are locales and the values are the string labels
+   * Either a string or an object where the keys are i18n codes and the values are the string labels
    */
   tenantSelectorLabel?:
     | Partial<{


### PR DESCRIPTION
### What? Missing key console message
Custom labels support internationalization, but when you do not provide internationalized labels a console message is logged.

### Why?
The plugin was using the `t` function which _works_, it falls back to the key passed in if it cannot find a match. But it logs a message so we know when keys are used that are not available.

To remedy this, this PR uses the `getTranslation` function instead of the `t` function and passes the value set on the config to the selector so it can use the `getTranslation` function.

Fixes https://github.com/payloadcms/payload/issues/11682
