### PR TITLE
fix: typescriptSchema override required to false

### DIFF
--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -411,4 +411,36 @@ describe('configToJSONSchema', () => {
 
     expect(schema?.definitions?.SharedBlock).toBeDefined()
   })
+
+  it('should allow overriding required to false', async () => {
+    // @ts-expect-error
+    const config: Config = {
+      collections: [
+        {
+          slug: 'test',
+          fields: [
+            {
+              name: 'title',
+              type: 'text',
+              required: true,
+              defaultValue: 'test',
+              typescriptSchema: [
+                () => ({
+                  type: 'string',
+                  required: false,
+                }),
+              ],
+            },
+          ],
+          timestamps: false,
+        },
+      ],
+    }
+
+    const sanitizedConfig = await sanitizeConfig(config)
+    const schema = configToJSONSchema(sanitizedConfig, 'text')
+
+    // @ts-expect-error
+    expect(schema.definitions.test.properties.title.required).toStrictEqual(false)
+  })
 })

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -258,9 +258,6 @@ export function fieldsToJSONSchema(
     properties: Object.fromEntries(
       fields.reduce((fieldSchemas, field, index) => {
         const isRequired = fieldAffectsData(field) && fieldIsRequired(field)
-        if (isRequired) {
-          requiredFieldNames.add(field.name)
-        }
 
         const fieldDescription = entityOrFieldToJsDocs({ entity: field, i18n })
         const baseFieldSchema: JSONSchema4 = {}
@@ -706,6 +703,9 @@ export function fieldsToJSONSchema(
         }
 
         if (fieldSchema && fieldAffectsData(field)) {
+          if (isRequired && fieldSchema.required !== false) {
+            requiredFieldNames.add(field.name)
+          }
           fieldSchemas.set(field.name, fieldSchema)
         }
 


### PR DESCRIPTION
### What?
Previously if you used the typescriptSchema and `returned: false`, the field would still be required anyways.

### Why?
We were adding fields to be required on the collection without comparing the returned schema from typescriptSchema functions.

### How?
This changes the order of logic so that `requiredFieldNames` on the collection is only after running and checking the field schema.