### PR TITLE
chore: add ignores .next folder in eslint config for templates template

### DIFF
--- a/templates/_template/eslint.config.mjs
+++ b/templates/_template/eslint.config.mjs
@@ -30,6 +30,9 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    ignores: ['.next/'],
+  },
 ]
 
 export default eslintConfig


### PR DESCRIPTION
The automated PR will override this config in other templates, so I'm just copying it into the base template eslint config

```
 {
    ignores: ['.next/'],
  },
```