### PR TITLE
docs: remove link to outdated ecommerce template from stripe plugin docs

### DIFF
--- a/docs/plugins/stripe.mdx
+++ b/docs/plugins/stripe.mdx
@@ -309,7 +309,3 @@ import {
   ...
 } from '@payloadcms/plugin-stripe/types';
 ```
-
-## Examples
-
-The [Templates Directory](https://github.com/payloadcms/payload/tree/main/templates) contains an official [E-commerce Template](https://github.com/payloadcms/payload/tree/main/templates/ecommerce) which demonstrates exactly how to configure this plugin in Payload and implement it on your front-end. You can also check out [How to Build An E-Commerce Site With Next.js](https://payloadcms.com/blog/how-to-build-an-e-commerce-site-with-nextjs) post for a bit more context around this template.


### PR DESCRIPTION
Closes https://github.com/payloadcms/payload/issues/12347

We previously linked to a non existent ecommerce template and example from the stripe plugin docs.