### PR TITLE
fix(templates): missing default value in select field

### DIFF
--- a/templates/website/src/blocks/Form/Select/index.tsx
+++ b/templates/website/src/blocks/Form/Select/index.tsx
@@ -20,7 +20,7 @@ export const Select: React.FC<
     control: Control
     errors: Partial<FieldErrorsImpl>
   }
-> = ({ name, control, errors, label, options, required, width }) => {
+> = ({ name, control, errors, label, options, required, width, defaultValue }) => {
   return (
     <Width width={width}>
       <Label htmlFor={name}>
@@ -33,7 +33,7 @@ export const Select: React.FC<
       </Label>
       <Controller
         control={control}
-        defaultValue=""
+        defaultValue={defaultValue}
         name={name}
         render={({ field: { onChange, value } }) => {
           const controlledValue = options.find((t) => t.value === value)


### PR DESCRIPTION
### What?
The default value is hardcoded instead of respecting the value filled in the form setting

Fixes #
pass it down from props