### PR TITLE
docs: update form builder docs

### DIFF
--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -123,9 +123,9 @@ formBuilderPlugin({
 For full types with `beforeChangeParams`, you can import the types from the plugin:
 
 ```ts
-import type { BeforeEmail } from '@payloadcms/plugin-form-builder'
+import type { BeforeEmail } from '@payloadcms/plugin-form-builder/types'
 // Your generated FormSubmission type
-import type { FormSubmission } from '@payload-types'
+import type { FormSubmission } from '@/payload-types'
 
 // Pass it through and 'data' or 'originalDoc' will now be typed
 const beforeEmail: BeforeEmail<FormSubmission> = (


### PR DESCRIPTION
Simple updates to documentation after testing out the options for a video script. 

BeforeEmail doesn't exist in '@payloadcms/plugin-form-builder' but it does in '@payloadcms/plugin-form-builder/types.'
Importing anything from '@payload-types' doesn't work, as it should be '@/payload-types'

<img width="791" alt="image" src="https://github.com/user-attachments/assets/60d3d702-dff0-42a7-b615-4ea2f3bcad29" />

### What?
Simple update to the documentation to correctly reflect where to find the BeforeEmail types. Also correcting a type that didn't include the proper file path to payload-types.

### Why?
Clarification and fixing typos.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
