### PR TITLE
docs: fix links to locked document docs

### DIFF
--- a/docs/admin/react-hooks.mdx
+++ b/docs/admin/react-hooks.mdx
@@ -718,7 +718,7 @@ The `useDocumentInfo` hook provides information about the current document being
 | **`currentEditor`**                | The user currently editing the document.                                                                                                         |
 | **`docConfig`**                    | Either the Collection or Global config of the document, depending on what is being edited.                                                       |
 | **`docPermissions`**               | The current document's permissions. Fallback to collection permissions when no id is present.                                                    |
-| **`documentIsLocked`**             | Whether the document is currently locked by another user. More details](./locked-documents).                                                     |
+| **`documentIsLocked`**             | Whether the document is currently locked by another user. [More details](./locked-documents).                                                     |
 | **`getDocPermissions`**            | Method to retrieve document-level permissions.                                                                                                   |
 | **`getDocPreferences`**            | Method to retrieve document-level user preferences. [More details](./preferences).                                                               |
 | **`globalSlug`**                   | The slug of the global if editing a global document.                                                                                             |
@@ -730,7 +730,7 @@ The `useDocumentInfo` hook provides information about the current document being
 | **`initialData`**                  | The initial data of the document.                                                                                                                |
 | **`isEditing`**                    | Whether the document is being edited (as opposed to created).                                                                                    |
 | **`isInitializing`**               | Whether the document info is still initializing.                                                                                                 |
-| **`isLocked`**                     | Whether the document is locked. More details](./locked-documents).                                                                               |
+| **`isLocked`**                     | Whether the document is locked. [More details](./locked-documents).                                                                               |
 | **`lastUpdateTime`**               | Timestamp of the last update to the document.                                                                                                    |
 | **`mostRecentVersionIsAutosaved`** | Whether the most recent version is an autosaved version.                                                                                         |
 | **`preferencesKey`**               | The `preferences` key to use when interacting with document-level user preferences. [More details](./preferences).                               |
@@ -739,9 +739,9 @@ The `useDocumentInfo` hook provides information about the current document being
 | **`setDocumentTitle`**             | Method to set the document title.                                                                                                                |
 | **`setHasPublishedDoc`**           | Method to update whether the document has been published.                                                                                        |
 | **`title`**                        | The title of the document.                                                                                                                       |
-| **`unlockDocument`**               | Method to unlock a document. More details](./locked-documents).                                                                                  |
+| **`unlockDocument`**               | Method to unlock a document. [More details](./locked-documents).                                                                                  |
 | **`unpublishedVersionCount`**      | The number of unpublished versions of the document.                                                                                              |
-| **`updateDocumentEditor`**         | Method to update who is currently editing the document. More details](./locked-documents).                                                       |
+| **`updateDocumentEditor`**         | Method to update who is currently editing the document. [More details](./locked-documents).                                                       |
 | **`updateSavedDocumentData`**      | Method to update the saved document data.                                                                                                        |
 | **`uploadStatus`**                 | Status of any uploads in progress ('idle', 'uploading', or 'failed').                                                                            |
 | **`versionCount`**                 | The current version count of the document.                                                                                                       |


### PR DESCRIPTION
Follow-up fixing my copy-paste mistake introduced in #11686.
