### PR TITLE
chore(examples): fix read permission in auth example

### DIFF
--- a/examples/auth/src/collections/Users.ts
+++ b/examples/auth/src/collections/Users.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from 'payload/types'
 
 import { admins } from './access/admins'
-import adminsAndUser from './access/adminsAndUser'
+import { adminsAndUser } from './access/adminsAndUser'
 import { anyone } from './access/anyone'
 import { checkRole } from './access/checkRole'
 import { loginAfterCreate } from './hooks/loginAfterCreate'

--- a/examples/auth/src/collections/Users.ts
+++ b/examples/auth/src/collections/Users.ts
@@ -25,6 +25,7 @@ export const Users: CollectionConfig = {
     create: anyone,
     update: adminsAndUser,
     delete: admins,
+    unlock: admins,
     admin: ({ req: { user } }) => checkRole(['admin'], user),
   },
   hooks: {

--- a/examples/auth/src/collections/access/admins.ts
+++ b/examples/auth/src/collections/access/admins.ts
@@ -1,4 +1,4 @@
-import type { Access } from 'payload/config'
+import type { Access } from 'payload'
 
 import { checkRole } from './checkRole'
 

--- a/examples/auth/src/collections/access/adminsAndUser.ts
+++ b/examples/auth/src/collections/access/adminsAndUser.ts
@@ -1,4 +1,4 @@
-import type { Access } from 'payload/config'
+import type { Access } from 'payload'
 
 import { checkRole } from './checkRole'
 

--- a/examples/auth/src/collections/access/adminsAndUser.ts
+++ b/examples/auth/src/collections/access/adminsAndUser.ts
@@ -9,7 +9,7 @@ const adminsAndUser: Access = ({ req: { user } }) => {
     }
 
     return {
-      id: user.id,
+      id: { equals: user.id },
     }
   }
 

--- a/examples/auth/src/collections/access/adminsAndUser.ts
+++ b/examples/auth/src/collections/access/adminsAndUser.ts
@@ -2,7 +2,7 @@ import type { Access } from 'payload'
 
 import { checkRole } from './checkRole'
 
-const adminsAndUser: Access = ({ req: { user } }) => {
+export const adminsAndUser: Access = ({ req: { user } }) => {
   if (user) {
     if (checkRole(['admin'], user)) {
       return true
@@ -15,5 +15,3 @@ const adminsAndUser: Access = ({ req: { user } }) => {
 
   return false
 }
-
-export default adminsAndUser

--- a/examples/auth/src/collections/access/anyone.ts
+++ b/examples/auth/src/collections/access/anyone.ts
@@ -1,3 +1,3 @@
-import type { Access } from 'payload/config'
+import type { Access } from 'payload'
 
 export const anyone: Access = () => true

--- a/examples/auth/src/collections/access/checkRole.ts
+++ b/examples/auth/src/collections/access/checkRole.ts
@@ -1,6 +1,6 @@
 import type { User } from '../../payload-types'
 
-export const checkRole = (allRoles: User['roles'] = [], user: User = undefined): boolean => {
+export const checkRole = (allRoles: User['roles'] = [], user: User | null = null): boolean => {
   if (user) {
     if (
       allRoles.some((role) => {
@@ -8,8 +8,9 @@ export const checkRole = (allRoles: User['roles'] = [], user: User = undefined):
           return individualRole === role
         })
       })
-    )
-      {return true}
+    ) {
+      return true
+    }
   }
 
   return false

--- a/examples/auth/src/collections/hooks/protectRoles.ts
+++ b/examples/auth/src/collections/hooks/protectRoles.ts
@@ -1,4 +1,4 @@
-import type { FieldHook } from 'payload/types'
+import type { FieldHook } from 'payload'
 
 import type { User } from '../../payload-types'
 


### PR DESCRIPTION
The return value of the `adminsAndUser` method was not a proper Query to limit the read scope of the read access. So users could read all user data of the system.

Alongside I streamlined the type imports (fixes #12323) and fixed some typescript typings. And aligned the export of the mentioned to align with the other access methods.

