### PR TITLE
fix(db-postgres): use correct export path for codegen in `createSchemaGenerator`

### DIFF
--- a/packages/drizzle/src/utilities/createSchemaGenerator.ts
+++ b/packages/drizzle/src/utilities/createSchemaGenerator.ts
@@ -131,7 +131,7 @@ export const createSchemaGenerator = ({
           let foreignKeyDeclaration = `${sanitizeObjectKey(key)}: foreignKey({
       columns: [${foreignKey.columns.map((col) => `columns['${col}']`).join(', ')}],
       foreignColumns: [${foreignKey.foreignColumns.map((col) => `${accessProperty(col.table, col.name)}`).join(', ')}],
-      name: '${foreignKey.name}' 
+      name: '${foreignKey.name}'
     })`
 
           if (foreignKey.onDelete) {
@@ -167,11 +167,11 @@ ${Object.entries(table.columns)
 }${
         extrasDeclarations.length
           ? `, (columns) => ({
-    ${extrasDeclarations.join('\n    ')}  
+    ${extrasDeclarations.join('\n    ')}
   })`
           : ''
       }
-) 
+)
 `
 
       tableDeclarations.push(tableCode)
@@ -250,7 +250,7 @@ type DatabaseSchema = {
     `
 
     const finalDeclaration = `
-declare module '${this.packageName}/types' {
+declare module '${this.packageName}' {
   export interface GeneratedDatabaseSchema {
     schema: DatabaseSchema
   }


### PR DESCRIPTION
following changes made by Commit a6f7ef8

> feat(db-*): export types from main export (#11914)
In 3.0, we made the decision to export all types from the main package
export (e.g. `payload/types` => `payload`). This improves type
discoverability by IDEs and simplifies importing types.

> This PR does the same for our db adapters, which still have a separate
`/types` subpath export. While those are kept for
backwards-compatibility, we can remove them in 4.0.

https://github.com/payloadcms/payload/commit/a6f7ef837aafda92d0be85dd1ffa2d26cd105f12


the script responsible for generating file generated-schema.ts was not updated to reflect this change in export paths

drizzle/src/utilities/createSchemaGenerator.ts

CURRENT 
```typescript
    const finalDeclaration = `
declare module '${this.packageName}/types' {
  export interface GeneratedDatabaseSchema {
    schema: DatabaseSchema
  }
}
```

AFTER THIS PULL REQUEST
```typescript
    const finalDeclaration = `
declare module '${this.packageName}' {
  export interface GeneratedDatabaseSchema {
    schema: DatabaseSchema
  }
}
```

this pull request fixes the generation of generated-schema.ts avoiding errors while building for production with command
```bash
npm run build
```
![Screenshot 2025-04-08 at 17 00 11](https://github.com/user-attachments/assets/203de476-0f8f-4d65-90e6-58c50bd3e2a6)



