### PR TITLE
fix(db-postgres): count operation returns totalDocs:0 correctly when queried by a field of realtionship field

### DIFF
--- a/packages/db-sqlite/src/countDistinct.ts
+++ b/packages/db-sqlite/src/countDistinct.ts
@@ -39,5 +39,5 @@ export const countDistinct: CountDistinct = async function countDistinct(
   // Instead, COUNT (GROUP BY id) can be used which is still slower than COUNT(*) but acceptable.
   const countResult = await query
 
-  return Number(countResult[0]?.count)
+  return Number(countResult[0]?.count) || 0
 }

--- a/packages/drizzle/src/postgres/countDistinct.ts
+++ b/packages/drizzle/src/postgres/countDistinct.ts
@@ -39,5 +39,5 @@ export const countDistinct: CountDistinct = async function countDistinct(
   // Instead, COUNT (GROUP BY id) can be used which is still slower than COUNT(*) but acceptable.
   const countResult = await query
 
-  return Number(countResult[0].count)
+  return Number(countResult[0]?.count) || 0
 }

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -268,6 +268,41 @@ describe('Relationships', () => {
         expect(query.totalDocs).toEqual(2)
       })
 
+      it('should count documents correctly when queried by a relationship field', async () => {
+        const user = (
+          await payload.find({
+            collection: 'users',
+          })
+        ).docs[0]!
+
+        for (let i = 0; i < 8; i++) {
+          await payload.create({
+            collection: 'movieReviews',
+            data: {
+              movieReviewer: user.id,
+              visibility: 'public',
+            },
+          })
+        }
+
+        const { totalDocs: countReviewedByUser } = await payload.count({
+          collection: 'movieReviews',
+          where: {
+            'movieReviewer.email': { equals: user.email },
+          },
+        })
+
+        expect(countReviewedByUser).toEqual(8)
+
+        const { totalDocs: countReviewedByNonExistent } = await payload.count({
+          collection: 'movieReviews',
+          where: {
+            'movieReviewer.email': { equals: 'nonExistent@usermail.com' },
+          },
+        })
+        expect(countReviewedByNonExistent).toEqual(0)
+      })
+
       // https://github.com/payloadcms/payload/issues/4240
       it('should allow querying by relationship id field', async () => {
         /**


### PR DESCRIPTION
### What?

When queried by a field of a relationship and the result should be 0, count operation was returning NaN for sqlite and throwing error for postgres database. 

### Why?

It was caused by the return statements of countDistinc functions of the db adapters

### How?

Providing 0 as default value in return statements fixed the issue

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
