### PR TITLE
fix(ui): prefer adminThumbnail even if file is non-image

### DIFF
--- a/packages/ui/src/elements/Table/DefaultCell/fields/File/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/File/index.tsx
@@ -30,9 +30,12 @@ export const FileCell: React.FC<FileCellProps> = ({
   const previewAllowed = fieldPreviewAllowed ?? collectionConfig.upload?.displayPreview ?? true
 
   if (previewAllowed) {
-    let fileSrc: string | undefined = rowData?.thumbnailURL ?? rowData?.url
+    const isFileImage = isImage(rowData?.mimeType)
+    let fileSrc: string | undefined = isFileImage
+      ? rowData?.thumbnailURL || rowData?.url
+      : rowData?.thumbnailURL
 
-    if (isImage(rowData?.mimeType)) {
+    if (isFileImage) {
       fileSrc = getBestFitFromSizes({
         sizes: rowData?.sizes,
         thumbnailURL: rowData?.thumbnailURL,

--- a/packages/ui/src/elements/Thumbnail/index.tsx
+++ b/packages/ui/src/elements/Thumbnail/index.tsx
@@ -21,13 +21,13 @@ export type ThumbnailProps = {
 }
 
 export const Thumbnail: React.FC<ThumbnailProps> = (props) => {
-  const { className = '', doc: { filename, mimeType } = {}, fileSrc, imageCacheTag, size } = props
+  const { className = '', doc: { filename } = {}, fileSrc, imageCacheTag, size } = props
   const [fileExists, setFileExists] = React.useState(undefined)
 
   const classNames = [baseClass, `${baseClass}--size-${size || 'medium'}`, className].join(' ')
 
   React.useEffect(() => {
-    if (!fileSrc || (typeof mimeType === 'string' && !mimeType.startsWith('image'))) {
+    if (!fileSrc) {
       setFileExists(false)
       return
     }
@@ -41,7 +41,7 @@ export const Thumbnail: React.FC<ThumbnailProps> = (props) => {
     img.onerror = () => {
       setFileExists(false)
     }
-  }, [fileSrc, mimeType])
+  }, [fileSrc])
 
   let src: null | string = null
 

--- a/packages/ui/src/fields/Upload/RelationshipContent/index.tsx
+++ b/packages/ui/src/fields/Upload/RelationshipContent/index.tsx
@@ -99,7 +99,7 @@ export function RelationshipContent(props: Props) {
             alt={alt}
             className={`${baseClass}__thumbnail`}
             filename={filename}
-            fileSrc={isImage(mimeType) && thumbnailSrc}
+            fileSrc={isImage(mimeType) ? thumbnailSrc || src : thumbnailSrc}
             size="small"
           />
         )}

--- a/packages/ui/src/fields/Upload/RelationshipContent/index.tsx
+++ b/packages/ui/src/fields/Upload/RelationshipContent/index.tsx
@@ -99,7 +99,7 @@ export function RelationshipContent(props: Props) {
             alt={alt}
             className={`${baseClass}__thumbnail`}
             filename={filename}
-            fileSrc={isImage(mimeType) ? thumbnailSrc || src : thumbnailSrc}
+            fileSrc={thumbnailSrc}
             size="small"
           />
         )}


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR relaxes the mimeType checks in the thumbnail and file cell components to accommodate an `adminThumbnail` even if the file is a non-image. This is useful when, for example, using an `adminThumbnail` function to retrieve or generate thumbnails for files that are non-images such as videos.

### Why?
To prioritize an admin thumbnail if/when available on file cells and upload field thumbnails in both edit and list views.

### How?
By relaxing the mimeType checks in the `Thumbnail` component and instead lifting that responsibility on the caller of this component. Some of these checks were not needed as the best-fit helper utility function will automatically select the thumbnailURL if available or revert to the original url if no best-fit is found.

Demo of admin thumbnail being loaded on non-image while still selecting best-fit size for images:
![chrome_2025-04-01_18-56-25](https://github.com/user-attachments/assets/befd3647-92c5-45c6-90e2-87459bca8bea)
