### PR TITLE
feat(db-*): export types from main export

### DIFF
--- a/packages/db-postgres/package.json
+++ b/packages/db-postgres/package.json
@@ -25,9 +25,9 @@
       "default": "./src/index.ts"
     },
     "./types": {
-      "import": "./src/types.ts",
-      "types": "./src/types.ts",
-      "default": "./src/types.ts"
+      "import": "./src/exports/types-deprecated.ts",
+      "types": "./src/exports/types-deprecated.ts",
+      "default": "./src/exports/types-deprecated.ts"
     },
     "./migration-utils": {
       "import": "./src/exports/migration-utils.ts",
@@ -56,7 +56,7 @@
     }
   },
   "main": "./src/index.ts",
-  "types": "./src/types.ts",
+  "types": "./src/index.ts",
   "files": [
     "dist",
     "mock.js"
@@ -102,9 +102,9 @@
         "default": "./dist/index.js"
       },
       "./types": {
-        "import": "./dist/types.js",
-        "types": "./dist/types.d.ts",
-        "default": "./dist/types.js"
+        "import": "./dist/exports/types-deprecated.js",
+        "types": "./dist/exports/types-deprecated.d.ts",
+        "default": "./dist/exports/types-deprecated.js"
       },
       "./migration-utils": {
         "import": "./dist/exports/migration-utils.js",

--- a/packages/db-postgres/src/exports/types-deprecated.ts
+++ b/packages/db-postgres/src/exports/types-deprecated.ts
@@ -1,0 +1,20 @@
+import type {
+  Args as _Args,
+  GeneratedDatabaseSchema as _GeneratedDatabaseSchema,
+  PostgresAdapter as _PostgresAdapter,
+} from '../types.js'
+
+/**
+ * @deprecated - import from `@payloadcms/db-postgres` instead
+ */
+export type Args = _Args
+
+/**
+ * @deprecated - import from `@payloadcms/db-postgres` instead
+ */
+export type GeneratedDatabaseSchema = _GeneratedDatabaseSchema
+
+/**
+ * @deprecated - import from `@payloadcms/db-postgres` instead
+ */
+export type PostgresAdapter = _PostgresAdapter

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -214,9 +214,6 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
   }
 }
 
-/**
- * @todo deprecate /types subpath export in 4.0
- */
 export type {
   Args as PostgresAdapterArgs,
   GeneratedDatabaseSchema,

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -214,6 +214,14 @@ export function postgresAdapter(args: Args): DatabaseAdapterObj<PostgresAdapter>
   }
 }
 
+/**
+ * @todo deprecate /types subpath export in 4.0
+ */
+export type {
+  Args as PostgresAdapterArgs,
+  GeneratedDatabaseSchema,
+  PostgresAdapter,
+} from './types.js'
 export type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/drizzle/postgres'
 export { geometryColumn } from '@payloadcms/drizzle/postgres'
 export { sql } from 'drizzle-orm'

--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -25,9 +25,9 @@
       "types": "./src/index.ts"
     },
     "./types": {
-      "import": "./src/types.ts",
-      "require": "./src/types.ts",
-      "types": "./src/types.ts"
+      "import": "./src/exports/types-deprecated.ts",
+      "require": "./src/exports/types-deprecated.ts",
+      "types": "./src/exports/types-deprecated.ts"
     },
     "./migration-utils": {
       "import": "./src/exports/migration-utils.ts",
@@ -56,7 +56,7 @@
     }
   },
   "main": "./src/index.ts",
-  "types": "./src/types.ts",
+  "types": "./src/index.ts",
   "files": [
     "dist",
     "mock.js"
@@ -99,9 +99,9 @@
         "types": "./dist/index.d.ts"
       },
       "./types": {
-        "import": "./dist/types.js",
-        "require": "./dist/types.js",
-        "types": "./dist/types.d.ts"
+        "import": "./dist/exports/types-deprecated.js",
+        "require": "./dist/exports/types-deprecated.js",
+        "types": "./dist/exports/types-deprecated.d.ts"
       },
       "./migration-utils": {
         "import": "./dist/exports/migration-utils.js",

--- a/packages/db-sqlite/src/exports/types-deprecated.ts
+++ b/packages/db-sqlite/src/exports/types-deprecated.ts
@@ -1,0 +1,79 @@
+import type {
+  Args as _Args,
+  CountDistinct as _CountDistinct,
+  DeleteWhere as _DeleteWhere,
+  DropDatabase as _DropDatabase,
+  Execute as _Execute,
+  GeneratedDatabaseSchema as _GeneratedDatabaseSchema,
+  GenericColumns as _GenericColumns,
+  GenericRelation as _GenericRelation,
+  GenericTable as _GenericTable,
+  IDType as _IDType,
+  Insert as _Insert,
+  MigrateDownArgs as _MigrateDownArgs,
+  MigrateUpArgs as _MigrateUpArgs,
+  SQLiteAdapter as _SQLiteAdapter,
+  SQLiteSchemaHook as _SQLiteSchemaHook,
+} from '../types.js'
+
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type SQLiteAdapter = _SQLiteAdapter
+
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type Args = _Args
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type CountDistinct = _CountDistinct
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type DeleteWhere = _DeleteWhere
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type DropDatabase = _DropDatabase
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type Execute<T> = _Execute<T>
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type GeneratedDatabaseSchema = _GeneratedDatabaseSchema
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type GenericColumns = _GenericColumns
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type GenericRelation = _GenericRelation
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type GenericTable = _GenericTable
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type IDType = _IDType
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type Insert = _Insert
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type MigrateDownArgs = _MigrateDownArgs
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type MigrateUpArgs = _MigrateUpArgs
+/**
+ * @deprecated - import from `@payloadcms/db-sqlite` instead
+ */
+export type SQLiteSchemaHook = _SQLiteSchemaHook

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -58,10 +58,6 @@ import { init } from './init.js'
 import { insert } from './insert.js'
 import { requireDrizzleKit } from './requireDrizzleKit.js'
 
-export type { MigrateDownArgs, MigrateUpArgs } from './types.js'
-
-export { sql } from 'drizzle-orm'
-
 const filename = fileURLToPath(import.meta.url)
 
 export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
@@ -202,3 +198,26 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
     init: adapter,
   }
 }
+
+/**
+ * @todo deprecate /types subpath export in 4.0
+ */
+export type {
+  Args as SQLiteAdapterArgs,
+  CountDistinct,
+  DeleteWhere,
+  DropDatabase,
+  Execute,
+  GeneratedDatabaseSchema,
+  GenericColumns,
+  GenericRelation,
+  GenericTable,
+  IDType,
+  Insert,
+  MigrateDownArgs,
+  MigrateUpArgs,
+  SQLiteAdapter,
+  SQLiteSchemaHook,
+} from './types.js'
+
+export { sql } from 'drizzle-orm'

--- a/packages/db-vercel-postgres/package.json
+++ b/packages/db-vercel-postgres/package.json
@@ -25,9 +25,9 @@
       "default": "./src/index.ts"
     },
     "./types": {
-      "import": "./src/types.ts",
-      "types": "./src/types.ts",
-      "default": "./src/types.ts"
+      "import": "./src/exports/types-deprecated.ts",
+      "types": "./src/exports/types-deprecated.ts",
+      "default": "./src/exports/types-deprecated.ts"
     },
     "./migration-utils": {
       "import": "./src/exports/migration-utils.ts",
@@ -56,7 +56,7 @@
     }
   },
   "main": "./src/index.ts",
-  "types": "./src/types.ts",
+  "types": "./src/index.ts",
   "files": [
     "dist",
     "mock.js"
@@ -103,9 +103,9 @@
         "default": "./dist/index.js"
       },
       "./types": {
-        "import": "./dist/types.js",
-        "types": "./dist/types.d.ts",
-        "default": "./dist/types.js"
+        "import": "./dist/exports/types-deprecated.js",
+        "types": "./dist/exports/types-deprecated.d.ts",
+        "default": "./dist/exports/types-deprecated.js"
       },
       "./migration-utils": {
         "import": "./dist/exports/migration-utils.js",

--- a/packages/db-vercel-postgres/src/exports/types-deprecated.ts
+++ b/packages/db-vercel-postgres/src/exports/types-deprecated.ts
@@ -1,0 +1,20 @@
+import type {
+  Args as _Args,
+  GeneratedDatabaseSchema as _GeneratedDatabaseSchema,
+  VercelPostgresAdapter as _VercelPostgresAdapter,
+} from '../types.js'
+
+/**
+ * @deprecated - import from `@payloadcms/db-vercel-postgres` instead
+ */
+export type Args = _Args
+
+/**
+ * @deprecated - import from `@payloadcms/db-vercel-postgres` instead
+ */
+export type GeneratedDatabaseSchema = _GeneratedDatabaseSchema
+
+/**
+ * @deprecated - import from `@payloadcms/db-vercel-postgres` instead
+ */
+export type VercelPostgresAdapter = _VercelPostgresAdapter

--- a/packages/db-vercel-postgres/src/index.ts
+++ b/packages/db-vercel-postgres/src/index.ts
@@ -211,6 +211,14 @@ export function vercelPostgresAdapter(args: Args = {}): DatabaseAdapterObj<Verce
   }
 }
 
+/**
+ * @todo deprecate /types subpath export in 4.0
+ */
+export type {
+  Args as VercelPostgresAdapterArgs,
+  GeneratedDatabaseSchema,
+  VercelPostgresAdapter,
+} from './types.js'
 export type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/drizzle/postgres'
 export { geometryColumn } from '@payloadcms/drizzle/postgres'
 export { sql } from 'drizzle-orm'

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -30,13 +30,13 @@
       "default": "./src/exports/postgres.ts"
     },
     "./types": {
-      "import": "./src/types.ts",
-      "types": "./src/types.ts",
-      "default": "./src/types.ts"
+      "import": "./src/exports/types-deprecated.ts",
+      "types": "./src/exports/types-deprecated.ts",
+      "default": "./src/exports/types-deprecated.ts"
     }
   },
   "main": "./src/index.ts",
-  "types": "./src/types.ts",
+  "types": "./src/index.ts",
   "files": [
     "dist",
     "mock.js"
@@ -81,9 +81,9 @@
         "default": "./dist/exports/postgres.js"
       },
       "./types": {
-        "import": "./dist/types.js",
-        "types": "./dist/types.d.ts",
-        "default": "./dist/types.js"
+        "import": "./dist/exports/types-deprecated.js",
+        "types": "./dist/exports/types-deprecated.d.ts",
+        "default": "./dist/exports/types-deprecated.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/drizzle/src/exports/types-deprecated.ts
+++ b/packages/drizzle/src/exports/types-deprecated.ts
@@ -1,0 +1,188 @@
+import type {
+  BaseRawColumn as _BaseRawColumn,
+  BuildDrizzleTable as _BuildDrizzleTable,
+  BuildQueryJoinAliases as _BuildQueryJoinAliases,
+  ChainedMethods as _ChainedMethods,
+  ColumnToCodeConverter as _ColumnToCodeConverter,
+  CountDistinct as _CountDistinct,
+  CreateJSONQueryArgs as _CreateJSONQueryArgs,
+  DeleteWhere as _DeleteWhere,
+  DrizzleAdapter as _DrizzleAdapter,
+  DrizzleTransaction as _DrizzleTransaction,
+  DropDatabase as _DropDatabase,
+  EnumRawColumn as _EnumRawColumn,
+  Execute as _Execute,
+  GenericColumn as _GenericColumn,
+  GenericColumns as _GenericColumns,
+  GenericPgColumn as _GenericPgColumn,
+  GenericRelation as _GenericRelation,
+  GenericTable as _GenericTable,
+  IDType as _IDType,
+  Insert as _Insert,
+  IntegerRawColumn as _IntegerRawColumn,
+  Migration as _Migration,
+  PostgresDB as _PostgresDB,
+  RawColumn as _RawColumn,
+  RawForeignKey as _RawForeignKey,
+  RawIndex as _RawIndex,
+  RawRelation as _RawRelation,
+  RawTable as _RawTable,
+  RelationMap as _RelationMap,
+  RequireDrizzleKit as _RequireDrizzleKit,
+  SetColumnID as _SetColumnID,
+  SQLiteDB as _SQLiteDB,
+  TimestampRawColumn as _TimestampRawColumn,
+  TransactionPg as _TransactionPg,
+  TransactionSQLite as _TransactionSQLite,
+  UUIDRawColumn as _UUIDRawColumn,
+  VectorRawColumn as _VectorRawColumn,
+} from '../types.js'
+
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type BaseRawColumn = _BaseRawColumn
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type BuildDrizzleTable = _BuildDrizzleTable
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type BuildQueryJoinAliases = _BuildQueryJoinAliases
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type ChainedMethods = _ChainedMethods
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type ColumnToCodeConverter = _ColumnToCodeConverter
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type CountDistinct = _CountDistinct
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type CreateJSONQueryArgs = _CreateJSONQueryArgs
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type DeleteWhere = _DeleteWhere
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type DrizzleAdapter = _DrizzleAdapter
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type DrizzleTransaction = _DrizzleTransaction
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type DropDatabase = _DropDatabase
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type EnumRawColumn = _EnumRawColumn
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type Execute<T> = _Execute<T>
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type GenericColumn = _GenericColumn
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type GenericColumns<T> = _GenericColumns<T>
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type GenericPgColumn = _GenericPgColumn
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type GenericRelation = _GenericRelation
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type GenericTable = _GenericTable
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type IDType = _IDType
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type Insert = _Insert
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type IntegerRawColumn = _IntegerRawColumn
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type Migration = _Migration
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type PostgresDB = _PostgresDB
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type RawColumn = _RawColumn
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type RawForeignKey = _RawForeignKey
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type RawIndex = _RawIndex
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type RawRelation = _RawRelation
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type RawTable = _RawTable
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type RelationMap = _RelationMap
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type RequireDrizzleKit = _RequireDrizzleKit
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type SetColumnID = _SetColumnID
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type SQLiteDB = _SQLiteDB
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type TimestampRawColumn = _TimestampRawColumn
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type TransactionPg = _TransactionPg
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type TransactionSQLite = _TransactionSQLite
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type UUIDRawColumn = _UUIDRawColumn
+/**
+ * @deprecated - import from `@payloadcms/drizzle` instead
+ */
+export type VectorRawColumn = _VectorRawColumn

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -31,6 +31,45 @@ export { buildRawSchema } from './schema/buildRawSchema.js'
 export { beginTransaction } from './transactions/beginTransaction.js'
 export { commitTransaction } from './transactions/commitTransaction.js'
 export { rollbackTransaction } from './transactions/rollbackTransaction.js'
+export type {
+  BaseRawColumn,
+  BuildDrizzleTable,
+  BuildQueryJoinAliases,
+  ChainedMethods,
+  ColumnToCodeConverter,
+  CountDistinct,
+  CreateJSONQueryArgs,
+  DeleteWhere,
+  DrizzleAdapter,
+  DrizzleTransaction,
+  DropDatabase,
+  EnumRawColumn,
+  Execute,
+  GenericColumn,
+  GenericColumns,
+  GenericPgColumn,
+  GenericRelation,
+  GenericTable,
+  IDType,
+  Insert,
+  IntegerRawColumn,
+  Migration,
+  PostgresDB,
+  RawColumn,
+  RawForeignKey,
+  RawIndex,
+  RawRelation,
+  RawTable,
+  RelationMap,
+  RequireDrizzleKit,
+  SetColumnID,
+  SQLiteDB,
+  TimestampRawColumn,
+  TransactionPg,
+  TransactionSQLite,
+  UUIDRawColumn,
+  VectorRawColumn,
+} from './types.js'
 export { updateGlobal } from './updateGlobal.js'
 export { updateGlobalVersion } from './updateGlobalVersion.js'
 export { updateJobs } from './updateJobs.js'


### PR DESCRIPTION
In 3.0, we made the decision to export all types from the main package export (e.g. `payload/types` => `payload`). This improves type discoverability by IDEs and simplifies importing types.

This PR does the same for our db adapters, which still have a separate `/types` subpath export. While those are kept for backwards-compatibility, we can remove them in 4.0.