### PR TITLE
feat: make the title cells in the join table links to documents

### DIFF
--- a/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/cells/DrawerLink/index.tsx
@@ -47,7 +47,7 @@ export const DrawerLink: React.FC<{
 
   return (
     <div className="drawer-link">
-      <DefaultCell {...cellProps} className="drawer-link__cell" link={false} onClick={null} />
+      <DefaultCell {...cellProps} className="drawer-link__cell" link />
       <DocumentDrawerToggler>
         <EditIcon />
       </DocumentDrawerToggler>


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

-->

### What?

This PR makes the title cells of each row in the Join field into links to the document that's linked.

<img width="816" alt="image" src="https://github.com/user-attachments/assets/8ee9f218-a91f-4463-8371-5b18d99c2bca" />

### Why?

The current UI of the Join field gives a way to make modifications to the linked document by clicking the small Edit icon, but there's no way to navigate from that editor to the full page of a linked document. This functionality would convenient for quickly finding the right document from the linked collection, so long as you know the parent document that links it.

I'm not sure if there's a particular reason why it was decided not to make it a link, but it would make navigation around Payload easier for me, so I thought I'd propose it.

### How?

The cell component being used already supports the linking functionality, all that's needed is to enable it.