### PR TITLE
feat: change version view `modifiedOnly` default to `true`

### DIFF
--- a/packages/next/src/views/Version/Default/index.tsx
+++ b/packages/next/src/views/Version/Default/index.tsx
@@ -83,10 +83,10 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
       current.set('localeCodes', JSON.stringify(selectedLocales.map((locale) => locale.value)))
     }
 
-    if (!modifiedOnly) {
-      current.delete('modifiedOnly')
+    if (modifiedOnly === false) {
+      current.set('modifiedOnly', 'false')
     } else {
-      current.set('modifiedOnly', 'true')
+      current.delete('modifiedOnly')
     }
 
     const search = current.toString()

--- a/packages/next/src/views/Version/index.tsx
+++ b/packages/next/src/views/Version/index.tsx
@@ -39,7 +39,7 @@ export async function VersionView(props: DocumentViewServerProps) {
     : null
   const comparisonVersionIDFromParams: string = searchParams.compareValue as string
 
-  const modifiedOnly: boolean = searchParams.modifiedOnly === 'true'
+  const modifiedOnly: boolean = searchParams.modifiedOnly === 'false' ? false : true
 
   const { localization } = config
 

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -1323,11 +1323,11 @@ describe('Versions', () => {
 
       const textInArrayES = page.locator('[data-field-path="arrayLocalized"][data-locale="es"]')
 
-      await expect(textInArrayES).toContainText('No Array Localizeds found')
+      await expect(textInArrayES).toBeHidden()
 
       await page.locator('#modifiedOnly').click()
 
-      await expect(textInArrayES).toBeHidden()
+      await expect(textInArrayES).toContainText('No Array Localizeds found')
     })
 
     test('correctly renders diff for block fields', async () => {


### PR DESCRIPTION
Replaces a more elaborate approach from https://github.com/payloadcms/payload/pull/11520 with the simplest solution, just changing the default.