### PR TITLE
refactor(ui): replace autosave queue pattern with useQueues hook

### DIFF
--- a/packages/ui/src/hooks/useQueues.ts
+++ b/packages/ui/src/hooks/useQueues.ts
@@ -4,33 +4,46 @@ type queuedFunction = () => Promise<void>
 
 /**
  * A React hook that allows you to queue up functions to be executed in order.
- * This is useful when you need to ensure log running networks requests are processed sequentially.
- * Builds up a "queue" of functions to be executed, and only ever processes the last function in the queue.
- * The remaining queue is cleared out to ensure it remains shallow.
+ * This is useful when you need to ensure long running networks requests are processed sequentially.
+ * Builds up a "queue" of functions to be executed in order, only ever processing the last function in the queue.
+ * This ensures that a long queue of tasks doesn't cause a backlog of tasks to be processed.
+ * E.g. if you queue a task and it begins running, then you queue 9 more tasks:
+ *   1. The currently task will finish
+ *   2. The next task in the queue will run
+ *   3. All remaining tasks will be discarded
+ * @returns {queueTask} A function used to queue a function.
+ * @example
+ * const { queueTask } = useQueues()
+ * queueTask(async () => {
+ *   await fetch('https://api.example.com')
+ * })
  */
 export function useQueues(): {
   queueTask: (fn: queuedFunction) => void
 } {
   const queue = useRef<queuedFunction[]>([])
+  const isProcessing = useRef(false)
 
   const queueTask = useCallback((fn: queuedFunction) => {
     queue.current.push(fn)
 
-    const processQueue = async () => {
-      if (queue.current.length === 0) {
+    async function processQueue() {
+      if (isProcessing.current) {
         return
       }
 
       while (queue.current.length > 0) {
         const latestTask = queue.current.pop() // Only process the last task in the queue
-        queue.current = [] // Reset the queue to ensure it remains shallow
+        queue.current = [] // Discard all other tasks
 
-        if (latestTask) {
-          try {
-            await latestTask()
-          } catch (err) {
-            console.error('Error in queued function:', err) // eslint-disable-line no-console
-          }
+        isProcessing.current = true
+
+        try {
+          await latestTask()
+        } catch (err) {
+          console.error('Error in queued function:', err) // eslint-disable-line no-console
+        } finally {
+          isProcessing.current = false
         }
       }
     }


### PR DESCRIPTION
Replaces the queue pattern used within autosave with the `useQueues` hook introduced in #11579. To do this, queued tasks now accept an options object with callbacks which can be used to tie into events of the process, such as before it begins to prevent it from running, and after it has finished to perform side effects.

The `useQueues` hook now also maintains an array of queued tasks as opposed to individual refs.