### PR TITLE
docs: add FerretDB to join caveats

### DIFF
--- a/docs/database/mongodb.mdx
+++ b/docs/database/mongodb.mdx
@@ -55,9 +55,9 @@ You can access Mongoose models as follows:
 
 ## Using other MongoDB implementations
 
-Limitations with [DocumentDB](https://aws.amazon.com/documentdb/) and [Azure Cosmos DB](https://azure.microsoft.com/en-us/products/cosmos-db):
+Limitations with [FerretDB](https://www.ferretdb.com/), [DocumentDB](https://aws.amazon.com/documentdb/) and [Azure Cosmos DB](https://azure.microsoft.com/en-us/products/cosmos-db):
 
 - For Azure Cosmos DB you must pass `transactionOptions: false` to the adapter options. Azure Cosmos DB does not support transactions that update two and more documents in different collections, which is a common case when using Payload (via hooks).
 - For Azure Cosmos DB the root config property `indexSortableFields` must be set to `true`.
-- The [Join Field](../fields/join) is not supported in DocumentDB and Azure Cosmos DB, as we internally use MongoDB aggregations to query data for that field, which are limited there. This can be changed in the future.
+- The [Join Field](../fields/join) is not supported in FerretDB, DocumentDB and Azure Cosmos DB, as we internally use MongoDB aggregations to query data for that field, which are limited there. This can be changed in the future.
 - For DocumentDB pass `disableIndexHints: true` to disable hinting to the DB to use `id` as index which can cause problems with DocumentDB.

--- a/docs/fields/join.mdx
+++ b/docs/fields/join.mdx
@@ -66,7 +66,7 @@ of relationship types in an easy manner.
 </Banner>
 
 <Banner type="warning">
-  The Join Field is not supported in
+  The Join Field is not supported in [FerretDB](https://www.ferretdb.com/),
   [DocumentDB](https://aws.amazon.com/documentdb/) and [Azure Cosmos
   DB](https://azure.microsoft.com/en-us/products/cosmos-db), as we internally
   use MongoDB aggregations to query data for that field, which are limited


### PR DESCRIPTION
### What?
Update docs to include FerretDB amongst DocumentDB and Cosmos DB in lacking support for Join Fields.

### Why?
Join Fields don't work inside FerretDB, presumably because (Microsoft) DocumentDB is now being used within FerretDB to connect to Postgres. This update also resolves the corresponding issue, [12188](https://github.com/payloadcms/payload/issues/12188).

### How?
Updated the documentation in the two places where Join Field caveats are mentioned, inside the MongoDB documentation, and the Join Field documentation.
