### PR TITLE
fix(ui): respect `filterOptions: { id: { in: [] } }`

### DIFF
--- a/packages/ui/src/fields/Relationship/index.tsx
+++ b/packages/ui/src/fields/Relationship/index.tsx
@@ -33,6 +33,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import './index.scss'
+import { sanitizeFilterOptionsQuery } from '../../utilities/sanitizeFilterOptionsQuery.js'
 import { mergeFieldStyles } from '../mergeFieldStyles.js'
 import { fieldBaseClass } from '../shared/index.js'
 import { createRelationMap } from './createRelationMap.js'
@@ -298,6 +299,8 @@ const RelationshipFieldComponent: RelationshipFieldClientComponent = (props) => 
             if (relationFilterOption && typeof relationFilterOption !== 'boolean') {
               query.where.and.push(relationFilterOption)
             }
+
+            sanitizeFilterOptionsQuery(query.where)
 
             const response = await fetch(`${serverURL}${api}/${relation}`, {
               body: qs.stringify(query),

--- a/packages/ui/src/utilities/sanitizeFilterOptionsQuery.ts
+++ b/packages/ui/src/utilities/sanitizeFilterOptionsQuery.ts
@@ -8,7 +8,6 @@ export const sanitizeFilterOptionsQuery = (query: Where): Where => {
         sanitizeFilterOptionsQuery(val)
       }
     } else if (
-      key === 'id' &&
       value &&
       typeof value === 'object' &&
       'in' in value &&
@@ -16,7 +15,7 @@ export const sanitizeFilterOptionsQuery = (query: Where): Where => {
       value.in.length === 0
     ) {
       {
-        query['id'] = { exists: false }
+        query[key] = { exists: false }
       }
     }
   }

--- a/packages/ui/src/utilities/sanitizeFilterOptionsQuery.ts
+++ b/packages/ui/src/utilities/sanitizeFilterOptionsQuery.ts
@@ -1,0 +1,25 @@
+import type { Where } from 'payload'
+
+export const sanitizeFilterOptionsQuery = (query: Where): Where => {
+  for (const key in query) {
+    const value = query[key]
+    if ((key.toLowerCase() === 'and' || key.toLowerCase() === 'or') && Array.isArray(value)) {
+      for (const val of value) {
+        sanitizeFilterOptionsQuery(val)
+      }
+    } else if (
+      key === 'id' &&
+      value &&
+      typeof value === 'object' &&
+      'in' in value &&
+      Array.isArray(value.in) &&
+      value.in.length === 0
+    ) {
+      {
+        query['id'] = { exists: false }
+      }
+    }
+  }
+
+  return query
+}


### PR DESCRIPTION
Fixes the issue where this returns all the documents:
```
{
  name: 'post',
  type: 'relationship',
  relationTo: 'posts',
  filterOptions: { id: { in: [] } }
}
```

The issue isn't with the Local API but with how we send the query to the REST API through `qs.stringify`. `qs.stringify({ id: { in: [] } }` becomes `""`, so the server ignores the original query. I don't think it's possible to encode empty arrays with this library https://github.com/sindresorhus/query-string/issues/231, so I just made sanitization to `{ exists: false }` for this case.