### PR TITLE
docs: add getDataByPath to useForm table

### DIFF
--- a/docs/admin/react-hooks.mdx
+++ b/docs/admin/react-hooks.mdx
@@ -296,6 +296,17 @@ The `useForm` hook returns an object with the following properties:
     ],
     [
       {
+        value: "**`getDataByPath`**",
+      },
+      {
+        value: 'Returns form field data for the given field path. Useful when dealing with arrays, blocks, or other form state.',
+      },
+      {
+        value: '',
+      },
+    ],
+    [
+      {
         value: "**`setModified`**",
       },
       {


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR adds the `getDataByPath` utility function to the `useForm` table in the docs.

### Why?
This utility is useful for dealing with arrays and other form state. Users commonly ask for examples on how to deal with arrays when using `useField` as this function will return a length instead of the expected value object. 

### How?
Addition of `getDataByPath` to the `useForm` object table in `docs/admin/react-hooks.mdx`.