### PR TITLE
feat(db-sqlite): make drizzle casing configurable

### DIFF
--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -40,6 +40,7 @@ export default buildConfig({
 | `push`                     | Disable Drizzle's [`db push`](https://orm.drizzle.team/kit-docs/overview#prototyping-with-db-push) in development mode. By default, `push` is enabled for development mode only. |
 | `migrationDir`             | Customize the directory that migrations are stored.                                                                                                                              |
 | `logger`                   | The instance of the logger to be passed to drizzle. By default Payload's will be used.                                                                                           |
+| `casing`                   | The [casing](https://orm.drizzle.team/docs/sql-schema-declaration#camel-and-snake-casing) to be passed to drizzle. Default is 'snake_case'.                                      |
 | `idType`                   | A string of 'number', or 'uuid' that is used for the data type given to id columns.                                                                                              |
 | `transactionOptions`       | A SQLiteTransactionConfig object for transactions, or set to `false` to disable using transactions. [More details](https://orm.drizzle.team/docs/transactions)                   |
 | `localesSuffix`            | A string appended to the end of table names for storing localized fields. Default is '\_locales'.                                                                                |

--- a/packages/db-sqlite/src/connect.ts
+++ b/packages/db-sqlite/src/connect.ts
@@ -21,7 +21,8 @@ export const connect: Connect = async function connect(
     }
 
     const logger = this.logger || false
-    this.drizzle = drizzle(this.client, { logger, schema: this.schema })
+    const casing = this.casing || 'snake_case'
+    this.drizzle = drizzle(this.client, { casing, logger, schema: this.schema })
 
     if (!hotReload) {
       if (process.env.PAYLOAD_DROP_DATABASE === 'true') {

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -94,6 +94,7 @@ export function sqliteAdapter(args: Args): DatabaseAdapterObj<SQLiteAdapter> {
       autoIncrement: args.autoIncrement ?? false,
       beforeSchemaInit: args.beforeSchemaInit ?? [],
       blocksAsJSON: args.blocksAsJSON ?? false,
+      casing: args.casing || 'snake_case',
       // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
       client: undefined,
       clientConfig: args.client,

--- a/packages/db-sqlite/src/types.ts
+++ b/packages/db-sqlite/src/types.ts
@@ -56,6 +56,7 @@ export type Args = {
    * Store blocks as JSON column instead of storing them in relational structure.
    */
   blocksAsJSON?: boolean
+  casing?: DrizzleConfig['casing']
   client: Config
 } & BaseSQLiteArgs
 
@@ -127,6 +128,7 @@ type ResolveSchemaType<T> = 'schema' extends keyof T
 type Drizzle = { $client: Client } & LibSQLDatabase<ResolveSchemaType<GeneratedDatabaseSchema>>
 
 export type SQLiteAdapter = {
+  casing: DrizzleConfig['casing']
   client: Client
   clientConfig: Args['client']
   drizzle: Drizzle


### PR DESCRIPTION
### What?
integrating payload-cms, table name casing not consist with my existing tables

### Why?
casing config can pass to drizzle, but not in payload sqlite adapter

### How?
add casing field to Arg for SQLiteAdapter


<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
