### PR TITLE
fix: postgres null value breaks orderable hook

### DIFF
--- a/packages/payload/src/config/orderable/index.ts
+++ b/packages/payload/src/config/orderable/index.ts
@@ -108,7 +108,7 @@ export const addOrderableFieldsAndHook = (
 
   const orderBeforeChangeHook: BeforeChangeHook = async ({ data, originalDoc, req }) => {
     for (const orderableFieldName of orderableFieldNames) {
-      if (!data[orderableFieldName] || (originalDoc && !originalDoc[orderableFieldName])) {
+      if (!data[orderableFieldName] && !originalDoc?.[orderableFieldName]) {
         const lastDoc = await req.payload.find({
           collection: collection.slug,
           depth: 0,

--- a/packages/payload/src/config/orderable/index.ts
+++ b/packages/payload/src/config/orderable/index.ts
@@ -109,6 +109,7 @@ export const addOrderableFieldsAndHook = (
   const orderBeforeChangeHook: BeforeChangeHook = async ({ data, originalDoc, req }) => {
     for (const orderableFieldName of orderableFieldNames) {
       if (!data[orderableFieldName] && !originalDoc?.[orderableFieldName]) {
+        console.log('do not enter')
         const lastDoc = await req.payload.find({
           collection: collection.slug,
           depth: 0,
@@ -165,7 +166,7 @@ export const addOrderableEndpoint = (config: SanitizedConfig) => {
     }
     if (
       typeof target !== 'object' ||
-      typeof target.id !== 'string' ||
+      typeof target.id === 'undefined' ||
       typeof target.key !== 'string'
     ) {
       return new Response(JSON.stringify({ error: 'target must be an object with id and key' }), {


### PR DESCRIPTION
When postgres is used and orderable is enabled, payload cannot update the docs to set the order correctly. This is because the sort on postgres pushes `null` values to the top causing unique constraints to error when two documents are updated to the same _order value.