### PR TITLE
fix(ui): optimistic rows disappear while form state requests are pending

### DIFF
--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -106,6 +106,20 @@ export const mergeServerFormState = ({
               delete newFieldState[propFromServer]
             }
           } else {
+            if (propFromServer === 'rows') {
+              // use a for loop to ensure that empty indices are not skipped
+              for (const [index, existingRow] of Object.entries(newFieldState.rows)) {
+                // check if a row has been added to local state while the request was still pending
+                const indexOfLocalRow = incomingState[path].rows.findIndex(
+                  (row) => row.id === existingRow.id,
+                )
+
+                if (indexOfLocalRow !== -1) {
+                  incomingState[path].rows.splice(indexOfLocalRow, 1, existingRow)
+                }
+              }
+            }
+
             newFieldState[propFromServer as any] = incomingState[path][propFromServer]
           }
         }

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -105,7 +105,7 @@ export const mergeServerFormState = ({
               delete newFieldState[propFromServer]
             }
           } else {
-            // Need to intelligently merge the rows array to ensure no rows are lost or added while requests are pending
+            // Need to intelligently merge the rows array to ensure no rows are lost or added while the request was pending
             if (propFromServer === 'rows') {
               // If a row was added to local state while the request was pending, add it to incoming state
               newFieldState.rows.forEach((row, index) => {
@@ -119,7 +119,10 @@ export const mergeServerFormState = ({
               })
 
               // If an row was deleted from local state while the request was pending, remove it from incoming state
-              incomingState[path].rows.forEach((incomingRow, i) => {
+              // Do this in reverse order to avoid index issues when removing items
+              for (let i = incomingState[path].rows.length - 1; i >= 0; i--) {
+                const incomingRow = incomingState[path].rows[i]
+
                 const indexInExistingState = newFieldState.rows.findIndex(
                   (existingRow) => existingRow.id === incomingRow.id,
                 )
@@ -127,7 +130,7 @@ export const mergeServerFormState = ({
                 if (indexInExistingState === -1) {
                   incomingState[path].rows.splice(i, 1)
                 }
-              })
+              }
             }
 
             newFieldState[propFromServer as any] = incomingState[path][propFromServer]

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -107,7 +107,7 @@ export const mergeServerFormState = ({
           } else {
             // Need to intelligently merge the rows array to ensure no rows are lost or added while requests are pending
             if (propFromServer === 'rows') {
-              // When adding rows to local state while a request is pending, add them to incoming state
+              // If a row was added to local state while the request was pending, add it to incoming state
               newFieldState.rows.forEach((row, index) => {
                 const indexInIncomingState = incomingState[path].rows.findIndex(
                   (incomingRow) => incomingRow.id === row.id,
@@ -118,9 +118,8 @@ export const mergeServerFormState = ({
                 }
               })
 
-              // When deleting rows from local state while a request is pending, remove them from incoming state
-              for (let i = 0; i < incomingState[path].rows.length; i++) {
-                const incomingRow = incomingState[path].rows[i]
+              // If an row was deleted from local state while the request was pending, remove it from incoming state
+              incomingState[path].rows.forEach((incomingRow, i) => {
                 const indexInExistingState = newFieldState.rows.findIndex(
                   (existingRow) => existingRow.id === incomingRow.id,
                 )
@@ -128,7 +127,7 @@ export const mergeServerFormState = ({
                 if (indexInExistingState === -1) {
                   incomingState[path].rows.splice(i, 1)
                 }
-              }
+              })
             }
 
             newFieldState[propFromServer as any] = incomingState[path][propFromServer]

--- a/packages/ui/src/forms/Form/mergeServerFormState.ts
+++ b/packages/ui/src/forms/Form/mergeServerFormState.ts
@@ -121,8 +121,6 @@ export const mergeServerFormState = ({
 
               // If an row was deleted from local state while the request was pending, remove it from incoming state
               // Do this in reverse order to avoid index issues when removing items
-              // While in the loop, merge locally stored properties into incoming state
-              // This is important, as the incoming state may not contain all properties of the row, such as custom components that were not part of this request
               for (let i = incomingState[path].rows.length - 1; i >= 0; i--) {
                 const incomingRow = incomingState[path].rows[i]
 
@@ -132,12 +130,6 @@ export const mergeServerFormState = ({
 
                 if (indexInCurrentState === -1) {
                   incomingState[path].rows.splice(i, 1)
-                } else {
-                  incomingState[path].rows[i] = {
-                    ...newFieldState.rows[indexInCurrentState],
-                    ...incomingState[path].rows[i],
-                    isLoading: false, // the server does not send this back so we need to explicitly set it to false
-                  }
                 }
               }
             }

--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -316,6 +316,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
 
             acc.rows.push({
               id: row.id,
+              isLoading: false,
             })
 
             const previousRows = previousFormState?.[path]?.rows || []
@@ -495,6 +496,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
               acc.rowMetadata.push({
                 id: row.id,
                 blockType: row.blockType,
+                isLoading: false,
               })
 
               const collapsedRowIDs = preferences?.fields?.[path]?.collapsed


### PR DESCRIPTION
When manipulating array and blocks rows on slow networks, rows can sometimes disappear and then reappear as requests in the queue arrive.

Consider this scenario:

1. You add a row to form state: this pushes the row in local state optimistically then triggers a long-running form state request containing a single row
2. You add another row to form state: this pushes a second row into local state optimistically then triggers another long-running form state request containing two rows
3. The first form state request returns with a single row in the response and replaces local state (which contained two rows)
4. AT THIS MOMENT IN TIME, THE SECOND ROW DISAPPEARS
5. The second form state request returns with two rows in the response and replaces local state
6. THE UI IS NO LONGER STALE AND BOTH ROWS APPEAR AS EXPECTED

The same issue applies when deleting, moving, and duplicating rows. Local state becomes out of sync with the form state response and is ultimately overridden.

The issue is that when we merge the result from form state, we do not traverse the rows themselves, and instead take the rows in their entirety. This means that we lose local row state. Instead, we need to compare the results with what is saved to local state and intelligently merge them.