### PR TITLE
fix: filter state resetting when removing previous condition in WhereBuilder

### DIFF
--- a/packages/payload/src/admin/components/elements/WhereBuilder/Condition/index.tsx
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/Condition/index.tsx
@@ -122,7 +122,7 @@ const Condition: React.FC<Props> = (props) => {
                 onChange: setInternalValue,
                 operator: operatorValue,
                 options: valueOptions,
-                value: internalValue,
+                value: internalValue ?? '',
               }}
             />
           </div>

--- a/packages/payload/src/admin/components/elements/WhereBuilder/index.tsx
+++ b/packages/payload/src/admin/components/elements/WhereBuilder/index.tsx
@@ -273,19 +273,26 @@ const WhereBuilder: React.FC<Props> = (props) => {
                 {orIndex !== 0 && <div className={`${baseClass}__label`}>{t('or')}</div>}
                 <ul className={`${baseClass}__and-filters`}>
                   {Array.isArray(or?.and) &&
-                    or.and.map((_, andIndex) => (
-                      <li key={andIndex}>
-                        {andIndex !== 0 && <div className={`${baseClass}__label`}>{t('and')}</div>}
-                        <Condition
-                          andIndex={andIndex}
-                          dispatch={dispatchConditions}
-                          fields={reducedFields}
-                          key={andIndex}
-                          orIndex={orIndex}
-                          value={conditions[orIndex].and[andIndex]}
-                        />
-                      </li>
-                    ))}
+                    or.and.map((_, andIndex) => {
+                      const condition = conditions[orIndex].and[andIndex]
+                      const fieldName = Object.keys(condition)[0]
+                      const operator = Object.keys(condition?.[fieldName] || {})?.[0]
+                      return (
+                        <li key={andIndex}>
+                          {andIndex !== 0 && (
+                            <div className={`${baseClass}__label`}>{t('and')}</div>
+                          )}
+                          <Condition
+                            andIndex={andIndex}
+                            dispatch={dispatchConditions}
+                            fields={reducedFields}
+                            key={`${fieldName}-${operator}-${andIndex}-${orIndex}`}
+                            orIndex={orIndex}
+                            value={condition}
+                          />
+                        </li>
+                      )
+                    })}
                 </ul>
               </li>
             ))}


### PR DESCRIPTION
### What?

This PR fixes an issue in the `WhereBuilder` component where removing a previous filter condition would cause remaining conditions to reset their `operator` and `value`.

The problem was that the `Condition` components were keyed only by their index, causing React to incorrectly reuse component instances when the condition list changed. This led to stale or mismatched internal state after a filter was removed.

The fix updates the key for each `Condition` to be based on a combination of field `name`, `operator`, and `indexes`. This ensures the components are correctly recreated when necessary and that the selected `field`, `operator`, and `value` persist properly across updates.
