### PR TITLE
fix(richtext-lexical): unchecked list items were rendered as checked in html converter

### DIFF
--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/converters/list.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/async/converters/list.ts
@@ -37,7 +37,7 @@ export const ListHTMLConverterAsync: HTMLConvertersAsync<
           ${
             hasSubLists
               ? children
-              : `<input checked="${node.checked}" id="${uuid}" readOnly="true" type="checkbox" />
+              : `<input${node.checked ? ' checked' : ''} id="${uuid}" readOnly="true" type="checkbox" />
             <label htmlFor="${uuid}">${children}</label>
             <br />`
           }

--- a/packages/richtext-lexical/src/features/converters/lexicalToHtml/sync/converters/list.ts
+++ b/packages/richtext-lexical/src/features/converters/lexicalToHtml/sync/converters/list.ts
@@ -31,7 +31,7 @@ export const ListHTMLConverter: HTMLConverters<SerializedListItemNode | Serializ
           ${
             hasSubLists
               ? children
-              : `<input checked="${node.checked}" id="${uuid}" readOnly="true" type="checkbox" />
+              : `<input${node.checked ? ' checked' : ''} id="${uuid}" readOnly="true" type="checkbox" />
             <label htmlFor="${uuid}">${children}</label>
             <br />`
           }


### PR DESCRIPTION
Previously, unchecked list items had the `checked="false"` attribute, which is not valid in HTML and renders them as checked. 

This PR omits the `checked` attribute if the list item is unchecked, which is the correct behavior.