### PR TITLE
fix(plugin-import-export): export with draft true

### DIFF
--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -10,6 +10,7 @@ import { getSelect } from './getSelect.js'
 
 type Export = {
   collectionSlug: string
+  drafts?: 'no' | 'yes'
   exportsCollection: string
   fields?: string[]
   format: 'csv' | 'json'
@@ -41,6 +42,7 @@ export const createExport = async (args: CreateExportArgs) => {
       id,
       name: nameArg,
       collectionSlug,
+      drafts,
       exportsCollection,
       fields,
       format,
@@ -64,11 +66,12 @@ export const createExport = async (args: CreateExportArgs) => {
   const findArgs = {
     collection: collectionSlug,
     depth: 0,
+    draft: drafts === 'yes',
     limit: 100,
     locale,
     overrideAccess: false,
     page: 0,
-    select: fields ? getSelect(fields) : undefined,
+    select: Array.isArray(fields) && fields.length > 0 ? getSelect(fields) : undefined,
     sort,
     user,
     where,

--- a/packages/plugin-import-export/src/export/getFields.ts
+++ b/packages/plugin-import-export/src/export/getFields.ts
@@ -97,16 +97,16 @@ export const getFields = (config: Config): Field[] => {
                 },
                 width: '33%',
               },
-              defaultValue: 'true',
+              defaultValue: 'yes',
               label: 'Drafts',
               options: [
                 {
-                  label: 'True',
-                  value: 'true',
+                  label: 'Yes',
+                  value: 'yes',
                 },
                 {
-                  label: 'False',
-                  value: 'false',
+                  label: 'No',
+                  value: 'no',
                 },
               ],
             },

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -54,6 +54,7 @@ export type SupportedTimezones =
   | 'Asia/Singapore'
   | 'Asia/Tokyo'
   | 'Asia/Seoul'
+  | 'Australia/Brisbane'
   | 'Australia/Sydney'
   | 'Pacific/Guam'
   | 'Pacific/Noumea'


### PR DESCRIPTION
### What?

- GraphQL was broken because of an error with the enum for the drafts input which cannot be 'true'.
- Selecting Draft was not doing anything as it wasn't being passed through to the find arguments.

### Why?

This was causing any graphql calls to error.

### How?

- Changed draft options to Yes/No instead of True/False
- Correctly pass the drafts arg to `draft`

Fixes #
