### PR TITLE
fix(plugin-nested-docs): fix bug in logic to determine if doc is a draft

### DIFF
--- a/docs/plugins/nested-docs.mdx
+++ b/docs/plugins/nested-docs.mdx
@@ -43,6 +43,13 @@ but different parents.
 - Dynamically generate labels and URLs for each breadcrumb
 - Supports localization
 
+<Banner type="warning">
+  **Note:**
+
+When versions are enabled for a collection, only published documents will recursively update their descendants. If a parent document is in a draft state, its children will not be updated until the parent is published.
+
+</Banner>
+
 ## Installation
 
 Install the plugin using any JavaScript package manager like [pnpm](https://pnpm.io), [npm](https://npmjs.com), or [Yarn](https://yarnpkg.com):

--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -115,7 +115,7 @@ export const resaveChildren =
     await resave({
       collection,
       doc,
-      draft: doc._status === 'published' ? false : true,
+      draft: (!doc._status || doc._status === 'published') ? false : true,
       pluginConfig,
       req,
     })

--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -112,10 +112,15 @@ const resave = async ({ collection, doc, draft, pluginConfig, req }: ResaveArgs)
 export const resaveChildren =
   (pluginConfig: NestedDocsPluginConfig, collection: CollectionConfig): CollectionAfterChangeHook =>
   async ({ doc, req }) => {
+    const isDraftsEnabled =
+      typeof collection.versions === 'object' ? !!collection.versions.drafts : !!collection.versions
+
     await resave({
       collection,
       doc,
-      draft: (!doc._status || doc._status === 'published') ? false : true,
+      // If drafts are enabled, only resave children if the parent is published.
+      // If drafts are not enabled, always resave children.
+      draft: isDraftsEnabled ? doc._status === 'published' : false,
       pluginConfig,
       req,
     })


### PR DESCRIPTION
The current approach fails to handle documents in collections that don't have versioning enabled. In these situations, `doc._status` is undefined, which causes the current logic to return `draft=true` and no children are resaved.


Issue: https://github.com/payloadcms/payload/issues/12411
