### PR TITLE
feat: types custom component props

### DIFF
--- a/packages/payload/src/admin/fields/Array.ts
+++ b/packages/payload/src/admin/fields/Array.ts
@@ -39,15 +39,11 @@ export type ArrayFieldServerComponent = FieldServerComponent<
   ArrayFieldBaseServerProps
 >
 
-export type ArrayFieldClientComponent = FieldClientComponent<
-  ArrayFieldClientWithoutType,
-  ArrayFieldBaseClientProps
->
+export type ArrayFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<ArrayFieldClientWithoutType, ArrayFieldBaseClientProps>
 
-export type ArrayFieldLabelServerComponent = FieldLabelServerComponent<
-  ArrayField,
-  ArrayFieldClientWithoutType
->
+export type ArrayFieldLabelServerComponent<T extends Record<string, unknown> = {}> =
+  FieldLabelServerComponent<ArrayField, ArrayFieldClientWithoutType>
 
 export type ArrayFieldLabelClientComponent = FieldLabelClientComponent<ArrayFieldClientWithoutType>
 

--- a/packages/payload/src/admin/fields/Blocks.ts
+++ b/packages/payload/src/admin/fields/Blocks.ts
@@ -34,16 +34,11 @@ export type BlocksFieldClientProps = BlocksFieldBaseClientProps &
 export type BlocksFieldServerProps = BlocksFieldBaseServerProps &
   ServerFieldBase<BlocksField, BlocksFieldClientWithoutType>
 
-export type BlocksFieldServerComponent = FieldServerComponent<
-  BlocksField,
-  BlocksFieldClientWithoutType,
-  BlocksFieldBaseServerProps
->
+export type BlocksFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<BlocksField, BlocksFieldClientWithoutType, BlocksFieldBaseServerProps & T>
 
-export type BlocksFieldClientComponent = FieldClientComponent<
-  BlocksFieldClientWithoutType,
-  BlocksFieldBaseClientProps
->
+export type BlocksFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<BlocksFieldClientWithoutType, BlocksFieldBaseClientProps & T>
 
 export type BlocksFieldLabelServerComponent = FieldLabelServerComponent<
   BlocksField,

--- a/packages/payload/src/admin/fields/Checkbox.ts
+++ b/packages/payload/src/admin/fields/Checkbox.ts
@@ -39,16 +39,15 @@ export type CheckboxFieldClientProps = CheckboxFieldBaseClientProps &
 export type CheckboxFieldServerProps = CheckboxFieldBaseServerProps &
   ServerFieldBase<CheckboxField, CheckboxFieldClientWithoutType>
 
-export type CheckboxFieldServerComponent = FieldServerComponent<
-  CheckboxField,
-  CheckboxFieldClientWithoutType,
-  CheckboxFieldBaseServerProps
->
+export type CheckboxFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<
+    CheckboxField,
+    CheckboxFieldClientWithoutType,
+    CheckboxFieldBaseServerProps & T
+  >
 
-export type CheckboxFieldClientComponent = FieldClientComponent<
-  CheckboxFieldClientWithoutType,
-  CheckboxFieldBaseClientProps
->
+export type CheckboxFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<CheckboxFieldClientWithoutType, CheckboxFieldBaseClientProps & T>
 
 export type CheckboxFieldLabelServerComponent = FieldLabelServerComponent<
   CheckboxField,

--- a/packages/payload/src/admin/fields/Code.ts
+++ b/packages/payload/src/admin/fields/Code.ts
@@ -37,15 +37,15 @@ export type CodeFieldClientProps = ClientFieldBase<CodeFieldClientWithoutType> &
 export type CodeFieldServerProps = CodeFieldBaseServerProps &
   ServerFieldBase<CodeField, CodeFieldClientWithoutType>
 
-export type CodeFieldServerComponent = FieldServerComponent<
+export type CodeFieldServerComponent<T extends Record<string, unknown> = {}> = FieldServerComponent<
   CodeField,
   CodeFieldClientWithoutType,
-  CodeFieldBaseServerProps
+  CodeFieldBaseServerProps & T
 >
 
-export type CodeFieldClientComponent = FieldClientComponent<
+export type CodeFieldClientComponent<T extends Record<string, unknown> = {}> = FieldClientComponent<
   CodeFieldClientWithoutType,
-  CodeFieldBaseClientProps
+  CodeFieldBaseClientProps & T
 >
 
 export type CodeFieldLabelServerComponent = FieldLabelServerComponent<

--- a/packages/payload/src/admin/fields/Collapsible.ts
+++ b/packages/payload/src/admin/fields/Collapsible.ts
@@ -30,15 +30,11 @@ export type CollapsibleFieldServerProps = ServerFieldBase<
   CollapsibleFieldClientWithoutType
 >
 
-export type CollapsibleFieldServerComponent = FieldServerComponent<
-  CollapsibleField,
-  CollapsibleFieldClientWithoutType
->
+export type CollapsibleFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<CollapsibleField, CollapsibleFieldClientWithoutType & T>
 
-export type CollapsibleFieldClientComponent = FieldClientComponent<
-  CollapsibleFieldClientWithoutType,
-  CollapsibleFieldBaseClientProps
->
+export type CollapsibleFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<CollapsibleFieldClientWithoutType, CollapsibleFieldBaseClientProps & T>
 
 export type CollapsibleFieldLabelServerComponent = FieldLabelServerComponent<
   CollapsibleField,

--- a/packages/payload/src/admin/fields/Date.ts
+++ b/packages/payload/src/admin/fields/Date.ts
@@ -34,15 +34,15 @@ export type DateFieldClientProps = ClientFieldBase<DateFieldClientWithoutType> &
 export type DateFieldServerProps = DateFieldBaseServerProps &
   ServerFieldBase<DateField, DateFieldClientWithoutType>
 
-export type DateFieldServerComponent = FieldServerComponent<
+export type DateFieldServerComponent<T extends Record<string, unknown> = {}> = FieldServerComponent<
   DateField,
   DateFieldClientWithoutType,
-  DateFieldBaseServerProps
+  DateFieldBaseServerProps & T
 >
 
-export type DateFieldClientComponent = FieldClientComponent<
+export type DateFieldClientComponent<T extends Record<string, unknown> = {}> = FieldClientComponent<
   DateFieldClientWithoutType,
-  DateFieldBaseClientProps
+  DateFieldBaseClientProps & T
 >
 
 export type DateFieldLabelServerComponent = FieldLabelServerComponent<

--- a/packages/payload/src/admin/fields/Email.ts
+++ b/packages/payload/src/admin/fields/Email.ts
@@ -34,16 +34,11 @@ export type EmailFieldClientProps = ClientFieldBase<EmailFieldClientWithoutType>
 export type EmailFieldServerProps = EmailFieldBaseServerProps &
   ServerFieldBase<EmailField, EmailFieldClientWithoutType>
 
-export type EmailFieldServerComponent = FieldServerComponent<
-  EmailField,
-  EmailFieldClientWithoutType,
-  EmailFieldBaseServerProps
->
+export type EmailFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<EmailField, EmailFieldClientWithoutType, EmailFieldBaseServerProps & T>
 
-export type EmailFieldClientComponent = FieldClientComponent<
-  EmailFieldClientWithoutType,
-  EmailFieldBaseClientProps
->
+export type EmailFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<EmailFieldClientWithoutType, EmailFieldBaseClientProps & T>
 
 export type EmailFieldLabelServerComponent = FieldLabelServerComponent<
   EmailField,

--- a/packages/payload/src/admin/fields/Group.ts
+++ b/packages/payload/src/admin/fields/Group.ts
@@ -30,16 +30,11 @@ export type GroupFieldClientProps = ClientFieldBase<GroupFieldClientWithoutType>
 export type GroupFieldServerProps = GroupFieldBaseServerProps &
   ServerFieldBase<GroupField, GroupFieldClientWithoutType>
 
-export type GroupFieldServerComponent = FieldServerComponent<
-  GroupField,
-  GroupFieldClientWithoutType,
-  GroupFieldBaseServerProps
->
+export type GroupFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<GroupField, GroupFieldClientWithoutType, GroupFieldBaseServerProps & T>
 
-export type GroupFieldClientComponent = FieldClientComponent<
-  GroupFieldClientWithoutType,
-  GroupFieldBaseClientProps
->
+export type GroupFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<GroupFieldClientWithoutType, GroupFieldBaseClientProps & T>
 
 export type GroupFieldLabelServerComponent = FieldLabelServerComponent<
   GroupField,

--- a/packages/payload/src/admin/fields/JSON.ts
+++ b/packages/payload/src/admin/fields/JSON.ts
@@ -34,15 +34,15 @@ export type JSONFieldClientProps = ClientFieldBase<JSONFieldClientWithoutType> &
 export type JSONFieldServerProps = JSONFieldBaseServerProps &
   ServerFieldBase<JSONField, JSONFieldClientWithoutType>
 
-export type JSONFieldServerComponent = FieldServerComponent<
+export type JSONFieldServerComponent<T extends Record<string, unknown> = {}> = FieldServerComponent<
   JSONField,
   JSONFieldClientWithoutType,
-  JSONFieldBaseServerProps
+  JSONFieldBaseServerProps & T
 >
 
-export type JSONFieldClientComponent = FieldClientComponent<
+export type JSONFieldClientComponent<T extends Record<string, unknown> = {}> = FieldClientComponent<
   JSONFieldClientWithoutType,
-  JSONFieldBaseClientProps
+  JSONFieldBaseClientProps & T
 >
 
 export type JSONFieldLabelServerComponent = FieldLabelServerComponent<

--- a/packages/payload/src/admin/fields/Join.ts
+++ b/packages/payload/src/admin/fields/Join.ts
@@ -31,15 +31,15 @@ export type JoinFieldClientProps = ClientFieldBase<JoinFieldClientWithoutType> &
 
 export type JoinFieldServerProps = JoinFieldBaseServerProps & ServerFieldBase<JoinField>
 
-export type JoinFieldServerComponent = FieldServerComponent<
+export type JoinFieldServerComponent<T extends Record<string, unknown> = {}> = FieldServerComponent<
   JoinField,
   JoinFieldClientWithoutType,
-  JoinFieldBaseServerProps
+  JoinFieldBaseServerProps & T
 >
 
-export type JoinFieldClientComponent = FieldClientComponent<
+export type JoinFieldClientComponent<T extends Record<string, unknown> = {}> = FieldClientComponent<
   JoinFieldClientWithoutType,
-  JoinFieldBaseClientProps
+  JoinFieldBaseClientProps & T
 >
 
 export type JoinFieldLabelServerComponent = FieldLabelServerComponent<JoinField>

--- a/packages/payload/src/admin/fields/Number.ts
+++ b/packages/payload/src/admin/fields/Number.ts
@@ -35,16 +35,11 @@ export type NumberFieldClientProps = ClientFieldBase<NumberFieldClientWithoutTyp
 export type NumberFieldServerProps = NumberFieldBaseServerProps &
   ServerFieldBase<NumberField, NumberFieldClientWithoutType>
 
-export type NumberFieldServerComponent = FieldServerComponent<
-  NumberField,
-  NumberFieldClientWithoutType,
-  NumberFieldBaseServerProps
->
+export type NumberFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<NumberField, NumberFieldClientWithoutType, NumberFieldBaseServerProps & T>
 
-export type NumberFieldClientComponent = FieldClientComponent<
-  NumberFieldClientWithoutType,
-  NumberFieldBaseClientProps
->
+export type NumberFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<NumberFieldClientWithoutType, NumberFieldBaseClientProps & T>
 
 export type NumberFieldLabelServerComponent = FieldLabelServerComponent<
   NumberField,

--- a/packages/payload/src/admin/fields/Point.ts
+++ b/packages/payload/src/admin/fields/Point.ts
@@ -34,16 +34,11 @@ export type PointFieldClientProps = ClientFieldBase<PointFieldClientWithoutType>
 export type PointFieldServerProps = PointFieldBaseServerProps &
   ServerFieldBase<PointField, PointFieldClientWithoutType>
 
-export type PointFieldServerComponent = FieldServerComponent<
-  PointField,
-  PointFieldClientWithoutType,
-  PointFieldBaseServerProps
->
+export type PointFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<PointField, PointFieldClientWithoutType, PointFieldBaseServerProps & T>
 
-export type PointFieldClientComponent = FieldClientComponent<
-  PointFieldClientWithoutType,
-  PointFieldBaseClientProps
->
+export type PointFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<PointFieldClientWithoutType, PointFieldBaseClientProps & T>
 
 export type PointFieldLabelServerComponent = FieldLabelServerComponent<
   PointField,

--- a/packages/payload/src/admin/fields/Radio.ts
+++ b/packages/payload/src/admin/fields/Radio.ts
@@ -40,16 +40,11 @@ export type RadioFieldClientProps = ClientFieldBase<RadioFieldClientWithoutType>
 export type RadioFieldServerProps = RadioFieldBaseServerProps &
   ServerFieldBase<RadioField, RadioFieldClientWithoutType>
 
-export type RadioFieldServerComponent = FieldServerComponent<
-  RadioField,
-  RadioFieldClientWithoutType,
-  RadioFieldBaseServerProps
->
+export type RadioFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<RadioField, RadioFieldClientWithoutType, RadioFieldBaseServerProps & T>
 
-export type RadioFieldClientComponent = FieldClientComponent<
-  RadioFieldClientWithoutType,
-  RadioFieldBaseClientProps
->
+export type RadioFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<RadioFieldClientWithoutType, RadioFieldBaseClientProps & T>
 
 type OnChange<T = string> = (value: T) => void
 

--- a/packages/payload/src/admin/fields/Relationship.ts
+++ b/packages/payload/src/admin/fields/Relationship.ts
@@ -34,16 +34,15 @@ export type RelationshipFieldClientProps = ClientFieldBase<RelationshipFieldClie
 export type RelationshipFieldServerProps = RelationshipFieldBaseServerProps &
   ServerFieldBase<RelationshipField, RelationshipFieldClientWithoutType>
 
-export type RelationshipFieldServerComponent = FieldServerComponent<
-  RelationshipField,
-  RelationshipFieldClientWithoutType,
-  RelationshipFieldBaseServerProps
->
+export type RelationshipFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<
+    RelationshipField,
+    RelationshipFieldClientWithoutType,
+    RelationshipFieldBaseServerProps & T
+  >
 
-export type RelationshipFieldClientComponent = FieldClientComponent<
-  RelationshipFieldClientWithoutType,
-  RelationshipFieldBaseClientProps
->
+export type RelationshipFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<RelationshipFieldClientWithoutType, RelationshipFieldBaseClientProps & T>
 
 export type RelationshipFieldLabelServerComponent = FieldLabelServerComponent<
   RelationshipField,

--- a/packages/payload/src/admin/fields/RichText.ts
+++ b/packages/payload/src/admin/fields/RichText.ts
@@ -46,16 +46,15 @@ export type RichTextFieldClientProps<
 export type RichTextFieldServerProps = RichTextFieldBaseServerProps &
   ServerFieldBase<RichTextField, RichTextFieldClientWithoutType>
 
-export type RichTextFieldServerComponent = FieldServerComponent<
-  RichTextField,
-  RichTextFieldClientWithoutType,
-  RichTextFieldBaseServerProps
->
+export type RichTextFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<
+    RichTextField,
+    RichTextFieldClientWithoutType,
+    RichTextFieldBaseServerProps & T
+  >
 
-export type RichTextFieldClientComponent = FieldClientComponent<
-  RichTextFieldClientWithoutType,
-  RichTextFieldBaseClientProps
->
+export type RichTextFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<RichTextFieldClientWithoutType, RichTextFieldBaseClientProps & T>
 
 export type RichTextFieldLabelServerComponent = FieldLabelServerComponent<
   RichTextField,

--- a/packages/payload/src/admin/fields/Row.ts
+++ b/packages/payload/src/admin/fields/Row.ts
@@ -30,11 +30,14 @@ export type RowFieldClientProps = Omit<ClientFieldBase<RowFieldClientWithoutType
 
 export type RowFieldServerProps = ServerFieldBase<RowField, RowFieldClientWithoutType>
 
-export type RowFieldServerComponent = FieldServerComponent<RowField, RowFieldClientWithoutType>
+export type RowFieldServerComponent<T extends Record<string, unknown> = {}> = FieldServerComponent<
+  RowField,
+  RowFieldClientWithoutType & T
+>
 
-export type RowFieldClientComponent = FieldClientComponent<
+export type RowFieldClientComponent<T extends Record<string, unknown> = {}> = FieldClientComponent<
   RowFieldClientWithoutType,
-  RowFieldBaseClientProps
+  RowFieldBaseClientProps & T
 >
 
 export type RowFieldLabelServerComponent = FieldLabelServerComponent<

--- a/packages/payload/src/admin/fields/Select.ts
+++ b/packages/payload/src/admin/fields/Select.ts
@@ -36,16 +36,11 @@ export type SelectFieldClientProps = ClientFieldBase<SelectFieldClientWithoutTyp
 export type SelectFieldServerProps = SelectFieldBaseServerProps &
   ServerFieldBase<SelectField, SelectFieldClientWithoutType>
 
-export type SelectFieldServerComponent = FieldServerComponent<
-  SelectField,
-  SelectFieldClientWithoutType,
-  SelectFieldBaseServerProps
->
+export type SelectFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<SelectField, SelectFieldClientWithoutType, SelectFieldBaseServerProps & T>
 
-export type SelectFieldClientComponent = FieldClientComponent<
-  SelectFieldClientWithoutType,
-  SelectFieldBaseClientProps
->
+export type SelectFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<SelectFieldClientWithoutType, SelectFieldBaseClientProps & T>
 
 export type SelectFieldLabelServerComponent = FieldLabelServerComponent<
   SelectField,

--- a/packages/payload/src/admin/fields/Tabs.ts
+++ b/packages/payload/src/admin/fields/Tabs.ts
@@ -40,11 +40,14 @@ export type TabsFieldClientProps = ClientFieldBase<TabsFieldClientWithoutType> &
 
 export type TabsFieldServerProps = ServerFieldBase<TabsField, TabsFieldClientWithoutType>
 
-export type TabsFieldServerComponent = FieldServerComponent<TabsField, TabsFieldClientWithoutType>
+export type TabsFieldServerComponent<T extends Record<string, unknown> = {}> = FieldServerComponent<
+  TabsField,
+  T & TabsFieldClientWithoutType
+>
 
-export type TabsFieldClientComponent = FieldClientComponent<
+export type TabsFieldClientComponent<T extends Record<string, unknown> = {}> = FieldClientComponent<
   TabsFieldClientWithoutType,
-  TabsFieldBaseClientProps
+  T & TabsFieldBaseClientProps
 >
 
 export type TabsFieldLabelServerComponent = FieldLabelServerComponent<

--- a/packages/payload/src/admin/fields/Text.ts
+++ b/packages/payload/src/admin/fields/Text.ts
@@ -43,15 +43,13 @@ export type TextFieldServerComponent = FieldServerComponent<
   TextFieldBaseServerProps
 >
 
-export type TextFieldClientComponent = FieldClientComponent<
+export type TextFieldClientComponent<T extends Record<string, unknown> = {}> = FieldClientComponent<
   TextFieldClientWithoutType,
-  TextFieldBaseClientProps
+  T & TextFieldBaseClientProps
 >
 
-export type TextFieldLabelServerComponent = FieldLabelServerComponent<
-  TextField,
-  TextFieldClientWithoutType
->
+export type TextFieldLabelServerComponent<T extends Record<string, unknown> = {}> =
+  FieldLabelServerComponent<TextField, T & TextFieldClientWithoutType>
 
 export type TextFieldLabelClientComponent = FieldLabelClientComponent<TextFieldClientWithoutType>
 

--- a/packages/payload/src/admin/fields/Textarea.ts
+++ b/packages/payload/src/admin/fields/Textarea.ts
@@ -40,16 +40,15 @@ export type TextareaFieldServerProps = ServerFieldBase<
 > &
   TextareaFieldBaseServerProps
 
-export type TextareaFieldServerComponent = FieldServerComponent<
-  TextareaField,
-  TextareaFieldClientWithoutType,
-  TextareaFieldBaseServerProps
->
+export type TextareaFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<
+    TextareaField,
+    TextareaFieldClientWithoutType,
+    T & TextareaFieldBaseServerProps
+  >
 
-export type TextareaFieldClientComponent = FieldClientComponent<
-  TextareaFieldClientWithoutType,
-  TextareaFieldBaseClientProps
->
+export type TextareaFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<TextareaFieldClientWithoutType, T & TextareaFieldBaseClientProps>
 
 export type TextareaFieldLabelServerComponent = FieldLabelServerComponent<
   TextareaField,

--- a/packages/payload/src/admin/fields/UI.ts
+++ b/packages/payload/src/admin/fields/UI.ts
@@ -24,15 +24,15 @@ export type UIFieldClientProps = ClientFieldBase<UIFieldClientWithoutType> & UIF
 export type UIFieldServerProps = ServerFieldBase<UIField, UIFieldClientWithoutType> &
   UIFieldBaseServerProps
 
-export type UIFieldClientComponent = FieldClientComponent<
+export type UIFieldClientComponent<T extends Record<string, unknown> = {}> = FieldClientComponent<
   UIFieldClientWithoutType,
-  UIFieldBaseClientProps
+  T & UIFieldBaseClientProps
 >
 
-export type UIFieldServerComponent = FieldServerComponent<
+export type UIFieldServerComponent<T extends Record<string, unknown> = {}> = FieldServerComponent<
   UIField,
   UIFieldClientWithoutType,
-  UIFieldBaseServerProps
+  T & UIFieldBaseServerProps
 >
 
 export type UIFieldDiffServerComponent = FieldDiffServerComponent<UIField, UIFieldClient>

--- a/packages/payload/src/admin/fields/Upload.ts
+++ b/packages/payload/src/admin/fields/Upload.ts
@@ -34,16 +34,11 @@ export type UploadFieldClientProps = ClientFieldBase<UploadFieldClientWithoutTyp
 export type UploadFieldServerProps = ServerFieldBase<UploadField, UploadFieldClientWithoutType> &
   UploadFieldBaseServerProps
 
-export type UploadFieldServerComponent = FieldServerComponent<
-  UploadField,
-  UploadFieldClientWithoutType,
-  UploadFieldBaseServerProps
->
+export type UploadFieldServerComponent<T extends Record<string, unknown> = {}> =
+  FieldServerComponent<UploadField, UploadFieldClientWithoutType, T & UploadFieldBaseServerProps>
 
-export type UploadFieldClientComponent = FieldClientComponent<
-  UploadFieldClientWithoutType,
-  UploadFieldBaseClientProps
->
+export type UploadFieldClientComponent<T extends Record<string, unknown> = {}> =
+  FieldClientComponent<UploadFieldClientWithoutType, T & UploadFieldBaseClientProps>
 
 export type UploadFieldLabelServerComponent = FieldLabelServerComponent<
   UploadField,

--- a/test/admin/collections/CustomFields/fields/Text/FieldClient.tsx
+++ b/test/admin/collections/CustomFields/fields/Text/FieldClient.tsx
@@ -2,8 +2,15 @@
 import type { TextFieldClientComponent } from 'payload'
 
 import { TextField } from '@payloadcms/ui'
-import React from 'react'
+import React, { Fragment } from 'react'
 
-export const CustomClientField: TextFieldClientComponent = (props) => {
-  return <TextField {...props} />
+import type { CustomProps } from './types.js'
+
+export const CustomClientField: TextFieldClientComponent<CustomProps> = (props) => {
+  return (
+    <Fragment>
+      <div id="custom-prop">{props.customProp}</div>
+      <TextField {...props} />
+    </Fragment>
+  )
 }

--- a/test/admin/collections/CustomFields/fields/Text/types.ts
+++ b/test/admin/collections/CustomFields/fields/Text/types.ts
@@ -1,0 +1,3 @@
+export type CustomProps = {
+  customProp: string
+}

--- a/test/admin/collections/CustomFields/index.ts
+++ b/test/admin/collections/CustomFields/index.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
+import type { CustomProps } from './fields/Text/types.js'
+
 import { customFieldsSlug } from '../../slugs.js'
 
 export const CustomFields: CollectionConfig = {
@@ -32,7 +34,12 @@ export const CustomFields: CollectionConfig = {
           afterInput: ['/collections/CustomFields/AfterInput.js#AfterInput'],
           beforeInput: ['/collections/CustomFields/BeforeInput.js#BeforeInput'],
           Label: '/collections/CustomFields/fields/Text/LabelClient.js#CustomClientLabel',
-          Field: '/collections/CustomFields/fields/Text/FieldClient.js#CustomClientField',
+          Field: {
+            path: '/collections/CustomFields/fields/Text/FieldClient.js#CustomClientField',
+            clientProps: {
+              customProp: 'This is a custom prop',
+            } satisfies CustomProps,
+          },
           Description:
             '/collections/CustomFields/fields/Text/DescriptionClient.js#CustomClientDescription',
           Error: '/collections/CustomFields/CustomError.js#CustomError',

--- a/test/admin/components/Banner/index.tsx
+++ b/test/admin/components/Banner/index.tsx
@@ -4,6 +4,7 @@ export function Banner(props: {
   message?: string
 }) {
   const { children, description, message } = props
+
   return (
     <div
       style={{

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/query-presets/config.ts"],
+      "@payload-config": ["./test/versions/config.ts"],
       "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],


### PR DESCRIPTION
Edit: After thinking about this more, I think the component-level types should be deprecated in favor of direct props.

Reasons:
1. Component-level type only works for components defined as arrow functions, not components defined as regular functions
2. This has snowballed into types for every single field "slot", i.e. `FieldLabelClientComponent` and has become an awful pattern

This feels like a mistake. Should have never been written this way. Encouraging the use of props directly eliminates all of this.

Here's the previous description of this PR if anyone is curious:

When creating custom fields and injecting custom props, it is currently not possible to have those props typed within the base fields types that Payload provides.

For example:

```ts
{
  type: 'text',
  admin: {
    Field: {
      path: './path-to-my-component',
      clientProps: {
        customProp: 'This is a custom prop'
      }
  }
}
```

In your component definition, `customProp` does not exist on the `TextFieldServerComponent` type:

```ts
import { TextFieldServerComponent } from 'payload'

const MyComponent: TextFieldServerComponent = ({
  customProp // THIS DOES NOT EXIST
}) => {
 // ...
}
```

Currently, to do this you'd need to use the prop types directly:

```ts
import { TextFieldServerProps } from 'payload'

const MyComponent: React.FC<TextFieldServerProps & {
  customProp: string
}> = (props) => {
 // ...
}
```

With this change you could define the custom props on the component-level type by passing it as a generic:

```ts

import { TextFieldServerComponent } from 'payload'

const MyComponent: TextFieldServerComponent<{
  customProp: string
}> = ({
  customProp // EXISTS
}) => {
 // ...
}
```