### PR TITLE
fix: orderable with groups and tabs requires migration

### DIFF
--- a/packages/drizzle/src/transform/read/traverseFields.ts
+++ b/packages/drizzle/src/transform/read/traverseFields.ts
@@ -666,10 +666,6 @@ export const traverseFields = <T extends Record<string, unknown>>({
             withinArrayOrBlockLocale: locale || withinArrayOrBlockLocale,
           })
 
-          if ('_order' in ref) {
-            delete ref._order
-          }
-
           return
         }
 

--- a/packages/payload/src/config/orderable/index.ts
+++ b/packages/payload/src/config/orderable/index.ts
@@ -1,8 +1,14 @@
+import { status as httpStatus } from 'http-status'
+
 import type { BeforeChangeHook, CollectionConfig } from '../../collections/config/types.js'
 import type { Field } from '../../fields/config/types.js'
 import type { Endpoint, PayloadHandler, SanitizedConfig } from '../types.js'
 
 import executeAccess from '../../auth/executeAccess.js'
+import { APIError } from '../../errors/index.js'
+import { commitTransaction } from '../../utilities/commitTransaction.js'
+import { initTransaction } from '../../utilities/initTransaction.js'
+import { killTransaction } from '../../utilities/killTransaction.js'
 import { traverseFields } from '../../utilities/traverseFields.js'
 import { generateKeyBetween, generateNKeysBetween } from './fractional-indexing.js'
 
@@ -37,7 +43,12 @@ export const setupOrderable = (config: SanitizedConfig) => {
         }
         if (field.type === 'join' && field.orderable === true) {
           if (Array.isArray(field.collection)) {
-            throw new Error('Orderable joins must target a single collection')
+            throw new APIError(
+              'Orderable joins must target a single collection',
+              httpStatus.BAD_REQUEST,
+              {},
+              true,
+            )
           }
           const relationshipCollection = config.collections.find((c) => c.slug === field.collection)
           if (!relationshipCollection) {
@@ -206,6 +217,8 @@ export const addOrderableEndpoint = (config: SanitizedConfig) => {
     if (!target.key) {
       const { docs } = await req.payload.find({
         collection: collection.slug,
+        depth: 0,
+        limit: 0,
         req,
         select: { [orderableFieldName]: true },
         where: {
@@ -214,18 +227,29 @@ export const addOrderableEndpoint = (config: SanitizedConfig) => {
           },
         },
       })
+      await initTransaction(req)
       // We cannot update all documents in a single operation with `payload.update`,
       // because they would all end up with the same order key (`a0`).
-      for (const doc of docs) {
-        await req.payload.update({
-          id: doc.id,
-          collection: collection.slug,
-          data: {
-            // no data needed since the order hooks will handle this
-          },
-          req,
-        })
+      try {
+        for (const doc of docs) {
+          await req.payload.update({
+            id: doc.id,
+            collection: collection.slug,
+            data: {
+              // no data needed since the order hooks will handle this
+            },
+            depth: 0,
+            req,
+          })
+          await commitTransaction(req)
+        }
+      } catch (e) {
+        await killTransaction(req)
+        if (e instanceof Error) {
+          throw new APIError(e.message, httpStatus.INTERNAL_SERVER_ERROR)
+        }
       }
+
       return new Response(JSON.stringify({ message: 'initial migration', success: true }), {
         headers: { 'Content-Type': 'application/json' },
         status: 200,

--- a/packages/payload/src/config/orderable/index.ts
+++ b/packages/payload/src/config/orderable/index.ts
@@ -214,6 +214,8 @@ export const addOrderableEndpoint = (config: SanitizedConfig) => {
           },
         },
       })
+      // We cannot update all documents in a single operation with `payload.update`,
+      // because they would all end up with the same order key (`a0`).
       for (const doc of docs) {
         await req.payload.update({
           id: doc.id,

--- a/packages/payload/src/config/orderable/index.ts
+++ b/packages/payload/src/config/orderable/index.ts
@@ -208,15 +208,12 @@ export const addOrderableEndpoint = (config: SanitizedConfig) => {
         collection: collection.slug,
         req,
         select: { [orderableFieldName]: true },
+        where: {
+          [orderableFieldName]: {
+            exists: false,
+          },
+        },
       })
-      if (docs.some((doc) => doc[orderableFieldName] !== null)) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          "Corrupted data: Some documents don't have an orderable field, " +
-            "while others do. This shouldn't happen. " +
-            'Please open an issue with a reproduction.',
-        )
-      }
       for (const doc of docs) {
         await req.payload.update({
           id: doc.id,

--- a/packages/ui/src/elements/Table/OrderableTable.tsx
+++ b/packages/ui/src/elements/Table/OrderableTable.tsx
@@ -133,6 +133,14 @@ export const OrderableTable: React.FC<Props> = ({
           'Failed to reorder. This can happen if you reorder several rows too quickly. Please try again.',
         )
       }
+
+      if (response.status === 200 && (await response.json())['message'] === 'initial migration') {
+        throw new Error(
+          'It looks like you have enabled "orderable" on a collection with existing documents' +
+            'and this is the first time you have sorted documents. We have run an automatic migration' +
+            'to add an initial sort order to the documents. Please refresh the page and try again.',
+        )
+      }
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err)
       // Rollback to previous state if the request fails

--- a/packages/ui/src/elements/Table/OrderableTable.tsx
+++ b/packages/ui/src/elements/Table/OrderableTable.tsx
@@ -136,9 +136,9 @@ export const OrderableTable: React.FC<Props> = ({
 
       if (response.status === 200 && (await response.json())['message'] === 'initial migration') {
         throw new Error(
-          'It looks like you have enabled "orderable" on a collection with existing documents' +
-            'and this is the first time you have sorted documents. We have run an automatic migration' +
-            'to add an initial sort order to the documents. Please refresh the page and try again.',
+          'You have enabled "orderable" on a collection with existing documents' +
+            'and this is the first time you have sorted documents. We have run an automatic migration ' +
+            'to add an initial order to the documents. Please refresh the page and try again.',
         )
       }
     } catch (err) {

--- a/test/sort/payload-types.ts
+++ b/test/sort/payload-types.ts
@@ -151,6 +151,7 @@ export interface Post {
  */
 export interface Draft {
   id: string;
+  _order?: string | null;
   text?: string | null;
   number?: number | null;
   number2?: number | null;
@@ -191,9 +192,9 @@ export interface Localized {
  */
 export interface Orderable {
   id: string;
-  _orderable_orderableJoinField2_order?: string;
-  _orderable_orderableJoinField1_order?: string;
-  _order?: string;
+  _orderable_orderableJoinField2_order?: string | null;
+  _orderable_orderableJoinField1_order?: string | null;
+  _order?: string | null;
   title?: string | null;
   orderableField?: (string | null) | OrderableJoin;
   updatedAt: string;
@@ -340,6 +341,7 @@ export interface PostsSelect<T extends boolean = true> {
  * via the `definition` "drafts_select".
  */
 export interface DraftsSelect<T extends boolean = true> {
+  _order?: T;
   text?: T;
   number?: T;
   number2?: T;


### PR DESCRIPTION
⚠️ `orderable` fields will no longer be `required` and `unique`, so your database may prompt you to accept an automatic migration if you're using [this feature](https://payloadcms.com/docs/configuration/collections#config-options). Note that the `orderable` feature is still experimental, so it may still receive breaking changes without a major upgrade or contain bugs. Use it with caution.
___

The `orderable` fields will not have `required` and `unique` constraints at the database schema level, in order to automatically migrate collections that incorporate this property.

Now, when a user adds the `orderable` property to a collection or join field, existing documents will have the order field set to undefined. The first time you try to reorder them, the documents will be automatically assigned an initial order, and you will be prompted to refresh the page.

We believe this provides a better development experience than having to manually migrate data with a script.

Additionally, it fixes a bug that occurred when using `orderable` in conjunction with groups and tabs fields.

Closes:
- #12129
- #12331
- #12212