### PR TITLE
feat(ui): configure toasts to stack

### DIFF
--- a/packages/ui/src/providers/ToastContainer/index.tsx
+++ b/packages/ui/src/providers/ToastContainer/index.tsx
@@ -14,6 +14,7 @@ export const ToastContainer: React.FC = () => {
       closeButton
       // @ts-expect-error
       dir="undefined"
+      expand={true}
       gap={8}
       icons={{
         error: <Error />,


### PR DESCRIPTION
When multiple actions trigger toasts in rapid succession, newer toast is shown in front of the older ones, preventing users from reading all notification messages.

This commit modified the Toast admin component to customize Sonner toast behavior by adding `expand={true}` which keeps all toasts visible in a stacked layout rather than hidden after one another.

Documentation reference: https://sonner.emilkowal.ski/ (see "Expand")

#### Before

https://github.com/user-attachments/assets/1e951f26-036a-4cd6-b8f4-115319f0bd0e

#### After

https://github.com/user-attachments/assets/f77e2989-4840-44a3-b364-048463ebfe17

