### PR TITLE
fix(richtext-slate): add `li` element if needed

### DIFF
--- a/packages/richtext-slate/src/field/rscEntry.tsx
+++ b/packages/richtext-slate/src/field/rscEntry.tsx
@@ -87,7 +87,14 @@ export const RscEntrySlateField: React.FC<
       }
     }
   })
-  ;(args?.admin?.elements || Object.values(elementTypes)).forEach((el) => {
+
+  const elements = args?.admin?.elements ?? Object.values(elementTypes)
+
+  if ((elements.includes('ol') || elements.includes('ul')) && !elements.includes(elementTypes.li)) {
+    elements.push(elementTypes.li)
+  }
+
+  elements.forEach((el) => {
     let element: RichTextCustomElement
 
     if (typeof el === 'object' && el !== null) {


### PR DESCRIPTION
### What?

Fixes a bug that caused the Slate editor to render lists improperly when specifying `admin.elements`.

### Why?

When overriding the permitted elements in `slateEditor({...})`, the type of `RichTextElement` prevents registering `li` as an element type. However, omitting it causes ordered and unordered lists to be rendered without `li` tags.

### How?

The `li` element is automatically added if  `admin.elements` specifies either `ol` or `ul`.