### PR TITLE
docs: fix query preset config link

### DIFF
--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -193,13 +193,13 @@ export const MyCollection: CollectionConfig = {
 
 The following options are available:
 
-| Option            | Description                                                                                                                                                                                               |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SaveButton`      | Replace the default Save Button within the Edit View. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#save-button).                                          |
-| `SaveDraftButton` | Replace the default Save Draft Button within the Edit View. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#save-draft-button). |
-| `PublishButton`   | Replace the default Publish Button within the Edit View. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publish-button).                                     |
-| `PreviewButton`   | Replace the default Preview Button within the Edit View. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#preview-button).                                      |
-| `Upload`          | Replace the default Upload component within the Edit View. [Upload](../upload/overview) must be enabled. [More details](../custom-components/edit-view#upload).                                           |
+| Option            | Description                                                                                                                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SaveButton`      | Replace the default Save Button within the Edit View. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#savebutton).                                         |
+| `SaveDraftButton` | Replace the default Save Draft Button within the Edit View. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#savedraftbutton). |
+| `PublishButton`   | Replace the default Publish Button within the Edit View. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publishbutton).                                    |
+| `PreviewButton`   | Replace the default Preview Button within the Edit View. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#previewbutton).                                     |
+| `Upload`          | Replace the default Upload component within the Edit View. [Upload](../upload/overview) must be enabled. [More details](../custom-components/edit-view#upload).                                         |
 
 <Banner type="success">
   **Note:** For details on how to build Custom Components, see [Building Custom

--- a/docs/configuration/globals.mdx
+++ b/docs/configuration/globals.mdx
@@ -179,12 +179,12 @@ export const MyGlobal: SanitizedGlobalConfig = {
 
 The following options are available:
 
-| Option            | Description                                                                                                                                                                                                  |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `SaveButton`      | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#save-button).                                          |
-| `SaveDraftButton` | Replace the default Save Draft Button with a Custom Component. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#save-draft-button). |
-| `PublishButton`   | Replace the default Publish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publish-button).                                     |
-| `PreviewButton`   | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#preview-button).                                      |
+| Option            | Description                                                                                                                                                                                                |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SaveButton`      | Replace the default Save Button with a Custom Component. [Drafts](../versions/drafts) must be disabled. [More details](../custom-components/edit-view#savebutton).                                         |
+| `SaveDraftButton` | Replace the default Save Draft Button with a Custom Component. [Drafts](../versions/drafts) must be enabled and autosave must be disabled. [More details](../custom-components/edit-view#savedraftbutton). |
+| `PublishButton`   | Replace the default Publish Button with a Custom Component. [Drafts](../versions/drafts) must be enabled. [More details](../custom-components/edit-view#publishbutton).                                    |
+| `PreviewButton`   | Replace the default Preview Button with a Custom Component. [Preview](../admin/preview) must be enabled. [More details](../custom-components/edit-view#previewbutton).                                     |
 
 <Banner type="success">
   **Note:** For details on how to build Custom Components, see [Building Custom

--- a/docs/query-presets/overview.mdx
+++ b/docs/query-presets/overview.mdx
@@ -128,26 +128,28 @@ const config = buildConfig({
     // ...
     // highlight-start
     constraints: {
-      read: {
-        label: 'Specific Roles',
-        value: 'specificRoles',
-        fields: [
-          {
-            name: 'roles',
-            type: 'select',
-            hasMany: true,
-            options: [
-              { label: 'Admin', value: 'admin' },
-              { label: 'User', value: 'user' },
-            ],
-          },
-        ],
-        access: ({ req: { user } }) => ({
-          'access.read.roles': {
-            in: [user?.roles],
-          },
-        }),
-      },
+      read: [
+        {
+          label: 'Specific Roles',
+          value: 'specificRoles',
+          fields: [
+            {
+              name: 'roles',
+              type: 'select',
+              hasMany: true,
+              options: [
+                { label: 'Admin', value: 'admin' },
+                { label: 'User', value: 'user' },
+              ],
+            },
+          ],
+          access: ({ req: { user } }) => ({
+            'access.read.roles': {
+              in: [user?.roles],
+            },
+          }),
+        },
+      ],
       // highlight-end
     },
   },

--- a/docs/query-presets/overview.mdx
+++ b/docs/query-presets/overview.mdx
@@ -117,7 +117,7 @@ Adding custom access control rules requires:
 2. A set of fields to conditionally render when that option is selected
 3. A function that returns the access control rules for that option
 
-To do this, use the `queryPresets.constraints` property in your [Payload Config](../configuration/payload-config).
+To do this, use the `queryPresets.constraints` property in your [Payload Config](../configuration/overview).
 
 ```ts
 import { buildConfig } from 'payload'


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR fixes a link to the Payload config in the query presets docs, and adjusts the links to the edit view components in the collections and global config pages.

### Why?
To direct users to the correct location.

### How?
Changes to a few docs.

Fixes #12199 