### PR TITLE
feat: aligns user _strategy returned from API

### DIFF
--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -184,6 +184,7 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     }
 
     user.collection = collectionConfig.slug
+    user._strategy = args.req.user._strategy
 
     if (isLocked(new Date(user.lockUntil).getTime())) {
       throw new LockedAuth(req.t)

--- a/packages/payload/src/auth/operations/login.ts
+++ b/packages/payload/src/auth/operations/login.ts
@@ -184,7 +184,7 @@ export const loginOperation = async <TSlug extends CollectionSlug>(
     }
 
     user.collection = collectionConfig.slug
-    user._strategy = args.req.user._strategy
+    user._strategy = 'local-jwt'
 
     if (isLocked(new Date(user.lockUntil).getTime())) {
       throw new LockedAuth(req.t)

--- a/packages/payload/src/auth/operations/me.ts
+++ b/packages/payload/src/auth/operations/me.ts
@@ -8,6 +8,12 @@ import type { ClientUser, User } from '../types.js'
 export type MeOperationResult = {
   collection?: string
   exp?: number
+  /** @deprecated
+   * use:
+   * ```ts
+   * user._strategy
+   * ```
+   */
   strategy?: string
   token?: string
   user?: ClientUser
@@ -66,6 +72,12 @@ export const meOperation = async (args: Arguments): Promise<MeOperationResult> =
     }
 
     result.collection = req.user.collection
+    /** @deprecated
+     * use:
+     * ```ts
+     * user._strategy
+     * ```
+     */
     result.strategy = req.user._strategy
 
     if (!result.user) {

--- a/packages/payload/src/auth/operations/me.ts
+++ b/packages/payload/src/auth/operations/me.ts
@@ -41,6 +41,7 @@ export const meOperation = async (args: Arguments): Promise<MeOperationResult> =
 
     if (user) {
       user.collection = collection.config.slug
+      user._strategy = req.user._strategy
     }
 
     if (req.user.collection !== collection.config.slug) {

--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -76,6 +76,7 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
 
     if (user) {
       user.collection = args.req.user.collection
+      user._strategy = args.req.user._strategy
     }
 
     let result: Result

--- a/packages/payload/src/auth/operations/refresh.ts
+++ b/packages/payload/src/auth/operations/refresh.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import url from 'url'
 
-import type { BeforeOperationHook, Collection } from '../../collections/config/types.js'
+import type { Collection } from '../../collections/config/types.js'
 import type { Document, PayloadRequest } from '../../types/index.js'
 
 import { buildAfterOperation } from '../../collections/operations/utils.js'
@@ -16,6 +16,12 @@ export type Result = {
   exp: number
   refreshedToken: string
   setCookie?: boolean
+  /** @deprecated
+   * use:
+   * ```ts
+   * user._strategy
+   * ```
+   */
   strategy?: string
   user: Document
 }
@@ -111,6 +117,12 @@ export const refreshOperation = async (incomingArgs: Arguments): Promise<Result>
         exp,
         refreshedToken,
         setCookie: true,
+        /** @deprecated
+         * use:
+         * ```ts
+         * user._strategy
+         * ```
+         */
         strategy: args.req.user._strategy,
         user,
       }

--- a/packages/payload/src/auth/operations/registerFirstUser.ts
+++ b/packages/payload/src/auth/operations/registerFirstUser.ts
@@ -101,7 +101,7 @@ export const registerFirstUserOperation = async <TSlug extends CollectionSlug>(
 
     if (user) {
       user.collection = slug
-      user._strategy = req.user._strategy
+      user._strategy = req.user ? req.user._strategy : 'local'
     }
 
     if (shouldCommit) {

--- a/packages/payload/src/auth/operations/registerFirstUser.ts
+++ b/packages/payload/src/auth/operations/registerFirstUser.ts
@@ -93,11 +93,16 @@ export const registerFirstUserOperation = async <TSlug extends CollectionSlug>(
     // Log in new user
     // /////////////////////////////////////
 
-    const { exp, token } = await payload.login({
+    const { exp, token, user } = await payload.login({
       ...args,
       collection: slug,
       req,
     })
+
+    if (user) {
+      user.collection = slug
+      user._strategy = req.user._strategy
+    }
 
     if (shouldCommit) {
       await commitTransaction(req)
@@ -106,7 +111,7 @@ export const registerFirstUserOperation = async <TSlug extends CollectionSlug>(
     return {
       exp,
       token,
-      user: result,
+      user,
     }
   } catch (error: unknown) {
     await killTransaction(req)

--- a/packages/payload/src/auth/operations/registerFirstUser.ts
+++ b/packages/payload/src/auth/operations/registerFirstUser.ts
@@ -93,16 +93,14 @@ export const registerFirstUserOperation = async <TSlug extends CollectionSlug>(
     // Log in new user
     // /////////////////////////////////////
 
-    const { exp, token, user } = await payload.login({
+    const { exp, token } = await payload.login({
       ...args,
       collection: slug,
       req,
     })
 
-    if (user) {
-      user.collection = slug
-      user._strategy = req.user ? req.user._strategy : 'local'
-    }
+    result.collection = slug
+    result._strategy = 'local-jwt'
 
     if (shouldCommit) {
       await commitTransaction(req)
@@ -111,7 +109,7 @@ export const registerFirstUserOperation = async <TSlug extends CollectionSlug>(
     return {
       exp,
       token,
-      user,
+      user: result,
     }
   } catch (error: unknown) {
     await killTransaction(req)

--- a/packages/payload/src/auth/operations/resetPassword.ts
+++ b/packages/payload/src/auth/operations/resetPassword.ts
@@ -139,6 +139,11 @@ export const resetPasswordOperation = async (args: Arguments): Promise<Result> =
       await commitTransaction(req)
     }
 
+    if (fullUser) {
+      fullUser.collection = collectionConfig.slug
+      fullUser._strategy = req.user._strategy
+    }
+
     const result = {
       token,
       user: fullUser,

--- a/packages/payload/src/auth/operations/resetPassword.ts
+++ b/packages/payload/src/auth/operations/resetPassword.ts
@@ -141,7 +141,7 @@ export const resetPasswordOperation = async (args: Arguments): Promise<Result> =
 
     if (fullUser) {
       fullUser.collection = collectionConfig.slug
-      fullUser._strategy = req.user._strategy
+      fullUser._strategy = req.user ? req.user._strategy : 'local'
     }
 
     const result = {

--- a/packages/payload/src/auth/operations/resetPassword.ts
+++ b/packages/payload/src/auth/operations/resetPassword.ts
@@ -141,7 +141,7 @@ export const resetPasswordOperation = async (args: Arguments): Promise<Result> =
 
     if (fullUser) {
       fullUser.collection = collectionConfig.slug
-      fullUser._strategy = req.user ? req.user._strategy : 'local'
+      fullUser._strategy = 'local-jwt'
     }
 
     const result = {

--- a/packages/payload/src/auth/strategies/jwt.ts
+++ b/packages/payload/src/auth/strategies/jwt.ts
@@ -2,7 +2,7 @@
 import { jwtVerify } from 'jose'
 
 import type { Payload, Where } from '../../types/index.js'
-import type { AuthStrategyFunction, User } from '../index.js'
+import type { AuthStrategyFunction, AuthStrategyResult, User } from '../index.js'
 
 import { extractJWT } from '../extractJWT.js'
 
@@ -20,7 +20,7 @@ async function autoLogin({
   payload: Payload
   strategyName?: string
 }): Promise<{
-  user: null | User
+  user: AuthStrategyResult['user']
 }> {
   if (
     typeof payload?.config?.admin?.autoLogin !== 'object' ||
@@ -58,7 +58,7 @@ async function autoLogin({
       pagination: false,
       where,
     })
-  ).docs[0]
+  ).docs[0] as AuthStrategyResult['user']
 
   if (!user) {
     return { user: null }
@@ -67,7 +67,7 @@ async function autoLogin({
   user._strategy = strategyName
 
   return {
-    user: user as User,
+    user,
   }
 }
 
@@ -94,17 +94,17 @@ export const JWTAuthentication: AuthStrategyFunction = async ({
     const { payload: decodedPayload } = await jwtVerify<JWTToken>(token, secretKey)
     const collection = payload.collections[decodedPayload.collection]
 
-    const user = await payload.findByID({
+    const user = (await payload.findByID({
       id: decodedPayload.id,
       collection: decodedPayload.collection,
       depth: isGraphQL ? 0 : collection.config.auth.depth,
-    })
+    })) as AuthStrategyResult['user']
 
     if (user && (!collection.config.auth.verify || user._verified)) {
       user.collection = collection.config.slug
       user._strategy = strategyName
       return {
-        user: user as User,
+        user,
       }
     } else {
       if (headers.get('DisableAutologin') !== 'true') {

--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -169,7 +169,12 @@ export type AuthStrategyFunctionArgs = {
 
 export type AuthStrategyResult = {
   responseHeaders?: Headers
-  user: null | User
+  user:
+    | ({
+        _strategy?: string
+        collection?: string
+      } & User)
+    | null
 }
 
 export type AuthStrategyFunction = (

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -993,6 +993,7 @@ export { JWTAuthentication } from './auth/strategies/jwt.js'
 export type {
   AuthStrategyFunction,
   AuthStrategyFunctionArgs,
+  AuthStrategyResult,
   CollectionPermission,
   DocumentPermissions,
   FieldPermissions,


### PR DESCRIPTION
### What? Inconsistent `_strategy` returned on user object
- `req.user` has `_strategy` on it (the initial user in the auth provider)
- `/me` & `/refresh-token` return `strategy` outside of the user object
- `/login` does not return either

This PR ensures that `_strategy` is returned on the user object for auth operations that return a user.

Fixes https://github.com/payloadcms/payload/issues/11539
