### PR TITLE
feat(storage-azure): support TokenCredential as alternative to connectionString

### DIFF
--- a/packages/storage-azure/README.md
+++ b/packages/storage-azure/README.md
@@ -43,11 +43,12 @@ export default buildConfig({
 ### Configuration Options
 
 | Option                 | Description                                                              | Default |
-| ---------------------- | ------------------------------------------------------------------------ | ------- |
+| ---------------------- | ------------------------------------------------------------------------ | ------- | ------ | --- |
 | `enabled`              | Whether or not to enable the plugin                                      | `true`  |
 | `collections`          | Collections to apply the Azure Blob adapter to                           |         |
 | `allowContainerCreate` | Whether or not to allow the container to be created if it does not exist | `false` |
 | `baseURL`              | Base URL for the Azure Blob storage account                              |         |
-| `connectionString`     | Azure Blob storage connection string                                     |         |
+| `connectionString`     | Azure Blob storage connection                                            |
+| `credential`           | Alternative to connection string you can use TokenCredential to connect  |         | string |     |
 | `containerName`        | Azure Blob storage container name                                        |         |
 | `clientUploads`        | Do uploads directly on the client to bypass limits on Vercel.            |         |

--- a/packages/storage-azure/README.md
+++ b/packages/storage-azure/README.md
@@ -43,12 +43,11 @@ export default buildConfig({
 ### Configuration Options
 
 | Option                 | Description                                                              | Default |
-| ---------------------- | ------------------------------------------------------------------------ | ------- | ------ | --- |
+| ---------------------- | ------------------------------------------------------------------------ | ------- |
 | `enabled`              | Whether or not to enable the plugin                                      | `true`  |
 | `collections`          | Collections to apply the Azure Blob adapter to                           |         |
 | `allowContainerCreate` | Whether or not to allow the container to be created if it does not exist | `false` |
 | `baseURL`              | Base URL for the Azure Blob storage account                              |         |
-| `connectionString`     | Azure Blob storage connection                                            |
-| `credential`           | Alternative to connection string you can use TokenCredential to connect  |         | string |     |
+| `connectionString`     | Azure Blob storage connection string                                     |         |
 | `containerName`        | Azure Blob storage container name                                        |         |
 | `clientUploads`        | Do uploads directly on the client to bypass limits on Vercel.            |         |

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -1,4 +1,4 @@
-import type { ContainerClient } from '@azure/storage-blob'
+import type { BatchSubRequest, ContainerClient } from '@azure/storage-blob'
 import type {
   Adapter,
   ClientUploadsConfig,
@@ -44,12 +44,17 @@ export type AzureStorageOptions = {
   /**
    * Azure Blob storage connection string
    */
-  connectionString: string
+  connectionString?: string
 
   /**
    * Azure Blob storage container name
    */
   containerName: string
+
+  /**
+   * Instead of a connection string you can chose to use any object that implements the TokenCredential interface from `@azure/identity` package to authenticate requests to the service.
+   */
+  credential?: Pick<BatchSubRequest, 'credential'>['credential']
 
   /**
    * Whether or not to enable the plugin
@@ -66,8 +71,10 @@ export const azureStorage: AzureStoragePlugin =
   (incomingConfig: Config): Config => {
     const getStorageClient = () =>
       getStorageClientFunc({
+        baseURL: azureStorageOptions.baseURL,
         connectionString: azureStorageOptions.connectionString,
         containerName: azureStorageOptions.containerName,
+        credential: azureStorageOptions.credential,
       })
 
     const isPluginDisabled = azureStorageOptions.enabled === false
@@ -140,10 +147,16 @@ function azureStorageInternal(
     clientUploads,
     connectionString,
     containerName,
+    credential,
   }: AzureStorageOptions,
 ): Adapter {
   const createContainerIfNotExists = () => {
-    void getStorageClientFunc({ connectionString, containerName }).createIfNotExists({
+    void getStorageClientFunc({
+      baseURL,
+      connectionString,
+      containerName,
+      credential,
+    }).createIfNotExists({
       access: 'blob',
     })
   }

--- a/packages/storage-azure/src/utils/getStorageClient.ts
+++ b/packages/storage-azure/src/utils/getStorageClient.ts
@@ -7,15 +7,24 @@ import type { AzureStorageOptions } from '../index.js'
 let storageClient: ContainerClient | null = null
 
 export function getStorageClient(
-  options: Pick<AzureStorageOptions, 'connectionString' | 'containerName'>,
+  options: Pick<
+    AzureStorageOptions,
+    'baseURL' | 'connectionString' | 'containerName' | 'credential'
+  >,
 ): ContainerClient {
   if (storageClient) {
     return storageClient
   }
 
-  const { connectionString, containerName } = options
-
-  const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString)
+  const { baseURL, connectionString, containerName, credential } = options
+  let blobServiceClient: BlobServiceClient | undefined = undefined
+  if (typeof connectionString === 'string') {
+    blobServiceClient = BlobServiceClient.fromConnectionString(connectionString)
+  } else if (typeof credential === 'object' && baseURL) {
+    blobServiceClient = new BlobServiceClient(baseURL, credential, {})
+  } else {
+    throw new Error('connectionString or credential with baseURL must be provided')
+  }
   storageClient = blobServiceClient.getContainerClient(containerName)
   return storageClient
 }


### PR DESCRIPTION
feat(storage-azure): support TokenCredential as alternative to connectionString

Closed stale PR and fixed a small typo, previous: 
https://github.com/payloadcms/payload/pull/10593

### What

Made the `connectionString` configuration in `storage-azure` optional, and
added support for using `TokenCredential` to authenticate the StorageClient.

### Why

This allows organizations to move away from `connectionString`-based
authentication and instead use Azure Role-Based Access Control (RBAC), which is
the recommended approach by Azure for production environments.

### How

- Introduced `credential` as an optional configuration property
- Updated `getStorageClient` to use `baseURL` + `TokenCredential` when provided
- Fallback to `connectionString` if no credential is set
- Improved validation and error handling to guide correct usage

### Configuration Example

```ts
export default buildConfig({
  plugins: [
    azureStorage({
      collections: {
        media: true,
        'media-with-prefix': { prefix },
      },
      allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
      baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL,
      // connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
      credential: new ChainedTokenCredential(
        new VisualStudioCodeCredential(),
        new AzureCliCredential(),
        new DefaultAzureCredential(),
      ),
      containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
    }),
  ],
});
