### PR TITLE
fix: querying by polymorphic join field `relationTo` with `overrideAccess: false`

### DIFF
--- a/packages/payload/src/database/queryValidation/validateQueryPaths.ts
+++ b/packages/payload/src/database/queryValidation/validateQueryPaths.ts
@@ -13,6 +13,7 @@ type Args = {
   errors?: { path: string }[]
   overrideAccess: boolean
   policies?: EntityPolicies
+  polymorphicJoin?: boolean
   req: PayloadRequest
   versionFields?: FlattenedField[]
   where: Where
@@ -52,6 +53,7 @@ export async function validateQueryPaths({
     collections: {},
     globals: {},
   },
+  polymorphicJoin,
   req,
   versionFields,
   where,
@@ -77,6 +79,7 @@ export async function validateQueryPaths({
                 overrideAccess,
                 path,
                 policies,
+                polymorphicJoin,
                 req,
                 val,
                 versionFields,

--- a/packages/payload/src/database/queryValidation/validateSearchParams.ts
+++ b/packages/payload/src/database/queryValidation/validateSearchParams.ts
@@ -21,6 +21,7 @@ type Args = {
   parentIsLocalized?: boolean
   path: string
   policies: EntityPolicies
+  polymorphicJoin?: boolean
   req: PayloadRequest
   val: unknown
   versionFields?: FlattenedField[]
@@ -39,6 +40,7 @@ export async function validateSearchParam({
   parentIsLocalized,
   path: incomingPath,
   policies,
+  polymorphicJoin,
   req,
   val,
   versionFields,
@@ -102,6 +104,10 @@ export async function validateSearchParam({
         errors.push({ path })
       }
 
+      if (polymorphicJoin && path === 'relationTo') {
+        return
+      }
+
       if (!overrideAccess && fieldAffectsData(field)) {
         if (collectionSlug) {
           if (!policies.collections[collectionSlug]) {
@@ -140,8 +146,10 @@ export async function validateSearchParam({
         const segments = fieldPath.split('.')
 
         let fieldAccess
+
         if (versionFields) {
           fieldAccess = policies[entityType][entitySlug]
+
           if (segments[0] === 'parent' || segments[0] === 'version') {
             segments.shift()
           }

--- a/packages/payload/src/database/sanitizeJoinQuery.ts
+++ b/packages/payload/src/database/sanitizeJoinQuery.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import type { SanitizedCollectionConfig, SanitizedJoin } from '../collections/config/types.js'
+import type { FlattenedField } from '../fields/config/types.js'
 import type { JoinQuery, PayloadRequest } from '../types/index.js'
 
 import executeAccess from '../auth/executeAccess.js'
@@ -67,6 +68,7 @@ const sanitizeJoinFieldQuery = async ({
       collectionConfig: joinCollectionConfig,
       errors,
       overrideAccess,
+      polymorphicJoin: Array.isArray(join.field.collection),
       req,
       // incoming where input, but we shouldn't validate generated from the access control.
       where: joinQuery.where,

--- a/test/joins/config.ts
+++ b/test/joins/config.ts
@@ -222,6 +222,7 @@ export default buildConfigWithDefaults({
     },
     {
       slug: 'multiple-collections-parents',
+      access: { read: () => true },
       fields: [
         {
           type: 'join',
@@ -236,6 +237,7 @@ export default buildConfigWithDefaults({
     },
     {
       slug: 'multiple-collections-1',
+      access: { read: () => true },
       admin: { useAsTitle: 'title' },
       fields: [
         {
@@ -255,6 +257,7 @@ export default buildConfigWithDefaults({
     },
     {
       slug: 'multiple-collections-2',
+      access: { read: () => true },
       admin: { useAsTitle: 'title' },
       fields: [
         {

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -1389,10 +1389,27 @@ describe('Joins Field', () => {
       expect(parent.children?.docs).toHaveLength(1)
       expect(parent.children.docs[0]?.value.title).toBe('doc-1')
 
-      // WHERE by _relationTo (join for specific collectionSlug)
+      // WHERE by relationTo (join for specific collectionSlug)
       parent = await payload.findByID({
         collection: 'multiple-collections-parents',
         id: parent.id,
+        depth: 1,
+        joins: {
+          children: {
+            where: {
+              relationTo: {
+                equals: 'multiple-collections-2',
+              },
+            },
+          },
+        },
+      })
+
+      // WHERE by relationTo with overrideAccess:false
+      parent = await payload.findByID({
+        collection: 'multiple-collections-parents',
+        id: parent.id,
+        overrideAccess: false,
         depth: 1,
         joins: {
           children: {


### PR DESCRIPTION
Previously, querying by polymorphic joins `relationTo` with `overrideAccess: false` caused an error:
```
QueryError: The following paths cannot be queried: relationTo
```

As this field actually doesn't exist in the schema. Now, under condition that the query comes from a polymorphic join we skip checking `relationTo` field access.