### PR TITLE
chore: removes unused ts-expect-error

### DIFF
--- a/packages/storage-s3/src/staticHandler.ts
+++ b/packages/storage-s3/src/staticHandler.ts
@@ -66,7 +66,6 @@ export const getHandler = ({
       if (signedDownloads && !clientUploadContext) {
         const command = new GetObjectCommand({ Bucket: bucket, Key: key })
         const signedUrl = await getSignedUrl(
-          // @ts-expect-error mismatch versions
           getStorageClient(),
           command,
           typeof signedDownloads === 'object' ? signedDownloads : { expiresIn: 7200 },


### PR DESCRIPTION
This [PR](https://github.com/payloadcms/payload/actions/runs/15026016085/job/42227045777?pr=12213) is failing to build because of this unused ts-expect-error.