### PR TITLE
fix(ui): nested fields disappear when queued in form state

### DIFF
--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -130,6 +130,7 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
     queueRef.current = []
 
     setBackgroundProcessing(true)
+
     try {
       await latestAction()
     } finally {

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -720,53 +720,51 @@ export const Form: React.FC<FormProps> = (props) => {
 
   const classes = [className, baseClass].filter(Boolean).join(' ')
 
-  const executeOnChange = useEffectEvent(async (submitted: boolean, signal: AbortSignal) => {
-    if (Array.isArray(onChange)) {
-      let revalidatedFormState: FormState = contextRef.current.fields
+  const executeOnChange = useEffectEvent((submitted: boolean) => {
+    void queueTask(async () => {
+      if (Array.isArray(onChange)) {
+        let revalidatedFormState: FormState = contextRef.current.fields
 
-      for (const onChangeFn of onChange) {
-        if (signal.aborted) {
+        for (const onChangeFn of onChange) {
+          // Edit view default onChange is in packages/ui/src/views/Edit/index.tsx. This onChange usually sends a form state request
+          revalidatedFormState = await onChangeFn({
+            formState: deepCopyObjectSimpleWithoutReactComponents(contextRef.current.fields),
+            submitted,
+          })
+        }
+
+        if (!revalidatedFormState) {
           return
         }
 
-        // Edit view default onChange is in packages/ui/src/views/Edit/index.tsx. This onChange usually sends a form state request
-        revalidatedFormState = await onChangeFn({
-          formState: deepCopyObjectSimpleWithoutReactComponents(contextRef.current.fields),
-          submitted,
+        const { changed, newState } = mergeServerFormState({
+          existingState: contextRef.current.fields || {},
+          incomingState: revalidatedFormState,
         })
+
+        if (changed) {
+          prevFields.current = newState
+
+          dispatchFields({
+            type: 'REPLACE_STATE',
+            optimize: false,
+            state: newState,
+          })
+        }
       }
-
-      if (!revalidatedFormState) {
-        return
-      }
-
-      const { changed, newState } = mergeServerFormState({
-        existingState: contextRef.current.fields || {},
-        incomingState: revalidatedFormState,
-      })
-
-      if (changed && !signal.aborted) {
-        prevFields.current = newState
-
-        dispatchFields({
-          type: 'REPLACE_STATE',
-          optimize: false,
-          state: newState,
-        })
-      }
-    }
+    })
   })
 
   useDebouncedEffect(
     () => {
       if ((isFirstRenderRef.current || !dequal(fields, prevFields.current)) && modified) {
-        queueTask(async (signal) => executeOnChange(submitted, signal))
+        void executeOnChange(submitted)
       }
 
       prevFields.current = fields
       isFirstRenderRef.current = false
     },
-    [modified, submitted, fields, queueTask],
+    [modified, submitted, fields],
     250,
   )
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -721,7 +721,7 @@ export const Form: React.FC<FormProps> = (props) => {
   const classes = [className, baseClass].filter(Boolean).join(' ')
 
   const executeOnChange = useEffectEvent((submitted: boolean) => {
-    void queueTask(async () => {
+    queueTask(async () => {
       if (Array.isArray(onChange)) {
         let revalidatedFormState: FormState = contextRef.current.fields
 
@@ -758,7 +758,7 @@ export const Form: React.FC<FormProps> = (props) => {
   useDebouncedEffect(
     () => {
       if ((isFirstRenderRef.current || !dequal(fields, prevFields.current)) && modified) {
-        void executeOnChange(submitted)
+        executeOnChange(submitted)
       }
 
       prevFields.current = fields

--- a/test/form-state/collections/Posts/index.ts
+++ b/test/form-state/collections/Posts/index.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
+
 export const postsSlug = 'posts'
 
 export const PostsCollection: CollectionConfig = {
@@ -61,6 +63,17 @@ export const PostsCollection: CollectionConfig = {
               type: 'number',
             },
           ],
+        },
+      ],
+    },
+    {
+      name: 'array',
+      type: 'array',
+      fields: [
+        {
+          name: 'richText',
+          type: 'richText',
+          editor: lexicalEditor(),
         },
       ],
     },

--- a/test/form-state/payload-types.ts
+++ b/test/form-state/payload-types.ts
@@ -54,6 +54,7 @@ export type SupportedTimezones =
   | 'Asia/Singapore'
   | 'Asia/Tokyo'
   | 'Asia/Seoul'
+  | 'Australia/Brisbane'
   | 'Australia/Sydney'
   | 'Pacific/Guam'
   | 'Pacific/Noumea'
@@ -139,6 +140,26 @@ export interface Post {
             blockType: 'number';
           }
       )[]
+    | null;
+  array?:
+    | {
+        richText?: {
+          root: {
+            type: string;
+            children: {
+              type: string;
+              version: number;
+              [k: string]: unknown;
+            }[];
+            direction: ('ltr' | 'rtl') | null;
+            format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+            indent: number;
+            version: number;
+          };
+          [k: string]: unknown;
+        } | null;
+        id?: string | null;
+      }[]
     | null;
   updatedAt: string;
   createdAt: string;
@@ -242,6 +263,12 @@ export interface PostsSelect<T extends boolean = true> {
               id?: T;
               blockName?: T;
             };
+      };
+  array?:
+    | T
+    | {
+        richText?: T;
+        id?: T;
       };
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
When rendering custom fields nested within arrays or blocks, such as the Lexical rich text editor which is treated as a custom field, these fields will sometimes disappear when form state requests are invoked sequentially. This is especially reproducible on slow networks.

Here's a screen recording demonstrating the issue:

https://github.com/user-attachments/assets/ea53751e-77d9-45d3-ac4a-9fda5bc3e448

The problem is that form state invocations are placed into a [task queue](https://github.com/payloadcms/payload/pull/11579) which aborts the currently running tasks when a new one arrives. By doing this, local form state is never dispatched, and the second task in the queue becomes stale.

The fix is to _not_ abort the currently running task. This will trigger a complete rendering cycle, and when the second task is invoked, local state will be up to date.

Fixes #11340, #11425, and #11824.

Related: #11906.