### PR TITLE
fix: removes `onClick` from DefaultCellComponentProps

### DIFF
--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -745,10 +745,9 @@ export const myField: Field = {
 
 All Cell Components receive the same [Default Field Component Props](#field), plus the following:
 
-| Property      | Description                                                           |
-| ------------- | --------------------------------------------------------------------- |
-| **`link`**    | A boolean representing whether this cell should be wrapped in a link. |
-| **`onClick`** | A function that is called when the cell is clicked.                   |
+| Property   | Description                                                           |
+| ---------- | --------------------------------------------------------------------- |
+| **`link`** | A boolean representing whether this cell should be wrapped in a link. |
 
 For details on how to build Custom Components themselves, see [Building Custom Components](../custom-components/overview#building-custom-components).
 

--- a/packages/payload/src/admin/elements/Cell.ts
+++ b/packages/payload/src/admin/elements/Cell.ts
@@ -76,11 +76,6 @@ export type DefaultCellComponentProps<
   customCellProps?: Record<string, any>
   field: TField
   link?: boolean
-  onClick?: (args: {
-    cellData: unknown
-    collectionSlug: SanitizedCollectionConfig['slug']
-    rowData: RowData
-  }) => void
   rowData: RowData
 }
 

--- a/packages/payload/src/admin/types.ts
+++ b/packages/payload/src/admin/types.ts
@@ -50,7 +50,11 @@ export type {
    */
   CustomComponent as CustomSaveDraftButton,
 } from '../config/types.js'
-export type { DefaultCellComponentProps, DefaultServerCellComponentProps } from './elements/Cell.js'
+export type {
+  DefaultCellComponentProps,
+  DefaultServerCellComponentProps,
+  RowData,
+} from './elements/Cell.js'
 export type { ConditionalDateProps } from './elements/DatePicker.js'
 export type { DayPickerProps, SharedProps, TimePickerProps } from './elements/DatePicker.js'
 export type { NavGroupPreferences, NavPreferences } from './elements/Nav.js'

--- a/packages/richtext-lexical/src/cell/rscEntry.tsx
+++ b/packages/richtext-lexical/src/cell/rscEntry.tsx
@@ -46,10 +46,8 @@ export const RscEntryLexicalCell: React.FC<
     field,
     i18n,
     link,
-    onClick: onClickFromProps,
     payload,
     rowData,
-    sanitizedEditorConfig,
   } = props
 
   const classNameFromConfigContext = admin && 'className' in admin ? admin.className : undefined
@@ -59,8 +57,6 @@ export const RscEntryLexicalCell: React.FC<
     (field.admin && 'className' in field.admin ? field.admin.className : null) ||
     classNameFromConfigContext
   const adminRoute = payload.config.routes.admin
-
-  const onClick = onClickFromProps
 
   let WrapElement: React.ComponentType<any> | string = 'span'
 
@@ -83,18 +79,6 @@ export const RscEntryLexicalCell: React.FC<
           path: `/collections/${collectionConfig?.slug}/${rowData.id}`,
         })
       : ''
-  }
-
-  if (typeof onClick === 'function') {
-    WrapElement = 'button'
-    wrapElementProps.type = 'button'
-    wrapElementProps.onClick = () => {
-      onClick({
-        cellData,
-        collectionSlug: collectionConfig?.slug,
-        rowData,
-      })
-    }
   }
 
   let textContent: React.ReactNode[] = []

--- a/packages/richtext-lexical/src/cell/rscEntry.tsx
+++ b/packages/richtext-lexical/src/cell/rscEntry.tsx
@@ -1,5 +1,5 @@
 import type { SerializedLexicalNode } from 'lexical'
-import type { Payload } from 'payload'
+import type { Payload, RowData, SanitizedCollectionConfig } from 'payload'
 
 import { getTranslation, type I18nClient } from '@payloadcms/translations'
 import { Link } from '@payloadcms/ui'
@@ -34,6 +34,11 @@ export const RscEntryLexicalCell: React.FC<
   {
     admin: LexicalFieldAdminProps
     i18n: I18nClient
+    onClick?: (args: {
+      cellData: unknown
+      collectionSlug: SanitizedCollectionConfig['slug']
+      rowData: RowData
+    }) => void
     payload: Payload
     sanitizedEditorConfig: SanitizedServerEditorConfig
   } & LexicalRichTextCellProps
@@ -46,6 +51,7 @@ export const RscEntryLexicalCell: React.FC<
     field,
     i18n,
     link,
+    onClick: onClickFromProps,
     payload,
     rowData,
   } = props
@@ -57,6 +63,8 @@ export const RscEntryLexicalCell: React.FC<
     (field.admin && 'className' in field.admin ? field.admin.className : null) ||
     classNameFromConfigContext
   const adminRoute = payload.config.routes.admin
+
+  const onClick = onClickFromProps
 
   let WrapElement: React.ComponentType<any> | string = 'span'
 
@@ -79,6 +87,18 @@ export const RscEntryLexicalCell: React.FC<
           path: `/collections/${collectionConfig?.slug}/${rowData.id}`,
         })
       : ''
+  }
+
+  if (typeof onClick === 'function') {
+    WrapElement = 'button'
+    wrapElementProps.type = 'button'
+    wrapElementProps.onClick = () => {
+      onClick({
+        cellData,
+        collectionSlug: collectionConfig?.slug,
+        rowData,
+      })
+    }
   }
 
   let textContent: React.ReactNode[] = []

--- a/packages/richtext-slate/src/cell/rscEntry.tsx
+++ b/packages/richtext-slate/src/cell/rscEntry.tsx
@@ -1,4 +1,9 @@
-import type { DefaultServerCellComponentProps, Payload } from 'payload'
+import type {
+  DefaultServerCellComponentProps,
+  Payload,
+  RowData,
+  SanitizedCollectionConfig,
+} from 'payload'
 
 import { getTranslation, type I18nClient } from '@payloadcms/translations'
 import { Link } from '@payloadcms/ui'
@@ -8,6 +13,11 @@ import React from 'react'
 export const RscEntrySlateCell: React.FC<
   {
     i18n: I18nClient
+    onClick?: (args: {
+      cellData: unknown
+      collectionSlug: SanitizedCollectionConfig['slug']
+      rowData: RowData
+    }) => void
     payload: Payload
   } & DefaultServerCellComponentProps
 > = (props) => {
@@ -19,6 +29,7 @@ export const RscEntrySlateCell: React.FC<
     field,
     i18n,
     link,
+    onClick: onClickFromProps,
     payload,
     rowData,
   } = props
@@ -30,6 +41,8 @@ export const RscEntrySlateCell: React.FC<
     (field.admin && 'className' in field.admin ? field.admin.className : null) ||
     classNameFromConfigContext
   const adminRoute = payload.config.routes.admin
+
+  const onClick = onClickFromProps
 
   let WrapElement: React.ComponentType<any> | string = 'span'
 
@@ -52,6 +65,18 @@ export const RscEntrySlateCell: React.FC<
           path: `/collections/${collectionConfig?.slug}/${rowData.id}`,
         })
       : ''
+  }
+
+  if (typeof onClick === 'function') {
+    WrapElement = 'button'
+    wrapElementProps.type = 'button'
+    wrapElementProps.onClick = () => {
+      onClick({
+        cellData,
+        collectionSlug: collectionConfig?.slug,
+        rowData,
+      })
+    }
   }
 
   let textContent = ''

--- a/packages/richtext-slate/src/cell/rscEntry.tsx
+++ b/packages/richtext-slate/src/cell/rscEntry.tsx
@@ -19,7 +19,6 @@ export const RscEntrySlateCell: React.FC<
     field,
     i18n,
     link,
-    onClick: onClickFromProps,
     payload,
     rowData,
   } = props
@@ -31,8 +30,6 @@ export const RscEntrySlateCell: React.FC<
     (field.admin && 'className' in field.admin ? field.admin.className : null) ||
     classNameFromConfigContext
   const adminRoute = payload.config.routes.admin
-
-  const onClick = onClickFromProps
 
   let WrapElement: React.ComponentType<any> | string = 'span'
 
@@ -55,18 +52,6 @@ export const RscEntrySlateCell: React.FC<
           path: `/collections/${collectionConfig?.slug}/${rowData.id}`,
         })
       : ''
-  }
-
-  if (typeof onClick === 'function') {
-    WrapElement = 'button'
-    wrapElementProps.type = 'button'
-    wrapElementProps.onClick = () => {
-      onClick({
-        cellData,
-        collectionSlug: collectionConfig?.slug,
-        rowData,
-      })
-    }
   }
 
   let textContent = ''

--- a/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.tsx
@@ -47,7 +47,7 @@ export const DrawerLink: React.FC<{
 
   return (
     <div className="drawer-link">
-      <DefaultCell {...cellProps} className="drawer-link__cell" link={false} onClick={null} />
+      <DefaultCell {...cellProps} className="drawer-link__cell" link={false} />
       <DocumentDrawerToggler>
         <EditIcon />
       </DocumentDrawerToggler>

--- a/packages/ui/src/elements/Table/DefaultCell/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/index.tsx
@@ -21,7 +21,6 @@ export const DefaultCell: React.FC<DefaultCellComponentProps> = (props) => {
     field,
     field: { admin },
     link,
-    onClick: onClickFromProps,
     rowData,
   } = props
 
@@ -42,8 +41,6 @@ export const DefaultCell: React.FC<DefaultCellComponentProps> = (props) => {
     classNameFromProps ||
     (field.admin && 'className' in field.admin ? field.admin.className : null) ||
     classNameFromConfigContext
-
-  const onClick = onClickFromProps
 
   let WrapElement: React.ComponentType<any> | string = 'span'
 
@@ -66,18 +63,6 @@ export const DefaultCell: React.FC<DefaultCellComponentProps> = (props) => {
           path: `/collections/${collectionConfig?.slug}/${encodeURIComponent(rowData.id)}`,
         })
       : ''
-  }
-
-  if (typeof onClick === 'function') {
-    WrapElement = 'button'
-    wrapElementProps.type = 'button'
-    wrapElementProps.onClick = () => {
-      onClick({
-        cellData,
-        collectionSlug: collectionConfig?.slug,
-        rowData,
-      })
-    }
   }
 
   if (fieldIsID(field)) {

--- a/packages/ui/src/elements/Table/DefaultCell/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/index.tsx
@@ -1,5 +1,10 @@
 'use client'
-import type { DefaultCellComponentProps, UploadFieldClient } from 'payload'
+import type {
+  DefaultCellComponentProps,
+  RowData,
+  SanitizedCollectionConfig,
+  UploadFieldClient,
+} from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
 import { fieldAffectsData, fieldIsID } from 'payload/shared'
@@ -13,7 +18,15 @@ import { Link } from '../../Link/index.js'
 import { CodeCell } from './fields/Code/index.js'
 import { cellComponents } from './fields/index.js'
 
-export const DefaultCell: React.FC<DefaultCellComponentProps> = (props) => {
+export type DefaultCellProps = {
+  onClick?: (args: {
+    cellData: unknown
+    collectionSlug: SanitizedCollectionConfig['slug']
+    rowData: RowData
+  }) => void
+} & DefaultCellComponentProps
+
+export const DefaultCell: React.FC<DefaultCellProps> = (props) => {
   const {
     cellData,
     className: classNameFromProps,
@@ -21,6 +34,7 @@ export const DefaultCell: React.FC<DefaultCellComponentProps> = (props) => {
     field,
     field: { admin },
     link,
+    onClick: onClickFromProps,
     rowData,
   } = props
 
@@ -41,6 +55,8 @@ export const DefaultCell: React.FC<DefaultCellComponentProps> = (props) => {
     classNameFromProps ||
     (field.admin && 'className' in field.admin ? field.admin.className : null) ||
     classNameFromConfigContext
+
+  const onClick = onClickFromProps
 
   let WrapElement: React.ComponentType<any> | string = 'span'
 
@@ -63,6 +79,18 @@ export const DefaultCell: React.FC<DefaultCellComponentProps> = (props) => {
           path: `/collections/${collectionConfig?.slug}/${encodeURIComponent(rowData.id)}`,
         })
       : ''
+  }
+
+  if (typeof onClick === 'function') {
+    WrapElement = 'button'
+    wrapElementProps.type = 'button'
+    wrapElementProps.onClick = () => {
+      onClick({
+        cellData,
+        collectionSlug: collectionConfig?.slug,
+        rowData,
+      })
+    }
   }
 
   if (fieldIsID(field)) {

--- a/packages/ui/src/providers/TableColumns/RenderDefaultCell/index.tsx
+++ b/packages/ui/src/providers/TableColumns/RenderDefaultCell/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { DefaultCellComponentProps } from 'payload'
+import type { DefaultCellComponentProps, RowData, SanitizedCollectionConfig } from 'payload'
 
 import React from 'react'
 
@@ -23,7 +23,13 @@ export const RenderDefaultCell: React.FC<{
   const { drawerSlug, onSelect } = useListDrawerContext()
   const { LinkedCellOverride } = useTableColumns()
 
-  const propsToPass: DefaultCellComponentProps = {
+  const propsToPass: {
+    onClick?: (args: {
+      cellData: unknown
+      collectionSlug: SanitizedCollectionConfig['slug']
+      rowData: RowData
+    }) => void
+  } & DefaultCellComponentProps = {
     ...clientProps,
     columnIndex,
   }

--- a/packages/ui/src/providers/TableColumns/buildColumnState.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState.tsx
@@ -225,7 +225,7 @@ export const buildColumnState = (args: Args): Column[] => {
         ? docs.map((doc, i) => {
             const isLinkedColumn = index === activeColumnsIndices[0]
 
-            const cellClientProps: DefaultCellComponentProps = {
+            const cellClientProps = {
               ...baseCellClientProps,
               cellData: 'name' in field ? doc[field.name] : undefined,
               link: isLinkedColumn,
@@ -234,15 +234,12 @@ export const buildColumnState = (args: Args): Column[] => {
 
             const cellServerProps: DefaultServerCellComponentProps = {
               cellData: cellClientProps.cellData,
-              className: baseCellClientProps.className,
               collectionConfig,
               collectionSlug: collectionConfig.slug,
-              columnIndex: baseCellClientProps.columnIndex,
               customCellProps: baseCellClientProps.customCellProps,
               field: _field,
               i18n,
               link: cellClientProps.link,
-              onClick: baseCellClientProps.onClick,
               payload,
               rowData: doc,
             }

--- a/packages/ui/src/providers/TableColumns/buildPolymorphicColumnState.tsx
+++ b/packages/ui/src/providers/TableColumns/buildPolymorphicColumnState.tsx
@@ -25,13 +25,13 @@ import React from 'react'
 
 import type { SortColumnProps } from '../../elements/SortColumn/index.js'
 
+import { RenderServerComponent } from '../../elements/RenderServerComponent/index.js'
 import {
   RenderCustomComponent,
   RenderDefaultCell,
   SortColumn,
   // eslint-disable-next-line payload/no-imports-from-exports-dir
 } from '../../exports/client/index.js'
-import { RenderServerComponent } from '../../elements/RenderServerComponent/index.js'
 import { filterFields } from './filterFields.js'
 
 type Args = {
@@ -219,15 +219,12 @@ export const buildPolymorphicColumnState = (args: Args): Column[] => {
 
             const cellServerProps: DefaultServerCellComponentProps = {
               cellData: cellClientProps.cellData,
-              className: baseCellClientProps.className,
               collectionConfig: payload.collections[collectionSlug].config,
               collectionSlug,
-              columnIndex: baseCellClientProps.columnIndex,
               customCellProps: baseCellClientProps.customCellProps,
               field: _field,
               i18n,
               link: cellClientProps.link,
-              onClick: baseCellClientProps.onClick,
               payload,
               rowData: doc,
             }


### PR DESCRIPTION
### What

Previously, the `onClick` prop was included in `DefaultCellComponentProps` for use when creating custom cell components but was always returning as `undefined`.

### Why

The `onClick` prop was never intended for external use and was always returning undefined when used. It was mistakenly left in the `DefaultCellComponentProps` type when it was a prop type only meant to be used internally.

### How

The prop was removed from the `DefaultCellComponentProps` type to prevent it from being used externally.

Updated the docs to reflect this change and clarify that `onClick` should not be set or used when defining custom cell components.
