### PR TITLE
fix(db-postgres): build `near` sort query properly for point fields

### DIFF
--- a/packages/drizzle/src/queries/buildQuery.ts
+++ b/packages/drizzle/src/queries/buildQuery.ts
@@ -79,6 +79,7 @@ const buildQuery = function buildQuery({
     joins,
     locale,
     parentIsLocalized,
+    rawSort: context.rawSort,
     selectFields,
     sort: context.sort,
     tableName,

--- a/packages/drizzle/src/queries/parseParams.ts
+++ b/packages/drizzle/src/queries/parseParams.ts
@@ -14,7 +14,7 @@ import { buildAndOrConditions } from './buildAndOrConditions.js'
 import { getTableColumnFromPath } from './getTableColumnFromPath.js'
 import { sanitizeQueryValue } from './sanitizeQueryValue.js'
 
-export type QueryContext = { sort: Sort }
+export type QueryContext = { rawSort?: SQL; sort: Sort }
 
 type Args = {
   adapter: DrizzleAdapter
@@ -348,6 +348,7 @@ export function parseParams({
                       }
                       if (geoConstraints.length) {
                         context.sort = relationOrPath
+                        context.rawSort = sql`${table[columnName]} <-> ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326)`
                         constraints.push(and(...geoConstraints))
                       }
                       break


### PR DESCRIPTION
Continuation of https://github.com/payloadcms/payload/pull/12185 and fix https://github.com/payloadcms/payload/issues/12221

The mentioned PR introduced auto sorting by the point field when a `near` query is used, but it didn't build actual needed query to order results by their distance to a _given_ (from the `near` query) point.

Now, we build:
```sql
order by pont_field <-> ST_SetSRID(ST_MakePoint(lng, lat), 4326)
```

Which does what we want