### PR TITLE
templates: add eslint ignore rule for '.next/'

### DIFF
--- a/templates/blank/eslint.config.mjs
+++ b/templates/blank/eslint.config.mjs
@@ -30,6 +30,9 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    ignores: ['.next/'],
+  },
 ]
 
 export default eslintConfig

--- a/templates/with-payload-cloud/eslint.config.mjs
+++ b/templates/with-payload-cloud/eslint.config.mjs
@@ -30,6 +30,9 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    ignores: ['.next/'],
+  },
 ]
 
 export default eslintConfig

--- a/templates/with-postgres/eslint.config.mjs
+++ b/templates/with-postgres/eslint.config.mjs
@@ -30,6 +30,9 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    ignores: ['.next/'],
+  },
 ]
 
 export default eslintConfig

--- a/templates/with-vercel-mongodb/eslint.config.mjs
+++ b/templates/with-vercel-mongodb/eslint.config.mjs
@@ -30,6 +30,9 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    ignores: ['.next/'],
+  },
 ]
 
 export default eslintConfig

--- a/templates/with-vercel-postgres/eslint.config.mjs
+++ b/templates/with-vercel-postgres/eslint.config.mjs
@@ -30,6 +30,9 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    ignores: ['.next/'],
+  },
 ]
 
 export default eslintConfig


### PR DESCRIPTION
### What?
Standardizes ESLint configurations across all template projects like website template to ensure consistent code quality enforcement.

### Why?
Previously, there were inconsistencies in the ESLint configurations between different template projects. Some templates were missing the .next/ ignore pattern, which could lead to unnecessary linting of build files. By standardizing these configurations, we ensure consistent code quality standards and developer experience across all template projects.

### How?
Added the missing ignores: ['.next/'] configuration to templates that were missing it
