### PR TITLE
fix(richtext-lexical): error in admin panel when block collapsed preference is not an array

### DIFF
--- a/packages/richtext-lexical/src/utilities/buildInitialState.ts
+++ b/packages/richtext-lexical/src/utilities/buildInitialState.ts
@@ -96,7 +96,7 @@ export async function buildInitialState({
       if (node.type === 'block') {
         const currentFieldPreferences = context.preferences?.fields?.[context.field.name]
         const collapsedArray = currentFieldPreferences?.collapsed
-        if (collapsedArray && collapsedArray.includes(id)) {
+        if (Array.isArray(collapsedArray) && collapsedArray.includes(id)) {
           initialState[id].collapsed = true
         }
       }


### PR DESCRIPTION
### What?

Got an error in the admin panel when opening a document with richtext and block. The error is:
`TypeError: collapsedArray.includes is not a function`

Screenshot of the error:
 
![collapsedArray_includes_error](https://github.com/user-attachments/assets/99c25810-0a10-4d23-a735-127edf7e87d6)

After reseting the preferences the error is gone. I did not take a copy of the database before using reset settings, so I'm not sure what the preferences where set to. So not sure how it got that way.

### Why?

Make the reading of preferences more robust against wrong data type to avoid error.

### How?

Make sure collapsedArray is actually an array before using it as such.
