### PR TITLE
fix: do not append `doc` input for scheduled publish job if it's enabled only for globals

### DIFF
--- a/packages/payload/src/versions/schedule/job.ts
+++ b/packages/payload/src/versions/schedule/job.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import type { User } from '../../auth/types.js'
+import type { Field } from '../../fields/config/types.js'
 import type { TaskConfig } from '../../queues/config/types/taskTypes.js'
 import type { SchedulePublishTaskInput } from './types.js'
 
@@ -87,11 +88,15 @@ export const getSchedulePublishTask = ({
         name: 'locale',
         type: 'text',
       },
-      {
-        name: 'doc',
-        type: 'relationship',
-        relationTo: collections,
-      },
+      ...(collections.length > 0
+        ? [
+            {
+              name: 'doc',
+              type: 'relationship',
+              relationTo: collections,
+            } satisfies Field,
+          ]
+        : []),
       {
         name: 'global',
         type: 'select',


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11891


Previously, if you had scheduled publish enabled only for globals, not collections - you'd get an error on `payload generate:types`:
<img width="886" alt="image" src="https://github.com/user-attachments/assets/78125ce8-bd89-4269-bc56-966d8e0c3968" />

This was caused by appending the `doc` field to the scheduled publish job input schema with empty `collections` array. Now we skip this field if we don't have any collections.