### PR TITLE
fix(ui): updates useField to read initializing from useForm

### DIFF
--- a/packages/ui/src/forms/useField/index.tsx
+++ b/packages/ui/src/forms/useField/index.tsx
@@ -47,7 +47,6 @@ export const useField = <TValue,>(options?: Options): FieldType<TValue> => {
 
   const submitted = useFormSubmitted()
   const processing = useFormProcessing()
-  const initializing = useFormInitializing()
   const { user } = useAuth()
   const { id, collectionSlug } = useDocumentInfo()
   const operation = useOperation()
@@ -58,7 +57,7 @@ export const useField = <TValue,>(options?: Options): FieldType<TValue> => {
   const { t } = useTranslation()
   const { config } = useConfig()
 
-  const { getData, getDataByPath, getSiblingData, setModified } = useForm()
+  const { getData, getDataByPath, getSiblingData, initializing, setModified } = useForm()
   const documentForm = useDocumentForm()
   const modified = useFormModified()
 


### PR DESCRIPTION
### What?
Fixes `formInitializing` from `useField` to stay in sync with the `initializing` value returned from `useForm()`.

### Why?
- `useField()` was reading `formInitializing` from `useFormInitializing()`
- `useForm()` was providing `initializing` directly from the form context

This was causing the two values to diverge briefly during form initialization.

### How?
Updated `useField()` to get `initializing` directly from `useForm()` instead of `useFormInitializing()`, so both values now reference the same state from the form context.

Fixes #9263