### PR TITLE
fix(examples): static generation - check slug for null values

### DIFF
--- a/examples/draft-preview/src/app/(app)/[slug]/page.tsx
+++ b/examples/draft-preview/src/app/(app)/[slug]/page.tsx
@@ -21,13 +21,10 @@ export async function generateStaticParams() {
     overrideAccess: false,
   })
 
-  const params = pages.docs
-    ?.filter((doc) => {
-      return doc.slug !== 'home'
-    })
-    .map(({ slug }) => {
-      return { slug }
-    })
+  const params =
+    pages.docs
+      ?.filter((doc) => doc.slug !== null && doc.slug !== 'home')
+      .map(({ slug }) => ({ slug })) || ''
 
   return params || []
 }

--- a/examples/localization/src/app/(frontend)/[locale]/[slug]/page.tsx
+++ b/examples/localization/src/app/(frontend)/[locale]/[slug]/page.tsx
@@ -24,13 +24,10 @@ export async function generateStaticParams() {
     overrideAccess: false,
   })
 
-  const params = pages.docs
-    ?.filter((doc) => {
-      return doc.slug !== 'home'
-    })
-    .map(({ slug }) => {
-      return { slug }
-    })
+  const params =
+    pages.docs
+      ?.filter((doc) => doc.slug !== null && doc.slug !== 'home')
+      .map(({ slug }) => ({ slug })) || ''
 
   return params
 }

--- a/examples/localization/src/app/(frontend)/[locale]/posts/[slug]/page.tsx
+++ b/examples/localization/src/app/(frontend)/[locale]/posts/[slug]/page.tsx
@@ -24,9 +24,11 @@ export async function generateStaticParams() {
     overrideAccess: false,
   })
 
-  const params = posts.docs.map(({ slug }) => {
-    return { slug }
-  })
+  const params = posts.docs
+    ?.filter((doc) => doc.slug !== null)
+    .map(({ slug }) => {
+      return { slug }
+    })
 
   return params
 }

--- a/templates/website/src/app/(frontend)/[slug]/page.tsx
+++ b/templates/website/src/app/(frontend)/[slug]/page.tsx
@@ -26,13 +26,10 @@ export async function generateStaticParams() {
     },
   })
 
-  const params = pages.docs
-    ?.filter((doc) => {
-      return doc.slug !== 'home'
-    })
-    .map(({ slug }) => {
-      return { slug }
-    })
+  const params =
+    pages.docs
+      ?.filter((doc) => doc.slug !== null && doc.slug !== 'home')
+      .map(({ slug }) => ({ slug })) || ''
 
   return params
 }

--- a/templates/website/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/templates/website/src/app/(frontend)/posts/[slug]/page.tsx
@@ -28,9 +28,11 @@ export async function generateStaticParams() {
     },
   })
 
-  const params = posts.docs.map(({ slug }) => {
-    return { slug }
-  })
+  const params = posts.docs
+    ?.filter((doc) => doc.slug !== null)
+    .map(({ slug }) => {
+      return { slug }
+    })
 
   return params
 }

--- a/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/[slug]/page.tsx
@@ -26,13 +26,10 @@ export async function generateStaticParams() {
     },
   })
 
-  const params = pages.docs
-    ?.filter((doc) => {
-      return doc.slug !== 'home'
-    })
-    .map(({ slug }) => {
-      return { slug }
-    })
+  const params =
+    pages.docs
+      ?.filter((doc) => doc.slug !== null && doc.slug !== 'home')
+      .map(({ slug }) => ({ slug })) || ''
 
   return params
 }

--- a/templates/with-vercel-website/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/posts/[slug]/page.tsx
@@ -28,9 +28,11 @@ export async function generateStaticParams() {
     },
   })
 
-  const params = posts.docs.map(({ slug }) => {
-    return { slug }
-  })
+  const params = posts.docs
+    ?.filter((doc) => doc.slug !== null)
+    .map(({ slug }) => {
+      return { slug }
+    })
 
   return params
 }


### PR DESCRIPTION
### What?
Fixes an issue where generateStaticParams() receives null values for slug, causing the build to fail. This ensures that only valid slugs (non-null, non-empty strings) are included in the returned params.

```
 ✓ Linting and checking validity of types 
   Collecting page data  ..
Slug (pages):  [
  { slug: null },
  { slug: null },
  { slug: null },
  { slug: null },
  { slug: 'page-1' }
]
Error: A required parameter (slug) was not provided as a string received object in generateStaticParams for /[slug]
    at Array.forEach (<anonymous>)
    at Array.forEach (<anonymous>)
```


### Why?
During the build process, generateStaticParams() is expected to return an array of objects with valid slug values. If null values are present, Next.js fails to generate static pages correctly, leading to build errors.


### How?
Filters out any pages where slug is null or not a string before mapping the results.

```
export async function generateStaticParams() {
  const payload = await getPayload({ config: configPromise })
  const pages = await payload.find({
    collection: 'pages',
    draft: false,
    limit: 1000,
    overrideAccess: true,
    pagination: false,
    select: {
      slug: true,
    },
  })

  const params =
    pages?.docs
      ?.filter((doc) => typeof doc.slug === 'string' && doc.slug !== 'home')
      .map(({ slug }) => ({ slug })) || []

  return params
}

```

This ensures that only valid slugs are passed to Next.js, preventing the build from failing.







