### PR TITLE
fix(next): tells webpack not to bundle the require-in-the-middle pkg

### DIFF
--- a/packages/next/src/withPayload.js
+++ b/packages/next/src/withPayload.js
@@ -132,6 +132,7 @@ export const withPayload = (nextConfig = {}, options = {}) => {
           'drizzle-kit/api',
           'sharp',
           'libsql',
+          'require-in-the-middle',
         ],
         ignoreWarnings: [
           ...(incomingWebpackConfig?.ignoreWarnings || []),


### PR DESCRIPTION
After this [PR](https://github.com/payloadcms/payload/pull/12193) was merged, webpack started throwing a warning because it is attempting to bundle the `require-in-the-middle` package which uses dynamic imports with `require()`.

This PR adds `require-in-the-middle` to the externals array in the withPayload webpack configuration.

Error:
```
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted

Import trace for requested module:
./node_modules/.pnpm/require-in-the-middle@7.5.2/node_modules/require-in-the-middle/index.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/instrumentation.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/index.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/index.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/index.js
./node_modules/.pnpm/@sentry+opentelemetry@8.55.0_@opentelemetry+api@1.9.0_@opentelemetry+context-async-hooks@1.30_rsagi454t2fgzs5kzoro32otdq/node_modules/@sentry/opentelemetry/build/cjs/index.js
./node_modules/.pnpm/@sentry+nextjs@8.55.0_@opentelemetry+context-async-hooks@1.30.1_@opentelemetry+api@1.9.0__@op_o7zfzxgzd3z73l42wzlti44h4i/node_modules/@sentry/nextjs/build/cjs/server/index.js
./node_modules/.pnpm/@sentry+nextjs@8.55.0_@opentelemetry+context-async-hooks@1.30.1_@opentelemetry+api@1.9.0__@op_o7zfzxgzd3z73l42wzlti44h4i/node_modules/@sentry/nextjs/build/cjs/index.server.js
./sentry.server.config.ts
```