### PR TITLE
fix(templates): align form fields order in editor link modal

### DIFF
--- a/templates/website/src/fields/defaultLexical.ts
+++ b/templates/website/src/fields/defaultLexical.ts
@@ -18,29 +18,26 @@ export const defaultLexical = lexicalEditor({
     LinkFeature({
       enabledCollections: ['pages', 'posts'],
       fields: ({ defaultFields }) => {
-        const defaultFieldsWithoutUrl = defaultFields.filter((field) => {
-          if ('name' in field && field.name === 'url') return false
-          return true
+        return defaultFields.map((field) => {
+          if (!('name' in field && field.name === 'url')) {
+            return {
+              name: 'url',
+              type: 'text',
+              admin: {
+                condition: (_data, siblingData) => siblingData?.linkType !== 'internal',
+              },
+              label: ({ t }) => t('fields:enterURL'),
+              required: true,
+              validate: ((value, options) => {
+                if ((options?.siblingData as LinkFields)?.linkType === 'internal') {
+                  return true // no validation needed, as no url should exist for internal links
+                }
+                return value ? true : 'URL is required'
+              }) as TextFieldSingleValidation,
+            }
+          }
+          return field
         })
-
-        return [
-          ...defaultFieldsWithoutUrl,
-          {
-            name: 'url',
-            type: 'text',
-            admin: {
-              condition: (_data, siblingData) => siblingData?.linkType !== 'internal',
-            },
-            label: ({ t }) => t('fields:enterURL'),
-            required: true,
-            validate: ((value, options) => {
-              if ((options?.siblingData as LinkFields)?.linkType === 'internal') {
-                return true // no validation needed, as no url should exist for internal links
-              }
-              return value ? true : 'URL is required'
-            }) as TextFieldSingleValidation,
-          },
-        ]
       },
     }),
   ],


### PR DESCRIPTION
### What?

The order of `Open in new tab` checkbox & link swapped when changing Link Type as shown below:

<img width="941" alt="Screenshot 2025-03-15 at 4 31 46 AM" src="https://github.com/user-attachments/assets/07654767-d539-4a99-bd49-f856dbd4c120" />

<img width="941" alt="Screenshot 2025-03-15 at 4 31 51 AM" src="https://github.com/user-attachments/assets/24a7cce5-d8ad-4a2c-926a-0875e3ad1d32" />


### Why?

It isn't comfortable in UX when switching the link type

### How?

The checkbox field is discarded in the default fields, and the new link field is appended, so the order changes

Fixes #

use `map` instead of `filter` to preserve the order of fields