### PR TITLE
fix(storage-uploadthing): pass `clientUploads.routerInputConfig` to the handler

### DIFF
--- a/packages/storage-uploadthing/src/index.ts
+++ b/packages/storage-uploadthing/src/index.ts
@@ -76,6 +76,10 @@ export const uploadthingStorage: UploadthingPlugin =
             ? uploadthingStorageOptions.clientUploads.access
             : undefined,
         acl: uploadthingStorageOptions.options.acl || 'public-read',
+        routerInputConfig:
+          typeof uploadthingStorageOptions.clientUploads === 'object'
+            ? uploadthingStorageOptions.clientUploads.routerInputConfig
+            : undefined,
         token: uploadthingStorageOptions.options.token,
       }),
       serverHandlerPath: '/storage-uploadthing-client-upload-route',


### PR DESCRIPTION
PR https://github.com/payloadcms/payload/pull/11954 added this property but didn't actually pass it through to the handler.