### PR TITLE
fix(richtext-lexical): diff component css was not included in css bundle

### DIFF
--- a/packages/richtext-lexical/bundle.js
+++ b/packages/richtext-lexical/bundle.js
@@ -21,7 +21,7 @@ const removeCSSImports = {
 async function build() {
   // Bundle only the .scss files into a single css file
   await esbuild.build({
-    entryPoints: ['src/exports/client/index.ts'],
+    entryPoints: ['src/exports/cssEntry.ts'],
     bundle: true,
     minify: true,
     outdir: 'dist/bundled_scss',
@@ -35,7 +35,7 @@ async function build() {
   fs.mkdirSync('dist/exports/client_optimized')
 
   try {
-    fs.renameSync('dist/bundled_scss/index.css', 'dist/field/bundled.css')
+    fs.renameSync('dist/bundled_scss/cssEntry.css', 'dist/field/bundled.css')
     fs.copyFileSync('dist/field/bundled.css', 'dist/exports/client_optimized/bundled.css')
     fs.rmSync('dist/bundled_scss', { recursive: true })
   } catch (err) {

--- a/packages/richtext-lexical/eslint.config.js
+++ b/packages/richtext-lexical/eslint.config.js
@@ -9,6 +9,7 @@ const { rules } = reactCompiler
 export const index = [
   ...rootEslintConfig,
   {
+    ignores: ['bundle.js'],
     languageOptions: {
       parserOptions: {
         ...rootParserOptions,

--- a/packages/richtext-lexical/src/exports/cssEntry.ts
+++ b/packages/richtext-lexical/src/exports/cssEntry.ts
@@ -1,0 +1,5 @@
+// The purpose of this file is to export all modules that may contain SCSS.
+// These will then be bundled into one CSS file by our bundler.
+
+export * from './client/index.js'
+export * from './server/rsc.js'

--- a/packages/richtext-lexical/src/field/Diff/index.tsx
+++ b/packages/richtext-lexical/src/field/Diff/index.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 
 import './htmlDiff/index.scss'
 import './index.scss'
+import '../bundled.css'
 
 import type { HTMLConvertersFunctionAsync } from '../../features/converters/lexicalToHtml/async/types.js'
 


### PR DESCRIPTION
Currently, the lexical version diff component is completely unstyled, as the scss was never included in our css bundle. This PR ensures that the diff component scss is included in our css bundle