### PR TITLE
chore: assign available port to env variable in dev suite

### DIFF
--- a/test/dev.ts
+++ b/test/dev.ts
@@ -101,6 +101,10 @@ const port = process.env.PORT ? Number(process.env.PORT) : 3000
 
 const availablePort = await findOpenPort(port)
 
+// Assign the available port to process.env.PORT so that the next and our HMR server uses it
+// @ts-expect-error - PORT is a string from somewhere
+process.env.PORT = availablePort
+
 // @ts-expect-error the same as in test/helpers/initPayloadE2E.ts
 const app = nextImport({
   dev: true,


### PR DESCRIPTION
Previously when the port number was bumped up (eg `3001`) in our dev suite, HMR wouldn't work because it couldn't reliably read the new used port and it would default to `3000`.

This assigns it properly to the env var and fixes that issues so HMR in our dev suite works on other ports too.

Testing steps:
- Have a local instance of dev suite running already on port 3000
- New repo run dev, it will bump to `3001`
- Make any config change and you will see that HMR does not work without this fix