### PR TITLE
fix(ui): error after clearing selected collection in ListDrawer when multiple collections are available

### DIFF
--- a/packages/ui/src/views/List/ListHeader/index.tsx
+++ b/packages/ui/src/views/List/ListHeader/index.tsx
@@ -147,6 +147,7 @@ const ListDrawerHeader: React.FC<ListHeaderProps> = ({
           <FieldLabel label={t('upload:selectCollectionToBrowse')} />
           <ReactSelect
             className={`${baseClass}__select-collection`}
+            isClearable={false}
             onChange={setSelectedOption}
             options={enabledCollectionConfigs.map((coll) => ({
               label: getTranslation(coll.labels.singular, i18n),


### PR DESCRIPTION
### What?

The ListDrawer renders a list view for one or many collections. In the case where the drawer is rendering the list view for many collections (such as in the case of polymorphic relations) it is possible to clear the selected relationship from the select component in the ui, which throws an error as the renderList function expects a slug. 

### How?

This fix sets isClearable to 'false' in the ReactSelect component so that there is always a value passed in to the renderList function. I suppose an alternative would be to add logic to handle a null value being passed in to the renderList function, but I can't think of a case when we would ever not want to render a list in the ListDrawer so I think simply setting isClearable to 'false' should be enough.