### PR TITLE
fix(ui): excess error css coming from group fields

### DIFF
--- a/packages/ui/src/fields/Group/index.scss
+++ b/packages/ui/src/fields/Group/index.scss
@@ -126,9 +126,12 @@
   html[data-theme='light'] {
     .group-field {
       &--has-error {
-        color: var(--theme-error-750);
-        &:after {
-          background: var(--theme-error-500);
+        .group-field__header {
+          color: var(--theme-error-750);
+
+          &:after {
+            background: var(--theme-error-500);
+          }
         }
       }
     }
@@ -137,9 +140,12 @@
   html[data-theme='dark'] {
     .group-field {
       &--has-error {
-        color: var(--theme-error-500);
-        &:after {
-          background: var(--theme-error-500);
+        .group-field__header {
+          color: var(--theme-error-500);
+
+          &:after {
+            background: var(--theme-error-500);
+          }
         }
       }
     }


### PR DESCRIPTION
### What?
When a field within a group field has an error, the error styles were getting applied to everything within the group.

### Why?
The group field was applying `color: var(--theme-error-500);` to everything within it when an error is present.

### How?
The fields within a group will set their own error styling, the group field just needs to handle the group header.

### Before
🚨 See the dots and chevron on Link 1, these should not be in the error color.
<img width="1386" alt="Screenshot 2025-03-14 at 1 25 56 PM" src="https://github.com/user-attachments/assets/bcca4406-a69f-49d4-9757-e637b5d6a706" />

## After
<img width="1391" alt="Screenshot 2025-03-14 at 1 26 47 PM" src="https://github.com/user-attachments/assets/dbda5a33-eed6-45fa-a49c-d3d5da31beaf" />

Fixes #11691
