### PR TITLE
fix(db-postgres): ensure deletion of numbers and texts in upsertRow

### DIFF
--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -468,6 +468,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
     if (field.type === 'text' && field?.hasMany) {
       const textPathMatch = texts[`${sanitizedPath}${field.name}`]
       if (!textPathMatch) {
+        result[field.name] = []
         return result
       }
 
@@ -507,6 +508,7 @@ export const traverseFields = <T extends Record<string, unknown>>({
     if (field.type === 'number' && field.hasMany) {
       const numberPathMatch = numbers[`${sanitizedPath}${field.name}`]
       if (!numberPathMatch) {
+        result[field.name] = []
         return result
       }
 
@@ -686,8 +688,6 @@ export const traverseFields = <T extends Record<string, unknown>>({
     if (Object.keys(localizedFieldData).length > 0) {
       result[field.name] = localizedFieldData
     }
-
-    return result
 
     return result
   }, dataRef)

--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -90,6 +90,8 @@ export const traverseFields = <T extends Record<string, unknown>>({
   withinArrayOrBlockLocale,
 }: TraverseFieldsArgs): T => {
   const sanitizedPath = path ? `${path}.` : path
+  const localeCodes =
+    adapter.payload.config.localization && adapter.payload.config.localization.localeCodes
 
   const formatted = fields.reduce((result, field) => {
     if (fieldIsVirtual(field)) {
@@ -468,7 +470,10 @@ export const traverseFields = <T extends Record<string, unknown>>({
     if (field.type === 'text' && field?.hasMany) {
       const textPathMatch = texts[`${sanitizedPath}${field.name}`]
       if (!textPathMatch) {
-        result[field.name] = []
+        result[field.name] =
+          isLocalized && localeCodes
+            ? Object.fromEntries(localeCodes.map((locale) => [locale, []]))
+            : []
         return result
       }
 
@@ -508,7 +513,10 @@ export const traverseFields = <T extends Record<string, unknown>>({
     if (field.type === 'number' && field.hasMany) {
       const numberPathMatch = numbers[`${sanitizedPath}${field.name}`]
       if (!numberPathMatch) {
-        result[field.name] = []
+        result[field.name] =
+          isLocalized && localeCodes
+            ? Object.fromEntries(localeCodes.map((locale) => [locale, []]))
+            : []
         return result
       }
 
@@ -570,10 +578,8 @@ export const traverseFields = <T extends Record<string, unknown>>({
     }
 
     if (isLocalized && Array.isArray(table._locales)) {
-      if (!table._locales.length && adapter.payload.config.localization) {
-        adapter.payload.config.localization.localeCodes.forEach((_locale) =>
-          (table._locales as unknown[]).push({ _locale }),
-        )
+      if (!table._locales.length && localeCodes) {
+        localeCodes.forEach((_locale) => (table._locales as unknown[]).push({ _locale }))
       }
 
       table._locales.forEach((localeRow) => {

--- a/packages/drizzle/src/transform/write/array.ts
+++ b/packages/drizzle/src/transform/write/array.ts
@@ -3,7 +3,13 @@ import type { FlattenedArrayField } from 'payload'
 import { fieldShouldBeLocalized } from 'payload/shared'
 
 import type { DrizzleAdapter } from '../../types.js'
-import type { ArrayRowToInsert, BlockRowToInsert, RelationshipToDelete } from './types.js'
+import type {
+  ArrayRowToInsert,
+  BlockRowToInsert,
+  NumberToDelete,
+  RelationshipToDelete,
+  TextToDelete,
+} from './types.js'
 
 import { isArrayOfRows } from '../../utilities/isArrayOfRows.js'
 import { traverseFields } from './traverseFields.js'
@@ -20,6 +26,7 @@ type Args = {
   field: FlattenedArrayField
   locale?: string
   numbers: Record<string, unknown>[]
+  numbersToDelete: NumberToDelete[]
   parentIsLocalized: boolean
   path: string
   relationships: Record<string, unknown>[]
@@ -28,6 +35,7 @@ type Args = {
     [tableName: string]: Record<string, unknown>[]
   }
   texts: Record<string, unknown>[]
+  textsToDelete: TextToDelete[]
   /**
    * Set to a locale code if this set of fields is traversed within a
    * localized array or block field
@@ -45,12 +53,14 @@ export const transformArray = ({
   field,
   locale,
   numbers,
+  numbersToDelete,
   parentIsLocalized,
   path,
   relationships,
   relationshipsToDelete,
   selects,
   texts,
+  textsToDelete,
   withinArrayOrBlockLocale,
 }: Args) => {
   const newRows: ArrayRowToInsert[] = []
@@ -104,6 +114,7 @@ export const transformArray = ({
         insideArrayOrBlock: true,
         locales: newRow.locales,
         numbers,
+        numbersToDelete,
         parentIsLocalized: parentIsLocalized || field.localized,
         parentTableName: arrayTableName,
         path: `${path || ''}${field.name}.${i}.`,
@@ -112,6 +123,7 @@ export const transformArray = ({
         row: newRow.row,
         selects,
         texts,
+        textsToDelete,
         withinArrayOrBlockLocale,
       })
 

--- a/packages/drizzle/src/transform/write/blocks.ts
+++ b/packages/drizzle/src/transform/write/blocks.ts
@@ -4,7 +4,12 @@ import { fieldShouldBeLocalized } from 'payload/shared'
 import toSnakeCase from 'to-snake-case'
 
 import type { DrizzleAdapter } from '../../types.js'
-import type { BlockRowToInsert, RelationshipToDelete } from './types.js'
+import type {
+  BlockRowToInsert,
+  NumberToDelete,
+  RelationshipToDelete,
+  TextToDelete,
+} from './types.js'
 
 import { traverseFields } from './traverseFields.js'
 
@@ -19,6 +24,7 @@ type Args = {
   field: FlattenedBlocksField
   locale?: string
   numbers: Record<string, unknown>[]
+  numbersToDelete: NumberToDelete[]
   parentIsLocalized: boolean
   path: string
   relationships: Record<string, unknown>[]
@@ -27,6 +33,7 @@ type Args = {
     [tableName: string]: Record<string, unknown>[]
   }
   texts: Record<string, unknown>[]
+  textsToDelete: TextToDelete[]
   /**
    * Set to a locale code if this set of fields is traversed within a
    * localized array or block field
@@ -42,12 +49,14 @@ export const transformBlocks = ({
   field,
   locale,
   numbers,
+  numbersToDelete,
   parentIsLocalized,
   path,
   relationships,
   relationshipsToDelete,
   selects,
   texts,
+  textsToDelete,
   withinArrayOrBlockLocale,
 }: Args) => {
   data.forEach((blockRow, i) => {
@@ -113,6 +122,7 @@ export const transformBlocks = ({
       insideArrayOrBlock: true,
       locales: newRow.locales,
       numbers,
+      numbersToDelete,
       parentIsLocalized: parentIsLocalized || field.localized,
       parentTableName: blockTableName,
       path: `${path || ''}${field.name}.${i}.`,
@@ -121,6 +131,7 @@ export const transformBlocks = ({
       row: newRow.row,
       selects,
       texts,
+      textsToDelete,
       withinArrayOrBlockLocale,
     })
 

--- a/packages/drizzle/src/transform/write/index.ts
+++ b/packages/drizzle/src/transform/write/index.ts
@@ -29,11 +29,13 @@ export const transformForWrite = ({
     blocksToDelete: new Set(),
     locales: {},
     numbers: [],
+    numbersToDelete: [],
     relationships: [],
     relationshipsToDelete: [],
     row: {},
     selects: {},
     texts: [],
+    textsToDelete: [],
   }
 
   // This function is responsible for building up the
@@ -50,6 +52,7 @@ export const transformForWrite = ({
     fields,
     locales: rowToInsert.locales,
     numbers: rowToInsert.numbers,
+    numbersToDelete: rowToInsert.numbersToDelete,
     parentIsLocalized,
     parentTableName: tableName,
     path,
@@ -58,6 +61,7 @@ export const transformForWrite = ({
     row: rowToInsert.row,
     selects: rowToInsert.selects,
     texts: rowToInsert.texts,
+    textsToDelete: rowToInsert.textsToDelete,
   })
 
   return rowToInsert

--- a/packages/drizzle/src/transform/write/types.ts
+++ b/packages/drizzle/src/transform/write/types.ts
@@ -23,6 +23,16 @@ export type RelationshipToDelete = {
   path: string
 }
 
+export type TextToDelete = {
+  locale?: string
+  path: string
+}
+
+export type NumberToDelete = {
+  locale?: string
+  path: string
+}
+
 export type RowToInsert = {
   arrays: {
     [tableName: string]: ArrayRowToInsert[]
@@ -35,6 +45,7 @@ export type RowToInsert = {
     [locale: string]: Record<string, unknown>
   }
   numbers: Record<string, unknown>[]
+  numbersToDelete: NumberToDelete[]
   relationships: Record<string, unknown>[]
   relationshipsToDelete: RelationshipToDelete[]
   row: Record<string, unknown>
@@ -42,4 +53,5 @@ export type RowToInsert = {
     [tableName: string]: Record<string, unknown>[]
   }
   texts: Record<string, unknown>[]
+  textsToDelete: TextToDelete[]
 }

--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -211,7 +211,7 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
         parentColumnName: 'parent',
         parentID: insertedRow.id,
         pathColumnName: 'path',
-        rows: textsToInsert,
+        rows: [...textsToInsert, ...rowToInsert.textsToDelete],
         tableName: textsTableName,
       })
     }
@@ -238,7 +238,7 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
         parentColumnName: 'parent',
         parentID: insertedRow.id,
         pathColumnName: 'path',
-        rows: numbersToInsert,
+        rows: [...numbersToInsert, ...rowToInsert.numbersToDelete],
         tableName: numbersTableName,
       })
     }

--- a/packages/ui/src/fields/Number/index.tsx
+++ b/packages/ui/src/fields/Number/index.tsx
@@ -26,7 +26,7 @@ const NumberFieldComponent: NumberFieldClientComponent = (props) => {
       admin: {
         className,
         description,
-        placeholder,
+        placeholder: placeholderFromProps,
         step = 1,
       } = {} as NumberFieldClientProps['field']['admin'],
       hasMany = false,
@@ -125,6 +125,8 @@ const NumberFieldComponent: NumberFieldClientComponent = (props) => {
 
   const styles = useMemo(() => mergeFieldStyles(field), [field])
 
+  const placeholder = getTranslation(placeholderFromProps, i18n)
+
   return (
     <div
       className={[
@@ -173,7 +175,7 @@ const NumberFieldComponent: NumberFieldClientComponent = (props) => {
             // numberOnly
             onChange={handleHasManyChange}
             options={[]}
-            placeholder={t('general:enterAValue')}
+            placeholder={placeholder}
             showError={showError}
             value={valueToRender as Option[]}
           />
@@ -190,7 +192,7 @@ const NumberFieldComponent: NumberFieldClientComponent = (props) => {
                 // @ts-expect-error
                 e.target.blur()
               }}
-              placeholder={getTranslation(placeholder, i18n)}
+              placeholder={placeholder}
               step={step}
               type="number"
               value={typeof value === 'number' ? value : ''}

--- a/packages/ui/src/fields/Text/Input.tsx
+++ b/packages/ui/src/fields/Text/Input.tsx
@@ -33,7 +33,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     onChange,
     onKeyDown,
     path,
-    placeholder,
+    placeholder: placeholderFromProps,
     readOnly,
     required,
     rtl,
@@ -90,6 +90,8 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     }
   }
 
+  const placeholder = getTranslation(placeholderFromProps, i18n)
+
   return (
     <div
       className={[
@@ -142,7 +144,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
             }}
             onChange={onChange}
             options={[]}
-            placeholder={t('general:enterAValue')}
+            placeholder={placeholder}
             showError={showError}
             value={valueToRender}
           />
@@ -154,7 +156,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
             name={path}
             onChange={onChange as (e: ChangeEvent<HTMLInputElement>) => void}
             onKeyDown={onKeyDown}
-            placeholder={getTranslation(placeholder, i18n)}
+            placeholder={placeholder}
             ref={inputRef}
             type="text"
             value={value || ''}

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1011,7 +1011,7 @@ describe('Fields', () => {
         id: createdDocId,
       })
 
-      expect(resultingDoc.hasMany).toHaveLength(0)
+      expect(resultingDoc.localizedHasMany).toHaveLength(0)
     })
   })
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -32,6 +32,7 @@ import {
   blockFieldsSlug,
   collapsibleFieldsSlug,
   groupFieldsSlug,
+  numberFieldsSlug,
   relationshipFieldsSlug,
   tabsFieldsSlug,
   textFieldsSlug,
@@ -399,6 +400,32 @@ describe('Fields', () => {
       expect(resInSecond.docs.find((res) => res.id === docSecond.id)).toBeDefined()
 
       expect(resInSecond.totalDocs).toBe(1)
+    })
+
+    it('should delete rows when updating hasMany with empty array', async () => {
+      const { id: createdDocId } = await payload.create({
+        collection: textFieldsSlug,
+        data: {
+          text: 'hasMany deletion test',
+          hasMany: ['one', 'two', 'three'],
+        },
+      })
+
+      await payload.update({
+        collection: textFieldsSlug,
+        id: createdDocId,
+        data: {
+          hasMany: [],
+        },
+      })
+
+      const resultingDoc = await payload.findByID({
+        collection: textFieldsSlug,
+        id: createdDocId,
+      })
+
+      // In db-postgres expect undefined, in db-mongodb we get []
+      expect([undefined, []]).toContainEqual(resultingDoc.hasMany)
     })
   })
 
@@ -962,6 +989,31 @@ describe('Fields', () => {
       })
 
       expect(numbersNotExists.docs).toHaveLength(1)
+    })
+
+    it('should delete rows when updating hasMany with empty array', async () => {
+      const { id: createdDocId } = await payload.create({
+        collection: numberFieldsSlug,
+        data: {
+          localizedHasMany: [1, 2, 3],
+        },
+      })
+
+      await payload.update({
+        collection: numberFieldsSlug,
+        id: createdDocId,
+        data: {
+          localizedHasMany: [],
+        },
+      })
+
+      const resultingDoc = await payload.findByID({
+        collection: numberFieldsSlug,
+        id: createdDocId,
+      })
+
+      // In db-postgres expect undefined, in db-mongodb we get []
+      expect([undefined, []]).toContainEqual(resultingDoc.hasMany)
     })
   })
 

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -424,8 +424,7 @@ describe('Fields', () => {
         id: createdDocId,
       })
 
-      // In db-postgres expect undefined, in db-mongodb we get []
-      expect([undefined, []]).toContainEqual(resultingDoc.hasMany)
+      expect(resultingDoc.hasMany).toHaveLength(0)
     })
   })
 
@@ -1012,8 +1011,7 @@ describe('Fields', () => {
         id: createdDocId,
       })
 
-      // In db-postgres expect undefined, in db-mongodb we get []
-      expect([undefined, []]).toContainEqual(resultingDoc.hasMany)
+      expect(resultingDoc.hasMany).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes an issue while using `text` & `number` fields with `hasMany: true` where the last entry would be unreachable, and thus undeletable, because the `transformForWrite` function did not track these rows for deletion. This causes values that should've been deleted to remain in the edit view form, as well as the db, after a submission.

This PR also properly threads the placeholder value from `admin.placeholder` to `text` & `number` `hasMany: true` fields. 

### Why?
To remove rows from the db when a submission is made where these fields are empty arrays, and to properly show an appropriate placeholder when one is set in config.

### How?
Adjusting `transformForWrite` and the `traverseFields` to keep track of rows for deletion.

Fixes #11781

Before:

[Editing---Post-dbpg-before--Payload.webm](https://github.com/user-attachments/assets/5ba1708a-2672-4b36-ac68-05212f3aa6cb)

After:

[Editing---Post--dbpg-hasmany-after-Payload.webm](https://github.com/user-attachments/assets/1292e998-83ff-49d0-aa86-6199be319937)
