### PR TITLE
fix(plugin-multi-tenant): ensures redirect route is correctly formatted

### DIFF
--- a/packages/plugin-multi-tenant/src/components/GlobalViewRedirect/index.ts
+++ b/packages/plugin-multi-tenant/src/components/GlobalViewRedirect/index.ts
@@ -6,6 +6,7 @@ import { redirect } from 'next/navigation.js'
 import { getGlobalViewRedirect } from '../../utilities/getGlobalViewRedirect.js'
 
 type Args = {
+  basePath?: string
   collectionSlug: CollectionSlug
   docID?: number | string
   globalSlugs: string[]
@@ -21,6 +22,7 @@ export const GlobalViewRedirect = async (args: Args) => {
     const headers = await getHeaders()
     const redirectRoute = await getGlobalViewRedirect({
       slug: collectionSlug,
+      basePath: args.basePath,
       docID: args.docID,
       headers,
       payload: args.payload,

--- a/packages/plugin-multi-tenant/src/defaults.ts
+++ b/packages/plugin-multi-tenant/src/defaults.ts
@@ -1,4 +1,5 @@
 export const defaults = {
+  basePath: undefined,
   tenantCollectionSlug: 'tenants',
   tenantFieldName: 'tenant',
   tenantsArrayFieldName: 'tenants',

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -38,6 +38,7 @@ export const multiTenantPlugin =
     const tenantsArrayTenantFieldName =
       pluginConfig?.tenantsArrayField?.arrayTenantFieldName || defaults.tenantsArrayTenantFieldName
     const tenantSelectorLabel = pluginConfig.tenantSelectorLabel || defaults.tenantSelectorLabel
+    const basePath = pluginConfig.basePath || defaults.basePath
 
     /**
      * Add defaults for admin properties
@@ -320,6 +321,7 @@ export const multiTenantPlugin =
       incomingConfig.admin.components.actions.push({
         path: '@payloadcms/plugin-multi-tenant/rsc#GlobalViewRedirect',
         serverProps: {
+          basePath,
           globalSlugs: globalCollectionSlugs,
           tenantFieldName,
           tenantsCollectionSlug,

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -3,6 +3,14 @@ import type { ArrayField, CollectionSlug, Field, RelationshipField, User } from 
 
 export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   /**
+   * Base path for your application
+   *
+   * https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath
+   *
+   * @default undefined
+   */
+  basePath?: string
+  /**
    * After a tenant is deleted, the plugin will attempt to clean up related documents
    * - removing documents with the tenant ID
    * - removing the tenant from users

--- a/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
@@ -7,6 +7,7 @@ import { getCollectionIDType } from './getCollectionIDType.js'
 import { getTenantFromCookie } from './getTenantFromCookie.js'
 
 type Args = {
+  basePath?: string
   docID?: number | string
   headers: Headers
   payload: Payload
@@ -19,6 +20,7 @@ type Args = {
 }
 export async function getGlobalViewRedirect({
   slug,
+  basePath,
   docID,
   headers,
   payload,
@@ -91,6 +93,7 @@ export async function getGlobalViewRedirect({
   if (redirectRoute) {
     return formatAdminURL({
       adminRoute: payload.config.routes.admin,
+      basePath,
       path: redirectRoute,
       serverURL: payload.config.serverURL,
     })

--- a/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
@@ -1,5 +1,7 @@
 import type { Payload, User, ViewTypes } from 'payload'
 
+import { formatAdminURL } from 'payload/shared'
+
 import { findTenantOptions } from '../queries/findTenantOptions.js'
 import { getCollectionIDType } from './getCollectionIDType.js'
 import { getTenantFromCookie } from './getTenantFromCookie.js'
@@ -31,7 +33,7 @@ export async function getGlobalViewRedirect({
     payload,
   })
   let tenant = getTenantFromCookie(headers, idType)
-  let redirectRoute
+  let redirectRoute: `/${string}` | void = undefined
 
   if (!tenant) {
     const tenantsQuery = await findTenantOptions({
@@ -65,18 +67,18 @@ export async function getGlobalViewRedirect({
     if (view === 'document') {
       if (docID && !tenantDocID) {
         // viewing a document with an id but does not match the selected tenant, redirect to create route
-        redirectRoute = `${payload.config.routes.admin}/collections/${slug}/create`
+        redirectRoute = `/collections/${slug}/create`
       } else if (tenantDocID && docID !== tenantDocID) {
         // tenant document already exists but does not match current route doc ID, redirect to matching tenant doc
-        redirectRoute = `${payload.config.routes.admin}/collections/${slug}/${tenantDocID}`
+        redirectRoute = `/collections/${slug}/${tenantDocID}`
       }
     } else if (view === 'list') {
       if (tenantDocID) {
         // tenant document exists, redirect to edit view
-        redirectRoute = `${payload.config.routes.admin}/collections/${slug}/${tenantDocID}`
+        redirectRoute = `/collections/${slug}/${tenantDocID}`
       } else {
         // tenant document does not exist, redirect to create route
-        redirectRoute = `${payload.config.routes.admin}/collections/${slug}/create`
+        redirectRoute = `/collections/${slug}/create`
       }
     }
   } catch (e: unknown) {
@@ -85,5 +87,14 @@ export async function getGlobalViewRedirect({
       `${typeof e === 'object' && e && 'message' in e ? `e?.message - ` : ''}Multi Tenant Redirect Error`,
     )
   }
-  return redirectRoute
+
+  if (redirectRoute) {
+    return formatAdminURL({
+      adminRoute: payload.config.routes.admin,
+      path: redirectRoute,
+      serverURL: payload.config.serverURL,
+    })
+  }
+
+  return undefined
 }


### PR DESCRIPTION
### What?
Incorrect redirect route when admin route is `/`.

### How?
Now the plugin formats the entire redirect safely using the helper function `formatAdminURL` from payload.

Fixes https://github.com/payloadcms/payload/issues/11697