### PR TITLE
feat(storage-s3): presigned URLs for file downloads

### DIFF
--- a/docs/upload/storage-adapters.mdx
+++ b/docs/upload/storage-adapters.mdx
@@ -84,6 +84,7 @@ pnpm add @payloadcms/storage-s3
 - The `config` object can be any [`S3ClientConfig`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3) object (from [`@aws-sdk/client-s3`](https://github.com/aws/aws-sdk-js-v3)). _This is highly dependent on your AWS setup_. Check the AWS documentation for more information.
 - When enabled, this package will automatically set `disableLocalStorage` to `true` for each collection.
 - When deploying to Vercel, server uploads are limited with 4.5MB. Set `clientUploads` to `true` to do uploads directly on the client. You must allow CORS PUT method for the bucket to your website.
+- Configure `signedDownloads` (either globally of per-collection in `collections`) to use [presigned URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html) for files downloading. This can improve performance for large files (like videos) while still respecting your access control.
 
 ```ts
 import { s3Storage } from '@payloadcms/storage-s3'

--- a/packages/storage-s3/src/staticHandler.ts
+++ b/packages/storage-s3/src/staticHandler.ts
@@ -3,13 +3,23 @@ import type { StaticHandler } from '@payloadcms/plugin-cloud-storage/types'
 import type { CollectionConfig } from 'payload'
 import type { Readable } from 'stream'
 
+import { GetObjectCommand } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { getFilePrefix } from '@payloadcms/plugin-cloud-storage/utilities'
 import path from 'path'
+
+export type SignedDownloadsConfig =
+  | {
+      /** @default 7200 */
+      expiresIn?: number
+    }
+  | boolean
 
 interface Args {
   bucket: string
   collection: CollectionConfig
   getStorageClient: () => AWS.S3
+  signedDownloads?: SignedDownloadsConfig
 }
 
 // Type guard for NodeJS.Readable streams
@@ -40,13 +50,30 @@ const streamToBuffer = async (readableStream: any) => {
   return Buffer.concat(chunks)
 }
 
-export const getHandler = ({ bucket, collection, getStorageClient }: Args): StaticHandler => {
+export const getHandler = ({
+  bucket,
+  collection,
+  getStorageClient,
+  signedDownloads,
+}: Args): StaticHandler => {
   return async (req, { params: { clientUploadContext, filename } }) => {
     let object: AWS.GetObjectOutput | undefined = undefined
     try {
       const prefix = await getFilePrefix({ clientUploadContext, collection, filename, req })
 
       const key = path.posix.join(prefix, filename)
+
+      if (signedDownloads && !clientUploadContext) {
+        const command = new GetObjectCommand({ Bucket: bucket, Key: key })
+        const signedUrl = await getSignedUrl(
+          // @ts-expect-error mismatch versions
+          getStorageClient(),
+          command,
+          typeof signedDownloads === 'object' ? signedDownloads : { expiresIn: 7200 },
+        )
+        // new Response({}, {headers:{''}})
+        return Response.redirect(signedUrl)
+      }
 
       object = await getStorageClient().getObject({
         Bucket: bucket,

--- a/packages/storage-s3/src/staticHandler.ts
+++ b/packages/storage-s3/src/staticHandler.ts
@@ -71,7 +71,6 @@ export const getHandler = ({
           command,
           typeof signedDownloads === 'object' ? signedDownloads : { expiresIn: 7200 },
         )
-        // new Response({}, {headers:{''}})
         return Response.redirect(signedUrl)
       }
 

--- a/test/storage-s3/collections/MediaWithSignedDownloads.ts
+++ b/test/storage-s3/collections/MediaWithSignedDownloads.ts
@@ -1,0 +1,9 @@
+import type { CollectionConfig } from 'payload'
+
+import { mediaWithSignedDownloadsSlug } from '../shared.js'
+
+export const MediaWithSignedDownloads: CollectionConfig = {
+  slug: mediaWithSignedDownloadsSlug,
+  upload: true,
+  fields: [],
+}

--- a/test/storage-s3/config.ts
+++ b/test/storage-s3/config.ts
@@ -7,8 +7,9 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { Media } from './collections/Media.js'
 import { MediaWithPrefix } from './collections/MediaWithPrefix.js'
+import { MediaWithSignedDownloads } from './collections/MediaWithSignedDownloads.js'
 import { Users } from './collections/Users.js'
-import { mediaSlug, mediaWithPrefixSlug, prefix } from './shared.js'
+import { mediaSlug, mediaWithPrefixSlug, mediaWithSignedDownloadsSlug, prefix } from './shared.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
@@ -25,7 +26,7 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Media, MediaWithPrefix, Users],
+  collections: [Media, MediaWithPrefix, MediaWithSignedDownloads, Users],
   onInit: async (payload) => {
     await payload.create({
       collection: 'users',
@@ -41,6 +42,9 @@ export default buildConfigWithDefaults({
         [mediaSlug]: true,
         [mediaWithPrefixSlug]: {
           prefix,
+        },
+        [mediaWithSignedDownloadsSlug]: {
+          signedDownloads: true,
         },
       },
       bucket: process.env.S3_BUCKET,

--- a/test/storage-s3/payload-types.ts
+++ b/test/storage-s3/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     media: Media;
     'media-with-prefix': MediaWithPrefix;
+    'media-with-signed-downloads': MediaWithSignedDownload;
     users: User;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -78,6 +79,7 @@ export interface Config {
   collectionsSelect: {
     media: MediaSelect<false> | MediaSelect<true>;
     'media-with-prefix': MediaWithPrefixSelect<false> | MediaWithPrefixSelect<true>;
+    'media-with-signed-downloads': MediaWithSignedDownloadsSelect<false> | MediaWithSignedDownloadsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -173,6 +175,24 @@ export interface MediaWithPrefix {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media-with-signed-downloads".
+ */
+export interface MediaWithSignedDownload {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -202,6 +222,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'media-with-prefix';
         value: string | MediaWithPrefix;
+      } | null)
+    | ({
+        relationTo: 'media-with-signed-downloads';
+        value: string | MediaWithSignedDownload;
       } | null)
     | ({
         relationTo: 'users';
@@ -297,6 +321,23 @@ export interface MediaSelect<T extends boolean = true> {
  */
 export interface MediaWithPrefixSelect<T extends boolean = true> {
   prefix?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media-with-signed-downloads_select".
+ */
+export interface MediaWithSignedDownloadsSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   url?: T;

--- a/test/storage-s3/shared.ts
+++ b/test/storage-s3/shared.ts
@@ -1,3 +1,5 @@
 export const mediaSlug = 'media'
 export const mediaWithPrefixSlug = 'media-with-prefix'
 export const prefix = 'test-prefix'
+
+export const mediaWithSignedDownloadsSlug = 'media-with-signed-downloads'


### PR DESCRIPTION
Adds pre-signed URLs support file downloads with the S3 adapter. Can be enabled per-collection:
```ts
s3Storage({
  collections: {
    media: { signedDownloads: true }, // or { signedDownloads: { expiresIn: 3600 }} for custom expiresIn (default 7200)
  },
  bucket: process.env.S3_BUCKET,
  config: {
    credentials: {
      accessKeyId: process.env.S3_ACCESS_KEY_ID,
      secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
    },
    endpoint: process.env.S3_ENDPOINT,
    forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
    region: process.env.S3_REGION,
  },
}),
```

The main use case is when you care about the Payload access control (so you don't want to use `disablePayloadAccessControl: true` but you don't want your files to be served through Payload (which can affect performance with large videos for example). 
This feature instead generates a signed URL (after verifying the access control) and redirects you directly to the S3 provider.

This is an addition to https://github.com/payloadcms/payload/pull/11382 which added pre-signed URLs for file uploads.