### PR TITLE
fix(ui): passes value to server component args

### DIFF
--- a/packages/payload/src/admin/forms/Field.ts
+++ b/packages/payload/src/admin/forms/Field.ts
@@ -91,6 +91,7 @@ export type ServerComponentProps = {
   req: PayloadRequest
   siblingData: Data
   user: User
+  value?: unknown
 }
 
 export type ClientFieldBase<

--- a/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
+++ b/packages/ui/src/forms/fieldSchemasToFormState/renderField.tsx
@@ -100,6 +100,7 @@ export const renderField: RenderFieldMethod = ({
     req,
     siblingData,
     user: req.user,
+    value: 'name' in fieldConfig && data?.[fieldConfig.name],
   }
 
   switch (fieldConfig.type) {


### PR DESCRIPTION
### What?
Allows the field value (if defined) to be accessed from `args` with custom server components.

### Why?
Documentation states that the user can access `args.value` to get the value of the field at time of render (if a value is defined) when using a custom server component - however this isn't currently setup.

<img width="469" alt="Screenshot 2025-05-08 at 4 51 30 PM" src="https://github.com/user-attachments/assets/9c167f80-5c5e-4fea-a31c-166281d9f7db" />

Link to docs [here](https://payloadcms.com/docs/fields/overview#default-props).

### How?
Passes the value from `data` if it exists (does not exist for all field types) and adds `value` to the server component types as an optional property.

Fixes #10389
