### PR TITLE
docs: fix afterErrorHook export name in collection hooks

### DIFF
--- a/docs/hooks/collections.mdx
+++ b/docs/hooks/collections.mdx
@@ -286,7 +286,7 @@ The `afterError` Hook is triggered when an error occurs in the Payload applicati
 ```ts
 import type { CollectionAfterErrorHook } from 'payload';
 
-const afterDeleteHook: CollectionAfterErrorHook = async ({
+const afterErrorHook: CollectionAfterErrorHook = async ({
   req,
   id,
   doc,


### PR DESCRIPTION
## What
This PR fixes the exported hook name in the collection hooks documentation example.

### Why
The documentation example shows an incorrect/inconsistent export name for the collection hook example.

### How
Updated the hook export name to follow consistent naming patterns used throughout the documentation.

### Type of Change
- [x] Documentation update
