### PR TITLE
fix(ui): issue with schedule publish disappearing on autosave collections

### DIFF
--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -74,11 +74,16 @@ export function PublishButton({ label: labelProp }: PublishButtonClientProps) {
 
   const scheduledPublishEnabled = Boolean(schedulePublish)
 
+  // If autosave is enabled the modified will always be true so only conditionally check on modified state
+  const hasAutosave = Boolean(
+    typeof entityConfig?.versions?.drafts === 'object' && entityConfig?.versions?.drafts.autosave,
+  )
+
   const canSchedulePublish = Boolean(
     scheduledPublishEnabled &&
       hasPublishPermission &&
       (globalSlug || (collectionSlug && id)) &&
-      !modified,
+      (hasAutosave ?? !modified),
   )
 
   const operation = useOperation()

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -83,7 +83,7 @@ export function PublishButton({ label: labelProp }: PublishButtonClientProps) {
     scheduledPublishEnabled &&
       hasPublishPermission &&
       (globalSlug || (collectionSlug && id)) &&
-      (hasAutosave ?? !modified),
+      (hasAutosave || !modified),
   )
 
   const operation = useOperation()

--- a/test/versions/collections/Autosave.ts
+++ b/test/versions/collections/Autosave.ts
@@ -18,6 +18,7 @@ const AutosavePosts: CollectionConfig = {
       autosave: {
         interval: 2000,
       },
+      schedulePublish: true,
     },
   },
   access: {

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -655,6 +655,7 @@ describe('Versions', () => {
   describe('Scheduled publish', () => {
     beforeAll(() => {
       url = new AdminUrlUtil(serverURL, draftCollectionSlug)
+      autosaveURL = new AdminUrlUtil(serverURL, autosaveCollectionSlug)
     })
 
     test('should schedule publish', async () => {
@@ -721,6 +722,26 @@ describe('Versions', () => {
       // We customised it in config to not contain a 12 hour clock
       await expect(async () => {
         await expect(listItem).toHaveText('00:00')
+      }).toPass({
+        timeout: POLL_TOPASS_TIMEOUT,
+      })
+    })
+
+    test('can still schedule publish once autosave is triggered', async () => {
+      await page.goto(autosaveURL.create)
+      await page.locator('#field-title').fill('scheduled publish')
+      await page.locator('#field-description').fill('scheduled publish description')
+
+      await saveDocAndAssert(page)
+
+      await page.locator('#field-title').fill('scheduled publish updated')
+
+      await waitForAutoSaveToRunAndComplete(page)
+
+      await page.locator('#action-save-popup').click()
+
+      await expect(async () => {
+        await expect(page.locator('#schedule-publish')).toBeVisible()
       }).toPass({
         timeout: POLL_TOPASS_TIMEOUT,
       })


### PR DESCRIPTION
Fixes an issue where an autosave being triggered would turn off the ability to schedule a publish. This happened because we check against `modified` on the form but with autosave modified is always true.

Now we make an exception for autosave enabled collections when checking the modified state.