### PR TITLE
fix(ui): present hasMany upload thumbnail cells in line in list view

### DIFF
--- a/packages/ui/src/elements/Table/DefaultCell/fields/Relationship/index.scss
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Relationship/index.scss
@@ -1,0 +1,14 @@
+@import '../../../../../scss/styles.scss';
+
+@layer payload-default {
+  .relationship-cell {
+    &:has(.file) {
+      display: inline-flex;
+      align-items: center;
+    }
+
+    & .file:not(:first-child) {
+      padding-left: base(1);
+    }
+  }
+}

--- a/packages/ui/src/elements/Table/DefaultCell/fields/Relationship/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Relationship/index.tsx
@@ -139,7 +139,7 @@ export const RelationshipCell: React.FC<RelationshipCellProps> = ({
       })}
       {Array.isArray(cellData) &&
         cellData.length > totalToShow &&
-        t('fields:itemsAndMore', { count: cellData.length - totalToShow, items: '' })}
+        `, ${t('fields:itemsAndMore', { count: cellData.length - totalToShow, items: '' })}`}
       {values.length === 0 && t('general:noLabel', { label: getTranslation(label || '', i18n) })}
     </div>
   )


### PR DESCRIPTION
<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
### What?
This PR makes it so that hasMany upload fields render their cells in a singular row as opposed to the current behavior which renders thumbnails, commas and indicator text all on separate rows.

### Why?
To prevent image thumbnails from creating block space in the list view.

### How?
By adding some simple CSS rules the `.relationship-cell` class.

Before:
![Posts-Payload-inline-images-before](https://github.com/user-attachments/assets/3a88d26f-9325-470c-b539-154774c50ed3)

After:
![Posts-Payload-inline-images-after](https://github.com/user-attachments/assets/f9ca66d9-9636-49f1-9404-053f2b93c3be)
