### PR TITLE
fix(examples): incorrect documentation links for Live Preview example

### DIFF
--- a/examples/live-preview/README.md
+++ b/examples/live-preview/README.md
@@ -58,7 +58,7 @@ See the [Collections](https://payloadcms.com/docs/configuration/collections) doc
   }
   ```
 
-  For more details on how to extend this functionality, see the [Live Preview](https://payloadcms.com/docs/live-preview) docs.
+  For more details on how to extend this functionality, see the [Live Preview](https://payloadcms.com/docs/live-preview/overview) docs.
 
 ## Front-end
 

--- a/examples/live-preview/src/migrations/seed.ts
+++ b/examples/live-preview/src/migrations/seed.ts
@@ -36,7 +36,7 @@ export const home: Partial<Page> = {
           type: 'link',
           children: [{ text: 'Live Preview' }],
           newTab: true,
-          url: 'https://payloadcms.com/docs/live-preview',
+          url: 'https://payloadcms.com/docs/live-preview/overview',
         },
         {
           text: ' you can edit this page in the admin panel and see the changes reflected here in real time.',


### PR DESCRIPTION
Fixes a couple links in the Live Preview example that were pointing to `/docs/live-preview` instead of `/docs/live-preview/overview`.
