### PR TITLE
docs: add local api instructions for vercel content link

### DIFF
--- a/docs/integrations/vercel-content-link.mdx
+++ b/docs/integrations/vercel-content-link.mdx
@@ -63,19 +63,50 @@ const config = buildConfig({
 export default config
 ```
 
-Now in your Next.js app, include the `?encodeSourceMaps=true` parameter in any of your API requests. For performance reasons, this should only be done when in draft mode or on preview deployments.
+## Enabling Content Source Maps
+
+Now in your Next.js app, you need to add the `encodeSourceMaps` query parameter to your API requests. This will tell Payload to include the Content Source Maps in the API response.
+
+<Banner type="warning">
+  **Note:** For performance reasons, this should only be done when in draft mode
+  or on preview deployments.
+</Banner>
+
+#### REST API
+
+If you're using the REST API, include the `?encodeSourceMaps=true` search parameter.
 
 ```ts
 if (isDraftMode || process.env.VERCEL_ENV === 'preview') {
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_PAYLOAD_CMS_URL}/api/pages?where[slug][equals]=${slug}&encodeSourceMaps=true`,
+    `${process.env.NEXT_PUBLIC_PAYLOAD_CMS_URL}/api/pages?encodeSourceMaps=true&where[slug][equals]=${slug}`,
   )
+}
+```
+
+#### Local API
+
+If you're using the Local API, include the `encodeSourceMaps` via the `context` property.
+
+```ts
+if (isDraftMode || process.env.VERCEL_ENV === 'preview') {
+  const res = await payload.find({
+    collection: 'pages',
+    where: {
+      slug: {
+        equals: slug,
+      },
+    },
+    context: {
+      encodeSourceMaps: true,
+    },
+  })
 }
 ```
 
 And that's it! You are now ready to enter Edit Mode and begin visually editing your content.
 
-#### Edit Mode
+## Edit Mode
 
 To see Content Link on your site, you first need to visit any preview deployment on Vercel and login using the Vercel Toolbar. When Content Source Maps are detected on the page, a pencil icon will appear in the toolbar. Clicking this icon will enable Edit Mode, highlighting all editable fields on the page in blue.
 
@@ -94,7 +125,9 @@ const { cleaned, encoded } = vercelStegaSplit(text)
 
 ### Blocks and array fields
 
-All `blocks` and `array` fields by definition do not have plain text strings to encode. For this reason, they are given an additional `_encodedSourceMap` property, which you can use to enable Content Link on entire _sections_ of your site. You can then specify the editing container by adding the `data-vercel-edit-target` HTML attribute to any top-level element of your block.
+All `blocks` and `array` fields by definition do not have plain text strings to encode. For this reason, they are automatically given an additional `_encodedSourceMap` property, which you can use to enable Content Link on entire _sections_ of your site.
+
+You can then specify the editing container by adding the `data-vercel-edit-target` HTML attribute to any top-level element of your block.
 
 ```ts
 <div data-vercel-edit-target>


### PR DESCRIPTION
The docs for Vercel Content Link only included instructions on how to enable content source maps for the REST API. The Local API, although supported, was lacking documentation.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210524295135127