### PR TITLE
feat: allows for functional config definitions

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -27,6 +27,26 @@ The Payload Config is strongly typed and ties directly into Payload's TypeScript
   details](#customizing-the-config-location).
 </Banner>
 
+#### Functionally building your config
+
+You can optionally pass a function to `buildConfig` which is helpful if you need to first fetch secrets or define how you want Payload to work prior to initializing it.
+
+Here's an example:
+
+```ts
+import { buildConfig } from 'payload'
+import { fetchMySecrets } from './secrets'
+
+export default buildConfig(async () => {
+  const mySecrets = await fetchMySecrets()
+
+  return {
+    secret: mySecrets.PAYLOAD_SECRET,
+    // The rest of your config goes here
+  }
+})
+```
+
 ## Config Options
 
 To author your Payload Config, first determine which [Database](../database/overview) you'd like to use, then use [Collections](./collections) or [Globals](./globals) to define the schema of your data through [Fields](../fields/overview).

--- a/packages/payload/src/config/build.ts
+++ b/packages/payload/src/config/build.ts
@@ -4,10 +4,14 @@ import { sanitizeConfig } from './sanitize.js'
 
 /**
  * @description Builds and validates Payload configuration
- * @param config Payload Config
+ * @param config Payload Config or async function that returns a Config
  * @returns Built and sanitized Payload Config
  */
-export async function buildConfig(config: Config): Promise<SanitizedConfig> {
+export async function buildConfig(
+  configArg: (() => Config | Promise<Config>) | Config,
+): Promise<SanitizedConfig> {
+  const config = typeof configArg === 'function' ? await configArg() : configArg
+
   if (Array.isArray(config.plugins)) {
     let configAfterPlugins = config
     for (const plugin of config.plugins) {

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -216,13 +216,6 @@ export type StringKeyOf<T> = Extract<keyof T, string>
 // Define the types for slugs using the appropriate collections and globals
 export type CollectionSlug = StringKeyOf<TypedCollection>
 
-export type ResolveAuthCollectionSlug<T> = 'auth' extends keyof T
-  ? keyof T['auth']
-  : // @ts-expect-error
-    keyof T['authUntyped']
-
-export type AuthCollectionSlug = ResolveAuthCollectionSlug<GeneratedTypes>
-
 export type BlockSlug = StringKeyOf<TypedBlock>
 
 export type UploadCollectionSlug = StringKeyOf<TypedUploadCollection>

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -216,6 +216,13 @@ export type StringKeyOf<T> = Extract<keyof T, string>
 // Define the types for slugs using the appropriate collections and globals
 export type CollectionSlug = StringKeyOf<TypedCollection>
 
+export type ResolveAuthCollectionSlug<T> = 'auth' extends keyof T
+  ? keyof T['auth']
+  : // @ts-expect-error
+    keyof T['authUntyped']
+
+export type AuthCollectionSlug = ResolveAuthCollectionSlug<GeneratedTypes>
+
 export type BlockSlug = StringKeyOf<TypedBlock>
 
 export type UploadCollectionSlug = StringKeyOf<TypedUploadCollection>


### PR DESCRIPTION
It's common to want to first fetch secrets from a third-party location, or perform some other action before returning your Payload config. You could always do this using a pattern like this:

```js
const fetchAndBuildConfig = async () => {
  const mySecrets = await fetchSecrets()
  
  return buildConfig({
    secret: mySecrets.PAYLOAD_SECRET,
    // etc
  })
}

export default fetchAndBuildConfig()
```

But this is more verbose than it needs to be. We could simplify and handle that complexity just by allowing the developer to pass an async function to `buildConfig` itself, like this:

```js
export default buildConfig(async () => {
  const mySecrets = await fetchSecrets()
  
  return {
    secret: mySecrets.PAYLOAD_SECRET,
    // etc
  }
})
```

This PR makes this simpler pattern possible.