### PR TITLE
feat: add the ability to link existing documents in the join field

### DIFF
--- a/packages/ui/src/elements/ListDrawer/index.scss
+++ b/packages/ui/src/elements/ListDrawer/index.scss
@@ -1,0 +1,23 @@
+@import '../../scss/styles.scss';
+
+@layer payload-default {
+  .list-drawer {
+    &__toggler {
+      background: transparent;
+      border: 0;
+      margin: 0;
+      padding: 0;
+      cursor: pointer;
+      color: inherit;
+
+      &:focus,
+      &:focus-within {
+        outline: none;
+      }
+
+      &:disabled {
+        pointer-events: none;
+      }
+    }
+  }
+}

--- a/packages/ui/src/elements/ListDrawer/index.tsx
+++ b/packages/ui/src/elements/ListDrawer/index.tsx
@@ -10,6 +10,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
 import { Drawer, DrawerToggler } from '../Drawer/index.js'
 import { ListDrawerContent } from './DrawerContent.js'
+import './index.scss'
 
 export const baseClass = 'list-drawer'
 export const formatListDrawerSlug = ({


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

-->

### What?

This PR adds a new button to the Join field UI to take an existing document from the joined collection and link it to this joining document instead.

<img width="823" alt="the join field UI with two buttons titled 'Choose from existing' and 'Add new'" src="https://github.com/user-attachments/assets/84bde883-4b87-481f-813a-c61311c2fac4" />

### Why?

This is a custom functionality that I needed as part of my own usage of Payload. I found the integration to be a bit difficult — I had to modify the label component and extend it in width up to the `Add new` button to give an impression of a second action. Not to mention that after sending a PATCH request to do the linking, I had to call `window.location.reload()` because I couldn't come up with a better way to invalidate the table from within a custom component.

Since the new functionality was mostly using existing Payload components, I figured I'd try to contribute it back in case you decide that it's useful.

### How?

This uses the `ListDrawer` element to display a slide-out panel to browse existing documents that can be linked to the current document.

> [!NOTE]
> This PR is still not finished — after selection, the document isn't actually being linked. I wanted to get your input on whether this contribution is welcome, and if so, what would be the best way to implement the linking? The only thing I can think of is a `fetch` call, but perhaps there's a better way to do updates from inside Payload client components
