### PR TITLE
chore(admin-bar): enable TypeScript strict

### DIFF
--- a/packages/admin-bar/tsconfig.json
+++ b/packages/admin-bar/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    /* TODO: remove the following lines */
-    "strict": false,
-    "noUncheckedIndexedAccess": false,
-  },
   "references": [{ "path": "../payload" }]
 }


### PR DESCRIPTION
Looks like this one was bug-free! I don't know why strict was disabled