### PR TITLE
fix: prevent `in` & `not in` operators for relationship fields with hasMany: false

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
+++ b/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
@@ -130,7 +130,15 @@ export const reduceFields = ({
     if (typeof fieldTypes[field.type] === 'object') {
       const operatorKeys = new Set()
 
-      const operators = fieldTypes[field.type].operators.reduce((acc, operator) => {
+      let fieldTypeOperators = [...fieldTypes[field.type].operators]
+
+      if (field.type === 'relationship' && field.hasMany !== true) {
+        fieldTypeOperators = fieldTypeOperators.filter(
+          (op) => op.value !== 'in' && op.value !== 'not_in',
+        )
+      }
+
+      const operators = fieldTypeOperators.reduce((acc, operator) => {
         if (!operatorKeys.has(operator.value)) {
           operatorKeys.add(operator.value)
           const operatorKey = `operators:${operator.label}` as ClientTranslationKeys

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@playwright/test'
 import { addListFilter } from 'helpers/e2e/addListFilter.js'
 import { navigateToDoc } from 'helpers/e2e/navigateToDoc.js'
 import { openDocControls } from 'helpers/e2e/openDocControls.js'
+import { openListFilters } from 'helpers/e2e/openListFilters.js'
 import { openCreateDocDrawer, openDocDrawer } from 'helpers/e2e/toggleDocDrawer.js'
 import path from 'path'
 import { wait } from 'payload/shared'
@@ -649,6 +650,36 @@ describe('relationship', () => {
     })
 
     await expect(page.locator(tableRowLocator)).toHaveCount(1)
+  })
+
+  test('should not allow filtering by relationship field hasMany false / in & not in', async () => {
+    await page.goto(url.list)
+
+    await openListFilters(page, {})
+
+    const whereBuilder = page.locator('.where-builder')
+
+    await whereBuilder.locator('.where-builder__add-first-filter').click()
+
+    const conditionField = whereBuilder.locator('.condition__field')
+    await conditionField.click()
+
+    await conditionField
+      .locator('.rs__option', {
+        hasText: exactText('Relationship'),
+      })
+      ?.click()
+
+    await expect(whereBuilder.locator('.condition__field')).toContainText('Relationship')
+
+    const operatorInput = whereBuilder.locator('.condition__operator')
+    await operatorInput.click()
+
+    const operatorOptions = operatorInput.locator('.rs__option')
+    const optionTexts = await operatorOptions.allTextContents()
+
+    await expect.poll(() => optionTexts).not.toContain('is in')
+    await expect.poll(() => optionTexts).not.toContain('is not in')
   })
 })
 


### PR DESCRIPTION
### What?

This PR addresses a bug where `relationship` fields with `hasMany: false` (including polymorphic relationships) allowed filtering using the `in` and `not in` operators via the Admin UI, which led to query errors.

### Why?

MongoDB & Postgres expect an array when using `in` & `not in`, but these fields return a single object (not an array).

### How?

- `in` and `not in` operators are now **excluded** from the list of available filter operators for relationship fields where `hasMany: false`.

Fixes #12014 
