### PR TITLE
docs: use computed property value in docs

### DIFF
--- a/packages/storage-azure/README.md
+++ b/packages/storage-azure/README.md
@@ -26,8 +26,8 @@ export default buildConfig({
   plugins: [
     azureStorage({
       collections: {
-        media: true,
-        'media-with-prefix': {
+        [Media.slug]: true,
+        [MediaWithPrefix.slug]: {
           prefix,
         },
       },

--- a/packages/storage-gcs/README.md
+++ b/packages/storage-gcs/README.md
@@ -26,8 +26,8 @@ export default buildConfig({
   plugins: [
     gcsStorage({
       collections: {
-        media: true,
-        'media-with-prefix': {
+        [Media.slug]: true,
+        [MediaWithPrefix.slug]: {
           prefix,
         },
       },

--- a/packages/storage-s3/README.md
+++ b/packages/storage-s3/README.md
@@ -27,8 +27,8 @@ export default buildConfig({
   plugins: [
     s3Storage({
       collections: {
-        media: true,
-        'media-with-prefix': {
+        [Media.slug]: true,
+        [MediaWithPrefix.slug]: {
           prefix,
         },
       },

--- a/packages/storage-vercel-blob/README.md
+++ b/packages/storage-vercel-blob/README.md
@@ -29,8 +29,8 @@ export default buildConfig({
       enabled: true, // Optional, defaults to true
       // Specify which collections should use Vercel Blob
       collections: {
-        media: true,
-        'media-with-prefix': {
+        [Media.slug]: true,
+        [MediaWithPrefix.slug]: {
           prefix: 'my-prefix',
         },
       },


### PR DESCRIPTION
### What?

Refactor storage adapter collections config in the examples to use computed property values via .slug rather than raw string literals.

### Why?

Using computed values (e.g., [Media.slug]) ensures the adapter key stays in sync with the actual collection slug, avoiding silent mismatches due to typos or future refactors. While such mismatches shouldn’t happen in a well-managed codebase, “Anything that can happen will happen.” – Murphy’s Law.

This approach improves reliability and clarity. The original example mixed media (default collection key) with a literal string 'media-with-prefix', which could be confusing—especially since these examples are in documentation and readers cannot inspect the underlying collections directly to understand these are representing their respective slugs.

### How?
Replaced hard-coded keys in the collections config with computed property values:
```ts
collections: {
  [Media.slug]: true,
  [MediaWithPrefix.slug]: { prefix },
}
```


This ensures both configuration keys are explicitly tied to their respective collections.