### PR TITLE
feat(plugin-multi-tenant): add tenantSelectorComponent option to cust…

### DIFF
--- a/docs/plugins/multi-tenant.mdx
+++ b/docs/plugins/multi-tenant.mdx
@@ -170,6 +170,16 @@ type MultiTenantPluginConfig<ConfigTypes = unknown> = {
       }>
     | string
   /**
+   * Override or disable the TenantSelector shown above the nav.
+   *
+   * - supply a `CustomComponent` → your component is rendered
+   * - supply `null`              → no selector is rendered
+   * - leave it `undefined`       → the default selector is rendered
+   *
+   * @default undefined
+   */
+  tenantSelectorComponent?: CustomComponent | null
+  /**
    * The slug for the tenant collection
    *
    * @default 'tenants'

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -1,5 +1,5 @@
 import type { AcceptedLanguages } from '@payloadcms/translations'
-import type { CollectionConfig, Config } from 'payload'
+import type { CollectionConfig, Config, CustomComponent } from 'payload'
 
 import type { MultiTenantPluginConfig } from './types.js'
 
@@ -333,12 +333,16 @@ export const multiTenantPlugin =
     /**
      * Add tenant selector to admin UI
      */
-    incomingConfig.admin.components.beforeNavLinks.push({
-      clientProps: {
-        label: tenantSelectorLabel,
-      },
+    const defaultTenantSelector: CustomComponent = {
+      clientProps: { label: tenantSelectorLabel },
       path: '@payloadcms/plugin-multi-tenant/client#TenantSelector',
-    })
+    }
+
+    if (pluginConfig.tenantSelectorComponent !== null) {
+      incomingConfig.admin.components.beforeNavLinks.push(
+        pluginConfig.tenantSelectorComponent ?? defaultTenantSelector,
+      )
+    }
 
     return incomingConfig
   }

--- a/packages/plugin-multi-tenant/src/types.ts
+++ b/packages/plugin-multi-tenant/src/types.ts
@@ -1,5 +1,12 @@
 import type { AcceptedLanguages } from '@payloadcms/translations'
-import type { ArrayField, CollectionSlug, Field, RelationshipField, User } from 'payload'
+import type {
+  ArrayField,
+  CollectionSlug,
+  CustomComponent,
+  Field,
+  RelationshipField,
+  User,
+} from 'payload'
 
 export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
   /**
@@ -116,6 +123,16 @@ export type MultiTenantPluginConfig<ConfigTypes = unknown> = {
         rowFields?: never
         tenantFieldAccess?: never
       }
+  /**
+   * Override or disable the TenantSelector shown above the nav.
+   *
+   * - supply a `CustomComponent` → your component is rendered
+   * - supply `null`              → no selector is rendered
+   * - leave it `undefined`       → the default selector is rendered
+   *
+   * @default undefined
+   */
+  tenantSelectorComponent?: CustomComponent | null
   /**
    * Customize tenant selector label
    *


### PR DESCRIPTION
### What?

* **Add `tenantSelectorComponent` option**
  Introduces a new `tenantSelectorComponent?: CustomComponent | null` field on the multi-tenant plugin config, with three modes:
  1. **Custom**: supply your own component → rendered in the admin UI
  2. **Disabled**: supply `null` → no selector is rendered
  3. **Default**: leave it `undefined` → the existing default selector is used

### Why?

* **Enable multi-tenant selector UI and UX flexibility**
Developers can now completely disable the selector or swap in a custom implementation.

Examples:
* This is useful when willing to customise and workaround the UX problem described in the issue https://github.com/payloadcms/payload/issues/12369. 
In this issue switching tenants via the selector edits the current document’s tenant field, causing unintentional cross-tenant migrations. A custom tenant selector allowed me and others to customise the logic and redirect to the home page before mutating the tenant field (which avoids the document field unintentional modification).

* Some developers just want to opt it out (no needs for the selector) https://github.com/payloadcms/payload/discussions/11856

This property is an intuitive addition in the current design and it unlocks customization and workarounds for UI and UX

### How?

1. **Schema change**

   ```ts
   /**
    * Override or disable the TenantSelector shown above the nav.
    *
    * - supply a `CustomComponent` → your component is rendered
    * - supply `null`              → no selector is rendered
    * - leave it `undefined`       → the default selector is rendered
    *
    * @default undefined
    */
   tenantSelectorComponent?: CustomComponent | null
   ```
2. **Component setup**

   ```ts
   /**
    * Add tenant selector to admin UI
    */
   const defaultTenantSelector: CustomComponent = {
     clientProps: { label: tenantSelectorLabel },
     path: '@payloadcms/plugin-multi-tenant/client#TenantSelector',
   }

   if (pluginConfig.tenantSelectorComponent !== null) {
     incomingConfig.admin.components.beforeNavLinks.push(
       pluginConfig.tenantSelectorComponent ?? defaultTenantSelector,
     )
   }
   ```
3. **Link to issue**
   Provides a configuration-level workaround for the behavior detailed in [[#12369](https://github.com/payloadcms/payload/issues/12369)](https://github.com/payloadcms/payload/issues/12369) without baking in a specific redirect or mutation strategy.