### PR TITLE
feat(ui): add beforeDocumentItems and afterDocumentItems components

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -191,13 +191,15 @@ export const MyCollection: CollectionCOnfig = {
 
 The following options are available:
 
-| Option            | Description                                                                                                                                                                                               |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SaveButton`      | Replace the default Save Button within the Edit View. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#save-button).                                          |
-| `SaveDraftButton` | Replace the default Save Draft Button within the Edit View. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#save-draft-button). |
-| `PublishButton`   | Replace the default Publish Button within the Edit View. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publish-button).                                     |
-| `PreviewButton`   | Replace the default Preview Button within the Edit View. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#preview-button).                                      |
-| `Upload`          | Replace the default Upload component within the Edit View. [Upload](../upload/overview) must be enabled. [More details](../custom-components/edit-view#upload).                                           |
+| Option                    | Description                                                                                                                                                                                               |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SaveButton`              | Replace the default Save Button within the Edit View. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#save-button).                                          |
+| `SaveDraftButton`         | Replace the default Save Draft Button within the Edit View. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#save-draft-button). |
+| `PublishButton`           | Replace the default Publish Button within the Edit View. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publish-button).                                     |
+| `PreviewButton`           | Replace the default Preview Button within the Edit View. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#preview-button).                                      |
+| `Upload`                  | Replace the default Upload component within the Edit View. [Upload](../upload/overview) must be enabled. [More details](../custom-components/edit-view#upload).                                           |
+| `beforeDocumentMenuItems` | An array of components to inject _before_ the built-in menu items within the Edit View. [More details](../custom-components/edit-view#before-document-menu-items).                                        |
+| `afterDocumentMenuItems`  | An array of components to inject _after_ the built-in menu items within the Edit View. [More details](../custom-components/edit-view#after-document-menu-items).                                          |
 
 <Banner type="success">
   **Note:** For details on how to build Custom Components, see [Building Custom

--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -179,12 +179,14 @@ export const MyGlobal: SanitizedGlobalConfig = {
 
 The following options are available:
 
-| Option            | Description                                                                                                                                                                                                  |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `SaveButton`      | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#save-button).                                          |
-| `SaveDraftButton` | Replace the default Save Draft Button with a Custom Component. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#save-draft-button). |
-| `PublishButton`   | Replace the default Publish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publish-button).                                     |
-| `PreviewButton`   | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#preview-button).                                      |
+| Option                    | Description                                                                                                                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SaveButton`              | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#save-button).                                          |
+| `SaveDraftButton`         | Replace the default Save Draft Button with a Custom Component. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#save-draft-button). |
+| `PublishButton`           | Replace the default Publish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publish-button).                                     |
+| `PreviewButton`           | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#preview-button).                                      |
+| `beforeDocumentMenuItems` | An array of components to inject _before_ the built-in menu items within the Edit View. [More details](../custom-components/edit-view#before-document-menu-items).                                           |
+| `afterDocumentMenuItems`  | An array of components to inject _after_ the built-in menu items within the Edit View. [More details](../custom-components/edit-view#after-document-menu-items).                                             |
 
 <Banner type="success">
   **Note:** For details on how to build Custom Components, see [Building Custom

--- a/docs/custom-components/edit-view.mdx
+++ b/docs/custom-components/edit-view.mdx
@@ -101,14 +101,16 @@ export const MyCollection: CollectionConfig = {
 
 The following options are available:
 
-| Path              | Description                                                                            |
-| ----------------- | -------------------------------------------------------------------------------------- |
-| `SaveButton`      | A button that saves the current document. [More details](#SaveButton).                 |
-| `SaveDraftButton` | A button that saves the current document as a draft. [More details](#SaveDraftButton). |
-| `PublishButton`   | A button that publishes the current document. [More details](#PublishButton).          |
-| `PreviewButton`   | A button that previews the current document. [More details](#PreviewButton).           |
-| `Description`     | A description of the Collection. [More details](#Description).                         |
-| `Upload`          | A file upload component. [More details](#Upload).                                      |
+| Path                      | Description                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `SaveButton`              | A button that saves the current document. [More details](#SaveButton).                                       |
+| `SaveDraftButton`         | A button that saves the current document as a draft. [More details](#SaveDraftButton).                       |
+| `PublishButton`           | A button that publishes the current document. [More details](#PublishButton).                                |
+| `PreviewButton`           | A button that previews the current document. [More details](#PreviewButton).                                 |
+| `Description`             | A description of the Collection. [More details](#Description).                                               |
+| `Upload`                  | A file upload component. [More details](#Upload).                                                            |
+| `beforeDocumentMenuItems` | An array of components to inject _before_ the built-in menu items. [More details](#BeforeDocumentMenuItems). |
+| `afterDocumentMenuItems`  | An array of components to inject _after_ the built-in menu items. [More details](#AfterDocumentMenuItems).   |
 
 #### Globals
 
@@ -133,13 +135,15 @@ export const MyGlobal: GlobalConfig = {
 
 The following options are available:
 
-| Path              | Description                                                                            |
-| ----------------- | -------------------------------------------------------------------------------------- |
-| `SaveButton`      | A button that saves the current document. [More details](#SaveButton).                 |
-| `SaveDraftButton` | A button that saves the current document as a draft. [More details](#SaveDraftButton). |
-| `PublishButton`   | A button that publishes the current document. [More details](#PublishButton).          |
-| `PreviewButton`   | A button that previews the current document. [More details](#PreviewButton).           |
-| `Description`     | A description of the Global. [More details](#Description).                             |
+| Path                      | Description                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `SaveButton`              | A button that saves the current document. [More details](#SaveButton).                                       |
+| `SaveDraftButton`         | A button that saves the current document as a draft. [More details](#SaveDraftButton).                       |
+| `PublishButton`           | A button that publishes the current document. [More details](#PublishButton).                                |
+| `PreviewButton`           | A button that previews the current document. [More details](#PreviewButton).                                 |
+| `Description`             | A description of the Global. [More details](#Description).                                                   |
+| `beforeDocumentMenuItems` | An array of components to inject _before_ the built-in menu items. [More details](#BeforeDocumentMenuItems). |
+| `afterDocumentMenuItems`  | An array of components to inject _after_ the built-in menu items. [More details](#AfterDocumentMenuItems).   |
 
 ### SaveButton
 
@@ -426,5 +430,111 @@ import React from 'react'
 
 export function MyUploadComponent() {
   return <input type="file" />
+}
+```
+
+### BeforeDocumentMenuItems
+
+The `beforeDocumentMenuItems` property allows you to render an array of custom components before the built-in menu items.
+
+To add `beforeDocumentMenuItems` components, use the `components.edit.beforeDocumentMenuItems` property in your [Collection Config](../configuration/collections) or `components.elements.beforeDocumentMenuItems` in your [Global Config](../configuration/globals):
+
+```ts
+import type { CollectionConfig } from 'payload'
+
+export const MyCollection: CollectionConfig = {
+  // ...
+  admin: {
+    components: {
+      edit: {
+        // highlight-start
+        beforeDocumentMenuItems: [
+          '/path/to/MyBeforeDocumentMenuItemsComponent',
+        ],
+        // highlight-end
+      },
+    },
+  },
+}
+```
+
+Here's an example of a custom `beforeDocumentMenuItems` component:
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import type { BeforeDocumentMenuItemsServerProps } from 'payload'
+
+export function MyBeforeDocumentMenuItemsComponent(
+  props: BeforeDocumentMenuItemsServerProps,
+) {
+  return <div>This is a custom beforeDocumentMenuItems component (Server)</div>
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import type { BeforeDocumentMenuItemsClientProps } from 'payload'
+
+export function MyBeforeDocumentMenuItemsComponent(
+  props: BeforeDocumentMenuItemsClientProps,
+) {
+  return <div>This is a custom beforeDocumentMenuItems component (Client)</div>
+}
+```
+
+### AfterDocumentMenuItems
+
+The `afterDocumentMenuItems` property allows you to render an array of custom components before the built-in menu items.
+
+To add `afterDocumentMenuItems` components, use the `components.edit.afterDocumentMenuItems` property in your [Collection Config](../configuration/collections) or `components.elements.afterDocumentMenuItems` in your [Global Config](../configuration/globals):
+
+```ts
+import type { CollectionConfig } from 'payload'
+
+export const MyCollection: CollectionConfig = {
+  // ...
+  admin: {
+    components: {
+      edit: {
+        // highlight-start
+        afterDocumentMenuItems: ['/path/to/MyAfterDocumentMenuItemsComponent'],
+        // highlight-end
+      },
+    },
+  },
+}
+```
+
+Here's an example of a custom `afterDocumentMenuItems` component:
+
+#### Server Component
+
+```tsx
+import React from 'react'
+import type { AfterDocumentMenuItemsServerProps } from 'payload'
+
+export function MyAfterDocumentMenuItemsComponent(
+  props: AfterDocumentMenuItemsServerProps,
+) {
+  return <div>This is a custom afterDocumentMenuItems component (Server)</div>
+}
+```
+
+#### Client Component
+
+```tsx
+'use client'
+import React from 'react'
+import type { BeforeDocumentMenuItemsClientProps } from 'payload'
+
+export function MyAfterDocumentMenuItemsComponent(
+  props: AfterDocumentMenuItemsClientProps,
+) {
+  return <div>This is a custom afterDocumentMenuItems component (Client)</div>
 }
 ```

--- a/packages/next/src/views/Document/renderDocumentSlots.tsx
+++ b/packages/next/src/views/Document/renderDocumentSlots.tsx
@@ -1,4 +1,6 @@
 import type {
+  AfterDocumentMenuItemsServerPropsOnly,
+  BeforeDocumentMenuItemsServerPropsOnly,
   DefaultServerFunctionArgs,
   DocumentSlots,
   PayloadRequest,
@@ -78,6 +80,30 @@ export const renderDocumentSlots: (args: {
       Fallback: ViewDescription,
       importMap: req.payload.importMap,
       serverProps: serverProps satisfies ViewDescriptionServerPropsOnly,
+    })
+  }
+
+  const customBeforeDocumentMenuItems =
+    collectionConfig?.admin?.components?.edit?.beforeDocumentMenuItems ||
+    globalConfig?.admin?.components?.elements?.beforeDocumentMenuItems
+
+  if (customBeforeDocumentMenuItems) {
+    components.BeforeDocumentMenuItems = RenderServerComponent({
+      Component: customBeforeDocumentMenuItems,
+      importMap: req.payload.importMap,
+      serverProps: serverProps satisfies BeforeDocumentMenuItemsServerPropsOnly,
+    })
+  }
+
+  const customAfterDocumentMenuItems =
+    collectionConfig?.admin?.components?.edit?.afterDocumentMenuItems ||
+    globalConfig?.admin?.components?.elements?.afterDocumentMenuItems
+
+  if (customAfterDocumentMenuItems) {
+    components.AfterDocumentMenuItems = RenderServerComponent({
+      Component: customAfterDocumentMenuItems,
+      importMap: req.payload.importMap,
+      serverProps: serverProps satisfies AfterDocumentMenuItemsServerPropsOnly,
     })
   }
 

--- a/packages/next/src/views/LivePreview/index.client.tsx
+++ b/packages/next/src/views/LivePreview/index.client.tsx
@@ -71,6 +71,8 @@ const getAbsoluteUrl = (url) => {
 }
 
 const PreviewView: React.FC<Props> = ({
+  AfterDocumentMenuItems,
+  BeforeDocumentMenuItems,
   collectionConfig,
   config,
   Description,
@@ -495,6 +497,8 @@ const PreviewView: React.FC<Props> = ({
         <DocumentControls
           apiURL={apiURL}
           customComponents={{
+            AfterDocumentMenuItems,
+            BeforeDocumentMenuItems,
             PreviewButton,
             PublishButton,
             SaveButton,
@@ -603,7 +607,9 @@ export const LivePreviewClient: React.FC<
         url={url}
       >
         <PreviewView
+          AfterDocumentMenuItems={props.AfterDocumentMenuItems}
           apiRoute={apiRoute}
+          BeforeDocumentMenuItems={props.BeforeDocumentMenuItems}
           collectionConfig={collectionConfig}
           config={config}
           Description={props.Description}

--- a/packages/payload/src/admin/elements/AfterDocumentMenuItems.ts
+++ b/packages/payload/src/admin/elements/AfterDocumentMenuItems.ts
@@ -1,0 +1,8 @@
+import type { ServerProps } from '../../config/types.js'
+
+export type AfterDocumentMenuItemsClientProps = {}
+
+export type AfterDocumentMenuItemsServerPropsOnly = {} & ServerProps
+
+export type AfterDocumentMenuItemsServerProps = AfterDocumentMenuItemsClientProps &
+  AfterDocumentMenuItemsServerPropsOnly

--- a/packages/payload/src/admin/elements/BeforeDocumentMenuItems.ts
+++ b/packages/payload/src/admin/elements/BeforeDocumentMenuItems.ts
@@ -1,0 +1,8 @@
+import type { ServerProps } from '../../config/types.js'
+
+export type BeforeDocumentMenuItemsClientProps = {}
+
+export type BeforeDocumentMenuItemsServerPropsOnly = {} & ServerProps
+
+export type BeforeDocumentMenuItemsServerProps = BeforeDocumentMenuItemsClientProps &
+  BeforeDocumentMenuItemsServerPropsOnly

--- a/packages/payload/src/admin/types.ts
+++ b/packages/payload/src/admin/types.ts
@@ -50,6 +50,16 @@ export type {
    */
   CustomComponent as CustomSaveDraftButton,
 } from '../config/types.js'
+export type {
+  AfterDocumentMenuItemsClientProps,
+  AfterDocumentMenuItemsServerProps,
+  AfterDocumentMenuItemsServerPropsOnly,
+} from './elements/AfterDocumentMenuItems.js'
+export type {
+  BeforeDocumentMenuItemsClientProps,
+  BeforeDocumentMenuItemsServerProps,
+  BeforeDocumentMenuItemsServerPropsOnly,
+} from './elements/BeforeDocumentMenuItems.js'
 export type { DefaultCellComponentProps, DefaultServerCellComponentProps } from './elements/Cell.js'
 export type { ConditionalDateProps } from './elements/DatePicker.js'
 export type { DayPickerProps, SharedProps, TimePickerProps } from './elements/DatePicker.js'
@@ -553,6 +563,8 @@ export type FieldRow = {
 }
 
 export type DocumentSlots = {
+  AfterDocumentMenuItems?: React.ReactNode
+  BeforeDocumentMenuItems?: React.ReactNode
   Description?: React.ReactNode
   PreviewButton?: React.ReactNode
   PublishButton?: React.ReactNode

--- a/packages/payload/src/bin/generateImportMap/iterateCollections.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateCollections.ts
@@ -36,6 +36,8 @@ export function iterateCollections({
     addToImportMap(collection.admin?.components?.beforeListTable)
     addToImportMap(collection.admin?.components?.Description)
 
+    addToImportMap(collection.admin?.components?.edit?.afterDocumentMenuItems)
+    addToImportMap(collection.admin?.components?.edit?.beforeDocumentMenuItems)
     addToImportMap(collection.admin?.components?.edit?.PreviewButton)
     addToImportMap(collection.admin?.components?.edit?.PublishButton)
     addToImportMap(collection.admin?.components?.edit?.SaveButton)

--- a/packages/payload/src/bin/generateImportMap/iterateGlobals.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateGlobals.ts
@@ -29,6 +29,8 @@ export function iterateGlobals({
       imports,
     })
 
+    addToImportMap(global.admin?.components?.elements?.afterDocumentMenuItems)
+    addToImportMap(global.admin?.components?.elements?.beforeDocumentMenuItems)
     addToImportMap(global.admin?.components?.elements?.Description)
     addToImportMap(global.admin?.components?.elements?.PreviewButton)
     addToImportMap(global.admin?.components?.elements?.PublishButton)

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -279,6 +279,8 @@ export type CollectionAdminOptions = {
      * Components within the edit view
      */
     edit?: {
+      afterDocumentMenuItems?: CustomComponent[]
+      beforeDocumentMenuItems?: CustomComponent[]
       /**
        * Replaces the "Preview" button
        */

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../admin/types.js'
 import type {
   Access,
+  CustomComponent,
   EditConfig,
   Endpoint,
   EntityDescription,
@@ -80,6 +81,8 @@ export type GlobalAdminOptions = {
    */
   components?: {
     elements?: {
+      afterDocumentMenuItems?: CustomComponent[]
+      beforeDocumentMenuItems?: CustomComponent[]
       Description?: EntityDescriptionComponent
       /**
        * Replaces the "Preview" button

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -42,6 +42,8 @@ const baseClass = 'collection-edit'
 // When rendered within a drawer, props are empty
 // This is solely to support custom edit views which get server-rendered
 export function DefaultEditView({
+  AfterDocumentMenuItems,
+  BeforeDocumentMenuItems,
   Description,
   PreviewButton,
   PublishButton,
@@ -509,6 +511,8 @@ export function DefaultEditView({
           <DocumentControls
             apiURL={apiURL}
             customComponents={{
+              AfterDocumentMenuItems,
+              BeforeDocumentMenuItems,
               PreviewButton,
               PublishButton,
               SaveButton,

--- a/test/admin/collections/Posts.ts
+++ b/test/admin/collections/Posts.ts
@@ -69,6 +69,24 @@ export const Posts: CollectionConfig = {
           },
         },
       ],
+      edit: {
+        beforeDocumentMenuItems: [
+          {
+            path: '/components/Banner/index.js#Banner',
+            clientProps: {
+              message: 'BeforeDocumentMenuItems custom component',
+            },
+          },
+        ],
+        afterDocumentMenuItems: [
+          {
+            path: '/components/Banner/index.js#Banner',
+            clientProps: {
+              message: 'AfterDocumentMenuItems custom component',
+            },
+          },
+        ],
+      },
     },
     pagination: {
       defaultLimit: 5,

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -326,6 +326,56 @@ describe('Document View', () => {
       await expect(docTab).toContainText('Custom Tab Component')
       await expect(title).toContainText('Custom View With Tab Component')
     })
+
+    test('collection - should render custom beforeDocumentMenuItems component', async () => {
+      const { id } = await createPost()
+      await page.goto(postsUrl.edit(id))
+
+      await page.locator('.doc-controls__popup .popup-button').click()
+
+      await expect(
+        page.locator('.doc-controls__popup .popup__content').locator('div', {
+          hasText: exactText('BeforeDocumentMenuItems custom component'),
+        }),
+      ).toBeVisible()
+    })
+
+    test('collection - should render custom afterDocumentMenuItems component', async () => {
+      const { id } = await createPost()
+      await page.goto(postsUrl.edit(id))
+
+      await page.locator('.doc-controls__popup .popup-button').click()
+
+      await expect(
+        page.locator('.doc-controls__popup .popup__content').locator('div', {
+          hasText: exactText('AfterDocumentMenuItems custom component'),
+        }),
+      ).toBeVisible()
+    })
+
+    test('global - should render custom beforeDocumentMenuItems component', async () => {
+      await page.goto(globalURL.global(globalSlug))
+
+      await page.locator('.doc-controls__popup .popup-button').click()
+
+      await expect(
+        page.locator('.doc-controls__popup .popup__content').locator('div', {
+          hasText: exactText('BeforeDocumentMenuItems custom component'),
+        }),
+      ).toBeVisible()
+    })
+
+    test('global - should render custom afterDocumentMenuItems component', async () => {
+      await page.goto(globalURL.global(globalSlug))
+
+      await page.locator('.doc-controls__popup .popup-button').click()
+
+      await expect(
+        page.locator('.doc-controls__popup .popup__content').locator('div', {
+          hasText: exactText('AfterDocumentMenuItems custom component'),
+        }),
+      ).toBeVisible()
+    })
   })
 
   describe('drawers', () => {

--- a/test/admin/globals/Global.ts
+++ b/test/admin/globals/Global.ts
@@ -16,6 +16,24 @@ export const Global: GlobalConfig = {
           },
         },
       },
+      elements: {
+        beforeDocumentMenuItems: [
+          {
+            path: '/components/Banner/index.js#Banner',
+            clientProps: {
+              message: 'BeforeDocumentMenuItems custom component',
+            },
+          },
+        ],
+        afterDocumentMenuItems: [
+          {
+            path: '/components/Banner/index.js#Banner',
+            clientProps: {
+              message: 'AfterDocumentMenuItems custom component',
+            },
+          },
+        ],
+      },
     },
     group: 'Group',
     preview: () => 'https://payloadcms.com',


### PR DESCRIPTION
## What?

 - Adds `components.edit.beforeDocumentMenuItems` and `components.edit.afterDocumentMenuItems` to collection edit view custom components.
 - Adds `components.elements.beforeDocumentMenuItems` and `components.elements.afterDocumentMenuItems` to global edit view custom components.

![document-menu-items](https://github.com/user-attachments/assets/64b8ebf0-1f62-4264-a4d7-8b387833a256)

Some decisions were made for this feature that are open to suggestion and change:

- Naming (I've opted for `documentMenuItems` as it closely resembles the related `listMenuItems`).
- If custom components are available, the dot menu will be rendered on all screens, including the collection edit view, collection create view and the global edit view. It will be up to the developer to disable the custom components on certain screens as needed.

## Why?

Allows custom document menu items to be placed in the same area as the defaults (e.g. soft delete, restore).

