### PR TITLE
templates: set packageManager pnpm version for vercel templates

### DIFF
--- a/templates/website/package.json
+++ b/templates/website/package.json
@@ -68,9 +68,9 @@
     "tailwindcss": "^3.4.3",
     "typescript": "5.7.3"
   },
-  "packageManager": "pnpm@10.3.0",
   "engines": {
-    "node": "^18.20.2 || >=20.9.0"
+    "node": "^18.20.2 || >=20.9.0",
+    "pnpm": "^9"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/with-postgres/package.json
+++ b/templates/with-postgres/package.json
@@ -6,27 +6,27 @@
   "type": "module",
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
+    "ci": "payload migrate && pnpm build",
     "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
     "devsafe": "rm -rf .next && cross-env NODE_OPTIONS=--no-deprecation next dev",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
     "generate:types": "cross-env NODE_OPTIONS=--no-deprecation payload generate:types",
     "lint": "cross-env NODE_OPTIONS=--no-deprecation next lint",
     "payload": "cross-env NODE_OPTIONS=--no-deprecation payload",
-    "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
-    "ci": "payload migrate && pnpm build"
+    "start": "cross-env NODE_OPTIONS=--no-deprecation next start"
   },
   "dependencies": {
-    "@payloadcms/next": "3.31.0",
-    "@payloadcms/payload-cloud": "3.31.0",
-    "@payloadcms/richtext-lexical": "3.31.0",
+    "@payloadcms/db-postgres": "3.32.0",
+    "@payloadcms/next": "3.32.0",
+    "@payloadcms/payload-cloud": "3.32.0",
+    "@payloadcms/richtext-lexical": "3.32.0",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",
     "next": "15.2.3",
-    "payload": "3.31.0",
+    "payload": "3.32.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "sharp": "0.32.6",
-    "@payloadcms/db-postgres": "3.31.0"
+    "sharp": "0.32.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/templates/with-vercel-postgres/package.json
+++ b/templates/with-vercel-postgres/package.json
@@ -6,27 +6,27 @@
   "type": "module",
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
+    "ci": "payload migrate && pnpm build",
     "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
     "devsafe": "rm -rf .next && cross-env NODE_OPTIONS=--no-deprecation next dev",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
     "generate:types": "cross-env NODE_OPTIONS=--no-deprecation payload generate:types",
     "lint": "cross-env NODE_OPTIONS=--no-deprecation next lint",
     "payload": "cross-env NODE_OPTIONS=--no-deprecation payload",
-    "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
-    "ci": "payload migrate && pnpm build"
+    "start": "cross-env NODE_OPTIONS=--no-deprecation next start"
   },
   "dependencies": {
-    "@payloadcms/next": "3.31.0",
-    "@payloadcms/payload-cloud": "3.31.0",
-    "@payloadcms/richtext-lexical": "3.31.0",
+    "@payloadcms/db-vercel-postgres": "3.32.0",
+    "@payloadcms/next": "3.32.0",
+    "@payloadcms/payload-cloud": "3.32.0",
+    "@payloadcms/richtext-lexical": "3.32.0",
+    "@payloadcms/storage-vercel-blob": "3.32.0",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",
     "next": "15.2.3",
-    "payload": "3.31.0",
+    "payload": "3.32.0",
     "react": "19.0.0",
-    "react-dom": "19.0.0",
-    "@payloadcms/db-vercel-postgres": "3.31.0",
-    "@payloadcms/storage-vercel-blob": "3.31.0"
+    "react-dom": "19.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -38,9 +38,9 @@
     "prettier": "^3.4.2",
     "typescript": "5.7.3"
   },
+  "packageManager": "pnpm@10.7.1",
   "engines": {
-    "node": "^18.20.2 || >=20.9.0",
-    "pnpm": "^9"
+    "node": "^18.20.2 || >=20.9.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/with-vercel-website/package.json
+++ b/templates/with-vercel-website/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
     "postbuild": "next-sitemap --config next-sitemap.config.cjs",
+    "ci": "payload migrate && pnpm build",
     "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
     "dev:prod": "cross-env NODE_OPTIONS=--no-deprecation rm -rf .next && pnpm build && pnpm start",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
@@ -16,21 +17,22 @@
     "lint:fix": "cross-env NODE_OPTIONS=--no-deprecation next lint --fix",
     "payload": "cross-env NODE_OPTIONS=--no-deprecation payload",
     "reinstall": "cross-env NODE_OPTIONS=--no-deprecation rm -rf node_modules && rm pnpm-lock.yaml && pnpm --ignore-workspace install",
-    "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
-    "ci": "payload migrate && pnpm build"
+    "start": "cross-env NODE_OPTIONS=--no-deprecation next start"
   },
   "dependencies": {
-    "@payloadcms/admin-bar": "3.31.0",
-    "@payloadcms/live-preview-react": "3.31.0",
-    "@payloadcms/next": "3.31.0",
-    "@payloadcms/payload-cloud": "3.31.0",
-    "@payloadcms/plugin-form-builder": "3.31.0",
-    "@payloadcms/plugin-nested-docs": "3.31.0",
-    "@payloadcms/plugin-redirects": "3.31.0",
-    "@payloadcms/plugin-search": "3.31.0",
-    "@payloadcms/plugin-seo": "3.31.0",
-    "@payloadcms/richtext-lexical": "3.31.0",
-    "@payloadcms/ui": "3.31.0",
+    "@payloadcms/admin-bar": "3.32.0",
+    "@payloadcms/db-vercel-postgres": "3.32.0",
+    "@payloadcms/live-preview-react": "3.32.0",
+    "@payloadcms/next": "3.32.0",
+    "@payloadcms/payload-cloud": "3.32.0",
+    "@payloadcms/plugin-form-builder": "3.32.0",
+    "@payloadcms/plugin-nested-docs": "3.32.0",
+    "@payloadcms/plugin-redirects": "3.32.0",
+    "@payloadcms/plugin-search": "3.32.0",
+    "@payloadcms/plugin-seo": "3.32.0",
+    "@payloadcms/richtext-lexical": "3.32.0",
+    "@payloadcms/storage-vercel-blob": "3.32.0",
+    "@payloadcms/ui": "3.32.0",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-select": "^2.0.0",
@@ -43,16 +45,14 @@
     "lucide-react": "^0.378.0",
     "next": "15.2.3",
     "next-sitemap": "^4.2.3",
-    "payload": "3.31.0",
+    "payload": "3.32.0",
     "prism-react-renderer": "^2.3.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-hook-form": "7.45.4",
     "sharp": "0.32.6",
     "tailwind-merge": "^2.3.0",
-    "tailwindcss-animate": "^1.0.7",
-    "@payloadcms/db-vercel-postgres": "3.31.0",
-    "@payloadcms/storage-vercel-blob": "3.31.0"
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -70,7 +70,7 @@
     "tailwindcss": "^3.4.3",
     "typescript": "5.7.3"
   },
-  "packageManager": "pnpm@10.3.0",
+  "packageManager": "pnpm@10.7.1",
   "engines": {
     "node": "^18.20.2 || >=20.9.0"
   },


### PR DESCRIPTION
There have been issues with deploying our templates to Vercel when we rely on `engines.pnpm` configuration.

Vercel's deployments work best when we specify a `packageManager` in `package.json` since we ship our templates without lockfiles that would help Vercel determine the right package manager to use.

This PR adjusts the script so that it adds a `packageManager` with the latest version of `pnpm` to our Vercel templates and removes the `engines.pnpm` only for those variants.