### PR TITLE
chore(db-sqlite): enable TypeScript strict

### DIFF
--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -85,6 +85,7 @@
     "@payloadcms/eslint-config": "workspace:*",
     "@types/pg": "8.10.2",
     "@types/to-snake-case": "1.0.0",
+    "@types/uuid": "10.0.0",
     "payload": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/db-sqlite/src/columnToCodeConverter.ts
+++ b/packages/db-sqlite/src/columnToCodeConverter.ts
@@ -23,6 +23,9 @@ export const columnToCodeConverter: ColumnToCodeConverter = ({
     case 'enum': {
       let options: string[]
       if ('locale' in column) {
+        if (!locales?.length) {
+          throw new Error('Locales must be defined for locale columns')
+        }
         options = locales
       } else {
         options = column.options

--- a/packages/db-sqlite/src/connect.ts
+++ b/packages/db-sqlite/src/connect.ts
@@ -1,5 +1,5 @@
 import type { DrizzleAdapter } from '@payloadcms/drizzle/types'
-import type { Connect } from 'payload'
+import type { Connect, Migration } from 'payload'
 
 import { createClient } from '@libsql/client'
 import { pushDevSchema } from '@payloadcms/drizzle'
@@ -36,7 +36,8 @@ export const connect: Connect = async function connect(
       }
     }
   } catch (err) {
-    this.payload.logger.error({ err, msg: `Error: cannot connect to SQLite: ${err.message}` })
+    const message = err instanceof Error ? err.message : String(err)
+    this.payload.logger.error({ err, msg: `Error: cannot connect to SQLite: ${message}` })
     if (typeof this.rejectInitializing === 'function') {
       this.rejectInitializing()
     }
@@ -57,6 +58,6 @@ export const connect: Connect = async function connect(
   }
 
   if (process.env.NODE_ENV === 'production' && this.prodMigrations) {
-    await this.migrate({ migrations: this.prodMigrations })
+    await this.migrate({ migrations: this.prodMigrations as Migration[] })
   }
 }

--- a/packages/db-sqlite/src/countDistinct.ts
+++ b/packages/db-sqlite/src/countDistinct.ts
@@ -17,7 +17,7 @@ export const countDistinct: CountDistinct = async function countDistinct(
       })
       .from(this.tables[tableName])
       .where(where)
-    return Number(countResult[0].count)
+    return Number(countResult[0]?.count)
   }
 
   const chainedMethods: ChainedMethods = []
@@ -45,5 +45,5 @@ export const countDistinct: CountDistinct = async function countDistinct(
       .limit(1),
   })
 
-  return Number(countResult[0].count)
+  return Number(countResult[0]?.count)
 }

--- a/packages/db-sqlite/src/countDistinct.ts
+++ b/packages/db-sqlite/src/countDistinct.ts
@@ -17,7 +17,7 @@ export const countDistinct: CountDistinct = async function countDistinct(
       })
       .from(this.tables[tableName])
       .where(where)
-    return Number(countResult[0]?.count)
+    return Number(countResult[0]?.count ?? 0)
   }
 
   const chainedMethods: ChainedMethods = []
@@ -45,5 +45,5 @@ export const countDistinct: CountDistinct = async function countDistinct(
       .limit(1),
   })
 
-  return Number(countResult[0]?.count)
+  return Number(countResult[0]?.count ?? 0)
 }

--- a/packages/db-sqlite/src/countDistinct.ts
+++ b/packages/db-sqlite/src/countDistinct.ts
@@ -17,7 +17,7 @@ export const countDistinct: CountDistinct = async function countDistinct(
       })
       .from(this.tables[tableName])
       .where(where)
-    return Number(countResult[0]?.count ?? 0)
+    return Number(countResult[0]?.count)
   }
 
   const chainedMethods: ChainedMethods = []
@@ -45,5 +45,5 @@ export const countDistinct: CountDistinct = async function countDistinct(
       .limit(1),
   })
 
-  return Number(countResult[0]?.count ?? 0)
+  return Number(countResult[0]?.count)
 }

--- a/packages/db-sqlite/src/createJSONQuery/index.ts
+++ b/packages/db-sqlite/src/createJSONQuery/index.ts
@@ -74,7 +74,7 @@ export const createJSONQuery = ({
   treatAsArray,
   value,
 }: CreateJSONQueryArgs): string => {
-  if (treatAsArray.includes(pathSegments[1])) {
+  if (treatAsArray?.includes(pathSegments[1]!) && table) {
     return fromArray({
       operator,
       pathSegments,

--- a/packages/db-sqlite/src/deleteWhere.ts
+++ b/packages/db-sqlite/src/deleteWhere.ts
@@ -1,6 +1,11 @@
-import type { DeleteWhere } from './types.js'
+import type { DeleteWhere, SQLiteAdapter } from './types.js'
 
-export const deleteWhere: DeleteWhere = async function deleteWhere({ db, tableName, where }) {
+export const deleteWhere: DeleteWhere = async function (
+  // Here 'this' is not a parameter. See:
+  // https://www.typescriptlang.org/docs/handbook/2/classes.html#this-parameters
+  this: SQLiteAdapter,
+  { db, tableName, where },
+) {
   const table = this.tables[tableName]
   await db.delete(table).where(where)
 }

--- a/packages/db-sqlite/src/dropDatabase.ts
+++ b/packages/db-sqlite/src/dropDatabase.ts
@@ -1,21 +1,23 @@
-import type { DropDatabase } from './types.js'
+import type { Row } from '@libsql/client'
 
-const getTables = (adapter) => {
+import type { DropDatabase, SQLiteAdapter } from './types.js'
+
+const getTables = (adapter: SQLiteAdapter) => {
   return adapter.client.execute(`SELECT name
                                  FROM sqlite_master
                                  WHERE type = 'table'
                                    AND name NOT LIKE 'sqlite_%';`)
 }
 
-const dropTables = (adapter, rows) => {
+const dropTables = (adapter: SQLiteAdapter, rows: Row[]) => {
   const multi = `
   PRAGMA foreign_keys = OFF;\n
-  ${rows.map(({ name }) => `DROP TABLE IF EXISTS ${name}`).join(';\n ')};\n
+  ${rows.map(({ name }) => `DROP TABLE IF EXISTS ${name as string}`).join(';\n ')};\n
   PRAGMA foreign_keys = ON;`
   return adapter.client.executeMultiple(multi)
 }
 
-export const dropDatabase: DropDatabase = async function dropDatabase({ adapter }) {
+export const dropDatabase: DropDatabase = async function ({ adapter }) {
   const result = await getTables(adapter)
   await dropTables(adapter, result.rows)
 }

--- a/packages/db-sqlite/src/execute.ts
+++ b/packages/db-sqlite/src/execute.ts
@@ -3,13 +3,13 @@ import { sql } from 'drizzle-orm'
 import type { Execute } from './types.js'
 
 export const execute: Execute<any> = function execute({ db, drizzle, raw, sql: statement }) {
-  const executeFrom = db ?? drizzle
+  const executeFrom = (db ?? drizzle)!
 
   if (raw) {
     const result = executeFrom.run(sql.raw(raw))
     return result
   } else {
-    const result = executeFrom.run(statement)
+    const result = executeFrom.run(statement!)
     return result
   }
 }

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -92,9 +92,11 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       allowIDOnCreate,
       autoIncrement: args.autoIncrement ?? false,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       client: undefined,
       clientConfig: args.client,
       defaultDrizzleSnapshot,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       drizzle: undefined,
       features: {
         json: true,
@@ -112,6 +114,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       logger: args.logger,
       operators,
       prodMigrations: args.prodMigrations,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       push: args.push,
       rawRelations: {},
       rawTables: {},
@@ -122,6 +125,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       sessions: {},
       tableNameMap: new Map<string, string>(),
       tables: {},
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       transactionOptions: args.transactionOptions || undefined,
       updateMany,
       versionsSuffix: args.versionsSuffix || '_v',
@@ -160,6 +164,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       find,
       findGlobal,
       findGlobalVersions,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       findOne,
       findVersions,
       indexes: new Set<string>(),
@@ -175,8 +180,10 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       packageName: '@payloadcms/db-sqlite',
       payload,
       queryDrafts,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       rejectInitializing,
       requireDrizzleKit,
+      // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       resolveInitializing,
       rollbackTransaction,
       updateGlobal,

--- a/packages/db-sqlite/src/init.ts
+++ b/packages/db-sqlite/src/init.ts
@@ -28,7 +28,7 @@ export const init: Init = async function init(this: SQLiteAdapter) {
   await executeSchemaHooks({ type: 'beforeSchemaInit', adapter: this })
 
   for (const tableName in this.rawTables) {
-    buildDrizzleTable({ adapter, locales, rawTable: this.rawTables[tableName] })
+    buildDrizzleTable({ adapter, locales: locales!, rawTable: this.rawTables[tableName]! })
   }
 
   buildDrizzleRelations({

--- a/packages/db-sqlite/src/insert.ts
+++ b/packages/db-sqlite/src/insert.ts
@@ -1,19 +1,18 @@
-import type { Insert } from './types.js'
+import type { Insert, SQLiteAdapter } from './types.js'
 
-export const insert: Insert = async function insert({
-  db,
-  onConflictDoUpdate,
-  tableName,
-  values,
-}): Promise<Record<string, unknown>[]> {
+export const insert: Insert = async function (
+  // Here 'this' is not a parameter. See:
+  // https://www.typescriptlang.org/docs/handbook/2/classes.html#this-parameters
+  this: SQLiteAdapter,
+  { db, onConflictDoUpdate, tableName, values },
+): Promise<Record<string, unknown>[]> {
   const table = this.tables[tableName]
-  let result
 
-  if (onConflictDoUpdate) {
-    result = db.insert(table).values(values).onConflictDoUpdate(onConflictDoUpdate).returning()
-  } else {
-    result = db.insert(table).values(values).returning()
-  }
-  result = await result
-  return result
+  const result = onConflictDoUpdate
+    ? await db.insert(table).values(values).onConflictDoUpdate(onConflictDoUpdate).returning()
+    : await db.insert(table).values(values).returning()
+
+  // TODO: this is possibly a bug. Result is of type 'any[] | ResultSet', but ResultSet
+  // is not an array!
+  return result as Record<string, unknown>[]
 }

--- a/packages/db-sqlite/src/insert.ts
+++ b/packages/db-sqlite/src/insert.ts
@@ -12,7 +12,6 @@ export const insert: Insert = async function (
     ? await db.insert(table).values(values).onConflictDoUpdate(onConflictDoUpdate).returning()
     : await db.insert(table).values(values).returning()
 
-  // TODO: this is possibly a bug. Result is of type 'any[] | ResultSet', but ResultSet
-  // is not an array!
+  // See https://github.com/payloadcms/payload/pull/11831#discussion_r2010431908
   return result as Record<string, unknown>[]
 }

--- a/packages/db-sqlite/src/schema/buildDrizzleTable.ts
+++ b/packages/db-sqlite/src/schema/buildDrizzleTable.ts
@@ -81,8 +81,9 @@ export const buildDrizzleTable: BuildDrizzleTable = ({ adapter, locales, rawTabl
     }
 
     if (column.reference) {
-      columns[key].references(() => adapter.tables[column.reference.table][column.reference.name], {
-        onDelete: column.reference.onDelete,
+      const ref = column.reference
+      columns[key].references(() => adapter.tables[ref.table][ref.name], {
+        onDelete: ref.onDelete,
       })
     }
 

--- a/packages/db-sqlite/tsconfig.json
+++ b/packages/db-sqlite/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    /* TODO: remove the following lines */
-    "strict": false,
-    "noUncheckedIndexedAccess": false,
-  },
   "references": [
     {
       "path": "../payload"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 1.50.0
       '@sentry/nextjs':
         specifier: ^8.33.1
-        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
       '@sentry/node':
         specifier: ^8.33.1
         version: 8.37.1
@@ -135,7 +135,7 @@ importers:
         version: 10.1.3(@aws-sdk/credential-providers@3.687.0(@aws-sdk/client-sso-oidc@3.687.0(@aws-sdk/client-sts@3.687.0)))(socks@2.8.3)
       next:
         specifier: 15.2.3
-        version: 15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+        version: 15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
       open:
         specifier: ^10.1.0
         version: 10.1.0
@@ -387,6 +387,9 @@ importers:
       '@types/to-snake-case':
         specifier: 1.0.0
         version: 1.0.0
+      '@types/uuid':
+        specifier: 10.0.0
+        version: 10.0.0
       payload:
         specifier: workspace:*
         version: link:../payload
@@ -1073,7 +1076,7 @@ importers:
     dependencies:
       next:
         specifier: ^15.2.3
-        version: 15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+        version: 15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
     devDependencies:
       '@payloadcms/eslint-config':
         specifier: workspace:*
@@ -1138,7 +1141,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ^8.33.1
-        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
       '@sentry/types':
         specifier: ^8.33.1
         version: 8.37.1
@@ -1497,7 +1500,7 @@ importers:
         version: link:../plugin-cloud-storage
       uploadthing:
         specifier: 7.3.0
-        version: 7.3.0(next@15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))
+        version: 7.3.0(next@15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))
     devDependencies:
       payload:
         specifier: workspace:*
@@ -1783,7 +1786,7 @@ importers:
         version: link:../packages/ui
       '@sentry/nextjs':
         specifier: ^8.33.1
-        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
       '@sentry/react':
         specifier: ^7.77.0
         version: 7.119.2(react@19.0.0)
@@ -1840,7 +1843,7 @@ importers:
         version: 8.9.5(@aws-sdk/credential-providers@3.687.0(@aws-sdk/client-sso-oidc@3.687.0(@aws-sdk/client-sts@3.687.0)))(socks@2.8.3)
       next:
         specifier: 15.2.3
-        version: 15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+        version: 15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
       nodemailer:
         specifier: 6.9.16
         version: 6.9.16
@@ -7899,6 +7902,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lie@3.1.1:
@@ -13588,7 +13592,7 @@ snapshots:
       '@sentry/utils': 7.119.2
       localforage: 1.10.0
 
-  '@sentry/nextjs@8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))':
+  '@sentry/nextjs@8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(react@19.0.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation-http': 0.53.0(@opentelemetry/api@1.9.0)
@@ -13604,7 +13608,7 @@ snapshots:
       '@sentry/vercel-edge': 8.37.1
       '@sentry/webpack-plugin': 2.22.6(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
       chalk: 3.0.0
-      next: 15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+      next: 15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.10
@@ -18247,35 +18251,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4):
-    dependencies:
-      '@next/env': 15.2.3
-      '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.15
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001678
-      postcss: 8.4.31
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      styled-jsx: 5.1.6(@babel/core@7.26.7)(babel-plugin-macros@3.1.0)(react@19.0.0)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.2.3
-      '@next/swc-darwin-x64': 15.2.3
-      '@next/swc-linux-arm64-gnu': 15.2.3
-      '@next/swc-linux-arm64-musl': 15.2.3
-      '@next/swc-linux-x64-gnu': 15.2.3
-      '@next/swc-linux-x64-musl': 15.2.3
-      '@next/swc-win32-arm64-msvc': 15.2.3
-      '@next/swc-win32-x64-msvc': 15.2.3
-      '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.50.0
-      babel-plugin-react-compiler: 19.0.0-beta-714736e-20250131
-      sass: 1.77.4
-      sharp: 0.33.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   node-abi@3.71.0:
     dependencies:
       semver: 7.6.3
@@ -19934,14 +19909,14 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  uploadthing@7.3.0(next@15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)):
+  uploadthing@7.3.0(next@15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)):
     dependencies:
       '@effect/platform': 0.69.8(effect@3.10.3)
       '@uploadthing/mime-types': 0.3.2
       '@uploadthing/shared': 7.1.1
       effect: 3.10.3
     optionalDependencies:
-      next: 15.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
+      next: 15.2.3(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
- I installed `@types/uuid` because typescript required it in a file
- In `packages/db-sqlite/src/index.ts` I see four more errors in my IDE that don't appear when I run the typecheck in the CLI with `tsc --noEmit`. The same thing happened in https://github.com/payloadcms/payload/pull/11560. Also referencing https://github.com/payloadcms/payload/pull/11226#issuecomment-2713898801 for traceability.