### PR TITLE
feat(graphql): improve non-nullability in query result types

### DIFF
--- a/packages/graphql/src/schema/buildPaginatedListType.ts
+++ b/packages/graphql/src/schema/buildPaginatedListType.ts
@@ -1,21 +1,21 @@
-import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLObjectType } from 'graphql'
+import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql'
 
 export const buildPaginatedListType = (name, docType) =>
   new GraphQLObjectType({
     name,
     fields: {
       docs: {
-        type: new GraphQLList(docType),
+        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(docType))),
       },
-      hasNextPage: { type: GraphQLBoolean },
-      hasPrevPage: { type: GraphQLBoolean },
-      limit: { type: GraphQLInt },
-      nextPage: { type: GraphQLInt },
+      hasNextPage: { type: new GraphQLNonNull(GraphQLBoolean) },
+      hasPrevPage: { type: new GraphQLNonNull(GraphQLBoolean) },
+      limit: { type: new GraphQLNonNull(GraphQLInt) },
+      nextPage: { type: new GraphQLNonNull(GraphQLInt) },
       offset: { type: GraphQLInt },
-      page: { type: GraphQLInt },
-      pagingCounter: { type: GraphQLInt },
-      prevPage: { type: GraphQLInt },
-      totalDocs: { type: GraphQLInt },
-      totalPages: { type: GraphQLInt },
+      page: { type: new GraphQLNonNull(GraphQLInt) },
+      pagingCounter: { type: new GraphQLNonNull(GraphQLInt) },
+      prevPage: { type: new GraphQLNonNull(GraphQLInt) },
+      totalDocs: { type: new GraphQLNonNull(GraphQLInt) },
+      totalPages: { type: new GraphQLNonNull(GraphQLInt) },
     },
   })

--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -348,11 +348,15 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
         name: joinName,
         fields: {
           docs: {
-            type: Array.isArray(field.collection)
-              ? GraphQLJSON
-              : new GraphQLList(graphqlResult.collections[field.collection].graphQL.type),
+            type: new GraphQLNonNull(
+              Array.isArray(field.collection)
+                ? GraphQLJSON
+                : new GraphQLList(
+                    new GraphQLNonNull(graphqlResult.collections[field.collection].graphQL.type),
+                  ),
+            ),
           },
-          hasNextPage: { type: GraphQLBoolean },
+          hasNextPage: { type: new GraphQLNonNull(GraphQLBoolean) },
         },
       }),
       args: {
@@ -428,7 +432,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
       ...objectTypeConfig,
       [formatName(field.name)]: formattedNameResolver({
         type: withNullableType({
-          type: field?.hasMany === true ? new GraphQLList(type) : type,
+          type: field?.hasMany === true ? new GraphQLList(new GraphQLNonNull(type)) : type,
           field,
           forceNullable,
           parentIsLocalized,
@@ -856,7 +860,10 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
     ...objectTypeConfig,
     [formatName(field.name)]: formattedNameResolver({
       type: withNullableType({
-        type: field.hasMany === true ? new GraphQLList(GraphQLString) : GraphQLString,
+        type:
+          field.hasMany === true
+            ? new GraphQLList(new GraphQLNonNull(GraphQLString))
+            : GraphQLString,
         field,
         forceNullable,
         parentIsLocalized,

--- a/test/_community/schema.graphql
+++ b/test/_community/schema.graphql
@@ -1,24 +1,24 @@
 type Query {
   Post(id: String!, draft: Boolean): Post
-  Posts(draft: Boolean, where: Post_where, limit: Int, page: Int, sort: String): Posts
+  Posts(draft: Boolean, where: Post_where, limit: Int, page: Int, pagination: Boolean, sort: String): Posts
   countPosts(draft: Boolean, where: Post_where): countPosts
   docAccessPost(id: String!): postsDocAccess
-  versionPost(id: String): PostVersion
-  versionsPosts(where: versionsPost_where, limit: Int, page: Int, sort: String): versionsPosts
+  Media(id: String!, draft: Boolean): Media
+  allMedia(draft: Boolean, where: Media_where, limit: Int, page: Int, pagination: Boolean, sort: String): allMedia
+  countallMedia(draft: Boolean, where: Media_where): countallMedia
+  docAccessMedia(id: String!): mediaDocAccess
   User(id: String!, draft: Boolean): User
-  Users(draft: Boolean, where: User_where, limit: Int, page: Int, sort: String): Users
+  Users(draft: Boolean, where: User_where, limit: Int, page: Int, pagination: Boolean, sort: String): Users
   countUsers(draft: Boolean, where: User_where): countUsers
   docAccessUser(id: String!): usersDocAccess
   meUser: usersMe
   initializedUser: Boolean
+  PayloadLockedDocument(id: String!, draft: Boolean): PayloadLockedDocument
+  PayloadLockedDocuments(draft: Boolean, where: PayloadLockedDocument_where, limit: Int, page: Int, pagination: Boolean, sort: String): PayloadLockedDocuments
+  countPayloadLockedDocuments(draft: Boolean, where: PayloadLockedDocument_where): countPayloadLockedDocuments
+  docAccessPayloadLockedDocument(id: String!): payload_locked_documentsDocAccess
   PayloadPreference(id: String!, draft: Boolean): PayloadPreference
-  PayloadPreferences(
-    draft: Boolean
-    where: PayloadPreference_where
-    limit: Int
-    page: Int
-    sort: String
-  ): PayloadPreferences
+  PayloadPreferences(draft: Boolean, where: PayloadPreference_where, limit: Int, page: Int, pagination: Boolean, sort: String): PayloadPreferences
   countPayloadPreferences(draft: Boolean, where: PayloadPreference_where): countPayloadPreferences
   docAccessPayloadPreference(id: String!): payload_preferencesDocAccess
   Menu(draft: Boolean): Menu
@@ -27,30 +27,22 @@ type Query {
 }
 
 type Post {
-  id: String
-  text: String
-  richText(depth: Int): JSON
-  richText2(depth: Int): JSON
+  id: String!
+  title: String
+  content(depth: Int): JSON
   updatedAt: DateTime
   createdAt: DateTime
-  _status: Post__status
 }
 
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
-scalar JSON
-  @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 """
 A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
 """
 scalar DateTime
-
-enum Post__status {
-  draft
-  published
-}
 
 type Posts {
   docs: [Post]
@@ -67,18 +59,16 @@ type Posts {
 }
 
 input Post_where {
-  text: Post_text_operator
-  richText: Post_richText_operator
-  richText2: Post_richText2_operator
+  title: Post_title_operator
+  content: Post_content_operator
   updatedAt: Post_updatedAt_operator
   createdAt: Post_createdAt_operator
-  _status: Post__status_operator
   id: Post_id_operator
   AND: [Post_where_and]
   OR: [Post_where_or]
 }
 
-input Post_text_operator {
+input Post_title_operator {
   equals: String
   not_equals: String
   like: String
@@ -89,15 +79,7 @@ input Post_text_operator {
   exists: Boolean
 }
 
-input Post_richText_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_richText2_operator {
+input Post_content_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -127,20 +109,6 @@ input Post_createdAt_operator {
   exists: Boolean
 }
 
-input Post__status_operator {
-  equals: Post__status_Input
-  not_equals: Post__status_Input
-  in: [Post__status_Input]
-  not_in: [Post__status_Input]
-  all: [Post__status_Input]
-  exists: Boolean
-}
-
-enum Post__status_Input {
-  draft
-  published
-}
-
 input Post_id_operator {
   equals: String
   not_equals: String
@@ -153,24 +121,20 @@ input Post_id_operator {
 }
 
 input Post_where_and {
-  text: Post_text_operator
-  richText: Post_richText_operator
-  richText2: Post_richText2_operator
+  title: Post_title_operator
+  content: Post_content_operator
   updatedAt: Post_updatedAt_operator
   createdAt: Post_createdAt_operator
-  _status: Post__status_operator
   id: Post_id_operator
   AND: [Post_where_and]
   OR: [Post_where_or]
 }
 
 input Post_where_or {
-  text: Post_text_operator
-  richText: Post_richText_operator
-  richText2: Post_richText2_operator
+  title: Post_title_operator
+  content: Post_content_operator
   updatedAt: Post_updatedAt_operator
   createdAt: Post_createdAt_operator
-  _status: Post__status_operator
   id: Post_id_operator
   AND: [Post_where_and]
   OR: [Post_where_or]
@@ -186,84 +150,58 @@ type postsDocAccess {
   read: PostsReadDocAccess
   update: PostsUpdateDocAccess
   delete: PostsDeleteDocAccess
-  readVersions: PostsReadVersionsDocAccess
 }
 
 type PostsDocAccessFields {
-  text: PostsDocAccessFields_text
-  richText: PostsDocAccessFields_richText
-  richText2: PostsDocAccessFields_richText2
+  title: PostsDocAccessFields_title
+  content: PostsDocAccessFields_content
   updatedAt: PostsDocAccessFields_updatedAt
   createdAt: PostsDocAccessFields_createdAt
-  _status: PostsDocAccessFields__status
 }
 
-type PostsDocAccessFields_text {
-  create: PostsDocAccessFields_text_Create
-  read: PostsDocAccessFields_text_Read
-  update: PostsDocAccessFields_text_Update
-  delete: PostsDocAccessFields_text_Delete
+type PostsDocAccessFields_title {
+  create: PostsDocAccessFields_title_Create
+  read: PostsDocAccessFields_title_Read
+  update: PostsDocAccessFields_title_Update
+  delete: PostsDocAccessFields_title_Delete
 }
 
-type PostsDocAccessFields_text_Create {
+type PostsDocAccessFields_title_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_text_Read {
+type PostsDocAccessFields_title_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_text_Update {
+type PostsDocAccessFields_title_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_text_Delete {
+type PostsDocAccessFields_title_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_richText {
-  create: PostsDocAccessFields_richText_Create
-  read: PostsDocAccessFields_richText_Read
-  update: PostsDocAccessFields_richText_Update
-  delete: PostsDocAccessFields_richText_Delete
+type PostsDocAccessFields_content {
+  create: PostsDocAccessFields_content_Create
+  read: PostsDocAccessFields_content_Read
+  update: PostsDocAccessFields_content_Update
+  delete: PostsDocAccessFields_content_Delete
 }
 
-type PostsDocAccessFields_richText_Create {
+type PostsDocAccessFields_content_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_richText_Read {
+type PostsDocAccessFields_content_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_richText_Update {
+type PostsDocAccessFields_content_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_richText_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_richText2 {
-  create: PostsDocAccessFields_richText2_Create
-  read: PostsDocAccessFields_richText2_Read
-  update: PostsDocAccessFields_richText2_Update
-  delete: PostsDocAccessFields_richText2_Delete
-}
-
-type PostsDocAccessFields_richText2_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_richText2_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_richText2_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_richText2_Delete {
+type PostsDocAccessFields_content_Delete {
   permission: Boolean!
 }
 
@@ -313,29 +251,6 @@ type PostsDocAccessFields_createdAt_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields__status {
-  create: PostsDocAccessFields__status_Create
-  read: PostsDocAccessFields__status_Read
-  update: PostsDocAccessFields__status_Update
-  delete: PostsDocAccessFields__status_Delete
-}
-
-type PostsDocAccessFields__status_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields__status_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields__status_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields__status_Delete {
-  permission: Boolean!
-}
-
 type PostsCreateDocAccess {
   permission: Boolean!
   where: JSONObject
@@ -344,8 +259,7 @@ type PostsCreateDocAccess {
 """
 The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
-scalar JSONObject
-  @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 type PostsReadDocAccess {
   permission: Boolean!
@@ -362,36 +276,57 @@ type PostsDeleteDocAccess {
   where: JSONObject
 }
 
-type PostsReadVersionsDocAccess {
-  permission: Boolean!
-  where: JSONObject
-}
-
-type PostVersion {
-  parent(draft: Boolean): Post
-  version: PostVersion_Version
-  createdAt: DateTime
-  updatedAt: DateTime
-  latest: Boolean
-  id: String
-}
-
-type PostVersion_Version {
-  text: String
-  richText(depth: Int): JSON
-  richText2(depth: Int): JSON
+type Media {
+  id: String!
   updatedAt: DateTime
   createdAt: DateTime
-  _status: PostVersion_Version__status
+  url: String
+  thumbnailURL: String
+  filename: String
+  mimeType: String
+  filesize: Float
+  width: Float
+  height: Float
+  focalX: Float
+  focalY: Float
+  sizes: Media_Sizes
 }
 
-enum PostVersion_Version__status {
-  draft
-  published
+type Media_Sizes {
+  thumbnail: Media_Sizes_Thumbnail
+  medium: Media_Sizes_Medium
+  large: Media_Sizes_Large
 }
 
-type versionsPosts {
-  docs: [PostVersion]
+type Media_Sizes_Thumbnail {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+type Media_Sizes_Medium {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+type Media_Sizes_Large {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+type allMedia {
+  docs: [Media]
   hasNextPage: Boolean
   hasPrevPage: Boolean
   limit: Int
@@ -404,32 +339,64 @@ type versionsPosts {
   totalPages: Int
 }
 
-input versionsPost_where {
-  parent: versionsPost_parent_operator
-  version__text: versionsPost_version__text_operator
-  version__richText: versionsPost_version__richText_operator
-  version__richText2: versionsPost_version__richText2_operator
-  version__updatedAt: versionsPost_version__updatedAt_operator
-  version__createdAt: versionsPost_version__createdAt_operator
-  version___status: versionsPost_version___status_operator
-  createdAt: versionsPost_createdAt_operator
-  updatedAt: versionsPost_updatedAt_operator
-  latest: versionsPost_latest_operator
-  id: versionsPost_id_operator
-  AND: [versionsPost_where_and]
-  OR: [versionsPost_where_or]
+input Media_where {
+  updatedAt: Media_updatedAt_operator
+  createdAt: Media_createdAt_operator
+  url: Media_url_operator
+  thumbnailURL: Media_thumbnailURL_operator
+  filename: Media_filename_operator
+  mimeType: Media_mimeType_operator
+  filesize: Media_filesize_operator
+  width: Media_width_operator
+  height: Media_height_operator
+  focalX: Media_focalX_operator
+  focalY: Media_focalY_operator
+  sizes__thumbnail__url: Media_sizes__thumbnail__url_operator
+  sizes__thumbnail__width: Media_sizes__thumbnail__width_operator
+  sizes__thumbnail__height: Media_sizes__thumbnail__height_operator
+  sizes__thumbnail__mimeType: Media_sizes__thumbnail__mimeType_operator
+  sizes__thumbnail__filesize: Media_sizes__thumbnail__filesize_operator
+  sizes__thumbnail__filename: Media_sizes__thumbnail__filename_operator
+  sizes__medium__url: Media_sizes__medium__url_operator
+  sizes__medium__width: Media_sizes__medium__width_operator
+  sizes__medium__height: Media_sizes__medium__height_operator
+  sizes__medium__mimeType: Media_sizes__medium__mimeType_operator
+  sizes__medium__filesize: Media_sizes__medium__filesize_operator
+  sizes__medium__filename: Media_sizes__medium__filename_operator
+  sizes__large__url: Media_sizes__large__url_operator
+  sizes__large__width: Media_sizes__large__width_operator
+  sizes__large__height: Media_sizes__large__height_operator
+  sizes__large__mimeType: Media_sizes__large__mimeType_operator
+  sizes__large__filesize: Media_sizes__large__filesize_operator
+  sizes__large__filename: Media_sizes__large__filename_operator
+  id: Media_id_operator
+  AND: [Media_where_and]
+  OR: [Media_where_or]
 }
 
-input versionsPost_parent_operator {
-  equals: JSON
-  not_equals: JSON
-  in: [JSON]
-  not_in: [JSON]
-  all: [JSON]
+input Media_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
   exists: Boolean
 }
 
-input versionsPost_version__text_operator {
+input Media_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Media_url_operator {
   equals: String
   not_equals: String
   like: String
@@ -440,87 +407,7 @@ input versionsPost_version__text_operator {
   exists: Boolean
 }
 
-input versionsPost_version__richText_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__richText2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__updatedAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input versionsPost_version__createdAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input versionsPost_version___status_operator {
-  equals: versionsPost_version___status_Input
-  not_equals: versionsPost_version___status_Input
-  in: [versionsPost_version___status_Input]
-  not_in: [versionsPost_version___status_Input]
-  all: [versionsPost_version___status_Input]
-  exists: Boolean
-}
-
-enum versionsPost_version___status_Input {
-  draft
-  published
-}
-
-input versionsPost_createdAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input versionsPost_updatedAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input versionsPost_latest_operator {
-  equals: Boolean
-  not_equals: Boolean
-  exists: Boolean
-}
-
-input versionsPost_id_operator {
+input Media_thumbnailURL_operator {
   equals: String
   not_equals: String
   like: String
@@ -531,40 +418,1193 @@ input versionsPost_id_operator {
   exists: Boolean
 }
 
-input versionsPost_where_and {
-  parent: versionsPost_parent_operator
-  version__text: versionsPost_version__text_operator
-  version__richText: versionsPost_version__richText_operator
-  version__richText2: versionsPost_version__richText2_operator
-  version__updatedAt: versionsPost_version__updatedAt_operator
-  version__createdAt: versionsPost_version__createdAt_operator
-  version___status: versionsPost_version___status_operator
-  createdAt: versionsPost_createdAt_operator
-  updatedAt: versionsPost_updatedAt_operator
-  latest: versionsPost_latest_operator
-  id: versionsPost_id_operator
-  AND: [versionsPost_where_and]
-  OR: [versionsPost_where_or]
+input Media_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
 }
 
-input versionsPost_where_or {
-  parent: versionsPost_parent_operator
-  version__text: versionsPost_version__text_operator
-  version__richText: versionsPost_version__richText_operator
-  version__richText2: versionsPost_version__richText2_operator
-  version__updatedAt: versionsPost_version__updatedAt_operator
-  version__createdAt: versionsPost_version__createdAt_operator
-  version___status: versionsPost_version___status_operator
-  createdAt: versionsPost_createdAt_operator
-  updatedAt: versionsPost_updatedAt_operator
-  latest: versionsPost_latest_operator
-  id: versionsPost_id_operator
-  AND: [versionsPost_where_and]
-  OR: [versionsPost_where_or]
+input Media_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_focalX_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_focalY_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_sizes__thumbnail__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_sizes__thumbnail__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_sizes__thumbnail__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_sizes__thumbnail__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_sizes__thumbnail__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_sizes__thumbnail__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_sizes__medium__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_sizes__medium__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_sizes__medium__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_sizes__medium__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_sizes__medium__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_sizes__medium__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_sizes__large__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_sizes__large__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_sizes__large__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_sizes__large__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_sizes__large__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_sizes__large__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_where_and {
+  updatedAt: Media_updatedAt_operator
+  createdAt: Media_createdAt_operator
+  url: Media_url_operator
+  thumbnailURL: Media_thumbnailURL_operator
+  filename: Media_filename_operator
+  mimeType: Media_mimeType_operator
+  filesize: Media_filesize_operator
+  width: Media_width_operator
+  height: Media_height_operator
+  focalX: Media_focalX_operator
+  focalY: Media_focalY_operator
+  sizes__thumbnail__url: Media_sizes__thumbnail__url_operator
+  sizes__thumbnail__width: Media_sizes__thumbnail__width_operator
+  sizes__thumbnail__height: Media_sizes__thumbnail__height_operator
+  sizes__thumbnail__mimeType: Media_sizes__thumbnail__mimeType_operator
+  sizes__thumbnail__filesize: Media_sizes__thumbnail__filesize_operator
+  sizes__thumbnail__filename: Media_sizes__thumbnail__filename_operator
+  sizes__medium__url: Media_sizes__medium__url_operator
+  sizes__medium__width: Media_sizes__medium__width_operator
+  sizes__medium__height: Media_sizes__medium__height_operator
+  sizes__medium__mimeType: Media_sizes__medium__mimeType_operator
+  sizes__medium__filesize: Media_sizes__medium__filesize_operator
+  sizes__medium__filename: Media_sizes__medium__filename_operator
+  sizes__large__url: Media_sizes__large__url_operator
+  sizes__large__width: Media_sizes__large__width_operator
+  sizes__large__height: Media_sizes__large__height_operator
+  sizes__large__mimeType: Media_sizes__large__mimeType_operator
+  sizes__large__filesize: Media_sizes__large__filesize_operator
+  sizes__large__filename: Media_sizes__large__filename_operator
+  id: Media_id_operator
+  AND: [Media_where_and]
+  OR: [Media_where_or]
+}
+
+input Media_where_or {
+  updatedAt: Media_updatedAt_operator
+  createdAt: Media_createdAt_operator
+  url: Media_url_operator
+  thumbnailURL: Media_thumbnailURL_operator
+  filename: Media_filename_operator
+  mimeType: Media_mimeType_operator
+  filesize: Media_filesize_operator
+  width: Media_width_operator
+  height: Media_height_operator
+  focalX: Media_focalX_operator
+  focalY: Media_focalY_operator
+  sizes__thumbnail__url: Media_sizes__thumbnail__url_operator
+  sizes__thumbnail__width: Media_sizes__thumbnail__width_operator
+  sizes__thumbnail__height: Media_sizes__thumbnail__height_operator
+  sizes__thumbnail__mimeType: Media_sizes__thumbnail__mimeType_operator
+  sizes__thumbnail__filesize: Media_sizes__thumbnail__filesize_operator
+  sizes__thumbnail__filename: Media_sizes__thumbnail__filename_operator
+  sizes__medium__url: Media_sizes__medium__url_operator
+  sizes__medium__width: Media_sizes__medium__width_operator
+  sizes__medium__height: Media_sizes__medium__height_operator
+  sizes__medium__mimeType: Media_sizes__medium__mimeType_operator
+  sizes__medium__filesize: Media_sizes__medium__filesize_operator
+  sizes__medium__filename: Media_sizes__medium__filename_operator
+  sizes__large__url: Media_sizes__large__url_operator
+  sizes__large__width: Media_sizes__large__width_operator
+  sizes__large__height: Media_sizes__large__height_operator
+  sizes__large__mimeType: Media_sizes__large__mimeType_operator
+  sizes__large__filesize: Media_sizes__large__filesize_operator
+  sizes__large__filename: Media_sizes__large__filename_operator
+  id: Media_id_operator
+  AND: [Media_where_and]
+  OR: [Media_where_or]
+}
+
+type countallMedia {
+  totalDocs: Int
+}
+
+type mediaDocAccess {
+  fields: MediaDocAccessFields
+  create: MediaCreateDocAccess
+  read: MediaReadDocAccess
+  update: MediaUpdateDocAccess
+  delete: MediaDeleteDocAccess
+}
+
+type MediaDocAccessFields {
+  updatedAt: MediaDocAccessFields_updatedAt
+  createdAt: MediaDocAccessFields_createdAt
+  url: MediaDocAccessFields_url
+  thumbnailURL: MediaDocAccessFields_thumbnailURL
+  filename: MediaDocAccessFields_filename
+  mimeType: MediaDocAccessFields_mimeType
+  filesize: MediaDocAccessFields_filesize
+  width: MediaDocAccessFields_width
+  height: MediaDocAccessFields_height
+  focalX: MediaDocAccessFields_focalX
+  focalY: MediaDocAccessFields_focalY
+  sizes: MediaDocAccessFields_sizes
+}
+
+type MediaDocAccessFields_updatedAt {
+  create: MediaDocAccessFields_updatedAt_Create
+  read: MediaDocAccessFields_updatedAt_Read
+  update: MediaDocAccessFields_updatedAt_Update
+  delete: MediaDocAccessFields_updatedAt_Delete
+}
+
+type MediaDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_createdAt {
+  create: MediaDocAccessFields_createdAt_Create
+  read: MediaDocAccessFields_createdAt_Read
+  update: MediaDocAccessFields_createdAt_Update
+  delete: MediaDocAccessFields_createdAt_Delete
+}
+
+type MediaDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_url {
+  create: MediaDocAccessFields_url_Create
+  read: MediaDocAccessFields_url_Read
+  update: MediaDocAccessFields_url_Update
+  delete: MediaDocAccessFields_url_Delete
+}
+
+type MediaDocAccessFields_url_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_url_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_url_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_url_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_thumbnailURL {
+  create: MediaDocAccessFields_thumbnailURL_Create
+  read: MediaDocAccessFields_thumbnailURL_Read
+  update: MediaDocAccessFields_thumbnailURL_Update
+  delete: MediaDocAccessFields_thumbnailURL_Delete
+}
+
+type MediaDocAccessFields_thumbnailURL_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_thumbnailURL_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_thumbnailURL_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_thumbnailURL_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_filename {
+  create: MediaDocAccessFields_filename_Create
+  read: MediaDocAccessFields_filename_Read
+  update: MediaDocAccessFields_filename_Update
+  delete: MediaDocAccessFields_filename_Delete
+}
+
+type MediaDocAccessFields_filename_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_filename_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_filename_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_filename_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_mimeType {
+  create: MediaDocAccessFields_mimeType_Create
+  read: MediaDocAccessFields_mimeType_Read
+  update: MediaDocAccessFields_mimeType_Update
+  delete: MediaDocAccessFields_mimeType_Delete
+}
+
+type MediaDocAccessFields_mimeType_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_mimeType_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_mimeType_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_mimeType_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_filesize {
+  create: MediaDocAccessFields_filesize_Create
+  read: MediaDocAccessFields_filesize_Read
+  update: MediaDocAccessFields_filesize_Update
+  delete: MediaDocAccessFields_filesize_Delete
+}
+
+type MediaDocAccessFields_filesize_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_filesize_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_filesize_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_filesize_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_width {
+  create: MediaDocAccessFields_width_Create
+  read: MediaDocAccessFields_width_Read
+  update: MediaDocAccessFields_width_Update
+  delete: MediaDocAccessFields_width_Delete
+}
+
+type MediaDocAccessFields_width_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_width_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_width_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_width_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_height {
+  create: MediaDocAccessFields_height_Create
+  read: MediaDocAccessFields_height_Read
+  update: MediaDocAccessFields_height_Update
+  delete: MediaDocAccessFields_height_Delete
+}
+
+type MediaDocAccessFields_height_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_height_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_height_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_height_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_focalX {
+  create: MediaDocAccessFields_focalX_Create
+  read: MediaDocAccessFields_focalX_Read
+  update: MediaDocAccessFields_focalX_Update
+  delete: MediaDocAccessFields_focalX_Delete
+}
+
+type MediaDocAccessFields_focalX_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_focalX_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_focalX_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_focalX_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_focalY {
+  create: MediaDocAccessFields_focalY_Create
+  read: MediaDocAccessFields_focalY_Read
+  update: MediaDocAccessFields_focalY_Update
+  delete: MediaDocAccessFields_focalY_Delete
+}
+
+type MediaDocAccessFields_focalY_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_focalY_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_focalY_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_focalY_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes {
+  create: MediaDocAccessFields_sizes_Create
+  read: MediaDocAccessFields_sizes_Read
+  update: MediaDocAccessFields_sizes_Update
+  delete: MediaDocAccessFields_sizes_Delete
+  fields: MediaDocAccessFields_sizes_Fields
+}
+
+type MediaDocAccessFields_sizes_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_Fields {
+  thumbnail: MediaDocAccessFields_sizes_thumbnail
+  medium: MediaDocAccessFields_sizes_medium
+  large: MediaDocAccessFields_sizes_large
+}
+
+type MediaDocAccessFields_sizes_thumbnail {
+  create: MediaDocAccessFields_sizes_thumbnail_Create
+  read: MediaDocAccessFields_sizes_thumbnail_Read
+  update: MediaDocAccessFields_sizes_thumbnail_Update
+  delete: MediaDocAccessFields_sizes_thumbnail_Delete
+  fields: MediaDocAccessFields_sizes_thumbnail_Fields
+}
+
+type MediaDocAccessFields_sizes_thumbnail_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_Fields {
+  url: MediaDocAccessFields_sizes_thumbnail_url
+  width: MediaDocAccessFields_sizes_thumbnail_width
+  height: MediaDocAccessFields_sizes_thumbnail_height
+  mimeType: MediaDocAccessFields_sizes_thumbnail_mimeType
+  filesize: MediaDocAccessFields_sizes_thumbnail_filesize
+  filename: MediaDocAccessFields_sizes_thumbnail_filename
+}
+
+type MediaDocAccessFields_sizes_thumbnail_url {
+  create: MediaDocAccessFields_sizes_thumbnail_url_Create
+  read: MediaDocAccessFields_sizes_thumbnail_url_Read
+  update: MediaDocAccessFields_sizes_thumbnail_url_Update
+  delete: MediaDocAccessFields_sizes_thumbnail_url_Delete
+}
+
+type MediaDocAccessFields_sizes_thumbnail_url_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_url_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_url_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_url_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_width {
+  create: MediaDocAccessFields_sizes_thumbnail_width_Create
+  read: MediaDocAccessFields_sizes_thumbnail_width_Read
+  update: MediaDocAccessFields_sizes_thumbnail_width_Update
+  delete: MediaDocAccessFields_sizes_thumbnail_width_Delete
+}
+
+type MediaDocAccessFields_sizes_thumbnail_width_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_width_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_width_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_width_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_height {
+  create: MediaDocAccessFields_sizes_thumbnail_height_Create
+  read: MediaDocAccessFields_sizes_thumbnail_height_Read
+  update: MediaDocAccessFields_sizes_thumbnail_height_Update
+  delete: MediaDocAccessFields_sizes_thumbnail_height_Delete
+}
+
+type MediaDocAccessFields_sizes_thumbnail_height_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_height_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_height_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_height_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_mimeType {
+  create: MediaDocAccessFields_sizes_thumbnail_mimeType_Create
+  read: MediaDocAccessFields_sizes_thumbnail_mimeType_Read
+  update: MediaDocAccessFields_sizes_thumbnail_mimeType_Update
+  delete: MediaDocAccessFields_sizes_thumbnail_mimeType_Delete
+}
+
+type MediaDocAccessFields_sizes_thumbnail_mimeType_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_mimeType_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_mimeType_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_mimeType_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_filesize {
+  create: MediaDocAccessFields_sizes_thumbnail_filesize_Create
+  read: MediaDocAccessFields_sizes_thumbnail_filesize_Read
+  update: MediaDocAccessFields_sizes_thumbnail_filesize_Update
+  delete: MediaDocAccessFields_sizes_thumbnail_filesize_Delete
+}
+
+type MediaDocAccessFields_sizes_thumbnail_filesize_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_filesize_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_filesize_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_filesize_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_filename {
+  create: MediaDocAccessFields_sizes_thumbnail_filename_Create
+  read: MediaDocAccessFields_sizes_thumbnail_filename_Read
+  update: MediaDocAccessFields_sizes_thumbnail_filename_Update
+  delete: MediaDocAccessFields_sizes_thumbnail_filename_Delete
+}
+
+type MediaDocAccessFields_sizes_thumbnail_filename_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_filename_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_filename_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_thumbnail_filename_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium {
+  create: MediaDocAccessFields_sizes_medium_Create
+  read: MediaDocAccessFields_sizes_medium_Read
+  update: MediaDocAccessFields_sizes_medium_Update
+  delete: MediaDocAccessFields_sizes_medium_Delete
+  fields: MediaDocAccessFields_sizes_medium_Fields
+}
+
+type MediaDocAccessFields_sizes_medium_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_Fields {
+  url: MediaDocAccessFields_sizes_medium_url
+  width: MediaDocAccessFields_sizes_medium_width
+  height: MediaDocAccessFields_sizes_medium_height
+  mimeType: MediaDocAccessFields_sizes_medium_mimeType
+  filesize: MediaDocAccessFields_sizes_medium_filesize
+  filename: MediaDocAccessFields_sizes_medium_filename
+}
+
+type MediaDocAccessFields_sizes_medium_url {
+  create: MediaDocAccessFields_sizes_medium_url_Create
+  read: MediaDocAccessFields_sizes_medium_url_Read
+  update: MediaDocAccessFields_sizes_medium_url_Update
+  delete: MediaDocAccessFields_sizes_medium_url_Delete
+}
+
+type MediaDocAccessFields_sizes_medium_url_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_url_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_url_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_url_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_width {
+  create: MediaDocAccessFields_sizes_medium_width_Create
+  read: MediaDocAccessFields_sizes_medium_width_Read
+  update: MediaDocAccessFields_sizes_medium_width_Update
+  delete: MediaDocAccessFields_sizes_medium_width_Delete
+}
+
+type MediaDocAccessFields_sizes_medium_width_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_width_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_width_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_width_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_height {
+  create: MediaDocAccessFields_sizes_medium_height_Create
+  read: MediaDocAccessFields_sizes_medium_height_Read
+  update: MediaDocAccessFields_sizes_medium_height_Update
+  delete: MediaDocAccessFields_sizes_medium_height_Delete
+}
+
+type MediaDocAccessFields_sizes_medium_height_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_height_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_height_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_height_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_mimeType {
+  create: MediaDocAccessFields_sizes_medium_mimeType_Create
+  read: MediaDocAccessFields_sizes_medium_mimeType_Read
+  update: MediaDocAccessFields_sizes_medium_mimeType_Update
+  delete: MediaDocAccessFields_sizes_medium_mimeType_Delete
+}
+
+type MediaDocAccessFields_sizes_medium_mimeType_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_mimeType_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_mimeType_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_mimeType_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_filesize {
+  create: MediaDocAccessFields_sizes_medium_filesize_Create
+  read: MediaDocAccessFields_sizes_medium_filesize_Read
+  update: MediaDocAccessFields_sizes_medium_filesize_Update
+  delete: MediaDocAccessFields_sizes_medium_filesize_Delete
+}
+
+type MediaDocAccessFields_sizes_medium_filesize_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_filesize_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_filesize_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_filesize_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_filename {
+  create: MediaDocAccessFields_sizes_medium_filename_Create
+  read: MediaDocAccessFields_sizes_medium_filename_Read
+  update: MediaDocAccessFields_sizes_medium_filename_Update
+  delete: MediaDocAccessFields_sizes_medium_filename_Delete
+}
+
+type MediaDocAccessFields_sizes_medium_filename_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_filename_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_filename_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_medium_filename_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large {
+  create: MediaDocAccessFields_sizes_large_Create
+  read: MediaDocAccessFields_sizes_large_Read
+  update: MediaDocAccessFields_sizes_large_Update
+  delete: MediaDocAccessFields_sizes_large_Delete
+  fields: MediaDocAccessFields_sizes_large_Fields
+}
+
+type MediaDocAccessFields_sizes_large_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_Fields {
+  url: MediaDocAccessFields_sizes_large_url
+  width: MediaDocAccessFields_sizes_large_width
+  height: MediaDocAccessFields_sizes_large_height
+  mimeType: MediaDocAccessFields_sizes_large_mimeType
+  filesize: MediaDocAccessFields_sizes_large_filesize
+  filename: MediaDocAccessFields_sizes_large_filename
+}
+
+type MediaDocAccessFields_sizes_large_url {
+  create: MediaDocAccessFields_sizes_large_url_Create
+  read: MediaDocAccessFields_sizes_large_url_Read
+  update: MediaDocAccessFields_sizes_large_url_Update
+  delete: MediaDocAccessFields_sizes_large_url_Delete
+}
+
+type MediaDocAccessFields_sizes_large_url_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_url_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_url_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_url_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_width {
+  create: MediaDocAccessFields_sizes_large_width_Create
+  read: MediaDocAccessFields_sizes_large_width_Read
+  update: MediaDocAccessFields_sizes_large_width_Update
+  delete: MediaDocAccessFields_sizes_large_width_Delete
+}
+
+type MediaDocAccessFields_sizes_large_width_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_width_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_width_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_width_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_height {
+  create: MediaDocAccessFields_sizes_large_height_Create
+  read: MediaDocAccessFields_sizes_large_height_Read
+  update: MediaDocAccessFields_sizes_large_height_Update
+  delete: MediaDocAccessFields_sizes_large_height_Delete
+}
+
+type MediaDocAccessFields_sizes_large_height_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_height_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_height_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_height_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_mimeType {
+  create: MediaDocAccessFields_sizes_large_mimeType_Create
+  read: MediaDocAccessFields_sizes_large_mimeType_Read
+  update: MediaDocAccessFields_sizes_large_mimeType_Update
+  delete: MediaDocAccessFields_sizes_large_mimeType_Delete
+}
+
+type MediaDocAccessFields_sizes_large_mimeType_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_mimeType_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_mimeType_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_mimeType_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_filesize {
+  create: MediaDocAccessFields_sizes_large_filesize_Create
+  read: MediaDocAccessFields_sizes_large_filesize_Read
+  update: MediaDocAccessFields_sizes_large_filesize_Update
+  delete: MediaDocAccessFields_sizes_large_filesize_Delete
+}
+
+type MediaDocAccessFields_sizes_large_filesize_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_filesize_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_filesize_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_filesize_Delete {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_filename {
+  create: MediaDocAccessFields_sizes_large_filename_Create
+  read: MediaDocAccessFields_sizes_large_filename_Read
+  update: MediaDocAccessFields_sizes_large_filename_Update
+  delete: MediaDocAccessFields_sizes_large_filename_Delete
+}
+
+type MediaDocAccessFields_sizes_large_filename_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_filename_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_filename_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_sizes_large_filename_Delete {
+  permission: Boolean!
+}
+
+type MediaCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type MediaReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type MediaUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type MediaDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
 }
 
 type User {
-  id: String
+  id: String!
   updatedAt: DateTime
   createdAt: DateTime
   email: EmailAddress!
@@ -574,14 +1614,12 @@ type User {
   hash: String
   loginAttempts: Float
   lockUntil: DateTime
-  password: String!
 }
 
 """
 A field whose value conforms to the standard internet email address format as specified in HTML Spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address.
 """
-scalar EmailAddress
-  @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
+scalar EmailAddress @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
 
 type Users {
   docs: [User]
@@ -684,7 +1722,6 @@ type UsersDocAccessFields {
   updatedAt: UsersDocAccessFields_updatedAt
   createdAt: UsersDocAccessFields_createdAt
   email: UsersDocAccessFields_email
-  password: UsersDocAccessFields_password
 }
 
 type UsersDocAccessFields_updatedAt {
@@ -756,29 +1793,6 @@ type UsersDocAccessFields_email_Delete {
   permission: Boolean!
 }
 
-type UsersDocAccessFields_password {
-  create: UsersDocAccessFields_password_Create
-  read: UsersDocAccessFields_password_Read
-  update: UsersDocAccessFields_password_Update
-  delete: UsersDocAccessFields_password_Delete
-}
-
-type UsersDocAccessFields_password_Create {
-  permission: Boolean!
-}
-
-type UsersDocAccessFields_password_Read {
-  permission: Boolean!
-}
-
-type UsersDocAccessFields_password_Update {
-  permission: Boolean!
-}
-
-type UsersDocAccessFields_password_Delete {
-  permission: Boolean!
-}
-
 type UsersCreateDocAccess {
   permission: Boolean!
   where: JSONObject
@@ -807,12 +1821,312 @@ type UsersUnlockDocAccess {
 type usersMe {
   collection: String
   exp: Int
+  strategy: String
   token: String
   user: User
 }
 
+type PayloadLockedDocument {
+  id: String!
+  document: PayloadLockedDocument_Document_Relationship
+  globalSlug: String
+  user: PayloadLockedDocument_User_Relationship!
+  updatedAt: DateTime
+  createdAt: DateTime
+}
+
+type PayloadLockedDocument_Document_Relationship {
+  relationTo: PayloadLockedDocument_Document_RelationTo
+  value: PayloadLockedDocument_Document
+}
+
+enum PayloadLockedDocument_Document_RelationTo {
+  posts
+  media
+  users
+}
+
+union PayloadLockedDocument_Document = Post | Media | User
+
+type PayloadLockedDocument_User_Relationship {
+  relationTo: PayloadLockedDocument_User_RelationTo
+  value: PayloadLockedDocument_User
+}
+
+enum PayloadLockedDocument_User_RelationTo {
+  users
+}
+
+union PayloadLockedDocument_User = User
+
+type PayloadLockedDocuments {
+  docs: [PayloadLockedDocument]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input PayloadLockedDocument_where {
+  document: PayloadLockedDocument_document_Relation
+  globalSlug: PayloadLockedDocument_globalSlug_operator
+  user: PayloadLockedDocument_user_Relation
+  updatedAt: PayloadLockedDocument_updatedAt_operator
+  createdAt: PayloadLockedDocument_createdAt_operator
+  id: PayloadLockedDocument_id_operator
+  AND: [PayloadLockedDocument_where_and]
+  OR: [PayloadLockedDocument_where_or]
+}
+
+input PayloadLockedDocument_document_Relation {
+  relationTo: PayloadLockedDocument_document_Relation_RelationTo
+  value: JSON
+}
+
+enum PayloadLockedDocument_document_Relation_RelationTo {
+  posts
+  media
+  users
+}
+
+input PayloadLockedDocument_globalSlug_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadLockedDocument_user_Relation {
+  relationTo: PayloadLockedDocument_user_Relation_RelationTo
+  value: JSON
+}
+
+enum PayloadLockedDocument_user_Relation_RelationTo {
+  users
+}
+
+input PayloadLockedDocument_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadLockedDocument_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PayloadLockedDocument_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PayloadLockedDocument_where_and {
+  document: PayloadLockedDocument_document_Relation
+  globalSlug: PayloadLockedDocument_globalSlug_operator
+  user: PayloadLockedDocument_user_Relation
+  updatedAt: PayloadLockedDocument_updatedAt_operator
+  createdAt: PayloadLockedDocument_createdAt_operator
+  id: PayloadLockedDocument_id_operator
+  AND: [PayloadLockedDocument_where_and]
+  OR: [PayloadLockedDocument_where_or]
+}
+
+input PayloadLockedDocument_where_or {
+  document: PayloadLockedDocument_document_Relation
+  globalSlug: PayloadLockedDocument_globalSlug_operator
+  user: PayloadLockedDocument_user_Relation
+  updatedAt: PayloadLockedDocument_updatedAt_operator
+  createdAt: PayloadLockedDocument_createdAt_operator
+  id: PayloadLockedDocument_id_operator
+  AND: [PayloadLockedDocument_where_and]
+  OR: [PayloadLockedDocument_where_or]
+}
+
+type countPayloadLockedDocuments {
+  totalDocs: Int
+}
+
+type payload_locked_documentsDocAccess {
+  fields: PayloadLockedDocumentsDocAccessFields
+  create: PayloadLockedDocumentsCreateDocAccess
+  read: PayloadLockedDocumentsReadDocAccess
+  update: PayloadLockedDocumentsUpdateDocAccess
+  delete: PayloadLockedDocumentsDeleteDocAccess
+}
+
+type PayloadLockedDocumentsDocAccessFields {
+  document: PayloadLockedDocumentsDocAccessFields_document
+  globalSlug: PayloadLockedDocumentsDocAccessFields_globalSlug
+  user: PayloadLockedDocumentsDocAccessFields_user
+  updatedAt: PayloadLockedDocumentsDocAccessFields_updatedAt
+  createdAt: PayloadLockedDocumentsDocAccessFields_createdAt
+}
+
+type PayloadLockedDocumentsDocAccessFields_document {
+  create: PayloadLockedDocumentsDocAccessFields_document_Create
+  read: PayloadLockedDocumentsDocAccessFields_document_Read
+  update: PayloadLockedDocumentsDocAccessFields_document_Update
+  delete: PayloadLockedDocumentsDocAccessFields_document_Delete
+}
+
+type PayloadLockedDocumentsDocAccessFields_document_Create {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_document_Read {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_document_Update {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_document_Delete {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_globalSlug {
+  create: PayloadLockedDocumentsDocAccessFields_globalSlug_Create
+  read: PayloadLockedDocumentsDocAccessFields_globalSlug_Read
+  update: PayloadLockedDocumentsDocAccessFields_globalSlug_Update
+  delete: PayloadLockedDocumentsDocAccessFields_globalSlug_Delete
+}
+
+type PayloadLockedDocumentsDocAccessFields_globalSlug_Create {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_globalSlug_Read {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_globalSlug_Update {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_globalSlug_Delete {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_user {
+  create: PayloadLockedDocumentsDocAccessFields_user_Create
+  read: PayloadLockedDocumentsDocAccessFields_user_Read
+  update: PayloadLockedDocumentsDocAccessFields_user_Update
+  delete: PayloadLockedDocumentsDocAccessFields_user_Delete
+}
+
+type PayloadLockedDocumentsDocAccessFields_user_Create {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_user_Read {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_user_Update {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_user_Delete {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_updatedAt {
+  create: PayloadLockedDocumentsDocAccessFields_updatedAt_Create
+  read: PayloadLockedDocumentsDocAccessFields_updatedAt_Read
+  update: PayloadLockedDocumentsDocAccessFields_updatedAt_Update
+  delete: PayloadLockedDocumentsDocAccessFields_updatedAt_Delete
+}
+
+type PayloadLockedDocumentsDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_createdAt {
+  create: PayloadLockedDocumentsDocAccessFields_createdAt_Create
+  read: PayloadLockedDocumentsDocAccessFields_createdAt_Read
+  update: PayloadLockedDocumentsDocAccessFields_createdAt_Update
+  delete: PayloadLockedDocumentsDocAccessFields_createdAt_Delete
+}
+
+type PayloadLockedDocumentsDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadLockedDocumentsReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadLockedDocumentsUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadLockedDocumentsDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
 type PayloadPreference {
-  id: String
+  id: String!
   user: PayloadPreference_User_Relationship!
   key: String
   value: JSON
@@ -1196,7 +2510,9 @@ type MenuUpdateDocAccess {
 type Access {
   canAccessAdmin: Boolean!
   posts: postsAccess
+  media: mediaAccess
   users: usersAccess
+  payload_locked_documents: payload_locked_documentsAccess
   payload_preferences: payload_preferencesAccess
   menu: menuAccess
 }
@@ -1207,84 +2523,58 @@ type postsAccess {
   read: PostsReadAccess
   update: PostsUpdateAccess
   delete: PostsDeleteAccess
-  readVersions: PostsReadVersionsAccess
 }
 
 type PostsFields {
-  text: PostsFields_text
-  richText: PostsFields_richText
-  richText2: PostsFields_richText2
+  title: PostsFields_title
+  content: PostsFields_content
   updatedAt: PostsFields_updatedAt
   createdAt: PostsFields_createdAt
-  _status: PostsFields__status
 }
 
-type PostsFields_text {
-  create: PostsFields_text_Create
-  read: PostsFields_text_Read
-  update: PostsFields_text_Update
-  delete: PostsFields_text_Delete
+type PostsFields_title {
+  create: PostsFields_title_Create
+  read: PostsFields_title_Read
+  update: PostsFields_title_Update
+  delete: PostsFields_title_Delete
 }
 
-type PostsFields_text_Create {
+type PostsFields_title_Create {
   permission: Boolean!
 }
 
-type PostsFields_text_Read {
+type PostsFields_title_Read {
   permission: Boolean!
 }
 
-type PostsFields_text_Update {
+type PostsFields_title_Update {
   permission: Boolean!
 }
 
-type PostsFields_text_Delete {
+type PostsFields_title_Delete {
   permission: Boolean!
 }
 
-type PostsFields_richText {
-  create: PostsFields_richText_Create
-  read: PostsFields_richText_Read
-  update: PostsFields_richText_Update
-  delete: PostsFields_richText_Delete
+type PostsFields_content {
+  create: PostsFields_content_Create
+  read: PostsFields_content_Read
+  update: PostsFields_content_Update
+  delete: PostsFields_content_Delete
 }
 
-type PostsFields_richText_Create {
+type PostsFields_content_Create {
   permission: Boolean!
 }
 
-type PostsFields_richText_Read {
+type PostsFields_content_Read {
   permission: Boolean!
 }
 
-type PostsFields_richText_Update {
+type PostsFields_content_Update {
   permission: Boolean!
 }
 
-type PostsFields_richText_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_richText2 {
-  create: PostsFields_richText2_Create
-  read: PostsFields_richText2_Read
-  update: PostsFields_richText2_Update
-  delete: PostsFields_richText2_Delete
-}
-
-type PostsFields_richText2_Create {
-  permission: Boolean!
-}
-
-type PostsFields_richText2_Read {
-  permission: Boolean!
-}
-
-type PostsFields_richText2_Update {
-  permission: Boolean!
-}
-
-type PostsFields_richText2_Delete {
+type PostsFields_content_Delete {
   permission: Boolean!
 }
 
@@ -1334,29 +2624,6 @@ type PostsFields_createdAt_Delete {
   permission: Boolean!
 }
 
-type PostsFields__status {
-  create: PostsFields__status_Create
-  read: PostsFields__status_Read
-  update: PostsFields__status_Update
-  delete: PostsFields__status_Delete
-}
-
-type PostsFields__status_Create {
-  permission: Boolean!
-}
-
-type PostsFields__status_Read {
-  permission: Boolean!
-}
-
-type PostsFields__status_Update {
-  permission: Boolean!
-}
-
-type PostsFields__status_Delete {
-  permission: Boolean!
-}
-
 type PostsCreateAccess {
   permission: Boolean!
   where: JSONObject
@@ -1377,7 +2644,841 @@ type PostsDeleteAccess {
   where: JSONObject
 }
 
-type PostsReadVersionsAccess {
+type mediaAccess {
+  fields: MediaFields
+  create: MediaCreateAccess
+  read: MediaReadAccess
+  update: MediaUpdateAccess
+  delete: MediaDeleteAccess
+}
+
+type MediaFields {
+  updatedAt: MediaFields_updatedAt
+  createdAt: MediaFields_createdAt
+  url: MediaFields_url
+  thumbnailURL: MediaFields_thumbnailURL
+  filename: MediaFields_filename
+  mimeType: MediaFields_mimeType
+  filesize: MediaFields_filesize
+  width: MediaFields_width
+  height: MediaFields_height
+  focalX: MediaFields_focalX
+  focalY: MediaFields_focalY
+  sizes: MediaFields_sizes
+}
+
+type MediaFields_updatedAt {
+  create: MediaFields_updatedAt_Create
+  read: MediaFields_updatedAt_Read
+  update: MediaFields_updatedAt_Update
+  delete: MediaFields_updatedAt_Delete
+}
+
+type MediaFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type MediaFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type MediaFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type MediaFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_createdAt {
+  create: MediaFields_createdAt_Create
+  read: MediaFields_createdAt_Read
+  update: MediaFields_createdAt_Update
+  delete: MediaFields_createdAt_Delete
+}
+
+type MediaFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type MediaFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type MediaFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type MediaFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_url {
+  create: MediaFields_url_Create
+  read: MediaFields_url_Read
+  update: MediaFields_url_Update
+  delete: MediaFields_url_Delete
+}
+
+type MediaFields_url_Create {
+  permission: Boolean!
+}
+
+type MediaFields_url_Read {
+  permission: Boolean!
+}
+
+type MediaFields_url_Update {
+  permission: Boolean!
+}
+
+type MediaFields_url_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_thumbnailURL {
+  create: MediaFields_thumbnailURL_Create
+  read: MediaFields_thumbnailURL_Read
+  update: MediaFields_thumbnailURL_Update
+  delete: MediaFields_thumbnailURL_Delete
+}
+
+type MediaFields_thumbnailURL_Create {
+  permission: Boolean!
+}
+
+type MediaFields_thumbnailURL_Read {
+  permission: Boolean!
+}
+
+type MediaFields_thumbnailURL_Update {
+  permission: Boolean!
+}
+
+type MediaFields_thumbnailURL_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_filename {
+  create: MediaFields_filename_Create
+  read: MediaFields_filename_Read
+  update: MediaFields_filename_Update
+  delete: MediaFields_filename_Delete
+}
+
+type MediaFields_filename_Create {
+  permission: Boolean!
+}
+
+type MediaFields_filename_Read {
+  permission: Boolean!
+}
+
+type MediaFields_filename_Update {
+  permission: Boolean!
+}
+
+type MediaFields_filename_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_mimeType {
+  create: MediaFields_mimeType_Create
+  read: MediaFields_mimeType_Read
+  update: MediaFields_mimeType_Update
+  delete: MediaFields_mimeType_Delete
+}
+
+type MediaFields_mimeType_Create {
+  permission: Boolean!
+}
+
+type MediaFields_mimeType_Read {
+  permission: Boolean!
+}
+
+type MediaFields_mimeType_Update {
+  permission: Boolean!
+}
+
+type MediaFields_mimeType_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_filesize {
+  create: MediaFields_filesize_Create
+  read: MediaFields_filesize_Read
+  update: MediaFields_filesize_Update
+  delete: MediaFields_filesize_Delete
+}
+
+type MediaFields_filesize_Create {
+  permission: Boolean!
+}
+
+type MediaFields_filesize_Read {
+  permission: Boolean!
+}
+
+type MediaFields_filesize_Update {
+  permission: Boolean!
+}
+
+type MediaFields_filesize_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_width {
+  create: MediaFields_width_Create
+  read: MediaFields_width_Read
+  update: MediaFields_width_Update
+  delete: MediaFields_width_Delete
+}
+
+type MediaFields_width_Create {
+  permission: Boolean!
+}
+
+type MediaFields_width_Read {
+  permission: Boolean!
+}
+
+type MediaFields_width_Update {
+  permission: Boolean!
+}
+
+type MediaFields_width_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_height {
+  create: MediaFields_height_Create
+  read: MediaFields_height_Read
+  update: MediaFields_height_Update
+  delete: MediaFields_height_Delete
+}
+
+type MediaFields_height_Create {
+  permission: Boolean!
+}
+
+type MediaFields_height_Read {
+  permission: Boolean!
+}
+
+type MediaFields_height_Update {
+  permission: Boolean!
+}
+
+type MediaFields_height_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_focalX {
+  create: MediaFields_focalX_Create
+  read: MediaFields_focalX_Read
+  update: MediaFields_focalX_Update
+  delete: MediaFields_focalX_Delete
+}
+
+type MediaFields_focalX_Create {
+  permission: Boolean!
+}
+
+type MediaFields_focalX_Read {
+  permission: Boolean!
+}
+
+type MediaFields_focalX_Update {
+  permission: Boolean!
+}
+
+type MediaFields_focalX_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_focalY {
+  create: MediaFields_focalY_Create
+  read: MediaFields_focalY_Read
+  update: MediaFields_focalY_Update
+  delete: MediaFields_focalY_Delete
+}
+
+type MediaFields_focalY_Create {
+  permission: Boolean!
+}
+
+type MediaFields_focalY_Read {
+  permission: Boolean!
+}
+
+type MediaFields_focalY_Update {
+  permission: Boolean!
+}
+
+type MediaFields_focalY_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes {
+  create: MediaFields_sizes_Create
+  read: MediaFields_sizes_Read
+  update: MediaFields_sizes_Update
+  delete: MediaFields_sizes_Delete
+  fields: MediaFields_sizes_Fields
+}
+
+type MediaFields_sizes_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_Fields {
+  thumbnail: MediaFields_sizes_thumbnail
+  medium: MediaFields_sizes_medium
+  large: MediaFields_sizes_large
+}
+
+type MediaFields_sizes_thumbnail {
+  create: MediaFields_sizes_thumbnail_Create
+  read: MediaFields_sizes_thumbnail_Read
+  update: MediaFields_sizes_thumbnail_Update
+  delete: MediaFields_sizes_thumbnail_Delete
+  fields: MediaFields_sizes_thumbnail_Fields
+}
+
+type MediaFields_sizes_thumbnail_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_Fields {
+  url: MediaFields_sizes_thumbnail_url
+  width: MediaFields_sizes_thumbnail_width
+  height: MediaFields_sizes_thumbnail_height
+  mimeType: MediaFields_sizes_thumbnail_mimeType
+  filesize: MediaFields_sizes_thumbnail_filesize
+  filename: MediaFields_sizes_thumbnail_filename
+}
+
+type MediaFields_sizes_thumbnail_url {
+  create: MediaFields_sizes_thumbnail_url_Create
+  read: MediaFields_sizes_thumbnail_url_Read
+  update: MediaFields_sizes_thumbnail_url_Update
+  delete: MediaFields_sizes_thumbnail_url_Delete
+}
+
+type MediaFields_sizes_thumbnail_url_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_url_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_url_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_url_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_width {
+  create: MediaFields_sizes_thumbnail_width_Create
+  read: MediaFields_sizes_thumbnail_width_Read
+  update: MediaFields_sizes_thumbnail_width_Update
+  delete: MediaFields_sizes_thumbnail_width_Delete
+}
+
+type MediaFields_sizes_thumbnail_width_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_width_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_width_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_width_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_height {
+  create: MediaFields_sizes_thumbnail_height_Create
+  read: MediaFields_sizes_thumbnail_height_Read
+  update: MediaFields_sizes_thumbnail_height_Update
+  delete: MediaFields_sizes_thumbnail_height_Delete
+}
+
+type MediaFields_sizes_thumbnail_height_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_height_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_height_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_height_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_mimeType {
+  create: MediaFields_sizes_thumbnail_mimeType_Create
+  read: MediaFields_sizes_thumbnail_mimeType_Read
+  update: MediaFields_sizes_thumbnail_mimeType_Update
+  delete: MediaFields_sizes_thumbnail_mimeType_Delete
+}
+
+type MediaFields_sizes_thumbnail_mimeType_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_mimeType_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_mimeType_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_mimeType_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_filesize {
+  create: MediaFields_sizes_thumbnail_filesize_Create
+  read: MediaFields_sizes_thumbnail_filesize_Read
+  update: MediaFields_sizes_thumbnail_filesize_Update
+  delete: MediaFields_sizes_thumbnail_filesize_Delete
+}
+
+type MediaFields_sizes_thumbnail_filesize_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_filesize_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_filesize_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_filesize_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_filename {
+  create: MediaFields_sizes_thumbnail_filename_Create
+  read: MediaFields_sizes_thumbnail_filename_Read
+  update: MediaFields_sizes_thumbnail_filename_Update
+  delete: MediaFields_sizes_thumbnail_filename_Delete
+}
+
+type MediaFields_sizes_thumbnail_filename_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_filename_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_filename_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_thumbnail_filename_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium {
+  create: MediaFields_sizes_medium_Create
+  read: MediaFields_sizes_medium_Read
+  update: MediaFields_sizes_medium_Update
+  delete: MediaFields_sizes_medium_Delete
+  fields: MediaFields_sizes_medium_Fields
+}
+
+type MediaFields_sizes_medium_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_Fields {
+  url: MediaFields_sizes_medium_url
+  width: MediaFields_sizes_medium_width
+  height: MediaFields_sizes_medium_height
+  mimeType: MediaFields_sizes_medium_mimeType
+  filesize: MediaFields_sizes_medium_filesize
+  filename: MediaFields_sizes_medium_filename
+}
+
+type MediaFields_sizes_medium_url {
+  create: MediaFields_sizes_medium_url_Create
+  read: MediaFields_sizes_medium_url_Read
+  update: MediaFields_sizes_medium_url_Update
+  delete: MediaFields_sizes_medium_url_Delete
+}
+
+type MediaFields_sizes_medium_url_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_url_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_url_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_url_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_width {
+  create: MediaFields_sizes_medium_width_Create
+  read: MediaFields_sizes_medium_width_Read
+  update: MediaFields_sizes_medium_width_Update
+  delete: MediaFields_sizes_medium_width_Delete
+}
+
+type MediaFields_sizes_medium_width_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_width_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_width_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_width_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_height {
+  create: MediaFields_sizes_medium_height_Create
+  read: MediaFields_sizes_medium_height_Read
+  update: MediaFields_sizes_medium_height_Update
+  delete: MediaFields_sizes_medium_height_Delete
+}
+
+type MediaFields_sizes_medium_height_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_height_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_height_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_height_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_mimeType {
+  create: MediaFields_sizes_medium_mimeType_Create
+  read: MediaFields_sizes_medium_mimeType_Read
+  update: MediaFields_sizes_medium_mimeType_Update
+  delete: MediaFields_sizes_medium_mimeType_Delete
+}
+
+type MediaFields_sizes_medium_mimeType_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_mimeType_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_mimeType_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_mimeType_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_filesize {
+  create: MediaFields_sizes_medium_filesize_Create
+  read: MediaFields_sizes_medium_filesize_Read
+  update: MediaFields_sizes_medium_filesize_Update
+  delete: MediaFields_sizes_medium_filesize_Delete
+}
+
+type MediaFields_sizes_medium_filesize_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_filesize_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_filesize_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_filesize_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_filename {
+  create: MediaFields_sizes_medium_filename_Create
+  read: MediaFields_sizes_medium_filename_Read
+  update: MediaFields_sizes_medium_filename_Update
+  delete: MediaFields_sizes_medium_filename_Delete
+}
+
+type MediaFields_sizes_medium_filename_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_filename_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_filename_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_medium_filename_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large {
+  create: MediaFields_sizes_large_Create
+  read: MediaFields_sizes_large_Read
+  update: MediaFields_sizes_large_Update
+  delete: MediaFields_sizes_large_Delete
+  fields: MediaFields_sizes_large_Fields
+}
+
+type MediaFields_sizes_large_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_Fields {
+  url: MediaFields_sizes_large_url
+  width: MediaFields_sizes_large_width
+  height: MediaFields_sizes_large_height
+  mimeType: MediaFields_sizes_large_mimeType
+  filesize: MediaFields_sizes_large_filesize
+  filename: MediaFields_sizes_large_filename
+}
+
+type MediaFields_sizes_large_url {
+  create: MediaFields_sizes_large_url_Create
+  read: MediaFields_sizes_large_url_Read
+  update: MediaFields_sizes_large_url_Update
+  delete: MediaFields_sizes_large_url_Delete
+}
+
+type MediaFields_sizes_large_url_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_url_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_url_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_url_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_width {
+  create: MediaFields_sizes_large_width_Create
+  read: MediaFields_sizes_large_width_Read
+  update: MediaFields_sizes_large_width_Update
+  delete: MediaFields_sizes_large_width_Delete
+}
+
+type MediaFields_sizes_large_width_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_width_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_width_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_width_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_height {
+  create: MediaFields_sizes_large_height_Create
+  read: MediaFields_sizes_large_height_Read
+  update: MediaFields_sizes_large_height_Update
+  delete: MediaFields_sizes_large_height_Delete
+}
+
+type MediaFields_sizes_large_height_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_height_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_height_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_height_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_mimeType {
+  create: MediaFields_sizes_large_mimeType_Create
+  read: MediaFields_sizes_large_mimeType_Read
+  update: MediaFields_sizes_large_mimeType_Update
+  delete: MediaFields_sizes_large_mimeType_Delete
+}
+
+type MediaFields_sizes_large_mimeType_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_mimeType_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_mimeType_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_mimeType_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_filesize {
+  create: MediaFields_sizes_large_filesize_Create
+  read: MediaFields_sizes_large_filesize_Read
+  update: MediaFields_sizes_large_filesize_Update
+  delete: MediaFields_sizes_large_filesize_Delete
+}
+
+type MediaFields_sizes_large_filesize_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_filesize_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_filesize_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_filesize_Delete {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_filename {
+  create: MediaFields_sizes_large_filename_Create
+  read: MediaFields_sizes_large_filename_Read
+  update: MediaFields_sizes_large_filename_Update
+  delete: MediaFields_sizes_large_filename_Delete
+}
+
+type MediaFields_sizes_large_filename_Create {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_filename_Read {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_filename_Update {
+  permission: Boolean!
+}
+
+type MediaFields_sizes_large_filename_Delete {
+  permission: Boolean!
+}
+
+type MediaCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type MediaReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type MediaUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type MediaDeleteAccess {
   permission: Boolean!
   where: JSONObject
 }
@@ -1395,7 +3496,6 @@ type UsersFields {
   updatedAt: UsersFields_updatedAt
   createdAt: UsersFields_createdAt
   email: UsersFields_email
-  password: UsersFields_password
 }
 
 type UsersFields_updatedAt {
@@ -1467,29 +3567,6 @@ type UsersFields_email_Delete {
   permission: Boolean!
 }
 
-type UsersFields_password {
-  create: UsersFields_password_Create
-  read: UsersFields_password_Read
-  update: UsersFields_password_Update
-  delete: UsersFields_password_Delete
-}
-
-type UsersFields_password_Create {
-  permission: Boolean!
-}
-
-type UsersFields_password_Read {
-  permission: Boolean!
-}
-
-type UsersFields_password_Update {
-  permission: Boolean!
-}
-
-type UsersFields_password_Delete {
-  permission: Boolean!
-}
-
 type UsersCreateAccess {
   permission: Boolean!
   where: JSONObject
@@ -1511,6 +3588,157 @@ type UsersDeleteAccess {
 }
 
 type UsersUnlockAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type payload_locked_documentsAccess {
+  fields: PayloadLockedDocumentsFields
+  create: PayloadLockedDocumentsCreateAccess
+  read: PayloadLockedDocumentsReadAccess
+  update: PayloadLockedDocumentsUpdateAccess
+  delete: PayloadLockedDocumentsDeleteAccess
+}
+
+type PayloadLockedDocumentsFields {
+  document: PayloadLockedDocumentsFields_document
+  globalSlug: PayloadLockedDocumentsFields_globalSlug
+  user: PayloadLockedDocumentsFields_user
+  updatedAt: PayloadLockedDocumentsFields_updatedAt
+  createdAt: PayloadLockedDocumentsFields_createdAt
+}
+
+type PayloadLockedDocumentsFields_document {
+  create: PayloadLockedDocumentsFields_document_Create
+  read: PayloadLockedDocumentsFields_document_Read
+  update: PayloadLockedDocumentsFields_document_Update
+  delete: PayloadLockedDocumentsFields_document_Delete
+}
+
+type PayloadLockedDocumentsFields_document_Create {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_document_Read {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_document_Update {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_document_Delete {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_globalSlug {
+  create: PayloadLockedDocumentsFields_globalSlug_Create
+  read: PayloadLockedDocumentsFields_globalSlug_Read
+  update: PayloadLockedDocumentsFields_globalSlug_Update
+  delete: PayloadLockedDocumentsFields_globalSlug_Delete
+}
+
+type PayloadLockedDocumentsFields_globalSlug_Create {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_globalSlug_Read {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_globalSlug_Update {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_globalSlug_Delete {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_user {
+  create: PayloadLockedDocumentsFields_user_Create
+  read: PayloadLockedDocumentsFields_user_Read
+  update: PayloadLockedDocumentsFields_user_Update
+  delete: PayloadLockedDocumentsFields_user_Delete
+}
+
+type PayloadLockedDocumentsFields_user_Create {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_user_Read {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_user_Update {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_user_Delete {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_updatedAt {
+  create: PayloadLockedDocumentsFields_updatedAt_Create
+  read: PayloadLockedDocumentsFields_updatedAt_Read
+  update: PayloadLockedDocumentsFields_updatedAt_Update
+  delete: PayloadLockedDocumentsFields_updatedAt_Delete
+}
+
+type PayloadLockedDocumentsFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_createdAt {
+  create: PayloadLockedDocumentsFields_createdAt_Create
+  read: PayloadLockedDocumentsFields_createdAt_Read
+  update: PayloadLockedDocumentsFields_createdAt_Update
+  delete: PayloadLockedDocumentsFields_createdAt_Delete
+}
+
+type PayloadLockedDocumentsFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type PayloadLockedDocumentsCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadLockedDocumentsReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadLockedDocumentsUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type PayloadLockedDocumentsDeleteAccess {
   permission: Boolean!
   where: JSONObject
 }
@@ -1761,56 +3989,140 @@ type Mutation {
   createPost(data: mutationPostInput!, draft: Boolean): Post
   updatePost(id: String!, autosave: Boolean, data: mutationPostUpdateInput!, draft: Boolean): Post
   deletePost(id: String!): Post
-  duplicatePost(id: String!): Post
-  restoreVersionPost(id: String): Post
+  duplicatePost(id: String!, data: mutationPostInput!): Post
+  createMedia(data: mutationMediaInput!, draft: Boolean): Media
+  updateMedia(id: String!, autosave: Boolean, data: mutationMediaUpdateInput!, draft: Boolean): Media
+  deleteMedia(id: String!): Media
+  duplicateMedia(id: String!, data: mutationMediaInput!): Media
   createUser(data: mutationUserInput!, draft: Boolean): User
   updateUser(id: String!, autosave: Boolean, data: mutationUserUpdateInput!, draft: Boolean): User
   deleteUser(id: String!): User
-  refreshTokenUser(token: String): usersRefreshedUser
+  refreshTokenUser: usersRefreshedUser
   logoutUser: String
   unlockUser(email: String!): Boolean!
-  loginUser(email: String, password: String): usersLoginResult
-  forgotPasswordUser(disableEmail: Boolean, email: String!, expiration: Int): Boolean!
+  loginUser(email: String!, password: String): usersLoginResult
+  forgotPasswordUser(disableEmail: Boolean, expiration: Int, email: String!): Boolean!
   resetPasswordUser(password: String, token: String): usersResetPassword
   verifyEmailUser(token: String): Boolean
+  createPayloadLockedDocument(data: mutationPayloadLockedDocumentInput!, draft: Boolean): PayloadLockedDocument
+  updatePayloadLockedDocument(id: String!, autosave: Boolean, data: mutationPayloadLockedDocumentUpdateInput!, draft: Boolean): PayloadLockedDocument
+  deletePayloadLockedDocument(id: String!): PayloadLockedDocument
+  duplicatePayloadLockedDocument(id: String!, data: mutationPayloadLockedDocumentInput!): PayloadLockedDocument
   createPayloadPreference(data: mutationPayloadPreferenceInput!, draft: Boolean): PayloadPreference
-  updatePayloadPreference(
-    id: String!
-    autosave: Boolean
-    data: mutationPayloadPreferenceUpdateInput!
-    draft: Boolean
-  ): PayloadPreference
+  updatePayloadPreference(id: String!, autosave: Boolean, data: mutationPayloadPreferenceUpdateInput!, draft: Boolean): PayloadPreference
   deletePayloadPreference(id: String!): PayloadPreference
-  duplicatePayloadPreference(id: String!): PayloadPreference
+  duplicatePayloadPreference(id: String!, data: mutationPayloadPreferenceInput!): PayloadPreference
   updateMenu(data: mutationMenuInput!, draft: Boolean): Menu
 }
 
 input mutationPostInput {
-  text: String
-  richText: JSON
-  richText2: JSON
+  title: String
+  content: JSON
   updatedAt: String
   createdAt: String
-  _status: Post__status_MutationInput
-}
-
-enum Post__status_MutationInput {
-  draft
-  published
 }
 
 input mutationPostUpdateInput {
-  text: String
-  richText: JSON
-  richText2: JSON
+  title: String
+  content: JSON
   updatedAt: String
   createdAt: String
-  _status: PostUpdate__status_MutationInput
 }
 
-enum PostUpdate__status_MutationInput {
-  draft
-  published
+input mutationMediaInput {
+  updatedAt: String
+  createdAt: String
+  url: String
+  thumbnailURL: String
+  filename: String
+  mimeType: String
+  filesize: Float
+  width: Float
+  height: Float
+  focalX: Float
+  focalY: Float
+  sizes: mutationMedia_SizesInput
+}
+
+input mutationMedia_SizesInput {
+  thumbnail: mutationMedia_Sizes_ThumbnailInput
+  medium: mutationMedia_Sizes_MediumInput
+  large: mutationMedia_Sizes_LargeInput
+}
+
+input mutationMedia_Sizes_ThumbnailInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationMedia_Sizes_MediumInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationMedia_Sizes_LargeInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationMediaUpdateInput {
+  updatedAt: String
+  createdAt: String
+  url: String
+  thumbnailURL: String
+  filename: String
+  mimeType: String
+  filesize: Float
+  width: Float
+  height: Float
+  focalX: Float
+  focalY: Float
+  sizes: mutationMediaUpdate_SizesInput
+}
+
+input mutationMediaUpdate_SizesInput {
+  thumbnail: mutationMediaUpdate_Sizes_ThumbnailInput
+  medium: mutationMediaUpdate_Sizes_MediumInput
+  large: mutationMediaUpdate_Sizes_LargeInput
+}
+
+input mutationMediaUpdate_Sizes_ThumbnailInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationMediaUpdate_Sizes_MediumInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationMediaUpdate_Sizes_LargeInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
 }
 
 input mutationUserInput {
@@ -1842,6 +4154,7 @@ input mutationUserUpdateInput {
 type usersRefreshedUser {
   exp: Int
   refreshedToken: String
+  strategy: String
   user: usersJWT
 }
 
@@ -1859,6 +4172,62 @@ type usersLoginResult {
 type usersResetPassword {
   token: String
   user: User
+}
+
+input mutationPayloadLockedDocumentInput {
+  document: PayloadLockedDocument_DocumentRelationshipInput
+  globalSlug: String
+  user: PayloadLockedDocument_UserRelationshipInput
+  updatedAt: String
+  createdAt: String
+}
+
+input PayloadLockedDocument_DocumentRelationshipInput {
+  relationTo: PayloadLockedDocument_DocumentRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PayloadLockedDocument_DocumentRelationshipInputRelationTo {
+  posts
+  media
+  users
+}
+
+input PayloadLockedDocument_UserRelationshipInput {
+  relationTo: PayloadLockedDocument_UserRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PayloadLockedDocument_UserRelationshipInputRelationTo {
+  users
+}
+
+input mutationPayloadLockedDocumentUpdateInput {
+  document: PayloadLockedDocumentUpdate_DocumentRelationshipInput
+  globalSlug: String
+  user: PayloadLockedDocumentUpdate_UserRelationshipInput
+  updatedAt: String
+  createdAt: String
+}
+
+input PayloadLockedDocumentUpdate_DocumentRelationshipInput {
+  relationTo: PayloadLockedDocumentUpdate_DocumentRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PayloadLockedDocumentUpdate_DocumentRelationshipInputRelationTo {
+  posts
+  media
+  users
+}
+
+input PayloadLockedDocumentUpdate_UserRelationshipInput {
+  relationTo: PayloadLockedDocumentUpdate_UserRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PayloadLockedDocumentUpdate_UserRelationshipInputRelationTo {
+  users
 }
 
 input mutationPayloadPreferenceInput {

--- a/test/_community/schema.graphql
+++ b/test/_community/schema.graphql
@@ -45,17 +45,17 @@ A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `dat
 scalar DateTime
 
 type Posts {
-  docs: [Post]
-  hasNextPage: Boolean
-  hasPrevPage: Boolean
-  limit: Int
-  nextPage: Int
+  docs: [Post!]!
+  hasNextPage: Boolean!
+  hasPrevPage: Boolean!
+  limit: Int!
+  nextPage: Int!
   offset: Int
-  page: Int
-  pagingCounter: Int
-  prevPage: Int
-  totalDocs: Int
-  totalPages: Int
+  page: Int!
+  pagingCounter: Int!
+  prevPage: Int!
+  totalDocs: Int!
+  totalPages: Int!
 }
 
 input Post_where {
@@ -326,17 +326,17 @@ type Media_Sizes_Large {
 }
 
 type allMedia {
-  docs: [Media]
-  hasNextPage: Boolean
-  hasPrevPage: Boolean
-  limit: Int
-  nextPage: Int
+  docs: [Media!]!
+  hasNextPage: Boolean!
+  hasPrevPage: Boolean!
+  limit: Int!
+  nextPage: Int!
   offset: Int
-  page: Int
-  pagingCounter: Int
-  prevPage: Int
-  totalDocs: Int
-  totalPages: Int
+  page: Int!
+  pagingCounter: Int!
+  prevPage: Int!
+  totalDocs: Int!
+  totalPages: Int!
 }
 
 input Media_where {
@@ -1622,17 +1622,17 @@ A field whose value conforms to the standard internet email address format as sp
 scalar EmailAddress @specifiedBy(url: "https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address")
 
 type Users {
-  docs: [User]
-  hasNextPage: Boolean
-  hasPrevPage: Boolean
-  limit: Int
-  nextPage: Int
+  docs: [User!]!
+  hasNextPage: Boolean!
+  hasPrevPage: Boolean!
+  limit: Int!
+  nextPage: Int!
   offset: Int
-  page: Int
-  pagingCounter: Int
-  prevPage: Int
-  totalDocs: Int
-  totalPages: Int
+  page: Int!
+  pagingCounter: Int!
+  prevPage: Int!
+  totalDocs: Int!
+  totalPages: Int!
 }
 
 input User_where {
@@ -1860,17 +1860,17 @@ enum PayloadLockedDocument_User_RelationTo {
 union PayloadLockedDocument_User = User
 
 type PayloadLockedDocuments {
-  docs: [PayloadLockedDocument]
-  hasNextPage: Boolean
-  hasPrevPage: Boolean
-  limit: Int
-  nextPage: Int
+  docs: [PayloadLockedDocument!]!
+  hasNextPage: Boolean!
+  hasPrevPage: Boolean!
+  limit: Int!
+  nextPage: Int!
   offset: Int
-  page: Int
-  pagingCounter: Int
-  prevPage: Int
-  totalDocs: Int
-  totalPages: Int
+  page: Int!
+  pagingCounter: Int!
+  prevPage: Int!
+  totalDocs: Int!
+  totalPages: Int!
 }
 
 input PayloadLockedDocument_where {
@@ -2146,17 +2146,17 @@ enum PayloadPreference_User_RelationTo {
 union PayloadPreference_User = User
 
 type PayloadPreferences {
-  docs: [PayloadPreference]
-  hasNextPage: Boolean
-  hasPrevPage: Boolean
-  limit: Int
-  nextPage: Int
+  docs: [PayloadPreference!]!
+  hasNextPage: Boolean!
+  hasPrevPage: Boolean!
+  limit: Int!
+  nextPage: Int!
   offset: Int
-  page: Int
-  pagingCounter: Int
-  prevPage: Int
-  totalDocs: Int
-  totalPages: Int
+  page: Int!
+  pagingCounter: Int!
+  prevPage: Int!
+  totalDocs: Int!
+  totalPages: Int!
 }
 
 input PayloadPreference_where {


### PR DESCRIPTION
### What?
Makes several fields and list item types in query results (e.g. `docs`) non-nullable.

### Why?
When dealing with code generated from a Payload GraphQL schema, it is often necessary to use type guards and optional chaining.

For example:

```graphql
type Posts {
  docs: [Post]
  ...
}
```

This implies that the `docs` field itself is nullable and that the array can contain nulls. In reality, neither of these is true. But because of the types generated by tools like `graphql-code-generator`, the way to access `posts` ends up something like this:

```ts
const posts = (query.data.docs ?? []).filter(doc => doc != null);
```

Instead, we would like the schema to be:

```graphql
type Posts {
  docs: [Post!]!
  ...
}
```


### How?
The proposed change involves adding `GraphQLNonNull` where appropriate.
