### PR TITLE
fix(db-postgres): validation error when updating job

### DIFF
--- a/packages/drizzle/src/updateJobs.ts
+++ b/packages/drizzle/src/updateJobs.ts
@@ -43,6 +43,7 @@ export const updateJobs: UpdateJobs = async function updateMany(
       ...job,
       ...data,
     }
+    delete updateData.id
 
     const result = await upsertRow({
       id: job.id,

--- a/packages/payload/src/database/defaultUpdateJobs.ts
+++ b/packages/payload/src/database/defaultUpdateJobs.ts
@@ -35,10 +35,11 @@ export const defaultUpdateJobs: UpdateJobs = async function updateMany(
   }
 
   for (const job of jobsToUpdate) {
-    const updateData = {
+    const updateData: any = {
       ...job,
       ...data,
     }
+    delete updateData.id
     const updatedJob = await this.updateOne({
       id: job.id,
       collection: jobsCollectionSlug,

--- a/packages/payload/src/queues/utilities/sanitizeUpdateData.ts
+++ b/packages/payload/src/queues/utilities/sanitizeUpdateData.ts
@@ -10,9 +10,17 @@ const ObjectId = (ObjectIdImport.default ||
  * This function is used to manually sanitize the data for direct db adapter operations
  */
 export function sanitizeUpdateData({ data }: { data: Partial<BaseJob> }): Partial<BaseJob> {
-  if (data.log) {
-    const sanitizedData = { ...data }
-    sanitizedData.log = sanitizedData?.log?.map((log) => {
+  const sanitizedData = { ...data }
+  delete sanitizedData.id
+  if ('createdAt' in sanitizedData) {
+    delete sanitizedData.createdAt
+  }
+  if ('updatedAt' in sanitizedData) {
+    delete sanitizedData.updatedAt
+  }
+
+  if (sanitizedData?.log?.length) {
+    sanitizedData.log = sanitizedData.log.map((log) => {
       if (log.id) {
         return log
       }
@@ -21,8 +29,7 @@ export function sanitizeUpdateData({ data }: { data: Partial<BaseJob> }): Partia
         id: new ObjectId().toHexString(),
       }
     })
-    return sanitizedData
   }
 
-  return data
+  return sanitizedData
 }

--- a/packages/payload/src/queues/utilities/sanitizeUpdateData.ts
+++ b/packages/payload/src/queues/utilities/sanitizeUpdateData.ts
@@ -10,17 +10,9 @@ const ObjectId = (ObjectIdImport.default ||
  * This function is used to manually sanitize the data for direct db adapter operations
  */
 export function sanitizeUpdateData({ data }: { data: Partial<BaseJob> }): Partial<BaseJob> {
-  const sanitizedData = { ...data }
-  delete sanitizedData.id
-  if ('createdAt' in sanitizedData) {
-    delete sanitizedData.createdAt
-  }
-  if ('updatedAt' in sanitizedData) {
-    delete sanitizedData.updatedAt
-  }
-
-  if (sanitizedData?.log?.length) {
-    sanitizedData.log = sanitizedData.log.map((log) => {
+  if (data.log) {
+    const sanitizedData = { ...data }
+    sanitizedData.log = sanitizedData?.log?.map((log) => {
       if (log.id) {
         return log
       }
@@ -29,7 +21,8 @@ export function sanitizeUpdateData({ data }: { data: Partial<BaseJob> }): Partia
         id: new ObjectId().toHexString(),
       }
     })
+    return sanitizedData
   }
 
-  return sanitizedData
+  return data
 }


### PR DESCRIPTION
This ensures the job id is stripped out of the job update data. Previously, this was passed to `upsertRow`, causing a postgres validation error:

```bash
[23:25:08] ERROR: Error running job___ id: 3 attempt 1
    err: {
      "type": "ValidationError",
      "message": "The following field is invalid: id",
      "stack":
          ValidationError: The following field is invalid: id
              at upsertRow (webpack-internal:///(rsc)/./node_modules/@payloadcms/drizzle/dist/upsertRow/index.js:367:19)
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
              at async Object.updateMany [as updateJobs] (webpack-internal:///(rsc)/./node_modules/@payloadcms/drizzle/dist/updateJobs.js:47:24)
              at async updateJobs (webpack-internal:///(rsc)/./node_modules/payload/dist/queues/utilities/updateJob.js:59:25)
              at async updateJob (webpack-internal:///(rsc)/./node_modules/payload/dist/queues/utilities/updateJob.js:13:20)
              at async eval (webpack-internal:///(rsc)/./node_modules/payload/dist/queues/operations/runJobs/runJob/getUpdateJobFunction.js:10:28)
              at async Object.eval [as createVectorDoc] (webpack-internal:///(rsc)/./node_modules/payload/dist/queues/operations/runJobs/runJob/getRunTaskFunction.js:245:13)
              at async eval (webpack-internal:///(rsc)/./packages/___./src/jobs/workflows/___.ts:76:20)
              at async Promise.all (index 1)
              at async handler (webpack-internal:///(rsc)/./packages/___./src/jobs/workflows/___..ts:75:49)
              at async runJob (webpack-internal:///(rsc)/./node_modules/payload/dist/queues/operations/runJobs/runJob/index.js:18:9)
              at async eval (webpack-internal:///(rsc)/./node_modules/payload/dist/queues/operations/runJobs/index.js:178:28)
              at async Promise.all (index 0)
              at async runJobs (webpack-internal:///(rsc)/./node_modules/payload/dist/queues/operations/runJobs/index.js:209:26)
              at async Object.runByID (webpack-internal:///(rsc)/./node_modules/payload/dist/queues/localAPI.js:73:20)
      "data": {
        "id": 3,
        "errors": [
          {
            "message": "Value must be unique",
            "path": "id"
          }
        ]
      },
      "isOperational": true,
      "isPublic": false,
      "status": 400,
      "name": "ValidationError"
    }
```