### PR TITLE
fix: ensures cors headers are run against custom endpoints

### DIFF
--- a/packages/payload/src/utilities/handleEndpoints.ts
+++ b/packages/payload/src/utilities/handleEndpoints.ts
@@ -222,8 +222,12 @@ export const handleEndpoints = async ({
     }
 
     const response = await handler(req)
+
     return new Response(response.body, {
-      headers: mergeHeaders(req.responseHeaders ?? new Headers(), response.headers),
+      headers: headersWithCors({
+        headers: mergeHeaders(req.responseHeaders ?? new Headers(), response.headers),
+        req,
+      }),
       status: response.status,
       statusText: response.statusText,
     })


### PR DESCRIPTION
Restores goal of #10597 and reverts #10718

This is a more surgical way of adding CORS headers to custom endpoints