### PR TITLE
feat: added live preview svelte package

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -48,6 +48,8 @@ jobs:
             graphql
             live-preview
             live-preview-react
+            live-preview-svelte
+            live-preview-vue
             next
             payload-cloud
             plugin-cloud

--- a/docs/live-preview/client.mdx
+++ b/docs/live-preview/client.mdx
@@ -135,47 +135,6 @@ const { data } = useLivePreview<PageData>({
 </template>
 ```
 
-React
-
-If your front-end application is built with client-side [React](https://react.dev) like [Next.js Pages Router](https://nextjs.org/docs/pages), you can use the `useLivePreview` hook that Payload provides.
-
-First, install the `@payloadcms/live-preview-react` package:
-
-```bash
-npm install @payloadcms/live-preview-react
-```
-
-Then, use the `useLivePreview` hook in your React component:
-
-```tsx
-'use client'
-import { useLivePreview } from '@payloadcms/live-preview-react'
-import { Page as PageType } from '@/payload-types'
-
-// Fetch the page in a server component, pass it to the client component, then thread it through the hook
-// The hook will take over from there and keep the preview in sync with the changes you make
-// The `data` property will contain the live data of the document
-export const PageClient: React.FC<{
-  page: {
-    title: string
-  }
-}> = ({ page: initialPage }) => {
-  const { data } = useLivePreview<PageType>({
-    initialData: initialPage,
-    serverURL: PAYLOAD_SERVER_URL,
-    depth: 2,
-  })
-
-  return <h1>{data.title}</h1>
-}
-```
-
-<Banner type="warning">
-  **Reminder:** If you are using [React Server
-  Components](https://react.dev/reference/rsc/server-components), we strongly
-  suggest setting up [server-side Live Preview](./server) instead.
-</Banner>
-
 ### Svelte
 
 If your front-end application is built with [Svelte 5](https://svelte.dev/) or [SvelteKit 2](https://svelte.dev/docs/kit/introduction), you can use the `useLivePreview` writeable rune that Payload provides.
@@ -186,7 +145,7 @@ First, install the `@payloadcms/live-preview-svelte` package:
 npm install @payloadcms/live-preview-svelte
 ```
 
-Then, use the `useLivePreview` hook in your Vue component:
+Then, use the `useLivePreview` hook in your Svelte component:
 
 ```ts
 <script lang="ts">

--- a/docs/live-preview/client.mdx
+++ b/docs/live-preview/client.mdx
@@ -135,6 +135,88 @@ const { data } = useLivePreview<PageData>({
 </template>
 ```
 
+React
+
+If your front-end application is built with client-side [React](https://react.dev) like [Next.js Pages Router](https://nextjs.org/docs/pages), you can use the `useLivePreview` hook that Payload provides.
+
+First, install the `@payloadcms/live-preview-react` package:
+
+```bash
+npm install @payloadcms/live-preview-react
+```
+
+Then, use the `useLivePreview` hook in your React component:
+
+```tsx
+'use client'
+import { useLivePreview } from '@payloadcms/live-preview-react'
+import { Page as PageType } from '@/payload-types'
+
+// Fetch the page in a server component, pass it to the client component, then thread it through the hook
+// The hook will take over from there and keep the preview in sync with the changes you make
+// The `data` property will contain the live data of the document
+export const PageClient: React.FC<{
+  page: {
+    title: string
+  }
+}> = ({ page: initialPage }) => {
+  const { data } = useLivePreview<PageType>({
+    initialData: initialPage,
+    serverURL: PAYLOAD_SERVER_URL,
+    depth: 2,
+  })
+
+  return <h1>{data.title}</h1>
+}
+```
+
+<Banner type="warning">
+  **Reminder:** If you are using [React Server
+  Components](https://react.dev/reference/rsc/server-components), we strongly
+  suggest setting up [server-side Live Preview](./server) instead.
+</Banner>
+
+### Svelte
+
+If your front-end application is built with [Svelte 5](https://svelte.dev/) or [SvelteKit 2](https://svelte.dev/docs/kit/introduction), you can use the `useLivePreview` writeable rune that Payload provides.
+
+First, install the `@payloadcms/live-preview-svelte` package:
+
+```bash
+npm install @payloadcms/live-preview-svelte
+```
+
+Then, use the `useLivePreview` hook in your Vue component:
+
+```ts
+<script lang="ts">
+  import type { PageProps } from './$types';
+	import { useLivePreview } from '@payloadcms/live-preview-svelte';
+	import { convertLexicalToHTML } from '@payloadcms/richtext-lexical/html';
+  import { readable } from 'svelte/store';
+  import { PUBLIC_PAYLOAD_URL } from '$env/static/public';
+
+	let { data }: PageProps = $props();
+
+  let payloadDocStore = useLivePreview(data, {
+    serverURL: PUBLIC_PAYLOAD_URL,
+  });
+
+	const article: typeof data = $derived.by<typeof data>(() => {
+		const doc = $payloadDocStore;
+		return {
+      ...doc,
+			content: convertLexicalToHTML({ data: doc.content }),
+		};
+	});
+</script>
+
+<article>
+	<h1>{article.title}</h1>
+	<div>{@html article.content}</div>
+</article>
+```
+
 ## Building your own hook
 
 No matter what front-end framework you are using, you can build your own hook using the same underlying tooling that Payload provides.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:graphql": "turbo build --filter \"@payloadcms/graphql\"",
     "build:live-preview": "turbo build --filter \"@payloadcms/live-preview\"",
     "build:live-preview-react": "turbo build --filter \"@payloadcms/live-preview-react\"",
+    "build:live-preview-svelte": "turbo build --filter \"@payloadcms/live-preview-svelte\"",
     "build:live-preview-vue": "turbo build --filter \"@payloadcms/live-preview-vue\"",
     "build:next": "turbo build --filter \"@payloadcms/next\"",
     "build:packages": "turbo build --filter=./packages/*",

--- a/packages/live-preview-svelte/.prettierignore
+++ b/packages/live-preview-svelte/.prettierignore
@@ -1,0 +1,10 @@
+.tmp
+**/.git
+**/.hg
+**/.pnp.*
+**/.svn
+**/.yarn/**
+**/build
+**/dist/**
+**/node_modules
+**/temp

--- a/packages/live-preview-svelte/.swcrc
+++ b/packages/live-preview-svelte/.swcrc
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/swcrc",
+  "sourceMaps": "inline",
+  "jsc": {
+    "target": "esnext",
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "dts": true
+    }
+  },
+  "module": {
+    "type": "commonjs"
+  }
+}

--- a/packages/live-preview-svelte/LICENSE.md
+++ b/packages/live-preview-svelte/LICENSE.md
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2018-2025 Payload CMS, Inc. <info@payloadcms.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/live-preview-svelte/README.md
+++ b/packages/live-preview-svelte/README.md
@@ -1,0 +1,124 @@
+# Payload Live Preview - Svelte
+
+Svelte live preview using `@payloadcms/live-preview` package and Svelte `writable` and `readable` store.
+
+The `useLivePreview` returns a readable subscribe and loading, which is also a readable.
+
+## Simple Example without loading or $derived
+
+With this example, we a auto-subscribing to the response and then use `$article` in the body to access the data.
+In many cases you will want to use a $derived rune to alter the data, such as converting RichText.
+
+```svelte
+<script lang="ts">
+  import type { PageProps } from './$types';
+	import { useLivePreview } from '$lib/live-preview-store';
+  import { readable } from 'svelte/store';
+  import { PUBLIC_PAYLOAD_URL } from '$env/static/public';
+
+	let { data }: PageProps = $props();
+
+  let article = seLivePreview(data, {
+      serverURL: PUBLIC_PAYLOAD_URL,
+    });
+</script>
+
+<article>
+	<h1>{$article.title}</h1>
+	<div>{@html $article.content}</div>
+</article>
+
+```
+
+## Example without loading with $derived
+
+In this example we check to see if it's livePreview and then conditionally load useLivePreview.
+We also use $derived to alter the content field.
+
+```svelte
+
+<script lang="ts">
+  import type { PageProps } from './$types';
+  import { page } from '$app/state';
+	import { useLivePreview } from '$lib/live-preview-store';
+	import { convertLexicalToHTML } from '@payloadcms/richtext-lexical/html';
+  import { readable } from 'svelte/store';
+  import { PUBLIC_PAYLOAD_URL } from '$env/static/public';
+
+  const url = page.url;
+  const isLivePreview = url.searchParams.get('livePreview') === 'true';
+
+	let { data }: PageProps = $props();
+
+  let payloadDocStore = readable(data);
+
+	if (isLivePreview) {
+		payloadDocStore = useLivePreview(data, {
+      serverURL: PUBLIC_PAYLOAD_URL,
+    });
+	}
+
+	const article: typeof data = $derived.by<typeof data>(() => {
+		const doc = $payloadDocStore;
+		return {
+      ...doc,
+			content: convertLexicalToHTML({ data: doc.content }),
+		};
+	});
+</script>
+
+<article>
+	<h1>{article.title}</h1>
+	<div>{@html article.content}</div>
+</article>
+
+```
+
+## Example with loading and $derived
+
+Loading is in there mainly to replicate the other useLivePreview packages,
+however, in my tests, it's not really needed, as the data loads instantly.
+
+```svelte
+<script lang="ts">
+  import type { PageProps } from './$types';
+  import { page } from '$app/state';
+	import { useLivePreview } from '$lib/live-preview-store';
+	import { convertLexicalToHTML } from '@payloadcms/richtext-lexical/html';
+  import { readable } from 'svelte/store';
+  import { PUBLIC_PAYLOAD_URL } from '$env/static/public';
+
+  const url = page.url;
+  const isLivePreview = url.searchParams.get('livePreview') === 'true';
+
+	let { data }: PageProps = $props();
+
+  let payloadDocStore = readable(data);
+  let loading = readable(false);
+
+	if (isLivePreview) {
+		const livePreviewStore = useLivePreview(data, {
+      serverURL: PUBLIC_PAYLOAD_URL,
+    });
+
+    payloadDocStore = livePreviewStore;
+    loading = livePreviewStore.loading;
+	}
+
+	const article: typeof data = $derived.by<typeof data>(() => {
+		const doc = $payloadDocStore;
+		return {
+      ...doc,
+			content: convertLexicalToHTML({ data: doc.content }),
+		};
+	});
+</script>
+
+<article>
+  {#if $loading}
+    <div>Loading...</div>
+  {/if}
+	<h1>{article.title}</h1>
+	<div>{@html article.content}</div>
+</article>
+```

--- a/packages/live-preview-svelte/README.md
+++ b/packages/live-preview-svelte/README.md
@@ -12,15 +12,14 @@ In many cases you will want to use a $derived rune to alter the data, such as co
 ```svelte
 <script lang="ts">
   import type { PageProps } from './$types';
-	import { useLivePreview } from '$lib/live-preview-store';
+	import { useLivePreview } from '@payloadcms/live-preview-svelte';
   import { readable } from 'svelte/store';
   import { PUBLIC_PAYLOAD_URL } from '$env/static/public';
 
 	let { data }: PageProps = $props();
-
-  let article = seLivePreview(data, {
-      serverURL: PUBLIC_PAYLOAD_URL,
-    });
+  let article = useLivePreview(data, {
+    serverURL: PUBLIC_PAYLOAD_URL,
+  });
 </script>
 
 <article>
@@ -40,7 +39,7 @@ We also use $derived to alter the content field.
 <script lang="ts">
   import type { PageProps } from './$types';
   import { page } from '$app/state';
-	import { useLivePreview } from '$lib/live-preview-store';
+	import { useLivePreview } from '@payloadcms/live-preview-svelte';
 	import { convertLexicalToHTML } from '@payloadcms/richtext-lexical/html';
   import { readable } from 'svelte/store';
   import { PUBLIC_PAYLOAD_URL } from '$env/static/public';
@@ -83,7 +82,7 @@ however, in my tests, it's not really needed, as the data loads instantly.
 <script lang="ts">
   import type { PageProps } from './$types';
   import { page } from '$app/state';
-	import { useLivePreview } from '$lib/live-preview-store';
+	import { useLivePreview } from '@payloadcms/live-preview-svelte';
 	import { convertLexicalToHTML } from '@payloadcms/richtext-lexical/html';
   import { readable } from 'svelte/store';
   import { PUBLIC_PAYLOAD_URL } from '$env/static/public';

--- a/packages/live-preview-svelte/eslint.config.js
+++ b/packages/live-preview-svelte/eslint.config.js
@@ -1,0 +1,18 @@
+import { rootEslintConfig, rootParserOptions } from '../../eslint.config.js'
+
+/** @typedef {import('eslint').Linter.Config} Config */
+
+/** @type {Config[]} */
+export const index = [
+  ...rootEslintConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        ...rootParserOptions,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]
+
+export default index

--- a/packages/live-preview-svelte/package.json
+++ b/packages/live-preview-svelte/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@payloadcms/live-preview-svelte",
+  "version": "3.35.1",
+  "description": "The official Svelte SDK for Payload Live Preview",
+  "homepage": "https://payloadcms.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/payloadcms/payload.git",
+    "directory": "packages/live-preview-svelte"
+  },
+  "license": "MIT",
+  "author": "Payload <dev@payloadcms.com> (https://payloadcms.com)",
+  "maintainers": [
+    {
+      "name": "Payload",
+      "email": "info@payloadcms.com",
+      "url": "https://payloadcms.com"
+    }
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pnpm copyfiles && pnpm build:types && pnpm build:swc",
+    "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "clean": "rimraf -g {dist,*.tsbuildinfo}",
+    "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "prepublishOnly": "pnpm clean && pnpm turbo build"
+  },
+  "dependencies": {
+    "@payloadcms/live-preview": "workspace:*"
+  },
+  "devDependencies": {
+    "@payloadcms/eslint-config": "workspace:*",
+    "payload": "workspace:*",
+    "svelte": "^5.0.0"
+  },
+  "peerDependencies": {
+    "svelte": "^5.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "default": "./dist/index.js",
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "registry": "https://registry.npmjs.org/",
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/live-preview-svelte/src/index.ts
+++ b/packages/live-preview-svelte/src/index.ts
@@ -1,0 +1,74 @@
+import {
+  subscribe as payloadSubscribe,
+  unsubscribe as payloadUnsubscribe,
+  ready,
+} from '@payloadcms/live-preview'
+import { type Readable, writable } from 'svelte/store'
+
+interface LivePreviewStoreOptions<T extends Record<string, unknown>> {
+  initialData: T
+  serverURL: string
+}
+
+interface LivePreviewStore<T> {
+  loading: Readable<boolean>
+  subscribe: Readable<T>['subscribe']
+}
+
+function createLivePreviewStore<T extends Record<string, unknown>>({
+  initialData,
+  serverURL,
+}: LivePreviewStoreOptions<T>): LivePreviewStore<T> {
+  let subscription: ReturnType<typeof payloadSubscribe> | undefined
+  let initialized = false
+
+  const loading = writable(false)
+  const { subscribe } = writable<T>(initialData, (set) => {
+    // Called when the store gets its first subscriber
+
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (!initialized) {
+      initialized = true
+      ready({ serverURL })
+
+      loading.set(true)
+      subscription = payloadSubscribe({
+        callback: (doc) => {
+          set(doc)
+          loading.set(false)
+        },
+        depth: 1,
+        initialData,
+        serverURL,
+      })
+    }
+
+    return () => {
+      // Called when the last subscriber unsubscribes
+      if (typeof window !== 'undefined' && subscription) {
+        payloadUnsubscribe(subscription)
+        subscription = undefined
+      }
+    }
+  })
+
+  return {
+    loading: { subscribe: loading.subscribe },
+    subscribe,
+  }
+}
+
+export function useLivePreview<T extends Record<string, unknown>>(
+  initialData: T,
+  options: {
+    serverURL: string
+  },
+) {
+  return createLivePreviewStore({
+    initialData,
+    serverURL: options.serverURL,
+  })
+}

--- a/packages/live-preview-svelte/tsconfig.json
+++ b/packages/live-preview-svelte/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    /* TODO: remove the following lines */
+    "strict": false,
+    "noUncheckedIndexedAccess": false,
+  },
+  "references": [{ "path": "../payload" }] // db-mongodb depends on payload
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 1.50.0
       '@sentry/nextjs':
         specifier: ^8.33.1
-        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react@19.1.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react@19.1.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
       '@sentry/node':
         specifier: ^8.33.1
         version: 8.37.1
@@ -135,7 +135,7 @@ importers:
         version: 10.1.3(@aws-sdk/credential-providers@3.687.0(@aws-sdk/client-sso-oidc@3.687.0(@aws-sdk/client-sts@3.687.0)))(socks@2.8.3)
       next:
         specifier: 15.3.0
-        version: 15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
+        version: 15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
       open:
         specifier: ^10.1.0
         version: 10.1.0
@@ -539,7 +539,7 @@ importers:
         version: 6.10.2(eslint@9.22.0(jiti@1.21.6))
       eslint-plugin-perfectionist:
         specifier: 3.9.1
-        version: 3.9.1(eslint@9.22.0(jiti@1.21.6))(typescript@5.7.3)
+        version: 3.9.1(eslint@9.22.0(jiti@1.21.6))(svelte@5.28.2)(typescript@5.7.3)
       eslint-plugin-react-hooks:
         specifier: 0.0.0-experimental-d331ba04-20250307
         version: 0.0.0-experimental-d331ba04-20250307(eslint@9.22.0(jiti@1.21.6))
@@ -590,7 +590,7 @@ importers:
         version: 6.10.2(eslint@9.22.0(jiti@1.21.6))
       eslint-plugin-perfectionist:
         specifier: 3.9.1
-        version: 3.9.1(eslint@9.22.0(jiti@1.21.6))(typescript@5.7.3)
+        version: 3.9.1(eslint@9.22.0(jiti@1.21.6))(svelte@5.28.2)(typescript@5.7.3)
       eslint-plugin-react-hooks:
         specifier: 0.0.0-experimental-d331ba04-20250307
         version: 0.0.0-experimental-d331ba04-20250307(eslint@9.22.0(jiti@1.21.6))
@@ -671,6 +671,22 @@ importers:
       payload:
         specifier: workspace:*
         version: link:../payload
+
+  packages/live-preview-svelte:
+    dependencies:
+      '@payloadcms/live-preview':
+        specifier: workspace:*
+        version: link:../live-preview
+    devDependencies:
+      '@payloadcms/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      payload:
+        specifier: workspace:*
+        version: link:../payload
+      svelte:
+        specifier: ^5.0.0
+        version: 5.28.2
 
   packages/live-preview-vue:
     dependencies:
@@ -1141,7 +1157,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ^8.33.1
-        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react@19.1.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react@19.1.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
       '@sentry/types':
         specifier: ^8.33.1
         version: 8.37.1
@@ -1500,7 +1516,7 @@ importers:
         version: link:../plugin-cloud-storage
       uploadthing:
         specifier: 7.3.0
-        version: 7.3.0(next@15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))
+        version: 7.3.0(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))
     devDependencies:
       payload:
         specifier: workspace:*
@@ -1786,7 +1802,7 @@ importers:
         version: link:../packages/ui
       '@sentry/nextjs':
         specifier: ^8.33.1
-        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react@19.1.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
+        version: 8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react@19.1.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
       '@sentry/react':
         specifier: ^7.77.0
         version: 7.119.2(react@19.1.0)
@@ -1843,7 +1859,7 @@ importers:
         version: 8.9.5(@aws-sdk/credential-providers@3.687.0(@aws-sdk/client-sso-oidc@3.687.0(@aws-sdk/client-sts@3.687.0)))(socks@2.8.3)
       next:
         specifier: 15.3.0
-        version: 15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
+        version: 15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
       nodemailer:
         specifier: 6.9.16
         version: 6.9.16
@@ -5202,6 +5218,11 @@ packages:
     resolution: {integrity: sha512-d5yGlQtmN/z5eoTtIYgkvOw27US2Ous4VycnXatyoImIF9tzlcpnKqQ/V7qhvJmb2p6xZne1NopCLakdTnkBBQ==}
     engines: {node: '>=16.0.0'}
 
+  '@sveltejs/acorn-typescript@1.0.5':
+    resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@swc-node/core@1.13.3':
     resolution: {integrity: sha512-OGsvXIid2Go21kiNqeTIn79jcaX4l0G93X2rAnas4LFoDyA9wAwVK7xZdm+QsKoMn5Mus2yFLCc4OtX2dD/PWA==}
     engines: {node: '>= 10'}
@@ -6985,6 +7006,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.3.0:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -7002,6 +7026,9 @@ packages:
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
+
+  esrap@1.4.6:
+    resolution: {integrity: sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -7753,6 +7780,9 @@ packages:
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -8145,6 +8175,9 @@ packages:
 
   localforage@1.10.0:
     resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -9893,6 +9926,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svelte@5.28.2:
+    resolution: {integrity: sha512-FbWBxgWOpQfhKvoGJv/TFwzqb4EhJbwCD17dB0tEpQiw1XyUEKZJtgm4nA4xq3LLsMo7hu5UY/BOFmroAxKTMg==}
+    engines: {node: '>=18'}
+
   swc-plugin-transform-remove-imports@3.1.0:
     resolution: {integrity: sha512-zUc8RJDQnxVA3yKRoOpqLZWTsAX1H3wPf0A3LVq0cyj0Z62PKeAOPYANs09THO1X476mCAEyQKOmT7lCFSYpUA==}
 
@@ -10511,6 +10548,9 @@ packages:
   yocto-queue@1.1.1:
     resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
     engines: {node: '>=12.20'}
+
+  zimmerframe@1.1.2:
+    resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
 
   zod-validation-error@3.4.0:
     resolution: {integrity: sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==}
@@ -14022,7 +14062,7 @@ snapshots:
       '@sentry/utils': 7.119.2
       localforage: 1.10.0
 
-  '@sentry/nextjs@8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react@19.1.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))':
+  '@sentry/nextjs@8.37.1(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react@19.1.0)(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation-http': 0.53.0(@opentelemetry/api@1.9.0)
@@ -14038,7 +14078,7 @@ snapshots:
       '@sentry/vercel-edge': 8.37.1
       '@sentry/webpack-plugin': 2.22.6(webpack@5.96.1(@swc/core@1.10.12(@swc/helpers@0.5.15)))
       chalk: 3.0.0
-      next: 15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
+      next: 15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.10
@@ -14677,6 +14717,10 @@ snapshots:
       '@smithy/abort-controller': 3.1.6
       '@smithy/types': 3.6.0
       tslib: 2.8.1
+
+  '@sveltejs/acorn-typescript@1.0.5(acorn@8.12.1)':
+    dependencies:
+      acorn: 8.12.1
 
   '@swc-node/core@1.13.3(@swc/core@1.10.12(@swc/helpers@0.5.15))(@swc/types@0.1.17)':
     dependencies:
@@ -16598,13 +16642,15 @@ snapshots:
       safe-regex-test: 1.0.3
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-perfectionist@3.9.1(eslint@9.22.0(jiti@1.21.6))(typescript@5.7.3):
+  eslint-plugin-perfectionist@3.9.1(eslint@9.22.0(jiti@1.21.6))(svelte@5.28.2)(typescript@5.7.3):
     dependencies:
       '@typescript-eslint/types': 8.26.1
       '@typescript-eslint/utils': 8.26.1(eslint@9.22.0(jiti@1.21.6))(typescript@5.7.3)
       eslint: 9.22.0(jiti@1.21.6)
       minimatch: 9.0.5
       natural-compare-lite: 1.4.0
+    optionalDependencies:
+      svelte: 5.28.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -16818,6 +16864,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.3.0:
     dependencies:
       acorn: 8.14.0
@@ -16831,6 +16879,10 @@ snapshots:
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@1.4.6:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -17600,6 +17652,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.6
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.6
+
   is-regex@1.1.4:
     dependencies:
       call-bind: 1.0.7
@@ -18202,6 +18258,8 @@ snapshots:
     dependencies:
       lie: 3.1.1
 
+  locate-character@3.0.0: {}
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -18733,7 +18791,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4):
+  next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4):
     dependencies:
       '@next/env': 15.3.0
       '@swc/counter': 0.1.3
@@ -20166,6 +20224,23 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svelte@5.28.2:
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@sveltejs/acorn-typescript': 1.0.5(acorn@8.12.1)
+      '@types/estree': 1.0.6
+      acorn: 8.12.1
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      esm-env: 1.2.2
+      esrap: 1.4.6
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.12
+      zimmerframe: 1.1.2
+
   swc-plugin-transform-remove-imports@3.1.0: {}
 
   tabbable@6.2.0: {}
@@ -20533,14 +20608,14 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  uploadthing@7.3.0(next@15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)):
+  uploadthing@7.3.0(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)):
     dependencies:
       '@effect/platform': 0.69.8(effect@3.10.3)
       '@uploadthing/mime-types': 0.3.2
       '@uploadthing/shared': 7.1.1
       effect: 3.10.3
     optionalDependencies:
-      next: 15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
+      next: 15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250405)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
 
   uri-js@4.4.1:
     dependencies:
@@ -20802,6 +20877,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.1.1: {}
+
+  zimmerframe@1.1.2: {}
 
   zod-validation-error@3.4.0(zod@3.23.8):
     dependencies:

--- a/tools/releaser/src/lib/publishList.ts
+++ b/tools/releaser/src/lib/publishList.ts
@@ -12,6 +12,7 @@ export const packagePublishList = [
   'admin-bar',
   'live-preview',
   'live-preview-react',
+  'live-preview-svelte',
   'live-preview-vue',
   'richtext-slate',
   'richtext-lexical',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,10 +31,11 @@
       }
     ],
     "paths": {
-      "@payload-config": ["./test/query-presets/config.ts"],
+      "@payload-config": ["./test/_community/config.ts"],
       "@payloadcms/admin-bar": ["./packages/admin-bar/src"],
       "@payloadcms/live-preview": ["./packages/live-preview/src"],
       "@payloadcms/live-preview-react": ["./packages/live-preview-react/src/index.ts"],
+      "@payloadcms/live-preview-svelte": ["./packages/live-preview-svelte/src/index.ts"],
       "@payloadcms/live-preview-vue": ["./packages/live-preview-vue/src/index.ts"],
       "@payloadcms/ui": ["./packages/ui/src/exports/client/index.ts"],
       "@payloadcms/ui/shared": ["./packages/ui/src/exports/shared/index.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,9 @@
       "path": "./packages/live-preview-react"
     },
     {
+      "path": "./packages/live-preview-svelte"
+    },
+    {
       "path": "./packages/live-preview-vue"
     },
     {


### PR DESCRIPTION
# Live Preview Package | Svelte

This is the live preview package for Svelte.  Similar to the [Vue](https://github.com/payloadcms/payload/tree/main/packages/live-preview-vue) & [React](https://github.com/payloadcms/payload/tree/main/packages/live-preview-react) Live Preview packages.
There are details about implementing the package within the README file.  In general I have tried to keep it as close to the Vue implementation as possible.

The simplest example of how it can be used is:
```svelte
<script lang="ts">
  import type { PageProps } from './$types';
  import { useLivePreview } from '@payloadcms/live-preview-svelte';
  import { readable } from 'svelte/store';
  import { PUBLIC_PAYLOAD_URL } from '$env/static/public';

  let { data }: PageProps = $props();
  let article = useLivePreview(data, {
    serverURL: PUBLIC_PAYLOAD_URL,
  });
</script>

<article>
	<h1>{$article.title}</h1>
	<div>{@html $article.content}</div>
</article>
```
I've tried to keep the DX as clean as possible and to replicate all feature found in the Vue package.
useLivePreview also returns `loading` as a readable rune, but in most cases it's not needed.
There is further information about that in the README.

There have been some discussions about this on Discord: https://discord.com/channels/967097582721572934/967097582721572937/1366094097890279515

### What?
New Svelte Live Preview package

### Why?
Because there wasn't one, and many people use Svelte and want this package.

### How?
The package uses the `@payloadcms/live-preview` package and Svelte writable/readable store to extract the logic to a library package.
