### PR TITLE
fix(ui): fix typo in CodeEditor export

### DIFF
--- a/packages/ui/src/exports/client/index.ts
+++ b/packages/ui/src/exports/client/index.ts
@@ -161,7 +161,7 @@ export { BlocksField } from '../../fields/Blocks/index.js'
 export { CheckboxField, CheckboxInput } from '../../fields/Checkbox/index.js'
 export { CodeField } from '../../fields/Code/index.js'
 export { CodeEditor as CodeEditorLazy } from '../../elements/CodeEditor/index.js'
-export { default as CodeEdiftor } from '../../elements/CodeEditor/CodeEditor.js'
+export { default as CodeEditor } from '../../elements/CodeEditor/CodeEditor.js'
 
 export { CollapsibleField } from '../../fields/Collapsible/index.js'
 export { ConfirmPasswordField } from '../../fields/ConfirmPassword/index.js'


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change -->

### What?

Fixes a typo, the *CodeEditor* component is currently exported as *CodeEdi~~f~~tor*.

### Why?

I don't want to use `<CodeEdiftor />` in my codebase 😅

### How?

Magic ✨
