### PR TITLE
fix(db-postgres): ensure module augmentation for generated schema is picked up correctly in turborepo

### DIFF
--- a/packages/drizzle/src/utilities/createSchemaGenerator.ts
+++ b/packages/drizzle/src/utilities/createSchemaGenerator.ts
@@ -267,8 +267,11 @@ declare module '${this.packageName}' {
  */
 `
 
+    const importTypes = `import type {} from '${this.packageName}'`
+
     let code = [
       warning,
+      importTypes,
       ...importDeclarationsSanitized,
       schemaDeclaration,
       ...enumDeclarations,


### PR DESCRIPTION
### What?
Turborepo fails to compile due to type error in the generated drizzle schema. 
### Why?
TypeScript may not include the module augmentation for @payloadcms/db-postgres, especially in monorepo or isolated module builds. This causes type errors during the compilation process of turborepo project. Adding the type-only import guarantees that TypeScript loads the relevant type definitions and augmentations, resolving these errors.
### How?
This PR adds a type-only import statement to ensure TypeScript recognizes the module augmentation for @payloadcms/db-postgres in the generated drizzle schema from payload, and there is no runtime effect.

Fixes #12311

-->
![image](https://github.com/user-attachments/assets/cdec275c-c062-4eb7-9e6a-c3bc3871dd65)

