### PR TITLE
fix: duplicate with orderable

### DIFF
--- a/packages/payload/src/config/orderable/index.ts
+++ b/packages/payload/src/config/orderable/index.ts
@@ -83,6 +83,13 @@ export const addOrderableFieldsAndHook = (
         hidden: true,
         readOnly: true,
       },
+      hooks: {
+        beforeDuplicate: [
+          ({ siblingData }) => {
+            delete siblingData[orderableFieldName]
+          },
+        ],
+      },
       index: true,
       required: true,
       // override the schema to make order fields optional for payload.create()
@@ -275,5 +282,6 @@ export const addOrderableEndpoint = (config: SanitizedConfig) => {
   if (!config.endpoints) {
     config.endpoints = []
   }
+
   config.endpoints.push(reorderEndpoint)
 }


### PR DESCRIPTION
Previously, duplication with orderable collections worked incorrectly, for example

Document 1 is created - `_order: 'a5'`
Document 2 is duplicated from 1, - `_order: 'a5 - copy'` (result from https://github.com/payloadcms/payload/blob/47a1eee765e554db29a9370927bf90f0fb4947f2/packages/payload/src/fields/setDefaultBeforeDuplicate.ts#L6)

Now, the `_order` value is re-calculated properly.