### PR TITLE
chore(examples): add locale to revalidatePath in Pages hook

### DIFF
--- a/examples/localization/src/collections/Pages/hooks/revalidatePage.ts
+++ b/examples/localization/src/collections/Pages/hooks/revalidatePage.ts
@@ -7,10 +7,11 @@ import type { Page } from '../../../payload-types'
 export const revalidatePage: CollectionAfterChangeHook<Page> = ({
   doc,
   previousDoc,
-  req: { payload },
+  req: { payload, i18n },
 }) => {
+  const locale = i18n.language
   if (doc._status === 'published') {
-    const path = doc.slug === 'home' ? '/' : `/${doc.slug}`
+    const path = doc.slug === 'home' ? `/${locale}` : `/${locale}/${doc.slug}`
 
     payload.logger.info(`Revalidating page at path: ${path}`)
 
@@ -19,7 +20,7 @@ export const revalidatePage: CollectionAfterChangeHook<Page> = ({
 
   // If the page was previously published, we need to revalidate the old path
   if (previousDoc?._status === 'published' && doc._status !== 'published') {
-    const oldPath = previousDoc.slug === 'home' ? '/' : `/${previousDoc.slug}`
+    const oldPath = previousDoc.slug === 'home' ? `/${locale}` : `/${locale}/${previousDoc.slug}`
 
     payload.logger.info(`Revalidating old page at path: ${oldPath}`)
 

--- a/examples/localization/src/collections/Posts/hooks/revalidatePost.ts
+++ b/examples/localization/src/collections/Posts/hooks/revalidatePost.ts
@@ -7,10 +7,11 @@ import type { Post } from '../../../payload-types'
 export const revalidatePost: CollectionAfterChangeHook<Post> = ({
   doc,
   previousDoc,
-  req: { payload },
+  req: { payload, i18n },
 }) => {
+  const locale = i18n.language
   if (doc._status === 'published') {
-    const path = `/posts/${doc.slug}`
+    const path = `/${locale}/posts/${doc.slug}`
 
     payload.logger.info(`Revalidating post at path: ${path}`)
 
@@ -19,7 +20,7 @@ export const revalidatePost: CollectionAfterChangeHook<Post> = ({
 
   // If the post was previously published, we need to revalidate the old path
   if (previousDoc._status === 'published' && doc._status !== 'published') {
-    const oldPath = `/posts/${previousDoc.slug}`
+    const oldPath = `/${locale}/posts/${previousDoc.slug}`
 
     payload.logger.info(`Revalidating old post at path: ${oldPath}`)
 


### PR DESCRIPTION
### What?
In the localization example, changing the data in the admin panel does not update the public page.

### Why?
The afterChange hook revalidates the wrong path after page is changed.

### How?
The afterChange hook is revalidating "/[slug]" but it should in fact revalidate "/[locale]/[slug]"

Fixes #
Updated the path to include the locale before the slug.
