### PR TITLE
fix(ui): scheduled publish not displaying the timezone's label and timezones being reset when scheduling a publish, brisbane is now a default timezone

### DIFF
--- a/packages/payload/src/fields/baseFields/timezone/defaultTimezones.ts
+++ b/packages/payload/src/fields/baseFields/timezone/defaultTimezones.ts
@@ -51,6 +51,7 @@ export const defaultTimezones: Timezone[] = [
   { label: '(UTC+08:00) Singapore', value: 'Asia/Singapore' },
   { label: '(UTC+09:00) Tokyo, Osaka, Sapporo', value: 'Asia/Tokyo' },
   { label: '(UTC+09:00) Seoul', value: 'Asia/Seoul' },
+  { label: '(UTC+10:00) Brisbane', value: 'Australia/Brisbane' },
   { label: '(UTC+10:00) Sydney, Melbourne', value: 'Australia/Sydney' },
   { label: '(UTC+10:00) Guam, Port Moresby', value: 'Pacific/Guam' },
   { label: '(UTC+11:00) New Caledonia', value: 'Pacific/Noumea' },

--- a/packages/ui/src/elements/PublishButton/ScheduleDrawer/buildUpcomingColumns.tsx
+++ b/packages/ui/src/elements/PublishButton/ScheduleDrawer/buildUpcomingColumns.tsx
@@ -15,6 +15,7 @@ type Args = {
   docs: UpcomingEvent[]
   i18n: I18nClient
   localization: ClientConfig['localization']
+  supportedTimezones: ClientConfig['admin']['timezones']['supportedTimezones']
   t: TFunction
 }
 
@@ -24,6 +25,7 @@ export const buildUpcomingColumns = ({
   docs,
   i18n,
   localization,
+  supportedTimezones,
   t,
 }: Args): Column[] => {
   const columns: Column[] = [
@@ -74,7 +76,13 @@ export const buildUpcomingColumns = ({
       },
       Heading: <span>{t('general:timezone')}</span>,
       renderedCells: docs.map((doc) => {
-        return <span key={doc.id}>{doc.input.timezone || t('general:noValue')}</span>
+        const matchedTimezone = supportedTimezones.find(
+          (timezone) => timezone.value === doc.input.timezone,
+        )
+
+        const timezone = matchedTimezone?.label || doc.input.timezone
+
+        return <span key={doc.id}>{timezone || t('general:noValue')}</span>
       }),
     },
   ]

--- a/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
+++ b/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
@@ -148,11 +148,23 @@ export const ScheduleDrawer: React.FC<Props> = ({ slug, defaultType }) => {
         docs,
         i18n,
         localization,
+        supportedTimezones,
         t,
       }),
     )
     setUpcoming(docs)
-  }, [collectionSlug, globalSlug, serverURL, api, dateFormat, id, t, i18n, localization])
+  }, [
+    collectionSlug,
+    globalSlug,
+    serverURL,
+    api,
+    i18n,
+    dateFormat,
+    localization,
+    supportedTimezones,
+    t,
+    id,
+  ])
 
   const deleteHandler = React.useCallback(
     async (id: number | string) => {
@@ -202,7 +214,6 @@ export const ScheduleDrawer: React.FC<Props> = ({ slug, defaultType }) => {
         timezone,
       })
 
-      setTimezone(defaultTimezone)
       setDate(undefined)
       toast.success(t('version:scheduledSuccessfully'))
       void fetchUpcoming()
@@ -222,7 +233,6 @@ export const ScheduleDrawer: React.FC<Props> = ({ slug, defaultType }) => {
     id,
     globalSlug,
     timezone,
-    defaultTimezone,
     fetchUpcoming,
   ])
 


### PR DESCRIPTION
Fixes a problem where we would reset the value of the timezone field on submission of a new scheduled publish.

Timezones in the table now match with a label if possible.
![image](https://github.com/user-attachments/assets/19a28075-e929-4548-a8db-7ed3a81d57ec)

`Australia/Brisbane` is now part of the default list of timezones