### PR TITLE
fix(examples): Update adminsAndUser to use the filter correctly

### DIFF
--- a/examples/auth/src/collections/access/adminsAndUser.ts
+++ b/examples/auth/src/collections/access/adminsAndUser.ts
@@ -9,7 +9,7 @@ const adminsAndUser: Access = ({ req: { user } }) => {
     }
 
     return {
-      id: user.id,
+      id: {equals: user.id},
     }
   }
 


### PR DESCRIPTION
### What?
fix the filter for this role

### Why?
Using the filter in its current format produces:
```
Type error: Type '({ req: { user } }: AccessArgs<any>) => boolean | { id: string; }' is not assignable to type 'Access'.
  Type 'boolean | { id: string; }' is not assignable to type 'AccessResult | Promise<AccessResult>'.
    Type '{ id: string; }' is not assignable to type 'AccessResult | Promise<AccessResult>'.
      Type '{ id: string; }' is not assignable to type 'Where'.
        Property 'id' is incompatible with index signature.
          Type 'string' is not assignable to type 'Where[] | WhereField'.
```

### How?

`{id: user.id}` => `{id: {equals: user.id}}`

Fixes #
https://discord.com/channels/967097582721572934/1363435593454846054