### PR TITLE
perf(graphql): skip count query for join field using simple pagination

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -398,6 +398,7 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           depth: 0,
           draft,
           fallbackLocale: req.fallbackLocale,
+          // Fetch one extra document to determine if there are more documents beyond the requested limit (used for hasNextPage calculation).
           limit: typeof limit === 'number' && limit > 0 ? limit + 1 : 0,
           locale: req.locale,
           overrideAccess: false,

--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -393,19 +393,31 @@ export const fieldToSchemaMap: FieldToSchemaMap = {
           throw new Error('GraphQL with array of join.field.collection is not implemented')
         }
 
-        return await req.payload.find({
+        const { docs } = await req.payload.find({
           collection,
           depth: 0,
           draft,
           fallbackLocale: req.fallbackLocale,
-          limit,
+          limit: typeof limit === 'number' && limit > 0 ? limit + 1 : 0,
           locale: req.locale,
           overrideAccess: false,
           page,
+          pagination: false,
           req,
           sort,
           where: fullWhere,
         })
+
+        let shouldSlice = false
+
+        if (typeof limit === 'number' && limit !== 0 && limit < docs.length) {
+          shouldSlice = true
+        }
+
+        return {
+          docs: shouldSlice ? docs.slice(0, -1) : docs,
+          hasNextPage: limit === 0 ? false : limit < docs.length,
+        }
       },
     }
 


### PR DESCRIPTION
GraphQL requests with join fields  result in a lot of extra count rows queries that aren't necessary. This turns off pagination and uses a simple limit and slice instead.