### PR TITLE
feat(richtext-lexical): support escaping markdown characters

### DIFF
--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownExport.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownExport.ts
@@ -205,6 +205,12 @@ function exportTextFormat(
   // bring the whitespace back. So our returned string looks like this: "   **foo**   "
   const frozenString = textContent.trim()
   let output = frozenString
+
+  if (!node.hasFormat('code')) {
+    // Escape any markdown characters in the text content
+    output = output.replace(/([*_`~\\])/g, '\\$1')
+  }
+
   // the opening tags to be added to the result
   let openingTags = ''
   // the closing tags to be added to the result

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownImport.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownImport.ts
@@ -19,7 +19,6 @@ import {
   $getRoot,
   $getSelection,
   $isParagraphNode,
-  $isTextNode,
 } from 'lexical'
 
 import type {
@@ -212,15 +211,6 @@ function $importBlocks(
   }
 
   importTextTransformers(textNode, textFormatTransformersIndex, textMatchTransformers)
-
-  // Go through every text node in the element node and handle escape characters
-  for (const child of elementNode.getChildren()) {
-    if ($isTextNode(child)) {
-      const textContent = child.getTextContent()
-      const escapedText = textContent.replace(/\\([*_`~])/g, '$1')
-      child.setTextContent(escapedText)
-    }
-  }
 
   // If no transformer found and we left with original paragraph node
   // can check if its content can be appended to the previous node

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownImport.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/MarkdownImport.ts
@@ -282,6 +282,7 @@ function createTextFormatTransformersIndex(
     fullMatchRegExpByTag,
 
     // Regexp to locate *any* potential opening tag (longest first).
+    // eslint-disable-next-line regexp/no-useless-character-class, regexp/no-empty-capturing-group, regexp/no-empty-group
     openTagsRegExp: new RegExp(`${escapeRegExp}(${openTagsRegExp.join('|')})`, 'g'),
     transformersByTag,
   }

--- a/packages/richtext-lexical/src/packages/@lexical/markdown/importTextTransformers.ts
+++ b/packages/richtext-lexical/src/packages/@lexical/markdown/importTextTransformers.ts
@@ -78,7 +78,6 @@ export function importTextTransformers(
         textMatchTransformers,
       )
     }
-    return
   } else if (foundTextMatch) {
     const result = importFoundTextMatchTransformer(
       textNode,
@@ -112,9 +111,9 @@ export function importTextTransformers(
         textMatchTransformers,
       )
     }
-    return
-  } else {
-    // Done!
-    return
   }
+  // Handle escape characters
+  const textContent = textNode.getTextContent()
+  const escapedText = textContent.replace(/\\([*_`~])/g, '$1')
+  textNode.setTextContent(escapedText)
 }

--- a/test/lexical-mdx/tableJson.ts
+++ b/test/lexical-mdx/tableJson.ts
@@ -137,7 +137,7 @@ export const tableJson = {
                   format: 0,
                   mode: 'normal',
                   style: '',
-                  text: '         ',
+                  text: ' *         ',
                   type: 'text',
                   version: 1,
                 },

--- a/test/lexical-mdx/tests/default.test.ts
+++ b/test/lexical-mdx/tests/default.test.ts
@@ -1300,6 +1300,89 @@ Some line [Start of link
     },
   },
   {
+    input: `
+<Banner>
+  Some line [Text **bold** \\*normal\\*](/some/link)
+</Banner>
+`,
+    blockNode: {
+      fields: {
+        blockType: 'Banner',
+        content: {
+          root: {
+            children: [
+              {
+                children: [
+                  {
+                    detail: 0,
+                    format: 0,
+                    mode: 'normal',
+                    style: '',
+                    text: 'Some line ',
+                    type: 'text',
+                    version: 1,
+                  },
+                  {
+                    children: [
+                      {
+                        detail: 0,
+                        format: 0,
+                        mode: 'normal',
+                        style: '',
+                        text: 'Text ',
+                        type: 'text',
+                        version: 1,
+                      },
+                      {
+                        detail: 0,
+                        format: 1,
+                        mode: 'normal',
+                        style: '',
+                        text: 'bold',
+                        type: 'text',
+                        version: 1,
+                      },
+                      {
+                        detail: 0,
+                        format: 0,
+                        mode: 'normal',
+                        style: '',
+                        text: ' *normal*',
+                        type: 'text',
+                        version: 1,
+                      },
+                    ],
+                    fields: {
+                      linkType: 'custom',
+                      newTab: false,
+                      url: '/some/link',
+                    },
+                    format: '',
+                    indent: 0,
+                    type: 'link',
+                    version: 3,
+                  },
+                ],
+                direction: null,
+                format: '',
+                indent: 0,
+                textFormat: 0,
+                textStyle: '',
+                type: 'paragraph',
+                version: 1,
+              },
+            ],
+            direction: null,
+            format: '',
+            indent: 0,
+            type: 'root',
+            version: 1,
+          },
+        },
+      },
+    },
+  },
+  {
     inputAfterConvertFromEditorJSON: `
 <Banner>
   Text text [ Link ](/some/link) .

--- a/test/lexical-mdx/tests/default.test.ts
+++ b/test/lexical-mdx/tests/default.test.ts
@@ -376,13 +376,13 @@ there4
     input: `
 | Option            | Default route           | Description                                     |
 | ----------------- | ----------------------- | ----------------------------------------------- |
-| \`account\`         |                         | The user's account page.                        |
+| \`account\` \\*         |                         | The user's account page.                        |
 | \`createFirstUser\` | \`/create-first-user\`    | The page to create the first user.              |
 `,
     inputAfterConvertFromEditorJSON: `
 | Option            | Default route           | Description                                     |
 |---|---|---|
-| \`account\`         |                         | The user's account page.                        |
+| \`account\`  \\*         |                         | The user's account page.                        |
 | \`createFirstUser\` | \`/create-first-user\`    | The page to create the first user.              |
 `,
     rootChildren: [tableJson],
@@ -397,6 +397,19 @@ there4
       fields: {
         blockType: 'Banner',
         content: textToRichText('children text'),
+      },
+    },
+  },
+  {
+    input: `
+<Banner>
+  Escaped \\*
+</Banner>
+`,
+    blockNode: {
+      fields: {
+        blockType: 'Banner',
+        content: textToRichText('Escaped *'),
       },
     },
   },


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/10289 and https://github.com/payloadcms/payload/issues/11772

This adds support for escaping markdown characters. For example,` \*` is supposed to be imported as `*` and exported back to `\*`.

Equivalent PR in lexical repo: https://github.com/facebook/lexical/pull/7353