### PR TITLE
fix(db-mongodb): spread version schema options correctly

### DIFF
--- a/packages/db-mongodb/src/init.ts
+++ b/packages/db-mongodb/src/init.ts
@@ -37,8 +37,8 @@ export const init: Init = function init(this: MongooseAdapter) {
           options: {
             minimize: false,
             timestamps: false,
+            ...schemaOptions,
           },
-          ...schemaOptions,
         },
         compoundIndexes: buildVersionCompoundIndexes({ indexes: collection.sanitizedIndexes }),
         configFields: versionCollectionFields,


### PR DESCRIPTION
Schema options were not being spread inside the versionSchema like they were inside [`buildCollectionSchema`](https://github.com/payloadcms/payload/blob/6640b1cdfd97a3337125226a40148e9f5b0f539d/packages/db-mongodb/src/models/buildCollectionSchema.ts#L23).
