### PR TITLE
chore(db-*): import migration args as type

### DIFF
--- a/docs/database/migrations.mdx
+++ b/docs/database/migrations.mdx
@@ -36,7 +36,7 @@ all changes that you attempt to make within the migration, and the `down` should
 Here is an example migration file:
 
 ```ts
-import { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/your-db-adapter'
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/your-db-adapter'
 
 export async function up({ payload, req }: MigrateUpArgs): Promise<void> {
   // Perform changes to your database here.

--- a/packages/db-mongodb/src/createMigration.ts
+++ b/packages/db-mongodb/src/createMigration.ts
@@ -5,7 +5,11 @@ import path from 'path'
 import { getPredefinedMigration, writeMigrationIndex } from 'payload'
 import { fileURLToPath } from 'url'
 
-const migrationTemplate = ({ downSQL, imports, upSQL }: MigrationTemplateArgs): string => `import {
+const migrationTemplate = ({
+  downSQL,
+  imports,
+  upSQL,
+}: MigrationTemplateArgs): string => `import type {
   MigrateDownArgs,
   MigrateUpArgs,
 } from '@payloadcms/db-mongodb'

--- a/packages/drizzle/src/utilities/getMigrationTemplate.ts
+++ b/packages/drizzle/src/utilities/getMigrationTemplate.ts
@@ -11,7 +11,7 @@ export const getMigrationTemplate = ({
   imports,
   packageName,
   upSQL,
-}: MigrationTemplateArgs): string => `import { MigrateUpArgs, MigrateDownArgs, sql } from '${packageName}'
+}: MigrationTemplateArgs): string => `import { type MigrateUpArgs, type MigrateDownArgs, sql } from '${packageName}'
 ${imports ? `${imports}\n` : ''}
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
 ${indent(upSQL)}

--- a/packages/payload/src/database/migrations/migrationTemplate.ts
+++ b/packages/payload/src/database/migrations/migrationTemplate.ts
@@ -1,5 +1,5 @@
 export const migrationTemplate = `
-import {
+import type {
   MigrateUpArgs,
   MigrateDownArgs,
 } from "@payloadcms/db-mongodb";


### PR DESCRIPTION
### What?

If you have `verbatimModuleSyntax` enabled in tsconfig then creating migrations will give a TypeScript error due to the args not being imported as types.

When a migration is created we get this:
```ts
import { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/db-mongodb'
```

### Why?
This causes:
```ts
'MigrateDownArgs' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
'MigrateUpArgs' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
```

Screenshot:
<img width="950" alt="Screenshot 2025-04-05 at 15 37 44" src="https://github.com/user-attachments/assets/8b2e395e-ebc1-45a8-a875-3c3d7ac47f31" />

### How?
Added type in front of the imported types to avoid the error, which also makes it clearer that this is a type import.
```ts
import type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/db-mongodb'
```