### PR TITLE
feat(next): add support for custom props on the html element

### DIFF
--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -31,7 +31,7 @@ export const RootLayout = async ({
   readonly config: Promise<SanitizedConfig>
   readonly importMap: ImportMap
   readonly serverFunction: ServerFunctionClient
-  readonly htmlProps?: Omit<React.DetailedHTMLProps<React.HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement>, 'suppressHydrationWarning' | 'lang' | 'dir'>
+  readonly htmlProps?: React.HtmlHTMLAttributes<HTMLHtmlElement>
 }) => {
   checkDependencies()
 

--- a/packages/next/src/layouts/Root/index.tsx
+++ b/packages/next/src/layouts/Root/index.tsx
@@ -25,11 +25,13 @@ export const RootLayout = async ({
   config: configPromise,
   importMap,
   serverFunction,
+  htmlProps = {},
 }: {
   readonly children: React.ReactNode
   readonly config: Promise<SanitizedConfig>
   readonly importMap: ImportMap
   readonly serverFunction: ServerFunctionClient
+  readonly htmlProps?: Omit<React.DetailedHTMLProps<React.HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement>, 'suppressHydrationWarning' | 'lang' | 'dir'>
 }) => {
   checkDependencies()
 
@@ -105,6 +107,7 @@ export const RootLayout = async ({
       dir={dir}
       lang={languageCode}
       suppressHydrationWarning={config?.admin?.suppressHydrationWarning ?? false}
+      {...htmlProps}
     >
       <head>
         <style>{`@layer payload-default, payload;`}</style>


### PR DESCRIPTION
This PR adds support for passing additional props to the HTML element of Next.js `RootLayout`.  

#### Context  
In our setup, we use several custom Chakra UI components. This change enables us to add a custom font `className` to the HTML element, following the official Chakra UI documentation:  
[Using custom fonts in Chakra UI with Next.js](https://v2.chakra-ui.com/getting-started/nextjs-app-guide#using-custom-font)

#### Example Usage  
With this update, we can now pass a `className` for custom fonts like this:  

```tsx
import { Rubik } from 'next/font/google'

const rubik = Rubik({
  subsets: ['latin'],
  variable: '--font-rubik',
})

const Layout = ({ children }: Args) => {
  return (
    <RootLayout htmlProps={{ className: rubik.variable }}>
      {children}
    </RootLayout>
  );
}
```
