### PR TITLE
fix(ui): disableListFilter for array and group fields

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
+++ b/packages/ui/src/elements/WhereBuilder/reduceFields.tsx
@@ -99,7 +99,11 @@ export const reduceFields = ({
       return reduced
     }
 
-    if ((field.type === 'group' || field.type === 'array') && 'fields' in field) {
+    if (
+      (field.type === 'group' || field.type === 'array') &&
+      'fields' in field &&
+      !field.admin.disableListFilter
+    ) {
       const translatedLabel = getTranslation(field.label || '', i18n)
 
       const labelWithPrefix = labelPrefix


### PR DESCRIPTION
Now that `array` and `group` fields allow filtering to occur, you may want to set `admin.disableListFilter: true` to limit the options of the filters in the list view for the collection.

This change makes it so thes property is respected and disables all subfields from appearing in the dropdown.