### PR TITLE
fix(db-postgres): `count` crashes when query contains subqueries and doesn't return any rows

### DIFF
--- a/packages/db-sqlite/src/countDistinct.ts
+++ b/packages/db-sqlite/src/countDistinct.ts
@@ -16,7 +16,7 @@ export const countDistinct: CountDistinct = async function countDistinct(
       })
       .from(this.tables[tableName])
       .where(where)
-    return Number(countResult[0]?.count)
+    return Number(countResult?.[0]?.count ?? 0)
   }
 
   let query: SQLiteSelect = db
@@ -39,5 +39,5 @@ export const countDistinct: CountDistinct = async function countDistinct(
   // Instead, COUNT (GROUP BY id) can be used which is still slower than COUNT(*) but acceptable.
   const countResult = await query
 
-  return Number(countResult[0]?.count)
+  return Number(countResult?.[0]?.count ?? 0)
 }

--- a/packages/drizzle/src/postgres/countDistinct.ts
+++ b/packages/drizzle/src/postgres/countDistinct.ts
@@ -16,7 +16,8 @@ export const countDistinct: CountDistinct = async function countDistinct(
       })
       .from(this.tables[tableName])
       .where(where)
-    return Number(countResult[0].count)
+
+    return Number(countResult?.[0]?.count ?? 0)
   }
 
   let query = db
@@ -39,5 +40,5 @@ export const countDistinct: CountDistinct = async function countDistinct(
   // Instead, COUNT (GROUP BY id) can be used which is still slower than COUNT(*) but acceptable.
   const countResult = await query
 
-  return Number(countResult[0].count)
+  return Number(countResult?.[0]?.count ?? 0)
 }

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -84,7 +84,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {
     menu: Menu;
@@ -124,7 +124,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: number;
+  id: string;
   title?: string | null;
   content?: {
     root: {
@@ -149,7 +149,7 @@ export interface Post {
  * via the `definition` "media".
  */
 export interface Media {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -193,7 +193,7 @@ export interface Media {
  * via the `definition` "users".
  */
 export interface User {
-  id: number;
+  id: string;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -210,24 +210,24 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'posts';
-        value: number | Post;
+        value: string | Post;
       } | null)
     | ({
         relationTo: 'media';
-        value: number | Media;
+        value: string | Media;
       } | null)
     | ({
         relationTo: 'users';
-        value: number | User;
+        value: string | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -237,10 +237,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
-    value: number | User;
+    value: string | User;
   };
   key?: string | null;
   value?:
@@ -260,7 +260,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -379,7 +379,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "menu".
  */
 export interface Menu {
-  id: number;
+  id: string;
   globalText?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;

--- a/test/_community/payload-types.ts
+++ b/test/_community/payload-types.ts
@@ -84,7 +84,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: string;
+    defaultIDType: number;
   };
   globals: {
     menu: Menu;
@@ -124,7 +124,7 @@ export interface UserAuthOperations {
  * via the `definition` "posts".
  */
 export interface Post {
-  id: string;
+  id: number;
   title?: string | null;
   content?: {
     root: {
@@ -149,7 +149,7 @@ export interface Post {
  * via the `definition` "media".
  */
 export interface Media {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -193,7 +193,7 @@ export interface Media {
  * via the `definition` "users".
  */
 export interface User {
-  id: string;
+  id: number;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -210,24 +210,24 @@ export interface User {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: number;
   document?:
     | ({
         relationTo: 'posts';
-        value: string | Post;
+        value: number | Post;
       } | null)
     | ({
         relationTo: 'media';
-        value: string | Media;
+        value: number | Media;
       } | null)
     | ({
         relationTo: 'users';
-        value: string | User;
+        value: number | User;
       } | null);
   globalSlug?: string | null;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   updatedAt: string;
   createdAt: string;
@@ -237,10 +237,10 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: number;
   user: {
     relationTo: 'users';
-    value: string | User;
+    value: number | User;
   };
   key?: string | null;
   value?:
@@ -260,7 +260,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
+  id: number;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -379,7 +379,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "menu".
  */
 export interface Menu {
-  id: string;
+  id: number;
   globalText?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -2414,4 +2414,66 @@ describe('database', () => {
 
     expect(res.docs[0].id).toBe(customID.id)
   })
+
+  it('should count with a query that contains subqueries', async () => {
+    const category = await payload.create({
+      collection: 'categories',
+      data: { title: 'new-category' },
+    })
+    const post = await payload.create({
+      collection: 'posts',
+      data: { title: 'new-post', category: category.id },
+    })
+
+    const result_1 = await payload.count({
+      collection: 'posts',
+      where: {
+        or: [
+          {
+            category: {
+              equals: category.id,
+            },
+          },
+          {
+            'category.title': {
+              equals: 'new-category',
+            },
+          },
+          {
+            title: {
+              equals: 'new-post',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(result_1.totalDocs).toBe(1)
+
+    const result_2 = await payload.count({
+      collection: 'posts',
+      where: {
+        or: [
+          {
+            category: {
+              // eslint-disable-next-line jest/no-conditional-in-test
+              equals: payload.db.defaultIDType === 'number' ? 9999 : randomUUID(),
+            },
+          },
+          {
+            'category.title': {
+              equals: 'non-existing-category',
+            },
+          },
+          {
+            title: {
+              equals: 'non-existing-post',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(result_2.totalDocs).toBe(0)
+  })
 })

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -2428,23 +2428,9 @@ describe('database', () => {
     const result_1 = await payload.count({
       collection: 'posts',
       where: {
-        or: [
-          {
-            category: {
-              equals: category.id,
-            },
-          },
-          {
-            'category.title': {
-              equals: 'new-category',
-            },
-          },
-          {
-            title: {
-              equals: 'new-post',
-            },
-          },
-        ],
+        'category.title': {
+          equals: 'new-category',
+        },
       },
     })
 
@@ -2453,24 +2439,9 @@ describe('database', () => {
     const result_2 = await payload.count({
       collection: 'posts',
       where: {
-        or: [
-          {
-            category: {
-              // eslint-disable-next-line jest/no-conditional-in-test
-              equals: payload.db.defaultIDType === 'number' ? 9999 : randomUUID(),
-            },
-          },
-          {
-            'category.title': {
-              equals: 'non-existing-category',
-            },
-          },
-          {
-            title: {
-              equals: 'non-existing-post',
-            },
-          },
-        ],
+        'category.title': {
+          equals: 'non-existing-category',
+        },
       },
     })
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12264

Uses safe object access in `countDistinct`, fallbacks to `0`