### PR TITLE
fix(next): missing @payloadcms/next/auth export

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -156,6 +156,11 @@
         "types": "./dist/exports/templates.d.ts",
         "default": "./dist/exports/templates.js"
       },
+      "./auth": {
+        "import": "./dist/exports/auth.js",
+        "types": "./dist/exports/auth.d.ts",
+        "default": "./dist/exports/auth.js"
+      },
       "./utilities": {
         "import": "./dist/exports/utilities.js",
         "types": "./dist/exports/utilities.d.ts",


### PR DESCRIPTION
Follow up to #11900. The `@payloadcms/next/auth` export was missing from the published package.json because it was excluded from the `publishConfig` property.