### PR TITLE
chore: add logging templates script and fix engines for pnpm v10

### DIFF
--- a/templates/_template/package.json
+++ b/templates/_template/package.json
@@ -39,7 +39,7 @@
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
-    "pnpm": "^9"
+    "pnpm": "^9 || ^10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -39,7 +39,7 @@
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
-    "pnpm": "^9"
+    "pnpm": "^9 || ^10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/plugin/package.json
+++ b/templates/plugin/package.json
@@ -81,7 +81,7 @@
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
-    "pnpm": "^9"
+    "pnpm": "^9 || ^10"
   },
   "publishConfig": {
     "exports": {

--- a/templates/website/package.json
+++ b/templates/website/package.json
@@ -70,7 +70,7 @@
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
-    "pnpm": "^9"
+    "pnpm": "^9 || ^10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/with-payload-cloud/package.json
+++ b/templates/with-payload-cloud/package.json
@@ -39,7 +39,7 @@
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
-    "pnpm": "^9"
+    "pnpm": "^9 || ^10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/with-postgres/package.json
+++ b/templates/with-postgres/package.json
@@ -40,7 +40,7 @@
   },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
-    "pnpm": "^9"
+    "pnpm": "^9 || ^10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tools/scripts/src/generate-template-variations.ts
+++ b/tools/scripts/src/generate-template-variations.ts
@@ -435,9 +435,10 @@ function header(message: string) {
 function log(message: string) {
   console.log(chalk.dim(message))
 }
+
 function execSyncSafe(command: string, options?: Parameters<typeof execSync>[1]) {
   try {
-    console.log(`Executing: ${command}`)
+    log(`Executing: ${command}`)
     execSync(command, { stdio: 'inherit', ...options })
   } catch (error) {
     if (error instanceof Error) {
@@ -492,6 +493,11 @@ async function bumpPackageJson({
   )
 }
 
+/**
+ * Fetches the latest version of a package from the NPM registry.
+ *
+ * Used in determining the latest version of Payload to use in the generated templates.
+ */
 async function getLatestPackageVersion({
   packageName = 'payload',
 }: {
@@ -508,6 +514,8 @@ async function getLatestPackageVersion({
     const response = await fetch(`https://registry.npmjs.org/${packageName}`)
     const data = await response.json()
     const latestVersion = data['dist-tags'].latest
+
+    log(`Found latest version of ${packageName}: ${latestVersion}`)
 
     return latestVersion
   } catch (error) {


### PR DESCRIPTION
- Fixes issues with using pnpm v10 in some templates by allowing `^10` in engines as well
- Added logging to the template generation script so we can debug the latest version being pulled by CI