### PR TITLE
fix(db-sqlite): text field converts to floating point number

### DIFF
--- a/packages/drizzle/src/transform/write/traverseFields.ts
+++ b/packages/drizzle/src/transform/write/traverseFields.ts
@@ -496,6 +496,10 @@ export const traverseFields = ({
           formattedValue = sql`ST_GeomFromGeoJSON(${JSON.stringify(value)})`
         }
 
+        if (field.type === 'text' && typeof value !== 'string') {
+          formattedValue = JSON.stringify(value)
+        }
+
         if (field.type === 'date') {
           if (typeof value === 'number' && !Number.isNaN(value)) {
             formattedValue = new Date(value).toISOString()

--- a/packages/drizzle/src/transform/write/traverseFields.ts
+++ b/packages/drizzle/src/transform/write/traverseFields.ts
@@ -496,7 +496,7 @@ export const traverseFields = ({
           formattedValue = sql`ST_GeomFromGeoJSON(${JSON.stringify(value)})`
         }
 
-        if (field.type === 'text' && typeof value !== 'string') {
+        if (field.type === 'text' && value && typeof value !== 'string') {
           formattedValue = JSON.stringify(value)
         }
 

--- a/test/database/config.ts
+++ b/test/database/config.ts
@@ -45,6 +45,10 @@ export default buildConfigWithDefaults({
           required: true,
         },
         {
+          name: 'text',
+          type: 'text',
+        },
+        {
           name: 'number',
           type: 'number',
         },

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -1979,6 +1979,19 @@ describe('database', () => {
     })
   })
 
+  it('should convert numbers to text', async () => {
+    const result = await payload.create({
+      collection: postsSlug,
+      data: {
+        title: 'testing',
+        // @ts-expect-error hardcoding a number and expecting that it will convert to string
+        text: 1,
+      },
+    })
+
+    expect(result.text).toStrictEqual('1')
+  })
+
   it('should not allow to query by a field with `virtual: true`', async () => {
     await expect(
       payload.find({


### PR DESCRIPTION
### What?

Converts numbers passed to a text field to avoid the database/drizzle from converting it incorrectly.

### Why?

If you have a hook that passes a value to another field you can experience this problem where drizzle converts a number value for a text field to a floating point number in sqlite for example.

### How?

Adds logic to `transform/write/traverseFields.ts` to cast text field values to string.