### PR TITLE
fix: incorrect environment file loading

### DIFF
--- a/packages/payload/src/bin/loadEnv.ts
+++ b/packages/payload/src/bin/loadEnv.ts
@@ -13,7 +13,7 @@ export function loadEnv(path?: string) {
     return
   }
 
-  const dev = process.env.NODE_ENV === 'development'
+  const dev = process.env.NODE_ENV !== 'production'
   const { loadedEnvFiles } = loadEnvConfig(process.cwd(), dev)
 
   if (!loadedEnvFiles?.length) {

--- a/packages/payload/src/bin/loadEnv.ts
+++ b/packages/payload/src/bin/loadEnv.ts
@@ -13,7 +13,8 @@ export function loadEnv(path?: string) {
     return
   }
 
-  const { loadedEnvFiles } = loadEnvConfig(process.cwd(), true) // assuming this won't run in production
+  const dev = process.env.NODE_ENV === 'development'
+  const { loadedEnvFiles } = loadEnvConfig(process.cwd(), dev)
 
   if (!loadedEnvFiles?.length) {
     // use findUp to find the env file. So, run loadEnvConfig for every directory upwards


### PR DESCRIPTION
### What?

Fixes issue with the Payload CLI where environment files were silently always loaded as if in development mode, even when `NODE_ENV=production` is explicitly set. Achieved by dynamically checking the enviroment based on `process.env.NODE_ENV` (defaulting to "development") then passing that to the underlying library `@next/env`.

### Why?

Previously, the Payload CLI always passed `true` to the `dev` flag of `loadEnvConfig` from `@next/env`, causing it to load development-specific `.env` files even when `NODE_ENV=production` was explicitly set. Frustratingly for the user there was also no warning message that this was happening.

For example, previously when running:
```sh
NODE_ENV=production pnpm payload run ./seed.ts
```
It would still load `.env.development*` and not `.env.production*`.

The inability to override the dev flag previously made it difficult, bar impossible (depending on ones setup), to run the CLI in a production-like environment. Which is useful for several reasons, a few examples being:
- Seeding production data:
```
NODE_ENV=production payload run seed.ts
```
- Capturing current schema:
```
NODE_ENV=production payload migrate:create
```
- Running one-off jobs with live data:
```
NODE_ENV=production payload run jobs/consolidate-payments.ts
```

This fix allows users to correctly target production without surprises.

### How?

- Introduced a dev constant that checks `NODE_ENV !== 'production'`
- Passed dev to `loadEnvConfig` to allow `@next/env` to resolve the correct `.env.*` files based on the environment:

**Before:**
```ts
const { loadedEnvFiles } = loadEnvConfig(process.cwd(), true) // assuming this won't run in production
```
**After:**
```ts
const dev = process.env.NODE_ENV !== 'production'
const { loadedEnvFiles } = loadEnvConfig(process.cwd(), dev)
```

The signature of `loadEnvConfig` from [packages/next-env/index.ts](https://github.com/vercel/next.js/blob/2086975c3c27d453e4a74fb584b76ea714a05631/packages/next-env/index.ts#L114) is:
```ts
export function loadEnvConfig(
  dir: string,
  dev?: boolean,
  log: Log = console,
  forceReload = false,
  onReload?: (envFilePath: string) => void
): {
  combinedEnv: Env
  parsedEnv: Env | undefined
  loadedEnvFiles: LoadedEnvFiles
} 
```

Logic from `loadEnvConfig` in [packages/next-env/index.ts](https://github.com/vercel/next.js/blob/2086975c3c27d453e4a74fb584b76ea714a05631/packages/next-env/index.ts#L136) that handles loading dependant on the `dev` variable:
```ts
const mode = isTest ? 'test' : dev ? 'development' : 'production'
const dotenvFiles = [
  `.env.${mode}.local`,
  mode !== 'test' && `.env.local`,
  `.env.${mode}`,
  '.env',
]
```

This change allows Payload CLI commands to honor the current `NODE_ENV`, loading `.env.production*`, as intended when running with `NODE_ENV=production`.

No behavioral changes for existing dev users, but adds expected support for production workflows.
---
Note:
There are a few consideration I made here.
1. Default to development if not explicitly set (I think most would agree).
2. I haven't implemented warning for non standard `NODE_ENV` values, as the `Next.js` cli does. For example `NODE_ENV=alpha`.
3. Extension of point 2, I haven't implemented loading of non-standard `NODE_ENV` values.

I do believe either point 2 or 3 should be implemented however. So users are not left surprised by the actions of the CLI.

FYI, the `Next.js` cli does the warning in the main package and not `@next/env`. This logic exists in [packages/next/src/bin/next.ts](https://github.com/vercel/next.js/blob/2086975c3c27d453e4a74fb584b76ea714a05631/packages/next/src/bin/next.ts#L64):

```ts
const standardEnv = ['production', 'development', 'test']

if (process.env.NODE_ENV) {
  const isNotStandard = !standardEnv.includes(process.env.NODE_ENV)
  const shouldWarnCommands =
    process.env.NODE_ENV === 'development'
      ? ['start', 'build']
      : process.env.NODE_ENV === 'production'
        ? ['dev']
        : []

  if (isNotStandard || shouldWarnCommands.includes(commandName)) {
    warn(NON_STANDARD_NODE_ENV)
  }
}
```
This warns when using the wrong `NODE_ENV` for a command (I don't think that applies here?). Also warning when a non-standard `NODE_ENV` is used (e.g., `NODE_ENV=alpha`) and will not attempt to load `.env.alpha*`. This makes unexpected behaviour non-silent.

If desired, I can add the warning to this PR or follow up with a separate PR. However, loading non-standard `NODE_ENV` is a bigger discussion and implementation. That I would prefer to leave out of this PR so not to block it moving along. But I felt it was worth mentioning.