### PR TITLE
fix: allow custom `password` field when using `disableLocalStrategy: true`

### DIFF
--- a/packages/payload/src/collections/operations/utilities/update.ts
+++ b/packages/payload/src/collections/operations/utilities/update.ts
@@ -99,7 +99,14 @@ export const updateDocument = async <
   const password = data?.password
   const shouldSaveDraft =
     Boolean(draftArg && collectionConfig.versions.drafts) && data._status !== 'published'
-  const shouldSavePassword = Boolean(password && collectionConfig.auth && !shouldSaveDraft)
+  const shouldSavePassword = Boolean(
+    password &&
+      collectionConfig.auth &&
+      (!collectionConfig.auth.disableLocalStrategy ||
+        (typeof collectionConfig.auth.disableLocalStrategy === 'object' &&
+          collectionConfig.auth.disableLocalStrategy.enableFields)) &&
+      !shouldSaveDraft,
+  )
 
   // /////////////////////////////////////
   // Handle potentially locked documents

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -204,6 +204,17 @@ export default buildConfigWithDefaults({
       ],
     },
     {
+      slug: 'disable-local-strategy-password',
+      auth: { disableLocalStrategy: true },
+      fields: [
+        {
+          name: 'password',
+          type: 'text',
+          required: true,
+        },
+      ],
+    },
+    {
       slug: apiKeysSlug,
       access: {
         read: ({ req: { user } }) => {

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -786,6 +786,20 @@ describe('Auth', () => {
 
       expect(response.status).toBe(403)
     })
+
+    it('should allow to use password field', async () => {
+      const doc = await payload.create({
+        collection: 'disable-local-strategy-password',
+        data: { password: '123' },
+      })
+      expect(doc.password).toBe('123')
+      const updated = await payload.update({
+        collection: 'disable-local-strategy-password',
+        data: { password: '1234' },
+        id: doc.id,
+      })
+      expect(updated.password).toBe('1234')
+    })
   })
 
   describe('API Key', () => {

--- a/test/auth/payload-types.ts
+++ b/test/auth/payload-types.ts
@@ -54,6 +54,7 @@ export type SupportedTimezones =
   | 'Asia/Singapore'
   | 'Asia/Tokyo'
   | 'Asia/Seoul'
+  | 'Australia/Brisbane'
   | 'Australia/Sydney'
   | 'Pacific/Guam'
   | 'Pacific/Noumea'
@@ -64,6 +65,7 @@ export interface Config {
   auth: {
     users: UserAuthOperations;
     'partial-disable-local-strategies': PartialDisableLocalStrategyAuthOperations;
+    'disable-local-strategy-password': DisableLocalStrategyPasswordAuthOperations;
     'api-keys': ApiKeyAuthOperations;
     'public-users': PublicUserAuthOperations;
   };
@@ -71,6 +73,7 @@ export interface Config {
   collections: {
     users: User;
     'partial-disable-local-strategies': PartialDisableLocalStrategy;
+    'disable-local-strategy-password': DisableLocalStrategyPassword;
     'api-keys': ApiKey;
     'public-users': PublicUser;
     relationsCollection: RelationsCollection;
@@ -82,6 +85,7 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     'partial-disable-local-strategies': PartialDisableLocalStrategiesSelect<false> | PartialDisableLocalStrategiesSelect<true>;
+    'disable-local-strategy-password': DisableLocalStrategyPasswordSelect<false> | DisableLocalStrategyPasswordSelect<true>;
     'api-keys': ApiKeysSelect<false> | ApiKeysSelect<true>;
     'public-users': PublicUsersSelect<false> | PublicUsersSelect<true>;
     relationsCollection: RelationsCollectionSelect<false> | RelationsCollectionSelect<true>;
@@ -101,6 +105,9 @@ export interface Config {
       })
     | (PartialDisableLocalStrategy & {
         collection: 'partial-disable-local-strategies';
+      })
+    | (DisableLocalStrategyPassword & {
+        collection: 'disable-local-strategy-password';
       })
     | (ApiKey & {
         collection: 'api-keys';
@@ -132,6 +139,24 @@ export interface UserAuthOperations {
   };
 }
 export interface PartialDisableLocalStrategyAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
+export interface DisableLocalStrategyPasswordAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -244,6 +269,16 @@ export interface PartialDisableLocalStrategy {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "disable-local-strategy-password".
+ */
+export interface DisableLocalStrategyPassword {
+  id: string;
+  password: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "api-keys".
  */
 export interface ApiKey {
@@ -300,6 +335,10 @@ export interface PayloadLockedDocument {
         value: string | PartialDisableLocalStrategy;
       } | null)
     | ({
+        relationTo: 'disable-local-strategy-password';
+        value: string | DisableLocalStrategyPassword;
+      } | null)
+    | ({
         relationTo: 'api-keys';
         value: string | ApiKey;
       } | null)
@@ -320,6 +359,10 @@ export interface PayloadLockedDocument {
     | {
         relationTo: 'partial-disable-local-strategies';
         value: string | PartialDisableLocalStrategy;
+      }
+    | {
+        relationTo: 'disable-local-strategy-password';
+        value: string | DisableLocalStrategyPassword;
       }
     | {
         relationTo: 'api-keys';
@@ -346,6 +389,10 @@ export interface PayloadPreference {
     | {
         relationTo: 'partial-disable-local-strategies';
         value: string | PartialDisableLocalStrategy;
+      }
+    | {
+        relationTo: 'disable-local-strategy-password';
+        value: string | DisableLocalStrategyPassword;
       }
     | {
         relationTo: 'api-keys';
@@ -439,6 +486,15 @@ export interface PartialDisableLocalStrategiesSelect<T extends boolean = true> {
   hash?: T;
   loginAttempts?: T;
   lockUntil?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "disable-local-strategy-password_select".
+ */
+export interface DisableLocalStrategyPasswordSelect<T extends boolean = true> {
+  password?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11888

Previously, if you had `disableLocalStategy: true` and a custom `password` field, Payload would still control it in `update.ts` by deleting. Now, we don't do that in this case, unless we have `disableLocalStetegy.enableFields: true`.