### PR TITLE
perf(ui): prevent `blockType: "$undefined"` from being sent through the network

### DIFF
--- a/packages/ui/src/forms/Form/fieldReducer.ts
+++ b/packages/ui/src/forms/Form/fieldReducer.ts
@@ -28,9 +28,12 @@ export function fieldReducer(state: FormState, action: FieldAction): FormState {
 
       const newRow: Row = {
         id: (subFieldState?.id?.value as string) || new ObjectId().toHexString(),
-        blockType: blockType || undefined,
         collapsed: false,
         isLoading: true,
+      }
+
+      if (blockType) {
+        newRow.blockType = blockType
       }
 
       withNewRow.splice(rowIndex, 0, newRow)


### PR DESCRIPTION
Removes `$undefined` strings from being sent through the network when sending form state requests. When adding new array rows, we assign `blockType: undefined` which is stringified to `"$undefined"`. This is unnecessary, as simply not sending this property is equivalent, and this is only a requirement for blocks. This change will save on request size, albeit minimal.

| Before | After |
|--|--|
|<img width="1267" alt="Untitled" src="https://github.com/user-attachments/assets/699f38bd-7db9-4a52-931d-084b8af8530f" /> | <img width="1285" alt="image" src="https://github.com/user-attachments/assets/986ecd4c-f22d-4143-ad38-0c5f52439c67" /> |