### PR TITLE
fix(plugin-cloud-storage): missing 'prefix' in cloud storage plugin

### DIFF
--- a/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
@@ -26,6 +26,7 @@ export async function getFilePrefix({
   const files = await req.payload.find({
     collection: collection.slug,
     depth: 0,
+    draft: true,
     limit: 1,
     pagination: false,
     where: {


### PR DESCRIPTION
### Issue reproduction

In the community folder, enable versioning for the media collection and install the `s3storage` plugin (see Git patch). I use `minio` to have a local S3 compatible backend and then I run the app with: `AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin START_MEMORY_DB=true pnpm dev _community`.

Next, open the media collection and create a new entry. Then open that entry, remove the file it currently has, and upload a new file. Save as draft.

Now the media can no longer be accessed and the thumbnails are broken.

If you make an edit but save it by publishing the issue goes away. I also couldn't reproduce this by adding a text field, changing that, and saving the document as draft.

```diff
diff --git test/_community/collections/Media/index.ts test/_community/collections/Media/index.ts
index bb5edd0349..689423053c 100644
--- test/_community/collections/Media/index.ts
+++ test/_community/collections/Media/index.ts
@@ -9,6 +9,9 @@ export const MediaCollection: CollectionConfig = {
     read: () => true,
   },
   fields: [],
+  versions: {
+    drafts: true,
+  },
   upload: {
     crop: true,
     focalPoint: true,
diff --git test/_community/config.ts test/_community/config.ts
index ee1aee6e46..c81ec5f933 100644
--- test/_community/config.ts
+++ test/_community/config.ts
@@ -7,6 +7,7 @@ import { devUser } from '../credentials.js'
 import { MediaCollection } from './collections/Media/index.js'
 import { PostsCollection, postsSlug } from './collections/Posts/index.js'
 import { MenuGlobal } from './globals/Menu/index.js'
+import { s3Storage } from '@payloadcms/storage-s3'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -24,6 +25,21 @@ export default buildConfigWithDefaults({
     // ...add more globals here
     MenuGlobal,
   ],
+  plugins: [
+    s3Storage({
+      enabled: true,
+      bucket: 'amboss',
+      config: {
+        region: 'eu-west-1',
+        endpoint: 'http://localhost:9000',
+      },
+      collections: {
+        media: {
+          prefix: 'media',
+        },
+      },
+    }),
+  ],
   onInit: async (payload) => {
     await payload.create({
       collection: 'users',

```

## Screen recording

https://github.com/user-attachments/assets/b13be4a3-e858-427a-8bfa-6592b87748ee

## Fix

We were able to narrow it down to this call https://github.com/payloadcms/payload/blob/816fb28f552dfefc11704c7b379ca7fb31abd687/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts#L26-L41

Adding `draft: true` fixes the issue. It seems that the `prefix` can only be found in a draft, and without `draft: true` those drafts aren't searched. What I don't understand is why adding a text field, changing its value, and saving that as draft, doesn't cause any problems though. I'd assume that changing a field and uploading a new file results in the same outcome: a new version stored in the versions collection.

Maybe it's clear to you why it behaves like this.

