### PR TITLE
feat(db-*): allow to thread `id` to create operation data without custom IDs

### DIFF
--- a/docs/database/mongodb.mdx
+++ b/docs/database/mongodb.mdx
@@ -40,7 +40,7 @@ export default buildConfig({
 | `transactionOptions`       | An object with configuration properties used in [transactions](https://www.mongodb.com/docs/manual/core/transactions/) or `false` which will disable the use of transactions.                                                                                                                                |
 | `collation`                | Enable language-specific string comparison with customizable options. Available on MongoDB 3.4+. Defaults locale to "en". Example: `{ strength: 3 }`. For a full list of collation options and their definitions, see the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/collation/). |
 | `allowAdditionalKeys`      | By default, Payload strips all additional keys from MongoDB data that don't exist in the Payload schema. If you have some data that you want to include to the result but it doesn't exist in Payload, you can set this to `true`. Be careful as Payload access control _won't_ work for this data.          |
-| `acceptIDOnCreate`         | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                                                                                                                                                 |
+| `allowIDOnCreate`          | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                                                                                                                                                 |
 
 ## Access to Mongoose models
 

--- a/docs/database/mongodb.mdx
+++ b/docs/database/mongodb.mdx
@@ -40,7 +40,7 @@ export default buildConfig({
 | `transactionOptions`       | An object with configuration properties used in [transactions](https://www.mongodb.com/docs/manual/core/transactions/) or `false` which will disable the use of transactions.                                                                                                                                |
 | `collation`                | Enable language-specific string comparison with customizable options. Available on MongoDB 3.4+. Defaults locale to "en". Example: `{ strength: 3 }`. For a full list of collation options and their definitions, see the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/collation/). |
 | `allowAdditionalKeys`      | By default, Payload strips all additional keys from MongoDB data that don't exist in the Payload schema. If you have some data that you want to include to the result but it doesn't exist in Payload, you can set this to `true`. Be careful as Payload access control _won't_ work for this data.          |
-| `allowIDOnCreate`          | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                                                                                                                                                 |
+| `allowIDOnCreate`          | Set to `true` to use the `id` passed in data on the create API operations without using a custom ID field.                                                                                                                                                                                                   |
 
 ## Access to Mongoose models
 

--- a/docs/database/mongodb.mdx
+++ b/docs/database/mongodb.mdx
@@ -40,6 +40,7 @@ export default buildConfig({
 | `transactionOptions`       | An object with configuration properties used in [transactions](https://www.mongodb.com/docs/manual/core/transactions/) or `false` which will disable the use of transactions.                                                                                                                                |
 | `collation`                | Enable language-specific string comparison with customizable options. Available on MongoDB 3.4+. Defaults locale to "en". Example: `{ strength: 3 }`. For a full list of collation options and their definitions, see the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/collation/). |
 | `allowAdditionalKeys`      | By default, Payload strips all additional keys from MongoDB data that don't exist in the Payload schema. If you have some data that you want to include to the result but it doesn't exist in Payload, you can set this to `true`. Be careful as Payload access control _won't_ work for this data.          |
+| `acceptIDOnCreate`         | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                                                                                                                                                 |
 
 ## Access to Mongoose models
 

--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -79,7 +79,7 @@ export default buildConfig({
 | `beforeSchemaInit`          | Drizzle schema hook. Runs before the schema is built. [More Details](#beforeschemainit)                                                                                          |
 | `afterSchemaInit`           | Drizzle schema hook. Runs after the schema is built. [More Details](#afterschemainit)                                                                                            |
 | `generateSchemaOutputFile`  | Override generated schema from `payload generate:db-schema` file path. Defaults to `{CWD}/src/payload-generated.schema.ts`                                                       |
-| `acceptIDOnCreate`          | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                     |
+| `allowIDOnCreate`           | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                     |
 
 ## Access to Drizzle
 

--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -79,6 +79,7 @@ export default buildConfig({
 | `beforeSchemaInit`          | Drizzle schema hook. Runs before the schema is built. [More Details](#beforeschemainit)                                                                                          |
 | `afterSchemaInit`           | Drizzle schema hook. Runs after the schema is built. [More Details](#afterschemainit)                                                                                            |
 | `generateSchemaOutputFile`  | Override generated schema from `payload generate:db-schema` file path. Defaults to `{CWD}/src/payload-generated.schema.ts`                                                       |
+| `acceptIDOnCreate`          | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                     |
 
 ## Access to Drizzle
 

--- a/docs/database/postgres.mdx
+++ b/docs/database/postgres.mdx
@@ -79,7 +79,7 @@ export default buildConfig({
 | `beforeSchemaInit`          | Drizzle schema hook. Runs before the schema is built. [More Details](#beforeschemainit)                                                                                          |
 | `afterSchemaInit`           | Drizzle schema hook. Runs after the schema is built. [More Details](#afterschemainit)                                                                                            |
 | `generateSchemaOutputFile`  | Override generated schema from `payload generate:db-schema` file path. Defaults to `{CWD}/src/payload-generated.schema.ts`                                                       |
-| `allowIDOnCreate`           | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                     |
+| `allowIDOnCreate`           | Set to `true` to use the `id` passed in data on the create API operations without using a custom ID field.                                                                       |
 
 ## Access to Drizzle
 

--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -49,7 +49,7 @@ export default buildConfig({
 | `afterSchemaInit`          | Drizzle schema hook. Runs after the schema is built. [More Details](#afterschemainit)                                                                                            |
 | `generateSchemaOutputFile` | Override generated schema from `payload generate:db-schema` file path. Defaults to `{CWD}/src/payload-generated.schema.ts`                                                       |
 | `autoIncrement`            | Pass `true` to enable SQLite [AUTOINCREMENT](https://www.sqlite.org/autoinc.html) for primary keys to ensure the same ID cannot be reused from deleted rows                      |
-| `acceptIDOnCreate`         | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                     |
+| `allowIDOnCreate`          | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                     |
 
 ## Access to Drizzle
 

--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -49,7 +49,7 @@ export default buildConfig({
 | `afterSchemaInit`          | Drizzle schema hook. Runs after the schema is built. [More Details](#afterschemainit)                                                                                            |
 | `generateSchemaOutputFile` | Override generated schema from `payload generate:db-schema` file path. Defaults to `{CWD}/src/payload-generated.schema.ts`                                                       |
 | `autoIncrement`            | Pass `true` to enable SQLite [AUTOINCREMENT](https://www.sqlite.org/autoinc.html) for primary keys to ensure the same ID cannot be reused from deleted rows                      |
-| `allowIDOnCreate`          | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                     |
+| `allowIDOnCreate`          | Set to `true` to use the `id` passed in data on the create API operations without using a custom ID field.                                                                       |
 
 ## Access to Drizzle
 

--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -49,6 +49,7 @@ export default buildConfig({
 | `afterSchemaInit`          | Drizzle schema hook. Runs after the schema is built. [More Details](#afterschemainit)                                                                                            |
 | `generateSchemaOutputFile` | Override generated schema from `payload generate:db-schema` file path. Defaults to `{CWD}/src/payload-generated.schema.ts`                                                       |
 | `autoIncrement`            | Pass `true` to enable SQLite [AUTOINCREMENT](https://www.sqlite.org/autoinc.html) for primary keys to ensure the same ID cannot be reused from deleted rows                      |
+| `acceptIDOnCreate`         | Enable this flag if you want to thread your own ID to create operation data without using a custom ID field.                                                                     |
 
 ## Access to Drizzle
 

--- a/packages/db-mongodb/src/create.ts
+++ b/packages/db-mongodb/src/create.ts
@@ -30,7 +30,7 @@ export const create: Create = async function create(
 
   if (customIDType) {
     data._id = data.id
-  } else if (this.acceptIDOnCreate && data.id) {
+  } else if (this.allowIDOnCreate && data.id) {
     try {
       data._id = new Types.ObjectId(data.id as string)
     } catch (error) {

--- a/packages/db-mongodb/src/create.ts
+++ b/packages/db-mongodb/src/create.ts
@@ -1,5 +1,6 @@
-import type { CreateOptions } from 'mongoose'
 import type { Create } from 'payload'
+
+import { type CreateOptions, Types } from 'mongoose'
 
 import type { MongooseAdapter } from './index.js'
 
@@ -29,6 +30,15 @@ export const create: Create = async function create(
 
   if (customIDType) {
     data._id = data.id
+  } else if (this.acceptIDOnCreate && data.id) {
+    try {
+      data._id = new Types.ObjectId(data.id as string)
+    } catch (error) {
+      this.payload.logger.error(
+        `It appears you passed ID to create operation data but it cannot be sanitized to ObjectID, value - ${JSON.stringify(data.id)}`,
+      )
+      throw error
+    }
   }
 
   try {

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -63,6 +63,16 @@ import { upsert } from './upsert.js'
 export type { MigrateDownArgs, MigrateUpArgs } from './types.js'
 
 export interface Args {
+  /**
+   * Enable this flag if you want to thread your own ID to create operation data, for example:
+   * ```ts
+   * import { Types } from 'mongoose'
+   *
+   * const id = new Types.ObjectId().toHexString()
+   * const doc = await payload.create({ collection: 'posts', data: {id, title: "my title"}})
+   * assertEq(doc.id, id)
+   * ```
+   */
   acceptIDOnCreate?: boolean
   /**
    * By default, Payload strips all additional keys from MongoDB data that don't exist

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -63,6 +63,7 @@ import { upsert } from './upsert.js'
 export type { MigrateDownArgs, MigrateUpArgs } from './types.js'
 
 export interface Args {
+  acceptIDOnCreate?: boolean
   /**
    * By default, Payload strips all additional keys from MongoDB data that don't exist
    * in the Payload schema. If you have some data that you want to include to the result
@@ -72,6 +73,7 @@ export interface Args {
   allowAdditionalKeys?: boolean
   /** Set to false to disable auto-pluralization of collection names, Defaults to true */
   autoPluralization?: boolean
+
   /**
    * If enabled, collation allows for language-specific rules for string comparison.
    * This configuration can include the following options:
@@ -98,7 +100,6 @@ export interface Args {
   collation?: Omit<CollationOptions, 'locale'>
 
   collectionsSchemaOptions?: Partial<Record<CollectionSlug, SchemaOptions>>
-
   /** Extra configuration options */
   connectOptions?: {
     /**
@@ -182,6 +183,7 @@ declare module 'payload' {
 }
 
 export function mongooseAdapter({
+  acceptIDOnCreate = false,
   allowAdditionalKeys = false,
   autoPluralization = true,
   collectionsSchemaOptions = {},
@@ -219,6 +221,7 @@ export function mongooseAdapter({
       url,
       versions: {},
       // DatabaseAdapter
+      acceptIDOnCreate,
       allowAdditionalKeys,
       beginTransaction: transactionOptions === false ? defaultBeginTransaction() : beginTransaction,
       collectionsSchemaOptions,

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -272,6 +272,7 @@ export function mongooseAdapter({
   }
 
   return {
+    allowIDOnCreate,
     defaultIDType: 'text',
     init: adapter,
   }

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -64,6 +64,13 @@ export type { MigrateDownArgs, MigrateUpArgs } from './types.js'
 
 export interface Args {
   /**
+   * By default, Payload strips all additional keys from MongoDB data that don't exist
+   * in the Payload schema. If you have some data that you want to include to the result
+   * but it doesn't exist in Payload, you can enable this flag
+   * @default false
+   */
+  allowAdditionalKeys?: boolean
+  /**
    * Enable this flag if you want to thread your own ID to create operation data, for example:
    * ```ts
    * import { Types } from 'mongoose'
@@ -73,14 +80,7 @@ export interface Args {
    * assertEq(doc.id, id)
    * ```
    */
-  acceptIDOnCreate?: boolean
-  /**
-   * By default, Payload strips all additional keys from MongoDB data that don't exist
-   * in the Payload schema. If you have some data that you want to include to the result
-   * but it doesn't exist in Payload, you can enable this flag
-   * @default false
-   */
-  allowAdditionalKeys?: boolean
+  allowIDOnCreate?: boolean
   /** Set to false to disable auto-pluralization of collection names, Defaults to true */
   autoPluralization?: boolean
 
@@ -193,8 +193,8 @@ declare module 'payload' {
 }
 
 export function mongooseAdapter({
-  acceptIDOnCreate = false,
   allowAdditionalKeys = false,
+  allowIDOnCreate = false,
   autoPluralization = true,
   collectionsSchemaOptions = {},
   connectOptions,
@@ -231,8 +231,8 @@ export function mongooseAdapter({
       url,
       versions: {},
       // DatabaseAdapter
-      acceptIDOnCreate,
       allowAdditionalKeys,
+      allowIDOnCreate,
       beginTransaction: transactionOptions === false ? defaultBeginTransaction() : beginTransaction,
       collectionsSchemaOptions,
       commitTransaction,

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -157,10 +157,8 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       countVersions,
       create,
       createGlobal,
-      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       createGlobalVersion,
       createJSONQuery,
-      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       createVersion,
       defaultIDType: payloadIDType,
       deleteMany,
@@ -198,11 +196,9 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       resolveInitializing,
       rollbackTransaction,
       updateGlobal,
-      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       updateGlobalVersion,
       updateMany,
       updateOne,
-      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       updateVersion,
       upsert: updateOne,
     })

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -64,6 +64,7 @@ const filename = fileURLToPath(import.meta.url)
 export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter> {
   const postgresIDType = args.idType || 'serial'
   const payloadIDType = postgresIDType === 'serial' ? 'number' : 'text'
+  const allowIDOnCreate = args.allowIDOnCreate ?? false
 
   function adapter({ payload }: { payload: Payload }) {
     const migrationDir = findMigrationDir(args.migrationDir)
@@ -94,7 +95,7 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
     return createDatabaseAdapter<PostgresAdapter>({
       name: 'postgres',
       afterSchemaInit: args.afterSchemaInit ?? [],
-      allowIDOnCreate: args.allowIDOnCreate ?? false,
+      allowIDOnCreate,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,
       createExtensions,
@@ -205,6 +206,7 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
   }
 
   return {
+    allowIDOnCreate,
     defaultIDType: payloadIDType,
     init: adapter,
   }

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -93,8 +93,8 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
 
     return createDatabaseAdapter<PostgresAdapter>({
       name: 'postgres',
-      acceptIDOnCreate: args.acceptIDOnCreate ?? false,
       afterSchemaInit: args.afterSchemaInit ?? [],
+      allowIDOnCreate: args.allowIDOnCreate ?? false,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,
       createExtensions,

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -93,6 +93,7 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
 
     return createDatabaseAdapter<PostgresAdapter>({
       name: 'postgres',
+      acceptIDOnCreate: args.acceptIDOnCreate ?? false,
       afterSchemaInit: args.afterSchemaInit ?? [],
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,
@@ -156,8 +157,10 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       countVersions,
       create,
       createGlobal,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       createGlobalVersion,
       createJSONQuery,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       createVersion,
       defaultIDType: payloadIDType,
       deleteMany,
@@ -195,9 +198,11 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
       resolveInitializing,
       rollbackTransaction,
       updateGlobal,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       updateGlobalVersion,
       updateMany,
       updateOne,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       updateVersion,
       upsert: updateOne,
     })

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -14,19 +14,19 @@ import type { Pool, PoolConfig } from 'pg'
 
 export type Args = {
   /**
+   * Transform the schema after it's built.
+   * You can use it to customize the schema with features that aren't supported by Payload.
+   * Examples may include: composite indices, generated columns, vectors
+   */
+  afterSchemaInit?: PostgresSchemaHook[]
+  /**
    * Enable this flag if you want to thread your own ID to create operation data, for example:
    * ```ts
    * // doc created with id 1
    * const doc = await payload.create({ collection: 'posts', data: {id: 1, title: "my title"}})
    * ```
    */
-  acceptIDOnCreate?: boolean
-  /**
-   * Transform the schema after it's built.
-   * You can use it to customize the schema with features that aren't supported by Payload.
-   * Examples may include: composite indices, generated columns, vectors
-   */
-  afterSchemaInit?: PostgresSchemaHook[]
+  allowIDOnCreate?: boolean
   /**
    * Transform the schema before it's built.
    * You can use it to preserve an existing database schema and if there are any collissions Payload will override them.

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -13,6 +13,7 @@ import type { PgSchema, PgTableFn, PgTransactionConfig } from 'drizzle-orm/pg-co
 import type { Pool, PoolConfig } from 'pg'
 
 export type Args = {
+  acceptIDOnCreate?: boolean
   /**
    * Transform the schema after it's built.
    * You can use it to customize the schema with features that aren't supported by Payload.

--- a/packages/db-postgres/src/types.ts
+++ b/packages/db-postgres/src/types.ts
@@ -13,6 +13,13 @@ import type { PgSchema, PgTableFn, PgTransactionConfig } from 'drizzle-orm/pg-co
 import type { Pool, PoolConfig } from 'pg'
 
 export type Args = {
+  /**
+   * Enable this flag if you want to thread your own ID to create operation data, for example:
+   * ```ts
+   * // doc created with id 1
+   * const doc = await payload.create({ collection: 'posts', data: {id: 1, title: "my title"}})
+   * ```
+   */
   acceptIDOnCreate?: boolean
   /**
    * Transform the schema after it's built.

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -87,8 +87,8 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
 
     return createDatabaseAdapter<SQLiteAdapter>({
       name: 'sqlite',
-      acceptIDOnCreate: args.acceptIDOnCreate ?? false,
       afterSchemaInit: args.afterSchemaInit ?? [],
+      allowIDOnCreate: args.allowIDOnCreate ?? false,
       autoIncrement: args.autoIncrement ?? false,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       client: undefined,

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -66,6 +66,7 @@ const filename = fileURLToPath(import.meta.url)
 export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
   const sqliteIDType = args.idType || 'number'
   const payloadIDType = sqliteIDType === 'uuid' ? 'text' : 'number'
+  const allowIDOnCreate = args.allowIDOnCreate ?? false
 
   function adapter({ payload }: { payload: Payload }) {
     const migrationDir = findMigrationDir(args.migrationDir)
@@ -88,7 +89,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
     return createDatabaseAdapter<SQLiteAdapter>({
       name: 'sqlite',
       afterSchemaInit: args.afterSchemaInit ?? [],
-      allowIDOnCreate: args.allowIDOnCreate ?? false,
+      allowIDOnCreate,
       autoIncrement: args.autoIncrement ?? false,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       client: undefined,
@@ -187,6 +188,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
   }
 
   return {
+    allowIDOnCreate,
     defaultIDType: payloadIDType,
     init: adapter,
   }

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -87,6 +87,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
 
     return createDatabaseAdapter<SQLiteAdapter>({
       name: 'sqlite',
+      acceptIDOnCreate: args.acceptIDOnCreate ?? false,
       afterSchemaInit: args.afterSchemaInit ?? [],
       autoIncrement: args.autoIncrement ?? false,
       beforeSchemaInit: args.beforeSchemaInit ?? [],

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -25,6 +25,7 @@ type SQLiteSchemaHookArgs = {
 export type SQLiteSchemaHook = (args: SQLiteSchemaHookArgs) => Promise<SQLiteSchema> | SQLiteSchema
 
 export type Args = {
+  acceptIDOnCreate?: boolean
   /**
    * Transform the schema after it's built.
    * You can use it to customize the schema with features that aren't supported by Payload.

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -25,6 +25,13 @@ type SQLiteSchemaHookArgs = {
 export type SQLiteSchemaHook = (args: SQLiteSchemaHookArgs) => Promise<SQLiteSchema> | SQLiteSchema
 
 export type Args = {
+  /**
+   * Enable this flag if you want to thread your own ID to create operation data, for example:
+   * ```ts
+   * // doc created with id 1
+   * const doc = await payload.create({ collection: 'posts', data: {id: 1, title: "my title"}})
+   * ```
+   */
   acceptIDOnCreate?: boolean
   /**
    * Transform the schema after it's built.

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -26,19 +26,19 @@ export type SQLiteSchemaHook = (args: SQLiteSchemaHookArgs) => Promise<SQLiteSch
 
 export type Args = {
   /**
+   * Transform the schema after it's built.
+   * You can use it to customize the schema with features that aren't supported by Payload.
+   * Examples may include: composite indices, generated columns, vectors
+   */
+  afterSchemaInit?: SQLiteSchemaHook[]
+  /**
    * Enable this flag if you want to thread your own ID to create operation data, for example:
    * ```ts
    * // doc created with id 1
    * const doc = await payload.create({ collection: 'posts', data: {id: 1, title: "my title"}})
    * ```
    */
-  acceptIDOnCreate?: boolean
-  /**
-   * Transform the schema after it's built.
-   * You can use it to customize the schema with features that aren't supported by Payload.
-   * Examples may include: composite indices, generated columns, vectors
-   */
-  afterSchemaInit?: SQLiteSchemaHook[]
+  allowIDOnCreate?: boolean
   /**
    * Enable [AUTOINCREMENT](https://www.sqlite.org/autoinc.html) for Primary Keys.
    * This ensures that the same ID cannot be reused from previously deleted rows.

--- a/packages/db-vercel-postgres/src/index.ts
+++ b/packages/db-vercel-postgres/src/index.ts
@@ -89,6 +89,7 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
 
     return createDatabaseAdapter<VercelPostgresAdapter>({
       name: 'postgres',
+      acceptIDOnCreate: args.acceptIDOnCreate ?? false,
       afterSchemaInit: args.afterSchemaInit ?? [],
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,

--- a/packages/db-vercel-postgres/src/index.ts
+++ b/packages/db-vercel-postgres/src/index.ts
@@ -89,8 +89,8 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
 
     return createDatabaseAdapter<VercelPostgresAdapter>({
       name: 'postgres',
-      acceptIDOnCreate: args.acceptIDOnCreate ?? false,
       afterSchemaInit: args.afterSchemaInit ?? [],
+      allowIDOnCreate: args.allowIDOnCreate ?? false,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,
       createExtensions,

--- a/packages/db-vercel-postgres/src/index.ts
+++ b/packages/db-vercel-postgres/src/index.ts
@@ -64,6 +64,7 @@ const filename = fileURLToPath(import.meta.url)
 export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<VercelPostgresAdapter> {
   const postgresIDType = args.idType || 'serial'
   const payloadIDType = postgresIDType === 'serial' ? 'number' : 'text'
+  const allowIDOnCreate = args.allowIDOnCreate ?? false
 
   function adapter({ payload }: { payload: Payload }) {
     const migrationDir = findMigrationDir(args.migrationDir)
@@ -90,7 +91,7 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
     return createDatabaseAdapter<VercelPostgresAdapter>({
       name: 'postgres',
       afterSchemaInit: args.afterSchemaInit ?? [],
-      allowIDOnCreate: args.allowIDOnCreate ?? false,
+      allowIDOnCreate,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       createDatabase,
       createExtensions,
@@ -196,6 +197,7 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
   }
 
   return {
+    allowIDOnCreate,
     defaultIDType: payloadIDType,
     init: adapter,
   }

--- a/packages/db-vercel-postgres/src/types.ts
+++ b/packages/db-vercel-postgres/src/types.ts
@@ -13,6 +13,13 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
 import type { PgSchema, PgTableFn, PgTransactionConfig } from 'drizzle-orm/pg-core'
 
 export type Args = {
+  /**
+   * Enable this flag if you want to thread your own ID to create operation data, for example:
+   * ```ts
+   * // doc created with id 1
+   * const doc = await payload.create({ collection: 'posts', data: {id: 1, title: "my title"}})
+   * ```
+   */
   acceptIDOnCreate?: boolean
   /**
    * Transform the schema after it's built.

--- a/packages/db-vercel-postgres/src/types.ts
+++ b/packages/db-vercel-postgres/src/types.ts
@@ -14,19 +14,19 @@ import type { PgSchema, PgTableFn, PgTransactionConfig } from 'drizzle-orm/pg-co
 
 export type Args = {
   /**
+   * Transform the schema after it's built.
+   * You can use it to customize the schema with features that aren't supported by Payload.
+   * Examples may include: composite indices, generated columns, vectors
+   */
+  afterSchemaInit?: PostgresSchemaHook[]
+  /**
    * Enable this flag if you want to thread your own ID to create operation data, for example:
    * ```ts
    * // doc created with id 1
    * const doc = await payload.create({ collection: 'posts', data: {id: 1, title: "my title"}})
    * ```
    */
-  acceptIDOnCreate?: boolean
-  /**
-   * Transform the schema after it's built.
-   * You can use it to customize the schema with features that aren't supported by Payload.
-   * Examples may include: composite indices, generated columns, vectors
-   */
-  afterSchemaInit?: PostgresSchemaHook[]
+  allowIDOnCreate?: boolean
   /**
    * Transform the schema before it's built.
    * You can use it to preserve an existing database schema and if there are any collissions Payload will override them.

--- a/packages/db-vercel-postgres/src/types.ts
+++ b/packages/db-vercel-postgres/src/types.ts
@@ -13,6 +13,7 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
 import type { PgSchema, PgTableFn, PgTransactionConfig } from 'drizzle-orm/pg-core'
 
 export type Args = {
+  acceptIDOnCreate?: boolean
   /**
    * Transform the schema after it's built.
    * You can use it to customize the schema with features that aren't supported by Payload.

--- a/packages/drizzle/src/create.ts
+++ b/packages/drizzle/src/create.ts
@@ -9,7 +9,7 @@ import { getTransaction } from './utilities/getTransaction.js'
 
 export const create: Create = async function create(
   this: DrizzleAdapter,
-  { collection: collectionSlug, data, req, select, returning },
+  { collection: collectionSlug, data, req, returning, select },
 ) {
   const db = await getTransaction(this, req)
   const collection = this.payload.collections[collectionSlug].config
@@ -21,11 +21,11 @@ export const create: Create = async function create(
     data,
     db,
     fields: collection.flattenedFields,
+    ignoreResult: returning === false,
     operation: 'create',
     req,
     select,
     tableName,
-    ignoreResult: returning === false,
   })
 
   if (returning === false) {

--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -66,6 +66,9 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
         })
       }
     } else {
+      if (adapter.acceptIDOnCreate && data.id) {
+        rowToInsert.row.id = data.id
+      }
       ;[insertedRow] = await adapter.insert({
         db,
         tableName,

--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -66,7 +66,7 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
         })
       }
     } else {
-      if (adapter.acceptIDOnCreate && data.id) {
+      if (adapter.allowIDOnCreate && data.id) {
         rowToInsert.row.id = data.id
       }
       ;[insertedRow] = await adapter.insert({

--- a/packages/graphql/src/schema/initCollections.ts
+++ b/packages/graphql/src/schema/initCollections.ts
@@ -145,10 +145,25 @@ export function initCollections({ config, graphqlResult }: InitCollectionsGraphQ
       })
     }
 
+    let mutationCreateInputFields = mutationInputFields
+
+    if (
+      config.db.allowIDOnCreate &&
+      !collectionConfig.flattenedFields.some((field) => field.name === 'id')
+    ) {
+      mutationCreateInputFields = [
+        ...mutationCreateInputFields,
+        {
+          name: 'id',
+          type: config.db.defaultIDType,
+        } as Field,
+      ]
+    }
+
     const createMutationInputType = buildMutationInputType({
       name: singularName,
       config,
-      fields: mutationInputFields,
+      fields: mutationCreateInputFields,
       graphqlResult,
       parentIsLocalized: false,
       parentName: singularName,

--- a/packages/payload/src/database/createDatabaseAdapter.ts
+++ b/packages/payload/src/database/createDatabaseAdapter.ts
@@ -15,13 +15,14 @@ import { migrateRefresh } from './migrations/migrateRefresh.js'
 import { migrateReset } from './migrations/migrateReset.js'
 import { migrateStatus } from './migrations/migrateStatus.js'
 
-const beginTransaction: BeginTransaction = async () => null
-const rollbackTransaction: RollbackTransaction = async () => null
-const commitTransaction: CommitTransaction = async () => null
+const beginTransaction: BeginTransaction = () => Promise.resolve(null)
+const rollbackTransaction: RollbackTransaction = () => Promise.resolve(null)
+const commitTransaction: CommitTransaction = () => Promise.resolve(null)
 
 export function createDatabaseAdapter<T extends BaseDatabaseAdapter>(
   args: MarkOptional<
     T,
+    | 'acceptIDOnCreate'
     | 'createMigration'
     | 'migrate'
     | 'migrateDown'
@@ -39,14 +40,13 @@ export function createDatabaseAdapter<T extends BaseDatabaseAdapter>(
     createMigration,
     migrate,
     migrateDown,
-    migrateFresh: async ({ forceAcceptWarning = null }) => null,
+    migrateFresh: () => Promise.resolve(null),
     migrateRefresh,
     migrateReset,
     migrateStatus,
     rollbackTransaction,
 
     ...args,
-
     // Ensure migrationDir is set
     migrationDir: args.migrationDir || 'migrations',
   } as T

--- a/packages/payload/src/database/createDatabaseAdapter.ts
+++ b/packages/payload/src/database/createDatabaseAdapter.ts
@@ -22,7 +22,7 @@ const commitTransaction: CommitTransaction = () => Promise.resolve(null)
 export function createDatabaseAdapter<T extends BaseDatabaseAdapter>(
   args: MarkOptional<
     T,
-    | 'acceptIDOnCreate'
+    | 'allowIDOnCreate'
     | 'createMigration'
     | 'migrate'
     | 'migrateDown'

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -14,11 +14,13 @@ import type { TypeWithVersion } from '../versions/types.js'
 export type { TypeWithVersion }
 
 export interface BaseDatabaseAdapter {
+  acceptIDOnCreate?: boolean
   /**
    * Start a transaction, requiring commitTransaction() to be called for any changes to be made.
    * @returns an identifier for the transaction or null if one cannot be established
    */
   beginTransaction: BeginTransaction
+
   /**
    * Persist the changes made since the start of the transaction.
    */
@@ -28,16 +30,16 @@ export interface BaseDatabaseAdapter {
    * Open the connection to the database
    */
   connect?: Connect
-
   count: Count
   countGlobalVersions: CountGlobalVersions
+
   countVersions: CountVersions
 
   create: Create
 
   createGlobal: CreateGlobal
-
   createGlobalVersion: CreateGlobalVersion
+
   /**
    * Output a migration file
    */
@@ -53,8 +55,8 @@ export interface BaseDatabaseAdapter {
   deleteMany: DeleteMany
 
   deleteOne: DeleteOne
-
   deleteVersions: DeleteVersions
+
   /**
    * Terminate the connection with the database
    */
@@ -86,16 +88,15 @@ export interface BaseDatabaseAdapter {
    * Run any migration down functions that have been performed
    */
   migrateDown: () => Promise<void>
-
   /**
    * Drop the current database and run all migrate up functions
    */
   migrateFresh: (args: { forceAcceptWarning?: boolean }) => Promise<void>
+
   /**
    * Run all migration down functions before running up
    */
   migrateRefresh: () => Promise<void>
-
   /**
    * Run all migrate down functions
    */
@@ -108,6 +109,7 @@ export interface BaseDatabaseAdapter {
    * Path to read and write migration files from
    */
   migrationDir: string
+
   /**
    * The name of the database adapter
    */
@@ -119,12 +121,12 @@ export interface BaseDatabaseAdapter {
    * @example @payloadcms/db-postgres
    */
   packageName: string
-
   /**
    * reference to the instance of payload
    */
   payload: Payload
   queryDrafts: QueryDrafts
+
   /**
    * Abort any changes since the start of the transaction.
    */
@@ -150,7 +152,6 @@ export interface BaseDatabaseAdapter {
   updateOne: UpdateOne
 
   updateVersion: UpdateVersion
-
   upsert: Upsert
 }
 

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -14,7 +14,7 @@ import type { TypeWithVersion } from '../versions/types.js'
 export type { TypeWithVersion }
 
 export interface BaseDatabaseAdapter {
-  acceptIDOnCreate?: boolean
+  allowIDOnCreate?: boolean
   /**
    * Start a transaction, requiring commitTransaction() to be called for any changes to be made.
    * @returns an identifier for the transaction or null if one cannot be established

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -608,6 +608,7 @@ export type PaginatedDocs<T = any> = {
 }
 
 export type DatabaseAdapterResult<T = BaseDatabaseAdapter> = {
+  allowIDOnCreate?: boolean
   defaultIDType: 'number' | 'text'
   init: (args: { payload: Payload }) => T
 }

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -83,7 +83,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {
     menu: Menu;
@@ -123,7 +123,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: number;
+  id: string;
   title?: string | null;
   content?: {
     root: {
@@ -148,7 +148,7 @@ export interface Post {
  * via the `definition` "media".
  */
 export interface Media {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -192,7 +192,7 @@ export interface Media {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -209,24 +209,24 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'posts';
-        value: number | Post;
+        value: string | Post;
       } | null)
     | ({
         relationTo: 'media';
-        value: number | Media;
+        value: string | Media;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -236,10 +236,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -259,7 +259,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -378,7 +378,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "menu".
  */
 export interface Menu {
-  id: number;
+  id: string;
   globalText?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -1837,7 +1837,7 @@ describe('database', () => {
   })
 
   it('accepts ID on create', async () => {
-    payload.db.acceptIDOnCreate = true
+    payload.db.allowIDOnCreate = true
     let id: any = null
     if (payload.db.name === 'mongoose') {
       id = new mongoose.Types.ObjectId().toHexString()
@@ -1850,6 +1850,6 @@ describe('database', () => {
     const post = await payload.create({ collection: 'posts', data: { id, title: 'created' } })
 
     expect(post.id).toBe(id)
-    payload.db.acceptIDOnCreate = false
+    payload.db.allowIDOnCreate = false
   })
 })

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -12,7 +12,7 @@ import { type Table } from 'drizzle-orm'
 import * as drizzlePg from 'drizzle-orm/pg-core'
 import * as drizzleSqlite from 'drizzle-orm/sqlite-core'
 import fs from 'fs'
-import { Types } from 'mongoose'
+import mongoose, { Types } from 'mongoose'
 import path from 'path'
 import {
   commitTransaction,
@@ -1834,5 +1834,22 @@ describe('database', () => {
     expect(payloadRes.arrayWithIDs[0].additionalKeyInArray).toBe('true')
 
     payload.db.allowAdditionalKeys = false
+  })
+
+  it('accepts ID on create', async () => {
+    payload.db.acceptIDOnCreate = true
+    let id: any = null
+    if (payload.db.name === 'mongoose') {
+      id = new mongoose.Types.ObjectId().toHexString()
+    } else if (payload.db.idType === 'uuid') {
+      id = randomUUID()
+    } else {
+      id = 9999
+    }
+
+    const post = await payload.create({ collection: 'posts', data: { id, title: 'created' } })
+
+    expect(post.id).toBe(id)
+    payload.db.acceptIDOnCreate = false
   })
 })


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/6884

Adds a new flag `acceptIDOnCreate` that allows you to thread your own `id` to `payload.create` `data`, for example:

```ts
// doc created with id 1
const doc = await payload.create({ collection: 'posts', data: {id: 1, title: "my title"}})
```

```ts
import { Types } from 'mongoose'
const id = new Types.ObjectId().toHexString()
const doc = await payload.create({ collection: 'posts', data: {id, title: "my title"}})
```