### PR TITLE
fix(graphql): respect `draft: true` when querying joins

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -379,6 +379,8 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
         const { limit, page, sort, where } = args
         const { req } = context
 
+        const draft = Boolean(args.draft ?? context.req.query?.draft)
+
         const fullWhere = combineQueries(where, {
           [field.on]: { equals: parent._id ?? parent.id },
         })
@@ -390,6 +392,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
         return await req.payload.find({
           collection,
           depth: 0,
+          draft,
           fallbackLocale: req.fallbackLocale,
           limit,
           locale: req.locale,

--- a/test/joins/collections/Versions.ts
+++ b/test/joins/collections/Versions.ts
@@ -6,6 +6,11 @@ export const Versions: CollectionConfig = {
   slug: versionsSlug,
   fields: [
     {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
       name: 'category',
       relationTo: 'categories',
       type: 'relationship',

--- a/test/joins/payload-types.ts
+++ b/test/joins/payload-types.ts
@@ -54,6 +54,7 @@ export type SupportedTimezones =
   | 'Asia/Singapore'
   | 'Asia/Tokyo'
   | 'Asia/Seoul'
+  | 'Australia/Brisbane'
   | 'Australia/Sydney'
   | 'Pacific/Guam'
   | 'Pacific/Noumea'
@@ -464,6 +465,7 @@ export interface Singular {
  */
 export interface Version {
   id: string;
+  title: string;
   category?: (string | null) | Category;
   categoryVersion?: (string | null) | CategoriesVersion;
   categoryVersions?: (string | CategoriesVersion)[] | null;
@@ -999,6 +1001,7 @@ export interface UploadsSelect<T extends boolean = true> {
  * via the `definition` "versions_select".
  */
 export interface VersionsSelect<T extends boolean = true> {
+  title?: T;
   category?: T;
   categoryVersion?: T;
   categoryVersions?: T;
@@ -1232,7 +1235,6 @@ export interface Auth {
 
 
 declare module 'payload' {
-  // @ts-ignore
+  // @ts-ignore 
   export interface GeneratedTypes extends Config {}
 }
-


### PR DESCRIPTION
The same as https://github.com/payloadcms/payload/pull/11763 but also for GraphQL. The previous fix was working only for the Local API and REST API due to a different method for querying joins in GraphQL.