### PR TITLE
chore: reproduce postgres bug when updating currently logged-in user

### DIFF
--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -35,16 +35,18 @@ export default buildConfigWithDefaults({
       },
       hooks: {
         afterChange: [
-          async ({ req }) => {
-            // This afterChange hook is required to reproduce the "should update user with afterChange hook while logged in with same user" test
-            await req.payload.create({
-              collection: 'relationsCollection',
-              depth: 0,
-              overrideAccess: true,
-              data: {
-                rel: req?.user?.id,
-              },
-            })
+          async ({ req, doc, operation }) => {
+            if (operation === 'update') {
+              // This afterChange hook is required to reproduce the "should update user with afterChange hook while logged in with same user" test
+              await req.payload.create({
+                collection: 'relationsCollection',
+                depth: 0,
+                overrideAccess: true,
+                data: {
+                  rel: doc?.id,
+                },
+              })
+            }
           },
         ],
       },

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -33,6 +33,21 @@ export default buildConfigWithDefaults({
       admin: {
         useAsTitle: 'custom',
       },
+      hooks: {
+        afterChange: [
+          async ({ req }) => {
+            // This afterChange hook is required to reproduce the "should update user with afterChange hook while logged in with same user" test
+            await req.payload.create({
+              collection: 'relationsCollection',
+              depth: 0,
+              overrideAccess: true,
+              data: {
+                rel: req?.user?.id,
+              },
+            })
+          },
+        ],
+      },
       auth: {
         cookies: {
           domain: undefined,

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -1062,8 +1062,6 @@ describe('Auth', () => {
             equals: user.id,
           },
         },
-        user,
-        overrideAccess: false,
         data: {
           email: user.email,
         },

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -1045,5 +1045,32 @@ describe('Auth', () => {
       expect(emailValidation('user@-example.com', mockContext)).toBe('validation:emailAddress')
       expect(emailValidation('user@example-.com', mockContext)).toBe('validation:emailAddress')
     })
+
+    it('should update user with afterChange hook while logged in with same user', async () => {
+      // Reproduces a bug where updating the user causes payload to hang on postgres.
+      const { user } = await payload.login({
+        collection: slug,
+        data: {
+          email: 'dev@payloadcms.com',
+          password: 'test',
+        },
+      })
+      const updatedUser = await payload.update({
+        collection: slug,
+        where: {
+          id: {
+            equals: user.id,
+          },
+        },
+        user,
+        overrideAccess: false,
+        data: {
+          email: user.email,
+        },
+      })
+
+      expect(updatedUser.docs).toHaveLength(1)
+      expect(updatedUser?.docs?.[0]?.email).toStrictEqual(user.email)
+    })
   })
 })


### PR DESCRIPTION
Following scenario:
1. update user while currently logged in with said user
2. that user has an afterChange hook, which creates a new document
3. that document has a relation back to said user
4. the create operation in the afterChange hook will freeze when trying to insert that relationship: https://github.com/payloadcms/payload/blob/fix/user-bug/packages/drizzle/src/upsertRow/index.ts#L192