### PR TITLE
feat: adds `showSaveDraftButton` option to show draft button with autosave enabled

### DIFF
--- a/docs/versions/autosave.mdx
+++ b/docs/versions/autosave.mdx
@@ -53,10 +53,10 @@ export const Pages: CollectionConfig = {
 
       // Alternatively, you can specify an object to customize autosave:
       // autosave: {
-      //   // Define how often the document should be autosaved (in milliseconds)
+      // Define how often the document should be autosaved (in milliseconds)
       //   interval: 1500,
       //
-      //   // Show the "Save as draft" button even while autosave is enabled
+      // Show the "Save as draft" button even while autosave is enabled
       //   showSaveDraftButton: true,
       // },
     },

--- a/docs/versions/autosave.mdx
+++ b/docs/versions/autosave.mdx
@@ -22,7 +22,7 @@ Collections and Globals both support the same options for configuring autosave. 
 | Drafts Autosave Options | Description                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `interval`              | Define an `interval` in milliseconds to automatically save progress while documents are edited. Document updates are "debounced" at this interval. Defaults to `800`. |
-| `showSaveDraftButton`   | Set this to `true` to show the "Save as draft" button even while autosave is running. By default, the "Save as draft" button is hidden when autosave is enabled.      |
+| `showSaveDraftButton`   | Set this to `true` to show the "Save as draft" button even while autosave is enabled. Defaults to `false`.                                                            |
 
 **Example config with versions, drafts, and autosave enabled:**
 

--- a/docs/versions/autosave.mdx
+++ b/docs/versions/autosave.mdx
@@ -22,6 +22,7 @@ Collections and Globals both support the same options for configuring autosave. 
 | Drafts Autosave Options | Description                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `interval`              | Define an `interval` in milliseconds to automatically save progress while documents are edited. Document updates are "debounced" at this interval. Defaults to `800`. |
+| `showSaveDraftButton`   | Set this to `true` to show the "Save as draft" button even while autosave is running. By default, the "Save as draft" button is hidden when autosave is enabled.      |
 
 **Example config with versions, drafts, and autosave enabled:**
 
@@ -50,9 +51,13 @@ export const Pages: CollectionConfig = {
     drafts: {
       autosave: true,
 
-      // Alternatively, you can specify an `interval`:
+      // Alternatively, you can specify an object to customize autosave:
       // autosave: {
+      //   // Define how often the document should be autosaved (in milliseconds)
       //   interval: 1500,
+      //
+      //   // Show the "Save as draft" button even while autosave is enabled
+      //   showSaveDraftButton: true,
       // },
     },
   },

--- a/packages/payload/src/versions/types.ts
+++ b/packages/payload/src/versions/types.ts
@@ -6,6 +6,13 @@ export type Autosave = {
    * @default 800
    */
   interval?: number
+  /**
+   * When set to `true`, the "Save as draft" button will be displayed even while autosave is enabled.
+   * By default, this button is hidden to avoid redundancy with autosave behavior.
+   *
+   * @default false
+   */
+  showSaveDraftButton?: boolean
 }
 
 export type SchedulePublish = {

--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -232,7 +232,9 @@ export const DocumentControls: React.FC<{
               <Fragment>
                 {collectionConfig?.versions?.drafts || globalConfig?.versions?.drafts ? (
                   <Fragment>
-                    {(unsavedDraftWithValidations || !autosaveEnabled || showSaveDraftButton) && (
+                    {(unsavedDraftWithValidations ||
+                      !autosaveEnabled ||
+                      (autosaveEnabled && showSaveDraftButton)) && (
                       <RenderCustomComponent
                         CustomComponent={CustomSaveDraftButton}
                         Fallback={<SaveDraftButton />}

--- a/packages/ui/src/elements/DocumentControls/index.tsx
+++ b/packages/ui/src/elements/DocumentControls/index.tsx
@@ -133,9 +133,23 @@ export const DocumentControls: React.FC<{
   const unsavedDraftWithValidations =
     !id && collectionConfig?.versions?.drafts && collectionConfig.versions?.drafts.validate
 
+  const collectionConfigDrafts = collectionConfig?.versions?.drafts
+  const globalConfigDrafts = globalConfig?.versions?.drafts
+
   const autosaveEnabled =
-    (collectionConfig?.versions?.drafts && collectionConfig?.versions?.drafts?.autosave) ||
-    (globalConfig?.versions?.drafts && globalConfig?.versions?.drafts?.autosave)
+    (collectionConfigDrafts && collectionConfigDrafts?.autosave) ||
+    (globalConfigDrafts && globalConfigDrafts?.autosave)
+
+  const collectionAutosaveEnabled = collectionConfigDrafts && collectionConfigDrafts?.autosave
+  const globalAutosaveEnabled = globalConfigDrafts && globalConfigDrafts?.autosave
+
+  const showSaveDraftButton =
+    (collectionAutosaveEnabled &&
+      collectionConfigDrafts.autosave !== false &&
+      collectionConfigDrafts.autosave.showSaveDraftButton === true) ||
+    (globalAutosaveEnabled &&
+      globalConfigDrafts.autosave !== false &&
+      globalConfigDrafts.autosave.showSaveDraftButton === true)
 
   const showCopyToLocale = localization && !collectionConfig?.admin?.disableCopyToLocale
 
@@ -218,7 +232,7 @@ export const DocumentControls: React.FC<{
               <Fragment>
                 {collectionConfig?.versions?.drafts || globalConfig?.versions?.drafts ? (
                   <Fragment>
-                    {(unsavedDraftWithValidations || !autosaveEnabled) && (
+                    {(unsavedDraftWithValidations || !autosaveEnabled || showSaveDraftButton) && (
                       <RenderCustomComponent
                         CustomComponent={CustomSaveDraftButton}
                         Fallback={<SaveDraftButton />}

--- a/test/versions/collections/AutosaveWithDraftButton.ts
+++ b/test/versions/collections/AutosaveWithDraftButton.ts
@@ -1,0 +1,32 @@
+import type { CollectionConfig } from 'payload'
+
+import { autosaveWithDraftButtonSlug } from '../slugs.js'
+
+const AutosaveWithDraftButtonPosts: CollectionConfig = {
+  slug: autosaveWithDraftButtonSlug,
+  labels: {
+    singular: 'Autosave with Draft Button Post',
+    plural: 'Autosave with Draft Button Posts',
+  },
+  admin: {
+    useAsTitle: 'title',
+    defaultColumns: ['title', 'subtitle', 'createdAt', '_status'],
+  },
+  versions: {
+    drafts: {
+      autosave: {
+        showSaveDraftButton: true,
+        interval: 1000,
+      },
+    },
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+  ],
+}
+
+export default AutosaveWithDraftButtonPosts

--- a/test/versions/config.ts
+++ b/test/versions/config.ts
@@ -4,6 +4,7 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import AutosavePosts from './collections/Autosave.js'
+import AutosaveWithDraftButtonPosts from './collections/AutosaveWithDraftButton.js'
 import AutosaveWithValidate from './collections/AutosaveWithValidate.js'
 import CustomIDs from './collections/CustomIDs.js'
 import { Diff } from './collections/Diff/index.js'
@@ -17,6 +18,7 @@ import Posts from './collections/Posts.js'
 import { TextCollection } from './collections/Text.js'
 import VersionPosts from './collections/Versions.js'
 import AutosaveGlobal from './globals/Autosave.js'
+import AutosaveWithDraftButtonGlobal from './globals/AutosaveWithDraftButton.js'
 import DisablePublishGlobal from './globals/DisablePublish.js'
 import DraftGlobal from './globals/Draft.js'
 import DraftWithMaxGlobal from './globals/DraftWithMax.js'
@@ -35,6 +37,7 @@ export default buildConfigWithDefaults({
     DisablePublish,
     Posts,
     AutosavePosts,
+    AutosaveWithDraftButtonPosts,
     AutosaveWithValidate,
     DraftPosts,
     DraftWithMax,
@@ -46,7 +49,14 @@ export default buildConfigWithDefaults({
     TextCollection,
     Media,
   ],
-  globals: [AutosaveGlobal, DraftGlobal, DraftWithMaxGlobal, DisablePublishGlobal, LocalizedGlobal],
+  globals: [
+    AutosaveGlobal,
+    AutosaveWithDraftButtonGlobal,
+    DraftGlobal,
+    DraftWithMaxGlobal,
+    DisablePublishGlobal,
+    LocalizedGlobal,
+  ],
   indexSortableFields: true,
   localization: {
     defaultLocale: 'en',

--- a/test/versions/globals/AutosaveWithDraftButton.ts
+++ b/test/versions/globals/AutosaveWithDraftButton.ts
@@ -1,0 +1,26 @@
+import type { GlobalConfig } from 'payload'
+
+import { autosaveWithDraftButtonGlobal } from '../slugs.js'
+
+const AutosaveWithDraftButtonGlobal: GlobalConfig = {
+  slug: autosaveWithDraftButtonGlobal,
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      localized: true,
+      required: true,
+    },
+  ],
+  label: 'Autosave with Draft Button Global',
+  versions: {
+    drafts: {
+      autosave: {
+        showSaveDraftButton: true,
+        interval: 1000,
+      },
+    },
+  },
+}
+
+export default AutosaveWithDraftButtonGlobal

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -70,6 +70,7 @@ export interface Config {
     'disable-publish': DisablePublish;
     posts: Post;
     'autosave-posts': AutosavePost;
+    'autosave-with-draft-button-posts': AutosaveWithDraftButtonPost;
     'autosave-with-validate-posts': AutosaveWithValidatePost;
     'draft-posts': DraftPost;
     'draft-with-max-posts': DraftWithMaxPost;
@@ -91,6 +92,7 @@ export interface Config {
     'disable-publish': DisablePublishSelect<false> | DisablePublishSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
     'autosave-posts': AutosavePostsSelect<false> | AutosavePostsSelect<true>;
+    'autosave-with-draft-button-posts': AutosaveWithDraftButtonPostsSelect<false> | AutosaveWithDraftButtonPostsSelect<true>;
     'autosave-with-validate-posts': AutosaveWithValidatePostsSelect<false> | AutosaveWithValidatePostsSelect<true>;
     'draft-posts': DraftPostsSelect<false> | DraftPostsSelect<true>;
     'draft-with-max-posts': DraftWithMaxPostsSelect<false> | DraftWithMaxPostsSelect<true>;
@@ -112,6 +114,7 @@ export interface Config {
   };
   globals: {
     'autosave-global': AutosaveGlobal;
+    'autosave-with-draft-button-global': AutosaveWithDraftButtonGlobal;
     'draft-global': DraftGlobal;
     'draft-with-max-global': DraftWithMaxGlobal;
     'disable-publish-global': DisablePublishGlobal;
@@ -119,6 +122,7 @@ export interface Config {
   };
   globalsSelect: {
     'autosave-global': AutosaveGlobalSelect<false> | AutosaveGlobalSelect<true>;
+    'autosave-with-draft-button-global': AutosaveWithDraftButtonGlobalSelect<false> | AutosaveWithDraftButtonGlobalSelect<true>;
     'draft-global': DraftGlobalSelect<false> | DraftGlobalSelect<true>;
     'draft-with-max-global': DraftWithMaxGlobalSelect<false> | DraftWithMaxGlobalSelect<true>;
     'disable-publish-global': DisablePublishGlobalSelect<false> | DisablePublishGlobalSelect<true>;
@@ -224,6 +228,17 @@ export interface DraftPost {
     | null;
   relation?: (string | null) | DraftPost;
   restrictedToUpdate?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "autosave-with-draft-button-posts".
+ */
+export interface AutosaveWithDraftButtonPost {
+  id: string;
+  title: string;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -555,6 +570,10 @@ export interface PayloadLockedDocument {
         value: string | AutosavePost;
       } | null)
     | ({
+        relationTo: 'autosave-with-draft-button-posts';
+        value: string | AutosaveWithDraftButtonPost;
+      } | null)
+    | ({
         relationTo: 'autosave-with-validate-posts';
         value: string | AutosaveWithValidatePost;
       } | null)
@@ -672,6 +691,16 @@ export interface PostsSelect<T extends boolean = true> {
 export interface AutosavePostsSelect<T extends boolean = true> {
   title?: T;
   description?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "autosave-with-draft-button-posts_select".
+ */
+export interface AutosaveWithDraftButtonPostsSelect<T extends boolean = true> {
+  title?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
@@ -975,6 +1004,17 @@ export interface AutosaveGlobal {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "autosave-with-draft-button-global".
+ */
+export interface AutosaveWithDraftButtonGlobal {
+  id: string;
+  title: string;
+  _status?: ('draft' | 'published') | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "draft-global".
  */
 export interface DraftGlobal {
@@ -1023,6 +1063,17 @@ export interface LocalizedGlobal {
  * via the `definition` "autosave-global_select".
  */
 export interface AutosaveGlobalSelect<T extends boolean = true> {
+  title?: T;
+  _status?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "autosave-with-draft-button-global_select".
+ */
+export interface AutosaveWithDraftButtonGlobalSelect<T extends boolean = true> {
   title?: T;
   _status?: T;
   updatedAt?: T;
@@ -1082,10 +1133,15 @@ export interface TaskSchedulePublish {
   input: {
     type?: ('publish' | 'unpublish') | null;
     locale?: string | null;
-    doc?: {
-      relationTo: 'draft-posts';
-      value: string | DraftPost;
-    } | null;
+    doc?:
+      | ({
+          relationTo: 'autosave-posts';
+          value: string | AutosavePost;
+        } | null)
+      | ({
+          relationTo: 'draft-posts';
+          value: string | DraftPost;
+        } | null);
     global?: 'draft-global' | null;
     user?: (string | null) | User;
   };

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -1,5 +1,7 @@
 export const autosaveCollectionSlug = 'autosave-posts'
 
+export const autosaveWithDraftButtonSlug = 'autosave-with-draft-button-posts'
+
 export const autosaveWithValidateCollectionSlug = 'autosave-with-validate-posts'
 
 export const customIDSlug = 'custom-ids'
@@ -33,7 +35,11 @@ export const collectionSlugs = [
 ]
 
 export const autoSaveGlobalSlug = 'autosave-global'
+
+export const autosaveWithDraftButtonGlobal = 'autosave-with-draft-button-global'
+
 export const draftGlobalSlug = 'draft-global'
+
 export const draftWithMaxGlobalSlug = 'draft-with-max-global'
 
 export const globalSlugs = [autoSaveGlobalSlug, draftGlobalSlug]


### PR DESCRIPTION
This adds a new `showSaveDraftButton` option to the `versions.drafts.autosave` config for collections and globals.

By default, the "Save as draft" button is hidden when autosave is enabled. This new option allows the button to remain visible for manual saves while autosave is active.

Also updates the admin UI logic to conditionally render the button when this flag is set, and updates the documentation with an example usage.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210547304672290