### PR TITLE
fix(plugin-seo): allow uploading images directly

### DIFF
--- a/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
@@ -31,6 +31,7 @@ export const MetaImageComponent: React.FC<MetaImageProps> = (props) => {
     field: { label, localized, relationTo, required },
     hasGenerateImageFn,
     readOnly,
+    allowCreate=true,
   } = props
 
   const {
@@ -190,6 +191,7 @@ export const MetaImageComponent: React.FC<MetaImageProps> = (props) => {
           }}
           path={path}
           readOnly={readOnly}
+          allowCreate={allowCreate}
           relationTo={relationTo}
           required={required}
           serverURL={serverURL}


### PR DESCRIPTION
There is no way to upload images in the plugin-seo/images field using the current custom component. Can we add in this field for the ui/upload component to enable uploads?  Can be disabled by passing a prop to the custom component.

<img width="460" alt="image" src="https://github.com/user-attachments/assets/422e177e-f404-4f18-b805-dce22b1462c2" />

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
