### PR TITLE
perf(plugin-search): reduce query depth in hooks

### DIFF
--- a/packages/plugin-search/src/utilities/generateReindexHandler.ts
+++ b/packages/plugin-search/src/utilities/generateReindexHandler.ts
@@ -124,14 +124,15 @@ export const generateReindexHandler =
         for (let i = 0; i < totalBatches; i++) {
           const { docs } = await payload.find({
             collection,
+            depth: 0,
             limit: batchSize,
             locale: localeToSync,
             page: i + 1,
             ...defaultLocalApiProps,
           })
 
-          const promises = docs.map((doc) =>
-            syncDocAsSearchIndex({
+          for (const doc of docs) {
+            await syncDocAsSearchIndex({
               collection,
               doc,
               locale: localeToSync,
@@ -139,12 +140,7 @@ export const generateReindexHandler =
               operation,
               pluginConfig,
               req,
-            }),
-          )
-
-          // Sequentially await promises to avoid transaction issues
-          for (const promise of promises) {
-            await promise
+            })
           }
         }
       }

--- a/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
+++ b/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
@@ -64,18 +64,17 @@ export const syncDocAsSearchIndex = async ({
   const doSync = syncDrafts || (!syncDrafts && status !== 'draft')
 
   try {
-    if (operation === 'create') {
-      if (doSync) {
-        await payload.create({
-          collection: searchSlug,
-          data: {
-            ...dataToSave,
-            priority: defaultPriority,
-          },
-          locale: syncLocale,
-          req,
-        })
-      }
+    if (operation === 'create' && doSync) {
+      await payload.create({
+        collection: searchSlug,
+        data: {
+          ...dataToSave,
+          priority: defaultPriority,
+        },
+        depth: 0,
+        locale: syncLocale,
+        req,
+      })
     }
 
     if (operation === 'update') {
@@ -110,6 +109,7 @@ export const syncDocAsSearchIndex = async ({
             const duplicativeDocIDs = duplicativeDocs.map(({ id }) => id)
             await payload.delete({
               collection: searchSlug,
+              depth: 0,
               req,
               where: { id: { in: duplicativeDocIDs } },
             })
@@ -134,6 +134,7 @@ export const syncDocAsSearchIndex = async ({
                   ...dataToSave,
                   priority: foundDoc.priority || defaultPriority,
                 },
+                depth: 0,
                 locale: syncLocale,
                 req,
               })
@@ -148,6 +149,7 @@ export const syncDocAsSearchIndex = async ({
               docs: [docWithPublish],
             } = await payload.find({
               collection,
+              depth: 0,
               draft: false,
               limit: 1,
               locale: syncLocale,
@@ -175,6 +177,7 @@ export const syncDocAsSearchIndex = async ({
                 await payload.delete({
                   id: searchDocID,
                   collection: searchSlug,
+                  depth: 0,
                   req,
                 })
               } catch (err: unknown) {
@@ -190,6 +193,7 @@ export const syncDocAsSearchIndex = async ({
                 ...dataToSave,
                 priority: defaultPriority,
               },
+              depth: 0,
               locale: syncLocale,
               req,
             })


### PR DESCRIPTION
Perf improvements and reliability of document reindexing and synchronization of plugin-search functions.

## What

Reindex Handler (generateReindexHandler.ts):
- Replaced `Promise.all` with sequential `await` to prevent transaction issues.
- Added `depth: 0` to payload.find for lighter queries.

Sync Operations (syncDocAsSearchIndex.ts):
- Standardized depth: 0 across create, delete, update, and find API calls.
- Streamlined conditionals for create operations.

## Why
Improved performance with reduced query overhead.
Enhanced transaction safety by avoiding parallel database operations.