### PR TITLE
templates: change postgres URIs

### DIFF
--- a/templates/with-postgres/.env.example
+++ b/templates/with-postgres/.env.example
@@ -1,2 +1,2 @@
-DATABASE_URI=postgresql://127.0.0.1:5432/your-database-name
+DATABASE_URI=postgres://postgres:<password>@127.0.0.1:5432/your-database-name
 PAYLOAD_SECRET=YOUR_SECRET_HERE

--- a/templates/with-vercel-postgres/.env.example
+++ b/templates/with-vercel-postgres/.env.example
@@ -1,2 +1,2 @@
-POSTGRES_URL=postgresql://127.0.0.1:5432/your-database-name
+POSTGRES_URL=postgres://postgres:<password>@127.0.0.1:5432/your-database-name
 PAYLOAD_SECRET=YOUR_SECRET_HERE


### PR DESCRIPTION
### What?

Changed values in .env.example files within postgres templates

### Why?

I was playing around with the postgres examples that are output from the create-payload cli. I was getting a database error around a role when trying to run the with-postgres template

### How?

The cli with the blank option generated a DATABASE_URI like my changes and that did not have the role error so I have copied that value over to the relevant .env.example files
