### PR TITLE
feat(storage-uploadthing): configurable upload router input config

### DIFF
--- a/packages/storage-uploadthing/src/getClientUploadRoute.ts
+++ b/packages/storage-uploadthing/src/getClientUploadRoute.ts
@@ -12,6 +12,7 @@ type Args = {
     req: PayloadRequest
   }) => boolean | Promise<boolean>
   acl: 'private' | 'public-read'
+  routerInputConfig?: FileRouterInputConfig
   token?: string
 }
 
@@ -22,18 +23,24 @@ import type { FileRouter } from 'uploadthing/server'
 import { createRouteHandler } from 'uploadthing/next'
 import { createUploadthing } from 'uploadthing/server'
 
+import type { FileRouterInputConfig } from './index.js'
+
 export const getClientUploadRoute = ({
   access = defaultAccess,
   acl,
+  routerInputConfig = {},
   token,
 }: Args): PayloadHandler => {
   const f = createUploadthing()
 
   const uploadRouter = {
     uploader: f({
+      ...routerInputConfig,
       blob: {
         acl,
         maxFileCount: 1,
+        maxFileSize: '512MB',
+        ...('blob' in routerInputConfig ? routerInputConfig.blob : {}),
       },
     })
       .middleware(async ({ req: rawReq }) => {

--- a/packages/storage-uploadthing/src/index.ts
+++ b/packages/storage-uploadthing/src/index.ts
@@ -1,17 +1,17 @@
 import type {
   Adapter,
-  ClientUploadsConfig,
+  ClientUploadsAccess,
   PluginOptions as CloudStoragePluginOptions,
   CollectionOptions,
   GeneratedAdapter,
 } from '@payloadcms/plugin-cloud-storage/types'
 import type { Config, Field, Plugin, UploadCollectionSlug } from 'payload'
+import type { createUploadthing } from 'uploadthing/server'
 import type { UTApiOptions } from 'uploadthing/types'
 
 import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
 import { initClientUploads } from '@payloadcms/plugin-cloud-storage/utilities'
-import { createRouteHandler } from 'uploadthing/next'
-import { createUploadthing, UTApi } from 'uploadthing/server'
+import { UTApi } from 'uploadthing/server'
 
 import { generateURL } from './generateURL.js'
 import { getClientUploadRoute } from './getClientUploadRoute.js'
@@ -19,11 +19,18 @@ import { getHandleDelete } from './handleDelete.js'
 import { getHandleUpload } from './handleUpload.js'
 import { getHandler } from './staticHandler.js'
 
+export type FileRouterInputConfig = Parameters<ReturnType<typeof createUploadthing>>[0]
+
 export type UploadthingStorageOptions = {
   /**
    * Do uploads directly on the client, to bypass limits on Vercel.
    */
-  clientUploads?: ClientUploadsConfig
+  clientUploads?:
+    | {
+        access?: ClientUploadsAccess
+        routerInputConfig?: FileRouterInputConfig
+      }
+    | boolean
 
   /**
    * Collection options to apply the adapter to.


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11949 by setting the default limit to `512MB`.
Additionally, makes this configurable via `clientUploads.routerInputConfig`. Details are here https://docs.uploadthing.com/file-routes#route-config