### PR TITLE
fix(db-mongodb): fallback `version` when not selected

### DIFF
--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -166,7 +166,7 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
 
   for (let i = 0; i < result.docs.length; i++) {
     const id = result.docs[i].parent
-    result.docs[i] = result.docs[i].version
+    result.docs[i] = result.docs[i].version ?? {}
     result.docs[i].id = id
   }
 

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -2351,4 +2351,15 @@ describe('database', () => {
 
     payload.db.allowAdditionalKeys = false
   })
+
+  it('should not crash when the version field is not selected', async () => {
+    const customID = await payload.create({ collection: 'custom-ids', data: {} })
+    const res = await payload.db.queryDrafts({
+      collection: 'custom-ids',
+      where: { parent: { equals: customID.id } },
+      select: { parent: true },
+    })
+
+    expect(res.docs[0].id).toBe(customID.id)
+  })
 })


### PR DESCRIPTION
When doing `payload.db.queryDrafts` with `select` without `version`, or simply your select looks like:
`select: { version: { nonExistingField: true } }` - the `queryDrafts` function will crash because it tries to access the `version` field.
This PR adds a fallback.