### PR TITLE
fix: virtual relationship fields with `select`

### DIFF
--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -247,6 +247,7 @@ export const createOperation = async <
     let doc
 
     const select = sanitizeSelect({
+      fields: collectionConfig.flattenedFields,
       forceSelect: collectionConfig.forceSelect,
       select: incomingSelect,
     })

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -110,6 +110,7 @@ export const deleteOperation = async <
     const fullWhere = combineQueries(where, accessResult)
 
     const select = sanitizeSelect({
+      fields: collectionConfig.flattenedFields,
       forceSelect: collectionConfig.forceSelect,
       select: incomingSelect,
     })

--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -168,6 +168,7 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
     }
 
     const select = sanitizeSelect({
+      fields: collectionConfig.flattenedFields,
       forceSelect: collectionConfig.forceSelect,
       select: incomingSelect,
     })

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -102,6 +102,7 @@ export const findOperation = async <
     } = args
 
     const select = sanitizeSelect({
+      fields: collectionConfig.flattenedFields,
       forceSelect: collectionConfig.forceSelect,
       select: incomingSelect,
     })

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -87,6 +87,7 @@ export const findByIDOperation = async <
     } = args
 
     const select = sanitizeSelect({
+      fields: collectionConfig.flattenedFields,
       forceSelect: collectionConfig.forceSelect,
       select: incomingSelect,
     })

--- a/packages/payload/src/collections/operations/findVersionByID.ts
+++ b/packages/payload/src/collections/operations/findVersionByID.ts
@@ -11,6 +11,7 @@ import { APIError, Forbidden, NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
+import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
 import { getQueryDraftsSelect } from '../../versions/drafts/getQueryDraftsSelect.js'
 
 export type Arguments = {
@@ -70,8 +71,10 @@ export const findVersionByIDOperation = async <TData extends TypeWithID = any>(
     // /////////////////////////////////////
 
     const select = sanitizeSelect({
+      fields: buildVersionCollectionFields(payload.config, collectionConfig, true),
       forceSelect: getQueryDraftsSelect({ select: collectionConfig.forceSelect }),
       select: incomingSelect,
+      versions: true,
     })
 
     const versionsQuery = await payload.db.findVersions<TData>({

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -72,8 +72,10 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
     const fullWhere = combineQueries(where, accessResults)
 
     const select = sanitizeSelect({
+      fields: buildVersionCollectionFields(payload.config, collectionConfig, true),
       forceSelect: getQueryDraftsSelect({ select: collectionConfig.forceSelect }),
       select: incomingSelect,
+      versions: true,
     })
 
     // /////////////////////////////////////

--- a/packages/payload/src/collections/operations/restoreVersion.ts
+++ b/packages/payload/src/collections/operations/restoreVersion.ts
@@ -117,6 +117,7 @@ export const restoreVersionOperation = async <TData extends TypeWithID = any>(
     // /////////////////////////////////////
 
     const select = sanitizeSelect({
+      fields: collectionConfig.flattenedFields,
       forceSelect: collectionConfig.forceSelect,
       select: incomingSelect,
     })

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -201,6 +201,7 @@ export const updateOperation = async <
 
       try {
         const select = sanitizeSelect({
+          fields: collectionConfig.flattenedFields,
           forceSelect: collectionConfig.forceSelect,
           select: incomingSelect,
         })

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -161,6 +161,7 @@ export const updateByIDOperation = async <
     })
 
     const select = sanitizeSelect({
+      fields: collectionConfig.flattenedFields,
       forceSelect: collectionConfig.forceSelect,
       select: incomingSelect,
     })

--- a/packages/payload/src/globals/operations/findOne.ts
+++ b/packages/payload/src/globals/operations/findOne.ts
@@ -53,6 +53,7 @@ export const findOneOperation = async <T extends Record<string, unknown>>(
     }
 
     const select = sanitizeSelect({
+      fields: globalConfig.flattenedFields,
       forceSelect: globalConfig.forceSelect,
       select: incomingSelect,
     })

--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -11,6 +11,8 @@ import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { deepCopyObjectSimple } from '../../utilities/deepCopyObject.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
+import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
+import { buildVersionGlobalFields } from '../../versions/buildGlobalFields.js'
 import { getQueryDraftsSelect } from '../../versions/drafts/getQueryDraftsSelect.js'
 
 export type Arguments = {
@@ -60,8 +62,10 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
     const hasWhereAccess = typeof accessResults === 'object'
 
     const select = sanitizeSelect({
+      fields: buildVersionGlobalFields(payload.config, globalConfig, true),
       forceSelect: getQueryDraftsSelect({ select: globalConfig.forceSelect }),
       select: incomingSelect,
+      versions: true,
     })
 
     const findGlobalVersionsArgs: FindGlobalVersionsArgs = {

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -70,8 +70,10 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
     const fullWhere = combineQueries(where, accessResults)
 
     const select = sanitizeSelect({
+      fields: buildVersionGlobalFields(payload.config, globalConfig, true),
       forceSelect: getQueryDraftsSelect({ select: globalConfig.forceSelect }),
       select: incomingSelect,
+      versions: true,
     })
 
     // /////////////////////////////////////

--- a/packages/payload/src/globals/operations/update.ts
+++ b/packages/payload/src/globals/operations/update.ts
@@ -246,6 +246,7 @@ export const updateOperation = async <
     // /////////////////////////////////////
 
     const select = sanitizeSelect({
+      fields: globalConfig.flattenedFields,
       forceSelect: globalConfig.forceSelect,
       select: incomingSelect,
     })

--- a/packages/payload/src/utilities/sanitizeSelect.ts
+++ b/packages/payload/src/utilities/sanitizeSelect.ts
@@ -1,17 +1,129 @@
 import { deepMergeSimple } from '@payloadcms/translations/utilities'
 
-import type { SelectType } from '../types/index.js'
+import type { FlattenedField } from '../fields/config/types.js'
+import type { SelectIncludeType, SelectType } from '../types/index.js'
 
 import { getSelectMode } from './getSelectMode.js'
 
+// Transform post.title -> post, post.category.title -> post
+const stripVirtualPathToCurrentCollection = ({
+  fields,
+  path,
+  versions,
+}: {
+  fields: FlattenedField[]
+  path: string
+  versions: boolean
+}) => {
+  const resultSegments: string[] = []
+
+  if (versions) {
+    resultSegments.push('version')
+    const versionField = fields.find((each) => each.name === 'version')
+
+    if (versionField && versionField.type === 'group') {
+      fields = versionField.flattenedFields
+    }
+  }
+
+  for (const segment of path.split('.')) {
+    const field = fields.find((each) => each.name === segment)
+
+    if (!field) {
+      continue
+    }
+
+    resultSegments.push(segment)
+
+    if (field.type === 'relationship' || field.type === 'upload') {
+      return resultSegments.join('.')
+    }
+  }
+
+  return resultSegments.join('.')
+}
+
+const getAllVirtualRelations = ({ fields }: { fields: FlattenedField[] }) => {
+  const result: string[] = []
+
+  for (const field of fields) {
+    if ('virtual' in field && typeof field.virtual === 'string') {
+      result.push(field.virtual)
+    } else if (field.type === 'group' || field.type === 'tab') {
+      const nestedResult = getAllVirtualRelations({ fields: field.flattenedFields })
+
+      for (const nestedItem of nestedResult) {
+        result.push(nestedItem)
+      }
+    }
+  }
+
+  return result
+}
+
+const resolveVirtualRelationsToSelect = ({
+  fields,
+  selectValue,
+  topLevelFields,
+  versions,
+}: {
+  fields: FlattenedField[]
+  selectValue: SelectIncludeType | true
+  topLevelFields: FlattenedField[]
+  versions: boolean
+}) => {
+  const result: string[] = []
+  if (selectValue === true) {
+    for (const item of getAllVirtualRelations({ fields })) {
+      result.push(
+        stripVirtualPathToCurrentCollection({ fields: topLevelFields, path: item, versions }),
+      )
+    }
+  } else {
+    for (const fieldName in selectValue) {
+      const field = fields.find((each) => each.name === fieldName)
+      if (!field) {
+        continue
+      }
+
+      if ('virtual' in field && typeof field.virtual === 'string') {
+        result.push(
+          stripVirtualPathToCurrentCollection({
+            fields: topLevelFields,
+            path: field.virtual,
+            versions,
+          }),
+        )
+      } else if (field.type === 'group' || field.type === 'tab') {
+        for (const item of resolveVirtualRelationsToSelect({
+          fields: field.flattenedFields,
+          selectValue: selectValue[fieldName],
+          topLevelFields,
+          versions,
+        })) {
+          result.push(
+            stripVirtualPathToCurrentCollection({ fields: topLevelFields, path: item, versions }),
+          )
+        }
+      }
+    }
+  }
+
+  return result
+}
+
 export const sanitizeSelect = ({
+  fields,
   forceSelect,
   select,
+  versions,
 }: {
+  fields: FlattenedField[]
   forceSelect?: SelectType
   select?: SelectType
+  versions?: boolean
 }): SelectType | undefined => {
-  if (!forceSelect || !select) {
+  if (!select) {
     return select
   }
 
@@ -21,5 +133,36 @@ export const sanitizeSelect = ({
     return select
   }
 
-  return deepMergeSimple(select, forceSelect)
+  if (forceSelect) {
+    select = deepMergeSimple(select, forceSelect)
+  }
+
+  if (select) {
+    const virtualRelations = resolveVirtualRelationsToSelect({
+      fields,
+      selectValue: select as SelectIncludeType,
+      topLevelFields: fields,
+      versions: versions ?? false,
+    })
+
+    for (const path of virtualRelations) {
+      let currentRef = select
+      const segments = path.split('.')
+      for (let i = 0; i < segments.length; i++) {
+        const isLast = segments.length - 1 === i
+        const segment = segments[i]
+
+        if (isLast) {
+          currentRef[segment] = true
+        } else {
+          if (!(segment in currentRef)) {
+            currentRef[segment] = {}
+            currentRef = currentRef[segment]
+          }
+        }
+      }
+    }
+  }
+
+  return select
 }

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -1997,6 +1997,23 @@ describe('database', () => {
       expect(draft.docs[0]?.postTitle).toBe('my-title')
     })
 
+    it('should not break when using select', async () => {
+      const post = await payload.create({ collection: 'posts', data: { title: 'my-title-10' } })
+      const { id } = await payload.create({
+        collection: 'virtual-relations',
+        depth: 0,
+        data: { post: post.id },
+      })
+
+      const doc = await payload.findByID({
+        collection: 'virtual-relations',
+        depth: 0,
+        id,
+        select: { postTitle: true },
+      })
+      expect(doc.postTitle).toBe('my-title-10')
+    })
+
     it('should allow virtual field as reference to ID', async () => {
       const post = await payload.create({ collection: 'posts', data: { title: 'my-title' } })
       const { id } = await payload.create({
@@ -2127,6 +2144,26 @@ describe('database', () => {
       })
       const doc = await payload.create({ collection: 'virtual-relations', data: { post: post.id } })
       expect(doc.postCategoryTitle).toBe('1-category')
+    })
+
+    it('should not break when using select 2x deep', async () => {
+      const category = await payload.create({
+        collection: 'categories',
+        data: { title: '3-category' },
+      })
+      const post = await payload.create({
+        collection: 'posts',
+        data: { title: '3-post', category: category.id },
+      })
+      const doc = await payload.create({ collection: 'virtual-relations', data: { post: post.id } })
+
+      const docWithSelect = await payload.findByID({
+        collection: 'virtual-relations',
+        depth: 0,
+        id: doc.id,
+        select: { postCategoryTitle: true },
+      })
+      expect(docWithSelect.postCategoryTitle).toBe('3-category')
     })
 
     it('should allow to query by virtual field 2x deep', async () => {

--- a/test/plugin-import-export/collections/Pages.ts
+++ b/test/plugin-import-export/collections/Pages.ts
@@ -99,6 +99,19 @@ export const Pages: CollectionConfig = {
       relationTo: 'users',
     },
     {
+      name: 'virtualRelationship',
+      type: 'text',
+      virtual: 'author.name',
+    },
+    {
+      name: 'virtual',
+      type: 'text',
+      virtual: true,
+      hooks: {
+        afterRead: [() => 'virtual value'],
+      },
+    },
+    {
       name: 'hasManyNumber',
       type: 'number',
       hasMany: true,

--- a/test/plugin-import-export/collections/Users.ts
+++ b/test/plugin-import-export/collections/Users.ts
@@ -10,6 +10,10 @@ export const Users: CollectionConfig = {
     read: () => true,
   },
   fields: [
+    {
+      name: 'name',
+      type: 'text',
+    },
     // Email added by default
     // Add more fields as needed
   ],

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -279,7 +279,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const expectedPath = path.join(dirname, './uploads', exportDoc.filename as string)
       const data = await readCSV(expectedPath)
 
-      // Assert that the header row matches the fields array
+      // Assert that the csv file contains the expected virtual fields
       expect(data[0].virtual).toStrictEqual('virtual value')
       expect(data[0].virtualRelationship).toStrictEqual('name value')
     })

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -255,6 +255,35 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(str.indexOf('createdAt')).toBeLessThan(str.indexOf('updatedAt'))
     })
 
+    it('should create a CSV file with virtual fields', async () => {
+      const fields = ['id', 'virtual', 'virtualRelationship']
+      const doc = await payload.create({
+        collection: 'exports',
+        user,
+        data: {
+          collectionSlug: 'pages',
+          fields,
+          format: 'csv',
+          where: {
+            title: { contains: 'Virtual ' },
+          },
+        },
+      })
+
+      const exportDoc = await payload.findByID({
+        collection: 'exports',
+        id: doc.id,
+      })
+
+      expect(exportDoc.filename).toBeDefined()
+      const expectedPath = path.join(dirname, './uploads', exportDoc.filename as string)
+      const data = await readCSV(expectedPath)
+
+      // Assert that the header row matches the fields array
+      expect(data[0].virtual).toStrictEqual('virtual value')
+      expect(data[0].virtualRelationship).toStrictEqual('name value')
+    })
+
     it('should create a file for collection csv from array.subfield', async () => {
       let doc = await payload.create({
         collection: 'exports',

--- a/test/plugin-import-export/payload-types.ts
+++ b/test/plugin-import-export/payload-types.ts
@@ -131,6 +131,7 @@ export interface UserAuthOperations {
  */
 export interface User {
   id: string;
+  name?: string | null;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -199,6 +200,8 @@ export interface Page {
       )[]
     | null;
   author?: (string | null) | User;
+  virtualRelationship?: string | null;
+  virtual?: string | null;
   hasManyNumber?: number[] | null;
   relationship?: (string | null) | User;
   excerpt?: string | null;
@@ -444,6 +447,7 @@ export interface PayloadMigration {
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
+  name?: T;
   updatedAt?: T;
   createdAt?: T;
   email?: T;
@@ -500,6 +504,8 @@ export interface PagesSelect<T extends boolean = true> {
             };
       };
   author?: T;
+  virtualRelationship?: T;
+  virtual?: T;
   hasManyNumber?: T;
   relationship?: T;
   excerpt?: T;

--- a/test/plugin-import-export/seed/index.ts
+++ b/test/plugin-import-export/seed/index.ts
@@ -6,11 +6,12 @@ import { richTextData } from './richTextData.js'
 export const seed = async (payload: Payload): Promise<boolean> => {
   payload.logger.info('Seeding data...')
   try {
-    await payload.create({
+    const user = await payload.create({
       collection: 'users',
       data: {
         email: devUser.email,
         password: devUser.password,
+        name: 'name value',
       },
     })
     // create pages
@@ -76,6 +77,16 @@ export const seed = async (payload: Payload): Promise<boolean> => {
               field2: 'baz',
             },
           ],
+        },
+      })
+    }
+
+    for (let i = 0; i < 5; i++) {
+      await payload.create({
+        collection: 'pages',
+        data: {
+          author: user.id,
+          title: `Virtual ${i}`,
         },
       })
     }


### PR DESCRIPTION
Continuation of https://github.com/payloadcms/payload/pull/12265.

Currently, using `select` on new relationship virtual fields:
```
const doc = await payload.findByID({
  collection: 'virtual-relations',
  depth: 0,
  id,
  select: { postTitle: true },
})
```
doesn't work, because in order to calculate `post.title`, the `post` field must be selected as well. This PR adds logic that sanitizes the incoming `select` to include those relationships into `select` (that are related to selected virtual fields)