### PR TITLE
fix(storage-gcs): return error status 404 on file not found instead of 500

### DIFF
--- a/packages/storage-gcs/src/staticHandler.ts
+++ b/packages/storage-gcs/src/staticHandler.ts
@@ -1,7 +1,7 @@
-import type { Storage } from '@google-cloud/storage'
 import type { StaticHandler } from '@payloadcms/plugin-cloud-storage/types'
 import type { CollectionConfig } from 'payload'
 
+import { ApiError, type Storage } from '@google-cloud/storage'
 import { getFilePrefix } from '@payloadcms/plugin-cloud-storage/utilities'
 import path from 'path'
 
@@ -58,6 +58,9 @@ export const getHandler = ({ bucket, collection, getStorageClient }: Args): Stat
         status: 200,
       })
     } catch (err: unknown) {
+      if (err instanceof ApiError && err.code === 404) {
+        return new Response(null, { status: 404, statusText: 'Not Found' })
+      }
       req.payload.logger.error(err)
       return new Response('Internal Server Error', { status: 500 })
     }


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
In a similar vein to #11734, #11733, #10327 - this PR returns a 404 in the response when a file is not found while using the `storage-gcs` adapter. Currently a 500 is returned.

### Why?
To return the correct error level in the response when a file is not found when using `storage-gcs`.

### How?
The GCS nodejs library exposes the `ApiError` as a general error - these changes check that the caught error is an instance of this class and if the provided code is a `404`.