### PR TITLE
feat: adds color values between 0 and 50 for `--color-base` and `--theme-elevation` color palettes

### DIFF
--- a/packages/next/src/scss/colors.scss
+++ b/packages/next/src/scss/colors.scss
@@ -1,6 +1,7 @@
 @layer payload-default {
   :root {
     --color-base-0: rgb(255, 255, 255);
+    --color-base-25: rgb(251, 251, 251);
     --color-base-50: rgb(245, 245, 245);
     --color-base-100: rgb(235, 235, 235);
     --color-base-150: rgb(221, 221, 221);
@@ -18,6 +19,7 @@
     --color-base-750: rgb(60, 60, 60);
     --color-base-800: rgb(47, 47, 47);
     --color-base-850: rgb(34, 34, 34);
+    --color-base-875: rgb(26, 26, 26);
     --color-base-900: rgb(20, 20, 20);
     --color-base-950: rgb(7, 7, 7);
     --color-base-1000: rgb(0, 0, 0);
@@ -165,6 +167,7 @@
     --theme-error-950: var(--color-error-950);
 
     --theme-elevation-0: var(--color-base-0);
+    --theme-elevation-25: var(--color-base-25);
     --theme-elevation-50: var(--color-base-50);
     --theme-elevation-100: var(--color-base-100);
     --theme-elevation-150: var(--color-base-150);
@@ -191,6 +194,7 @@
     --theme-border-color: var(--theme-elevation-150);
 
     --theme-elevation-0: var(--color-base-900);
+    --theme-elevation-25: var(--color-base-875);
     --theme-elevation-50: var(--color-base-850);
     --theme-elevation-100: var(--color-base-800);
     --theme-elevation-150: var(--color-base-750);

--- a/packages/richtext-lexical/src/scss/colors.scss
+++ b/packages/richtext-lexical/src/scss/colors.scss
@@ -1,6 +1,7 @@
 @layer payload-default {
   :root {
     --color-base-0: rgb(255, 255, 255);
+    --color-base-25: rgb(251, 251, 251);
     --color-base-50: rgb(245, 245, 245);
     --color-base-100: rgb(235, 235, 235);
     --color-base-150: rgb(221, 221, 221);
@@ -18,6 +19,7 @@
     --color-base-750: rgb(60, 60, 60);
     --color-base-800: rgb(47, 47, 47);
     --color-base-850: rgb(34, 34, 34);
+    --color-base-875: rgb(26, 26, 26);
     --color-base-900: rgb(20, 20, 20);
     --color-base-950: rgb(7, 7, 7);
     --color-base-1000: rgb(0, 0, 0);
@@ -165,6 +167,7 @@
     --theme-error-950: var(--color-error-950);
 
     --theme-elevation-0: var(--color-base-0);
+    --theme-elevation-25: var(--color-base-25);
     --theme-elevation-50: var(--color-base-50);
     --theme-elevation-100: var(--color-base-100);
     --theme-elevation-150: var(--color-base-150);
@@ -191,6 +194,7 @@
     --theme-border-color: var(--theme-elevation-150);
 
     --theme-elevation-0: var(--color-base-900);
+    --theme-elevation-25: var(--color-base-875);
     --theme-elevation-50: var(--color-base-850);
     --theme-elevation-100: var(--color-base-800);
     --theme-elevation-150: var(--color-base-750);

--- a/packages/richtext-slate/src/scss/colors.scss
+++ b/packages/richtext-slate/src/scss/colors.scss
@@ -1,6 +1,7 @@
 @layer payload-default {
   :root {
     --color-base-0: rgb(255, 255, 255);
+    --color-base-25: rgb(251, 251, 251);
     --color-base-50: rgb(245, 245, 245);
     --color-base-100: rgb(235, 235, 235);
     --color-base-150: rgb(221, 221, 221);
@@ -18,6 +19,7 @@
     --color-base-750: rgb(60, 60, 60);
     --color-base-800: rgb(47, 47, 47);
     --color-base-850: rgb(34, 34, 34);
+    --color-base-875: rgb(26, 26, 26);
     --color-base-900: rgb(20, 20, 20);
     --color-base-950: rgb(7, 7, 7);
     --color-base-1000: rgb(0, 0, 0);
@@ -165,6 +167,7 @@
     --theme-error-950: var(--color-error-950);
 
     --theme-elevation-0: var(--color-base-0);
+    --theme-elevation-25: var(--color-base-25);
     --theme-elevation-50: var(--color-base-50);
     --theme-elevation-100: var(--color-base-100);
     --theme-elevation-150: var(--color-base-150);
@@ -191,6 +194,7 @@
     --theme-border-color: var(--theme-elevation-150);
 
     --theme-elevation-0: var(--color-base-900);
+    --theme-elevation-25: var(--color-base-875);
     --theme-elevation-50: var(--color-base-850);
     --theme-elevation-100: var(--color-base-800);
     --theme-elevation-150: var(--color-base-750);

--- a/packages/ui/src/scss/colors.scss
+++ b/packages/ui/src/scss/colors.scss
@@ -1,6 +1,7 @@
 @layer payload-default {
   :root {
     --color-base-0: rgb(255, 255, 255);
+    --color-base-25: rgb(251, 251, 251);
     --color-base-50: rgb(245, 245, 245);
     --color-base-100: rgb(235, 235, 235);
     --color-base-150: rgb(221, 221, 221);
@@ -18,6 +19,7 @@
     --color-base-750: rgb(60, 60, 60);
     --color-base-800: rgb(47, 47, 47);
     --color-base-850: rgb(34, 34, 34);
+    --color-base-875: rgb(26, 26, 26);
     --color-base-900: rgb(20, 20, 20);
     --color-base-950: rgb(7, 7, 7);
     --color-base-1000: rgb(0, 0, 0);
@@ -165,6 +167,7 @@
     --theme-error-950: var(--color-error-950);
 
     --theme-elevation-0: var(--color-base-0);
+    --theme-elevation-25: var(--color-base-25);
     --theme-elevation-50: var(--color-base-50);
     --theme-elevation-100: var(--color-base-100);
     --theme-elevation-150: var(--color-base-150);
@@ -191,6 +194,7 @@
     --theme-border-color: var(--theme-elevation-150);
 
     --theme-elevation-0: var(--color-base-900);
+    --theme-elevation-25: var(--color-base-875);
     --theme-elevation-50: var(--color-base-850);
     --theme-elevation-100: var(--color-base-800);
     --theme-elevation-150: var(--color-base-750);


### PR DESCRIPTION
### What?

Introduce color values between 0 and 50 on the greyscale color ramps.

### Why?

Some of the forthcoming features as well as some existing components would benefit from a value with weaker contrast against the `--theme-bg` value.

### How?

Adds color values that fall between 0 and 50 on the greyscale color ramps.

- `--color-base-25`
- `--color-base-875` (elevation starts at 900 in darkmode)
- `--theme-elevation-25` (light and dark)

**Note:** In a future iteration of the admin panel UI, we should rework the `theme` color palettes for more intentional use in a way that reduces the number of variables and also provide more guidance on how/where to use specific tokens.