### PR TITLE
fix: reordering draft documents causes data loss

### DIFF
--- a/packages/payload/src/config/orderable/index.ts
+++ b/packages/payload/src/config/orderable/index.ts
@@ -257,7 +257,6 @@ export const addOrderableEndpoint = (config: SanitizedConfig) => {
         },
         depth: 0,
         req,
-        select: { id: true },
       })
     }
 

--- a/test/sort/collections/Drafts/index.ts
+++ b/test/sort/collections/Drafts/index.ts
@@ -7,6 +7,7 @@ export const DraftsCollection: CollectionConfig = {
   admin: {
     useAsTitle: 'text',
   },
+  orderable: true,
   versions: {
     drafts: true,
   },


### PR DESCRIPTION
Re-ordering documents with drafts uses `payload.update()` with `select: { id: true }` and that causes draft versions of those docs to be updated without any data. I've removed the `select` optimization to prevent data loss.

Fixes #12097
