### PR TITLE
fix(ui): render missing group children fields for unnamed group

### DIFF
--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -123,7 +123,7 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
               parentIndexPath={indexPath}
               parentPath={parentPath}
               parentSchemaPath={parentSchemaPath}
-              permissions={permissions === true ? permissions : permissions?.fields}
+              permissions={permissions}
               readOnly={readOnly}
             />
           )}


### PR DESCRIPTION
### What?
Basically an unnamed group moves all of its children to the same level with the group. When another field at the same level has a unique access setting, the permissions will return a json of permissions for each fields at the same level instead of return a default `true` value. For traditional group field, there will be a `fields` property inside the permissions object, so it can use  ```permissions={permissions === true ? permissions : permissions?.fields``` as the attribution of <RenderFields> in `packages/ui/src/fields/Group/index.tsx`. Right now, since we promoted the group's children to the upper level, which makes the `fields` property no longer exists in the `permissions` object. Hence, the `permissions?.fields` mentioned above will always be undefined, which will lead to return null for this field, because the getFieldPermissions will always get read permission as undefined.

### Why?
The only reason we use `permissions : permissions?.fields` before because the traditional group field moves all its children to a child property `fields`. Since we somehow promoted those children to upper level, so there is no need to access the fields property anymore.

### How?
For the permissions attribute for unnamed group's <RenderFields>, simple pass in `permissions={permissions}` instead of `{permissions === true ? permissions : permissions?.fields}`, since you have already gotten all you want in permissions. No worry about the extra permission property brought in(the access permission in the unnamed group level), because `getFieldPermissions` will filter those redundant ones out.

Fixes #12430 

