### PR TITLE
fix(ui): nested fields disappear when manipulating rows in form state

### DIFF
--- a/packages/payload/src/admin/forms/Form.ts
+++ b/packages/payload/src/admin/forms/Form.ts
@@ -45,6 +45,7 @@ export type FieldState = {
    */
   fieldSchema?: Field
   filterOptions?: FilterOptionsResult
+  ignoreRequiresRenderResult?: boolean
   initialValue?: unknown
   passesCondition?: boolean
   requiresRender?: boolean

--- a/packages/payload/src/admin/forms/Form.ts
+++ b/packages/payload/src/admin/forms/Form.ts
@@ -45,11 +45,22 @@ export type FieldState = {
    */
   fieldSchema?: Field
   filterOptions?: FilterOptionsResult
-  ignoreServerProps?: Partial<Record<keyof FieldState, boolean>>
   initialValue?: unknown
   passesCondition?: boolean
   requiresRender?: boolean
   rows?: Row[]
+  /**
+   * The `serverPropsToIgnore` obj is used to prevent the various properties from being overridden across form state requests.
+   * This can happen when queueing a form state request with `requiresRender: true` while the another is already processing.
+   * For example:
+   *   1. One "add row" action will set `requiresRender: true` and dispatch a form state request
+   *   2. Another "add row" action will set `requiresRender: true` and queue a form state request
+   *   3. The first request will return with `requiresRender: false`
+   *   4. The second request will be dispatched with `requiresRender: false` but should be `true`
+   * To fix this, only merge the `requiresRender` property if the previous state has not set it to `true`.
+   * See the `mergeServerFormState` function for implementation details.
+   */
+  serverPropsToIgnore?: Array<keyof FieldState>
   valid?: boolean
   validate?: Validate
   value?: unknown

--- a/packages/payload/src/admin/forms/Form.ts
+++ b/packages/payload/src/admin/forms/Form.ts
@@ -45,7 +45,7 @@ export type FieldState = {
    */
   fieldSchema?: Field
   filterOptions?: FilterOptionsResult
-  ignoreRequiresRenderResult?: boolean
+  ignoreServerProps?: Partial<Record<keyof FieldState, boolean>>
   initialValue?: unknown
   passesCondition?: boolean
   requiresRender?: boolean

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -58,7 +58,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
   const minRows = (minRowsProp ?? required) ? 1 : 0
 
   const { setDocFieldPreferences } = useDocumentInfo()
-  const { addFieldRow, dispatchFields, setModified } = useForm()
+  const { addFieldRow, dispatchFields, moveFieldRow, removeFieldRow, setModified } = useForm()
   const submitted = useFormSubmitted()
   const { code: locale } = useLocale()
   const { i18n, t } = useTranslation()
@@ -153,18 +153,20 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
 
   const removeRow = useCallback(
     (rowIndex: number) => {
-      dispatchFields({ type: 'REMOVE_ROW', path, rowIndex })
-      setModified(true)
+      removeFieldRow({ path, rowIndex })
     },
-    [dispatchFields, path, setModified],
+    [removeFieldRow, path],
   )
 
   const moveRow = useCallback(
     (moveFromIndex: number, moveToIndex: number) => {
-      dispatchFields({ type: 'MOVE_ROW', moveFromIndex, moveToIndex, path })
-      setModified(true)
+      moveFieldRow({
+        moveFromIndex,
+        moveToIndex,
+        path,
+      })
     },
-    [dispatchFields, path, setModified],
+    [path, moveFieldRow],
   )
 
   const toggleCollapseAll = useCallback(

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -60,7 +60,7 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
   const minRows = (minRowsProp ?? required) ? 1 : 0
 
   const { setDocFieldPreferences } = useDocumentInfo()
-  const { addFieldRow, dispatchFields, setModified } = useForm()
+  const { addFieldRow, dispatchFields, moveFieldRow, removeFieldRow, setModified } = useForm()
   const { code: locale } = useLocale()
   const {
     config: { localization },
@@ -141,23 +141,19 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
 
   const removeRow = useCallback(
     (rowIndex: number) => {
-      dispatchFields({
-        type: 'REMOVE_ROW',
+      removeFieldRow({
         path,
         rowIndex,
       })
-
-      setModified(true)
     },
-    [path, dispatchFields, setModified],
+    [path, removeFieldRow],
   )
 
   const moveRow = useCallback(
     (moveFromIndex: number, moveToIndex: number) => {
-      dispatchFields({ type: 'MOVE_ROW', moveFromIndex, moveToIndex, path })
-      setModified(true)
+      moveFieldRow({ moveFromIndex, moveToIndex, path })
     },
-    [dispatchFields, path, setModified],
+    [moveFieldRow, path],
   )
 
   const toggleCollapseAll = useCallback(
@@ -166,6 +162,7 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
         collapsed,
         rows,
       })
+
       dispatchFields({ type: 'SET_ALL_ROWS_COLLAPSED', path, updatedRows })
       setDocFieldPreferences(path, { collapsed: collapsedIDs })
     },
@@ -179,6 +176,7 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
         rowID,
         rows,
       })
+
       dispatchFields({ type: 'SET_ROW_COLLAPSED', path, updatedRows })
       setDocFieldPreferences(path, { collapsed: collapsedIDs })
     },

--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -63,25 +63,14 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
           requiresRender: true,
           rows: withNewRow,
           value: siblingRows.length,
-          /**
-           * The `ignoreServerProps` obj is used to prevent the various properties from being overridden across form state requests.
-           * This can happen when queueing a form state request with `requiresRender: true` while the another is already processing.
-           * For example:
-           *   1. One "add row" action will set `requiresRender: true` and dispatch a form state request
-           *   2. Another "add row" action will set `requiresRender: true` and queue a form state request
-           *   3. The first request will return with `requiresRender: false`
-           *   4. The second request will be dispatched with `requiresRender: false` but should be `true`
-           * To fix this, only merge the `requiresRender` property if the previous state has not set it to `true`.
-           * See the `mergeServerFormState` function for implementation details.
-           */
           ...(state[path]?.requiresRender === true
             ? {
-                ignoreServerProps: {
-                  ...(state[path]?.ignoreServerProps || {}),
-                  requiresRender: true,
-                },
+                serverPropsToIgnore: [
+                  ...(state[path]?.serverPropsToIgnore || []),
+                  'requiresRender',
+                ],
               }
-            : state[path]?.ignoreServerProps || ({} as any)),
+            : state[path]?.serverPropsToIgnore || []),
         },
       }
 
@@ -191,15 +180,14 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
           requiresRender: true,
           rows: rowsMetadata,
           value: rows.length,
-          // See note above about `ignoreServerProps`
           ...(state[path]?.requiresRender === true
             ? {
-                ignoreServerProps: {
-                  ...(state[path]?.ignoreServerProps || {}),
-                  requiresRender: true,
-                },
+                serverPropsToIgnore: [
+                  ...(state[path]?.serverPropsToIgnore || []),
+                  'requiresRender',
+                ],
               }
-            : state[path]?.ignoreServerProps || ({} as any)),
+            : state[path]?.serverPropsToIgnore || ([] as any)),
         },
       }
 
@@ -228,15 +216,14 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
           ...state[path],
           requiresRender: true,
           rows: rowsWithinField,
-          // See note above about `ignoreServerProps`
           ...(state[path]?.requiresRender === true
             ? {
-                ignoreServerProps: {
-                  ...(state[path]?.ignoreServerProps || {}),
-                  requiresRender: true,
-                },
+                serverPropsToIgnore: [
+                  ...(state[path]?.serverPropsToIgnore || []),
+                  'requiresRender',
+                ],
               }
-            : state[path]?.ignoreServerProps || ({} as any)),
+            : state[path]?.serverPropsToIgnore || ([] as any)),
         },
       }
 
@@ -289,15 +276,14 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
           requiresRender: true,
           rows: rowsMetadata,
           value: rows.length,
-          // See note above about `ignoreServerProps`
           ...(state[path]?.requiresRender === true
             ? {
-                ignoreServerProps: {
-                  ...(state[path]?.ignoreServerProps || {}),
-                  requiresRender: true,
-                },
+                serverPropsToIgnore: [
+                  ...(state[path]?.serverPropsToIgnore || []),
+                  'requiresRender',
+                ],
               }
-            : state[path]?.ignoreServerProps || ({} as any)),
+            : state[path]?.serverPropsToIgnore || []),
         },
         ...flattenRows(path, rows),
       }
@@ -337,15 +323,14 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
           disableFormData: true,
           rows: rowsMetadata,
           value: siblingRows.length,
-          // See note above about `ignoreServerProps`
           ...(state[path]?.requiresRender === true
             ? {
-                ignoreServerProps: {
-                  ...(state[path]?.ignoreServerProps || {}),
-                  requiresRender: true,
-                },
+                serverPropsToIgnore: [
+                  ...(state[path]?.serverPropsToIgnore || []),
+                  'requiresRender',
+                ],
               }
-            : state[path]?.ignoreServerProps || ({} as any)),
+            : state[path]?.serverPropsToIgnore || []),
         },
       }
 

--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -60,6 +60,14 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
         [path]: {
           ...state[path],
           disableFormData: true,
+          // The `ignoreRequiresRenderResult` property is used to prevent the `requiresRender` property from being overridden across requests.
+          // This can happen when queueing a form state request with `requiresRender: true` while the another is already processing.
+          // For example:
+          //   1. One "add row" action will set `requiresRender: true` and dispatch a form state request
+          //   2. Another "add row" action will set `requiresRender: true` and queue a form state request
+          //   3. The first request will return with `requiresRender: false`
+          //   4. The second request will be dispatched with `requiresRender: false` but should be `true`
+          ignoreRequiresRenderResult: state[path]?.requiresRender === true,
           requiresRender: true,
           rows: withNewRow,
           value: siblingRows.length,

--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -60,14 +60,18 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
         [path]: {
           ...state[path],
           disableFormData: true,
-          // The `ignoreRequiresRenderResult` property is used to prevent the `requiresRender` property from being overridden across requests.
+          // The `ignoreServerProps` obj is used to prevent the various properties from being overridden across form state requests.
           // This can happen when queueing a form state request with `requiresRender: true` while the another is already processing.
           // For example:
           //   1. One "add row" action will set `requiresRender: true` and dispatch a form state request
           //   2. Another "add row" action will set `requiresRender: true` and queue a form state request
           //   3. The first request will return with `requiresRender: false`
           //   4. The second request will be dispatched with `requiresRender: false` but should be `true`
-          ignoreRequiresRenderResult: state[path]?.requiresRender === true,
+          // To fix this, only merge the `requiresRender` property if the previous state has not set it to `true`.
+          // See the `mergeServerFormState` function for implementation details.
+          ignoreServerProps: {
+            requiresRender: state[path]?.requiresRender === true,
+          },
           requiresRender: true,
           rows: withNewRow,
           value: siblingRows.length,

--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -60,21 +60,28 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
         [path]: {
           ...state[path],
           disableFormData: true,
-          // The `ignoreServerProps` obj is used to prevent the various properties from being overridden across form state requests.
-          // This can happen when queueing a form state request with `requiresRender: true` while the another is already processing.
-          // For example:
-          //   1. One "add row" action will set `requiresRender: true` and dispatch a form state request
-          //   2. Another "add row" action will set `requiresRender: true` and queue a form state request
-          //   3. The first request will return with `requiresRender: false`
-          //   4. The second request will be dispatched with `requiresRender: false` but should be `true`
-          // To fix this, only merge the `requiresRender` property if the previous state has not set it to `true`.
-          // See the `mergeServerFormState` function for implementation details.
-          ignoreServerProps: {
-            requiresRender: state[path]?.requiresRender === true,
-          },
           requiresRender: true,
           rows: withNewRow,
           value: siblingRows.length,
+          /**
+           * The `ignoreServerProps` obj is used to prevent the various properties from being overridden across form state requests.
+           * This can happen when queueing a form state request with `requiresRender: true` while the another is already processing.
+           * For example:
+           *   1. One "add row" action will set `requiresRender: true` and dispatch a form state request
+           *   2. Another "add row" action will set `requiresRender: true` and queue a form state request
+           *   3. The first request will return with `requiresRender: false`
+           *   4. The second request will be dispatched with `requiresRender: false` but should be `true`
+           * To fix this, only merge the `requiresRender` property if the previous state has not set it to `true`.
+           * See the `mergeServerFormState` function for implementation details.
+           */
+          ...(state[path]?.requiresRender === true
+            ? {
+                ignoreServerProps: {
+                  ...(state[path]?.ignoreServerProps || {}),
+                  requiresRender: true,
+                },
+              }
+            : state[path]?.ignoreServerProps || ({} as any)),
         },
       }
 
@@ -184,6 +191,15 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
           requiresRender: true,
           rows: rowsMetadata,
           value: rows.length,
+          // See note above about `ignoreServerProps`
+          ...(state[path]?.requiresRender === true
+            ? {
+                ignoreServerProps: {
+                  ...(state[path]?.ignoreServerProps || {}),
+                  requiresRender: true,
+                },
+              }
+            : state[path]?.ignoreServerProps || ({} as any)),
         },
       }
 
@@ -212,6 +228,15 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
           ...state[path],
           requiresRender: true,
           rows: rowsWithinField,
+          // See note above about `ignoreServerProps`
+          ...(state[path]?.requiresRender === true
+            ? {
+                ignoreServerProps: {
+                  ...(state[path]?.ignoreServerProps || {}),
+                  requiresRender: true,
+                },
+              }
+            : state[path]?.ignoreServerProps || ({} as any)),
         },
       }
 
@@ -230,9 +255,8 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
 
         const copyOfMovingLabel = customComponents.RowLabels[moveFromIndex]
 
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         customComponents.RowLabels.splice(moveFromIndex, 1)
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+
         customComponents.RowLabels.splice(moveToIndex, 0, copyOfMovingLabel)
 
         newState[path].customComponents = customComponents
@@ -265,6 +289,15 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
           requiresRender: true,
           rows: rowsMetadata,
           value: rows.length,
+          // See note above about `ignoreServerProps`
+          ...(state[path]?.requiresRender === true
+            ? {
+                ignoreServerProps: {
+                  ...(state[path]?.ignoreServerProps || {}),
+                  requiresRender: true,
+                },
+              }
+            : state[path]?.ignoreServerProps || ({} as any)),
         },
         ...flattenRows(path, rows),
       }
@@ -304,6 +337,15 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
           disableFormData: true,
           rows: rowsMetadata,
           value: siblingRows.length,
+          // See note above about `ignoreServerProps`
+          ...(state[path]?.requiresRender === true
+            ? {
+                ignoreServerProps: {
+                  ...(state[path]?.ignoreServerProps || {}),
+                  requiresRender: true,
+                },
+              }
+            : state[path]?.ignoreServerProps || ({} as any)),
         },
       }
 
@@ -339,7 +381,7 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
         return newState
       }
 
-      //TODO: Remove this in 4.0 - this is a temporary fix to prevent a breaking change
+      // TODO: Remove this in 4.0 - this is a temporary fix to prevent a breaking change
       if (action.sanitize) {
         for (const field of Object.values(action.state)) {
           if (field.valid !== false) {

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -606,19 +606,9 @@ export const Form: React.FC<FormProps> = (props) => {
         subFieldState,
       })
 
-      queueTask(
-        () => {
-          contextRef.current.fields[path].requiresRender = true
-        },
-        {
-          discard: false,
-          priority: true,
-        },
-      )
-
       setModified(true)
     },
-    [dispatchFields, getDataByPath, queueTask],
+    [dispatchFields, getDataByPath],
   )
 
   const moveFieldRow: FormContextType['moveFieldRow'] = useCallback(
@@ -630,37 +620,18 @@ export const Form: React.FC<FormProps> = (props) => {
         path,
       })
 
-      queueTask(
-        () => {
-          contextRef.current.fields[path].requiresRender = true
-        },
-        {
-          discard: false,
-          priority: true,
-        },
-      )
       setModified(true)
     },
-    [dispatchFields, queueTask],
+    [dispatchFields],
   )
 
   const removeFieldRow: FormContextType['removeFieldRow'] = useCallback(
     ({ path, rowIndex }) => {
       dispatchFields({ type: 'REMOVE_ROW', path, rowIndex })
 
-      queueTask(
-        () => {
-          contextRef.current.fields[path].requiresRender = true
-        },
-        {
-          discard: false,
-          priority: true,
-        },
-      )
-
       setModified(true)
     },
-    [dispatchFields, queueTask],
+    [dispatchFields],
   )
 
   const replaceFieldRow: FormContextType['replaceFieldRow'] = useCallback(
@@ -676,19 +647,9 @@ export const Form: React.FC<FormProps> = (props) => {
         subFieldState,
       })
 
-      queueTask(
-        () => {
-          contextRef.current.fields[path].requiresRender = true
-        },
-        {
-          discard: false,
-          priority: true,
-        },
-      )
-
       setModified(true)
     },
-    [dispatchFields, getDataByPath, queueTask],
+    [dispatchFields, getDataByPath],
   )
 
   useEffect(() => {

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -121,11 +121,11 @@ export const Form: React.FC<FormProps> = (props) => {
 
   const fieldsReducer = useReducer(fieldReducer, {}, () => initialState)
 
-  const [fields, dispatchFields] = fieldsReducer
+  const [formState, dispatchFields] = fieldsReducer
 
-  contextRef.current.fields = fields
+  contextRef.current.fields = formState
 
-  const prevFields = useRef(fields)
+  const prevFields = useRef(formState)
 
   const validateForm = useCallback(async () => {
     const validatedFieldState = {}
@@ -710,7 +710,7 @@ export const Form: React.FC<FormProps> = (props) => {
       refreshCookie()
     },
     15000,
-    [fields],
+    [formState],
   )
 
   useEffect(() => {
@@ -723,12 +723,12 @@ export const Form: React.FC<FormProps> = (props) => {
   const executeOnChange = useEffectEvent((submitted: boolean) => {
     queueTask(async () => {
       if (Array.isArray(onChange)) {
-        let revalidatedFormState: FormState = contextRef.current.fields
+        let revalidatedFormState: FormState = formState
 
         for (const onChangeFn of onChange) {
           // Edit view default onChange is in packages/ui/src/views/Edit/index.tsx. This onChange usually sends a form state request
           revalidatedFormState = await onChangeFn({
-            formState: deepCopyObjectSimpleWithoutReactComponents(contextRef.current.fields),
+            formState: deepCopyObjectSimpleWithoutReactComponents(formState),
             submitted,
           })
         }
@@ -738,7 +738,7 @@ export const Form: React.FC<FormProps> = (props) => {
         }
 
         const { changed, newState } = mergeServerFormState({
-          existingState: contextRef.current.fields || {},
+          existingState: formState || {},
           incomingState: revalidatedFormState,
         })
 
@@ -757,14 +757,14 @@ export const Form: React.FC<FormProps> = (props) => {
 
   useDebouncedEffect(
     () => {
-      if ((isFirstRenderRef.current || !dequal(fields, prevFields.current)) && modified) {
+      if ((isFirstRenderRef.current || !dequal(formState, prevFields.current)) && modified) {
         executeOnChange(submitted)
       }
 
-      prevFields.current = fields
+      prevFields.current = formState
       isFirstRenderRef.current = false
     },
-    [modified, submitted, fields],
+    [modified, submitted, formState],
     250,
   )
 
@@ -793,7 +793,7 @@ export const Form: React.FC<FormProps> = (props) => {
         <FormContext value={contextRef.current}>
           <FormWatchContext
             value={{
-              fields,
+              fields: formState,
               ...contextRef.current,
             }}
           >

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -606,16 +606,61 @@ export const Form: React.FC<FormProps> = (props) => {
         subFieldState,
       })
 
+      queueTask(
+        () => {
+          contextRef.current.fields[path].requiresRender = true
+        },
+        {
+          discard: false,
+          priority: true,
+        },
+      )
+
       setModified(true)
     },
-    [dispatchFields, getDataByPath],
+    [dispatchFields, getDataByPath, queueTask],
+  )
+
+  const moveFieldRow: FormContextType['moveFieldRow'] = useCallback(
+    ({ moveFromIndex, moveToIndex, path }) => {
+      dispatchFields({
+        type: 'MOVE_ROW',
+        moveFromIndex,
+        moveToIndex,
+        path,
+      })
+
+      queueTask(
+        () => {
+          contextRef.current.fields[path].requiresRender = true
+        },
+        {
+          discard: false,
+          priority: true,
+        },
+      )
+      setModified(true)
+    },
+    [dispatchFields, queueTask],
   )
 
   const removeFieldRow: FormContextType['removeFieldRow'] = useCallback(
     ({ path, rowIndex }) => {
       dispatchFields({ type: 'REMOVE_ROW', path, rowIndex })
+
+      queueTask(
+        () => {
+          contextRef.current.fields[path].requiresRender = true
+        },
+        {
+          discard: false,
+          priority: true,
+        },
+      )
+
+      setModified(true)
     },
-    [dispatchFields],
+    [dispatchFields, queueTask],
   )
 
   const replaceFieldRow: FormContextType['replaceFieldRow'] = useCallback(
@@ -631,9 +676,19 @@ export const Form: React.FC<FormProps> = (props) => {
         subFieldState,
       })
 
+      queueTask(
+        () => {
+          contextRef.current.fields[path].requiresRender = true
+        },
+        {
+          discard: false,
+          priority: true,
+        },
+      )
+
       setModified(true)
     },
-    [dispatchFields, getDataByPath],
+    [dispatchFields, getDataByPath, queueTask],
   )
 
   useEffect(() => {
@@ -672,6 +727,7 @@ export const Form: React.FC<FormProps> = (props) => {
   contextRef.current.dispatchFields = dispatchFields
   contextRef.current.addFieldRow = addFieldRow
   contextRef.current.removeFieldRow = removeFieldRow
+  contextRef.current.moveFieldRow = moveFieldRow
   contextRef.current.replaceFieldRow = replaceFieldRow
   contextRef.current.uuid = uuid
   contextRef.current.initializing = initializing
@@ -725,8 +781,6 @@ export const Form: React.FC<FormProps> = (props) => {
       if (Array.isArray(onChange)) {
         let revalidatedFormState: FormState = contextRef.current.fields
 
-        console.log('before send', formState)
-
         for (const onChangeFn of onChange) {
           // Edit view default onChange is in packages/ui/src/views/Edit/index.tsx. This onChange usually sends a form state request
           revalidatedFormState = await onChangeFn({
@@ -734,8 +788,6 @@ export const Form: React.FC<FormProps> = (props) => {
             submitted,
           })
         }
-
-        console.log('after send', formState)
 
         if (!revalidatedFormState) {
           return
@@ -758,8 +810,6 @@ export const Form: React.FC<FormProps> = (props) => {
       }
     })
   })
-
-  console.log(formState)
 
   useDebouncedEffect(
     () => {

--- a/packages/ui/src/forms/Form/initContextState.ts
+++ b/packages/ui/src/forms/Form/initContextState.ts
@@ -41,6 +41,7 @@ export const initContextState: Context = {
   getSiblingData,
   initializing: undefined,
   isValid: true,
+  moveFieldRow: () => undefined,
   removeFieldRow: () => undefined,
   replaceFieldRow: () => undefined,
   replaceState: () => undefined,

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -93,6 +93,14 @@ export const mergeServerFormState = ({
           // To fix this, only merge the `requiresRender` property if the previous state has not set it to `true`.
           // See the `fieldReducer` function for where this gets set.
           if (newFieldState?.ignoreServerProps?.[propFromServer]) {
+            // Remove the ignored prop for the next request
+            delete newFieldState.ignoreServerProps[propFromServer]
+
+            // if no keys left, remove the entire object
+            if (Object.keys(newFieldState.ignoreServerProps).length === 0) {
+              delete newFieldState.ignoreServerProps
+            }
+
             return
           }
 

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -106,7 +106,7 @@ export const mergeServerFormState = ({
               delete newFieldState[propFromServer]
             }
           } else {
-            newFieldState[propFromServer] = incomingState[path][propFromServer]
+            newFieldState[propFromServer as any] = incomingState[path][propFromServer]
           }
         }
       })

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -42,10 +42,13 @@ export const mergeServerFormState = ({
       serverPropsToAccept.push('initialValue')
     }
 
-    for (const [path, newFieldState] of Object.entries(existingState)) {
+    for (const [path, fieldState] of Object.entries(existingState)) {
+      const newFieldState = { ...fieldState }
+
       if (!incomingState[path]) {
         continue
       }
+
       let fieldChanged = false
 
       /**
@@ -55,10 +58,12 @@ export const mergeServerFormState = ({
         newFieldState.errorPaths,
         incomingState[path].errorPaths as unknown as string[],
       )
+
       if (errorPathsResult.result) {
         if (errorPathsResult.changed) {
           changed = errorPathsResult.changed
         }
+
         newFieldState.errorPaths = errorPathsResult.result
       }
 
@@ -80,6 +85,7 @@ export const mergeServerFormState = ({
         if (!dequal(incomingState[path]?.[prop], newFieldState[prop])) {
           changed = true
           fieldChanged = true
+
           if (!(prop in incomingState[path])) {
             // Regarding excluding the customComponents prop from being deleted: the incoming state might not have been rendered, as rendering components for every form onchange is expensive.
             // Thus, we simply re-use the initial render state
@@ -95,12 +101,12 @@ export const mergeServerFormState = ({
       if (newFieldState.valid !== false) {
         newFieldState.valid = true
       }
+
       if (newFieldState.passesCondition !== false) {
         newFieldState.passesCondition = true
       }
 
-      // Conditions don't work if we don't memcopy the new state, as the object references would otherwise be the same
-      newState[path] = fieldChanged ? { ...newFieldState } : newFieldState
+      newState[path] = newFieldState
     }
 
     // Now loop over values that are part of incoming state but not part of existing state, and add them to the new state.

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -42,9 +42,7 @@ export const mergeServerFormState = ({
       serverPropsToAccept.push('initialValue')
     }
 
-    for (const [path, fieldState] of Object.entries(existingState)) {
-      const newFieldState = { ...fieldState }
-
+    for (const [path, newFieldState] of Object.entries(existingState)) {
       if (!incomingState[path]) {
         continue
       }
@@ -63,7 +61,6 @@ export const mergeServerFormState = ({
         if (errorPathsResult.changed) {
           changed = errorPathsResult.changed
         }
-
         newFieldState.errorPaths = errorPathsResult.result
       }
 
@@ -85,7 +82,6 @@ export const mergeServerFormState = ({
         if (!dequal(incomingState[path]?.[prop], newFieldState[prop])) {
           changed = true
           fieldChanged = true
-
           if (!(prop in incomingState[path])) {
             // Regarding excluding the customComponents prop from being deleted: the incoming state might not have been rendered, as rendering components for every form onchange is expensive.
             // Thus, we simply re-use the initial render state
@@ -106,7 +102,8 @@ export const mergeServerFormState = ({
         newFieldState.passesCondition = true
       }
 
-      newState[path] = newFieldState
+      // Conditions don't work if we don't memcopy the new state, as the object references would otherwise be the same
+      newState[path] = fieldChanged ? { ...newFieldState } : newFieldState
     }
 
     // Now loop over values that are part of incoming state but not part of existing state, and add them to the new state.

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -83,14 +83,16 @@ export const mergeServerFormState = ({
           changed = true
           fieldChanged = true
 
-          // The `ignoreRequiresRenderResult` property is used to prevent the `requiresRender` property from being overridden across requests.
+          // The `ignoreServerProps` obj is used to prevent the various properties from being overridden across form state requests.
           // This can happen when queueing a form state request with `requiresRender: true` while the another is already processing.
           // For example:
           //   1. One "add row" action will set `requiresRender: true` and dispatch a form state request
           //   2. Another "add row" action will set `requiresRender: true` and queue a form state request
           //   3. The first request will return with `requiresRender: false`
           //   4. The second request will be dispatched with `requiresRender: false` but should be `true`
-          if (propFromServer === 'requiresRender' && newFieldState.ignoreRequiresRenderResult) {
+          // To fix this, only merge the `requiresRender` property if the previous state has not set it to `true`.
+          // See the `fieldReducer` function for where this gets set.
+          if (newFieldState?.ignoreServerProps?.[propFromServer]) {
             return
           }
 

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -236,6 +236,15 @@ export type Context = {
    * For example the state could be submitted but invalid as field errors have been returned.
    */
   isValid: boolean
+  moveFieldRow: ({
+    moveFromIndex,
+    moveToIndex,
+    path,
+  }: {
+    moveFromIndex: number
+    moveToIndex: number
+    path: string
+  }) => void
   removeFieldRow: ({ path, rowIndex }: { path: string; rowIndex: number }) => void
   replaceFieldRow: ({
     blockType,

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -80,7 +80,9 @@ export type Submit = (
   options?: SubmitOptions,
   e?: React.FormEvent<HTMLFormElement>,
 ) => Promise<void>
+
 export type ValidateForm = () => Promise<boolean>
+
 export type CreateFormData = (
   overrides?: Record<string, unknown>,
   /**
@@ -89,6 +91,7 @@ export type CreateFormData = (
    */
   options?: { mergeOverrideData?: boolean },
 ) => FormData | Promise<FormData>
+
 export type GetFields = () => FormState
 export type GetField = (path: string) => FormField
 export type GetData = () => Data

--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -356,8 +356,6 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
           fieldState.rows = rows
         }
 
-        // Unset requiresRender
-        // so it will be removed from form state
         fieldState.requiresRender = false
 
         // Add values to field state

--- a/packages/ui/src/hooks/useQueues.ts
+++ b/packages/ui/src/hooks/useQueues.ts
@@ -1,8 +1,12 @@
 import { useCallback, useRef } from 'react'
 
-type QueuedFunction = () => Promise<void>
+type QueuedTask = {
+  discard?: TaskOptions['discard']
+  fn: () => Promise<void> | void
+  priority?: TaskOptions['priority']
+}
 
-type QueuedTaskOptions = {
+type TaskOptions = {
   /**
    * A function that is called after the queue has processed a function
    * Used to perform side effects after processing the queue
@@ -15,9 +19,21 @@ type QueuedTaskOptions = {
    * @returns {boolean} If `false`, the queue will not process
    */
   beforeProcess?: () => boolean
+  /**
+   * All tasks that except the last task in the queue will be discarded to prevent a backlog.
+   * To ensure a task is not discarded, set the `discard` option to `false`
+   * @default undefined
+   */
+  discard?: boolean
+  /**
+   * Priority tasks will be processed before non-priority tasks
+   * This is helpful to ensure a task added later in the queue is processed first
+   * @default false
+   */
+  priority?: boolean
 }
 
-type QueueTask = (fn: QueuedFunction, options?: QueuedTaskOptions) => void
+type QueueTask = (fn: QueuedTask['fn'], options?: TaskOptions) => void
 
 /**
  * A React hook that allows you to queue up functions to be executed in order.
@@ -38,12 +54,16 @@ type QueueTask = (fn: QueuedFunction, options?: QueuedTaskOptions) => void
 export function useQueues(): {
   queueTask: QueueTask
 } {
-  const queue = useRef<QueuedFunction[]>([])
+  const queue = useRef<QueuedTask[]>([])
 
   const isProcessing = useRef(false)
 
   const queueTask = useCallback<QueueTask>((fn, options) => {
-    queue.current.push(fn)
+    queue.current.push({
+      discard: options?.discard,
+      fn,
+      priority: options?.priority,
+    })
 
     async function processQueue() {
       if (isProcessing.current) {
@@ -60,13 +80,21 @@ export function useQueues(): {
       }
 
       while (queue.current.length > 0) {
-        const latestTask = queue.current.pop() // Only process the last task in the queue
-        queue.current = [] // Discard all other tasks
+        // Only process the latest, prioritized task in the queue
+        const latestTask = queue.current.find((task) => task.priority) || queue.current.pop()
+
+        // This task is about to run, so remove the discard option if it exists
+        if ('discard' in latestTask) {
+          latestTask.discard = undefined
+        }
+
+        // Discard all other tasks that are not explicitly set to not be discarded
+        queue.current = queue.current.filter((task) => task.discard === false)
 
         isProcessing.current = true
 
         try {
-          await latestTask()
+          await latestTask.fn()
         } catch (err) {
           console.error('Error in queued function:', err) // eslint-disable-line no-console
         } finally {

--- a/test/eslint.config.js
+++ b/test/eslint.config.js
@@ -70,6 +70,7 @@ export const testEslintConfig = [
             'saveDocAndAssert',
             'runFilterOptionsTest',
             'assertNetworkRequests',
+            'assertRequestBody',
           ],
         },
       ],

--- a/test/form-state/e2e.spec.ts
+++ b/test/form-state/e2e.spec.ts
@@ -1,9 +1,11 @@
 import type { BrowserContext, Page } from '@playwright/test'
 import type { PayloadTestSDK } from 'helpers/sdk/index.js'
+import type { FormState } from 'payload'
 
 import { expect, test } from '@playwright/test'
 import { addBlock } from 'helpers/e2e/addBlock.js'
 import { assertNetworkRequests } from 'helpers/e2e/assertNetworkRequests.js'
+import { assertRequestBody } from 'helpers/e2e/assertRequestBody.js'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 
@@ -180,7 +182,7 @@ test.describe('Form State', () => {
     await cdpSession.detach()
   })
 
-  test('should not cause nested custom components to disappear when queuing form state (1)', async () => {
+  test('should not cause nested custom fields to disappear when queuing form state (1)', async () => {
     await page.goto(postsUrl.create)
     const field = page.locator('#field-title')
     await field.fill('Test')
@@ -197,9 +199,17 @@ test.describe('Form State', () => {
       page,
       postsUrl.create,
       async () => {
-        await page.locator('#field-array .array-field__add-row').click()
+        // Ensure `requiresRender` is `true` is set for the first request
+        await assertRequestBody<{ args: { formState: FormState } }[]>(page, {
+          action: page.locator('#field-array .array-field__add-row').click(),
+          expect: (body) => body[0]?.args?.formState?.array?.requiresRender === true,
+        })
 
-        await page.locator('#field-title').fill('Title 2')
+        // Ensure `requiresRender` is `false` for the second request
+        await assertRequestBody<{ args: { formState: FormState } }[]>(page, {
+          action: page.locator('#field-title').fill('Title 2'),
+          expect: (body) => body[0]?.args?.formState?.array?.requiresRender === false,
+        })
 
         // use `waitForSelector` to ensure the element doesn't appear and then disappear
         // eslint-disable-next-line playwright/no-wait-for-selector
@@ -227,7 +237,7 @@ test.describe('Form State', () => {
     await cdpSession.detach()
   })
 
-  test('should not cause nested custom components to disappear when queuing form state (2)', async () => {
+  test('should not cause nested custom fields to disappear when queuing form state (2)', async () => {
     await page.goto(postsUrl.create)
     const field = page.locator('#field-title')
     await field.fill('Test')
@@ -244,8 +254,17 @@ test.describe('Form State', () => {
       page,
       postsUrl.create,
       async () => {
-        await page.locator('#field-array .array-field__add-row').click()
-        await page.locator('#field-array .array-field__add-row').click()
+        // Ensure `requiresRender` is `true` is set for the first request
+        await assertRequestBody<{ args: { formState: FormState } }[]>(page, {
+          action: page.locator('#field-array .array-field__add-row').click(),
+          expect: (body) => body[0]?.args?.formState?.array?.requiresRender === true,
+        })
+
+        // Ensure `requiresRender` is `true` is set for the second request
+        await assertRequestBody<{ args: { formState: FormState } }[]>(page, {
+          action: page.locator('#field-array .array-field__add-row').click(),
+          expect: (body) => body[0]?.args?.formState?.array?.requiresRender === true,
+        })
 
         // use `waitForSelector` to ensure the element doesn't appear and then disappear
         // eslint-disable-next-line playwright/no-wait-for-selector
@@ -272,6 +291,12 @@ test.describe('Form State', () => {
         timeout: 10000,
       },
     )
+
+    // Ensure `requiresRender` is `false` for the third request
+    await assertRequestBody<{ args: { formState: FormState } }[]>(page, {
+      action: page.locator('#field-title').fill('Title 2'),
+      expect: (body) => body[0]?.args?.formState?.array?.requiresRender === false,
+    })
 
     await cdpSession.send('Network.emulateNetworkConditions', {
       offline: false,

--- a/test/form-state/e2e.spec.ts
+++ b/test/form-state/e2e.spec.ts
@@ -180,7 +180,7 @@ test.describe('Form State', () => {
     await cdpSession.detach()
   })
 
-  test('sequentially queued form state should not cause nested custom components to disappear', async () => {
+  test('should not cause nested custom components to disappear when queuing form state (1)', async () => {
     await page.goto(postsUrl.create)
     const field = page.locator('#field-title')
     await field.fill('Test')
@@ -227,7 +227,7 @@ test.describe('Form State', () => {
     await cdpSession.detach()
   })
 
-  test('sequentially queued form state should not cause nested custom components to disappear (2)', async () => {
+  test('should not cause nested custom components to disappear when queuing form state (2)', async () => {
     await page.goto(postsUrl.create)
     const field = page.locator('#field-title')
     await field.fill('Test')

--- a/test/helpers/e2e/assertRequestBody.ts
+++ b/test/helpers/e2e/assertRequestBody.ts
@@ -1,0 +1,28 @@
+import type { Page } from '@playwright/test'
+
+import { expect } from '@playwright/test'
+
+export const assertRequestBody = async <T>(
+  page: Page,
+  options: {
+    action: Promise<void> | void
+    expect?: (requestBody: T) => boolean | Promise<boolean>
+  },
+): Promise<T | undefined> => {
+  const [request] = await Promise.all([
+    page.waitForRequest((request) => request.method() === 'POST'), // Adjust condition as needed
+    await options.action,
+  ])
+
+  const requestBody = request.postData()
+
+  if (typeof requestBody === 'string') {
+    const parsedBody = JSON.parse(requestBody) as T
+
+    if (typeof options.expect === 'function') {
+      expect(await options.expect(parsedBody)).toBeTruthy()
+    }
+
+    return parsedBody
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/query-presets/config.ts"],
+      "@payload-config": ["./test/form-state/config.ts"],
       "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/versions/config.ts"],
+      "@payload-config": ["./test/form-state/config.ts"],
       "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/form-state/config.ts"],
+      "@payload-config": ["./test/versions/config.ts"],
       "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],


### PR DESCRIPTION
Continuation of #11867. When rendering custom fields nested within arrays or blocks, such as the Lexical rich text editor which is treated as a custom field, these fields will sometimes disappear when form state requests are invoked sequentially. This is especially reproducible on slow networks.

This is different from the previous PR in that this issue is caused by adding _rows_ back-to-back, whereas the previous issue was caused when adding a single row followed by a change to another field.

Here's a screen recording demonstrating the issue:

https://github.com/user-attachments/assets/5ecfa9ec-b747-49ed-8618-df282e64519d

The problem is that `requiresRender` is never sent in the form state request for row 2. This is because the [task queue](https://github.com/payloadcms/payload/pull/11579) processes tasks within a single `useEffect`. This forces React to batch the results of these tasks into a single rendering cycle. So if request 1 sets state that request 2 relies on, request 2 will never use that state since they'll execute within the same lifecycle.

Here's a play-by-play of the current behavior:

1. The "add row" event is dispatched
    a. This sets `requiresRender: true` in form state
1. A form state request is sent with `requiresRender: true`
1. While that request is processing, another "add row" event is dispatched
    a. This sets `requiresRender: true` in form state
    b. This adds a form state request into the queue
1. The initial form state request finishes
    a. This sets `requiresRender: false` in form state
1. The next form state request that was queued up in 3b is sent with `requiresRender: false`
    a. THIS IS EXPECTED, BUT SHOULD ACTUALLY BE `true`!!

To fix this this, we need to ensure that the `requiresRender` property is persisted into the second request instead of overridden. To do this, we can add a new `serverPropsToIgnore` to form state which is read when the processing results from the server. So if `requiresRender` exists in `serverPropsToIgnore`, we do not merge it. This works because we actually mutate form state in between requests. So request 2 can read the results from request 1 without going through an additional rendering cycle.

Here's a play-by-play of the fix:

1. The "add row" event is dispatched
    a. This sets `requiresRender: true` in form state
    b. This adds a task in the queue to mutate form state with `requiresRender: true`
1. A form state request is sent with `requiresRender: true`
1. While that request is processing, another "add row" event is dispatched
    a. This sets `requiresRender: true` in form state AND `serverPropsToIgnore: [ "requiresRender" ]`
    c. This adds a form state request into the queue
1. The initial form state request finishes
    a. This returns `requiresRender: false` from the form state endpoint BUT IS IGNORED
1. The next form state request that was queued up in 3c is sent with `requiresRender: true`