### PR TITLE
chore(db-postgres): improve messaging create migration prompts

### DIFF
--- a/packages/drizzle/src/utilities/buildCreateMigration.ts
+++ b/packages/drizzle/src/utilities/buildCreateMigration.ts
@@ -86,7 +86,7 @@ export const buildCreateMigration = ({
 
       if (sqlStatementsUp.length) {
         payload.logger.info({
-          msg: 'Generating SQL statements to migrate current config down down to the previous schema.',
+          msg: 'Generating SQL statements to migrate current config down to the previous schema.',
         })
         sqlStatementsDown = await generateMigration(drizzleJsonAfter, drizzleJsonBefore)
         upSQL = sanitizeStatements({ sqlExecute, statements: sqlStatementsUp })

--- a/packages/drizzle/src/utilities/buildCreateMigration.ts
+++ b/packages/drizzle/src/utilities/buildCreateMigration.ts
@@ -77,13 +77,21 @@ export const buildCreateMigration = ({
         }
       }
 
-      const sqlStatementsUp = await generateMigration(drizzleJsonBefore, drizzleJsonAfter)
-      const sqlStatementsDown = await generateMigration(drizzleJsonAfter, drizzleJsonBefore)
       const sqlExecute = `await db.${executeMethod}(` + 'sql`'
+      payload.logger.info({
+        msg: 'Generating SQL statements to migrate previous schema up to the current config.',
+      })
+      const sqlStatementsUp = await generateMigration(drizzleJsonBefore, drizzleJsonAfter)
+      let sqlStatementsDown: string[] = []
 
-      if (sqlStatementsUp?.length) {
+      if (sqlStatementsUp.length) {
+        payload.logger.info({
+          msg: 'Generating SQL statements to migrate current config down down to the previous schema.',
+        })
+        sqlStatementsDown = await generateMigration(drizzleJsonAfter, drizzleJsonBefore)
         upSQL = sanitizeStatements({ sqlExecute, statements: sqlStatementsUp })
       }
+
       if (sqlStatementsDown?.length) {
         downSQL = sanitizeStatements({ sqlExecute, statements: sqlStatementsDown })
       }


### PR DESCRIPTION
When using `payload migrate:create` after lots of database changes you can get lost in the prompts between `up` and `down`.
This improves the messaging between the prompt for better DX.