### PR TITLE
fix: update docs default limit value to 0 in Local API example

### DIFF
--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -150,7 +150,7 @@ const result = await payload.find({
   collection: 'posts', // required
   depth: 2,
   page: 1,
-  limit: 10,
+  limit: 0, // default to 0 to disable limit, to enable increase the limit
   pagination: false, // If you want to disable pagination count, etc.
   where: {}, // pass a `where` query here
   sort: '-title',


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change
-->
### What?
An implicit default limit of 10 documents returned when using the Payload Local API as mentioned in the document as I have set the `limit:0` to disable it.

### Why?
Because all of the time it's not necessary to fix the limit to 10 as default, there can be cases to disable it.

### How?
```js
const result = await payload.find({
  collection: 'posts', // required
  depth: 2,
  page: 1,
  limit: 0, // default to 0 to disable limit, to enable increase the limit
})
```
Fixes #12140 


