### PR TITLE
fix(plugin-multi-tenant): make tenant selector respect order if orderable enabled for tenant collection

### DIFF
--- a/packages/plugin-multi-tenant/src/queries/findTenantOptions.ts
+++ b/packages/plugin-multi-tenant/src/queries/findTenantOptions.ts
@@ -14,6 +14,7 @@ export const findTenantOptions = async ({
   useAsTitle,
   user,
 }: Args): Promise<PaginatedDocs> => {
+  const isOrderable = payload.collections[tenantsCollectionSlug]?.config?.orderable || false
   return payload.find({
     collection: tenantsCollectionSlug,
     depth: 0,
@@ -21,8 +22,9 @@ export const findTenantOptions = async ({
     overrideAccess: false,
     select: {
       [useAsTitle]: true,
+      ...(isOrderable ? { _order: true } : {}),
     },
-    sort: useAsTitle,
+    sort: isOrderable ? '_order' : useAsTitle,
     user,
   })
 }


### PR DESCRIPTION
### What?
Tenant Selector doesn’t honor the custom order when ‘orderable’ is enabled for Tenant collection
### Why?
Currently, it uses "useAsTitle" to sort. In some use cases, for example, when a user manages multiple tenants that have an inherent priority (such as usage frequency), sorting purely by the useAsTitle isn’t very practical.
### How?
Get "orderable" config from the tenant collection's config, if it has "orderable" set as true, it will use _order to sort. If not, it will use "useAsTitle" to sort as default.

Fixes #12246

![image](https://github.com/user-attachments/assets/b5c4ad5e-3503-4789-91f6-a7aafb326e32)

