### PR TITLE
test: deflake indexed e2e

### DIFF
--- a/test/fields/collections/Indexed/e2e.spec.ts
+++ b/test/fields/collections/Indexed/e2e.spec.ts
@@ -100,6 +100,7 @@ describe('Radio', () => {
     await assertToastErrors({
       page,
       errors: ['uniqueText'],
+      dismissAfterAssertion: true,
     })
 
     await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('create')

--- a/test/helpers/assertToastErrors.ts
+++ b/test/helpers/assertToastErrors.ts
@@ -5,7 +5,9 @@ import { expect } from '@playwright/test'
 export async function assertToastErrors({
   page,
   errors,
+  dismissAfterAssertion,
 }: {
+  dismissAfterAssertion?: boolean
   errors: string[]
   page: Page
 }): Promise<void> {
@@ -22,6 +24,15 @@ export async function assertToastErrors({
       await expect(
         page.locator('.payload-toast-container [data-testid="field-errors"] li').nth(i),
       ).toHaveText(error)
+    }
+  }
+
+  if (dismissAfterAssertion) {
+    const closeButtons = page.locator('.payload-toast-container button.payload-toast-close-button')
+    const count = await closeButtons.count()
+
+    for (let i = 0; i < count; i++) {
+      await closeButtons.nth(i).click()
     }
   }
 }


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR aims to deflake the indexed fields e2e test in `test/fields/collections/Indexed/e2e.spec.ts`.

The issue is that this test is setup in a way where sometimes two toasts will present themselves in the ui. The second toast assertion will fail with a strict mode violation as the toast locator will resolve to two elements.

### Why?
To prevent this test from flaking in ci.

### How?
Adding a new `dismissAfterAssertion` flag to the `assertToastErrors` helper function which dismisses the toasts. This way, the toasts will not raise the aforementioned error as they will be dismissed from the ui.

The logic is handled in a separate loop through such that the assertions occur first. This is done so that dismissing a toast does not surface errors due to the order of toasts being shown changing.