### PR TITLE
feat(ui): custom ordering for rte fixed toolbar

### DIFF
--- a/packages/richtext-lexical/src/features/toolbars/fixed/server/index.ts
+++ b/packages/richtext-lexical/src/features/toolbars/fixed/server/index.ts
@@ -10,6 +10,12 @@ export type FixedToolbarFeatureProps = {
    */
   applyToFocusedEditor?: boolean
   /**
+   * Custom ordering for toolbar groups
+   * Key is the group key (e.g. 'format', 'text', 'align')
+   * Value is the new order number
+   */
+  customGroupOrders?: Record<string, number>
+  /**
    * @default false
    *
    * If there is a parent editor with a fixed toolbar, this will disable the toolbar for this editor.
@@ -26,6 +32,7 @@ export const FixedToolbarFeature = createServerFeature<
     const sanitizedProps: FixedToolbarFeatureProps = {
       applyToFocusedEditor:
         props?.applyToFocusedEditor === undefined ? false : props.applyToFocusedEditor,
+      customGroupOrders: props?.customGroupOrders,
       disableIfParentHasFixedToolbar:
         props?.disableIfParentHasFixedToolbar === undefined
           ? false

--- a/packages/richtext-lexical/src/lexical/config/client/sanitize.ts
+++ b/packages/richtext-lexical/src/lexical/config/client/sanitize.ts
@@ -31,6 +31,19 @@ export const sanitizeClientFeatures = (
     },
   }
 
+  // Find custom group orders if they exist in any feature
+  let customGroupOrders: Record<string, number> = {}
+
+  // First pass to collect custom orders from features
+  features.forEach((feature) => {
+    if (feature.key === 'toolbarFixed' && feature.sanitizedClientFeatureProps?.customGroupOrders) {
+      customGroupOrders = {
+        ...customGroupOrders,
+        ...feature.sanitizedClientFeatureProps.customGroupOrders,
+      }
+    }
+  })
+
   if (!features?.size) {
     return sanitized
   }
@@ -170,13 +183,21 @@ export const sanitizeClientFeatures = (
       return 0
     }
   })
+
   // Sort sanitized.toolbarFixed.groups by order property
   sanitized.toolbarFixed.groups.sort((a, b) => {
-    if (a.order && b.order) {
-      return a.order - b.order
-    } else if (a.order) {
+    const aCustomOrder = customGroupOrders[a.key]
+    const bCustomOrder = customGroupOrders[b.key]
+
+    // Use custom orders if available, otherwise fall back to default logic
+    const aOrder = aCustomOrder !== undefined ? aCustomOrder : a.order
+    const bOrder = bCustomOrder !== undefined ? bCustomOrder : b.order
+
+    if (aOrder && bOrder) {
+      return aOrder - bOrder
+    } else if (aOrder) {
       return -1
-    } else if (b.order) {
+    } else if (bOrder) {
       return 1
     } else {
       return 0


### PR DESCRIPTION
### What
This PR introduces a customizable ordering system for toolbar groups in the Lexical Rich Text Editor. It allows developers to override the default order of toolbar components (such as format, align, indent) by specifying custom order values through the `FixedToolbarFeature` configuration.

### Why
Previously, toolbar group ordering was hardcoded in each component (e.g., format group had order=40, align group had order=30, etc.). This made it impossible for developers to rearrange these components without modifying the source code.
This enhancement provides more flexibility for customizing the rich text editor interface to match specific project requirements or design preferences, without compromising the default behavior for users who don't need customization.

### How
The implementation consists of three key parts:
1. Extended the FixedToolbarFeature API:
- Added a new `customGroupOrders` property to `FixedToolbarFeatureProps` that accepts a record mapping group keys to custom order values
- Preserved all existing functionality while adding this new capability
2. Modified the sanitization process:
- Updated the `sanitizeClientFeatures` function to detect and collect custom order configurations from toolbar features
- Enhanced the toolbar group sorting logic to prioritize custom order values when available, while falling back to default ordering when no custom configuration exists
3. Maintained backward compatibility:
- The implementation is opt-in, preserving the existing behavior for all current users
- Default orders are still respected when no custom order is specified

### Usage Example
```
import { FixedToolbarFeature } from '@payloadcms/richtext-lexical'

{
  name: 'content',
  type: 'richText',
  admin: {
    features: [
      // Other features...
      FixedToolbarFeature({
        customGroupOrders: {
          'text': 10,
          'format': 15,
          'add': 20,
        }
      })
    ]
  }
}
```

### Before
https://github.com/user-attachments/assets/ac97ff81-f05c-49eb-bdb6-cfc6edc3041d

###  After
https://github.com/user-attachments/assets/529c6611-4e98-44bd-961b-8f7149197138


