### PR TITLE
fix(templates): make images visible in live preview if it is not running on port 3000

### DIFF
--- a/templates/website/next.config.js
+++ b/templates/website/next.config.js
@@ -4,7 +4,7 @@ import redirects from './redirects.js'
 
 const NEXT_PUBLIC_SERVER_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-  : undefined || process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000'
+  : undefined || process.env.__NEXT_PRIVATE_ORIGIN || 'http://localhost:3000'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/templates/with-vercel-website/next.config.js
+++ b/templates/with-vercel-website/next.config.js
@@ -4,7 +4,7 @@ import redirects from './redirects.js'
 
 const NEXT_PUBLIC_SERVER_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-  : undefined || process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000'
+  : undefined || process.env.__NEXT_PRIVATE_ORIGIN || 'http://localhost:3000'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
I couldn't find much information on the internet about `__NEXT_PRIVATE_ORIGIN`, but I could observe that when port 3000 was busy and 3001 was used, `NEXT_PUBLIC_SERVER_URL` was `http://localhost:3000`, while `__NEXT_PRIVATE_ORIGIN` was `http://localhost:3001`.

Fixes #12431


