### PR TITLE
fix(ui): adding guard check for populate docs in upload field

### DIFF
--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -189,6 +189,10 @@ export function UploadInput(props: UploadInputProps) {
 
   const populateDocs = React.useCallback<PopulateDocs>(
     async (ids, relatedCollectionSlug) => {
+      if (!ids.length) {
+        return;
+      }
+
       const query: {
         [key: string]: unknown
         where: Where


### PR DESCRIPTION
### What?

When a user lands on an edit page that has a relationship to an `Upload` field (which is `HasMany`). The UI will make a request with `limit=0` to the backend providing there is no IDs populated already.

When a media collection is large, it will try and load all media items into memory which causes OOM crashes.

### Why?

Fixes: https://github.com/payloadcms/payload/issues/11655 causing OOM issues.

### How?

Adding guard check on the `populate` to ensure that it doesn't make a request if not needed.

https://github.com/user-attachments/assets/f195025f-3e31-423e-b13e-6faf8db40129