### PR TITLE
fix: allow custom admin user collection in query presets constraints

### DIFF
--- a/packages/payload/src/query-presets/constraints.ts
+++ b/packages/payload/src/query-presets/constraints.ts
@@ -74,7 +74,7 @@ export const getConstraints = (config: Config): Field => ({
                 },
               ],
             },
-            relationTo: config.admin?.user ?? 'users'
+            relationTo: config.admin?.user ?? 'users', // TODO: remove this fallback when the args are properly typed as `SanitizedConfig`
           },
           ...(config?.queryPresets?.constraints?.[operation]?.reduce(
             (acc: Field[], option: QueryPresetConstraint) => {

--- a/packages/payload/src/query-presets/constraints.ts
+++ b/packages/payload/src/query-presets/constraints.ts
@@ -74,7 +74,7 @@ export const getConstraints = (config: Config): Field => ({
                 },
               ],
             },
-            relationTo: config.admin?.user ?? 'users',
+            relationTo: config.admin?.user
           },
           ...(config?.queryPresets?.constraints?.[operation]?.reduce(
             (acc: Field[], option: QueryPresetConstraint) => {

--- a/packages/payload/src/query-presets/constraints.ts
+++ b/packages/payload/src/query-presets/constraints.ts
@@ -74,7 +74,7 @@ export const getConstraints = (config: Config): Field => ({
                 },
               ],
             },
-            relationTo: 'users',
+            relationTo: config.admin?.user ?? 'users',
           },
           ...(config?.queryPresets?.constraints?.[operation]?.reduce(
             (acc: Field[], option: QueryPresetConstraint) => {

--- a/packages/payload/src/query-presets/constraints.ts
+++ b/packages/payload/src/query-presets/constraints.ts
@@ -74,7 +74,7 @@ export const getConstraints = (config: Config): Field => ({
                 },
               ],
             },
-            relationTo: config.admin?.user
+            relationTo: config.admin?.user ?? 'users'
           },
           ...(config?.queryPresets?.constraints?.[operation]?.reduce(
             (acc: Field[], option: QueryPresetConstraint) => {


### PR DESCRIPTION
Query preset "Specific User" constraints is currently fixed to `users` collection.  
However, this will fail if one has a custom admin user collection.


<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
