### PR TITLE
fix: array minRow validation should not show when non-required with no rows

### DIFF
--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -201,7 +201,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
   const fieldHasErrors = submitted && errorPaths.length > 0
 
   const showRequired = (readOnly || disabled) && rows.length === 0
-  const showMinRows = rows.length < minRows || (required && rows.length === 0)
+  const showMinRows = (rows.length > 1 && rows.length < minRows) || (required && rows.length === 0)
 
   return (
     <div

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -201,7 +201,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
   const fieldHasErrors = submitted && errorPaths.length > 0
 
   const showRequired = (readOnly || disabled) && rows.length === 0
-  const showMinRows = (rows.length > 1 && rows.length < minRows) || (required && rows.length === 0)
+  const showMinRows = (rows.length && rows.length < minRows) || (required && rows.length === 0)
 
   return (
     <div


### PR DESCRIPTION
### What?
UI only issue: An array row with `required: false` and `minRows: x` was displaying an error banner - this should only happen if one or more rows are present. 

The validation is not affected, the document still saved as expected, but the error should not be inaccurately displayed.

### Why?
The logic for displaying the `minRow` validation error was `rows.length > minRows` and it needs to be `rows.length > 1 && rows.length > minRows`

### How?
Updates the UI logic.

Fixes #12010