### PR TITLE
chore: add NODE_OPTIONS to vscode settings by default in the repo for playwright extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,8 @@
     "runtimeArgs": ["--no-deprecation"]
   },
   // Essentially disables bun test buttons
-  "bun.test.filePattern": "bun.test.ts"
+  "bun.test.filePattern": "bun.test.ts",
+  "playwright.env": {
+    "NODE_OPTIONS": "--no-deprecation --no-experimental-strip-types"
+  }
 }


### PR DESCRIPTION
The official playwright extension when using the debug button to run tests in debug mode doesn't pick up the `tests/test.env` file as expected.

I've added the same `NODE_OPTIONS` to the vscode settings JSON for this extension which fixes an error when running e2e tests in debug mode.