### PR TITLE
fix(ui): orderable table rendering

### DIFF
--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -22,6 +22,10 @@ export { useEffectEvent } from '../../hooks/useEffectEvent.js'
 
 export { useUseTitleField } from '../../hooks/useUseAsTitle.js'
 
+export { SortHeader } from '../../elements/SortHeader/index.js'
+export { SortRow } from '../../elements/SortRow/index.js'
+export { OrderableTable } from '../../elements/Table/OrderableTable.js'
+
 // query preset elements
 export { QueryPresetsColumnsCell } from '../../elements/QueryPresets/cells/ColumnsCell/index.js'
 export { QueryPresetsWhereCell } from '../../elements/QueryPresets/cells/WhereCell/index.js'

--- a/packages/ui/src/utilities/renderTable.tsx
+++ b/packages/ui/src/utilities/renderTable.tsx
@@ -19,15 +19,20 @@ import React from 'react'
 import type { Column } from '../exports/client/index.js'
 
 import { RenderServerComponent } from '../elements/RenderServerComponent/index.js'
-import { SortHeader } from '../elements/SortHeader/index.js'
-import { SortRow } from '../elements/SortRow/index.js'
-import { OrderableTable } from '../elements/Table/OrderableTable.js'
+import {
+  OrderableTable,
+  Pill,
+  SelectAll,
+  SelectRow,
+  SortHeader,
+  SortRow,
+  Table,
+  // eslint-disable-next-line payload/no-imports-from-exports-dir
+} from '../exports/client/index.js'
 import { buildColumnState } from '../providers/TableColumns/buildColumnState.js'
 import { buildPolymorphicColumnState } from '../providers/TableColumns/buildPolymorphicColumnState.js'
 import { filterFields } from '../providers/TableColumns/filterFields.js'
 import { getInitialColumns } from '../providers/TableColumns/getInitialColumns.js'
-// eslint-disable-next-line payload/no-imports-from-exports-dir
-import { Pill, SelectAll, SelectRow, Table } from '../exports/client/index.js'
 
 export const renderFilters = (
   fields: Field[],


### PR DESCRIPTION
Adds components used in the renderTable component to the client exports.

Components that are returned via server functions, must import client components from the exports dir.