### PR TITLE
fix(db-mongodb): localized dates being returned as date objects instead of strings

### DIFF
--- a/packages/db-mongodb/src/utilities/transform.ts
+++ b/packages/db-mongodb/src/utilities/transform.ts
@@ -425,6 +425,7 @@ export const transform = ({
         for (const locale of config.localization.localeCodes) {
           sanitizeDate({
             field,
+            locale,
             ref: fieldRef,
             value: fieldRef[locale],
           })

--- a/test/localization/collections/LocalizedDateFields/index.ts
+++ b/test/localization/collections/LocalizedDateFields/index.ts
@@ -1,0 +1,21 @@
+import type { CollectionConfig } from 'payload'
+
+import { localizedDateFieldsSlug } from '../../shared.js'
+
+export const LocalizedDateFields: CollectionConfig = {
+  slug: localizedDateFieldsSlug,
+  versions: {
+    drafts: true,
+  },
+  fields: [
+    {
+      type: 'date',
+      name: 'localizedDate',
+      localized: true,
+    },
+    {
+      type: 'date',
+      name: 'date',
+    },
+  ],
+}

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -11,6 +11,7 @@ import { devUser } from '../credentials.js'
 import { ArrayCollection } from './collections/Array/index.js'
 import { BlocksCollection } from './collections/Blocks/index.js'
 import { Group } from './collections/Group/index.js'
+import { LocalizedDateFields } from './collections/LocalizedDateFields/index.js'
 import { LocalizedDrafts } from './collections/LocalizedDrafts/index.js'
 import { LocalizedWithinLocalized } from './collections/LocalizedWithinLocalized/index.js'
 import { NestedArray } from './collections/NestedArray/index.js'
@@ -25,6 +26,7 @@ import {
   defaultLocale,
   englishTitle,
   hungarianLocale,
+  localizedDateFieldsSlug,
   localizedPostsSlug,
   localizedSortSlug,
   portugueseLocale,
@@ -64,6 +66,7 @@ export default buildConfigWithDefaults({
     NestedArray,
     NestedFields,
     LocalizedDrafts,
+    LocalizedDateFields,
     {
       admin: {
         listSearchableFields: 'name',
@@ -475,6 +478,14 @@ export default buildConfigWithDefaults({
       collection,
       data: {
         title: englishTitle,
+      },
+    })
+
+    await payload.create({
+      collection: localizedDateFieldsSlug,
+      data: {
+        localizedDate: new Date().toISOString(),
+        date: new Date().toISOString(),
       },
     })
 

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -27,6 +27,7 @@ import {
   defaultLocale as englishLocale,
   englishTitle,
   hungarianLocale,
+  localizedDateFieldsSlug,
   localizedPostsSlug,
   localizedSortSlug,
   portugueseLocale,
@@ -428,6 +429,32 @@ describe('Localization', () => {
             })
           })
         }
+      })
+    })
+
+    describe('Localized date', () => {
+      it('can create a localized date', async () => {
+        const document = await payload.create({
+          collection: localizedDateFieldsSlug,
+          data: {
+            localizedDate: new Date().toISOString(),
+            date: new Date().toISOString(),
+          },
+        })
+        expect(document.localizedDate).toBeTruthy()
+      })
+
+      it('data is typed as string', async () => {
+        const document = await payload.create({
+          collection: localizedDateFieldsSlug,
+          data: {
+            localizedDate: new Date().toISOString(),
+            date: new Date().toISOString(),
+          },
+        })
+
+        expect(typeof document.localizedDate).toBe('string')
+        expect(typeof document.date).toBe('string')
       })
     })
 

--- a/test/localization/payload-types.ts
+++ b/test/localization/payload-types.ts
@@ -72,6 +72,7 @@ export interface Config {
     'nested-arrays': NestedArray;
     'nested-field-tables': NestedFieldTable;
     'localized-drafts': LocalizedDraft;
+    'localized-date-fields': LocalizedDateField;
     users: User;
     'localized-posts': LocalizedPost;
     'no-localized-fields': NoLocalizedField;
@@ -97,6 +98,7 @@ export interface Config {
     'nested-arrays': NestedArraysSelect<false> | NestedArraysSelect<true>;
     'nested-field-tables': NestedFieldTablesSelect<false> | NestedFieldTablesSelect<true>;
     'localized-drafts': LocalizedDraftsSelect<false> | LocalizedDraftsSelect<true>;
+    'localized-date-fields': LocalizedDateFieldsSelect<false> | LocalizedDateFieldsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'localized-posts': LocalizedPostsSelect<false> | LocalizedPostsSelect<true>;
     'no-localized-fields': NoLocalizedFieldsSelect<false> | NoLocalizedFieldsSelect<true>;
@@ -326,6 +328,18 @@ export interface NestedFieldTable {
 export interface LocalizedDraft {
   id: string;
   title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-date-fields".
+ */
+export interface LocalizedDateField {
+  id: string;
+  localizedDate?: string | null;
+  date?: string | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -714,6 +728,10 @@ export interface PayloadLockedDocument {
         value: string | LocalizedDraft;
       } | null)
     | ({
+        relationTo: 'localized-date-fields';
+        value: string | LocalizedDateField;
+      } | null)
+    | ({
         relationTo: 'users';
         value: string | User;
       } | null)
@@ -948,6 +966,17 @@ export interface NestedFieldTablesSelect<T extends boolean = true> {
  */
 export interface LocalizedDraftsSelect<T extends boolean = true> {
   title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-date-fields_select".
+ */
+export interface LocalizedDateFieldsSelect<T extends boolean = true> {
+  localizedDate?: T;
+  date?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;

--- a/test/localization/shared.ts
+++ b/test/localization/shared.ts
@@ -12,6 +12,7 @@ export const hungarianLocale = 'hu'
 
 // Slugs
 export const localizedPostsSlug = 'localized-posts'
+export const localizedDateFieldsSlug = 'localized-date-fields'
 export const withLocalizedRelSlug = 'with-localized-relationship'
 export const relationshipLocalizedSlug = 'relationship-localized'
 export const withRequiredLocalizedFields = 'localized-required'


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/12334

We weren't passing locale through to the Date transformer function so localized dates were being read as objects instead of strings.