### PR TITLE
fix(next): adds safe redirect utility and apply to login redirects

### DIFF
--- a/packages/next/src/utilities/getSafeRedirect.ts
+++ b/packages/next/src/utilities/getSafeRedirect.ts
@@ -1,0 +1,23 @@
+export const getSafeRedirect = (
+  redirectParam: string | string[],
+  fallback: string = '/',
+): string => {
+  if (typeof redirectParam !== 'string') {
+    return fallback
+  }
+
+  // Ensures that any leading or trailing whitespace doesn’t affect the checks
+  const redirectPath = redirectParam.trim()
+
+  const isSafeRedirect =
+    // Must start with a single forward slash (e.g., "/admin")
+    redirectPath.startsWith('/') &&
+    // Prevent protocol-relative URLs (e.g., "//evil.com")
+    !redirectPath.startsWith('//') &&
+    // Prevent javascript-based schemes (e.g., "/javascript:alert(1)")
+    !redirectPath.toLowerCase().startsWith('/javascript:') &&
+    // Prevent attempts to redirect to full URLs using "/http:" or "/https:"
+    !redirectPath.toLowerCase().startsWith('/http')
+
+  return isSafeRedirect ? redirectPath : fallback
+}

--- a/packages/next/src/views/Login/LoginForm/index.tsx
+++ b/packages/next/src/views/Login/LoginForm/index.tsx
@@ -20,6 +20,7 @@ import { formatAdminURL, getLoginOptions } from 'payload/shared'
 
 import type { LoginFieldProps } from '../LoginField/index.js'
 
+import { getSafeRedirect } from '../../../utilities/getSafeRedirect.js'
 import { LoginField } from '../LoginField/index.js'
 import './index.scss'
 
@@ -91,13 +92,7 @@ export const LoginForm: React.FC<{
       initialState={initialState}
       method="POST"
       onSuccess={handleLogin}
-      redirect={
-        typeof searchParams?.redirect === 'string'
-          ? searchParams.redirect.startsWith('/')
-            ? searchParams.redirect
-            : encodeURIComponent(searchParams.redirect)
-          : adminRoute
-      }
+      redirect={getSafeRedirect(searchParams?.redirect, adminRoute)}
       waitForAutocomplete
     >
       <div className={`${baseClass}__inputWrap`}>

--- a/packages/next/src/views/Login/index.tsx
+++ b/packages/next/src/views/Login/index.tsx
@@ -5,9 +5,9 @@ import { redirect } from 'next/navigation.js'
 import React, { Fragment } from 'react'
 
 import { Logo } from '../../elements/Logo/index.js'
+import { getSafeRedirect } from '../../utilities/getSafeRedirect.js'
 import { LoginForm } from './LoginForm/index.js'
 import './index.scss'
-
 export const loginBaseClass = 'login'
 
 export function LoginView({ initPageResult, params, searchParams }: AdminViewServerProps) {
@@ -25,12 +25,7 @@ export function LoginView({ initPageResult, params, searchParams }: AdminViewSer
     routes: { admin },
   } = config
 
-  const redirectUrl =
-    typeof searchParams.redirect === 'string'
-      ? searchParams.redirect.startsWith('/') // If it's a relative path, keep it
-        ? searchParams.redirect
-        : encodeURIComponent(searchParams.redirect) // Otherwise, encode it
-      : admin
+  const redirectUrl = getSafeRedirect(searchParams.redirect, admin)
 
   if (user) {
     redirect(redirectUrl)


### PR DESCRIPTION
This PR introduces a new utility function, `getSafeRedirect`, to sanitize and validate redirect paths used in the login flow. 

It replaces the previous use of `encodeURIComponent` and inline string checks with a centralized, reusable, and more secure approach.

#### `getSafeRedirect` utility:
- Ensures redirect paths start with a single `/`
- Blocks protocol-relative URLs (e.g., `//evil.com`)
- Blocks JavaScript schemes (e.g., `/javascript:alert(1)`)
- Blocks full URL redirects like `/http:` or `/https:`
