### PR TITLE
fix(db-postgres): start transaction in v2-v3 migration only after drizzle prompts to avoid timeout

### DIFF
--- a/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/index.ts
+++ b/packages/drizzle/src/postgres/predefinedMigrations/v2-v3/index.ts
@@ -36,7 +36,6 @@ type Args = {
  */
 export const migratePostgresV2toV3 = async ({ debug, payload, req }: Args) => {
   const adapter = payload.db as unknown as BasePostgresAdapter
-  const db = await getTransaction(adapter, req)
   const dir = payload.db.migrationDir
 
   // get the drizzle migrateUpSQL from drizzle using the last schema
@@ -88,6 +87,8 @@ export const migratePostgresV2toV3 = async ({ debug, payload, req }: Args) => {
     payload.logger.info('CREATING NEW RELATIONSHIP COLUMNS')
     payload.logger.info(addColumnsStatement)
   }
+
+  const db = await getTransaction(adapter, req)
 
   await db.execute(sql.raw(addColumnsStatement))
 


### PR DESCRIPTION
When running the v2-v3 migration you might receive prompts for renaming columns. Since we start a transaction before, you might end up with a fail if you don't answer within your transaction session period timeout. This moves the `getTransaction` call after prompts were answered, since we don't have a reason to start it earlier.