### PR TITLE
fix(plugin-cloud-storage): ensure client handlers are added to import map regardless of enabled state

### DIFF
--- a/packages/payload/src/bin/generateImportMap/iterateConfig.ts
+++ b/packages/payload/src/bin/generateImportMap/iterateConfig.ts
@@ -95,8 +95,7 @@ export function iterateConfig({
   }
 
   if (config?.admin?.dependencies) {
-    for (const key in config.admin.dependencies) {
-      const dependency = config.admin.dependencies[key]
+    for (const dependency of Object.values(config.admin.dependencies)) {
       addToImportMap(dependency.path)
     }
   }

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -793,9 +793,7 @@ export type Config = {
     /** Global date format that will be used for all dates in the Admin panel. Any valid date-fns format pattern can be used. */
     dateFormat?: string
     /**
-     * Each entry in this map generates an entry in the importMap,
-     * as well as an entry in the componentMap if the type of the
-     * dependency is 'component'
+     * Each entry in this map generates an entry in the importMap.
      */
     dependencies?: AdminDependencies
     /**

--- a/packages/plugin-cloud-storage/src/utilities/initClientUploads.ts
+++ b/packages/plugin-cloud-storage/src/utilities/initClientUploads.ts
@@ -53,6 +53,16 @@ export const initClientUploads = <ExtraProps extends Record<string, unknown>, T>
     config.admin = {}
   }
 
+  if (!config.admin.dependencies) {
+    config.admin.dependencies = {}
+  }
+  // Ensure client handler is always part of the import map, to avoid
+  // import map discrepancies between dev and prod
+  config.admin.dependencies[clientHandler] = {
+    type: 'function',
+    path: clientHandler,
+  }
+
   if (!config.admin.components) {
     config.admin.components = {}
   }


### PR DESCRIPTION
There are cases when a storage plugin is disabled during development and enabled in production. This will result in import maps that differ depending on if they're generated during development or production.

In a lot of cases, those import maps are generated during development-only. During production, we just re-use what was generated locally. This will cause missing import map entries for those plugins that are disabled during development.

This PR ensures the import map entries are added regardless of the enabled state of those plugins. This is necessary for our generate-templates script to not omit the vercel blob storage import map entry.