### PR TITLE
fix: save button styles in edit-many modal

### DIFF
--- a/packages/ui/src/elements/EditMany/index.scss
+++ b/packages/ui/src/elements/EditMany/index.scss
@@ -126,12 +126,11 @@
 
     &__document-actions {
       display: flex;
-      flex-wrap: wrap;
       padding: base(1);
       gap: base(0.5);
 
       .form-submit {
-        width: calc(50% - #{base(1)});
+        width: 100%;
 
         @include mid-break {
           width: auto;

--- a/packages/ui/src/elements/EditMany/index.scss
+++ b/packages/ui/src/elements/EditMany/index.scss
@@ -124,6 +124,19 @@
       }
     }
 
+    &__save {
+      width: calc(50% - #{base(1)});
+
+      @include mid-break {
+        width: 100%;
+      }
+    }
+
+    &__publish,
+    &__draft {
+      width: 100%;
+    }
+
     &__document-actions {
       display: flex;
       padding: base(1);
@@ -138,7 +151,6 @@
         }
 
         .btn {
-          width: 100%;
           padding-left: base(0.5);
           padding-right: base(0.5);
           margin-bottom: 0;


### PR DESCRIPTION
### What?

This PR updates the styles of the form submit buttons in the edit-many modal.

### Why?

Previously, the styles on the submit buttons caused a wrapping issue on the Publish Document button when editing many documents with versions enabled.

### How?

Adjusts the styles to prevent text wrapping of the Publish Document button

#### Before:
![Screenshot 2025-03-19 at 3 17 42 PM](https://github.com/user-attachments/assets/911b77c1-98ac-4b58-8f1f-026273af7550)


#### After:
![Screenshot 2025-03-19 at 3 18 13 PM](https://github.com/user-attachments/assets/efcfe543-1329-4ee7-8ebe-25352a9bf388)

