### PR TITLE
perf(ui): only select necessary data for relationship options

### DIFF
--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -271,6 +271,9 @@ const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => 
               limit: maxResultsPerRequest,
               locale,
               page: lastLoadedPageToUse,
+              select: {
+                [fieldToSearch]: true,
+              },
               sort: fieldToSort,
               where: {
                 and: [


### PR DESCRIPTION
### What?
Improve performance of the relationship select options by reducing the fetched documents to only necessary data.

### Why?
The relationship select only requires an ID and title. Fetching the whole document instead leads to slow performance on collections with large documents.

### How?
Add a select parameter to the query, the same way it is done in the [WhereBuilder](https://github.com/payloadcms/payload/blob/main/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx#L105-L107) already.
