### PR TITLE
fix: add locale support to relationship filter options in WhereBuilder

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -10,6 +10,7 @@ import type { Props, ValueWithRelation } from './types.js'
 import { useDebounce } from '../../../../hooks/useDebounce.js'
 import { useEffectEvent } from '../../../../hooks/useEffectEvent.js'
 import { useConfig } from '../../../../providers/Config/index.js'
+import { useLocale } from '../../../../providers/Locale/index.js'
 import { useTranslation } from '../../../../providers/Translation/index.js'
 import { ReactSelect } from '../../../ReactSelect/index.js'
 import optionsReducer from './optionsReducer.js'
@@ -43,6 +44,7 @@ export const RelationshipFilter: React.FC<Props> = (props) => {
   const [errorLoading, setErrorLoading] = useState('')
   const [hasLoadedFirstOptions, setHasLoadedFirstOptions] = useState(false)
   const { i18n, t } = useTranslation()
+  const locale = useLocale()
 
   const relationSlugs = hasMultipleRelations ? relationTo : [relationTo]
 
@@ -98,6 +100,7 @@ export const RelationshipFilter: React.FC<Props> = (props) => {
         const query = {
           depth: 0,
           limit: maxResultsPerRequest,
+          locale: locale.code,
           page: loadedRelationship.nextPage,
           select: {
             [fieldToSearch]: true,


### PR DESCRIPTION
### What?

This PR fixes a bug in the relationship filter UI where no options are displayed when working in a non-default locale with localized collections. The query to fetch relationship options wasn't including the current locale parameter, causing the select dropdown to appear empty.

### Why?

When using localized collections with relationship fields:
1. If you create entries (e.g., Categories) only in a non-default locale
2. Set the global locale to that non-default locale
3. Try to filter another collection by its relationship to those Categories

The filter dropdown would be empty, despite Categories existing in that locale. This was happening because the `loadOptions` method in the RelationshipFilter component didn't include the current locale in its query.

### How?

The fix is implemented in `packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx` by:
1. Adding the `useLocale` hook to get the current locale in the RelationshipFilter component
2. Including this locale in the query parameters when fetching relationship options

![Before: Dropdown showing relationship options as empty options](https://github.com/user-attachments/assets/b796840b-9001-4f38-98c4-7b37ee4121d7)

![After: Dropdown properly showing relationship options in non-default locale](https://github.com/user-attachments/assets/a2f58d52-881e-49f7-b4dd-4b4ec7d07f10)

Fixes #11782 
Discussion: https://discord.com/channels/967097582721572934/1350888604150534164