### PR TITLE
perf(db-postgres): skip pagination overhead if `limit: 0` is passed

### DIFF
--- a/packages/drizzle/src/find/findMany.ts
+++ b/packages/drizzle/src/find/findMany.ts
@@ -46,6 +46,7 @@ export const findMany = async function find({
   const offset = skip || (page - 1) * limit
 
   if (limit === 0) {
+    pagination = false
     limit = undefined
   }
 


### PR DESCRIPTION
This improves performance when querying data in Postgers / SQLite with `limit: 0`. Before, unless you additionally passed `pagination: false` we executed additional count query to calculate the pagination. Now we skip this as this is unnecessary since we can retrieve the count just from `rows.length`.

This logic already existed in `db-mongodb` - https://github.com/payloadcms/payload/blob/1b17df9e0ba43978c52e3f05fdab44c97bd29896/packages/db-mongodb/src/find.ts#L114-L124