### PR TITLE
feat: threads operation through field condition function

### DIFF
--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -541,6 +541,7 @@ The `ctx` object:
 | Property        | Description                                                                                                                                                  |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **`blockData`** | The nearest parent block's data. If the field is not inside a block, this will be `undefined`.                                                               |
+| **`operation`** | A string relating to which operation the field type is currently executing within.                                                                           |
 | **`path`**      | The full path to the field in the schema, represented as an array of string segments, including array indexes. I.e `['group', 'myArray', '1', 'textField']`. |
 | **`user`**      | The currently authenticated user object.                                                                                                                     |
 

--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -269,6 +269,7 @@ export type Condition<TData extends TypeWithID = any, TSiblingData = any> = (
   siblingData: Partial<TSiblingData>,
   {
     blockData,
+    operation,
     path,
     user,
   }: {
@@ -276,6 +277,10 @@ export type Condition<TData extends TypeWithID = any, TSiblingData = any> = (
      * The data of the nearest parent block. If the field is not within a block, `blockData` will be equal to `undefined`.
      */
     blockData: Partial<TData>
+    /**
+     * A string relating to which operation the field type is currently executing within.
+     */
+    operation: Operation
     /**
      * The path of the field, e.g. ["group", "myArray", 1, "textField"]. The path is the schemaPath but with indexes and would be used in the context of field data, not field schemas.
      */

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -109,7 +109,12 @@ export const promise = async ({
 
   const passesCondition = field.admin?.condition
     ? Boolean(
-        field.admin.condition(data, siblingData, { blockData, path: pathSegments, user: req.user }),
+        field.admin.condition(data, siblingData, {
+          blockData,
+          operation,
+          path: pathSegments,
+          user: req.user,
+        }),
       )
     : true
   let skipValidationFromHere = skipValidation || !passesCondition

--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -827,6 +827,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       if (passesCondition && typeof tab.admin?.condition === 'function') {
         tabPassesCondition = tab.admin.condition(fullData, data, {
           blockData,
+          operation,
           path: pathSegments,
           user: req.user,
         })

--- a/packages/ui/src/forms/fieldSchemasToFormState/iterateFields.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/iterateFields.ts
@@ -151,6 +151,7 @@ export const iterateFields = async ({
             ? Boolean(
                 field.admin.condition(fullData || {}, data || {}, {
                   blockData,
+                  operation,
                   path: pathSegments,
                   user: req.user,
                 }),

--- a/test/fields/collections/ConditionalLogic/e2e.spec.ts
+++ b/test/fields/collections/ConditionalLogic/e2e.spec.ts
@@ -10,6 +10,7 @@ import type { Config } from '../../payload-types.js'
 import {
   ensureCompilationIsDone,
   initPageConsoleErrorCatch,
+  saveDocAndAssert,
   // throttleTest,
 } from '../../../helpers.js'
 import { AdminUrlUtil } from '../../../helpers/adminUrlUtil.js'
@@ -229,8 +230,15 @@ describe('Conditional Logic', () => {
   test('should render field based on operation argument', async () => {
     await page.goto(url.create)
 
+    const textField = page.locator('#field-text')
     const fieldWithOperationCondition = page.locator('#field-fieldWithOperationCondition')
 
+    await textField.fill('some text')
+
     await expect(fieldWithOperationCondition).toBeVisible()
+
+    await saveDocAndAssert(page)
+
+    await expect(fieldWithOperationCondition).toBeHidden()
   })
 })

--- a/test/fields/collections/ConditionalLogic/e2e.spec.ts
+++ b/test/fields/collections/ConditionalLogic/e2e.spec.ts
@@ -225,4 +225,12 @@ describe('Conditional Logic', () => {
 
     await expect(numberField).toBeVisible()
   })
+
+  test('should render field based on operation argument', async () => {
+    await page.goto(url.create)
+
+    const fieldWithOperationCondition = page.locator('#field-fieldWithOperationCondition')
+
+    await expect(fieldWithOperationCondition).toBeVisible()
+  })
 })

--- a/test/fields/collections/ConditionalLogic/index.ts
+++ b/test/fields/collections/ConditionalLogic/index.ts
@@ -25,6 +25,19 @@ const ConditionalLogic: CollectionConfig = {
       },
     },
     {
+      name: 'fieldWithOperationCondition',
+      type: 'text',
+      admin: {
+        condition: (data, siblingData, { operation }) => {
+          if (operation === 'create') {
+            return true
+          }
+
+          return false
+        },
+      },
+    },
+    {
       name: 'customFieldWithField',
       type: 'text',
       admin: {
@@ -217,7 +230,7 @@ const ConditionalLogic: CollectionConfig = {
                   name: 'numberField',
                   type: 'number',
                   admin: {
-                    condition: (data, siblingData, { path, user }) => {
+                    condition: (data, siblingData, { path }) => {
                       // Ensure path has enough depth
                       if (path.length < 5) {
                         return false

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -790,6 +790,7 @@ export interface ConditionalLogic {
   text: string;
   toggleField?: boolean | null;
   fieldWithCondition?: string | null;
+  fieldWithOperationCondition?: string | null;
   customFieldWithField?: string | null;
   customFieldWithHOC?: string | null;
   customClientFieldWithCondition?: string | null;
@@ -2364,6 +2365,7 @@ export interface ConditionalLogicSelect<T extends boolean = true> {
   text?: T;
   toggleField?: T;
   fieldWithCondition?: T;
+  fieldWithOperationCondition?: T;
   customFieldWithField?: T;
   customFieldWithHOC?: T;
   customClientFieldWithCondition?: T;


### PR DESCRIPTION
This PR updates the field `condition` function property to include a new `operation` argument. 

The `operation` arg provides a string relating to which operation the field type is currently executing within.

#### Changes:

- Added `operation: Operation` in the Condition type.
- Updated relevant condition checks to ensure correct parameter usage.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210547304672295