### PR TITLE
fix: support multiple instances of the s3Storage plugin with client uploads enabled

### DIFF
--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -111,7 +111,7 @@ export const s3Storage: S3StoragePlugin =
         getStorageClient,
       }),
       // Prevent colliding of multiple s3Storage plugin instances with client uploads enabled.
-      serverHandlerPath: `/storage-s3-generate-signed-url/${Math.random().toString(36).substring(2, 15)}`
+      serverHandlerPath: `/storage-s3-generate-signed-url-${Math.random().toString(36).substring(2, 15)}`
     })
 
     if (isPluginDisabled) {

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -110,7 +110,8 @@ export const s3Storage: S3StoragePlugin =
         collections: s3StorageOptions.collections,
         getStorageClient,
       }),
-      serverHandlerPath: '/storage-s3-generate-signed-url',
+      // Prevent colliding of multiple s3Storage plugin instances with client uploads enabled.
+      serverHandlerPath: `/storage-s3-generate-signed-url/${Math.random().toString(36).substring(2, 15)}`
     })
 
     if (isPluginDisabled) {


### PR DESCRIPTION
Fixes #11729

### What?

This is a small fix that allows multiple instances of the s3Storage() plugin to use client uploads. 

### Why?

Having multiple instances is currently the only way of using different buckets for different upload collections. Different buckets are needed as soon as you need different permissions, backup or storage type configurations for your different buckets. Someone already posted the question https://github.com/payloadcms/payload/discussions/9399 with no alternative solutions so I assume other people are using multiple instances of the storage plugin for the same reason.

Currently, every instance binds its handler that generates the s3 presigned URL to the same URL: `/storage-s3-generate-signed-url`. This causes only the first instance to work and the instances defined after to break.

More info and a MRE can be found in the attached issue.

### How?

Since every instance bind its handler to the same URL path, having a different path per instance allows all of them to live in harmony. In this PR I add a random string to the path but I understand that you would like to see different solution that uses more descriptive data from the storage config for example. 

```ts
initClientUploads({
    clientHandler: '@payloadcms/storage-s3/client#S3ClientUploadHandler',
    collections: s3StorageOptions.collections,
    config: incomingConfig,
    enabled: !isPluginDisabled && Boolean(s3StorageOptions.clientUploads),
    serverHandler: getGenerateSignedURLHandler({
      access:
        typeof s3StorageOptions.clientUploads === 'object'
          ? s3StorageOptions.clientUploads.access
          : undefined,
      acl: s3StorageOptions.acl,
      bucket: s3StorageOptions.bucket,
      collections: s3StorageOptions.collections,
      getStorageClient,
    }),
    // Prevent colliding of multiple s3Storage plugin instances with client uploads enabled.
    serverHandlerPath: `/storage-s3-generate-signed-url-${Math.random().toString(36).substring(2, 15)}`
})
```