### PR TITLE
fix(richtext-lexical): allow to indent children even if their parents are not indentable

### DIFF
--- a/packages/richtext-lexical/src/features/indent/client/index.tsx
+++ b/packages/richtext-lexical/src/features/indent/client/index.tsx
@@ -68,12 +68,7 @@ const toolbarGroups = ({ disabledNodes }: IndentFeatureProps): ToolbarGroup[] =>
         if (!nodes?.length) {
           return false
         }
-        if (nodes.some((node) => disabledNodes?.includes(node.getType()))) {
-          return false
-        }
-        return !$pointsAncestorMatch(selection, (node) =>
-          (disabledNodes ?? []).includes(node.getType()),
-        )
+        return !nodes.some((node) => disabledNodes?.includes(node.getType()))
       },
       key: 'indentIncrease',
       label: ({ i18n }) => {


### PR DESCRIPTION
### What?
Allows to indent children in richtext-lexical if the parent of that child is not indentable. Changes the behavior introduced in https://github.com/payloadcms/payload/pull/11739

### Why?
If there is a document structure with e.g. `tableNode > list > listItem` and indentation of `tableNode` is disabled, it should still be possible to indent the list items.

### How?
Disable the indent button only if indentation of one of the selected nodes itself is disabled.
