### PR TITLE
chore: ignore .idea run configuration templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ package-lock.json
 dist
 /.idea/*
 !/.idea/runConfigurations
+/.idea/runConfigurations/_template*
 !/.idea/payload.iml
 
 # Custom actions


### PR DESCRIPTION
Webstorm run configuration template files are trying to sneak into my commits.