### PR TITLE
chore(deps): bump image-size to 2.0.2 version

### DIFF
--- a/packages/payload/package.json
+++ b/packages/payload/package.json
@@ -98,7 +98,7 @@
     "file-type": "19.3.0",
     "get-tsconfig": "4.8.1",
     "http-status": "2.1.0",
-    "image-size": "1.2.1",
+    "image-size": "2.0.2",
     "jose": "5.9.6",
     "json-schema-to-typescript": "15.0.3",
     "minimist": "1.2.8",

--- a/packages/payload/src/uploads/getImageSize.ts
+++ b/packages/payload/src/uploads/getImageSize.ts
@@ -1,19 +1,16 @@
 // @ts-strict-ignore
 import fs from 'fs/promises'
-import sizeOfImport from 'image-size'
-import { promisify } from 'util'
+import { imageSize } from 'image-size'
+import { imageSizeFromFile } from 'image-size/fromFile'
 
 import type { PayloadRequest } from '../types/index.js'
 import type { ProbedImageSize } from './types.js'
 
 import { temporaryFileTask } from './tempFile.js'
 
-const { imageSize } = sizeOfImport
-const imageSizePromise = promisify(imageSize)
-
 export async function getImageSize(file: PayloadRequest['file']): Promise<ProbedImageSize> {
   if (file.tempFilePath) {
-    return imageSizePromise(file.tempFilePath)
+    return imageSizeFromFile(file.tempFilePath)
   }
 
   // Tiff file do not support buffers or streams, so we must write to file first
@@ -22,7 +19,7 @@ export async function getImageSize(file: PayloadRequest['file']): Promise<Probed
     const dimensions = await temporaryFileTask(
       async (filepath: string) => {
         await fs.writeFile(filepath, file.data)
-        return imageSizePromise(filepath)
+        return imageSizeFromFile(filepath)
       },
       { extension: 'tiff' },
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,8 +842,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
       image-size:
-        specifier: 1.2.1
-        version: 1.2.1
+        specifier: 2.0.2
+        version: 2.0.2
       jose:
         specifier: 5.9.6
         version: 5.9.6
@@ -7395,8 +7395,8 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  image-size@1.2.1:
-    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+  image-size@2.0.2:
+    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
     engines: {node: '>=16.x'}
     hasBin: true
 
@@ -8867,9 +8867,6 @@ packages:
 
   queue-tick@1.0.1:
     resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
-
-  queue@6.0.2:
-    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -17140,9 +17137,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  image-size@1.2.1:
-    dependencies:
-      queue: 6.0.2
+  image-size@2.0.2: {}
 
   immediate@3.0.6: {}
 
@@ -18951,10 +18946,6 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   queue-tick@1.0.1: {}
-
-  queue@6.0.2:
-    dependencies:
-      inherits: 2.0.4
 
   quick-format-unescaped@4.0.4: {}
 


### PR DESCRIPTION
Bumps our `image-size` dependency to 2.0.2 which includes the [DDOS fix](https://github.com/payloadcms/payload/pull/12040) previously released.

The [2.0](https://github.com/image-size/image-size/releases/tag/v2.0.0) of this library comes with some benefits such as no dependencies and improved performance.