### PR TITLE
feat(db-*): return database name to unsanitized config

### DIFF
--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -273,6 +273,7 @@ export function mongooseAdapter({
   }
 
   return {
+    name: 'mongoose',
     allowIDOnCreate,
     defaultIDType: 'text',
     init: adapter,

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -208,6 +208,7 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
   }
 
   return {
+    name: 'postgres',
     allowIDOnCreate,
     defaultIDType: payloadIDType,
     init: adapter,

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -197,6 +197,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
   }
 
   return {
+    name: 'sqlite',
     allowIDOnCreate,
     defaultIDType: payloadIDType,
     init: adapter,

--- a/packages/db-vercel-postgres/src/index.ts
+++ b/packages/db-vercel-postgres/src/index.ts
@@ -205,6 +205,7 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
   }
 
   return {
+    name: 'postgres',
     allowIDOnCreate,
     defaultIDType: payloadIDType,
     init: adapter,

--- a/packages/payload/src/database/types.ts
+++ b/packages/payload/src/database/types.ts
@@ -642,6 +642,12 @@ export type DatabaseAdapterResult<T = BaseDatabaseAdapter> = {
   allowIDOnCreate?: boolean
   defaultIDType: 'number' | 'text'
   init: (args: { payload: Payload }) => T
+  /**
+   * The name of the database adapter. For example, "postgres" or "mongoose".
+   *
+   * @todo make required in 4.0
+   */
+  name?: string
 }
 
 export type DBIdentifierName =


### PR DESCRIPTION
You can access the database name from `sanitizedConfig.db.name`. But currently, it' not possible to access the db name from the unsanitized config.

Plugins only have access to the unsanitized config. This change allows db adapters to return the db name early, which will allow plugins to conditionally initialize db-specific functionality