### PR TITLE
fix: `ValidationError` error message when `label` is a function

### DIFF
--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -423,6 +423,7 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
               path: fieldName,
             },
           ],
+          req,
         },
         req?.t,
       )

--- a/packages/payload/src/errors/ValidationError.ts
+++ b/packages/payload/src/errors/ValidationError.ts
@@ -42,12 +42,24 @@ export class ValidationError extends APIError<{
     super(
       `${message} ${results.errors
         .map((f) => {
-          if (typeof f.label === 'function') {
-            if (!results.req || !results.req.i18n || !results.req.t) {
-              return f.path
+          if (f.label) {
+            if (typeof f.label === 'function') {
+              if (!results.req || !results.req.i18n || !results.req.t) {
+                return f.path
+              }
+
+              return f.label({ i18n: results.req.i18n, t: results.req.t })
             }
 
-            return f.label({ i18n: results.req.i18n, t: results.req.t })
+            if (typeof f.label === 'object') {
+              if (results.req?.i18n?.language) {
+                return f.label[results.req.i18n.language]
+              }
+
+              return f.label[Object.keys(f.label)[0]]
+            }
+
+            return f.label
           }
 
           return f.path

--- a/packages/payload/src/errors/ValidationError.ts
+++ b/packages/payload/src/errors/ValidationError.ts
@@ -29,6 +29,9 @@ export class ValidationError extends APIError<{
       errors: ValidationFieldError[]
       global?: string
       id?: number | string
+      /**
+       *  req needs to be passed through (if you have one) in order to resolve label functions that may be part of the errors array
+       */
       req?: Partial<PayloadRequest>
     },
     t?: TFunction,
@@ -40,6 +43,7 @@ export class ValidationError extends APIError<{
         : en.translations.error.followingFieldsInvalid_other
 
     const req = results.req
+    // delete to avoid logging the whole req
     delete results['req']
 
     super(

--- a/packages/payload/src/errors/ValidationError.ts
+++ b/packages/payload/src/errors/ValidationError.ts
@@ -39,21 +39,24 @@ export class ValidationError extends APIError<{
         ? en.translations.error.followingFieldsInvalid_one
         : en.translations.error.followingFieldsInvalid_other
 
+    const req = results.req
+    delete results['req']
+
     super(
       `${message} ${results.errors
         .map((f) => {
           if (f.label) {
             if (typeof f.label === 'function') {
-              if (!results.req || !results.req.i18n || !results.req.t) {
+              if (!req || !req.i18n || !req.t) {
                 return f.path
               }
 
-              return f.label({ i18n: results.req.i18n, t: results.req.t })
+              return f.label({ i18n: req.i18n, t: req.t })
             }
 
             if (typeof f.label === 'object') {
-              if (results.req?.i18n?.language) {
-                return f.label[results.req.i18n.language]
+              if (req?.i18n?.language) {
+                return f.label[req.i18n.language]
               }
 
               return f.label[Object.keys(f.label)[0]]

--- a/packages/payload/src/errors/ValidationError.ts
+++ b/packages/payload/src/errors/ValidationError.ts
@@ -4,6 +4,7 @@ import { en } from '@payloadcms/translations/languages/en'
 import { status as httpStatus } from 'http-status'
 
 import type { LabelFunction, StaticLabel } from '../config/types.js'
+import type { PayloadRequest } from '../types/index.js'
 
 import { APIError } from './APIError.js'
 
@@ -28,6 +29,7 @@ export class ValidationError extends APIError<{
       errors: ValidationFieldError[]
       global?: string
       id?: number | string
+      req?: Partial<PayloadRequest>
     },
     t?: TFunction,
   ) {
@@ -38,7 +40,19 @@ export class ValidationError extends APIError<{
         : en.translations.error.followingFieldsInvalid_other
 
     super(
-      `${message} ${results.errors.map((f) => f.label || f.path).join(', ')}`,
+      `${message} ${results.errors
+        .map((f) => {
+          if (typeof f.label === 'function') {
+            if (!results.req || !results.req.i18n || !results.req.t) {
+              return f.path
+            }
+
+            return f.label({ i18n: results.req.i18n, t: results.req.t })
+          }
+
+          return f.path
+        })
+        .join(', ')}`,
       httpStatus.BAD_REQUEST,
       results,
     )

--- a/packages/payload/src/fields/hooks/beforeChange/index.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/index.ts
@@ -77,6 +77,7 @@ export const beforeChange = async <T extends JsonObject>({
         collection: collection?.slug,
         errors,
         global: global?.slug,
+        req,
       },
       req.t,
     )


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11901

Previously, when `ValidationError` `errors.path` was referring to a field with `label` defined as a function, the error message was generated with `[object Object]`. Now, we call that function instead. Since the `i18n` argument is required for `StaticLabel`, this PR introduces so you can pass a partial `req` to `ValidationError` from which we thread `req.i18n` to the label args.