### PR TITLE
fix(ui): add uuid fallback for non-secure contexts in JSON fields

### DIFF
--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -81,8 +81,8 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
 
       const uri = jsonSchema.uri
       const newUri = uri.includes('?')
-        ? `${uri}&${typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : uuidv4()}`
-        : `${uri}?${typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : uuidv4()}`
+        ? `${uri}&${(crypto.randomUUID || uuidv4)()}`
+        : `${uri}?${(crypto.randomUUID || uuidv4)()}`
 
       editor.setModel(
         monaco.editor.createModel(JSON.stringify(value, null, 2), 'json', monaco.Uri.parse(newUri)),

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -81,8 +81,8 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
 
       const uri = jsonSchema.uri
       const newUri = uri.includes('?')
-        ? `${uri}&${(crypto.randomUUID || uuidv4)()}`
-        : `${uri}?${(crypto.randomUUID || uuidv4)()}`
+        ? `${uri}&${crypto.randomUUID ? crypto.randomUUID() : uuidv4()}`
+        : `${uri}?${crypto.randomUUID ? crypto.randomUUID() : uuidv4()}`
 
       editor.setModel(
         monaco.editor.createModel(JSON.stringify(value, null, 2), 'json', monaco.Uri.parse(newUri)),

--- a/packages/ui/src/fields/JSON/index.tsx
+++ b/packages/ui/src/fields/JSON/index.tsx
@@ -3,6 +3,7 @@ import type { JSONFieldClientComponent } from 'payload'
 
 import { type OnMount } from '@monaco-editor/react'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 
 import { CodeEditor } from '../../elements/CodeEditor/index.js'
 import { RenderCustomComponent } from '../../elements/RenderCustomComponent/index.js'
@@ -80,8 +81,8 @@ const JSONFieldComponent: JSONFieldClientComponent = (props) => {
 
       const uri = jsonSchema.uri
       const newUri = uri.includes('?')
-        ? `${uri}&${crypto.randomUUID()}`
-        : `${uri}?${crypto.randomUUID()}`
+        ? `${uri}&${typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : uuidv4()}`
+        : `${uri}?${typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : uuidv4()}`
 
       editor.setModel(
         monaco.editor.createModel(JSON.stringify(value, null, 2), 'json', monaco.Uri.parse(newUri)),


### PR DESCRIPTION
### What

The `crypto.randomUUID()` function was causing errors in non-secure contexts (HTTP), as it is only available in secure contexts (HTTPS).

### How

Added a fallback to generate UUIDs using the `uuid` library when `crypto.randomUUID()` is not available.

Fixes #11825 
