### PR TITLE
fix : express deprecated req.host warning

### DIFF
--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -38,7 +38,7 @@ const attachFakeURLProperties = (req: Partial<PayloadRequest>, urlSuffix?: strin
       return urlObject
     }
 
-    const fallbackURL = `http://${req.host || 'localhost'}${urlSuffix || ''}`
+    const fallbackURL = `http://${req?.hostname || req?.host || 'localhost'}${urlSuffix || ''}`
 
     const urlToUse =
       req?.url || req.payload.config?.serverURL


### PR DESCRIPTION

fixes issue/ warning `express deprecated req.host: Use req.hostname`

Fixes #
error like this 
Sun, 23 Mar 2025 12:25:18 GMT express deprecated req.host: Use req.hostname instead at node_modules/.pnpm/payload@3.29.0_graphql@16.10.0_typescript@5.7.3/node_modules/payload/dist/utilities/createLocalReq.js:44:9



