### PR TITLE
fix(db-postgres): long array field table aliases cause error even when `dbName` is used

### DIFF
--- a/packages/drizzle/src/deleteOne.ts
+++ b/packages/drizzle/src/deleteOne.ts
@@ -72,6 +72,7 @@ export const deleteOne: DeleteOne = async function deleteOne(
           data: docToDelete,
           fields: collection.flattenedFields,
           joinQuery: false,
+          tableName,
         })
 
   await this.deleteWhere({

--- a/packages/drizzle/src/find/findMany.ts
+++ b/packages/drizzle/src/find/findMany.ts
@@ -158,6 +158,7 @@ export const findMany = async function find({
       data,
       fields,
       joinQuery,
+      tableName,
     })
   })
 

--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -196,7 +196,8 @@ export const traverseFields = ({
           }
         }
 
-        currentArgs.with[`${path}${field.name}`] = withArray
+        const relationName = field.dbName ? `_${arrayTableName}` : `${path}${field.name}`
+        currentArgs.with[relationName] = withArray
 
         traverseFields({
           _locales: withArray.with._locales,

--- a/packages/drizzle/src/schema/traverseFields.ts
+++ b/packages/drizzle/src/schema/traverseFields.ts
@@ -2,6 +2,7 @@ import type { CompoundIndex, FlattenedField } from 'payload'
 
 import { InvalidConfiguration } from 'payload'
 import {
+  array,
   fieldAffectsData,
   fieldIsVirtual,
   fieldShouldBeLocalized,
@@ -287,7 +288,9 @@ export const traverseFields = ({
           }
         }
 
-        relationsToBuild.set(fieldName, {
+        const relationName = field.dbName ? `_${arrayTableName}` : fieldName
+
+        relationsToBuild.set(relationName, {
           type: 'many',
           // arrays have their own localized table, independent of the base table.
           localized: false,
@@ -304,7 +307,7 @@ export const traverseFields = ({
               },
             ],
             references: ['id'],
-            relationName: fieldName,
+            relationName,
             to: parentTableName,
           },
         }

--- a/packages/drizzle/src/transform/read/index.ts
+++ b/packages/drizzle/src/transform/read/index.ts
@@ -15,6 +15,7 @@ type TransformArgs = {
   joinQuery?: JoinQuery
   locale?: string
   parentIsLocalized?: boolean
+  tableName: string
 }
 
 // This is the entry point to transform Drizzle output data
@@ -26,6 +27,7 @@ export const transform = <T extends Record<string, unknown> | TypeWithID>({
   fields,
   joinQuery,
   parentIsLocalized,
+  tableName,
 }: TransformArgs): T => {
   let relationships: Record<string, Record<string, unknown>[]> = {}
   let texts: Record<string, Record<string, unknown>[]> = {}
@@ -53,6 +55,7 @@ export const transform = <T extends Record<string, unknown> | TypeWithID>({
     adapter,
     blocks,
     config,
+    currentTableName: tableName,
     dataRef: {
       id: data.id,
     },
@@ -65,7 +68,9 @@ export const transform = <T extends Record<string, unknown> | TypeWithID>({
     path: '',
     relationships,
     table: data,
+    tablePath: '',
     texts,
+    topLevelTableName: tableName,
   })
 
   deletions.forEach((deletion) => deletion())

--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -467,6 +467,7 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
     data: doc,
     fields,
     joinQuery: false,
+    tableName,
   })
 
   return result

--- a/test/database/config.ts
+++ b/test/database/config.ts
@@ -604,6 +604,29 @@ export default buildConfigWithDefaults({
         },
       ],
     },
+    {
+      slug: 'aliases',
+      fields: [
+        {
+          name: 'thisIsALongFieldNameThatCanCauseAPostgresErrorEvenThoughWeSetAShorterDBName',
+          dbName: 'shortname',
+          type: 'array',
+          fields: [
+            {
+              name: 'nestedArray',
+              type: 'array',
+              dbName: 'short_nested_1',
+              fields: [
+                {
+                  type: 'text',
+                  name: 'text',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
   globals: [
     {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -21,6 +21,7 @@ import {
   killTransaction,
   QueryError,
 } from 'payload'
+import { assert } from 'ts-essentials'
 import { fileURLToPath } from 'url'
 
 import type { Global2 } from './payload-types.js'
@@ -782,6 +783,28 @@ describe('database', () => {
       expect(doc.array[0].localizedText).toStrictEqual('goodbye')
       expect(doc.blocks[0].text).toStrictEqual('hello')
       expect(doc.blocks[0].localizedText).toStrictEqual('goodbye')
+    })
+
+    it('arrays should work with both long field names and dbName', async () => {
+      const { id } = await payload.create({
+        collection: 'aliases',
+        data: {
+          thisIsALongFieldNameThatCanCauseAPostgresErrorEvenThoughWeSetAShorterDBName: [
+            {
+              nestedArray: [{ text: 'some-text' }],
+            },
+          ],
+        },
+      })
+      const res = await payload.findByID({ collection: 'aliases', id })
+      expect(
+        res.thisIsALongFieldNameThatCanCauseAPostgresErrorEvenThoughWeSetAShorterDBName,
+      ).toHaveLength(1)
+      const item =
+        res.thisIsALongFieldNameThatCanCauseAPostgresErrorEvenThoughWeSetAShorterDBName?.[0]
+      assert(item)
+      expect(item.nestedArray).toHaveLength(1)
+      expect(item.nestedArray?.[0]?.text).toBe('some-text')
     })
   })
 

--- a/test/database/payload-types.ts
+++ b/test/database/payload-types.ts
@@ -80,6 +80,7 @@ export interface Config {
     'fake-custom-ids': FakeCustomId;
     'relationships-migration': RelationshipsMigration;
     'compound-indexes': CompoundIndex;
+    aliases: Alias;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -100,6 +101,7 @@ export interface Config {
     'fake-custom-ids': FakeCustomIdsSelect<false> | FakeCustomIdsSelect<true>;
     'relationships-migration': RelationshipsMigrationSelect<false> | RelationshipsMigrationSelect<true>;
     'compound-indexes': CompoundIndexesSelect<false> | CompoundIndexesSelect<true>;
+    aliases: AliasesSelect<false> | AliasesSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -421,6 +423,26 @@ export interface CompoundIndex {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "aliases".
+ */
+export interface Alias {
+  id: string;
+  thisIsALongFieldNameThatCanCauseAPostgresErrorEvenThoughWeSetAShorterDBName?:
+    | {
+        nestedArray?:
+          | {
+              text?: string | null;
+              id?: string | null;
+            }[]
+          | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -494,6 +516,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'compound-indexes';
         value: string | CompoundIndex;
+      } | null)
+    | ({
+        relationTo: 'aliases';
+        value: string | Alias;
       } | null)
     | ({
         relationTo: 'users';
@@ -791,6 +817,25 @@ export interface CompoundIndexesSelect<T extends boolean = true> {
     | T
     | {
         four?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "aliases_select".
+ */
+export interface AliasesSelect<T extends boolean = true> {
+  thisIsALongFieldNameThatCanCauseAPostgresErrorEvenThoughWeSetAShorterDBName?:
+    | T
+    | {
+        nestedArray?:
+          | T
+          | {
+              text?: T;
+              id?: T;
+            };
+        id?: T;
       };
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/11975

Previously, this configuration was causing errors in postgres due to long names, even though `dbName` is used:
```
{
  slug: 'aliases',
  fields: [
    {
      name: 'thisIsALongFieldNameThatWillCauseAPostgresErrorEvenThoughWeSetAShorterDBName',
      dbName: 'shortname',
      type: 'array',
      fields: [
        {
          name: 'nested_field_1',
          type: 'array',
          dbName: 'short_nested_1',
          fields: [],
        },
        {
          name: 'nested_field_2',
          type: 'text',
        },
      ],
    },
  ],
},
```

This is because we were generating Drizzle relation name (for arrays) always based on the field path and internally, drizzle uses this name for aliasing. Now, if `dbName` is present, we use `_{dbName}` instead for the relation name.